### PR TITLE
fix(ci): build-agent-images startup failure -- illegal matrix context in job if

### DIFF
--- a/.github/workflows/build-agent-images.yml
+++ b/.github/workflows/build-agent-images.yml
@@ -147,13 +147,12 @@ jobs:
             runner: ubuntu-24.04-arm
             debarch: arm64
     runs-on: ${{ matrix.runner }}
-    # Skip matrix legs whose base did not change (detect gates them per base).
-    # A skipped leg is not a failure, so the release job still proceeds and
-    # keeps the unchanged base's existing published asset.
-    if: >-
-      (matrix.base == 'openclaw' && needs.detect.outputs.openclaw == 'true') ||
-      (matrix.base == 'generic'  && needs.detect.outputs.generic  == 'true') ||
-      (matrix.base == 'hermes'   && needs.detect.outputs.hermes   == 'true')
+    # Build every base on every run (the historical default). A job-level `if:`
+    # cannot reference the `matrix` context (it is evaluated before the matrix
+    # expands), so the previous per-base skip caused a workflow startup failure
+    # that ran 0 jobs on every push. The detect job still stamps current upstream
+    # versions for the release manifest; re-introducing per-base gating needs the
+    # matrix itself to be emitted by detect (fromJSON), not a job-level if.
     env:
       # Map the "openclaw"/"generic"/"hermes" base label to its published alias.
       ALIAS: ${{ matrix.base == 'openclaw' && 'taos-openclaw-base' || (matrix.base == 'generic' && 'taos-base' || 'taos-hermes-base') }}


### PR DESCRIPTION
**Root cause (confirmed via actionlint):** the build job's job-level `if:` (introduced by #1449) referenced `matrix.base`. A job-level `if:` is evaluated *before* the matrix expands, so the `matrix` context is not available there. GitHub rejected the whole workflow at parse/startup time and ran **0 jobs on every push to every branch** (startup failures bypass the master-only branch filter) -- which is why dev and every feature branch showed a red X, and why no agent base image has rebuilt since #1449 (2026-06-28).

```
build-agent-images.yml:153: context "matrix" is not allowed here.
available contexts are "github", "inputs", "needs", "vars".
```

**Fix:** remove the illegal job-level `if:`. This restores the historical build-all-bases behaviour (exactly what push/dispatch already did pre-gating). `runs-on` and `env` keep using `matrix` legally (those are evaluated per-leg). actionlint now reports **0 matrix-context errors**; YAML valid.

**Behaviour change:** scheduled runs now rebuild all 3 bases instead of only changed ones (a CI-cost optimisation, not correctness). The runtime `taos-framework-update` self-heal already covers freshness, so impact was low. To re-add per-base gating *correctly* later, `detect` should emit the matrix as JSON and the build job consume it via `fromJSON(needs.detect.outputs.matrix)` -- I can do that as a follow-up if you want the optimisation back.

**Held for your review** -- it is my fix, actionlint-validated at the parse level, but it touches the base-image build automation and I cannot runtime-test the full incus build unattended. On merge, the next push should produce a clean run (no startup failure).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured base image builds run for every architecture and release check, even when upstream versions haven’t changed.
  * Improved consistency of image updates and version stamping during release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->