### PR TITLE
fix(updater): pin Settings-update deps to uv sync --frozen (#157)

### DIFF
--- a/tests/test_updater_dep_install.py
+++ b/tests/test_updater_dep_install.py
@@ -1,0 +1,166 @@
+"""The in-app updater dependency step must install exactly what CI tested.
+
+These tests pin the behaviour of the dependency-install helpers used by the
+Settings "Install Update" flow:
+
+  * `_find_uv` resolves uv robustly (uv is not always on PATH; on the Pi it
+    lives at <install_dir>/.local/bin/uv).
+  * `_install_dependencies` prefers a lockfile-pinned `uv sync --frozen` and
+    falls back to `pip install -e .` only when uv is absent.
+  * a non-zero install return code aborts the update WITHOUT writing the
+    pending-restart marker (the crash-loop safety net stays intact).
+
+All subprocess execution is mocked; nothing actually runs uv/pip/git.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tinyagentos.routes import settings as settings_mod
+
+
+# --- _find_uv resolution order -------------------------------------------
+
+def test_find_uv_prefers_path(monkeypatch):
+    """(a) shutil.which wins when uv is on PATH."""
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/uv")
+    # Should never reach the filesystem candidates.
+    monkeypatch.setattr(Path, "exists", lambda self: pytest.fail("must not stat"))
+    assert settings_mod._find_uv(Path("/srv/taos")) == "/usr/bin/uv"
+
+
+def test_find_uv_project_local_bin(monkeypatch):
+    """(b) <project_dir>/.local/bin/uv is used when not on PATH."""
+    project = Path("/srv/taos")
+    expected = project / ".local" / "bin" / "uv"
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(Path, "exists", lambda self: self == expected)
+    monkeypatch.setattr(settings_mod.os, "access", lambda p, mode: True)
+    assert settings_mod._find_uv(project) == str(expected)
+
+
+def test_find_uv_not_found_returns_none(monkeypatch):
+    """uv absent everywhere -> None so the caller falls back to pip."""
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+    monkeypatch.setattr(settings_mod.os, "access", lambda p, mode: True)
+    assert settings_mod._find_uv(Path("/srv/taos")) is None
+
+
+# --- _install_dependencies dispatch --------------------------------------
+
+@pytest.mark.asyncio
+async def test_install_uses_uv_sync_frozen(monkeypatch):
+    """uv found -> runs `uv sync --frozen` with cwd + HOME=project_dir."""
+    project = Path("/srv/taos")
+    monkeypatch.setattr(settings_mod, "_find_uv", lambda pd: "/opt/uv")
+
+    captured = {}
+
+    async def fake_run(cmd, cwd=None, timeout=600.0, env=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["env"] = env
+        return 0, "synced"
+
+    monkeypatch.setattr(settings_mod, "_run_capture", fake_run)
+
+    rc, out = await settings_mod._install_dependencies(project)
+
+    assert rc == 0
+    assert out == "synced"
+    assert captured["cmd"] == ["/opt/uv", "sync", "--frozen"]
+    assert captured["cwd"] == str(project)
+    assert captured["env"]["HOME"] == str(project)
+
+
+@pytest.mark.asyncio
+async def test_install_falls_back_to_pip(monkeypatch):
+    """uv absent -> runs `pip install -e .` (legacy path unchanged)."""
+    project = Path("/srv/taos")
+    monkeypatch.setattr(settings_mod, "_find_uv", lambda pd: None)
+    # No venv pip on disk -> bare "pip".
+    monkeypatch.setattr(Path, "exists", lambda self: False)
+
+    captured = {}
+
+    async def fake_run(cmd, cwd=None, timeout=600.0, env=None):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["env"] = env
+        return 0, "installed"
+
+    monkeypatch.setattr(settings_mod, "_run_capture", fake_run)
+
+    rc, out = await settings_mod._install_dependencies(project)
+
+    assert rc == 0
+    assert captured["cmd"] == ["pip", "install", "-e", "."]
+    assert captured["cwd"] == str(project)
+    # pip path inherits the parent env (no override).
+    assert captured["env"] is None
+
+
+@pytest.mark.asyncio
+async def test_install_uses_venv_pip_when_present(monkeypatch):
+    """uv absent + .venv present -> uses the venv pip binary."""
+    project = Path("/srv/taos")
+    venv_pip = project / ".venv" / "bin" / "pip"
+    monkeypatch.setattr(settings_mod, "_find_uv", lambda pd: None)
+    monkeypatch.setattr(Path, "exists", lambda self: self == venv_pip)
+
+    captured = {}
+
+    async def fake_run(cmd, cwd=None, timeout=600.0, env=None):
+        captured["cmd"] = cmd
+        return 0, ""
+
+    monkeypatch.setattr(settings_mod, "_run_capture", fake_run)
+
+    await settings_mod._install_dependencies(project)
+    assert captured["cmd"] == [str(venv_pip), "install", "-e", "."]
+
+
+@pytest.mark.asyncio
+async def test_install_nonzero_rc_is_propagated(monkeypatch):
+    """A failed install returns (rc, output) so the caller aborts safely."""
+    project = Path("/srv/taos")
+    monkeypatch.setattr(settings_mod, "_find_uv", lambda pd: "/opt/uv")
+
+    async def fake_run(cmd, cwd=None, timeout=600.0, env=None):
+        return 7, "uv: lockfile out of date"
+
+    monkeypatch.setattr(settings_mod, "_run_capture", fake_run)
+
+    rc, out = await settings_mod._install_dependencies(project)
+    assert rc == 7
+    assert "lockfile out of date" in out
+
+
+# --- abort ordering: failed install must NOT write pending restart -------
+
+@pytest.mark.asyncio
+async def test_failed_install_does_not_write_pending_restart(monkeypatch):
+    """The crash-loop safety net: if the dep install fails, the update aborts
+    and write_pending_restart is never called."""
+    project = Path("/srv/taos")
+
+    async def failing_install(pd):
+        return 1, "install boom"
+
+    monkeypatch.setattr(settings_mod, "_install_dependencies", failing_install)
+
+    wrote = {"called": False}
+
+    def fake_write(sha):
+        wrote["called"] = True
+
+    monkeypatch.setattr(settings_mod, "write_pending_restart", fake_write)
+
+    rc, out = await settings_mod._pip_rebuild_restart(project, "deadbeef")
+
+    assert rc == 1
+    assert out == "install boom"
+    assert wrote["called"] is False

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -3,6 +3,8 @@ import asyncio
 import datetime
 import io
 import logging
+import os
+import shutil
 import tarfile
 import time
 from pathlib import Path
@@ -26,6 +28,7 @@ async def _run_capture(
     cmd: list[str],
     cwd: str | None = None,
     timeout: float | None = 600.0,
+    env: dict[str, str] | None = None,
 ) -> tuple[int, str]:
     """Run a subprocess capturing combined stdout+stderr, with timeout.
 
@@ -50,12 +53,17 @@ async def _run_capture(
         ``(returncode, combined_output)``.  On timeout, returncode is
         ``-1`` and the output ends with a clear ``[TIMEOUT after Ns]``
         marker so callers can include it in the error surface.
+    env:
+        Optional environment mapping for the child process. ``None`` (the
+        default) inherits the parent environment unchanged; callers that
+        need an override (e.g. uv's ``HOME``) pass a full env dict.
     """
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
         cwd=cwd,
+        env=env,
     )
     try:
         out, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
@@ -629,29 +637,88 @@ async def force_update_check(request: Request):
 
 
 
+def _find_uv(project_dir: Path) -> str | None:
+    """Locate the uv binary for the dependency-install step.
+
+    uv is not always on PATH: on the Pi the service user's HOME is the install
+    dir, so uv lives at ``<install_dir>/.local/bin/uv`` rather than a global
+    location. Resolution order:
+      (a) ``shutil.which("uv")``
+      (b) ``<project_dir>/.local/bin/uv``
+      (c) ``~/.local/bin/uv`` for the process user
+      (d) ``/usr/local/bin/uv``
+
+    Returns the first path that exists and is executable, else ``None`` so the
+    caller can fall back to pip.
+    """
+    found = shutil.which("uv")
+    if found:
+        return found
+    for candidate in (
+        project_dir / ".local" / "bin" / "uv",
+        Path.home() / ".local" / "bin" / "uv",
+        Path("/usr/local/bin/uv"),
+    ):
+        if candidate.exists() and os.access(str(candidate), os.X_OK):
+            return str(candidate)
+    return None
+
+
+async def _install_dependencies(project_dir: Path) -> tuple[int, str]:
+    """Install/sync the update's Python deps, preferring a pinned uv sync.
+
+    A lockfile-pinned ``uv sync --frozen`` installs exactly what CI tested
+    (uv.lock) instead of a fresh pip resolve that can pull newer transitive
+    deps onto a user's box. When uv is not present we fall back to the legacy
+    ``pip install -e .`` so installs without uv still update.
+
+    Capture output and surface failures -- silently swallowing a failed install
+    lands users on a grey-screen the next time they restart, because the new
+    code imports a module that's not on disk. See issue #323's sibling failure
+    mode.
+
+    Returns (returncode, output); non-zero means the install failed and the
+    caller must abort the update (no restart).
+    """
+    uv_cmd = _find_uv(project_dir)
+    if uv_cmd is not None:
+        logger.info("Updater dependency install: uv sync --frozen (%s)", uv_cmd)
+        # HOME=project_dir so uv resolves its data/cache dir correctly under the
+        # service user whose HOME is the install dir (the Pi layout).
+        env = {**os.environ, "HOME": str(project_dir)}
+        return await _run_capture(
+            [uv_cmd, "sync", "--frozen"],
+            cwd=str(project_dir),
+            env=env,
+        )
+
+    pip_cmd = "pip"
+    for candidate in (project_dir / ".venv" / "bin" / "pip", project_dir / "venv" / "bin" / "pip"):
+        if candidate.exists():
+            pip_cmd = str(candidate)
+            break
+    logger.info("Updater dependency install: uv not found, using %s install -e .", pip_cmd)
+    return await _run_capture(
+        [pip_cmd, "install", "-e", "."],
+        cwd=str(project_dir),
+    )
+
+
 async def _pip_rebuild_restart(project_dir: Path, target_sha: str) -> tuple[int, str]:
     """Sync deps, rebuild the SPA, flag the pending restart, trigger restart.
 
     Returns (returncode, output); non-zero means a step failed.
     """
-    # Pip install to pick up new deps. Capture output and surface failures —
-    # silently swallowing a failed install lands users on a grey-screen the
-    # next time they restart, because the new code imports a module that's
-    # not on disk. See issue #323's sibling failure mode.
+    install_returncode, install_output = await _install_dependencies(project_dir)
+    if install_returncode != 0:
+        return install_returncode, install_output
+
+    # Venv python for the import smoke test below (.venv/bin/python).
     venv_python: Path | None = None
-    for candidate in (project_dir / ".venv" / "bin" / "pip", project_dir / "venv" / "bin" / "pip"):
+    for candidate in (project_dir / ".venv" / "bin" / "python", project_dir / "venv" / "bin" / "python"):
         if candidate.exists():
-            pip_cmd = str(candidate)
-            venv_python = candidate.parent / "python"
+            venv_python = candidate
             break
-    else:
-        pip_cmd = "pip"
-    pip_returncode, pip_output = await _run_capture(
-        [pip_cmd, "install", "-e", "."],
-        cwd=str(project_dir),
-    )
-    if pip_returncode != 0:
-        return pip_returncode, pip_output
 
     # Import smoke test in a fresh interpreter — verifies the new code can
     # actually load with the freshly installed deps. Without this a partial


### PR DESCRIPTION
Hardens the in-app Settings update path so user updates install EXACTLY what CI tested (the committed uv.lock), instead of a fresh `pip install -e .` resolve that can pull newer transitive deps onto a user's box.

- New `_find_uv(project_dir)`: resolves uv via PATH -> `<install>/.local/bin/uv` -> `~/.local/bin/uv` -> `/usr/local/bin/uv` (the Pi's service-user HOME is the install dir, so uv isn't on PATH).
- New `_install_dependencies(project_dir)`: `uv sync --frozen` (HOME=install dir) when uv is found, else falls back to the legacy `pip install -e .` so installs without uv still work. Non-zero return aborts the update.
- The import smoke test, desktop rebuild, and "only write_pending_restart after install+smoke pass" ordering are unchanged -- the safety net that prevents a crash-loop stays.

Surfaced 2026-06-30 while deploying #1507: a raw git deploy crash-looped on a missing dep, which is exactly why updates must run a lockfile-pinned install + smoke test. 8 new unit tests (uv discovery + fallback + abort-on-failure + no-restart-on-failed-install); 411 pass in the update/settings slice.

Per Jay: build + auto-merge if gate-clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the in-app update install flow to handle dependency installation more reliably, with better fallback behavior when a preferred installer isn’t available.
  * Added safer failure handling so update installation stops cleanly if dependency setup fails, instead of continuing with a broken restart flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->