### PR TITLE
feat(receipts): action-receipt store + API at the OS boundary (#155 slice 1)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,6 +309,10 @@ async def client(app, tmp_data_dir):
     if board_audit._db is not None:
         await board_audit.close()
     await board_audit.init()
+    receipt_store = app.state.receipt_store
+    if receipt_store._db is not None:
+        await receipt_store.close()
+    await receipt_store.init()
     project_task_store = app.state.project_task_store
     if project_task_store._db is not None:
         await project_task_store.close()

--- a/tests/test_receipt_store.py
+++ b/tests/test_receipt_store.py
@@ -1,0 +1,109 @@
+import pytest
+import pytest_asyncio
+
+from tinyagentos.receipt_store import ReceiptStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ReceiptStore(tmp_path / "receipts.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_record_and_get_round_trips_json(store):
+    rid = await store.record(
+        "taos-dev-20260629-090000",
+        handle="@taOS-dev",
+        project_id="prj-1",
+        workspace_hash="abc123",
+        capability="files.write",
+        capability_granted_at="2026-06-29T09:00:00+00:00",
+        tool_name="file_write",
+        tool_args={"path": "a.py", "bytes": 12},
+        input_refs=[{"name": "spec", "hash": "deadbeef"}],
+        output_ref="sha256:cafe",
+        result_summary="wrote a.py",
+        files_changed=[{"path": "a.py", "hash_before": "", "hash_after": "x", "bytes_delta": 12}],
+        stop_reason="completed",
+        redactions=[{"field": "tool_args.secret", "reason": "credential"}],
+        human_approval={"decision_id": "dec-abc123", "answered_by": "u1", "value": "approve"},
+        trace_id="trace-1",
+        board_audit_event_id="ba-aaaa1111",
+        decision_id="dec-abc123",
+        created_by_user_id="u1",
+        metadata={"note": "first"},
+    )
+    assert rid.startswith("rct-")
+    got = await store.get(rid)
+    # JSON fields come back as parsed Python objects, not strings.
+    assert got["tool_args"] == {"path": "a.py", "bytes": 12}
+    assert got["files_changed"][0]["bytes_delta"] == 12
+    assert got["human_approval"]["answered_by"] == "u1"
+    assert got["redactions"][0]["reason"] == "credential"
+    assert got["agent_canonical_id"] == "taos-dev-20260629-090000"
+    assert got["trace_id"] == "trace-1"
+    assert got["decision_id"] == "dec-abc123"
+
+
+@pytest.mark.asyncio
+async def test_agent_canonical_id_is_required(store):
+    with pytest.raises(ValueError):
+        await store.record("")
+
+
+@pytest.mark.asyncio
+async def test_minimal_receipt_defaults(store):
+    rid = await store.record("agent-x")
+    got = await store.get(rid)
+    assert got["tool_args"] == {}
+    assert got["files_changed"] == []
+    assert got["redactions"] == []
+    assert got["human_approval"] is None  # absent side-effect approval stays null
+    assert got["capability"] == ""
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(store):
+    assert await store.get("rct-nope") is None
+
+
+@pytest.mark.asyncio
+async def test_list_newest_first_and_filters(store):
+    a = await store.record("agent-a", project_id="prj-1", trace_id="t1")
+    b = await store.record("agent-b", project_id="prj-2", trace_id="t2")
+    c = await store.record("agent-a", project_id="prj-1", trace_id="t1")
+
+    everything = await store.list()
+    # Newest first by insertion order.
+    assert [r["id"] for r in everything] == [c, b, a]
+
+    by_agent = await store.list(agent_canonical_id="agent-a")
+    assert {r["id"] for r in by_agent} == {a, c}
+
+    by_project = await store.list(project_id="prj-2")
+    assert [r["id"] for r in by_project] == [b]
+
+    by_trace = await store.list(trace_id="t1")
+    assert {r["id"] for r in by_trace} == {a, c}
+
+
+@pytest.mark.asyncio
+async def test_list_limit_is_clamped(store):
+    for _ in range(5):
+        await store.record("agent-a")
+    assert len(await store.list(limit=2)) == 2
+    # Over-large + non-positive limits are clamped, never error.
+    assert len(await store.list(limit=10_000)) == 5
+    assert len(await store.list(limit=0)) >= 1
+
+
+@pytest.mark.asyncio
+async def test_append_only_no_mutation_surface(store):
+    # The store is append-only: it must not expose update/delete (the Time
+    # Machine guarantee). Guards against a future regression adding one.
+    assert not hasattr(store, "update")
+    assert not hasattr(store, "delete")
+    assert not hasattr(store, "set_status")

--- a/tests/test_receipt_store.py
+++ b/tests/test_receipt_store.py
@@ -101,6 +101,17 @@ async def test_list_limit_is_clamped(store):
 
 
 @pytest.mark.asyncio
+async def test_corrupt_json_field_is_flagged_not_silent(store):
+    # An audit ledger must surface on-disk corruption, not pass a malformed JSON
+    # column off as valid data. Simulate corruption and read it back.
+    rid = await store.record("agent-x", tool_args={"ok": 1})
+    await store._db.execute("UPDATE receipts SET tool_args = ? WHERE id = ?", ("{not json", rid))
+    await store._db.commit()
+    got = await store.get(rid)
+    assert got["tool_args"] == {"_unparsed": "{not json"}  # flagged, lossless
+
+
+@pytest.mark.asyncio
 async def test_append_only_no_mutation_surface(store):
     # The store is append-only: it must not expose update/delete (the Time
     # Machine guarantee). Guards against a future regression adding one.

--- a/tests/test_routes_receipts.py
+++ b/tests/test_routes_receipts.py
@@ -1,0 +1,110 @@
+import pytest
+
+from tinyagentos.auth_context import CurrentUser, current_user
+
+
+def _as(app, user_id, is_admin=False):
+    app.dependency_overrides[current_user] = lambda: CurrentUser(user_id=user_id, is_admin=is_admin)
+
+
+def _clear(app):
+    app.dependency_overrides.pop(current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_post_creates_and_stamps_user(app, client):
+    _as(app, "u1")
+    try:
+        r = await client.post("/api/receipts", json={
+            "agent_canonical_id": "taos-dev-20260629-090000",
+            "tool_name": "file_write",
+            "tool_args": {"path": "a.py"},
+            "trace_id": "trace-1",
+        })
+        assert r.status_code == 200
+        rid = r.json()["id"]
+        assert rid.startswith("rct-")
+        got = await client.get(f"/api/receipts/{rid}")
+        assert got.status_code == 200
+        body = got.json()
+        assert body["created_by_user_id"] == "u1"  # stamped from the caller
+        assert body["tool_args"] == {"path": "a.py"}
+    finally:
+        _clear(app)
+
+
+@pytest.mark.asyncio
+async def test_blank_agent_rejected(app, client):
+    _as(app, "u1")
+    try:
+        r = await client.post("/api/receipts", json={"agent_canonical_id": "  "})
+        assert r.status_code == 400
+    finally:
+        _clear(app)
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_read_another_users_receipt(app, client):
+    _as(app, "u1")
+    try:
+        rid = (await client.post("/api/receipts", json={"agent_canonical_id": "a"})).json()["id"]
+    finally:
+        _clear(app)
+    _as(app, "u2")
+    try:
+        r = await client.get(f"/api/receipts/{rid}")
+        assert r.status_code == 404  # do not leak existence across users
+    finally:
+        _clear(app)
+
+
+@pytest.mark.asyncio
+async def test_admin_can_read_any_receipt(app, client):
+    _as(app, "u1")
+    try:
+        rid = (await client.post("/api/receipts", json={"agent_canonical_id": "a"})).json()["id"]
+    finally:
+        _clear(app)
+    _as(app, "root", is_admin=True)
+    try:
+        r = await client.get(f"/api/receipts/{rid}")
+        assert r.status_code == 200
+    finally:
+        _clear(app)
+
+
+@pytest.mark.asyncio
+async def test_list_scopes_non_admin_to_own(app, client):
+    _as(app, "u1")
+    try:
+        await client.post("/api/receipts", json={"agent_canonical_id": "a"})
+    finally:
+        _clear(app)
+    _as(app, "u2")
+    try:
+        await client.post("/api/receipts", json={"agent_canonical_id": "b"})
+        mine = await client.get("/api/receipts")
+        assert mine.status_code == 200
+        agents = [r["agent_canonical_id"] for r in mine.json()["receipts"]]
+        assert agents == ["b"]  # u2 sees only their own
+    finally:
+        _clear(app)
+    _as(app, "root", is_admin=True)
+    try:
+        allr = await client.get("/api/receipts")
+        assert allr.json()["count"] >= 2  # admin sees both
+    finally:
+        _clear(app)
+
+
+@pytest.mark.asyncio
+async def test_list_filter_by_agent(app, client):
+    _as(app, "u1")
+    try:
+        await client.post("/api/receipts", json={"agent_canonical_id": "agent-a"})
+        await client.post("/api/receipts", json={"agent_canonical_id": "agent-b"})
+        r = await client.get("/api/receipts", params={"agent": "agent-a"})
+        rows = r.json()["receipts"]
+        assert len(rows) == 1 and rows[0]["agent_canonical_id"] == "agent-a"
+    finally:
+        _clear(app)

--- a/tests/test_routes_receipts.py
+++ b/tests/test_routes_receipts.py
@@ -44,6 +44,20 @@ async def test_blank_agent_rejected(app, client):
 
 
 @pytest.mark.asyncio
+async def test_handle_is_not_caller_settable(app, client):
+    _as(app, "u1")
+    try:
+        # A caller-supplied handle must be ignored (not spoofable vs the canonical id).
+        rid = (await client.post(
+            "/api/receipts", json={"agent_canonical_id": "a", "handle": "spoofed"}
+        )).json()["id"]
+        got = await client.get(f"/api/receipts/{rid}")
+        assert got.json()["handle"] == ""
+    finally:
+        _clear(app)
+
+
+@pytest.mark.asyncio
 async def test_non_admin_cannot_read_another_users_receipt(app, client):
     _as(app, "u1")
     try:

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -367,6 +367,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     desktop_command_broker = DesktopCommandBroker()
     from tinyagentos.board_audit import BoardAuditLog
     board_audit_store = BoardAuditLog(data_dir / "board_audit.db")
+    from tinyagentos.receipt_store import ReceiptStore
+    receipt_store = ReceiptStore(data_dir / "receipts.db")
     project_task_store = ProjectTaskStore(
         data_dir / "projects.db", broker=project_event_broker, audit=board_audit_store
     )
@@ -481,6 +483,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await project_store.init()
         await board_audit_store.init()
         app.state.board_audit = board_audit_store
+        await receipt_store.init()
+        app.state.receipt_store = receipt_store
         await project_task_store.init()
         await project_canvas_store.init()
         await decision_store.init()
@@ -1432,6 +1436,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.chat_channels = chat_channels
     app.state.project_store = project_store
     app.state.board_audit = board_audit_store
+    app.state.receipt_store = receipt_store
     app.state.project_task_store = project_task_store
     app.state.project_event_broker = project_event_broker
     app.state.desktop_command_broker = desktop_command_broker

--- a/tinyagentos/receipt_store.py
+++ b/tinyagentos/receipt_store.py
@@ -1,0 +1,191 @@
+"""Action receipts: the per-action audit record at the OS boundary (#155).
+
+A receipt is the portable, append-only record of a single agent action. It does
+NOT duplicate the lower-level records other stores already keep; it LINKS them
+(trace_id -> trace_store, board_audit_event_id -> board_audit, decision_id ->
+decisions) and adds the per-action fields that no single existing store owns:
+the canonical agent identity, the project/workspace hash, the allowed
+capability used, input refs/hashes, the tool call requested, the output ref,
+files changed, the stop reason, redactions, and whether a human approved a side
+effect.
+
+Like board_audit, this is append-only: there is deliberately no public update or
+delete method. That is the seed of the replayable, auditable "time machine"
+record (#103), and the reason the receipt belongs at the OS boundary rather than
+in any one agent harness. Returned in insertion order (SQLite rowid) so history
+is stable even when two receipts share a timestamp.
+
+This module is the storage layer (slice 1). Automatic emission from the
+fs-tools/tool-call loop, workspace/input hashing for replay, and the UI are
+later slices; nothing writes receipts automatically yet, so adding this changes
+no live behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+
+from tinyagentos.base_store import BaseStore
+
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+RECEIPTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS receipts (
+    id                   TEXT PRIMARY KEY,
+    agent_canonical_id   TEXT NOT NULL,
+    handle               TEXT NOT NULL DEFAULT '',
+    project_id           TEXT NOT NULL DEFAULT '',
+    workspace_hash       TEXT NOT NULL DEFAULT '',
+    capability           TEXT NOT NULL DEFAULT '',
+    capability_granted_at TEXT,
+    tool_name            TEXT NOT NULL DEFAULT '',
+    tool_args            TEXT NOT NULL DEFAULT '{}',
+    input_refs           TEXT NOT NULL DEFAULT '[]',
+    output_ref           TEXT NOT NULL DEFAULT '',
+    result_summary       TEXT NOT NULL DEFAULT '',
+    files_changed        TEXT NOT NULL DEFAULT '[]',
+    stop_reason          TEXT NOT NULL DEFAULT '',
+    redactions           TEXT NOT NULL DEFAULT '[]',
+    human_approval       TEXT,
+    trace_id             TEXT NOT NULL DEFAULT '',
+    board_audit_event_id TEXT NOT NULL DEFAULT '',
+    decision_id          TEXT NOT NULL DEFAULT '',
+    created_at           REAL NOT NULL,
+    created_by_user_id   TEXT NOT NULL DEFAULT '',
+    metadata             TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_receipts_agent ON receipts(agent_canonical_id);
+CREATE INDEX IF NOT EXISTS idx_receipts_project ON receipts(project_id);
+CREATE INDEX IF NOT EXISTS idx_receipts_trace ON receipts(trace_id);
+CREATE INDEX IF NOT EXISTS idx_receipts_decision ON receipts(decision_id);
+"""
+
+_COLS = (
+    "id, agent_canonical_id, handle, project_id, workspace_hash, capability, "
+    "capability_granted_at, tool_name, tool_args, input_refs, output_ref, "
+    "result_summary, files_changed, stop_reason, redactions, human_approval, "
+    "trace_id, board_audit_event_id, decision_id, created_at, created_by_user_id, metadata"
+)
+
+# Fields persisted as JSON text and parsed back on read.
+_JSON_FIELDS = ("tool_args", "input_refs", "files_changed", "redactions", "human_approval", "metadata")
+
+
+def _new_id() -> str:
+    return "rct-" + "".join(secrets.choice(_ALPHABET) for _ in range(8))
+
+
+def _row(r) -> dict:
+    d = {
+        "id": r[0], "agent_canonical_id": r[1], "handle": r[2], "project_id": r[3],
+        "workspace_hash": r[4], "capability": r[5], "capability_granted_at": r[6],
+        "tool_name": r[7], "tool_args": r[8], "input_refs": r[9], "output_ref": r[10],
+        "result_summary": r[11], "files_changed": r[12], "stop_reason": r[13],
+        "redactions": r[14], "human_approval": r[15], "trace_id": r[16],
+        "board_audit_event_id": r[17], "decision_id": r[18], "created_at": r[19],
+        "created_by_user_id": r[20], "metadata": r[21],
+    }
+    for f in _JSON_FIELDS:
+        if d.get(f) is not None:
+            try:
+                d[f] = json.loads(d[f])
+            except (TypeError, ValueError):
+                pass
+    return d
+
+
+class ReceiptStore(BaseStore):
+    """Append-only store of per-action receipts (#155).
+
+    No public update or delete: a receipt, once written, is immutable history.
+    Everything is link-by-id to the stores that own the underlying detail, so a
+    receipt stays small and portable while remaining auditable.
+    """
+
+    SCHEMA = RECEIPTS_SCHEMA
+
+    async def record(
+        self,
+        agent_canonical_id: str,
+        *,
+        handle: str = "",
+        project_id: str = "",
+        workspace_hash: str = "",
+        capability: str = "",
+        capability_granted_at: str | None = None,
+        tool_name: str = "",
+        tool_args: dict | None = None,
+        input_refs: list | None = None,
+        output_ref: str = "",
+        result_summary: str = "",
+        files_changed: list | None = None,
+        stop_reason: str = "",
+        redactions: list | None = None,
+        human_approval: dict | None = None,
+        trace_id: str = "",
+        board_audit_event_id: str = "",
+        decision_id: str = "",
+        created_by_user_id: str = "",
+        metadata: dict | None = None,
+    ) -> str:
+        """Append a receipt. Returns the receipt id. agent_canonical_id is the
+        only required field, since a receipt must always attribute to a stable
+        subject; everything else is optional so partial receipts are still valid
+        history (the capture hooks fill in what each call site knows)."""
+        if not agent_canonical_id:
+            raise ValueError("agent_canonical_id is required")
+        rid = _new_id()
+        now = time.time()
+        await self._db.execute(
+            f"INSERT INTO receipts ({_COLS}) VALUES "
+            "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                rid, agent_canonical_id, handle, project_id, workspace_hash, capability,
+                capability_granted_at, tool_name, json.dumps(tool_args or {}),
+                json.dumps(input_refs or []), output_ref, result_summary,
+                json.dumps(files_changed or []), stop_reason, json.dumps(redactions or []),
+                json.dumps(human_approval) if human_approval is not None else None,
+                trace_id, board_audit_event_id, decision_id, now, created_by_user_id,
+                json.dumps(metadata or {}),
+            ),
+        )
+        await self._db.commit()
+        return rid
+
+    async def get(self, receipt_id: str) -> dict | None:
+        async with self._db.execute(
+            f"SELECT {_COLS} FROM receipts WHERE id = ?", (receipt_id,)
+        ) as cur:
+            r = await cur.fetchone()
+        return _row(r) if r else None
+
+    async def list(
+        self,
+        *,
+        agent_canonical_id: str | None = None,
+        project_id: str | None = None,
+        trace_id: str | None = None,
+        created_by_user_id: str | None = None,
+        limit: int = 200,
+    ) -> list[dict]:
+        """Newest-first receipts (insertion order via rowid), optionally filtered.
+        The result set is bounded so a long-lived ledger cannot return everything."""
+        conds, params = [], []
+        if agent_canonical_id is not None:
+            conds.append("agent_canonical_id = ?"); params.append(agent_canonical_id)
+        if project_id is not None:
+            conds.append("project_id = ?"); params.append(project_id)
+        if trace_id is not None:
+            conds.append("trace_id = ?"); params.append(trace_id)
+        if created_by_user_id is not None:
+            conds.append("created_by_user_id = ?"); params.append(created_by_user_id)
+        where = (" WHERE " + " AND ".join(conds)) if conds else ""
+        limit = max(1, min(int(limit), 1000))
+        async with self._db.execute(
+            f"SELECT {_COLS} FROM receipts{where} ORDER BY rowid DESC LIMIT ?",
+            [*params, limit],
+        ) as cur:
+            rows = await cur.fetchall()
+        return [_row(r) for r in rows]

--- a/tinyagentos/receipt_store.py
+++ b/tinyagentos/receipt_store.py
@@ -24,10 +24,13 @@ no live behaviour.
 from __future__ import annotations
 
 import json
+import logging
 import secrets
 import time
 
 from tinyagentos.base_store import BaseStore
+
+logger = logging.getLogger(__name__)
 
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
 
@@ -60,6 +63,7 @@ CREATE INDEX IF NOT EXISTS idx_receipts_agent ON receipts(agent_canonical_id);
 CREATE INDEX IF NOT EXISTS idx_receipts_project ON receipts(project_id);
 CREATE INDEX IF NOT EXISTS idx_receipts_trace ON receipts(trace_id);
 CREATE INDEX IF NOT EXISTS idx_receipts_decision ON receipts(decision_id);
+CREATE INDEX IF NOT EXISTS idx_receipts_user ON receipts(created_by_user_id);
 """
 
 _COLS = (
@@ -92,7 +96,11 @@ def _row(r) -> dict:
             try:
                 d[f] = json.loads(d[f])
             except (TypeError, ValueError):
-                pass
+                # An audit ledger must surface corruption, not silently pass a
+                # malformed entry off as valid data. Keep the raw value (lossless)
+                # but flag it so the bad row is visible, and log it.
+                logger.warning("receipt %s: unparseable JSON in field %r", d.get("id"), f)
+                d[f] = {"_unparsed": d[f]}
     return d
 
 

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -349,3 +349,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes.coding_sessions import router as coding_sessions_router
     app.include_router(coding_sessions_router)
+
+    from tinyagentos.routes.receipts import router as receipts_router
+    app.include_router(receipts_router)

--- a/tinyagentos/routes/receipts.py
+++ b/tinyagentos/routes/receipts.py
@@ -1,0 +1,97 @@
+"""Action receipts API (#155): the per-action audit ledger at the OS boundary.
+
+Append-only. Receipts link the records other stores already own (trace_id,
+board_audit_event_id, decision_id) plus the per-action fields no single store
+holds. Reads are scoped: an admin sees every receipt, a non-admin sees only the
+receipts stamped with their own user id, so the ledger never leaks across users.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user
+
+router = APIRouter()
+
+
+def _store(request: Request):
+    return getattr(request.app.state, "receipt_store", None)
+
+
+class ReceiptIn(BaseModel):
+    agent_canonical_id: str
+    handle: str = ""
+    project_id: str = ""
+    workspace_hash: str = ""
+    capability: str = ""
+    capability_granted_at: str | None = None
+    tool_name: str = ""
+    tool_args: dict | None = None
+    input_refs: list | None = None
+    output_ref: str = ""
+    result_summary: str = ""
+    files_changed: list | None = None
+    stop_reason: str = ""
+    redactions: list | None = None
+    human_approval: dict | None = None
+    trace_id: str = ""
+    board_audit_event_id: str = ""
+    decision_id: str = ""
+    metadata: dict | None = None
+
+
+@router.post("/api/receipts")
+async def create_receipt(body: ReceiptIn, request: Request, user: CurrentUser = Depends(current_user)):
+    """Append an action receipt. Any authenticated caller (an agent at the OS
+    boundary, or a tool) may write one; the receipt is stamped with the caller's
+    user id so reads can be scoped."""
+    store = _store(request)
+    if store is None:
+        return JSONResponse({"error": "receipt store unavailable"}, status_code=503)
+    if not body.agent_canonical_id.strip():
+        return JSONResponse({"error": "agent_canonical_id is required"}, status_code=400)
+    fields = body.model_dump()
+    agent = fields.pop("agent_canonical_id")
+    rid = await store.record(agent, created_by_user_id=user.user_id, **fields)
+    return {"id": rid, "agent_canonical_id": agent}
+
+
+@router.get("/api/receipts/{receipt_id}")
+async def get_receipt(receipt_id: str, request: Request, user: CurrentUser = Depends(current_user)):
+    store = _store(request)
+    if store is None:
+        return JSONResponse({"error": "receipt store unavailable"}, status_code=503)
+    rec = await store.get(receipt_id)
+    if rec is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    # Non-admins may only read their own receipts; do not leak existence either.
+    if not user.is_admin and rec.get("created_by_user_id") != user.user_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return rec
+
+
+@router.get("/api/receipts")
+async def list_receipts(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+    agent: str | None = None,
+    project: str | None = None,
+    trace: str | None = None,
+    limit: int = 200,
+):
+    """List receipts newest-first, optionally filtered by agent/project/trace.
+    Admins see all; everyone else is scoped to their own receipts."""
+    store = _store(request)
+    if store is None:
+        return JSONResponse({"error": "receipt store unavailable"}, status_code=503)
+    receipts = await store.list(
+        agent_canonical_id=agent,
+        project_id=project,
+        trace_id=trace,
+        created_by_user_id=None if user.is_admin else user.user_id,
+        limit=limit,
+    )
+    return {"count": len(receipts), "receipts": receipts}

--- a/tinyagentos/routes/receipts.py
+++ b/tinyagentos/routes/receipts.py
@@ -22,8 +22,11 @@ def _store(request: Request):
 
 
 class ReceiptIn(BaseModel):
+    # `handle` is deliberately NOT accepted from the caller: it is a display
+    # convenience that must derive from the agent registry, never be writer-set,
+    # so it cannot be spoofed against the authoritative canonical id. The capture
+    # hooks (slice 2) fill it server-side from the registry.
     agent_canonical_id: str
-    handle: str = ""
     project_id: str = ""
     workspace_hash: str = ""
     capability: str = ""


### PR DESCRIPTION
First slice of the action-receipt layer you greenlit (the Telos/Harper thread). A receipt is the per-action, append-only record at the OS boundary.

**Design: link, do not duplicate.** The receipt references the records other stores already own and adds the per-action fields no single store holds:
- `trace_id` -> trace_store, `board_audit_event_id` -> board_audit (ba-*), `decision_id` -> decisions (dec-*), `agent_canonical_id` -> agent_registry (the minted id, never the handle), `capability` + `capability_granted_at` -> agent_grants
- own fields: workspace_hash, tool_name/tool_args, input_refs, output_ref, result_summary, files_changed, stop_reason, redactions, human_approval (decision_id + answered_by + answered_at + value)

**Append-only** like board_audit (no update/delete) -- the seed of the replayable, auditable record (#103). It lives in the OS, not the harness, which is what makes it a portability layer between agents.

**Behaviour-inert:** nothing emits receipts automatically yet (capture hooks are slice 2), so this only adds a store + API.

What's here:
- `receipt_store.py` (record/get/list, JSON round-trip, clamped list)
- `routes/receipts.py`: `POST/GET /api/receipts`, `GET /api/receipts/{id}`; reads scoped (admin sees all, others only their own, no cross-user existence leak)
- registered in app.py + routes/__init__; conftest inits the store
- 13 tests (store round-trip, append-only surface guard, list filters, route scoping) -- all green locally

Build order in `~/tinyagentos-private/specs/action-receipts-design.md`: (1) this; (2) capture hooks in the fs-tools loop + deploy + trace boundary; (3) workspace/input hashing + replay; (4) human-approval link to Decisions; (5) ledger UI + signed/exportable receipt bundles.

**Held for your review** of the canonical schema before slice 2 builds on it. Open questions in the spec: receipt signing (Ed25519 registry keypair already exists), redaction policy, replay scope (coding-domain via git first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an append-only receipts API to create, fetch, and list action receipts.
  * Receipts include server-stamped creator identity, newest-first ordering, and filters (agent/project/trace) with clamped pagination.
  * Admins can access all receipts; non-admins are restricted to their own.

* **Bug Fixes**
  * Rejects blank `agent_canonical_id` on receipt creation.
  * Detects and surfaces malformed stored JSON instead of silently accepting it.
  * Ensures missing receipts return `null`/no data rather than errors.

* **Tests**
  * Expanded end-to-end and route coverage for stamping, access control, filtering, sorting, limits, and append-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->