### PR TITLE
feat(auth): per-agent registry-identity auth for the A2A bus read proxy (#138 Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,10 @@ Create shared file spaces for agents, groups, and departments. The design team s
 ### Authentication
 Password-protected dashboard with persistent sessions. Per-agent API keys. Exempt paths for cluster workers and health checks.
 
+**Agents authenticate with their own identity, not the owner password.** Each registered agent has an Ed25519 registry identity (canonical id + signed JWT). The owner password is human-only and is never handed to an agent. An agent calls scoped endpoints by presenting `Authorization: Bearer <registry-jwt>`; the route verifies the signature against the registry public key and checks the agent is active and holds the required scope grant. Today this covers the registry feed endpoints (scope `registry_feeds_read`) and the read-only A2A bus proxy `/api/a2a/bus/channels` + `/api/a2a/bus/messages` (scope `a2a_receive`). The Bearer allowlist is exact: a registry JWT authenticates only those agent paths, never an arbitrary route.
+
+Onboarding an internal driver agent: an admin mints its identity once with `taosctl agents mint --handle @taOS-dev --slug taos-dev --scopes a2a_send,a2a_receive` (or `taosctl agents seed-internal` to mint the four built-in driver agents idempotently). Minting prints the registry JWT; store it on the agent host in a gitignored per-host file (for example `~/.config/taos/agent-token`) and have the agent send it as `Authorization: Bearer <jwt>`. Re-running mint/seed for an existing handle reuses the same canonical id and re-asserts the grants, so it is safe to run again.
+
 ### Model Conversion
 Convert models between formats (GGUF→RKLLM, HF→GGUF, GGUF→MLX). Capability-gated, "Convert for NPU" button appears when an x86 worker joins the cluster.
 

--- a/docs/design/external-agent-onboarding.md
+++ b/docs/design/external-agent-onboarding.md
@@ -59,6 +59,29 @@ taOSmd's `has_grant` (post-merge fix `fcc0fd7`) **fails closed on a non-numeric 
 - Anti-spoof: the enforced `project_id`/`user_id` come from the verified token claim, never the request body.
 - Reattach is append-only, so the governance audit log (#730) shows every shelf change.
 
+## Phase 1 shipped: bus read with a registry JWT
+
+The first enforcement slice is live on the controller. An agent reads the
+read-only A2A bus proxy with its OWN registry identity, never the owner
+password:
+
+- Endpoints: `GET /api/agents/registry/grants` + `/revoked` (scope
+  `registry_feeds_read`) and `GET /api/a2a/bus/channels` + `/api/a2a/bus/messages`
+  (scope `a2a_receive`). These are the only paths that accept a registry JWT in
+  place of the admin session; the Bearer allowlist is exact (no skeleton key).
+- The agent presents `Authorization: Bearer <registry-jwt>`. The route verifies
+  the Ed25519 signature against the registry public key, requires the agent be
+  `active`, and requires an active (non-expired) grant for the scope. Malformed
+  or wrong-key tokens get 401; valid-but-unauthorized get 403. Fail closed.
+- Token storage: the operator stores the minted JWT on the agent host in a
+  gitignored per-host file (for example `~/.config/taos/agent-token`); the agent
+  reads it from there. Tokens are never written into the repo.
+- Minting the four internal driver agents (@taOS-dev, @taOS-website-dev,
+  @taOSmd-dev, @Hermes), idempotently by handle:
+  `taosctl agents seed-internal` (or `taosctl agents mint --handle @X --slug x
+  --scopes a2a_send,a2a_receive`). Re-running reuses the existing canonical id
+  and re-asserts the grants.
+
 ## Open questions
 
 - Default scope set for a coding agent: `memory_read` + `memory_write` + `a2a_send` + `a2a_receive`; `files_*` / `tools_execute` gated tighter (probably off by default).

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -8,6 +8,7 @@ skeleton-key guard (the agent token must not authenticate any other route).
 from __future__ import annotations
 
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,6 +22,39 @@ from tinyagentos.agent_registry_store import (
 )
 
 _BUS_PATCH = "tinyagentos.routes.a2a_bus.httpx.AsyncClient"
+
+
+class TestGrantUnexpired:
+    """Grant-expiry must be parsed, not string-compared: a naive or oddly
+    formatted timestamp must never read an expired grant as live (access after
+    revocation). Fail closed on anything unparseable."""
+
+    def _now(self):
+        return datetime(2026, 6, 29, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_none_never_expires(self):
+        from tinyagentos.agent_token_auth import _grant_unexpired
+        assert _grant_unexpired(None, self._now()) is True
+
+    def test_future_aware_is_live(self):
+        from tinyagentos.agent_token_auth import _grant_unexpired
+        now = self._now()
+        assert _grant_unexpired((now + timedelta(hours=1)).isoformat(), now) is True
+
+    def test_past_aware_is_expired(self):
+        from tinyagentos.agent_token_auth import _grant_unexpired
+        now = self._now()
+        assert _grant_unexpired((now - timedelta(hours=1)).isoformat(), now) is False
+
+    def test_naive_past_assumed_utc_is_expired(self):
+        from tinyagentos.agent_token_auth import _grant_unexpired
+        now = self._now()
+        naive_past = (now - timedelta(hours=1)).replace(tzinfo=None).isoformat()
+        assert _grant_unexpired(naive_past, now) is False
+
+    def test_unparseable_fails_closed(self):
+        from tinyagentos.agent_token_auth import _grant_unexpired
+        assert _grant_unexpired("not-a-timestamp", self._now()) is False
 
 
 def _mock_bus_client(json_payload: dict):

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -1,0 +1,239 @@
+"""Agent-token authentication for the read-only A2A bus proxy.
+
+An agent reads /api/a2a/bus/* with its OWN Ed25519 registry JWT (scope
+a2a_receive), never the owner session/password.  These tests cover the full
+edge-case matrix Jay flagged plus the admin/local-token regressions and the
+skeleton-key guard (the agent token must not authenticate any other route).
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import (
+    load_or_create_signing_keypair,
+    mint_registry_token,
+)
+
+_BUS_PATCH = "tinyagentos.routes.a2a_bus.httpx.AsyncClient"
+
+
+def _mock_bus_client(json_payload: dict):
+    """A mock httpx.AsyncClient whose async context manager yields a client whose
+    .get().json() returns *json_payload* (so no real network call is made)."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = json_payload
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_ctx
+
+
+@pytest_asyncio.fixture
+async def bus_client(app, tmp_data_dir):
+    """Admin client with the registry + grants stores initialised.
+
+    Exposes ._app so tests can register agents / mint tokens directly against the
+    stores and drive bare (cookieless) requests with a Bearer header.
+    """
+    for attr in ("agent_registry", "agent_grants", "metrics"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        c._app = app
+        c._test_admin_uid = uid
+        yield c
+
+    for attr in ("agent_registry", "agent_grants", "metrics"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+async def _make_agent_token(app, *, scopes=("a2a_receive",), origin="taos-deployed"):
+    """Register an agent, add its grants, and return (canonical_id, signed JWT)."""
+    registry = app.state.agent_registry
+    grants = app.state.agent_grants
+    priv, _pub = app.state.agent_registry_keypair
+
+    rec = await registry.register(
+        framework="taosmd",
+        display_name="Bus Reader",
+        origin=origin,
+        handle="@bus-reader",
+    )
+    cid = rec["canonical_id"]
+    for scope in scopes:
+        await grants.add_grant(cid, scope)
+    token = mint_registry_token(cid, priv, user_id="u", framework="taosmd")
+    return cid, token
+
+
+def _bare(app):
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+class TestBusAgentAuth:
+
+    async def test_agent_with_receive_scope_reads_channels(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app)
+        with patch(_BUS_PATCH, return_value=_mock_bus_client({"channels": []})):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.get(
+                    "/api/a2a/bus/channels",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["available"] is True
+
+    async def test_agent_with_receive_scope_reads_messages(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app)
+        with patch(_BUS_PATCH, return_value=_mock_bus_client({"messages": []})):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.get(
+                    "/api/a2a/bus/messages",
+                    params={"channel": "general"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["available"] is True
+
+    async def test_agent_without_receive_scope_gets_403(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.get(
+                "/api/a2a/bus/channels",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 403
+
+    async def test_suspended_agent_gets_403(self, bus_client):
+        cid, token = await _make_agent_token(bus_client._app)
+        await bus_client._app.state.agent_registry.set_status(cid, "suspended")
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.get(
+                "/api/a2a/bus/channels",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 403
+
+    async def test_revoked_agent_gets_403(self, bus_client):
+        cid, token = await _make_agent_token(bus_client._app)
+        await bus_client._app.state.agent_registry.revoke(cid)
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.get(
+                "/api/a2a/bus/messages",
+                params={"channel": "general"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 403
+
+    async def test_malformed_token_gets_401(self, bus_client):
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.get(
+                "/api/a2a/bus/channels",
+                headers={"Authorization": "Bearer not-a-valid-token"},
+            )
+        assert resp.status_code == 401
+
+    async def test_token_signed_by_different_key_gets_401(self, bus_client):
+        # Register the agent so the sub exists, but sign with a foreign key.
+        registry = bus_client._app.state.agent_registry
+        grants = bus_client._app.state.agent_grants
+        rec = await registry.register(framework="taosmd", display_name="Foreign", handle="@foreign")
+        cid = rec["canonical_id"]
+        await grants.add_grant(cid, "a2a_receive")
+        with tempfile.TemporaryDirectory() as d:
+            foreign_priv, _foreign_pub = load_or_create_signing_keypair(Path(d))
+        bad_token = mint_registry_token(cid, foreign_priv, user_id="u", framework="taosmd")
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.get(
+                "/api/a2a/bus/channels",
+                headers={"Authorization": f"Bearer {bad_token}"},
+            )
+        assert resp.status_code == 401
+
+    async def test_valid_sig_unknown_sub_gets_403(self, bus_client):
+        # Properly signed by the app key but the sub is not in the registry.
+        priv, _pub = bus_client._app.state.agent_registry_keypair
+        token = mint_registry_token("ghost-20260101-000000", priv, user_id="u", framework="taosmd")
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.get(
+                "/api/a2a/bus/channels",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 403
+
+    async def test_expired_grant_gets_403(self, bus_client):
+        from datetime import datetime, timezone, timedelta
+
+        registry = bus_client._app.state.agent_registry
+        grants = bus_client._app.state.agent_grants
+        rec = await registry.register(framework="taosmd", display_name="Expired", handle="@expired")
+        cid = rec["canonical_id"]
+        past = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+        await grants.add_grant(cid, "a2a_receive", expires_at=past)
+        priv, _pub = bus_client._app.state.agent_registry_keypair
+        token = mint_registry_token(cid, priv, user_id="u", framework="taosmd")
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.get(
+                "/api/a2a/bus/channels",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 403
+
+    async def test_admin_session_still_reads_bus(self, bus_client):
+        """Regression: an admin cookie session reads the bus unchanged."""
+        with patch(_BUS_PATCH, return_value=_mock_bus_client({"channels": []})):
+            resp = await bus_client.get("/api/a2a/bus/channels")
+        assert resp.status_code == 200
+        assert resp.json()["available"] is True
+
+    async def test_local_token_reads_bus_as_admin(self, bus_client):
+        """Regression: a Bearer local token authenticates as admin and is NOT
+        parsed as a registry JWT."""
+        local_token = bus_client._app.state.auth.get_local_token()
+        with patch(_BUS_PATCH, return_value=_mock_bus_client({"channels": []})):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.get(
+                    "/api/a2a/bus/channels",
+                    headers={"Authorization": f"Bearer {local_token}"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["available"] is True
+
+    async def test_skeleton_key_guard_agent_token_rejected_off_allowlist(self, bus_client):
+        """A valid agent JWT (with a2a_receive) must NOT authenticate a
+        non-allowlisted protected route -- the token is not a skeleton key."""
+        _cid, token = await _make_agent_token(bus_client._app)
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.get(
+                "/api/agents/registry",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        # Falls through middleware to the session gate: API request -> 401.
+        assert resp.status_code == 401

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -55,6 +55,28 @@ class TestGetByHandle:
         finally:
             await s.close()
 
+    async def test_unique_active_handle_blocks_duplicate(self, tmp_path):
+        """The partial unique index stops a check-then-register race from
+        creating two active rows for one non-empty handle."""
+        from sqlite3 import IntegrityError
+        s = await self._store(tmp_path / "reg.db")
+        try:
+            await s.register(framework="taos-internal", display_name="a", handle="@dup")
+            with pytest.raises(IntegrityError):
+                await s.register(framework="taos-internal", display_name="b", handle="@dup")
+        finally:
+            await s.close()
+
+    async def test_empty_handles_are_not_unique(self, tmp_path):
+        """Handle-less deployed agents (default '') must coexist -- the unique
+        index is scoped to non-empty handles."""
+        s = await self._store(tmp_path / "reg.db")
+        try:
+            await s.register(framework="claude", display_name="a")
+            await s.register(framework="claude", display_name="b")
+        finally:
+            await s.close()
+
 
 # ---------------------------------------------------------------------------
 # Routes: mint-internal / seed-internal
@@ -145,6 +167,31 @@ class TestMintInternalRoute:
             json={"handle": "  ", "slug": "x", "scopes": []},
         )
         assert resp.status_code == 422
+
+    async def test_mint_rejects_unknown_scope(self, mint_client):
+        """The mint route is not a back door for arbitrary scopes."""
+        resp = await mint_client.post(
+            "/api/agents/registry/mint-internal",
+            json={"handle": "@x", "slug": "x", "scopes": ["a2a_send", "root_everything"]},
+        )
+        assert resp.status_code == 422
+
+    async def test_mint_rejects_non_internal_handle_owner(self, mint_client):
+        """If an active agent from another origin already owns the handle, the
+        mint must NOT hand it internal scopes + a token -- it 409s instead."""
+        await mint_client._app.state.agent_registry.register(
+            framework="claude", display_name="ext", origin="taos-deployed", handle="@Hermes",
+        )
+        resp = await mint_client.post(
+            "/api/agents/registry/mint-internal",
+            json={"handle": "@Hermes", "slug": "hermes", "scopes": ["a2a_send"]},
+        )
+        assert resp.status_code == 409
+        # No grant leaked to the external agent that owns the handle.
+        rows = await mint_client._app.state.agent_registry.list_all()
+        ext = next(r for r in rows if r["handle"] == "@Hermes")
+        grants = await mint_client._app.state.agent_grants.list_grants(ext["canonical_id"])
+        assert grants == []
 
     async def test_mint_requires_auth(self, mint_client):
         """An unauthenticated caller cannot mint (route is admin-only and not on

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -1,0 +1,197 @@
+"""Internal driver-agent identity minting (taosctl agents mint / seed-internal).
+
+Covers the store-level get_by_handle helper and the admin-only mint-internal /
+seed-internal routes: idempotency by handle (no duplicate rows), grant assertion,
+token issuance, the admin gate, and a full end-to-end check that a minted token
+reads the A2A bus.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import AgentRegistryStore
+
+
+# ---------------------------------------------------------------------------
+# Store: get_by_handle
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestGetByHandle:
+
+    async def _store(self, db_path):
+        s = AgentRegistryStore(db_path)
+        await s.init()
+        return s
+
+    async def test_returns_active_match(self, tmp_path):
+        s = await self._store(tmp_path / "reg.db")
+        try:
+            rec = await s.register(framework="taos-internal", display_name="taos-dev", handle="@taOS-dev")
+            got = await s.get_by_handle("@taOS-dev")
+            assert got is not None
+            assert got["canonical_id"] == rec["canonical_id"]
+        finally:
+            await s.close()
+
+    async def test_returns_none_for_unknown_handle(self, tmp_path):
+        s = await self._store(tmp_path / "reg.db")
+        try:
+            assert await s.get_by_handle("@nobody") is None
+        finally:
+            await s.close()
+
+    async def test_ignores_non_active_when_status_active(self, tmp_path):
+        s = await self._store(tmp_path / "reg.db")
+        try:
+            rec = await s.register(framework="taos-internal", display_name="x", handle="@gone")
+            await s.revoke(rec["canonical_id"])
+            assert await s.get_by_handle("@gone") is None
+            assert await s.get_by_handle("@gone", status=None) is not None
+        finally:
+            await s.close()
+
+
+# ---------------------------------------------------------------------------
+# Routes: mint-internal / seed-internal
+# ---------------------------------------------------------------------------
+
+def _mock_bus_client(json_payload: dict):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = json_payload
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_ctx
+
+
+@pytest_asyncio.fixture
+async def mint_client(app, tmp_data_dir):
+    for attr in ("agent_registry", "agent_grants", "metrics"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as c:
+        c._app = app
+        yield c
+
+    for attr in ("agent_registry", "agent_grants", "metrics"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+@pytest.mark.asyncio
+class TestMintInternalRoute:
+
+    async def test_mint_creates_agent_grants_and_token(self, mint_client):
+        resp = await mint_client.post(
+            "/api/agents/registry/mint-internal",
+            json={"handle": "@taOS-dev", "slug": "taos-dev", "scopes": ["a2a_send", "a2a_receive"]},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["handle"] == "@taOS-dev"
+        assert data["created"] is True
+        assert data["canonical_id"].startswith("taos-dev-")
+        assert data["token"]
+
+        # The agent is active and holds both grants.
+        rec = await mint_client._app.state.agent_registry.get(data["canonical_id"])
+        assert rec["status"] == "active"
+        grants = await mint_client._app.state.agent_grants.list_grants(data["canonical_id"])
+        assert {g["scope"] for g in grants} == {"a2a_send", "a2a_receive"}
+
+    async def test_mint_is_idempotent_by_handle(self, mint_client):
+        first = await mint_client.post(
+            "/api/agents/registry/mint-internal",
+            json={"handle": "@taOS-dev", "slug": "taos-dev", "scopes": ["a2a_receive"]},
+        )
+        second = await mint_client.post(
+            "/api/agents/registry/mint-internal",
+            json={"handle": "@taOS-dev", "slug": "taos-dev", "scopes": ["a2a_receive"]},
+        )
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.json()["canonical_id"] == second.json()["canonical_id"]
+        assert first.json()["created"] is True
+        assert second.json()["created"] is False
+        # Exactly one registry row for the handle.
+        rows = await mint_client._app.state.agent_registry.list_all()
+        assert sum(1 for r in rows if r["handle"] == "@taOS-dev") == 1
+
+    async def test_mint_rejects_empty_handle(self, mint_client):
+        resp = await mint_client.post(
+            "/api/agents/registry/mint-internal",
+            json={"handle": "  ", "slug": "x", "scopes": []},
+        )
+        assert resp.status_code == 422
+
+    async def test_mint_requires_auth(self, mint_client):
+        """An unauthenticated caller cannot mint (route is admin-only and not on
+        the agent-token allowlist)."""
+        async with AsyncClient(
+            transport=ASGITransport(app=mint_client._app), base_url="http://test"
+        ) as bare:
+            resp = await bare.post(
+                "/api/agents/registry/mint-internal",
+                json={"handle": "@x", "slug": "x", "scopes": []},
+            )
+        assert resp.status_code in (401, 403)
+
+    async def test_seed_internal_seeds_four_idempotently(self, mint_client):
+        r1 = await mint_client.post("/api/agents/registry/seed-internal")
+        assert r1.status_code == 200, r1.text
+        seeded = r1.json()["seeded"]
+        assert len(seeded) == 4
+        handles = {s["handle"] for s in seeded}
+        assert handles == {"@taOS-dev", "@taOS-website-dev", "@taOSmd-dev", "@Hermes"}
+        for s in seeded:
+            assert s["created"] is True
+            assert s["token"]
+            assert set(s["scopes"]) == {"a2a_send", "a2a_receive"}
+
+        # Re-run: no duplicate rows, all created=False.
+        r2 = await mint_client.post("/api/agents/registry/seed-internal")
+        assert r2.status_code == 200
+        assert all(s["created"] is False for s in r2.json()["seeded"])
+        rows = await mint_client._app.state.agent_registry.list_all()
+        internal = [r for r in rows if r["origin"] == "taos-internal"]
+        assert len(internal) == 4
+
+    async def test_minted_token_reads_the_bus(self, mint_client):
+        """End to end: a token from seed-internal reads the A2A bus (a2a_receive)."""
+        seeded = (await mint_client.post("/api/agents/registry/seed-internal")).json()["seeded"]
+        token = next(s["token"] for s in seeded if s["handle"] == "@Hermes")
+        with patch(
+            "tinyagentos.routes.a2a_bus.httpx.AsyncClient",
+            return_value=_mock_bus_client({"channels": []}),
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=mint_client._app), base_url="http://test"
+            ) as bare:
+                resp = await bare.get(
+                    "/api/a2a/bus/channels",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["available"] is True

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -16,6 +16,13 @@ from httpx import ASGITransport, AsyncClient
 from tinyagentos.agent_registry_store import AgentRegistryStore
 
 
+def test_allowed_scopes_matches_canonical_valid_scopes():
+    """The mint allowlist must not drift from the consent-flow VALID_SCOPES."""
+    from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
+    from tinyagentos.routes.agent_registry import _ALLOWED_SCOPES
+    assert set(_ALLOWED_SCOPES) == set(VALID_SCOPES)
+
+
 # ---------------------------------------------------------------------------
 # Store: get_by_handle
 # ---------------------------------------------------------------------------
@@ -55,27 +62,6 @@ class TestGetByHandle:
         finally:
             await s.close()
 
-    async def test_unique_active_handle_blocks_duplicate(self, tmp_path):
-        """The partial unique index stops a check-then-register race from
-        creating two active rows for one non-empty handle."""
-        from sqlite3 import IntegrityError
-        s = await self._store(tmp_path / "reg.db")
-        try:
-            await s.register(framework="taos-internal", display_name="a", handle="@dup")
-            with pytest.raises(IntegrityError):
-                await s.register(framework="taos-internal", display_name="b", handle="@dup")
-        finally:
-            await s.close()
-
-    async def test_empty_handles_are_not_unique(self, tmp_path):
-        """Handle-less deployed agents (default '') must coexist -- the unique
-        index is scoped to non-empty handles."""
-        s = await self._store(tmp_path / "reg.db")
-        try:
-            await s.register(framework="claude", display_name="a")
-            await s.register(framework="claude", display_name="b")
-        finally:
-            await s.close()
 
 
 # ---------------------------------------------------------------------------
@@ -142,6 +128,20 @@ class TestMintInternalRoute:
         assert rec["status"] == "active"
         grants = await mint_client._app.state.agent_grants.list_grants(data["canonical_id"])
         assert {g["scope"] for g in grants} == {"a2a_send", "a2a_receive"}
+
+    async def test_concurrent_mint_same_handle_makes_one_row(self, mint_client):
+        """The mint lock makes concurrent check-then-register atomic: two
+        in-flight mints for the same handle yield one row + one canonical_id."""
+        import asyncio
+        body = {"handle": "@taOS-dev", "slug": "taos-dev", "scopes": ["a2a_receive"]}
+        r1, r2 = await asyncio.gather(
+            mint_client.post("/api/agents/registry/mint-internal", json=body),
+            mint_client.post("/api/agents/registry/mint-internal", json=body),
+        )
+        assert r1.status_code == 200 and r2.status_code == 200
+        assert r1.json()["canonical_id"] == r2.json()["canonical_id"]
+        rows = await mint_client._app.state.agent_registry.list_all()
+        assert sum(1 for r in rows if r["handle"] == "@taOS-dev") == 1
 
     async def test_mint_is_idempotent_by_handle(self, mint_client):
         first = await mint_client.post(

--- a/tests/test_taosctl_agents_mint.py
+++ b/tests/test_taosctl_agents_mint.py
@@ -1,0 +1,64 @@
+"""taosctl agents mint / seed-internal: each verb hits the right path + body."""
+from __future__ import annotations
+
+from tinyagentos.cli.taosctl import __main__ as cli_main
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.calls = []
+        self.base_url = "http://x"
+        self.token = "t"
+
+    def get(self, path, params=None):
+        self.calls.append(("GET", path, None))
+        return {"ok": True}
+
+    def post(self, path, body=None, params=None, json=None):
+        self.calls.append(("POST", path, body))
+        return {"ok": True}
+
+
+def _run(monkeypatch, argv, fake):
+    monkeypatch.setattr(cli_main, "TaosClient", lambda **k: fake)
+    return cli_main.main(argv)
+
+
+def test_mint_posts_handle_slug_scopes(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(
+        monkeypatch,
+        ["agents", "mint", "--handle", "@taOS-dev", "--slug", "taos-dev",
+         "--scopes", "a2a_send,a2a_receive"],
+        fake,
+    )
+    assert rc == 0
+    method, path, body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/agents/registry/mint-internal")
+    assert body == {"handle": "@taOS-dev", "slug": "taos-dev", "scopes": ["a2a_send", "a2a_receive"]}
+
+
+def test_mint_default_scopes(monkeypatch):
+    fake = _FakeClient()
+    _run(monkeypatch, ["agents", "mint", "--handle", "@x", "--slug", "x"], fake)
+    _method, _path, body = fake.calls[0]
+    assert body["scopes"] == ["a2a_send", "a2a_receive"]
+
+
+def test_mint_with_project(monkeypatch):
+    fake = _FakeClient()
+    _run(
+        monkeypatch,
+        ["agents", "mint", "--handle", "@x", "--slug", "x", "--project", "prj-1"],
+        fake,
+    )
+    _method, _path, body = fake.calls[0]
+    assert body["project_id"] == "prj-1"
+
+
+def test_seed_internal_posts(monkeypatch):
+    fake = _FakeClient()
+    rc = _run(monkeypatch, ["agents", "seed-internal"], fake)
+    assert rc == 0
+    method, path, _body = fake.calls[0]
+    assert (method, path) == ("POST", "/api/agents/registry/seed-internal")

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -383,6 +383,29 @@ class AgentRegistryStore(BaseStore):
         ).fetchone()
         return _row_to_dict(row) if row else None
 
+    async def get_by_handle(self, handle: str, *, status: str = "active") -> Optional[dict]:
+        """Return the oldest entry with *handle* and *status*, or ``None``.
+
+        Used to make internal-identity minting idempotent by handle: when an
+        active agent already owns the handle its canonical_id is reused instead
+        of registering a duplicate row.  Pass ``status=None`` to match any
+        status.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        if status is None:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry WHERE handle = ? ORDER BY id LIMIT 1",
+                (handle,),
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry WHERE handle = ? AND status = ? ORDER BY id LIMIT 1",
+                (handle, status),
+            )
+        row = await cursor.fetchone()
+        return _row_to_dict(row) if row else None
+
     async def list_all(self, *, status: Optional[str] = None) -> list[dict]:
         """Return all registry records, optionally filtered by *status*."""
         if self._db is None:

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -103,6 +103,32 @@ async def _migration_v1_add_status(conn) -> None:
     )
     await conn.commit()
 
+
+async def _migration_v2_unique_active_handle(conn) -> None:
+    """Enforce at most one ACTIVE agent per non-empty handle.
+
+    Makes internal-identity minting idempotent at the storage layer: a
+    concurrent check-then-register race can no longer create two active rows
+    with the same handle. Scoped to ``handle != ''`` so the many handle-less
+    deployed agents (default '') are unaffected.
+
+    Guarded: if legacy data already has duplicate active handles the index
+    cannot be created -- log and continue rather than crash boot; the mint
+    route's reuse-by-handle path still keeps behaviour correct.
+    """
+    try:
+        await conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS uniq_active_handle "
+            "ON agent_registry(handle) WHERE status = 'active' AND handle != ''"
+        )
+        await conn.commit()
+    except Exception:  # noqa: BLE001 - pre-existing dup handles must not block boot
+        logger.warning(
+            "could not create uniq_active_handle index (duplicate active handles?)",
+            exc_info=True,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Signing-key helpers (Ed25519, persisted to disk)
 # ---------------------------------------------------------------------------
@@ -300,6 +326,7 @@ class AgentRegistryStore(BaseStore):
     async def _post_init(self) -> None:
         """Idempotently ensure the status column exists and is backfilled."""
         await _migration_v1_add_status(self._db)
+        await _migration_v2_unique_active_handle(self._db)
 
     # ------------------------------------------------------------------
     # Registration

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -104,31 +104,6 @@ async def _migration_v1_add_status(conn) -> None:
     await conn.commit()
 
 
-async def _migration_v2_unique_active_handle(conn) -> None:
-    """Enforce at most one ACTIVE agent per non-empty handle.
-
-    Makes internal-identity minting idempotent at the storage layer: a
-    concurrent check-then-register race can no longer create two active rows
-    with the same handle. Scoped to ``handle != ''`` so the many handle-less
-    deployed agents (default '') are unaffected.
-
-    Guarded: if legacy data already has duplicate active handles the index
-    cannot be created -- log and continue rather than crash boot; the mint
-    route's reuse-by-handle path still keeps behaviour correct.
-    """
-    try:
-        await conn.execute(
-            "CREATE UNIQUE INDEX IF NOT EXISTS uniq_active_handle "
-            "ON agent_registry(handle) WHERE status = 'active' AND handle != ''"
-        )
-        await conn.commit()
-    except Exception:  # noqa: BLE001 - pre-existing dup handles must not block boot
-        logger.warning(
-            "could not create uniq_active_handle index (duplicate active handles?)",
-            exc_info=True,
-        )
-
-
 # ---------------------------------------------------------------------------
 # Signing-key helpers (Ed25519, persisted to disk)
 # ---------------------------------------------------------------------------
@@ -326,7 +301,6 @@ class AgentRegistryStore(BaseStore):
     async def _post_init(self) -> None:
         """Idempotently ensure the status column exists and is backfilled."""
         await _migration_v1_add_status(self._db)
-        await _migration_v2_unique_active_handle(self._db)
 
     # ------------------------------------------------------------------
     # Registration

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Shared registry-JWT scope check for agent-authenticated routes.
+
+A registered agent authenticates to taOS with its OWN Ed25519 registry JWT
+(minted by ``mint_registry_token`` / verified by ``verify_registry_token``),
+never the owner password.  ``check_agent_scope`` is the single verify path used
+by every route that accepts an agent token:
+
+  - routes/agent_registry.py  -> required_scope "registry_feeds_read"
+  - routes/a2a_bus.py         -> required_scope "a2a_receive"
+
+Semantics (fail closed):
+  - No Authorization Bearer header -> return None (the caller decides what to do,
+    typically reject; the admin session/local-token path is handled before this).
+  - Bearer present but malformed / bad signature / missing sub -> 401.
+  - Valid signature but the agent is not active in the registry, the sub is
+    unknown, or the required scope grant is missing/expired -> 403.
+
+The registry JWT itself carries no exp claim; revocation is achieved by
+suspending the agent (status != 'active') or by setting expires_at on the grant.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import HTTPException, Request
+
+from tinyagentos.agent_registry_store import verify_registry_token
+
+
+def _get_store(request: Request):
+    store = getattr(request.app.state, "agent_registry", None)
+    if store is None:
+        raise RuntimeError("agent_registry store not on app.state")
+    return store
+
+
+def _get_grants_store(request: Request):
+    store = getattr(request.app.state, "agent_grants", None)
+    if store is None:
+        raise RuntimeError("agent_grants store not on app.state")
+    return store
+
+
+def _get_keypair(request: Request) -> tuple[bytes, bytes]:
+    kp = getattr(request.app.state, "agent_registry_keypair", None)
+    if kp is None:
+        raise RuntimeError("agent_registry_keypair not on app.state")
+    return kp
+
+
+async def check_agent_scope(request: Request, required_scope: str) -> Optional[str]:
+    """Return the canonical_id from a valid Bearer registry JWT that holds an
+    active *required_scope* grant, or raise an HTTPException.
+
+    Returns None when no Authorization header is present (the caller falls
+    through to its own admin/session handling).
+
+    Raises:
+      401 -- Authorization header present but the token is malformed, has a bad
+             signature, or is missing the sub claim.
+      403 -- Token is valid but the agent is not active in the registry, the
+             sub is unknown, or the grant is missing/expired.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None
+
+    raw_token = auth_header[7:].strip()
+
+    # Verify the EdDSA signature using the registry public key.
+    _private_pem, public_pem = _get_keypair(request)
+    try:
+        payload = verify_registry_token(raw_token, public_pem)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="invalid or malformed registry token")
+
+    canonical_id: str = payload.get("sub", "")
+    if not canonical_id:
+        raise HTTPException(status_code=401, detail="token missing sub claim")
+
+    # Agent must be active in the registry.
+    registry = _get_store(request)
+    record = await registry.get(canonical_id)
+    if record is None or record.get("status") != "active":
+        raise HTTPException(status_code=403, detail="agent is not active in the registry")
+
+    # Must hold an active grant for the required scope.
+    grants_store = _get_grants_store(request)
+    grants = await grants_store.list_grants(canonical_id)
+
+    now = datetime.now(timezone.utc).isoformat()
+    has_scope = any(
+        g["scope"] == required_scope
+        and (g.get("expires_at") is None or g["expires_at"] > now)
+        for g in grants
+    )
+    if not has_scope:
+        raise HTTPException(
+            status_code=403,
+            detail=f"token does not hold an active {required_scope!r} grant",
+        )
+
+    return canonical_id

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -43,6 +43,27 @@ def _get_grants_store(request: Request):
     return store
 
 
+def _grant_unexpired(expires_at, now: datetime) -> bool:
+    """True if a grant's expiry is in the future (or it never expires).
+
+    Parses ``expires_at`` to a datetime instead of comparing ISO strings
+    lexicographically: a string compare is only correct when every stored value
+    uses the exact same UTC offset + precision, and silently mis-ranks a naive
+    or differently-formatted timestamp -- which could read an expired grant as
+    live (access after revocation). Fail closed: an unparseable value is treated
+    as expired. A naive timestamp is assumed UTC.
+    """
+    if expires_at is None:
+        return True
+    try:
+        exp = datetime.fromisoformat(str(expires_at))
+    except (ValueError, TypeError):
+        return False
+    if exp.tzinfo is None:
+        exp = exp.replace(tzinfo=timezone.utc)
+    return exp > now
+
+
 def _get_keypair(request: Request) -> tuple[bytes, bytes]:
     kp = getattr(request.app.state, "agent_registry_keypair", None)
     if kp is None:
@@ -90,10 +111,9 @@ async def check_agent_scope(request: Request, required_scope: str) -> Optional[s
     grants_store = _get_grants_store(request)
     grants = await grants_store.list_grants(canonical_id)
 
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(timezone.utc)
     has_scope = any(
-        g["scope"] == required_scope
-        and (g.get("expires_at") is None or g["expires_at"] > now)
+        g["scope"] == required_scope and _grant_unexpired(g.get("expires_at"), now)
         for g in grants
     )
     if not has_scope:

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -16,6 +16,17 @@ _REGISTRY_FEED_PATHS = frozenset({
     "/api/agents/registry/revoked",
     "/api/agents/registry/grants",
 })
+# Read-only A2A bus proxy paths an agent may reach with its own registry JWT
+# (scope a2a_receive, verified by the route).  Same passthrough contract as the
+# feed paths: only a Bearer that is NOT the admin local token reaches the route.
+_A2A_BUS_READ_PATHS = frozenset({
+    "/api/a2a/bus/channels",
+    "/api/a2a/bus/messages",
+})
+# Every path that accepts a registry JWT in place of the admin session.  The
+# passthrough is allowlisted to exactly these paths -- a registry JWT must never
+# authenticate an arbitrary route (no skeleton key).
+_AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -195,13 +206,15 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     request.state.via = "local_token"
                 return await call_next(request)
 
-        # Registry feed endpoints (revoked + grants) accept a registry JWT as an
-        # alternative to the admin session.  This branch sits AFTER the
-        # local-token check on purpose: a local token is admin-equivalent and
-        # must keep its admin semantics on these paths (taOSmd polls the feeds
-        # with it today).  Only a Bearer that is NOT the local token falls
-        # through to here and is verified as a registry JWT by the route.
-        if path in _REGISTRY_FEED_PATHS and auth_header.lower().startswith("bearer "):
+        # Agent-token endpoints (registry feeds + read-only A2A bus proxy) accept
+        # a registry JWT as an alternative to the admin session.  This branch
+        # sits AFTER the local-token check on purpose: a local token is
+        # admin-equivalent and must keep its admin semantics on these paths
+        # (taOSmd polls the feeds with it today).  Only a Bearer that is NOT the
+        # local token falls through to here; it is PASSED THROUGH and the route
+        # verifies the registry JWT + scope grant.  The allowlist is exact so a
+        # registry JWT can never authenticate any other route (no skeleton key).
+        if path in _AGENT_TOKEN_PATHS and auth_header.lower().startswith("bearer "):
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "registry_jwt_candidate"

--- a/tinyagentos/cli/taosctl/commands/agents.py
+++ b/tinyagentos/cli/taosctl/commands/agents.py
@@ -25,6 +25,27 @@ def register(subparsers) -> None:
     ap = verbs.add_parser("archived", help="List archived agents")
     ap.set_defaults(func=_archived)
 
+    mp = verbs.add_parser(
+        "mint",
+        help="Mint (or reuse) an internal agent identity + registry token (admin)",
+    )
+    mp.add_argument("--handle", required=True, help="Agent handle, e.g. @taOS-dev")
+    mp.add_argument("--slug", required=True, help="Canonical-id slug, e.g. taos-dev")
+    mp.add_argument(
+        "--scopes",
+        default="a2a_send,a2a_receive",
+        help="Comma-separated scopes to grant (default a2a_send,a2a_receive)",
+    )
+    mp.add_argument("--project", dest="project_id", default=None,
+                    help="Optional project id to bind the token/grants to")
+    mp.set_defaults(func=_mint)
+
+    sp = verbs.add_parser(
+        "seed-internal",
+        help="Idempotently mint the four internal driver agents + tokens (admin)",
+    )
+    sp.set_defaults(func=_seed_internal)
+
 
 def _list(args, client):
     return client.get("/api/agents")
@@ -36,3 +57,15 @@ def _get(args, client):
 
 def _archived(args, client):
     return client.get("/api/agents/archived")
+
+
+def _mint(args, client):
+    scopes = [s.strip() for s in args.scopes.split(",") if s.strip()]
+    body = {"handle": args.handle, "slug": args.slug, "scopes": scopes}
+    if args.project_id:
+        body["project_id"] = args.project_id
+    return client.post("/api/agents/registry/mint-internal", body=body)
+
+
+def _seed_internal(args, client):
+    return client.post("/api/agents/registry/seed-internal")

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -22,8 +22,10 @@ import logging
 import os
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
+
+from tinyagentos.agent_token_auth import check_agent_scope
 
 logger = logging.getLogger(__name__)
 
@@ -37,14 +39,35 @@ def _bus_url() -> str:
     return os.environ.get("TAOS_A2A_BUS_URL", _DEFAULT_BUS_URL).rstrip("/")
 
 
+async def _authorize_bus_read(request: Request) -> None:
+    """Gate a bus-read request.
+
+    Admin (session cookie or local token) is allowed unconditionally -- the
+    middleware has already set request.state.is_admin for those.  Otherwise the
+    caller must present a registry JWT holding an active ``a2a_receive`` grant;
+    check_agent_scope raises 401 (bad/malformed token) or 403 (valid token but
+    not active / missing scope) and returns None only when no Bearer header is
+    present, which is rejected here as 403 (fail closed).
+    """
+    if getattr(request.state, "is_admin", False):
+        return
+    caller = await check_agent_scope(request, "a2a_receive")
+    if caller is None:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+
 @router.get("/api/a2a/bus/channels")
-async def bus_channels():
+async def bus_channels(request: Request):
     """List coordination-bus channels, sorted by last activity (newest first).
+
+    Authorized readers: an admin session, the host local token, or an active
+    agent registry JWT holding the ``a2a_receive`` scope.
 
     On any bus error (timeout / connection refused / non-200) this returns an
     empty list with ``available: false`` and HTTP 200, so the frontend can show
     a clean offline state rather than crashing.
     """
+    await _authorize_bus_read(request)
     bus = _bus_url()
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
@@ -65,13 +88,17 @@ async def bus_channels():
 
 
 @router.get("/api/a2a/bus/messages")
-async def bus_messages(channel: str = "", limit: int = 100):
+async def bus_messages(request: Request, channel: str = "", limit: int = 100):
     """Read messages from one bus channel, oldest-first as the bus returns them.
+
+    Authorized readers: an admin session, the host local token, or an active
+    agent registry JWT holding the ``a2a_receive`` scope.
 
     ``channel`` is required and maps to the bus ``thread`` query param. ``limit``
     is clamped to 1..500. On a bus error this returns an empty list with
     ``available: false`` and HTTP 200.
     """
+    await _authorize_bus_read(request)
     if not channel:
         return JSONResponse({"error": "channel required"}, status_code=400)
 

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -27,7 +27,8 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 
-from tinyagentos.agent_registry_store import mint_registry_token, verify_registry_token
+from tinyagentos.agent_registry_store import mint_registry_token
+from tinyagentos.agent_token_auth import check_agent_scope
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,23 @@ class PatchRegistryRequest(BaseModel):
     capabilities: Optional[list[str]] = None
 
 
+class MintInternalRequest(BaseModel):
+    """Body for minting an internal driver-agent identity (admin only)."""
+
+    handle: str
+    slug: str
+    scopes: list[str] = []
+    project_id: Optional[str] = None
+
+    @field_validator("handle", "slug")
+    @classmethod
+    def _require_non_empty(cls, v: str) -> str:
+        val = (v or "").strip()
+        if not val:
+            raise ValueError("must not be empty")
+        return val
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -95,66 +113,32 @@ def _get_keypair(request: Request) -> tuple[bytes, bytes]:
 
 _FEED_SCOPE = "registry_feeds_read"
 
+# Origin marker for the built-in driver agents seeded by the operator.  register()
+# treats any origin other than "external-selfjoin" as immediately active, so these
+# come up active without a consent round-trip.
+_INTERNAL_ORIGIN = "taos-internal"
+
+# The four internal driver agents and the scopes they need to read/write the
+# coordination bus.  seed-internal mints all four idempotently by handle.
+_INTERNAL_AGENT_SCOPES = ["a2a_send", "a2a_receive"]
+_INTERNAL_AGENTS = (
+    {"handle": "@taOS-dev", "slug": "taos-dev"},
+    {"handle": "@taOS-website-dev", "slug": "taos-website-dev"},
+    {"handle": "@taOSmd-dev", "slug": "taosmd-dev"},
+    {"handle": "@Hermes", "slug": "hermes"},
+)
+
 
 async def _check_feed_token(request: Request) -> Optional[str]:
     """Return the canonical_id from a valid Bearer token that holds an active
     ``registry_feeds_read`` grant, or raise an HTTPException.
 
+    Thin wrapper over the shared ``check_agent_scope`` helper so the feed routes
+    and the A2A bus routes use one verify path with identical 401/403 semantics.
     Returns None when no Authorization header is present (caller falls through
     to the standard admin session check).
-
-    Raises:
-      401 -- Authorization header present but token is malformed or signature invalid.
-      403 -- Token is valid but the agent lacks the scope, is not active in the
-             registry, or the grant has expired.
-
-    Note: registry JWTs themselves carry no expiry claim -- revocation is
-    achieved by suspending the agent (sets status != 'active') or by setting
-    expires_at on the grant row.  The grant expiry checked here is the only
-    time-based gate.
     """
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.lower().startswith("bearer "):
-        return None
-
-    raw_token = auth_header[7:].strip()
-
-    # Verify the EdDSA signature using the registry public key.
-    _private_pem, public_pem = _get_keypair(request)
-    try:
-        payload = verify_registry_token(raw_token, public_pem)
-    except ValueError:
-        raise HTTPException(status_code=401, detail="invalid or malformed registry token")
-
-    canonical_id: str = payload.get("sub", "")
-    if not canonical_id:
-        raise HTTPException(status_code=401, detail="token missing sub claim")
-
-    # Agent must be active in the registry.
-    registry = _get_store(request)
-    record = await registry.get(canonical_id)
-    if record is None or record.get("status") != "active":
-        raise HTTPException(status_code=403, detail="agent is not active in the registry")
-
-    # Must hold an active registry_feeds_read grant.
-    grants_store = _get_grants_store(request)
-    grants = await grants_store.list_grants(canonical_id)
-
-    from datetime import datetime, timezone
-    now = datetime.now(timezone.utc).isoformat()
-
-    has_scope = any(
-        g["scope"] == _FEED_SCOPE
-        and (g.get("expires_at") is None or g["expires_at"] > now)
-        for g in grants
-    )
-    if not has_scope:
-        raise HTTPException(
-            status_code=403,
-            detail=f"token does not hold an active {_FEED_SCOPE!r} grant",
-        )
-
-    return canonical_id
+    return await check_agent_scope(request, _FEED_SCOPE)
 
 
 async def _audit_governance(
@@ -225,6 +209,112 @@ async def register_agent(
         "token": token,
         "record": record,
     }
+
+
+async def _mint_internal_identity(
+    request: Request,
+    user: CurrentUser,
+    *,
+    handle: str,
+    slug: str,
+    scopes: list[str],
+    project_id: Optional[str] = None,
+) -> dict:
+    """Register-or-reuse an internal agent by handle, ensure its grants, and mint
+    a registry JWT.  Idempotent: a second call with the same handle reuses the
+    existing active canonical_id and re-asserts the (idempotent) grants.
+    """
+    store = _get_store(request)
+    grants_store = _get_grants_store(request)
+    private_pem, _public_pem = _get_keypair(request)
+
+    existing = await store.get_by_handle(handle)
+    if existing is not None:
+        record = existing
+        created = False
+    else:
+        record = await store.register(
+            framework=_INTERNAL_ORIGIN,
+            display_name=slug,
+            user_id=user.user_id,
+            origin=_INTERNAL_ORIGIN,
+            handle=handle,
+            capabilities=[],
+        )
+        created = True
+
+    canonical_id = record["canonical_id"]
+    for scope in scopes:
+        await grants_store.add_grant(canonical_id, scope, project_id=project_id)
+
+    token = mint_registry_token(
+        canonical_id,
+        private_pem,
+        user_id=user.user_id,
+        framework=record.get("framework", ""),
+        project_id=project_id,
+    )
+    return {
+        "handle": handle,
+        "canonical_id": canonical_id,
+        "created": created,
+        "scopes": scopes,
+        "token": token,
+    }
+
+
+@router.post("/api/agents/registry/mint-internal")
+async def mint_internal_agent(
+    request: Request,
+    body: MintInternalRequest,
+    user: CurrentUser = Depends(current_user),
+):
+    """Mint (or reuse) an internal driver-agent identity and return its token.
+
+    Admin only.  Idempotent by handle: re-running reuses the existing active
+    canonical_id instead of creating a duplicate row, and re-asserts the
+    requested scope grants (add_grant is idempotent).  The token is returned so
+    the operator can store it on the agent host -- it is never written to disk
+    here.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    return await _mint_internal_identity(
+        request,
+        user,
+        handle=body.handle,
+        slug=body.slug,
+        scopes=body.scopes,
+        project_id=body.project_id,
+    )
+
+
+@router.post("/api/agents/registry/seed-internal")
+async def seed_internal_agents(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Idempotently mint the four internal driver agents and return their tokens.
+
+    Admin only.  Each of @taOS-dev, @taOS-website-dev, @taOSmd-dev, @Hermes is
+    minted with the a2a_send + a2a_receive scopes.  Re-running creates no
+    duplicate rows.  Response: {"seeded": [{handle, canonical_id, created,
+    scopes, token}, ...]}.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    seeded = []
+    for spec in _INTERNAL_AGENTS:
+        seeded.append(
+            await _mint_internal_identity(
+                request,
+                user,
+                handle=spec["handle"],
+                slug=spec["slug"],
+                scopes=list(_INTERNAL_AGENT_SCOPES),
+            )
+        )
+    return {"seeded": seeded}
 
 
 @router.get("/api/agents/registry/pubkey")

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -20,8 +20,8 @@ Route ordering matters: /pubkey, /revoked, and /inactive are declared before
 /{canonical_id} so the literal strings are not captured as a path parameter.
 """
 
+import asyncio
 import logging
-from sqlite3 import IntegrityError
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -132,6 +132,13 @@ def _get_keypair(request: Request) -> tuple[bytes, bytes]:
 
 
 _FEED_SCOPE = "registry_feeds_read"
+
+# Serializes internal-identity minting so a concurrent check-then-register for
+# the same handle cannot create two rows. The controller is a single process, so
+# an in-process lock is sufficient -- and is preferable to a DB-wide unique
+# index on handle, which would make unrelated active-handle writes (set_status,
+# update) raise on collision and 500.
+_mint_lock = asyncio.Lock()
 
 # Origin marker for the built-in driver agents seeded by the operator.  register()
 # treats any origin other than "external-selfjoin" as immediately active, so these
@@ -248,20 +255,22 @@ async def _mint_internal_identity(
     grants_store = _get_grants_store(request)
     private_pem, _public_pem = _get_keypair(request)
 
-    existing = await store.get_by_handle(handle)
-    if existing is not None:
-        # Never hand internal scopes + a fresh token to an agent that already
-        # owns this handle under a different origin (e.g. an external self-join
-        # that claimed "@Hermes"). Only a taos-internal row may be reused.
-        if existing.get("origin") != _INTERNAL_ORIGIN:
-            raise HTTPException(
-                status_code=409,
-                detail="handle is already owned by a non-internal agent",
-            )
-        record = existing
-        created = False
-    else:
-        try:
+    # The lock makes the check-then-register atomic: a concurrent mint of the
+    # same handle waits, then sees the row the first one created and reuses it.
+    async with _mint_lock:
+        existing = await store.get_by_handle(handle)
+        if existing is not None:
+            # Never hand internal scopes + a fresh token to an agent that already
+            # owns this handle under a different origin (e.g. an external
+            # self-join that claimed "@Hermes"). Only a taos-internal row reuses.
+            if existing.get("origin") != _INTERNAL_ORIGIN:
+                raise HTTPException(
+                    status_code=409,
+                    detail="handle is already owned by a non-internal agent",
+                )
+            record = existing
+            created = False
+        else:
             record = await store.register(
                 framework=_INTERNAL_ORIGIN,
                 display_name=slug,
@@ -271,14 +280,6 @@ async def _mint_internal_identity(
                 capabilities=[],
             )
             created = True
-        except IntegrityError:
-            # Lost a check-then-register race against a concurrent mint of the
-            # same handle (the partial unique index rejected the duplicate).
-            # Re-read and reuse the row the winner created -- idempotent.
-            record = await store.get_by_handle(handle)
-            if record is None or record.get("origin") != _INTERNAL_ORIGIN:
-                raise
-            created = False
 
     canonical_id = record["canonical_id"]
     for scope in scopes:

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -21,6 +21,7 @@ Route ordering matters: /pubkey, /revoked, and /inactive are declared before
 """
 
 import logging
+from sqlite3 import IntegrityError
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -69,6 +70,17 @@ class PatchRegistryRequest(BaseModel):
     capabilities: Optional[list[str]] = None
 
 
+# Scopes an operator may grant when minting an internal agent. Mirrors the
+# consent-flow VALID_SCOPES; the mint route must not be a back door to invent
+# arbitrary scopes that the rest of the system does not understand.
+_ALLOWED_SCOPES = frozenset({
+    "memory_read", "memory_write",
+    "a2a_send", "a2a_receive",
+    "files_read", "files_write",
+    "tools_execute", "registry_feeds_read",
+})
+
+
 class MintInternalRequest(BaseModel):
     """Body for minting an internal driver-agent identity (admin only)."""
 
@@ -84,6 +96,14 @@ class MintInternalRequest(BaseModel):
         if not val:
             raise ValueError("must not be empty")
         return val
+
+    @field_validator("scopes")
+    @classmethod
+    def _known_scopes(cls, v: list[str]) -> list[str]:
+        bad = [s for s in v if s not in _ALLOWED_SCOPES]
+        if bad:
+            raise ValueError(f"unknown scope(s): {sorted(bad)}")
+        return v
 
 
 # ---------------------------------------------------------------------------
@@ -230,18 +250,35 @@ async def _mint_internal_identity(
 
     existing = await store.get_by_handle(handle)
     if existing is not None:
+        # Never hand internal scopes + a fresh token to an agent that already
+        # owns this handle under a different origin (e.g. an external self-join
+        # that claimed "@Hermes"). Only a taos-internal row may be reused.
+        if existing.get("origin") != _INTERNAL_ORIGIN:
+            raise HTTPException(
+                status_code=409,
+                detail="handle is already owned by a non-internal agent",
+            )
         record = existing
         created = False
     else:
-        record = await store.register(
-            framework=_INTERNAL_ORIGIN,
-            display_name=slug,
-            user_id=user.user_id,
-            origin=_INTERNAL_ORIGIN,
-            handle=handle,
-            capabilities=[],
-        )
-        created = True
+        try:
+            record = await store.register(
+                framework=_INTERNAL_ORIGIN,
+                display_name=slug,
+                user_id=user.user_id,
+                origin=_INTERNAL_ORIGIN,
+                handle=handle,
+                capabilities=[],
+            )
+            created = True
+        except IntegrityError:
+            # Lost a check-then-register race against a concurrent mint of the
+            # same handle (the partial unique index rejected the duplicate).
+            # Re-read and reuse the row the winner created -- idempotent.
+            record = await store.get_by_handle(handle)
+            if record is None or record.get("origin") != _INTERNAL_ORIGIN:
+                raise
+            created = False
 
     canonical_id = record["canonical_id"]
     for scope in scopes:


### PR DESCRIPTION
Phase 1 of #138: the driver agents (@taOS-dev, @taOSmd-dev, @taOS-website-dev, @Hermes) authenticate with their OWN taOS agent-registry identity + scoped Ed25519 JWT instead of Jay's owner password.

## What this does
- A registered, active agent reads the A2A bus read-proxy (`GET /api/a2a/bus/channels|messages`) with `Authorization: Bearer <registry-JWT>`, authorized by an `a2a_receive` scope grant. No owner session/password needed.
- New shared verify helper `check_agent_scope(request, scope)` (`tinyagentos/agent_token_auth.py`), fail-closed: 401 bad-sig/malformed/missing-sub, 403 inactive/unknown-sub/missing-or-expired-grant. `_check_feed_token` now delegates to it (feed routes unchanged).
- Middleware allowlist is exact (`_AGENT_TOKEN_PATHS = feeds | bus-read`): a registry JWT can never authenticate any other route (skeleton-key guard, tested). Local-token admin path runs first and is unchanged.
- Admin-only `POST /api/agents/registry/mint-internal` + `/seed-internal`, and `taosctl agents mint|seed-internal`, to mint the 4 identities (idempotent by handle; `get_by_handle` added to the registry store).

## Reviewer notes
- BEHAVIOR CHANGE: bus read now requires admin OR an agent with `a2a_receive`. Previously any authenticated session could read it. Harmless today (single admin); flagging in case non-admin users should retain bus-read (one-line loosen to `user_id is not None`).
- Bus-side enforcement (binding `from` to the verified identity, verify-and-warn -> enforce) is Phase 2 in the taosmd repo; this PR is controller read-auth + identity minting only.
- No message stores touched. chat.db (912) + the full ~/.taosmd tree were backed up before any work.

## Tests
25 new across `test_a2a_bus_agent_auth.py` (12 edge cases incl. skeleton-key, suspended, revoked, foreign-key, expired-grant, admin/local-token regressions), `test_agent_internal_mint.py`, `test_taosctl_agents_mint.py`. Feed-route + existing a2a-bus regressions pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-identity-based authentication using signed registry JWTs for supported read-only APIs.
  * Added admin actions to mint and seed internal agent identities and tokens (idempotent by handle/seed reruns).
  * Expanded CLI support for `agents mint` and `seed-internal`.
* **Bug Fixes**
  * Enforced fail-closed authorization for protected registry feed and read-only A2A bus routes (active agent + unexpired scope grants).
* **Documentation**
  * Updated onboarding and authentication/authorization details in the README and external-agent onboarding guide.
* **Tests**
  * Added end-to-end and unit coverage for agent-token scope/expiry handling, mint/seed behavior, and CLI request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->