### PR TITLE
fix(install-scripts): clear shellcheck SC1010/SC1087 in deploy scripts (#117)

### DIFF
--- a/scripts/install-ltx-video.sh
+++ b/scripts/install-ltx-video.sh
@@ -107,7 +107,7 @@ log "installing CUDA torch from $TORCH_INDEX_URL (this can take a while)"
 
 # README: python -m pip install -e .[inference]   (package name: ltx-video)
 log "installing ltx-video (editable) with [inference] extra"
-"$PY_BIN" -m pip install -e "$REPO_DIR[inference]"
+"$PY_BIN" -m pip install -e "${REPO_DIR}[inference]"
 
 # huggingface_hub for a reproducible, revision-pinned weight download
 "$PY_BIN" -m pip install --quiet "huggingface_hub>=0.23"

--- a/tinyagentos/scripts/install_langroid.sh
+++ b/tinyagentos/scripts/install_langroid.sh
@@ -159,5 +159,5 @@ UNIT
 systemctl daemon-reload
 systemctl enable --now taos-langroid-bridge.service
 echo "langroid-1.x" > /opt/taos/framework.version
-log done
+log "done"
 

--- a/tinyagentos/scripts/install_openai-agents-sdk.sh
+++ b/tinyagentos/scripts/install_openai-agents-sdk.sh
@@ -165,5 +165,5 @@ UNIT
 systemctl daemon-reload
 systemctl enable --now taos-openai-agents-sdk-bridge.service
 echo "openai-agents-sdk-1.x" > /opt/taos/framework.version
-log done
+log "done"
 

--- a/tinyagentos/scripts/install_openai_agents_sdk.sh
+++ b/tinyagentos/scripts/install_openai_agents_sdk.sh
@@ -165,5 +165,5 @@ UNIT
 systemctl daemon-reload
 systemctl enable --now taos-openai-agents-sdk-bridge.service
 echo "openai-agents-sdk-1.x" > /opt/taos/framework.version
-log done
+log "done"
 

--- a/tinyagentos/scripts/install_pocketflow.sh
+++ b/tinyagentos/scripts/install_pocketflow.sh
@@ -156,5 +156,5 @@ UNIT
 systemctl daemon-reload
 systemctl enable --now taos-pocketflow-bridge.service
 echo "pocketflow-1.x" > /opt/taos/framework.version
-log done
+log "done"
 


### PR DESCRIPTION
Static-hygiene pass on the deploy/install scripts (part of #117 install-script robustness). All changes are behavior-identical; they only make shellcheck-flagged ambiguities explicit.

- **SC1010** (4 framework bridge installers: langroid, openai_agents_sdk, openai-agents-sdk, pocketflow): `log done` -> `log "done"`. A bare `done` argument reads as a loop keyword to shellcheck; quoting it is what install_opencrabs.sh already does. No behavior change.
- **SC1087** (install-ltx-video.sh, error severity): `"$REPO_DIR[inference]"` -> `"${REPO_DIR}[inference]"`. Inside double quotes both expand to the same `<repo>[inference]` pip-extras path; the braces stop shellcheck reading it as a malformed array subscript.

Deliberately NOT touched (avoiding churn / risk on live deploy scripts): SC2034 unused-var style warnings (likely intentional loop vars), SC2166 `[ -o ]` portability nit, and install-server.sh SC2024 which is a context false-positive (the redirect target is a user-owned mktemp /tmp log, so writing as the user is correct).

Checks: `bash -n` clean on all 5; SC1010/SC1087 cleared; ascii-clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an install command so an optional package extra is appended properly during setup.
  * Fixed several installer scripts to pass the final status message as a quoted argument, making completion logging more consistent.

* **Style**
  * Standardized final “done” output across multiple install scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->