### PR TITLE
docs(readme): audit accuracy fixes (counts, taosmd pin, dev commands, missing Done apps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 Self-hosted AI agent platform that runs on whatever hardware you have. An old laptop, a Raspberry Pi, a gaming PC, an SBC gathering dust, or all of them at once. taOS turns your spare hardware into a distributed AI compute cluster.
 
-A full web desktop environment with 36 bundled apps, 108 catalog apps, 47 MCP plugins, 17 agent frameworks, a curated local model catalog of 112 manifests covering LLMs, vision, embeddings, audio, and image generation (including RK3588 NPU variants via c01zaut/happyme531), plus 167k+ searchable models from HuggingFace, agent deployment, training, image/video/audio generation, and full system monitoring, all from a single web dashboard. Supports Apple Silicon (MLX), NVIDIA, AMD, Rockchip NPU, Raspberry Pi, Android phones, and more.
+A full web desktop environment with 40 bundled apps, 109 catalog apps, 47 MCP plugins, 17 agent frameworks, a curated local model catalog of 113 manifests covering LLMs, vision, embeddings, audio, and image generation (including RK3588 NPU variants via c01zaut/happyme531), plus 167k+ searchable models from HuggingFace, agent deployment, training, image/video/audio generation, and full system monitoring, all from a single web dashboard. Supports Apple Silicon (MLX), NVIDIA, AMD, Rockchip NPU, Raspberry Pi, Android phones, and more.
 
 **Framework-agnostic by design.** taOS owns everything that matters: your agent's memory, files, communication channels, model access, and configuration. The agent framework is just a replaceable execution engine. Switch from SmolAgents to LangChain to OpenClaw and your agent keeps its entire history, all its Telegram/Discord/Slack connections, its trained LoRA adapters, its files, and its API keys. No migration, no data loss, no reconfiguration. This is possible because taOS manages the full agent lifecycle outside the framework.
 
@@ -91,7 +91,7 @@ Open `http://your-host:6969` (or `http://taos.local:6969` with mDNS). The root U
 
 ## Web Desktop Experience
 
-taOS ships with a full browser-based desktop environment. Open it at `http://your-host:6969/` and you get a window manager, dock, launchpad, notifications, widgets, and 36 bundled apps, no native install required. On phones and tablets it automatically swaps to a widget-first home screen with swipeable pages, a persistent dock, and desktop-style app windows with close/minimise title bars, installable as a fullscreen PWA from the browser's "Add to Home Screen".
+taOS ships with a full browser-based desktop environment. Open it at `http://your-host:6969/` and you get a window manager, dock, launchpad, notifications, widgets, and 40 bundled apps, no native install required. On phones and tablets it automatically swaps to a widget-first home screen with swipeable pages, a persistent dock, and desktop-style app windows with close/minimise title bars, installable as a fullscreen PWA from the browser's "Add to Home Screen".
 
 - **Window manager.** Float, snap zones, drag, resize, minimise, maximise, close
 - **Top bar.** Global search (Ctrl+Space), clock, notifications, widget toggle
@@ -108,20 +108,20 @@ taOS ships with a full browser-based desktop environment. Open it at `http://you
 - **Standalone Chat PWA**. Messages available as a dedicated installable app at `/chat-pwa`
 - **shadcn/ui primitives**. Button, Card, Input, Tabs, Switch, Toolbar
 
-### 39 Bundled Desktop Apps
+### 40 Bundled Desktop Apps
 
-**Platform apps (22):** Messages (WebSocket chat), Mail (IMAP/SMTP accounts, read and send), Projects (Kanban + A2A), Agents (deploy wizard + logs + skills), Store (47+ apps), Settings (multi-section with Memory capture toggles), Models, Providers (cloud LLM provider management, add/test/remove OpenAI, Anthropic, DeepSeek, and compatible APIs), Memory (User + Agent sections), MCP (plugin manager), Channels, Secrets, Tasks, Import, Images (Image Studio: Create / Library / Edit with tier-aware inpaint + upscale backends), Dashboard (Activity), Cluster (worker management + health), Library (knowledge pipeline, document library with collections and search), Agent Browsers (manage agent browser sessions), Files (real VFS with workspace + shared folders), taOS Agent (Agent-as-a-Model endpoint), Guides.
+**Platform apps (27):** Messages (WebSocket chat), Mail (IMAP/SMTP accounts, read and send), Projects (Kanban + A2A), Agents (deploy wizard + logs + skills), Store (109+ apps), Settings (multi-section with Memory capture toggles), Models, Providers (cloud LLM provider management, add/test/remove OpenAI, Anthropic, DeepSeek, and compatible APIs), Memory (User + Agent sections), MCP (plugin manager), Channels, Secrets, Tasks, Import, Images (Image Studio: Create / Library / Edit with tier-aware inpaint + upscale backends), Dashboard (Activity), Cluster (worker management + health), Library (knowledge pipeline, document library with collections and search), Agent Browsers (manage agent browser sessions), Files (real VFS with workspace + shared folders), taOS Agent (Agent-as-a-Model endpoint), Guides, Feedback, Decisions, Observatory, Notes, Todo.
 
 **Optional taOS apps (4):** Reddit (subreddit browser with saved threads and memory ingest), YouTube (video library with transcript extraction), GitHub (repository browser with code search), and X (feed monitor with bookmarks and memory capture) ship in the build but are not installed by default; install or remove them from the Store's "taOS Apps" section.
 
-**OS apps (10):** Weather, Calculator (math.js), Calendar (month view), Contacts (CRUD), Browser (URL-rewriting proxy, agent-ready), Browser (Streamed) (real WebRTC Chromium streamed from the host), Media Player (Plyr), Text Editor (CodeMirror 6 with Obsidian-style theme), Image Viewer (zoom/rotate), Terminal (real PTY + SSH client).
+**OS apps (9):** Weather, Calculator (math.js), Calendar (month view), Contacts (CRUD), Browser (URL-rewriting proxy, agent-ready), Media Player (Plyr), Text Editor (CodeMirror 6 with Obsidian-style theme), Image Viewer (zoom/rotate), Terminal (real PTY + SSH client).
 
 **Games & studios (4):** Game Studio (offline-AI game maker, three.js + react-three-fiber, fullscreen play with mandatory exit-to-taOS, test then optionally share to the Store), Chess (plays against real agents via LLM), Wordle, Crosswords.
 
 The Activity app includes a Cluster overview panel showing live worker status and resource stats alongside the process monitor. The Model Browser surfaces cloud models (from configured providers) alongside local catalog models, with a provider badge per entry. The deploy wizard accepts cloud models as inference targets.
 
 <p align="center">
-  <img src="docs/images/desktop-store.jpg" alt="App store -- 108 catalog apps, 16 agent frameworks, hardware-filtered" width="100%">
+  <img src="docs/images/desktop-store.jpg" alt="App store -- 109 catalog apps, 17 agent frameworks, hardware-filtered" width="100%">
 </p>
 
 <p align="center"><sub>The Store -- agent frameworks, models, plugins, services. One-click install, hardware-filtered.</sub></p>
@@ -129,7 +129,7 @@ The Activity app includes a Cluster overview panel showing live worker status an
 ## Key Features
 
 ### Web Desktop Shell
-Full browser-based desktop OS with window manager (float + snap), dock, launchpad, right-click context menu, wallpaper picker, notifications, widgets, and persistent sessions that follow you across devices. 39 bundled apps, platform tools, OS utilities, and games, plus an optional password login gate. See [Web Desktop Experience](#web-desktop-experience) above.
+Full browser-based desktop OS with window manager (float + snap), dock, launchpad, right-click context menu, wallpaper picker, notifications, widgets, and persistent sessions that follow you across devices. 40 bundled apps, platform tools, OS utilities, and games, plus an optional password login gate. See [Web Desktop Experience](#web-desktop-experience) above.
 
 ### Mobile & Tablet Mode
 Auto-detects touch devices and swaps the desktop for a widget-first home screen with customisable multi-page layout (swipe or tap dots to navigate), a persistent dock with app launcher and app switcher, and desktop-style app windows with close/minimise title bars. The top bar features iOS 26-style frosted glass buttons for search and notifications, with a "taOS" home button. Installable as a fullscreen PWA on iOS and Android. A standalone Chat PWA is available at `/chat-pwa` and installs like a private Discord.
@@ -150,7 +150,7 @@ Personal memory powered by [taOSmd](https://github.com/jaylfc/taosmd), think Pie
 User memory is unified through taosmd (issue #25): `tinyagentos/routes/user_memory.py` proxies writes to taosmd `POST /ingest/batch` and reads to `GET /search?mode=bm25` (sub-300ms keyword search), with idempotent migration via `POST /api/user-memory/migrate`. A local SQLite FTS5 store is kept as a fallback for when taosmd is unreachable. taOS reaches taosmd at the URL configured in the `TAOS_USER_MEMORY_URL` environment variable.
 
 ### Skills & Plugins Registry
-Framework-agnostic skill system with 8 default skills, memory_search, file_read, file_write, web_search, code_exec, image_generation, list_image_models, http_request, categorised by search, files, code, media, browser, data, comms, system. Each skill declares compatibility per framework (native/adapter/unsupported) and works across all 17 supported frameworks via adapter translation. Assign or remove skills per agent from the Skills tab with compatibility badges.
+Framework-agnostic skill system with 8 core skills (plus 20 more platform skills), memory_search, file_read, file_write, web_search, code_exec, image_generation, list_image_models, http_request, categorised by search, files, code, media, system, desktop, projects, agent, notes. Each skill declares compatibility per framework (native/adapter/unsupported) and works across all 17 supported frameworks via adapter translation. Assign or remove skills per agent from the Skills tab with compatibility badges.
 
 ### Distributed Compute Cluster
 Combine ANY device into one AI compute mesh, desktops, laptops, SBCs, even phones and tablets. A gaming PC handles large models, a Mac runs MLX inference, a Pi handles embeddings, an old Android phone contributes from a drawer. Cross-platform worker apps connect from the system tray (Windows, macOS, Linux) or via Termux (Android).
@@ -204,12 +204,12 @@ lets the scheduler route work only to backends that are genuinely ready.
 See [docs/design/resource-scheduler.md](docs/design/resource-scheduler.md).
 
 ### Local Model Catalog + Live Model Browser
-A curated catalog of 112 vetted model manifests ships in-tree, every download URL is verified against HuggingFace, covering LLMs (Qwen3, Qwen2.5, Llama 3.1/3.3, Gemma 2/3, Phi-4, Mistral, Mixtral, DeepSeek, Granite, Command-R), vision models (Qwen2.5-VL, MiniCPM-V 2.6, Moondream2, Florence-2, LLaVA), embeddings (nomic, bge, mxbai, snowflake-arctic), rerankers (bge-reranker-v2, qwen3-reranker), speech (Whisper tiny→large-v3-turbo, Kokoro TTS, Piper, Parakeet), image generation (SD 1.5 LCM, Dreamshaper 8 LCM, SDXL Turbo/Lightning, Flux schnell/dev, SD3.5, PixArt-Σ, Playground v2.5, Kolors, AuraFlow), and image tools (RMBG-1.4, BiRefNet, Real-ESRGAN, 4x-UltraSharp, GFPGAN, CodeFormer, ControlNet canny/depth/pose). **RK3588 NPU variants** are included via c01zaut (Qwen2.5 1.5B→14B RKLLM) and happyme531 (LCM Dreamshaper SD as multi-file RKNN). The live Model Browser also searches 167k+ GGUF models from HuggingFace and the Ollama library. Hardware-filtered compatibility indicators show what runs on your device (green/yellow/red).
+A curated catalog of 113 vetted model manifests ships in-tree, every download URL is verified against HuggingFace, covering LLMs (Qwen3, Qwen2.5, Llama 3.1/3.3, Gemma 2/3, Phi-4, Mistral, Mixtral, DeepSeek, Granite, Command-R), vision models (Qwen2.5-VL, MiniCPM-V 2.6, Moondream2, Florence-2, LLaVA), embeddings (nomic, bge, mxbai, snowflake-arctic), rerankers (bge-reranker-v2, qwen3-reranker), speech (Whisper tiny→large-v3-turbo, Kokoro TTS, Piper, Parakeet), image generation (SD 1.5 LCM, Dreamshaper 8 LCM, SDXL Turbo/Lightning, Flux schnell/dev, SD3.5, PixArt-Σ, Playground v2.5, Kolors, AuraFlow), and image tools (RMBG-1.4, BiRefNet, Real-ESRGAN, 4x-UltraSharp, GFPGAN, CodeFormer, ControlNet canny/depth/pose). **RK3588 NPU variants** are included via c01zaut (Qwen2.5 1.5B→14B RKLLM) and happyme531 (LCM Dreamshaper SD as multi-file RKNN). The live Model Browser also searches 167k+ GGUF models from HuggingFace and the Ollama library. Hardware-filtered compatibility indicators show what runs on your device (green/yellow/red).
 
 ### Agent Templates (1,467 Templates)
-Pick from 1,467 agent templates, 12 built-in plus 196 from awesome-openclaw-agents and 1,259 from the System Prompt Library, and deploy in one click. Browse by category (27 categories), filter by source, or search. Each template includes a system prompt, recommended framework, model, and resource limits. All templates vendored locally so nothing depends on external services.
+Pick from 1,467 agent templates, 12 built-in plus 196 from awesome-openclaw-agents and 1,259 from the System Prompt Library, and deploy in one click. Browse by category (28 categories), filter by source, or search. Each template includes a system prompt, recommended framework, model, and resource limits. All templates vendored locally so nothing depends on external services.
 
-### App Store (108 Catalog Apps + 47 MCP Plugins, including 13 Streaming Apps)
+### App Store (109 Catalog Apps + 47 MCP Plugins, including 13 Streaming Apps)
 One-click install for agent frameworks, AI models, and services. Hardware-aware, only shows what works on your device.
 
 ### Agent Deployment
@@ -227,7 +227,7 @@ One-click install for agent frameworks, AI models, and services. Hardware-aware,
 Most agent frameworks force you to wire up Telegram, Discord, or Slack directly into their code. If you switch frameworks, you rebuild all those integrations from scratch. taOS flips this: the platform owns the messaging connections and routes messages to whichever framework the agent currently uses. Switch an agent from SmolAgents to LangChain and it keeps every channel, every conversation, every connection. The framework never touches the bot tokens.
 
 - **7 connectors**. Telegram, Discord, Slack, Matrix (beta), Email (IMAP/SMTP), Web Chat (WebSocket), Webhooks
-- **15 framework adapters.** Thin HTTP bridges (~25 lines each) that translate the universal message format to framework-specific APIs
+- **20 framework adapters.** Thin HTTP bridges (~25 lines each) that translate the universal message format to framework-specific APIs
 - **Rich responses.** Buttons, images, cards via universal format with inline hint fallback for any framework
 - **Per-agent or shared bots.** Each agent gets its own bot, or share one across a group
 
@@ -238,7 +238,7 @@ Hidden internal gateway that unifies all inference providers behind a single Ope
 Features unlock automatically based on your hardware and cluster. Solo Pi sees core features. Add a GPU worker and image generation, video, and training appear. No configuration, the platform just knows what's possible.
 
 ### Creative Studios
-Dedicated studio apps for every kind of project, each a focused, native taOS workspace that runs entirely on your own cluster. Two are in beta, with Coding, App, Design, Music, and Office studios on the way (App Studio is taOS's own app builder, so agents and users can build and share new apps).
+Dedicated studio apps for every kind of project, each a focused, native taOS workspace that runs entirely on your own cluster. Two are bundled (Images, Game Studio); Coding, App, Design, Music, and Office studios are implemented but gated as optional apps (App Studio is taOS's own app builder, so agents and users can build and share new apps).
 
 <p align="center">
   <img src="docs/images/images-studio.jpg" alt="Images Studio -- generate from a prompt and edit on a local GPU" width="49%">
@@ -262,14 +262,14 @@ Dedicated studio apps for every kind of project, each a focused, native taOS wor
 - **Deployment.** Auto-converts and deploys to all backends in the cluster
 
 ### Agent Memory System ([taOSmd](https://github.com/jaylfc/taosmd))
-taOSmd is installed as a Python dependency from PyPI (`pip install taosmd`, pinned to 0.3.0 in `pyproject.toml`, published via Trusted Publishing): **97.0% end-to-end Judge accuracy** on LongMemEval-S (retrieve, generate, LLM-grade against the reference answer). The most-cited open comparators (MemPalace 96.6%, agentmemory 95.2%) publish **Recall@5** retrieval scores on the same dataset, which measures only "did the right session land in the top-5" with no generation and no judge, so the numbers are not apples-to-apples until one of us re-runs end-to-end; ours is the stricter measurement. The Librarian layer's LLM-assisted query expansion adds a measured **+15.4% on the vocabulary-gap axis** (45% recall@lag25 with full pipeline + Librarian, vs 30% without) on long-horizon sessions where the cross-encoder alone isn't enough.
+taOSmd is installed as a Python dependency from PyPI (`pip install taosmd`, pinned to 0.4.0 in `pyproject.toml`, published via Trusted Publishing): **97.0% end-to-end Judge accuracy** on LongMemEval-S (retrieve, generate, LLM-grade against the reference answer). The most-cited open comparators (MemPalace 96.6%, agentmemory 95.2%) publish **Recall@5** retrieval scores on the same dataset, which measures only "did the right session land in the top-5" with no generation and no judge, so the numbers are not apples-to-apples until one of us re-runs end-to-end; ours is the stricter measurement. The Librarian layer's LLM-assisted query expansion adds a measured **+15.4% on the vocabulary-gap axis** (45% recall@lag25 with full pipeline + Librarian, vs 30% without) on long-horizon sessions where the cross-encoder alone isn't enough.
 
 Two recent additions (separate measurements -- not part of the LongMemEval-S headline above):
 
 - **Upgraded low-tier embedding default.** Low-tier dense retrieval now defaults to `snowflake-arctic-embed-s`: **+0.057 judged retrieval quality** on the full 1540-QA LoCoMo set (0.730 vs 0.674 for MiniLM) at the same 384 dimensions and the same latency (about 13ms/embed on an Orange Pi). A free accuracy upgrade for low-end and SBC installs. MiniLM stays supported and is the model the 97.0% LongMemEval-S headline was measured on; existing installs are unchanged.
 - **Provable Memory (opt-in, off by default).** Because taOSmd keeps a zero-loss archive, it can verify every extracted fact against the source spans it came from, mark it supported or unsupported, and demote (never delete) the unsupported ones at recall. That makes the extraction-hallucination rate a standing, measurable number: **18.8% of extracted facts on LoCoMo were not fully supported by their source** (cross-family verified) -- something extraction-based systems that discard the source cannot measure.
 
-Memory layers: temporal knowledge graph with validity windows + contradiction detection, hybrid semantic+keyword vector search (ONNX arctic-embed-s low-tier default / MiniLM / Nomic), zero-loss append-only archive with FTS5, session catalog over the archive, and a crystal store of compressed session digests with extracted lessons. Processing: regex + LLM fact extraction (qwen3:4b), 30-min-gap session splitter, tiered enricher (heuristic / 4B / 9B+), session crystallizer, **secret filtering with 17 regex patterns auto-redacting on every ingest**, and Ebbinghaus retention scoring with hot/warm/cold tiers. Retrieval: parallel fan-out across all layers, query expansion, intent classifier that weights an RRF merge, ms-marco-MiniLM cross-encoder reranking, BFS graph expansion, and a token-budgeted L0-L3 context assembler.
+Memory layers: temporal knowledge graph with validity windows + contradiction detection, hybrid semantic+keyword vector search (ONNX arctic-embed-s low-tier default / MiniLM / Nomic), zero-loss append-only archive with FTS5, session catalog over the archive, and a crystal store of compressed session digests with extracted lessons. Processing: regex + LLM fact extraction (qwen3:4b), 30-min-gap session splitter, tiered enricher (heuristic / 4B / 9B+), session crystallizer, **secret filtering with 23 regex patterns auto-redacting on every ingest**, and Ebbinghaus retention scoring with hot/warm/cold tiers. Retrieval: parallel fan-out across all layers, query expansion, intent classifier that weights an RRF merge, ms-marco-MiniLM cross-encoder reranking, BFS graph expansion, and a token-budgeted L0-L3 context assembler.
 
 taOS wraps taOSmd with platform-specific scheduling (job queue, resource manager, worker heartbeat, gaming detection) for multi-agent coordination on resource-constrained devices. QMD (`qmd.service`, port 7832) remains as the NPU-accelerated embedding / rerank / query-expansion backend. Per-tenant isolation is handled by `dbPath` routing: each agent's index lives at `data/agent-memory/{name}/index.sqlite`.
 
@@ -328,7 +328,7 @@ Built-in browser with two engines. A lightweight server-side rewriting proxy ren
 `app-catalog/plugins/` ships 47 MCP servers including the official set (filesystem, git, fetch, memory, sequential-thinking, time), GitHub, Playwright, Docker, Kubernetes, databases (Postgres/MySQL/SQLite dbhub, MongoDB, Redis, Chroma, Supabase), documents (pandoc, office docs, spreadsheet, markdownify, excel), comms (Slack, WhatsApp, email, Notion, Obsidian, Atlassian, Google Workspace), infra (AWS, Cloudflare, Grafana, arXiv, YouTube transcript, Firecrawl), agent-specific (browser-use, Camoufox, context7, supergateway, engram, Exa), Home Assistant, Todoist, and more.
 
 ### Global Search
-Search across agents, apps, messages, and files from a single endpoint. Finds anything on the platform instantly.
+Search across agents, apps, messages, and shared folders from a single endpoint. Finds anything on the platform instantly.
 
 ### Monitoring & Management
 
@@ -350,13 +350,13 @@ Search across agents, apps, messages, and files from a single endpoint. Finds an
 - **System Updates.** Pull latest from GitHub via Settings page. taOS periodically checks for updates and reports an anonymous install count (a daily aggregate estimate, no identifiers); disable with `TAOS_NO_UPDATE_PING=1` or in Settings.
 - **Provider Management.** Add/test/remove inference providers with live connectivity checks. The Providers desktop app manages cloud LLM credentials; the model browser reflects configured providers automatically.
 
-## App Catalog (108 Catalog Apps + 39 Desktop Apps + 47 MCP Plugins)
+## App Catalog (109 Catalog Apps + 49 Desktop Apps + 47 MCP Plugins)
 
 | Category | Apps |
 |----------|------|
 | **Agent Frameworks (17)** | SmolAgents, PocketFlow, OpenClaw, nanoclaw, PicoClaw, ZeroClaw, MicroClaw, IronClaw, NullClaw, Moltis, Hermes, Agent Zero, OpenAI Agents SDK, Langroid, ShibaClaw, DeerFlow, OpenCrabs (beta) |
 | **Streaming Apps (13)** | Blender, LibreOffice, Code Server, GIMP, Krita, FreeCAD, Obsidian, Excalidraw, JupyterLab, Grafana, n8n, Terminal, Neko Browser |
-| **LLM Models** | 112-manifest local catalog: Qwen3 0.6B-32B, Qwen2.5 0.5B-72B (+ RKLLM 1.5B-14B for RK3588), Llama 3.1/3.2/3.3, Gemma 2/3, Phi-3.5/4/4-mini, Mistral/Nemo/Mixtral, DeepSeek, Granite, Command-R, SmolLM2, TinyLlama, plus 167k+ searchable from HuggingFace |
+| **LLM Models** | 113-manifest local catalog: Qwen3 0.6B-32B, Qwen2.5 0.5B-72B (+ RKLLM 1.5B-14B for RK3588), Llama 3.1/3.2/3.3, Gemma 2/3, Phi-3.5/4/4-mini, Mistral/Nemo/Mixtral, DeepSeek, Granite, Command-R, SmolLM2, TinyLlama, plus 167k+ searchable from HuggingFace |
 | **Vision Models** | Qwen2-VL, Qwen2.5-VL, MiniCPM-V 2.6, Moondream2, Florence-2, LLaVA 1.6 / LLaVA-Phi-3 |
 | **Embeddings / Rerankers** | nomic-embed-text-v1.5, bge-large/small/m3, mxbai-embed-large, snowflake-arctic-embed, qwen3-embedding/reranker, bge-reranker-v2-m3 |
 | **Audio Models** | Whisper tiny→large-v3-turbo, Kokoro TTS, Piper voices, Parakeet TDT |
@@ -377,8 +377,8 @@ Search across agents, apps, messages, and files from a single endpoint. Finds an
 | **ARM + Rockchip NPU** | Orange Pi 5/5 Plus, Rock 5B | 6 TOPS NPU, primary SBC target |
 | **Raspberry Pi** | Pi 4 (8GB), Pi 5 (8/16GB) | CPU-only or with accelerator HATs |
 | **Pi Accelerators** | Hailo-10H (40T), M5Stack LLM-8850 (24T) | LLM-capable accelerators |
-| **NVIDIA** | GTX 1050 Ti through RTX 4090/5090 | CUDA 4-24GB or Vulkan legacy |
-| **AMD** | RX 6600 through RX 7900 XTX | ROCm 8-24GB |
+| **NVIDIA** | GTX 1050 Ti through RTX 4090/5090 | CUDA 4-32GB or Vulkan legacy |
+| **AMD** | RX 6600 through RX 7900 XTX | ROCm 4-24GB |
 | **Android** | Flagship phones/tablets (12-16GB) | 7-8B models at 15-30 tok/s via Termux + llama.cpp |
 | **iOS/iPadOS** | iPad Pro M4, iPhones (6-8GB+) | Dashboard via PWA, future native worker app |
 | **CPU Only** | Any device | Smallest quantized models |
@@ -388,12 +388,12 @@ Search across agents, apps, messages, and files from a single endpoint. Finds an
 
 ```
 taOS Controller (FastAPI + htmx + React Desktop Shell)
-├── Web Desktop Shell (window manager, dock, launchpad, widgets, 36 bundled apps)
+├── Web Desktop Shell (window manager, dock, launchpad, widgets, 40 bundled apps)
 ├── Mobile/Tablet Shell (widget home, dock, app title bars, swipeable pages, iOS PWA)
-├── Skills & Plugins Registry (8 default skills, 15 framework adapters)
+├── Skills & Plugins Registry (8 core skills + 20 platform skills, 20 framework adapters)
 ├── User Memory (taosmd proxy: /ingest/batch + /search?mode=bm25, SQLite FTS5 fallback, auto-capture, global search)
 ├── Web Dashboard (77 route modules, React SPA frontend)
-├── Channel Hub (6 connectors, 15 framework adapters)
+├── Channel Hub (7 connectors, 20 framework adapters)
 │   ├── Telegram, Discord, Slack, Matrix, Email, Web Chat, Webhooks
 │   └── Universal message format → framework-specific translation
 ├── LLM Proxy (LiteLLM, per-agent virtual keys)
@@ -403,7 +403,7 @@ taOS Controller (FastAPI + htmx + React Desktop Shell)
 ├── User Workspace (NAS-like file browser, shared with apps + agents)
 ├── Computer Use (vision + keyboard/mouse, agent escalation)
 ├── Message Hub (chat, channels, threads, canvas, dual PWA)
-├── App Store + Registry (108 apps + 47 MCP plugins, manifest-based)
+├── App Store + Registry (109 apps + 47 MCP plugins, manifest-based)
 ├── Live Model Browser (HuggingFace + Ollama search)
 ├── Container Manager (LXC or Docker, auto-detected)
 ├── Agent Memory (taOSmd -- temporal KG, hybrid vector search, zero-loss archive, session catalog, crystal store, librarian)
@@ -413,7 +413,7 @@ taOS Controller (FastAPI + htmx + React Desktop Shell)
 ├── Training Manager (LoRA, per-agent adapters)
 ├── Agent Export/Import (portable JSON config)
 ├── Agent Templates (1,467 vendored from 3 sources)
-├── Global Search (agents, apps, messages, folders)
+├── Global Search (agents, apps, messages, shared folders)
 ├── Backup Scheduler (daily/weekly automated backups)
 └── Backend Fallback (priority-based, auto-recovery)
 
@@ -637,8 +637,9 @@ uv run exo
 ## Development
 
 ```bash
-pip install -e ".[dev]"
-pytest tests/ -v          # ~3,590 tests
+uv sync --extra dev
+uv run pytest tests/ --ignore=tests/e2e -n auto   # ~7,400 tests
+cd desktop && npx vitest run                       # ~1,900 desktop tests
 ```
 
 CI runs automatically on every push (Python 3.12 and 3.13 on every PR; Python 3.11 on the nightly scheduled run).
@@ -646,8 +647,8 @@ CI runs automatically on every push (Python 3.12 and 3.13 on every PR; Python 3.
 ## Roadmap
 
 ### Done ✅
-- [x] Web desktop GUI with 36 bundled apps
-- [x] App Store (108 apps, 16 agent frameworks)
+- [x] Web desktop GUI with 40 bundled apps
+- [x] App Store (109 apps, 17 agent frameworks)
 - [x] Live model browser (HuggingFace + Ollama, 167k+ models)
 - [x] Agent deployment wizard (LXC containers)
 - [x] Image + video generation (multi-backend)
@@ -667,7 +668,7 @@ CI runs automatically on every push (Python 3.12 and 3.13 on every PR; Python 3.
 - [x] LLM Proxy (LiteLLM) with per-agent keys
 - [x] Webhook notifications (Slack/Discord/Telegram)
 - [x] Health debug page
-- [x] Channel Hub, framework-agnostic messaging (6 connectors, 18 adapters)
+- [x] Channel Hub, framework-agnostic messaging (6 connectors, 20 adapters)
 - [x] Agent config export/import
 - [x] Agent template library (1,467 templates from 3 sources)
 - [x] Global search across all platform data
@@ -680,18 +681,18 @@ CI runs automatically on every push (Python 3.12 and 3.13 on every PR; Python 3.
 - [x] Playwright E2E test scaffolding
 - [x] Message Hub, built-in chat with channels, threads, canvas, dual PWA
 - [x] Dual container runtime (LXC + Docker, auto-detected)
-- [x] Web desktop shell (window manager, dock, launchpad, widgets, 36 bundled apps)
+- [x] Web desktop shell (window manager, dock, launchpad, widgets, 40 bundled apps)
 - [x] Mobile/tablet responsive mode with iOS PWA support
 - [x] Persistent desktop sessions across devices (windows, dock, wallpaper)
 - [x] User memory system (taOSmd with temporal KG + FTS5 + auto-capture)
-- [x] Skills & plugins registry (8 default skills, per-framework compatibility)
+- [x] Skills & plugins registry (28 default skills, per-framework compatibility)
 - [x] Terminal app with real PTY + SSH client
 - [x] Standalone Chat PWA at /chat-pwa
-- [x] Browser app with URL-rewriting proxy
+- [x] Browser app with URL-rewriting proxy and Neko streamed Chromium toggle
 - [x] 47 MCP server plugins in app catalog
 - [x] Desktop notifications (toast stack + notification centre)
 - [x] Widget system (Clock, Agent Status, Notes, System Stats, Weather)
-- [x] Curated local model catalog, 112 manifests, all download URLs verified against HuggingFace
+- [x] Curated local model catalog, 113 manifests, all download URLs verified against HuggingFace
 - [x] Activity monitor app, rktop-inspired per-core CPU/NPU/thermal/GPU/process stats
 - [x] Loaded Models panel in Model Browser, shows running models, purpose, and VRAM/RAM usage
 - [x] iOS PWA pill bar, safe-area-aware bottom nav with back / home / card-switcher / notifications
@@ -703,6 +704,12 @@ CI runs automatically on every push (Python 3.12 and 3.13 on every PR; Python 3.
 - [x] Worker hardware detection without nvidia-smi, `/proc/driver/nvidia` probe + VRAM lookup table; installer offers nvidia-utils on native hosts
 - [x] install-server.sh, controller installer companion to install-worker.sh; supports Debian/Ubuntu/Fedora/Arch/Alpine + macOS; system or user-mode systemd unit
 - [x] install-rknpu.sh, opt-in Rockchip NPU setup; pins librknnrt 2.3.0, installs rkllama fork, preloads three chat models; all binaries from TAOS mirror with SHA256 verification
+- [x] Mail app (IMAP/SMTP send and receive, multi-account, threaded view)
+- [x] Coding Studio (offline-AI coding environment with file tree, editor, terminal, and tool-calling loop)
+- [x] Observatory app (fleet view with per-agent pause, resume, and steer controls)
+- [x] Decisions app (human-in-the-loop inbox: multiple-choice, approve/reject, and free-text request types)
+- [x] Notes app (tracked-edit history, markdown rendering, agent-writable)
+- [x] Todo app (agent-callable checklist with completion tracking and priority)
 
 ### In Progress
 - [ ] Unified streamed browser (#603), one WebRTC-streamed Chromium app that runs locally on the host including the Pi, replaces the URL-rewriting proxy, presents a native touch-friendly mobile layout on phones, surfaces agents' browser sessions, and migrates sessions between host and worker


### PR DESCRIPTION
The trivial half of the README accuracy audit (counts and stale facts verified against the codebase). 33 fixes:

- App/catalog/model counts: bundled apps 36/39 -> 40, catalog 108 -> 109, model manifests 112 -> 113, framework adapters 15/18 -> 20, template categories 27 -> 28, desktop apps 39 -> 49.
- Platform apps list: added Feedback, Decisions, Observatory, Notes, Todo (22 -> 27); Store 47+ -> 109+; OS apps 10 -> 9 (Browser streaming is an in-app toggle, not a separate app).
- taosmd pin 0.3.0 -> 0.4.0; secret-filter patterns 17 -> 23; Global Search 'files' -> 'shared folders'; hardware VRAM ranges (NVIDIA 4-32GB, AMD 4-24GB).
- Skills: '8 default' -> '8 core (plus 20 platform)' and corrected category list.
- Creative Studios: 'on the way' -> implemented-but-gated; Browser Done item notes the Neko toggle.
- Roadmap Done: added the six shipped apps (Mail, Coding Studio, Observatory, Decisions, Notes, Todo).
- Dev section: pip -> uv sync, pytest command + count (~7,400), added the vitest line.

Five items are intentionally left for Jay's decision (in ~/.taos-team/pending-decisions.md): update-ping wording, optional-apps Store claim, worker-LXC section rewrite, Exo roadmap, install-script repo name. The OpenCrabs/DeerFlow framework-list fix and the Matrix connector listing land in their own PRs (#1493 merged, #1492).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product documentation to reflect the latest app, catalog, and platform counts.
  * Revised descriptions for the web desktop experience, global search, creative studios, and supported hardware.
  * Expanded the product roadmap and status notes to match current availability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->