### PR TITLE
feat(store): re-seed the four optional social apps (Reddit, YouTube, GitHub, X)

### DIFF
--- a/desktop/src/registry/optional-apps.ts
+++ b/desktop/src/registry/optional-apps.ts
@@ -3,11 +3,6 @@
  * registry (app-registry.ts) owns the runtime manifest (component, sizing);
  * this owns how they look in the Store's "taOS Apps" section. ids must match
  * the registry entries marked `optional`.
- *
- * The platform social apps (Reddit / YouTube / GitHub / X) were DE-SEEDED from
- * the default Store: they are unfinished and now live as the operator's private
- * App Studio drafts, to be finished + published on stream rather than offered to
- * every user. Their registry manifests + components remain for that reseed.
  */
 
 export interface OptionalAppMeta {
@@ -23,5 +18,33 @@ export interface OptionalAppMeta {
   cover: string;
 }
 
-// Empty after the social-app de-seed. New optional Store apps get added here.
-export const OPTIONAL_APPS: OptionalAppMeta[] = [];
+export const OPTIONAL_APPS: OptionalAppMeta[] = [
+  {
+    id: "reddit",
+    name: "Reddit",
+    icon: "scroll-text",
+    tagline: "Browse communities and threads, AI-summarised",
+    cover: "radial-gradient(120% 120% at 35% 25%,#4a2a1a,transparent 60%),linear-gradient(140deg,#261408,#180d05)",
+  },
+  {
+    id: "youtube-library",
+    name: "YouTube",
+    icon: "play-circle",
+    tagline: "Watch and organise your video library",
+    cover: "radial-gradient(120% 120% at 65% 25%,#4a1a1a,transparent 60%),linear-gradient(140deg,#261008,#180805)",
+  },
+  {
+    id: "github-browser",
+    name: "GitHub",
+    icon: "github",
+    tagline: "Browse repos, issues, and PRs from your desktop",
+    cover: "radial-gradient(120% 120% at 30% 20%,#1a1a2e,transparent 60%),linear-gradient(140deg,#0d0d1a,#080810)",
+  },
+  {
+    id: "x-monitor",
+    name: "X",
+    icon: "at-sign",
+    tagline: "Follow topics and conversations in real time",
+    cover: "radial-gradient(120% 120% at 70% 20%,#1a1a1a,transparent 60%),linear-gradient(140deg,#111111,#0a0a0a)",
+  },
+];


### PR DESCRIPTION
## Summary

- Populates `OPTIONAL_APPS` in `desktop/src/registry/optional-apps.ts` with the four social apps that were previously de-seeded: Reddit (`reddit`), YouTube (`youtube-library`), GitHub (`github-browser`), and X (`x-monitor`).
- Ids, names, and icons match the existing `optional: true` registry entries in `app-registry.ts` exactly.
- Updates the now-stale file-level comment that described the apps as de-seeded.
- No changes to `app-registry.ts` or any other file.

## Effect

The Store's "taOS Apps" section (`TaosAppsSection`) iterates `OPTIONAL_APPS` to render install/remove cards. With this change it will render all four social apps, making the README claim ("installs from the Store's taOS Apps section") accurate.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified: no output, exit 0)
- [ ] `vitest run src/apps/StoreApp/updates-optional.test.tsx src/hooks/use-installed-optional-apps.test.ts` passes (verified: 9/9 tests pass)
- [ ] No test asserts `OPTIONAL_APPS` is empty; no test updates required