### PR TITLE
feat(channels): Matrix connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ One-click install for agent frameworks, AI models, and services. Hardware-aware,
 ### Channel Hub (Framework-Agnostic Messaging)
 Most agent frameworks force you to wire up Telegram, Discord, or Slack directly into their code. If you switch frameworks, you rebuild all those integrations from scratch. taOS flips this: the platform owns the messaging connections and routes messages to whichever framework the agent currently uses. Switch an agent from SmolAgents to LangChain and it keeps every channel, every conversation, every connection. The framework never touches the bot tokens.
 
-- **6 connectors**. Telegram, Discord, Slack, Email (IMAP/SMTP), Web Chat (WebSocket), Webhooks
+- **7 connectors**. Telegram, Discord, Slack, Matrix (beta), Email (IMAP/SMTP), Web Chat (WebSocket), Webhooks
 - **15 framework adapters.** Thin HTTP bridges (~25 lines each) that translate the universal message format to framework-specific APIs
 - **Rich responses.** Buttons, images, cards via universal format with inline hint fallback for any framework
 - **Per-agent or shared bots.** Each agent gets its own bot, or share one across a group
@@ -294,7 +294,7 @@ Click on any agent to enter their "virtual computer", a tablet-like interface wi
 Create shared file spaces for agents, groups, and departments. The design team shares mockups, the research team shares documents. Per-agent access control.
 
 ### Agent Management
-- **Communication Channels**. Telegram, Discord, Slack, web chat, email, webhooks (Easy/Advanced setup)
+- **Communication Channels**. Telegram, Discord, Slack, Matrix, web chat, email, webhooks (Easy/Advanced setup)
 - **Secrets Manager.** Encrypted storage with per-agent access control
 - **Inter-Agent Relationships.** Groups, departments, lead agents, permissions matrix
 - **Scheduled Tasks.** Cron jobs with presets, per-agent or group assignment
@@ -394,7 +394,7 @@ taOS Controller (FastAPI + htmx + React Desktop Shell)
 ├── User Memory (taosmd proxy: /ingest/batch + /search?mode=bm25, SQLite FTS5 fallback, auto-capture, global search)
 ├── Web Dashboard (77 route modules, React SPA frontend)
 ├── Channel Hub (6 connectors, 15 framework adapters)
-│   ├── Telegram, Discord, Slack, Email, Web Chat, Webhooks
+│   ├── Telegram, Discord, Slack, Matrix, Email, Web Chat, Webhooks
 │   └── Universal message format → framework-specific translation
 ├── LLM Proxy (LiteLLM, per-agent virtual keys)
 ├── Cluster Manager (worker registration, task routing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     # http://taos.local:<port>/ on the LAN without users knowing its IP
     # (tinyagentos/services/mdns_publisher.py).
     "zeroconf>=0.150.0",
+    "matrix-nio>=0.21.0",
     # Diff/patch for the notes revision log: computes and applies text diffs
     # for the Time Machine history layer (tinyagentos/notes/shared_docs_store.py).
     "diff-match-patch>=20230430",

--- a/tests/channel_hub/test_matrix_connector.py
+++ b/tests/channel_hub/test_matrix_connector.py
@@ -1,0 +1,211 @@
+"""Tests for the Matrix connector. Uses fake nio objects so no homeserver is needed."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tinyagentos.channel_hub.matrix_connector import MatrixConnector
+from tinyagentos.channel_hub.message import IncomingMessage, OutgoingMessage
+
+
+# ---------------------------------------------------------------------------
+# Fake nio objects
+# ---------------------------------------------------------------------------
+
+class FakeRoom:
+    def __init__(self, room_id: str, display_name: str | None = None):
+        self.room_id = room_id
+        self.display_name = display_name
+
+
+class FakeRoomMessageText:
+    """Minimal stand-in for nio.RoomMessageText."""
+    def __init__(self, event_id: str, sender: str, body: str):
+        self.event_id = event_id
+        self.sender = sender
+        self.body = body
+
+
+class FakeWhoamiResponse:
+    def __init__(self, user_id: str):
+        self.user_id = user_id
+
+
+class FakeAsyncClient:
+    """Minimal fake for nio.AsyncClient."""
+    def __init__(self, homeserver: str):
+        self.homeserver = homeserver
+        self.access_token: str | None = None
+        self._callbacks: list = []
+        self.room_send = AsyncMock(return_value=None)
+        self.close = AsyncMock(return_value=None)
+        self._sync_forever_called = False
+
+    async def whoami(self) -> FakeWhoamiResponse:
+        return FakeWhoamiResponse(user_id="@bot:example.org")
+
+    def add_event_callback(self, callback, event_type):
+        self._callbacks.append((callback, event_type))
+
+    async def sync_forever(self, timeout=30000, full_state=False):
+        # Block until cancelled so the task behaves like the real sync_forever.
+        self._sync_forever_called = True
+        await asyncio.sleep(9999)
+
+    async def fire_event(self, room, event):
+        """Test helper: invoke registered callbacks with a fake event."""
+        for cb, _et in self._callbacks:
+            await cb(room, event)
+
+
+def make_connector(agent_name="test-agent"):
+    fake_client = FakeAsyncClient("https://example.org")
+    mock_router = AsyncMock()
+    mock_router.route_message = AsyncMock(return_value=None)
+
+    def factory(homeserver: str):
+        return fake_client
+
+    connector = MatrixConnector(
+        homeserver="https://example.org",
+        access_token="tok_abc",
+        agent_name=agent_name,
+        router=mock_router,
+        client_factory=factory,
+    )
+    return connector, fake_client, mock_router
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestMatrixConnectorStart:
+    @pytest.mark.asyncio
+    async def test_start_registers_callback_and_spawns_sync(self):
+        connector, client, _ = make_connector()
+        await connector.start()
+        try:
+            assert connector._client is client
+            assert client.access_token == "tok_abc"
+            assert len(client._callbacks) == 1
+            assert connector._task is not None
+            assert not connector._task.done()
+        finally:
+            await connector.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_sets_own_user_id_from_whoami(self):
+        connector, client, _ = make_connector()
+        await connector.start()
+        try:
+            assert connector._own_user_id == "@bot:example.org"
+        finally:
+            await connector.stop()
+
+
+class TestMatrixInboundRouting:
+    @pytest.mark.asyncio
+    async def test_inbound_text_event_calls_route_message(self):
+        connector, client, router = make_connector()
+        router.route_message = AsyncMock(return_value=None)
+        await connector.start()
+        try:
+            room = FakeRoom("!room1:example.org", display_name="Test Room")
+            event = FakeRoomMessageText("$evt1", "@alice:example.org", "Hello bot")
+
+            # Patch isinstance check so FakeRoomMessageText passes the nio type guard.
+            import tinyagentos.channel_hub.matrix_connector as mod
+            with patch.dict("sys.modules", {"nio": MagicMock(RoomMessageText=FakeRoomMessageText)}):
+                await client.fire_event(room, event)
+
+            router.route_message.assert_called_once()
+            call_args = router.route_message.call_args
+            assert call_args[0][0] == "test-agent"
+            incoming: IncomingMessage = call_args[0][1]
+            assert incoming.platform == "matrix"
+            assert incoming.id == "$evt1"
+            assert incoming.from_id == "@alice:example.org"
+            assert incoming.channel_id == "!room1:example.org"
+            assert incoming.channel_name == "Test Room"
+            assert incoming.text == "Hello bot"
+        finally:
+            await connector.stop()
+
+    @pytest.mark.asyncio
+    async def test_own_message_is_ignored(self):
+        connector, client, router = make_connector()
+        router.route_message = AsyncMock(return_value=None)
+        await connector.start()
+        try:
+            room = FakeRoom("!room1:example.org")
+            # Sender is the bot's own user_id
+            event = FakeRoomMessageText("$own", "@bot:example.org", "I said this")
+            with patch.dict("sys.modules", {"nio": MagicMock(RoomMessageText=FakeRoomMessageText)}):
+                await client.fire_event(room, event)
+            router.route_message.assert_not_called()
+        finally:
+            await connector.stop()
+
+
+class TestMatrixOutboundSend:
+    @pytest.mark.asyncio
+    async def test_outgoing_message_calls_room_send(self):
+        connector, client, router = make_connector()
+        response = OutgoingMessage(content="Hi there!")
+        router.route_message = AsyncMock(return_value=response)
+        await connector.start()
+        try:
+            room = FakeRoom("!room1:example.org")
+            event = FakeRoomMessageText("$evt2", "@alice:example.org", "ping")
+            with patch.dict("sys.modules", {"nio": MagicMock(RoomMessageText=FakeRoomMessageText)}):
+                await client.fire_event(room, event)
+
+            client.room_send.assert_called_once()
+            call_kwargs = client.room_send.call_args[1]
+            assert call_kwargs["room_id"] == "!room1:example.org"
+            assert call_kwargs["message_type"] == "m.room.message"
+            assert call_kwargs["content"]["msgtype"] == "m.text"
+            assert call_kwargs["content"]["body"] == "Hi there!"
+        finally:
+            await connector.stop()
+
+    @pytest.mark.asyncio
+    async def test_empty_response_does_not_call_room_send(self):
+        connector, client, router = make_connector()
+        router.route_message = AsyncMock(return_value=OutgoingMessage(content=""))
+        await connector.start()
+        try:
+            room = FakeRoom("!room1:example.org")
+            event = FakeRoomMessageText("$evt3", "@alice:example.org", "anything")
+            with patch.dict("sys.modules", {"nio": MagicMock(RoomMessageText=FakeRoomMessageText)}):
+                await client.fire_event(room, event)
+            client.room_send.assert_not_called()
+        finally:
+            await connector.stop()
+
+
+class TestMatrixStop:
+    @pytest.mark.asyncio
+    async def test_stop_cancels_task_and_closes_client(self):
+        connector, client, _ = make_connector()
+        await connector.start()
+        task = connector._task
+        assert not task.done()
+        await connector.stop()
+        assert task.done()
+        client.close.assert_called_once()
+        assert connector._client is None
+        assert connector._task is None
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self):
+        connector, client, _ = make_connector()
+        await connector.start()
+        await connector.stop()
+        # Second stop should not raise.
+        await connector.stop()
+        # close should only have been called once (first stop)
+        client.close.assert_called_once()

--- a/tests/channel_hub/test_matrix_connector.py
+++ b/tests/channel_hub/test_matrix_connector.py
@@ -105,6 +105,23 @@ class TestMatrixConnectorStart:
         finally:
             await connector.stop()
 
+    @pytest.mark.asyncio
+    async def test_start_raises_when_whoami_has_no_user_id(self):
+        """Without a resolvable own user_id the bot would echo-loop, so start
+        must refuse rather than register the callback and sync."""
+        connector, client, _ = make_connector()
+
+        async def _no_user_id():
+            return FakeWhoamiResponse(user_id=None)
+
+        client.whoami = _no_user_id
+        with pytest.raises(RuntimeError):
+            await connector.start()
+        # It must not have left a running sync task or a callback behind.
+        assert connector._task is None
+        assert client._callbacks == []
+        assert client.close.await_count == 1
+
 
 class TestMatrixInboundRouting:
     @pytest.mark.asyncio

--- a/tinyagentos/channel_hub/matrix_connector.py
+++ b/tinyagentos/channel_hub/matrix_connector.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+import asyncio
+import logging
+from typing import Any, Callable
+from tinyagentos.channel_hub.message import IncomingMessage, OutgoingMessage
+
+logger = logging.getLogger(__name__)
+
+# Default factory so tests can inject a fake client without touching imports.
+def _default_client_factory(homeserver: str):
+    import nio
+    return nio.AsyncClient(homeserver)
+
+
+class MatrixConnector:
+    def __init__(
+        self,
+        homeserver: str,
+        access_token: str,
+        agent_name: str,
+        router,
+        *,
+        client_factory: Callable[[str], Any] | None = None,
+    ):
+        self.homeserver = homeserver
+        self.access_token = access_token
+        self.agent_name = agent_name
+        self.router = router
+        self._client_factory = client_factory or _default_client_factory
+        self._client = None
+        self._task = None
+        self._own_user_id: str | None = None
+
+    async def start(self):
+        self._client = self._client_factory(self.homeserver)
+        self._client.access_token = self.access_token
+
+        # Resolve the bot's own user_id so we can filter echo events.
+        try:
+            resp = await self._client.whoami()
+            self._own_user_id = getattr(resp, "user_id", None)
+        except Exception as exc:
+            logger.warning("Matrix whoami failed: %s", exc)
+
+        self._client.add_event_callback(self._handle_room_message, None)
+        self._task = asyncio.create_task(self._sync_loop())
+        logger.info("Matrix connector started for agent '%s'", self.agent_name)
+
+    async def stop(self):
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._task = None
+        if self._client:
+            try:
+                await self._client.close()
+            except Exception as exc:
+                logger.debug("Matrix client close error: %s", exc)
+            self._client = None
+
+    async def _sync_loop(self):
+        try:
+            await self._client.sync_forever(timeout=30000, full_state=False)
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.error("Matrix sync error: %s", exc)
+
+    async def _handle_room_message(self, room, event):
+        # Only handle text messages and ignore our own events.
+        try:
+            import nio
+            if not isinstance(event, nio.RoomMessageText):
+                return
+        except Exception:
+            pass
+
+        if self._own_user_id and event.sender == self._own_user_id:
+            return
+
+        room_id = room.room_id
+        room_name = getattr(room, "display_name", None) or room_id
+
+        incoming = IncomingMessage(
+            id=event.event_id,
+            from_id=event.sender,
+            from_name=event.sender,
+            platform="matrix",
+            channel_id=room_id,
+            channel_name=room_name,
+            text=event.body,
+            raw={"room_id": room_id, "event_id": event.event_id, "sender": event.sender},
+        )
+
+        response = await self.router.route_message(self.agent_name, incoming)
+        if response and response.content:
+            await self._send_response(room_id, response)
+
+    async def _send_response(self, room_id: str, response: OutgoingMessage):
+        try:
+            await self._client.room_send(
+                room_id=room_id,
+                message_type="m.room.message",
+                content={"msgtype": "m.text", "body": response.content},
+            )
+        except Exception as exc:
+            logger.error("Matrix send error in room %s: %s", room_id, exc)

--- a/tinyagentos/channel_hub/matrix_connector.py
+++ b/tinyagentos/channel_hub/matrix_connector.py
@@ -42,6 +42,20 @@ class MatrixConnector:
         except Exception as exc:
             logger.warning("Matrix whoami failed: %s", exc)
 
+        if not self._own_user_id:
+            # Without our own user_id we cannot filter our own messages and
+            # would echo-loop on every reply, so refuse to start rather than
+            # spam the room. A failed whoami usually means an invalid token.
+            try:
+                await self._client.close()
+            except Exception:
+                pass
+            self._client = None
+            raise RuntimeError(
+                "Matrix connector could not resolve its own user_id "
+                "(whoami failed; is the access token valid?)"
+            )
+
         self._client.add_event_callback(self._handle_room_message, None)
         self._task = asyncio.create_task(self._sync_loop())
         logger.info("Matrix connector started for agent '%s'", self.agent_name)
@@ -70,15 +84,18 @@ class MatrixConnector:
             logger.error("Matrix sync error: %s", exc)
 
     async def _handle_room_message(self, room, event):
-        # Only handle text messages and ignore our own events.
+        # Only handle text messages and ignore our own events. If matrix-nio is
+        # somehow unavailable we cannot classify the event, so do not process it
+        # (rather than swallowing the import error and treating it as text).
         try:
             import nio
-            if not isinstance(event, nio.RoomMessageText):
-                return
-        except Exception:
-            pass
-
-        if self._own_user_id and event.sender == self._own_user_id:
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Matrix: matrix-nio unavailable, dropping event: %s", exc)
+            return
+        if not isinstance(event, nio.RoomMessageText):
+            return
+        # start() guarantees _own_user_id is set, so this reliably drops echoes.
+        if event.sender == self._own_user_id:
             return
 
         room_id = room.room_id

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -133,6 +133,22 @@ async def connect_bot(request: Request):
         connectors[connector_key] = connector
         request.app.state.channel_hub_connectors = connectors
         return {"status": "connected", "platform": platform, "agent_name": agent_name}
+    elif platform == "matrix":
+        homeserver = body.get("homeserver", "")
+        if not homeserver:
+            return JSONResponse({"error": "homeserver is required for matrix"}, status_code=400)
+        from tinyagentos.channel_hub.matrix_connector import MatrixConnector
+        connector = MatrixConnector(
+            homeserver=homeserver,
+            access_token=bot_token,
+            agent_name=agent_name,
+            router=router_obj,
+        )
+        router_obj.assign_channel(platform, bot_token_secret, agent_name)
+        await connector.start()
+        connectors[connector_key] = connector
+        request.app.state.channel_hub_connectors = connectors
+        return {"status": "connected", "platform": platform, "agent_name": agent_name}
     else:
         return JSONResponse({"error": f"Platform '{platform}' not yet supported"}, status_code=400)
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.11, <3.14"
 
 [[package]]
+name = "aiofiles"
+version = "24.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -86,6 +95,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
     { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
     { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
+]
+
+[[package]]
+name = "aiohttp-socks"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "python-socks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/cc/e5bbd54f76bd56291522251e47267b645dac76327b2657ade9545e30522c/aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0", size = 11196, upload-time = "2025-12-09T13:35:52.564Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/7d/4b633d709b8901d59444d2e512b93e72fe62d2b492a040097c3f7ba017bb/aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1", size = 10556, upload-time = "2025-12-09T13:35:50.18Z" },
 ]
 
 [[package]]
@@ -853,6 +875,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -874,6 +909,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
     { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
     { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -970,6 +1014,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/27/629cfe58c582f92ded066c4a07d1a057ff617118ab7973200f770bd853cb/huggingface_hub-1.19.0.tar.gz", hash = "sha256:fd771622182d40977272a923953ee3b1b13538f9f8a7f5d78398f10af0f1c0bd", size = 824721, upload-time = "2026-06-11T12:33:18.665Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/a5/558da89f66464d8d0229ff497e8b8666977de2d8cf48c28a2862ecf1250f/huggingface_hub-1.19.0-py3-none-any.whl", hash = "sha256:1dc72e1f6b4d6df6b30eb72e57d00514ef453d660f04af2b87f0e67267f31ee0", size = 693398, upload-time = "2026-06-11T12:33:16.695Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1384,6 +1437,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
     { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
     { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "matrix-nio"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "aiohttp-socks" },
+    { name = "h11" },
+    { name = "h2" },
+    { name = "jsonschema" },
+    { name = "pycryptodome" },
+    { name = "unpaddedbase64" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/50/c20129fd6f0e1aad3510feefd3229427fc8163a111f3911ed834e414116b/matrix_nio-0.25.2.tar.gz", hash = "sha256:8ef8180c374e12368e5c83a692abfb3bab8d71efcd17c5560b5c40c9b6f2f600", size = 155480, upload-time = "2024-10-04T07:51:41.62Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/0f/8b958d46e23ed4f69d2cffd63b46bb097a1155524e2e7f5c4279c8691c4a/matrix_nio-0.25.2-py3-none-any.whl", hash = "sha256:9c2880004b0e475db874456c0f79b7dd2b6285073a7663bcaca29e0754a67495", size = 181982, upload-time = "2024-10-04T07:51:39.451Z" },
 ]
 
 [[package]]
@@ -1987,6 +2059,36 @@ wheels = [
 ]
 
 [[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2343,6 +2445,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "python-socks"
+version = "2.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/ad/5bbfab3d3a266963cca0c09e23a725bbf5f0535d21c8bd1d5272e4430771/python_socks-2.8.2.tar.gz", hash = "sha256:ffc493951854fa3fc0551e0434a09a7b9f9047f9ad666dce42cb94a52e8a34b6", size = 39656, upload-time = "2026-06-23T05:22:01.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/18/23b981b1cf58c1e7b7e36fa1392daf12878b6a3c26c5e4248601647a6d09/python_socks-2.8.2-py3-none-any.whl", hash = "sha256:7cf785d0631e0659384a773b3c402bc22cccdc23894ba1d65f8524748ace1193", size = 55501, upload-time = "2026-06-23T05:22:00.658Z" },
 ]
 
 [[package]]
@@ -2903,6 +3014,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "lxml" },
+    { name = "matrix-nio" },
     { name = "pillow" },
     { name = "psutil" },
     { name = "python-multipart" },
@@ -2954,6 +3066,7 @@ requires-dist = [
     { name = "libtorrent", marker = "extra == 'torrent'", specifier = ">=2.0.9" },
     { name = "litellm", extras = ["proxy"], marker = "extra == 'proxy'", specifier = ">=1.90.0" },
     { name = "lxml", specifier = ">=5.0.0" },
+    { name = "matrix-nio", specifier = ">=0.21.0" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "pillow", marker = "extra == 'worker'", specifier = ">=10.0" },
     { name = "prisma", marker = "extra == 'proxy'", specifier = ">=0.11.0" },
@@ -3101,6 +3214,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
+name = "unpaddedbase64"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f8/114266b21a7a9e3d09b352bb63c9d61d918bb7aa35d08c722793bfbfd28f/unpaddedbase64-2.1.0.tar.gz", hash = "sha256:7273c60c089de39d90f5d6d4a7883a79e319dc9d9b1c8924a7fab96178a5f005", size = 5621, upload-time = "2021-03-09T11:35:47.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/a7/563b2d8fb7edc07320bf69ac6a7eedcd7a1a9d663a6bb90a4d9bd2eda5f7/unpaddedbase64-2.1.0-py3-none-any.whl", hash = "sha256:485eff129c30175d2cd6f0cd8d2310dff51e666f7f36175f738d75dfdbd0b1c6", size = 6083, upload-time = "2021-03-09T11:35:46.7Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `MatrixConnector` class mirroring the existing `TelegramConnector` interface (start/stop/route_message mapping)
- Wires channel type `matrix` into `tinyagentos/routes/channel_hub.py` using the same secret-resolution path as Telegram/Discord/Slack (bot_token_secret resolved via secrets store)
- Adds `matrix-nio>=0.21.0` to `[project]` dependencies
- Creates `tests/channel_hub/test_matrix_connector.py` with a fully fake nio client

## Notes

- Channels = human-to-agent transport; A2A = agent-to-agent. This connector operates on the channels layer and coexists with the A2A bus.
- Depends on `matrix-nio` (async Matrix SDK for Python).
- The `client_factory` constructor param lets tests inject a fake client without network access.
- Secret resolution: `access_token_secret` in the channel config points to a secret name; the connect endpoint resolves it to the actual token via `secrets_store.get()`, same path as all other connectors.

## Test plan

- [ ] `python3 -m pytest tests/channel_hub/test_matrix_connector.py -q` passes (no homeserver required)
- [ ] `python3 -m pytest tests/test_channel_hub.py -q` still passes
- [ ] `python3 -m compileall tinyagentos/channel_hub/matrix_connector.py` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting bots to Matrix rooms.
  * Messages can now be sent and received through Matrix alongside existing platforms.
  * Matrix connections require a homeserver and use the bot’s token to sign in.

* **Tests**
  * Added coverage for Matrix connection startup, message handling, sending replies, and clean shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->