### PR TITLE
fix(desktop): recover from stale-chunk crash on WebKit/Firefox

### DIFF
--- a/desktop/src/components/AppErrorBoundary.test.tsx
+++ b/desktop/src/components/AppErrorBoundary.test.tsx
@@ -97,4 +97,28 @@ describe("AppErrorBoundary", () => {
     expect(screen.getByText("taOS was updated")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
   });
+
+  it("classifies the WebKit/Safari module-import failure as a chunk error", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("Importing a module script failed.");
+    render(
+      <AppErrorBoundary>
+        <ThrowOnRender error={err} />
+      </AppErrorBoundary>,
+    );
+    expect(screen.getByText("taOS was updated")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+  });
+
+  it("classifies the Firefox dynamic-import failure as a chunk error", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const err = new Error("error loading dynamically imported module: https://x/y.js");
+    render(
+      <AppErrorBoundary>
+        <ThrowOnRender error={err} />
+      </AppErrorBoundary>,
+    );
+    expect(screen.getByText("taOS was updated")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+  });
 });

--- a/desktop/src/components/AppErrorBoundary.tsx
+++ b/desktop/src/components/AppErrorBoundary.tsx
@@ -28,7 +28,18 @@ interface State {
 }
 
 const CHUNK_NAMES = new Set(["ChunkLoadError"]);
-const CHUNK_MESSAGES = [/Loading chunk \d+ failed/i, /Failed to fetch dynamically imported module/i];
+// A stale cached shell points at chunk URLs deleted by a newer deploy; the
+// dynamic import then fails. Each JS engine words that failure differently, so
+// match all three or the WebKit/Firefox variants fall through to the dead
+// "generic" screen instead of auto-reloading (Chrome: "Failed to fetch
+// dynamically imported module"; Firefox: "error loading dynamically imported
+// module"; Safari/WebKit: "Importing a module script failed").
+const CHUNK_MESSAGES = [
+  /Loading chunk \d+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /importing a module script failed/i,
+];
 
 function classify(err: Error): Mode {
   if (err instanceof BackendUnavailableError) return "waiting";


### PR DESCRIPTION
## Problem
The PWA crashes with a dead "Something went wrong" screen on macOS/Safari after a redeploy. Root cause: a stale service-worker-cached app shell points at chunk hashes deleted by the newer build, so the lazy dynamic import fails.

`AppErrorBoundary` already handles this (auto-reload to fetch the fresh shell), but its chunk-error matcher only recognised Chrome/webpack wording:
- `Loading chunk N failed`
- `Failed to fetch dynamically imported module`

WebKit/Safari words the identical failure as **"Importing a module script failed."** and Firefox as **"error loading dynamically imported module"**, so on those engines it fell through to the generic dead screen and never recovered. Confirmed live from the client-log ring buffer: `fatal / "Importing a module script failed." / AppErrorBoundary / /desktop`.

## Fix
Add the WebKit + Firefox wordings to `CHUNK_MESSAGES` so the auto-reload recovery fires on every engine. Two new tests cover the Safari and Firefox messages.

The served build is self-consistent (all chunks 200); this only affects clients holding a stale cached shell, who will now auto-recover instead of needing a manual cache clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of app update/load errors across more browsers, so users are more likely to see the correct reload prompt when a page chunk fails to load.
  * Added coverage for additional browser-specific error cases to help prevent missed reload recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->