### PR TITLE
feat(observatory): per-session approval-mode steer — storage+API (#133)

### DIFF
--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -98,6 +98,57 @@ async def test_non_admin_cannot_throttle(app, client):
 
 
 @pytest.mark.asyncio
+async def test_approval_mode_defaults_to_default(client):
+    resp = await client.get("/api/observatory/approval-mode")
+    assert resp.status_code == 200
+    assert resp.json() == {"global": "default", "lanes": {}}
+
+
+@pytest.mark.asyncio
+async def test_global_approval_mode_round_trips(client):
+    resp = await client.post("/api/observatory/approval-mode", json={"scope": "global", "mode": "accept_edits"})
+    assert resp.status_code == 200
+    assert resp.json()["global"] == "accept_edits"
+    resp = await client.get("/api/observatory/approval-mode")
+    assert resp.json()["global"] == "accept_edits"
+    # Resetting to default restores the baseline.
+    resp = await client.post("/api/observatory/approval-mode", json={"scope": "global", "mode": "default"})
+    assert resp.json()["global"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_per_lane_approval_mode_set_and_clear(client):
+    lane = "@taOS-dev-kilo-owl-alpha"
+    resp = await client.post("/api/observatory/approval-mode", json={"scope": lane, "mode": "dont_ask"})
+    assert resp.json()["lanes"] == {lane: "dont_ask"}
+    # mode=default clears the per-lane override (falls back to global).
+    resp = await client.post("/api/observatory/approval-mode", json={"scope": lane, "mode": "default"})
+    assert resp.json()["lanes"] == {}
+
+
+@pytest.mark.asyncio
+async def test_approval_mode_invalid_mode_rejected(client):
+    resp = await client.post("/api/observatory/approval-mode", json={"scope": "global", "mode": "yolo"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_approval_mode_empty_scope_rejected(client):
+    resp = await client.post("/api/observatory/approval-mode", json={"scope": "  ", "mode": "accept_edits"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_set_approval_mode(app, client):
+    app.dependency_overrides[current_user] = lambda: CurrentUser(user_id="bob", is_admin=False)
+    try:
+        resp = await client.post("/api/observatory/approval-mode", json={"scope": "global", "mode": "dont_ask"})
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.pop(current_user, None)
+
+
+@pytest.mark.asyncio
 async def test_fleet_empty_when_no_claims(client):
     resp = await client.get("/api/observatory/fleet")
     assert resp.status_code == 200

--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -127,6 +127,23 @@ async def test_per_session_approval_mode_set_and_clear(client):
 
 
 @pytest.mark.asyncio
+async def test_approval_mode_tolerates_malformed_file(app, client):
+    # Valid JSON but the wrong shape must degrade to the safe default, not 500.
+    from pathlib import Path
+    p = Path(app.state.data_dir) / "observatory_approval_mode.json"
+    p.write_text('"not a dict"')
+    r = await client.get("/api/observatory/approval-mode")
+    assert r.status_code == 200
+    assert r.json() == {"global": "default", "sessions": {}}
+    # A non-dict "sessions" is ignored, not crashed on.
+    p.write_text('{"global": "accept_edits", "sessions": "oops"}')
+    r = await client.get("/api/observatory/approval-mode")
+    assert r.status_code == 200
+    assert r.json()["global"] == "accept_edits"
+    assert r.json()["sessions"] == {}
+
+
+@pytest.mark.asyncio
 async def test_approval_mode_invalid_mode_rejected(client):
     resp = await client.post("/api/observatory/approval-mode", json={"scope": "global", "mode": "yolo"})
     assert resp.status_code == 400

--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -101,7 +101,7 @@ async def test_non_admin_cannot_throttle(app, client):
 async def test_approval_mode_defaults_to_default(client):
     resp = await client.get("/api/observatory/approval-mode")
     assert resp.status_code == 200
-    assert resp.json() == {"global": "default", "lanes": {}}
+    assert resp.json() == {"global": "default", "sessions": {}}
 
 
 @pytest.mark.asyncio
@@ -117,13 +117,13 @@ async def test_global_approval_mode_round_trips(client):
 
 
 @pytest.mark.asyncio
-async def test_per_lane_approval_mode_set_and_clear(client):
-    lane = "@taOS-dev-kilo-owl-alpha"
-    resp = await client.post("/api/observatory/approval-mode", json={"scope": lane, "mode": "dont_ask"})
-    assert resp.json()["lanes"] == {lane: "dont_ask"}
-    # mode=default clears the per-lane override (falls back to global).
-    resp = await client.post("/api/observatory/approval-mode", json={"scope": lane, "mode": "default"})
-    assert resp.json()["lanes"] == {}
+async def test_per_session_approval_mode_set_and_clear(client):
+    session = "cs-abc123"
+    resp = await client.post("/api/observatory/approval-mode", json={"scope": session, "mode": "dont_ask"})
+    assert resp.json()["sessions"] == {session: "dont_ask"}
+    # mode=default clears the per-session override (falls back to global).
+    resp = await client.post("/api/observatory/approval-mode", json={"scope": session, "mode": "default"})
+    assert resp.json()["sessions"] == {}
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -215,8 +215,16 @@ def _read_approval(request: Request) -> dict:
         data = json.loads(p.read_text())
     except (OSError, ValueError):
         return {"global": "default", "sessions": {}}
+    # A hand-edited file could be valid JSON but not the expected shape (a scalar,
+    # a list, or a non-dict "sessions"). Guard both so a malformed file degrades
+    # to the safe default instead of 500ing the GET.
+    if not isinstance(data, dict):
+        return {"global": "default", "sessions": {}}
+    raw_sessions = data.get("sessions")
+    if not isinstance(raw_sessions, dict):
+        raw_sessions = {}
     sessions = {}
-    for k, v in (data.get("sessions") or {}).items():
+    for k, v in raw_sessions.items():
         mode = _coerce_mode(v)
         if mode is not None and mode != "default":
             sessions[str(k)] = mode

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -183,8 +183,11 @@ async def set_throttle(body: ThrottleBody, request: Request, user: CurrentUser =
 # --- Per-session approval-mode steer (#133). A controller-owned mode the
 # dispatch loop will read each iteration to decide how much an agent may do
 # without asking: ``default`` (ask before edits), ``accept_edits`` (auto-allow
-# workspace/tmp edits), ``dont_ask`` (no prompts). Same shape as pause/throttle:
-# global plus per-lane overrides, JSON in data_dir, admin-gated writes. This is
+# workspace/tmp edits), ``dont_ask`` (no prompts). Approval mode is PER-SESSION
+# (the scope key is a session id), unlike pause/throttle which are per-lane: how
+# much an agent may do without asking is a property of the running session, not
+# the lane. Same storage shape as pause/throttle (global plus a per-session
+# override map, JSON in data_dir, admin-gated writes). This is
 # the storage+API layer only; wiring the dispatch loop to honour the mode and
 # the Observatory UI control are a deliberate follow-up (held for Jay). Until
 # then nothing reads this, so it changes no live agent behaviour. ---
@@ -203,26 +206,26 @@ def _coerce_mode(v) -> str | None:
 
 def _read_approval(request: Request) -> dict:
     """Current approval modes. ``global`` falls back to the safe ``default``
-    (ask before edits); only valid non-default per-lane overrides are kept so a
-    hand-edited or partial file cannot widen permissions unexpectedly."""
+    (ask before edits); only valid non-default per-session overrides are kept so
+    a hand-edited or partial file cannot widen permissions unexpectedly."""
     p = _approval_path(request)
     if not p.exists():
-        return {"global": "default", "lanes": {}}
+        return {"global": "default", "sessions": {}}
     try:
         data = json.loads(p.read_text())
     except (OSError, ValueError):
-        return {"global": "default", "lanes": {}}
-    lanes = {}
-    for k, v in (data.get("lanes") or {}).items():
+        return {"global": "default", "sessions": {}}
+    sessions = {}
+    for k, v in (data.get("sessions") or {}).items():
         mode = _coerce_mode(v)
         if mode is not None and mode != "default":
-            lanes[str(k)] = mode
-    return {"global": _coerce_mode(data.get("global")) or "default", "lanes": lanes}
+            sessions[str(k)] = mode
+    return {"global": _coerce_mode(data.get("global")) or "default", "sessions": sessions}
 
 
 class ApprovalModeBody(BaseModel):
-    scope: str  # "global" or a lane handle
-    mode: str  # one of APPROVAL_MODES; "default" clears a per-lane override
+    scope: str  # "global" or a session id
+    mode: str  # one of APPROVAL_MODES; "default" clears a per-session override
 
 
 @router.get("/api/observatory/approval-mode")
@@ -233,9 +236,9 @@ async def get_approval_mode(request: Request, user: CurrentUser = Depends(curren
 
 @router.post("/api/observatory/approval-mode")
 async def set_approval_mode(body: ApprovalModeBody, request: Request, user: CurrentUser = Depends(current_user)):
-    """Set the approval mode globally or for a single lane. Admin only, since it
-    relaxes how much an agent may do without asking. ``mode='default'`` on a lane
-    clears its override (it falls back to global)."""
+    """Set the approval mode globally or for a single session. Admin only, since
+    it relaxes how much an agent may do without asking. ``mode='default'`` on a
+    session clears its override (it falls back to global)."""
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="forbidden")
     scope = body.scope.strip()
@@ -252,9 +255,9 @@ async def set_approval_mode(body: ApprovalModeBody, request: Request, user: Curr
         if scope == "global":
             state["global"] = mode
         elif mode != "default":
-            state["lanes"][scope] = mode
+            state["sessions"][scope] = mode
         else:
-            state["lanes"].pop(scope, None)
+            state["sessions"].pop(scope, None)
         _atomic_write(_approval_path(request), state)
     return state
 

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -180,6 +180,85 @@ async def set_throttle(body: ThrottleBody, request: Request, user: CurrentUser =
     return state
 
 
+# --- Per-session approval-mode steer (#133). A controller-owned mode the
+# dispatch loop will read each iteration to decide how much an agent may do
+# without asking: ``default`` (ask before edits), ``accept_edits`` (auto-allow
+# workspace/tmp edits), ``dont_ask`` (no prompts). Same shape as pause/throttle:
+# global plus per-lane overrides, JSON in data_dir, admin-gated writes. This is
+# the storage+API layer only; wiring the dispatch loop to honour the mode and
+# the Observatory UI control are a deliberate follow-up (held for Jay). Until
+# then nothing reads this, so it changes no live agent behaviour. ---
+
+APPROVAL_MODES = ("default", "accept_edits", "dont_ask")
+
+
+def _approval_path(request: Request) -> Path:
+    return Path(request.app.state.data_dir) / "observatory_approval_mode.json"
+
+
+def _coerce_mode(v) -> str | None:
+    """Return *v* if it is a recognised mode, else None."""
+    return v if v in APPROVAL_MODES else None
+
+
+def _read_approval(request: Request) -> dict:
+    """Current approval modes. ``global`` falls back to the safe ``default``
+    (ask before edits); only valid non-default per-lane overrides are kept so a
+    hand-edited or partial file cannot widen permissions unexpectedly."""
+    p = _approval_path(request)
+    if not p.exists():
+        return {"global": "default", "lanes": {}}
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return {"global": "default", "lanes": {}}
+    lanes = {}
+    for k, v in (data.get("lanes") or {}).items():
+        mode = _coerce_mode(v)
+        if mode is not None and mode != "default":
+            lanes[str(k)] = mode
+    return {"global": _coerce_mode(data.get("global")) or "default", "lanes": lanes}
+
+
+class ApprovalModeBody(BaseModel):
+    scope: str  # "global" or a lane handle
+    mode: str  # one of APPROVAL_MODES; "default" clears a per-lane override
+
+
+@router.get("/api/observatory/approval-mode")
+async def get_approval_mode(request: Request, user: CurrentUser = Depends(current_user)):
+    """Current approval modes. The dispatch loop will poll this each iteration."""
+    return _read_approval(request)
+
+
+@router.post("/api/observatory/approval-mode")
+async def set_approval_mode(body: ApprovalModeBody, request: Request, user: CurrentUser = Depends(current_user)):
+    """Set the approval mode globally or for a single lane. Admin only, since it
+    relaxes how much an agent may do without asking. ``mode='default'`` on a lane
+    clears its override (it falls back to global)."""
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    scope = body.scope.strip()
+    if not scope:
+        return JSONResponse({"error": "scope required"}, status_code=400)
+    mode = _coerce_mode(body.mode)
+    if mode is None:
+        return JSONResponse(
+            {"error": f"invalid mode; expected one of {list(APPROVAL_MODES)}"},
+            status_code=400,
+        )
+    async with _write_lock:
+        state = _read_approval(request)
+        if scope == "global":
+            state["global"] = mode
+        elif mode != "default":
+            state["lanes"][scope] = mode
+        else:
+            state["lanes"].pop(scope, None)
+        _atomic_write(_approval_path(request), state)
+    return state
+
+
 @router.get("/api/observatory/fleet")
 async def get_fleet(request: Request, user: CurrentUser = Depends(current_user)):
     """The Observe half: which agents are working and what they hold right now.


### PR DESCRIPTION
First slice of #133 (Observatory per-session steer). Adds the approval-mode control the dispatch loop will read to decide how much an agent may do without asking.

What this adds (storage + API only):
- `GET /api/observatory/approval-mode` — current modes; the dispatch loop will poll this each iteration (any authed caller, like pause/throttle).
- `POST /api/observatory/approval-mode` — admin-only; set global or per-lane mode. Modes: `default` (ask before edits), `accept_edits` (auto-allow workspace/tmp), `dont_ask`. `mode=default` on a lane clears its override.
- Same shape as the existing pause/throttle steer (per the spec: "same shape as the existing pause"): JSON in data_dir, atomic write under the shared write-lock, normalized read that defaults to the safe `default` and drops invalid/partial entries so a hand-edited file can't widen permissions.

Deliberately NOT in this PR (held for your review — these are the parts that touch live behavior / design):
- Wiring the owl dispatch loop to actually honor the mode (changes what agents do without asking).
- The Observatory UI control + session badges + health/capabilities panel.

Because nothing reads the flag yet, this slice changes no live agent behavior — it's the inert, fully-tested foundation. **Held for Jay**: please confirm the per-lane-vs-per-session scope and the three mode semantics before I wire it into dispatch.

Checks: ast clean, ascii-clean (no em dashes), `pytest tests/test_routes_observatory.py` 30 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval mode settings in Observatory, with support for viewing the current mode and updating a global or lane-specific preference.
  * Validation now prevents invalid or blank settings from being saved, and admin-only access is enforced for changes.

* **Bug Fixes**
  * Improved handling of approval mode changes so values can be reset back to the default option cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->