### PR TITLE
docs(readme): apply audit decisions (update-ping, Exo roadmap, install-script repo name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Search across agents, apps, messages, and shared folders from a single endpoint.
 - **Notifications.** Health alerts, backend up/down, worker join/leave, webhook forwarding (Slack/Discord/Telegram). Toast notifications appear top-right. The welcome notification is gated on a `localStorage` flag so it fires once per install, not on every page load.
 - **Agent Logs.** Real-time log viewer with auto-refresh
 - **Backup & Restore.** Downloadable config backup, one-click restore, scheduled auto-backup (daily/weekly)
-- **System Updates.** Pull latest from GitHub via Settings page. taOS periodically checks for updates and reports an anonymous install count (a daily aggregate estimate, no identifiers); disable with `TAOS_NO_UPDATE_PING=1` or in Settings.
+- **System Updates.** Pull latest from GitHub via Settings page. taOS periodically checks for updates and sends an install ping carrying the version, platform, and a stable random per-install id (a UUID stored in the data dir, no personal data) so the project keeps an exact install count; disable with `TAOS_NO_UPDATE_PING=1` or in Settings.
 - **Provider Management.** Add/test/remove inference providers with live connectivity checks. The Providers desktop app manages cloud LLM credentials; the model browser reflects configured providers automatically.
 
 ## App Catalog (109 Catalog Apps + 49 Desktop Apps + 47 MCP Plugins)
@@ -589,7 +589,7 @@ taOS integrates [exo](https://github.com/exo-explore/exo) for running models tha
 
 **What exo enables:** Run 70B+ parameter models by pooling VRAM across multiple machines. A 70B model that needs ~40 GB can be split across a 12 GB desktop GPU + a 16 GB laptop + a 24 GB Mac, with exo handling the shard placement and inter-device communication automatically.
 
-**How it works with TAOS:** exo runs as a backend on participating workers, discovered automatically on port 52415. The TAOS worker probe detects it and advertises `llm-chat` capability. The deploy wizard can offer "Distributed (exo)" as a deployment option when a model exceeds any single worker's VRAM. Peer discovery is automatic via mDNS on the local network.
+**How it works with TAOS:** exo runs as a backend on participating workers, discovered automatically on port 52415. The TAOS worker probe detects it and advertises `llm-chat` capability. When an exo backend is running, its models appear in the deploy wizard alongside the other backends; an explicit "Distributed (exo)" mode for models that exceed a single worker's VRAM is in progress. exo handles its own peer discovery via mDNS on the local network.
 
 **Supported hardware:**
 
@@ -710,17 +710,18 @@ CI runs automatically on every push (Python 3.12 and 3.13 on every PR; Python 3.
 - [x] Decisions app (human-in-the-loop inbox: multiple-choice, approve/reject, and free-text request types)
 - [x] Notes app (tracked-edit history, markdown rendering, agent-writable)
 - [x] Todo app (agent-callable checklist with completion tracking and priority)
+- [x] Exo backend detection and task-parallel routing (worker probe on :52415, llm-chat capability, install-exo deploy command)
 
 ### In Progress
 - [ ] Unified streamed browser (#603), one WebRTC-streamed Chromium app that runs locally on the host including the Pi, replaces the URL-rewriting proxy, presents a native touch-friendly mobile layout on phones, surfaces agents' browser sessions, and migrates sessions between host and worker
 - [ ] Fresh install test on clean hardware (#2)
 - [ ] Containerised app streaming (#22), all 5 plans complete: session store, streaming pages, user workspace, agent-bridge, expert agents, 13 app manifests (Blender/LibreOffice/GIMP/Code Server/Neko Browser + 8 Phase 2), app orchestrator, computer-use with escalation, companion launcher API
+- [ ] Exo deploy-wizard option, an explicit Distributed (exo) mode for models that exceed a single worker's VRAM
 
 ### Planned
 - [ ] Local assistant LLM / Setup Agent (#4)
 - [ ] Pre-built Armbian images (#7)
 - [ ] Automated Playwright tests (#8)
-- [ ] Exo integration for pipeline-parallel inference
 
 ### Future Vision
 - [ ] Cloud services, tinyagentos.com (#5)

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -18,7 +18,7 @@
 #     sudo bash scripts/install-rknpu.sh --yes
 #
 #     # one-liner
-#     curl -sSL https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-rknpu.sh \
+#     curl -sSL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-rknpu.sh \
 #       | TAOS_RKNPU_SETUP=1 sudo bash
 #
 # Environment overrides:

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -6,17 +6,17 @@
 # http://<host>:6969 immediately after the script exits.
 #
 # Usage:
-#     curl -fsSL https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-server.sh | sudo bash
+#     curl -fsSL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-server.sh | sudo bash
 #
 # or download + inspect + run:
-#     curl -O https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-server.sh
+#     curl -O https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-server.sh
 #     chmod +x install-server.sh
 #     sudo ./install-server.sh
 #
 # Environment overrides:
 #     TAOS_INSTALL_DIR    where to install (default: ~/tinyagentos)
 #     TAOS_BRANCH         git branch or tag (default: master)
-#     TAOS_REPO           git remote (default: https://github.com/jaylfc/tinyagentos)
+#     TAOS_REPO           git remote (default: https://github.com/jaylfc/taOS)
 #     TAOS_PORT                 controller listen port (default: 6969)
 #     TAOS_BROWSER_PROXY_PORT   browser-proxy second-origin port (default: 6970); set to 0 to disable
 #     TAOS_QMD_PORT             qmd model service port (default: 7832)
@@ -43,7 +43,7 @@ fi
 [[ -z "$_existing_install" && -d /opt/tinyagentos/.git ]] && _existing_install=/opt/tinyagentos
 INSTALL_DIR="${TAOS_INSTALL_DIR:-${_existing_install:-$HOME/tinyagentos}}"
 BRANCH="${TAOS_BRANCH:-master}"
-REPO="${TAOS_REPO:-https://github.com/jaylfc/tinyagentos}"
+REPO="${TAOS_REPO:-https://github.com/jaylfc/taOS}"
 TAOS_PORT="${TAOS_PORT:-6969}"
 TAOS_BROWSER_PROXY_PORT="${TAOS_BROWSER_PROXY_PORT:-6970}"
 TAOS_QMD_PORT="${TAOS_QMD_PORT:-7832}"
@@ -2129,5 +2129,5 @@ else
 fi
 log ""
 log "  Now install workers on other machines with:"
-log "    curl -fsSL https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-worker.sh | sudo bash -s -- http://$host_ip:$TAOS_PORT"
+log "    curl -fsSL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-worker.sh | sudo bash -s -- http://$host_ip:$TAOS_PORT"
 log ""

--- a/scripts/install-worker.sh
+++ b/scripts/install-worker.sh
@@ -5,10 +5,10 @@
 # scheduler.
 #
 # Usage:
-#     curl -sL https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-worker.sh | bash -s -- http://controller:6969
+#     curl -sL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-worker.sh | bash -s -- http://controller:6969
 #
 # or download + inspect + run:
-#     curl -O https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-worker.sh
+#     curl -O https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-worker.sh
 #     chmod +x install-worker.sh
 #     ./install-worker.sh http://controller:6969
 #
@@ -17,7 +17,7 @@
 #     TAOS_WORKER_NAME        worker display name (default: hostname)
 #     TAOS_INSTALL_DIR        where to install (default: ~/.local/share/tinyagentos-worker)
 #     TAOS_BRANCH             git branch or tag (default: master)
-#     TAOS_REPO               git remote (default: https://github.com/jaylfc/tinyagentos)
+#     TAOS_REPO               git remote (default: https://github.com/jaylfc/taOS)
 #     TAOS_SKIP_BENCHMARK     if set, skip the on-join benchmark run
 #     TAOS_SERVICE            install as system service: auto (default), user, skip
 #     TAOS_PAIR_MANUAL        if set, use free-tier manual pairing: the worker
@@ -68,7 +68,7 @@ _default_worker_name() {
 WORKER_NAME="${TAOS_WORKER_NAME:-$(_default_worker_name)}"
 INSTALL_DIR="${TAOS_INSTALL_DIR:-$HOME/.local/share/tinyagentos-worker}"
 BRANCH="${TAOS_BRANCH:-master}"
-REPO="${TAOS_REPO:-https://github.com/jaylfc/tinyagentos}"
+REPO="${TAOS_REPO:-https://github.com/jaylfc/taOS}"
 SERVICE_MODE="${TAOS_SERVICE:-auto}"
 
 os_name="$(uname -s)"


### PR DESCRIPTION
Applies three of Jay's five README-audit decisions:

1. **Update-ping wording** -> honest description: a stable random per-install UUID (no PII, stored in the data dir) for an exact install count, opt-out via `TAOS_NO_UPDATE_PING`. Replaces the inaccurate 'no identifiers / daily aggregate estimate'.
2. **Exo roadmap** -> moved Exo backend detection + task-parallel routing to Done; added an In-Progress item for the explicit 'Distributed (exo)' deploy-wizard option; corrected the integrated-section claim (the wizard option is not wired yet, and exo handles its own mDNS peer discovery).
3. **Install-script repo name** -> `scripts/install-server.sh`, `install-worker.sh`, `install-rknpu.sh` now self-reference `jaylfc/taOS` (matches the git remote) instead of the old `jaylfc/tinyagentos`.

The remaining two decisions land separately: the worker-install LXC rewrite (own PR, in progress) and re-seeding the four social apps (own PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and monitoring docs with clearer guidance on update telemetry, opt-out options, and distributed inference discovery.
  * Refined the roadmap to reflect current progress on exo-related deployment support.
* **Chores**
  * Updated installer instructions and default repository references to use the new project URL across server, worker, and hardware install guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->