### PR TITLE
feat(auth): adopt flag for pre-existing driver agents (#138 follow-up)

### DIFF
--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -222,6 +222,28 @@ class TestMintInternalRoute:
         rows = await mint_client._app.state.agent_registry.list_all()
         assert sum(1 for r in rows if r["handle"] == "@taOS-dev") == 1
 
+    async def test_adopt_writes_governance_audit(self, mint_client):
+        """Adopting a pre-existing identity is trust-changing -- it must leave a
+        governance audit event (action='adopt') for a forensic trail."""
+        rec = await mint_client._app.state.agent_registry.register(
+            framework="claude-code", display_name="taos-dev",
+            origin="external-selfjoin", handle="@taOS-dev",
+        )
+        await mint_client._app.state.agent_registry.set_status(rec["canonical_id"], "active")
+        with patch("tinyagentos.routes.agent_registry._audit_governance",
+                   new_callable=AsyncMock) as audit:
+            resp = await mint_client.post(
+                "/api/agents/registry/mint-internal",
+                json={"handle": "@taOS-dev", "slug": "taos-dev",
+                      "scopes": ["a2a_receive"], "adopt": True},
+            )
+        assert resp.status_code == 200, resp.text
+        audit.assert_awaited_once()
+        kwargs = audit.await_args.kwargs
+        assert kwargs["action"] == "adopt"
+        assert kwargs["canonical_id"] == rec["canonical_id"]
+        assert kwargs["actor_user_id"]
+
     async def test_seed_internal_adopt_handles_preexisting(self, mint_client):
         """seed-internal?adopt=true vouches for a pre-existing driver handle and
         still seeds the rest."""

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -193,6 +193,52 @@ class TestMintInternalRoute:
         grants = await mint_client._app.state.agent_grants.list_grants(ext["canonical_id"])
         assert grants == []
 
+    async def test_mint_adopt_vouches_for_preexisting_agent(self, mint_client):
+        """With adopt=true the admin vouches for a pre-existing non-internal
+        agent (e.g. a driver that self-joined): it reuses that identity, grants
+        the scopes, and mints a token -- no new row, origin left untouched."""
+        rec = await mint_client._app.state.agent_registry.register(
+            framework="claude-code", display_name="taos-dev",
+            origin="external-selfjoin", handle="@taOS-dev",
+        )
+        # external-selfjoin starts 'pending'; the real @taOS-dev was approved -> active.
+        await mint_client._app.state.agent_registry.set_status(rec["canonical_id"], "active")
+        resp = await mint_client.post(
+            "/api/agents/registry/mint-internal",
+            json={"handle": "@taOS-dev", "slug": "taos-dev",
+                  "scopes": ["a2a_send", "a2a_receive"], "adopt": True},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["canonical_id"] == rec["canonical_id"]   # reused, not a new row
+        assert data["created"] is False and data["adopted"] is True
+        assert data["token"]
+        grants = await mint_client._app.state.agent_grants.list_grants(rec["canonical_id"])
+        assert {g["scope"] for g in grants} == {"a2a_send", "a2a_receive"}
+        # Origin is preserved (not silently rewritten to internal).
+        got = await mint_client._app.state.agent_registry.get(rec["canonical_id"])
+        assert got["origin"] == "external-selfjoin"
+        # Exactly one row for the handle.
+        rows = await mint_client._app.state.agent_registry.list_all()
+        assert sum(1 for r in rows if r["handle"] == "@taOS-dev") == 1
+
+    async def test_seed_internal_adopt_handles_preexisting(self, mint_client):
+        """seed-internal?adopt=true vouches for a pre-existing driver handle and
+        still seeds the rest."""
+        rec = await mint_client._app.state.agent_registry.register(
+            framework="claude-code", display_name="taos-dev",
+            origin="external-selfjoin", handle="@taOS-dev",
+        )
+        await mint_client._app.state.agent_registry.set_status(rec["canonical_id"], "active")
+        resp = await mint_client.post("/api/agents/registry/seed-internal?adopt=true")
+        assert resp.status_code == 200, resp.text
+        seeded = {s["handle"]: s for s in resp.json()["seeded"]}
+        assert seeded["@taOS-dev"]["adopted"] is True and seeded["@taOS-dev"]["created"] is False
+        assert seeded["@Hermes"]["created"] is True and seeded["@Hermes"]["adopted"] is False
+        # Without adopt it would have 409d on @taOS-dev:
+        resp2 = await mint_client.post("/api/agents/registry/seed-internal")
+        assert resp2.status_code == 409
+
     async def test_mint_requires_auth(self, mint_client):
         """An unauthenticated caller cannot mint (route is admin-only and not on
         the agent-token allowlist)."""

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -305,6 +305,20 @@ async def _mint_internal_identity(
         framework=record.get("framework", ""),
         project_id=project_id,
     )
+
+    # Minting a driver token is a privileged, trust-changing action -- leave a
+    # forensic trail. Adopt is the most sensitive (it elevates a possibly
+    # untrusted-origin identity), so it gets its own action name; create/reuse
+    # are logged too so every token issuance is traceable to an actor.
+    status_now = record.get("status", "")
+    await _audit_governance(
+        request,
+        action="adopt" if adopted else ("mint-internal-create" if created else "mint-internal-reuse"),
+        canonical_id=canonical_id,
+        actor_user_id=user.user_id,
+        before_status=status_now,
+        after_status=status_now,
+    )
     return {
         "handle": handle,
         "canonical_id": canonical_id,

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -88,6 +88,11 @@ class MintInternalRequest(BaseModel):
     slug: str
     scopes: list[str] = []
     project_id: Optional[str] = None
+    # When the handle is already owned by a non-internal agent (e.g. a driver
+    # agent that earlier self-joined via the consent flow), default-deny: the
+    # admin must set adopt=true to vouch for that existing identity and grant it
+    # driver scopes + a token. Guards against an impostor that grabbed a handle.
+    adopt: bool = False
 
     @field_validator("handle", "slug")
     @classmethod
@@ -246,10 +251,14 @@ async def _mint_internal_identity(
     slug: str,
     scopes: list[str],
     project_id: Optional[str] = None,
+    adopt: bool = False,
 ) -> dict:
-    """Register-or-reuse an internal agent by handle, ensure its grants, and mint
-    a registry JWT.  Idempotent: a second call with the same handle reuses the
-    existing active canonical_id and re-asserts the (idempotent) grants.
+    """Register-or-reuse a driver-agent identity by handle, ensure its grants,
+    and mint a registry JWT.  Idempotent: a second call with the same handle
+    reuses the existing active canonical_id and re-asserts the (idempotent)
+    grants.  When the handle is already owned by a NON-internal agent (e.g. a
+    driver that self-joined via the consent flow), default-deny with 409 unless
+    ``adopt`` is set -- then the admin is explicitly vouching for that identity.
     """
     store = _get_store(request)
     grants_store = _get_grants_store(request)
@@ -260,17 +269,21 @@ async def _mint_internal_identity(
     async with _mint_lock:
         existing = await store.get_by_handle(handle)
         if existing is not None:
-            # Never hand internal scopes + a fresh token to an agent that already
-            # owns this handle under a different origin (e.g. an external
-            # self-join that claimed "@Hermes"). Only a taos-internal row reuses.
-            if existing.get("origin") != _INTERNAL_ORIGIN:
+            # A non-internal owner is only reused when the admin adopts it: this
+            # blocks an impostor that grabbed "@Hermes" from silently receiving
+            # driver scopes + a token, while still letting the operator vouch for
+            # a legitimately pre-existing driver (its origin is left untouched).
+            adopted = existing.get("origin") != _INTERNAL_ORIGIN
+            if adopted and not adopt:
                 raise HTTPException(
                     status_code=409,
-                    detail="handle is already owned by a non-internal agent",
+                    detail=("handle is already owned by a non-internal agent; "
+                            "pass adopt=true to vouch for it and grant driver scopes"),
                 )
             record = existing
             created = False
         else:
+            adopted = False
             record = await store.register(
                 framework=_INTERNAL_ORIGIN,
                 display_name=slug,
@@ -296,6 +309,7 @@ async def _mint_internal_identity(
         "handle": handle,
         "canonical_id": canonical_id,
         "created": created,
+        "adopted": adopted,
         "scopes": scopes,
         "token": token,
     }
@@ -324,6 +338,7 @@ async def mint_internal_agent(
         slug=body.slug,
         scopes=body.scopes,
         project_id=body.project_id,
+        adopt=body.adopt,
     )
 
 
@@ -331,13 +346,16 @@ async def mint_internal_agent(
 async def seed_internal_agents(
     request: Request,
     user: CurrentUser = Depends(current_user),
+    adopt: bool = False,
 ):
     """Idempotently mint the four internal driver agents and return their tokens.
 
     Admin only.  Each of @taOS-dev, @taOS-website-dev, @taOSmd-dev, @Hermes is
     minted with the a2a_send + a2a_receive scopes.  Re-running creates no
-    duplicate rows.  Response: {"seeded": [{handle, canonical_id, created,
-    scopes, token}, ...]}.
+    duplicate rows.  ``adopt=true`` (query param) vouches for any of those
+    handles that already exist under a non-internal origin (e.g. a driver that
+    self-joined earlier) instead of 409ing.  Response: {"seeded": [{handle,
+    canonical_id, created, adopted, scopes, token}, ...]}.
     """
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="forbidden")
@@ -350,6 +368,7 @@ async def seed_internal_agents(
                 handle=spec["handle"],
                 slug=spec["slug"],
                 scopes=list(_INTERNAL_AGENT_SCOPES),
+                adopt=adopt,
             )
         )
     return {"seeded": seeded}


### PR DESCRIPTION
Surfaced during live seeding on the Pi: a driver agent can already exist via an earlier consent-flow self-join (origin external-selfjoin, active), so seed/mint-internal 409d on the origin guard and could never grant it driver scopes.

Adds an explicit `adopt` flag (default-deny preserved): `adopt=true` lets the admin vouch for a pre-existing active agent of any origin -- reuse its identity (origin untouched), grant the scopes, mint a token. An impostor that grabbed a handle still cannot silently get scopes without the admin explicitly adopting.

Tests cover adopt-reuse, origin preservation, seed --adopt, and the default 409. 32 local tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to adopt an existing agent handle during internal minting and internal seeding.
  * Internal mint/seed results now indicate whether an identity was newly created or adopted.
* **Bug Fixes**
  * Prevents duplicate registry entries when adopting a preexisting non-internal identity.
  * Adoption applies the requested internal access scopes while preserving the original identity details.
* **Behavior Updates**
  * If a handle already exists, reuse is rejected by default (returns a conflict) unless adoption is enabled.
* **Governance**
  * Adoption actions are now recorded distinctly in governance audit events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->