### PR TITLE
feat(receipts): content hashing for verifiable inputs/outputs (#155 slice 3)

### DIFF
--- a/tests/test_receipts_capture.py
+++ b/tests/test_receipts_capture.py
@@ -53,10 +53,18 @@ def test_redact_does_not_over_mask_long_benign_strings():
 
 
 def test_summarize_result_variants():
-    assert summarize_result({"error": "boom"})[3] == "error"
-    _, _, fc, stop = summarize_result({"status": "written", "bytes": 12})
-    assert stop == "completed" and fc == [{"bytes": 12}]
-    assert summarize_result("plain string")[3] == "completed"
+    assert summarize_result({"error": "boom"})[2] == "error"
+    out, _summary, stop = summarize_result({"status": "written", "bytes": 12})
+    assert stop == "completed" and out == ""
+    assert summarize_result("plain string")[2] == "completed"
+
+
+def test_derive_io_byte_count_is_utf8_not_char_count():
+    # Non-ASCII content: bytes must be the UTF-8 byte length, not the char count.
+    content = "h\u00e9llo"  # e-acute is 2 bytes in UTF-8: 6 bytes, 5 chars
+    _, fc = derive_io("file_write", {"path": "a.py", "content": content}, {"status": "written"})
+    assert fc[0]["bytes"] == len(content.encode("utf-8")) == 6
+    assert fc[0]["bytes"] != len(content)
 
 
 def test_hash_text_is_stable_and_prefixed():

--- a/tests/test_receipts_capture.py
+++ b/tests/test_receipts_capture.py
@@ -67,6 +67,13 @@ def test_derive_io_byte_count_is_utf8_not_char_count():
     assert fc[0]["bytes"] != len(content)
 
 
+def test_derive_io_byte_count_handles_bytes_content():
+    # bytes/bytearray content must count actual bytes, not len(str(b"...")) repr.
+    content = b"h\xc3\xa9llo"  # UTF-8 for h-e-acute-llo: 6 bytes
+    _, fc = derive_io("file_write", {"path": "a.bin", "content": content}, {"status": "written"})
+    assert fc[0]["bytes"] == len(content) == 6
+
+
 def test_hash_text_is_stable_and_prefixed():
     h = hash_text("hello")
     assert h.startswith("sha256:") and h == hash_text("hello")

--- a/tests/test_receipts_capture.py
+++ b/tests/test_receipts_capture.py
@@ -84,6 +84,21 @@ def test_derive_io_file_write_error_has_no_files_changed():
     assert refs and fc == []  # input recorded, but nothing was actually written
 
 
+def test_derive_io_file_write_unconfirmed_result_records_no_change():
+    # A non-error result that does NOT confirm the write (no status="written")
+    # must not put a false file change in the ledger.
+    refs, fc = derive_io("file_write", {"path": "a.py", "content": "x"}, {"queued": True})
+    assert refs and fc == []
+    refs2, fc2 = derive_io("file_write", {"path": "a.py", "content": "x"}, "weird-non-dict")
+    assert refs2 and fc2 == []
+
+
+def test_derive_io_file_write_prefers_tool_reported_bytes():
+    # When the tool reports the bytes it wrote, trust that over recomputing.
+    _, fc = derive_io("file_write", {"path": "a.py", "content": "hello"}, {"status": "written", "bytes": 99})
+    assert fc[0]["bytes"] == 99
+
+
 def test_derive_io_code_and_read():
     refs, _ = derive_io("code_exec", {"code": "print(1)"}, {"returncode": 0})
     assert refs[0]["name"] == "code" and refs[0]["hash"] == hash_text("print(1)")

--- a/tests/test_receipts_capture.py
+++ b/tests/test_receipts_capture.py
@@ -2,7 +2,7 @@ import pytest
 import pytest_asyncio
 
 from tinyagentos.receipt_store import ReceiptStore
-from tinyagentos.receipts import emit_tool_receipt, redact_args, summarize_result
+from tinyagentos.receipts import derive_io, emit_tool_receipt, hash_text, redact_args, summarize_result
 
 
 @pytest_asyncio.fixture
@@ -59,20 +59,45 @@ def test_summarize_result_variants():
     assert summarize_result("plain string")[3] == "completed"
 
 
+def test_hash_text_is_stable_and_prefixed():
+    h = hash_text("hello")
+    assert h.startswith("sha256:") and h == hash_text("hello")
+    assert hash_text("hello") != hash_text("world")
+
+
+def test_derive_io_file_write_hashes_content():
+    refs, fc = derive_io("file_write", {"path": "a.py", "content": "hello"}, {"status": "written", "bytes": 5})
+    assert refs[0]["name"] == "content" and refs[0]["hash"] == hash_text("hello")
+    assert fc[0]["path"] == "a.py" and fc[0]["hash_after"] == hash_text("hello") and fc[0]["bytes"] == 5
+
+
+def test_derive_io_file_write_error_has_no_files_changed():
+    refs, fc = derive_io("file_write", {"path": "a.py", "content": "x"}, {"error": "Path outside workspace"})
+    assert refs and fc == []  # input recorded, but nothing was actually written
+
+
+def test_derive_io_code_and_read():
+    refs, _ = derive_io("code_exec", {"code": "print(1)"}, {"returncode": 0})
+    assert refs[0]["name"] == "code" and refs[0]["hash"] == hash_text("print(1)")
+    refs2, _ = derive_io("file_read", {"path": "a.py"}, {"content": "data"})
+    assert any(r.get("name") == "content_read" and r["hash"] == hash_text("data") for r in refs2)
+
+
 @pytest.mark.asyncio
 async def test_emit_tool_receipt_writes_a_receipt(store):
     await emit_tool_receipt(
         store, agent="taos-dev-20260629-1", tool_name="file_write",
-        args={"path": "a.py", "secret": "shh"},
+        args={"path": "a.py", "content": "hello", "secret": "shh"},
         result={"status": "written", "bytes": 5},
-        files_changed=[{"path": "a.py", "bytes": 5}],
     )
     rows = await store.list(agent_canonical_id="taos-dev-20260629-1")
     assert len(rows) == 1
     r = rows[0]
     assert r["tool_name"] == "file_write"
     assert r["tool_args"]["secret"] == "[REDACTED]"      # baseline redaction applied
-    assert r["files_changed"] == [{"path": "a.py", "bytes": 5}]
+    fc = r["files_changed"][0]
+    assert fc["path"] == "a.py" and fc["bytes"] == 5 and fc["hash_after"].startswith("sha256:")
+    assert any(ir.get("name") == "content" for ir in r["input_refs"])
     assert r["stop_reason"] == "completed"
     assert any(x["field"] == "secret" for x in r["redactions"])
 

--- a/tinyagentos/receipts.py
+++ b/tinyagentos/receipts.py
@@ -50,7 +50,11 @@ def derive_io(tool_name: str, args: dict, result) -> tuple[list[dict], list[dict
             # recomputed count. Fall back to the UTF-8 byte length of content.
             byte_count = result.get("bytes")
             if byte_count is None:
-                byte_count = len(str(content).encode("utf-8", "replace"))
+                # Mirror hash_text: count bytes as-is, everything else as UTF-8.
+                byte_count = len(
+                    content if isinstance(content, (bytes, bytearray))
+                    else str(content).encode("utf-8", "replace")
+                )
             files_changed.append(
                 {"path": args.get("path", ""), "hash_after": h, "bytes": byte_count}
             )

--- a/tinyagentos/receipts.py
+++ b/tinyagentos/receipts.py
@@ -15,10 +15,43 @@ secrets-store value masking layer on in a later slice.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 
 logger = logging.getLogger(__name__)
+
+
+def hash_text(s) -> str:
+    """Content fingerprint for a receipt. Safe to store even when the content was
+    secret: the hash does not reveal it, but lets another person verify a replay
+    produced the same bytes."""
+    return "sha256:" + hashlib.sha256(str(s).encode("utf-8", "replace")).hexdigest()
+
+
+def derive_io(tool_name: str, args: dict, result) -> tuple[list[dict], list[dict]]:
+    """Return (input_refs, files_changed) with content hashes for the tool call,
+    so the receipt records exactly what went in and what changed. Tool-specific;
+    unknown tools get empty lists (the receipt still carries tool_name + args)."""
+    args = args or {}
+    is_error = isinstance(result, dict) and bool(result.get("error"))
+    input_refs: list[dict] = []
+    files_changed: list[dict] = []
+    if tool_name == "file_write":
+        content = args.get("content", "")
+        h = hash_text(content)
+        input_refs.append({"name": "content", "hash": h})
+        if not is_error:
+            files_changed.append(
+                {"path": args.get("path", ""), "hash_after": h, "bytes": len(str(content))}
+            )
+    elif tool_name == "code_exec":
+        input_refs.append({"name": "code", "hash": hash_text(args.get("code", ""))})
+    elif tool_name == "file_read":
+        input_refs.append({"name": "path", "value": args.get("path", "")})
+        if not is_error and isinstance(result, dict) and "content" in result:
+            input_refs.append({"name": "content_read", "hash": hash_text(result.get("content", ""))})
+    return input_refs, files_changed
 
 # Baseline secret patterns. Conservative on purpose: better to mask a few benign
 # long tokens than to leak a real key into a portable receipt. The user policy
@@ -85,23 +118,25 @@ async def emit_tool_receipt(
     args: dict,
     result,
     project_id: str = "",
-    files_changed: list | None = None,
 ) -> None:
     """Write one receipt for a tool call. Fail-soft: any error is logged and
     swallowed so a receipt write can never disrupt the agent. Intended to be
-    scheduled fire-and-forget by the route."""
+    scheduled fire-and-forget by the route. input_refs + files_changed (with
+    content hashes) are derived from the tool name, args, and result."""
     if store is None or not agent:
         return
     try:
         red_args, redactions = redact_args(args)
-        output_ref, summary, fc_from_result, stop_reason = summarize_result(result)
+        output_ref, summary, _fc, stop_reason = summarize_result(result)
+        input_refs, files_changed = derive_io(tool_name, args, result)
         await store.record(
             agent,
             tool_name=tool_name,
             tool_args=red_args,
             result_summary=summary,
             output_ref=output_ref,
-            files_changed=files_changed if files_changed is not None else fc_from_result,
+            input_refs=input_refs,
+            files_changed=files_changed,
             stop_reason=stop_reason,
             redactions=redactions,
             project_id=project_id,

--- a/tinyagentos/receipts.py
+++ b/tinyagentos/receipts.py
@@ -42,9 +42,17 @@ def derive_io(tool_name: str, args: dict, result) -> tuple[list[dict], list[dict
         content = args.get("content", "")
         h = hash_text(content)
         input_refs.append({"name": "content", "hash": h})
-        if not is_error:
+        # Only record a file change once the tool CONFIRMS the write (status ==
+        # "written"). A non-error-but-malformed result is not proof a write
+        # landed, so recording one would put a false change in the ledger.
+        if isinstance(result, dict) and result.get("status") == "written":
+            # The tool reports the bytes it actually wrote; trust that over a
+            # recomputed count. Fall back to the UTF-8 byte length of content.
+            byte_count = result.get("bytes")
+            if byte_count is None:
+                byte_count = len(str(content).encode("utf-8", "replace"))
             files_changed.append(
-                {"path": args.get("path", ""), "hash_after": h, "bytes": len(str(content).encode("utf-8", "replace"))}
+                {"path": args.get("path", ""), "hash_after": h, "bytes": byte_count}
             )
     elif tool_name == "code_exec":
         input_refs.append({"name": "code", "hash": hash_text(args.get("code", ""))})

--- a/tinyagentos/receipts.py
+++ b/tinyagentos/receipts.py
@@ -25,8 +25,9 @@ logger = logging.getLogger(__name__)
 def hash_text(s) -> str:
     """Content fingerprint for a receipt. Safe to store even when the content was
     secret: the hash does not reveal it, but lets another person verify a replay
-    produced the same bytes."""
-    return "sha256:" + hashlib.sha256(str(s).encode("utf-8", "replace")).hexdigest()
+    produced the same bytes. Hashes bytes as-is; everything else as UTF-8."""
+    data = s if isinstance(s, (bytes, bytearray)) else str(s).encode("utf-8", "replace")
+    return "sha256:" + hashlib.sha256(data).hexdigest()
 
 
 def derive_io(tool_name: str, args: dict, result) -> tuple[list[dict], list[dict]]:
@@ -43,7 +44,7 @@ def derive_io(tool_name: str, args: dict, result) -> tuple[list[dict], list[dict
         input_refs.append({"name": "content", "hash": h})
         if not is_error:
             files_changed.append(
-                {"path": args.get("path", ""), "hash_after": h, "bytes": len(str(content))}
+                {"path": args.get("path", ""), "hash_after": h, "bytes": len(str(content).encode("utf-8", "replace"))}
             )
     elif tool_name == "code_exec":
         input_refs.append({"name": "code", "hash": hash_text(args.get("code", ""))})
@@ -91,23 +92,18 @@ def redact_args(args: dict) -> tuple[dict, list[dict]]:
     return out, redactions
 
 
-def summarize_result(result) -> tuple[str, str, list[dict], str]:
-    """Derive (output_ref, result_summary, files_changed, stop_reason) from a
-    skill result dict. Kept small: full payloads live in the trace store, the
-    receipt only needs a pointer + a human summary."""
+def summarize_result(result) -> tuple[str, str, str]:
+    """Derive (output_ref, result_summary, stop_reason) from a skill result.
+    Kept small: full payloads live in the trace store, the receipt needs only a
+    pointer + a human summary. files_changed is owned by derive_io (which has the
+    args + content hashes), so it is intentionally not produced here."""
     if not isinstance(result, dict):
-        return "", str(result)[:200], [], "completed"
+        return "", str(result)[:200], "completed"
     if result.get("error"):
-        return "", str(result.get("error"))[:200], [], "error"
-    files_changed: list[dict] = []
-    # file_write returns {"status": "written", "bytes": N}; the path is in args,
-    # threaded in by the caller, so files_changed is enriched there. Here we only
-    # surface the byte count if present.
-    if result.get("status") == "written" and "bytes" in result:
-        files_changed = [{"bytes": result.get("bytes")}]
+        return "", str(result.get("error"))[:200], "error"
     # Short, lossy summary; the trace store holds the full result.
     summary = ", ".join(f"{k}={str(v)[:60]}" for k, v in result.items() if k != "content")[:200]
-    return "", summary, files_changed, "completed"
+    return "", summary, "completed"
 
 
 async def emit_tool_receipt(
@@ -127,7 +123,7 @@ async def emit_tool_receipt(
         return
     try:
         red_args, redactions = redact_args(args)
-        output_ref, summary, _fc, stop_reason = summarize_result(result)
+        output_ref, summary, stop_reason = summarize_result(result)
         input_refs, files_changed = derive_io(tool_name, args, result)
         await store.record(
             agent,

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -479,14 +479,11 @@ def _capture_tool_receipt(request: Request, skill_id: str, args: dict, result) -
         agent = (args.get("agent_name") or "").strip()
         if store is None or not agent:
             return
-        files_changed = None
-        if skill_id == "file_write" and isinstance(result, dict) and not result.get("error"):
-            files_changed = [{"path": args.get("path", ""), "bytes": result.get("bytes")}]
         # agent_name is identity, not a tool argument; keep it out of tool_args.
+        # input_refs + files_changed (with content hashes) are derived in receipts.
         tool_args = {k: v for k, v in args.items() if k != "agent_name"}
         task = asyncio.create_task(emit_tool_receipt(
-            store, agent=agent, tool_name=skill_id, args=tool_args,
-            result=result, files_changed=files_changed,
+            store, agent=agent, tool_name=skill_id, args=tool_args, result=result,
         ))
         # Keep a strong reference until the task finishes, else it can be GC'd.
         _bg_receipt_tasks.add(task)


### PR DESCRIPTION
Slice 3 of the action-receipt layer: receipts become **verifiable**. Each captured tool call now records content fingerprints, so someone auditing a receipt can confirm a replay produced the same bytes.

- `hash_text()` -> `sha256:...` fingerprint. Safe to store even if the content was a secret (the hash does not reveal it, but pins exactly what went in/out).
- `derive_io(tool_name, args, result)` centralises per-tool I/O capture: `file_write` records the content hash as an `input_ref` and as `files_changed.hash_after` (+ bytes); `code_exec` hashes the code; `file_read` records the path + the hash of what was read; an errored tool records its inputs but no `files_changed`.
- `emit_tool_receipt` derives `input_refs` + `files_changed` itself; the fs-tools hook simplifies to just pass args/result (no per-tool special case). Still fail-soft + fire-and-forget.
- 4 hashing tests added; 24 pass across capture + skill_exec + store, no regressions.

Replay itself (restore workspace + re-run) stays a later slice leaning on git/#102 -- this is the hashing foundation. Next: slice 4 wires the `approve_deny` Decision into `human_approval`; slice 5 is the ledger UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool receipt capture to record deterministic input references and hashed file-content fingerprints for file writes, reads, and code execution.
  * Receipt generation is more consistent: file changes are only recorded when writes succeed, and write-byte evidence now prefers tool-reported values when available.

* **Tests**
  * Expanded unit and integration test coverage for receipt I/O derivation and hashing behavior.
  * Updated assertions to match the new receipt structure and hash-based `files_changed` expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->