### PR TITLE
docs(readme): rewrite worker-install docs to the two-phase incus-LXC architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ iwr -useb https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-w
 
 **Sudo and freshness.** The Linux/macOS worker installer is designed to run on **either a fresh Debian install or your existing system.** No clean slate required. It installs cleanly on Debian, Ubuntu, Fedora, Arch, Alpine, and macOS.
 
-- **Run with `sudo`** (the recommended path) and the worker is installed as a **system-level systemd unit** at `/etc/systemd/system/tinyagentos-worker.service`. The service runs as your user (via `User=` in the unit), survives logout, auto-starts at boot, and survives container / SBC reboots without an active login session.
-- **Run without sudo** and the script falls back to a **user-mode systemd unit** under `~/.config/systemd/user/`. Linger is enabled automatically so the user manager keeps the worker running across logouts. This path is for environments where sudo is genuinely unavailable (corporate machines, shared hosts).
+- **Linux (recommended path):** the installer runs in two phases. Phase 1 runs on the bare host: it installs incus, nftables, and btrfs-progs, creates a privileged LXC named `taos-worker` backed by a btrfs storage pool (`taos-worker-pool`), adds an nftables DNAT rule that forwards bare-host port `:8443` to the LXC, then re-executes the script inside the container. Phase 2 runs inside the `taos-worker` LXC: it installs the Python runtime, clones the repo, builds the worker venv at `~/.local/share/tinyagentos-worker/`, and installs `/etc/systemd/system/tinyagentos-worker.service` as a root-run system unit inside the container. The worker daemon itself is outbound-only to the controller.
+- **macOS:** the two-phase LXC flow is skipped (incus is Linux-only). The script installs directly on the host and registers the worker as a launchd agent (`~/Library/LaunchAgents/com.tinyagentos.worker.plist`), auto-started at login.
 
 A truly clean Debian install is the smoothest experience because nothing else is competing for ports or sysfs paths, but the script is hardened against common existing-system gotchas: it detects headless environments and skips the desktop tray, it gracefully handles unreadable `/sys/kernel/debug` paths on hosts that mount debugfs but restrict it, and it scopes its writes to `~/.local/share/tinyagentos-worker/` plus the systemd unit.
 
@@ -453,15 +453,19 @@ Run `curl -fsSL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/ins
 
 ### Worker install (`scripts/install-worker.sh`)
 
+Linux uses a two-phase install. Phase 1 runs on the bare host; phase 2 runs inside the `taos-worker` LXC.
+
 | Where | What |
 |---|---|
-| `/etc/systemd/system/tinyagentos-worker.service` | Worker systemd unit (when run with sudo). Connects to the controller URL you passed and registers this machine as a cluster node. Runs as your user via `User=`, not root. |
-| `~/.config/systemd/user/tinyagentos-worker.service` | Same unit as above, but in user-mode (when run without sudo). Linger is enabled automatically. |
-| `~/.local/share/tinyagentos-worker/` | Worker repo checkout. ~150 MB on disk after install. Self-contained venv inside. |
+| `taos-worker` LXC | Privileged incus container created on the bare host during phase 1. All worker software lives inside it. |
+| `taos-worker-pool` | btrfs incus storage pool (loopback image, sized to 90% of free space on `/var/lib`) created on the bare host during phase 1. Backs the `taos-worker` container. |
+| `/etc/systemd/system/tinyagentos-worker.service` | Worker systemd unit installed inside the `taos-worker` LXC (phase 2). Runs as root inside the container. Connects to the controller URL and registers this machine as a cluster node. |
+| `~/.local/share/tinyagentos-worker/` | Repo checkout and venv, cloned inside the `taos-worker` LXC during phase 2. ~150 MB on disk after install. |
 | `~/.local/share/tinyagentos-worker/.venv/` | Python venv with worker-only deps: httpx, pydantic, psutil, fastapi, uvicorn, pyyaml, pillow, libtorrent. **Does NOT install controller-side deps** (no aiosqlite, no LiteLLM, no scheduler engine). |
-| Ports listened on | None. Workers are pure outbound, they connect TO the controller. |
-| OS packages added | python3, venv, pip, git, curl, ca-certificates, libtorrent (Debian/Ubuntu only, Arch/Fedora/Alpine equivalents on those distros). |
-| User accounts created | None. The worker runs as the user who ran the installer. |
+| Ports | `:8443` (incus HTTPS listener inside the LXC, DNAT'd from the bare-host port `:8443` via nftables -- used by the controller for LXC-based service deployment); `:21434` (TAOS-namespaced Ollama, localhost-only inside the LXC by default). The worker daemon itself is outbound-only to the controller. |
+| OS packages added (bare host, phase 1) | incus, nftables, btrfs-progs, curl |
+| OS packages added (inside LXC, phase 2) | incus, curl, python3, python3-venv, python3-pip, git, bees (if available in apt) |
+| User accounts created | None. All processes inside the LXC run as root (the container is privileged). macOS installs run as the invoking user via launchd. |
 
 ### Verify what's installed
 
@@ -472,8 +476,9 @@ ls /etc/systemd/system/tinyagentos*.service /etc/systemd/system/qmd.service
 ls ~/tinyagentos/data/
 
 # Worker side (after running install-worker.sh)
-systemctl status tinyagentos-worker
-ls ~/.local/share/tinyagentos-worker/
+sudo incus list                                                        # shows taos-worker container
+sudo incus exec taos-worker -- systemctl status tinyagentos-worker    # service status inside LXC
+sudo incus exec taos-worker -- ls ~/.local/share/tinyagentos-worker/  # repo + venv inside LXC
 ```
 
 ### Uninstall
@@ -487,13 +492,15 @@ sudo rm /etc/systemd/system/tinyagentos*.service /etc/systemd/system/qmd.service
 sudo systemctl daemon-reload
 # Repo + data are still at ~/tinyagentos, delete with: rm -rf ~/tinyagentos
 
-# Worker
+# Worker (two-phase LXC teardown -- bare host)
 scripts/uninstall-worker.sh
 # Or manually:
-sudo systemctl disable --now tinyagentos-worker
-sudo rm /etc/systemd/system/tinyagentos-worker.service
-sudo systemctl daemon-reload
-rm -rf ~/.local/share/tinyagentos-worker
+sudo incus stop taos-worker
+sudo incus delete taos-worker
+sudo incus storage delete taos-worker-pool
+# Remove the nftables DNAT rule (port :8443 forward) and persist:
+sudo nft delete table ip taos
+sudo bash -c 'nft list ruleset > /etc/nftables.conf.tmp && mv /etc/nftables.conf.tmp /etc/nftables.conf'
 ```
 
 ### Upgrading a long-running install
@@ -523,13 +530,10 @@ You do not build the UI on every machine. `install-server.sh` and the in-app upd
 **Worker:**
 
 ```bash
-cd ~/.local/share/tinyagentos-worker
-git pull
-find . -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null || true
-sudo systemctl restart tinyagentos-worker
+sudo incus exec taos-worker -- bash -c "cd ~/.local/share/tinyagentos-worker && git pull && find . -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null || true && systemctl restart tinyagentos-worker"
 ```
 
-The bytecode cleanup line is belt-and-braces; Python's mtime-based invalidation usually works, but on long-running boxes that have survived many upgrades it occasionally doesn't, and a stale `.pyc` is easy to mistake for a code bug.
+The bytecode cleanup step is belt-and-braces; Python's mtime-based invalidation usually works, but on long-running boxes that have survived many upgrades it occasionally doesn't, and a stale `.pyc` is easy to mistake for a code bug.
 
 ## Service Management
 

--- a/README.md
+++ b/README.md
@@ -498,8 +498,10 @@ scripts/uninstall-worker.sh
 sudo incus stop taos-worker
 sudo incus delete taos-worker
 sudo incus storage delete taos-worker-pool
-# Remove the nftables DNAT rule (port :8443 forward) and persist:
+# Remove the nftables DNAT rule (port :8443 forward):
 sudo nft delete table ip taos
+# Persist (optional). This snapshots the FULL live ruleset over /etc/nftables.conf,
+# so if you hand-maintain that file, edit it by hand instead of running this:
 sudo bash -c 'nft list ruleset > /etc/nftables.conf.tmp && mv /etc/nftables.conf.tmp /etc/nftables.conf'
 ```
 

--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ scripts/uninstall-worker.sh
 # Or manually:
 sudo incus stop taos-worker
 sudo incus delete taos-worker
+# Optional, DESTROYS worker data (the script keeps this unless you pass --purge); skip to keep it:
 sudo incus storage delete taos-worker-pool
 # Remove the nftables DNAT rule (port :8443 forward):
 sudo nft delete table ip taos

--- a/scripts/uninstall-worker.sh
+++ b/scripts/uninstall-worker.sh
@@ -71,10 +71,11 @@ case "$os_name" in
             # block from the saved file, leaving every other table intact.
             if [[ -f "$NFT_CONF" ]] && sudo grep -qE '^table ip taos[ {]' "$NFT_CONF" 2>/dev/null; then
                 log "removing persisted 'table ip taos' from $NFT_CONF"
-                nft_tmp="$(mktemp)"
-                # sudo only needs to READ the (possibly root-owned) conf; the
-                # redirect is intentionally user-level into the mktemp file.
-                # shellcheck disable=SC2024
+                # Write the cleaned ruleset to a sibling temp, then atomically
+                # rename it into place: a crash mid-write leaves $NFT_CONF intact
+                # (either the old file or the fully-written new one, never a
+                # half-written ruleset). sudo tee writes the root-owned temp.
+                nft_tmp="${NFT_CONF}.taos-uninstall.$$"
                 if sudo awk '
                     skip==0 && /^table ip taos \{/ {skip=1; depth=1; next}
                     skip==1 {
@@ -84,15 +85,15 @@ case "$os_name" in
                         next
                     }
                     {print}
-                ' "$NFT_CONF" >"$nft_tmp" && sudo cp "$nft_tmp" "$NFT_CONF"; then
+                ' "$NFT_CONF" | sudo tee "$nft_tmp" >/dev/null && sudo mv "$nft_tmp" "$NFT_CONF"; then
                     :
                 else
                     warn "failed to rewrite $NFT_CONF; 'table ip taos' may persist across reboot"
+                    sudo rm -f "$nft_tmp" 2>/dev/null || true
                 fi
-                rm -f "$nft_tmp"
             fi
         fi
-        [[ "$FAILED" == "0" ]] && log "worker LXC + port-forwards removed"
+        [[ "$FAILED" -eq 0 ]] && log "worker LXC + port-forwards removed"
         ;;
     Darwin)
         launchctl unload "$HOME/Library/LaunchAgents/com.tinyagentos.worker.plist" 2>/dev/null || true
@@ -106,7 +107,7 @@ if [[ -d "$INSTALL_DIR" ]]; then
     rm -rf "$INSTALL_DIR"
 fi
 
-if [[ "$FAILED" == "1" ]]; then
+if [[ "$FAILED" -eq 1 ]]; then
     log "uninstall finished WITH ERRORS (see warnings above); host may be partly torn down"
     exit 1
 fi

--- a/scripts/uninstall-worker.sh
+++ b/scripts/uninstall-worker.sh
@@ -4,39 +4,51 @@
 # Reverses install-worker.sh. On Linux the worker runs as the `taos-worker`
 # incus LXC behind an nftables DNAT port-forward, so a real uninstall must tear
 # those down, not just remove a host unit. Every step is guarded and idempotent:
-# a missing component or a re-run never errors under `set -e`.
+# a missing component is skipped and a re-run is safe.
 #
 # By default this removes the worker container and the port-forwards but KEEPS
 # the `taos-worker-pool` storage (which holds the worker's data). Pass --purge to
 # also delete the storage pool (irreversible data loss).
+#
+# Destructive steps surface their own errors and flip a failure flag rather than
+# swallowing failures, so a half-torn-down host is reported, not hidden.
 set -euo pipefail
 
 INSTALL_DIR="${TAOS_INSTALL_DIR:-$HOME/.local/share/tinyagentos-worker}"
+NFT_CONF="${TAOS_NFT_CONF:-/etc/nftables.conf}"
 os_name="$(uname -s)"
 PURGE=0
 [[ "${1:-}" == "--purge" ]] && PURGE=1
+FAILED=0
 
 log() { printf '\033[1;34m[worker-uninstall]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[worker-uninstall]\033[0m WARNING: %s\n' "$*"; FAILED=1; }
 
 case "$os_name" in
     Linux)
-        # Legacy flat-install path: a host user systemd unit (pre-LXC).
-        # Harmless if absent; kept so older installs still uninstall cleanly.
+        # Legacy flat-install path: a host user systemd unit (pre-LXC). "Not
+        # found" is the norm here, so these stay best-effort and quiet.
         systemctl --user stop tinyagentos-worker 2>/dev/null || true
         systemctl --user disable tinyagentos-worker 2>/dev/null || true
         rm -f "$HOME/.config/systemd/user/tinyagentos-worker.service"
         systemctl --user daemon-reload 2>/dev/null || true
 
-        # Two-phase incus-LXC teardown (the current architecture).
+        # Two-phase incus-LXC teardown (the current architecture). Each step is
+        # guarded by an existence check, so reaching the delete means the
+        # resource really exists: a failure now is genuine, so surface it.
         if command -v incus >/dev/null 2>&1; then
             if sudo incus list --format=csv -c n 2>/dev/null | grep -q '^taos-worker$'; then
                 log "deleting worker LXC 'taos-worker'"
-                sudo incus delete taos-worker --force </dev/null 2>/dev/null || true
+                if ! sudo incus delete taos-worker --force </dev/null; then
+                    warn "failed to delete LXC 'taos-worker'; it may still exist"
+                fi
             fi
             if sudo incus storage list --format=csv 2>/dev/null | awk -F',' '{print $1}' | grep -q '^taos-worker-pool$'; then
                 if [[ "$PURGE" == "1" ]]; then
                     log "purging storage pool 'taos-worker-pool' (--purge)"
-                    sudo incus storage delete taos-worker-pool </dev/null 2>/dev/null || true
+                    if ! sudo incus storage delete taos-worker-pool </dev/null; then
+                        warn "failed to delete storage pool 'taos-worker-pool'; it may still exist"
+                    fi
                 else
                     log "keeping storage pool 'taos-worker-pool' (re-run with --purge to delete worker data)"
                 fi
@@ -48,11 +60,39 @@ case "$os_name" in
         # host firewall rule untouched (never rewrites the whole ruleset).
         if command -v nft >/dev/null 2>&1; then
             if sudo nft list table ip taos >/dev/null 2>&1; then
-                log "removing nftables table 'ip taos' (worker port-forwards)"
-                sudo nft delete table ip taos 2>/dev/null || true
+                log "removing live nftables table 'ip taos' (worker port-forwards)"
+                if ! sudo nft delete table ip taos; then
+                    warn "failed to delete live nftables table 'ip taos'"
+                fi
+            fi
+            # install-worker.sh persists the whole ruleset to $NFT_CONF, so the
+            # taos table is saved there too; without this the forward returns on
+            # the next reboot / nftables reload. Strip ONLY the 'table ip taos'
+            # block from the saved file, leaving every other table intact.
+            if [[ -f "$NFT_CONF" ]] && sudo grep -qE '^table ip taos[ {]' "$NFT_CONF" 2>/dev/null; then
+                log "removing persisted 'table ip taos' from $NFT_CONF"
+                nft_tmp="$(mktemp)"
+                # sudo only needs to READ the (possibly root-owned) conf; the
+                # redirect is intentionally user-level into the mktemp file.
+                # shellcheck disable=SC2024
+                if sudo awk '
+                    skip==0 && /^table ip taos \{/ {skip=1; depth=1; next}
+                    skip==1 {
+                        depth += gsub(/\{/,"{");
+                        depth -= gsub(/\}/,"}");
+                        if (depth<=0) skip=0;
+                        next
+                    }
+                    {print}
+                ' "$NFT_CONF" >"$nft_tmp" && sudo cp "$nft_tmp" "$NFT_CONF"; then
+                    :
+                else
+                    warn "failed to rewrite $NFT_CONF; 'table ip taos' may persist across reboot"
+                fi
+                rm -f "$nft_tmp"
             fi
         fi
-        log "worker LXC + port-forwards removed"
+        [[ "$FAILED" == "0" ]] && log "worker LXC + port-forwards removed"
         ;;
     Darwin)
         launchctl unload "$HOME/Library/LaunchAgents/com.tinyagentos.worker.plist" 2>/dev/null || true
@@ -66,4 +106,8 @@ if [[ -d "$INSTALL_DIR" ]]; then
     rm -rf "$INSTALL_DIR"
 fi
 
+if [[ "$FAILED" == "1" ]]; then
+    log "uninstall finished WITH ERRORS (see warnings above); host may be partly torn down"
+    exit 1
+fi
 log "uninstall complete"

--- a/scripts/uninstall-worker.sh
+++ b/scripts/uninstall-worker.sh
@@ -1,19 +1,58 @@
 #!/usr/bin/env bash
-# TinyAgentOS worker uninstaller — Linux + macOS
+# TinyAgentOS worker uninstaller - Linux (incus LXC) + macOS.
+#
+# Reverses install-worker.sh. On Linux the worker runs as the `taos-worker`
+# incus LXC behind an nftables DNAT port-forward, so a real uninstall must tear
+# those down, not just remove a host unit. Every step is guarded and idempotent:
+# a missing component or a re-run never errors under `set -e`.
+#
+# By default this removes the worker container and the port-forwards but KEEPS
+# the `taos-worker-pool` storage (which holds the worker's data). Pass --purge to
+# also delete the storage pool (irreversible data loss).
 set -euo pipefail
 
 INSTALL_DIR="${TAOS_INSTALL_DIR:-$HOME/.local/share/tinyagentos-worker}"
 os_name="$(uname -s)"
+PURGE=0
+[[ "${1:-}" == "--purge" ]] && PURGE=1
 
 log() { printf '\033[1;34m[worker-uninstall]\033[0m %s\n' "$*"; }
 
 case "$os_name" in
     Linux)
+        # Legacy flat-install path: a host user systemd unit (pre-LXC).
+        # Harmless if absent; kept so older installs still uninstall cleanly.
         systemctl --user stop tinyagentos-worker 2>/dev/null || true
         systemctl --user disable tinyagentos-worker 2>/dev/null || true
         rm -f "$HOME/.config/systemd/user/tinyagentos-worker.service"
         systemctl --user daemon-reload 2>/dev/null || true
-        log "removed user systemd service"
+
+        # Two-phase incus-LXC teardown (the current architecture).
+        if command -v incus >/dev/null 2>&1; then
+            if sudo incus list --format=csv -c n 2>/dev/null | grep -q '^taos-worker$'; then
+                log "deleting worker LXC 'taos-worker'"
+                sudo incus delete taos-worker --force </dev/null 2>/dev/null || true
+            fi
+            if sudo incus storage list --format=csv 2>/dev/null | awk -F',' '{print $1}' | grep -q '^taos-worker-pool$'; then
+                if [[ "$PURGE" == "1" ]]; then
+                    log "purging storage pool 'taos-worker-pool' (--purge)"
+                    sudo incus storage delete taos-worker-pool </dev/null 2>/dev/null || true
+                else
+                    log "keeping storage pool 'taos-worker-pool' (re-run with --purge to delete worker data)"
+                fi
+            fi
+        fi
+
+        # Remove ONLY the taos nftables table, which holds the worker DNAT
+        # port-forwards (:8443, :21434). Deleting the table leaves every other
+        # host firewall rule untouched (never rewrites the whole ruleset).
+        if command -v nft >/dev/null 2>&1; then
+            if sudo nft list table ip taos >/dev/null 2>&1; then
+                log "removing nftables table 'ip taos' (worker port-forwards)"
+                sudo nft delete table ip taos 2>/dev/null || true
+            fi
+        fi
+        log "worker LXC + port-forwards removed"
         ;;
     Darwin)
         launchctl unload "$HOME/Library/LaunchAgents/com.tinyagentos.worker.plist" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Rewrites the worker-install README sections to reflect the actual two-phase incus-LXC architecture implemented in `scripts/install-worker.sh`, replacing stale flat-install descriptions.
- Five regions updated:
  1. **~L187-188 (Run with sudo):** replaced the old systemd-unit-as-user description with accurate two-phase Linux flow (phase 1 on bare host: incus + nftables + btrfs-progs + LXC creation + DNAT; phase 2 inside LXC: Python runtime + venv + root system unit) plus the macOS launchd path.
  2. **~L454-464 (Worker install table):** rewrote all rows -- added `taos-worker` LXC and `taos-worker-pool` storage pool rows; corrected unit location and user (root inside LXC, not `User=` on the host); split OS packages into phase 1 (bare host) and phase 2 (inside LXC); replaced the "None" ports row with the real `:8443` DNAT + `:21434` Ollama entries.
  3. **~L474-476 (Verify what's installed):** replaced bare `systemctl status` / `ls` with `sudo incus list`, `sudo incus exec taos-worker -- systemctl status tinyagentos-worker`, and `sudo incus exec taos-worker -- ls ...`.
  4. **Uninstall block:** replaced `systemctl disable` / `rm unit` with LXC teardown (`incus stop`, `incus delete`, `incus storage delete taos-worker-pool`) plus nftables DNAT removal (`nft delete table ip taos` + persist to `/etc/nftables.conf`).
  5. **Upgrade block:** replaced bare `cd && git pull && systemctl restart` with `sudo incus exec taos-worker -- bash -c "..."` to run everything inside the LXC.

This is the worker-docs half of Jay's README audit. No other sections (update-ping, Exo, Roadmap) were touched.

## Corrections vs. audit spec

All details matched the spec exactly as confirmed against `install-worker.sh`. No deviations to report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux worker setup, verification, upgrade, and removal steps to match the new container-based installation flow.
  * Clarified how service access and port forwarding work in the new environment.

* **Bug Fixes**
  * Improved worker uninstall behavior on Linux to cleanly remove container and network forwarding components.
  * Added optional full cleanup for storage when re-running installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->