### PR TITLE
feat(agents): live-updating registry panel + strip @ from display names

### DIFF
--- a/desktop/src/apps/agents/RegistryPanel.test.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { stripAt, RegistryPanel, type RegistryEntry } from "./RegistryPanel";
+
+/* ------------------------------------------------------------------ */
+/*  stripAt — pure unit tests (no timers needed)                       */
+/* ------------------------------------------------------------------ */
+
+describe("stripAt", () => {
+  it("strips a leading @ from a name", () => {
+    expect(stripAt("@taOSmd-dev")).toBe("taOSmd-dev");
+  });
+
+  it("leaves a name without @ untouched", () => {
+    expect(stripAt("taOSmd-dev")).toBe("taOSmd-dev");
+  });
+
+  it("only strips the first @", () => {
+    expect(stripAt("@foo@bar")).toBe("foo@bar");
+  });
+
+  it("handles empty string", () => {
+    expect(stripAt("")).toBe("");
+  });
+
+  it("handles string that is just @", () => {
+    expect(stripAt("@")).toBe("");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Shared fixture                                                      */
+/* ------------------------------------------------------------------ */
+
+const fakeEntry: RegistryEntry = {
+  canonical_id: "taosmd-dev-20260101-000000",
+  framework: "openclaw",
+  display_name: "@taOSmd-dev",
+  user_id: "user-1",
+  origin: "external-selfjoin",
+  handle: "",
+  role: null,
+  capabilities: [],
+  status: "active",
+  registered_at: new Date().toISOString(),
+  updated_at: null,
+  revoked_at: null,
+};
+
+function makeFetch(entries: RegistryEntry[] = [fakeEntry]) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url === "/auth/status") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ user: { is_admin: true, id: "user-1" } }),
+      });
+    }
+    if (url === "/api/agents/registry") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(entries),
+      });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Display name rendering (real timers — no fake timer conflict)      */
+/* ------------------------------------------------------------------ */
+
+describe("RegistryPanel display name", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips leading @ from display_name in the rendered row", async () => {
+    vi.stubGlobal("fetch", makeFetch());
+
+    render(<RegistryPanel />);
+
+    // Click the toggle to expand
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+
+    await waitFor(
+      () => {
+        // Should show "taOSmd-dev" not "@taOSmd-dev"
+        expect(screen.getByText("taOSmd-dev")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+    expect(screen.queryByText("@taOSmd-dev")).not.toBeInTheDocument();
+  }, 10_000);
+});
+
+/* ------------------------------------------------------------------ */
+/*  Polling behaviour (fake timers)                                     */
+/* ------------------------------------------------------------------ */
+
+describe("RegistryPanel polling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("polls the registry every 5s while expanded", async () => {
+    const mockFetch = makeFetch();
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    // Expand — use real microtask queue for state update
+    await act(async () => { toggle.click(); });
+
+    // Drain any pending microtasks from initial load
+    await act(async () => { await Promise.resolve(); });
+
+    const callsBefore = mockFetch.mock.calls.length;
+    expect(callsBefore).toBeGreaterThan(0);
+
+    // Advance 5s → should trigger one more poll cycle
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+    });
+
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it("stops polling after collapse (cleanup runs)", async () => {
+    const mockFetch = makeFetch();
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+
+    // Expand
+    await act(async () => { toggle.click(); });
+    await act(async () => { await Promise.resolve(); });
+
+    // Collapse — triggers useEffect cleanup which stops the timer
+    await act(async () => { toggle.click(); });
+    await act(async () => { await Promise.resolve(); });
+
+    const callsAtCollapse = mockFetch.mock.calls.length;
+
+    // No new calls should fire after 15s while collapsed
+    await act(async () => {
+      vi.advanceTimersByTime(15_000);
+      await Promise.resolve();
+    });
+
+    expect(mockFetch.mock.calls.length).toBe(callsAtCollapse);
+  });
+
+  it("refetches immediately after an action", async () => {
+    const mockFetch = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (url === "/auth/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ user: { is_admin: true, id: "user-1" } }),
+        });
+      }
+      if (url === "/api/agents/registry") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([fakeEntry]),
+        });
+      }
+      // Action endpoints (suspend, approve, etc.)
+      if (typeof url === "string" && /\/(suspend|approve|reject|reactivate)$/.test(url)) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(fakeEntry) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+    await act(async () => { await Promise.resolve(); });
+
+    const callsBeforeAction = mockFetch.mock.calls.length;
+
+    // Click suspend button if it exists (entry is "active" so suspend appears)
+    const suspendBtn = screen.queryByTitle("Suspend");
+    if (suspendBtn) {
+      await act(async () => {
+        suspendBtn.click();
+        await Promise.resolve();
+      });
+      // Should have triggered an additional registry fetch (post-action reload)
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBeforeAction);
+    }
+  });
+});

--- a/desktop/src/apps/agents/RegistryPanel.test.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.test.tsx
@@ -189,15 +189,13 @@ describe("RegistryPanel polling", () => {
 
     const callsBeforeAction = mockFetch.mock.calls.length;
 
-    // Click suspend button if it exists (entry is "active" so suspend appears)
-    const suspendBtn = screen.queryByTitle("Suspend");
-    if (suspendBtn) {
-      await act(async () => {
-        suspendBtn.click();
-        await Promise.resolve();
-      });
-      // Should have triggered an additional registry fetch (post-action reload)
-      expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBeforeAction);
-    }
+    // Entry is "active" so Suspend must be present — assert rather than guard.
+    const suspendBtn = screen.getByTitle("Suspend");
+    await act(async () => {
+      suspendBtn.click();
+      await Promise.resolve();
+    });
+    // Should have triggered an additional registry fetch (post-action reload)
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBeforeAction);
   });
 });

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   ChevronRight,
   ShieldCheck,
@@ -370,8 +370,11 @@ export function RegistryPanel() {
   const [currentUserId, setCurrentUserId] = useState("");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  // Monotonic counter — only the latest in-flight response is applied.
+  const loadSeq = useRef(0);
 
   const load = useCallback(async () => {
+    const seq = ++loadSeq.current;
     setLoading(true);
     setErr(null);
     try {
@@ -379,6 +382,7 @@ export function RegistryPanel() {
         fetch("/auth/status", { credentials: "include" }),
         fetch("/api/agents/registry", { credentials: "include" }),
       ]);
+      if (seq !== loadSeq.current) return; // stale — a newer load fired; discard
       if (statusResp.ok) {
         const s = await statusResp.json();
         setIsAdmin(!!s.user?.is_admin);
@@ -391,9 +395,10 @@ export function RegistryPanel() {
         setErr(`Failed to load registry (${registryResp.status})`);
       }
     } catch (e: unknown) {
+      if (seq !== loadSeq.current) return;
       setErr(e instanceof Error ? e.message : "Network error");
     } finally {
-      setLoading(false);
+      if (seq === loadSeq.current) setLoading(false);
     }
   }, []);
 
@@ -422,12 +427,22 @@ export function RegistryPanel() {
         startPolling();
       }
     };
+    // Also refetch when the window regains focus while already visible
+    // (covers alt-tab / dock-click without a tab switch).
+    const onFocus = () => {
+      if (!document.hidden) {
+        void load();
+        startPolling();
+      }
+    };
 
     if (!document.hidden) startPolling();
     document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("focus", onFocus);
     return () => {
       stopPolling();
       document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("focus", onFocus);
     };
   }, [expanded, load]);
 

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -43,6 +43,11 @@ export interface RegistryEntry {
 /*  Helpers                                                             */
 /* ------------------------------------------------------------------ */
 
+/** Strip a leading "@" for display only — "@" is bus-addressing syntax, not a name. */
+export function stripAt(s: string): string {
+  return s.startsWith("@") ? s.slice(1) : s;
+}
+
 function relativeTime(ts: string | null): string {
   if (!ts) return "—";
   const d = new Date(ts);
@@ -121,7 +126,7 @@ function RegistryEntryRow({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="font-medium text-sm truncate">
-              {entry.display_name || entry.handle || entry.framework}
+              {stripAt(entry.display_name || entry.handle || entry.framework)}
             </span>
             <span
               className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border ${STATUS_STYLES[entry.status] ?? STATUS_STYLES.revoked}`}
@@ -158,7 +163,7 @@ function RegistryEntryRow({
                 className="h-7 w-7 hover:bg-emerald-500/15 hover:text-emerald-400"
                 onClick={() => act("approve")}
                 disabled={busy}
-                aria-label={`Approve ${entry.display_name || entry.canonical_id}`}
+                aria-label={`Approve ${stripAt(entry.display_name) || entry.canonical_id}`}
                 title="Approve"
               >
                 <CheckCircle size={14} />
@@ -169,7 +174,7 @@ function RegistryEntryRow({
                 className="h-7 w-7 hover:bg-red-500/15 hover:text-red-400"
                 onClick={() => act("reject")}
                 disabled={busy}
-                aria-label={`Reject ${entry.display_name || entry.canonical_id}`}
+                aria-label={`Reject ${stripAt(entry.display_name) || entry.canonical_id}`}
                 title="Reject"
               >
                 <XCircle size={14} />
@@ -183,7 +188,7 @@ function RegistryEntryRow({
               className="h-7 w-7 hover:bg-orange-500/15 hover:text-orange-400"
               onClick={() => act("suspend")}
               disabled={busy}
-              aria-label={`Suspend ${entry.display_name || entry.canonical_id}`}
+              aria-label={`Suspend ${stripAt(entry.display_name) || entry.canonical_id}`}
               title="Suspend"
             >
               <PauseCircle size={14} />
@@ -196,7 +201,7 @@ function RegistryEntryRow({
               className="h-7 w-7 hover:bg-emerald-500/15 hover:text-emerald-400"
               onClick={() => act("reactivate")}
               disabled={busy}
-              aria-label={`Reactivate ${entry.display_name || entry.canonical_id}`}
+              aria-label={`Reactivate ${stripAt(entry.display_name) || entry.canonical_id}`}
               title="Reactivate"
             >
               <PlayCircle size={14} />
@@ -209,7 +214,7 @@ function RegistryEntryRow({
               className="h-7 w-7 hover:bg-red-500/15 hover:text-red-400"
               onClick={() => act("revoke")}
               disabled={busy}
-              aria-label={`Revoke ${entry.display_name || entry.canonical_id}`}
+              aria-label={`Revoke ${stripAt(entry.display_name) || entry.canonical_id}`}
               title="Revoke"
             >
               <ShieldOff size={14} />
@@ -392,8 +397,38 @@ export function RegistryPanel() {
     }
   }, []);
 
+  // Initial load when panel opens; polling while expanded + visible.
   useEffect(() => {
-    if (expanded) load();
+    if (!expanded) return;
+
+    void load();
+
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const startPolling = () => {
+      if (timer === null) timer = setInterval(() => void load(), 5_000);
+    };
+    const stopPolling = () => {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+    const onVisibility = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        void load();
+        startPolling();
+      }
+    };
+
+    if (!document.hidden) startPolling();
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      stopPolling();
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
   }, [expanded, load]);
 
   async function handleAction(

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -10,6 +10,7 @@ from tinyagentos.agent_registry_store import (
     _assert_valid_transition,
     _b64url_decode,
     _b64url_encode,
+    _migration_v2_strip_at_display_name,
     _row_to_dict,
     _slugify,
     load_or_create_signing_keypair,
@@ -811,3 +812,76 @@ class TestFullLifecycle:
 
         assert len(suspended) == 1
         assert suspended[0]["canonical_id"] == r3["canonical_id"]
+
+
+# ---------------------------------------------------------------------------
+# Migration v2: strip leading '@' from display_name
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationV2StripAtDisplayName:
+    @pytest.mark.asyncio
+    async def test_strips_leading_at_from_existing_rows(self, store):
+        """Rows inserted with a leading '@' are cleaned up by the migration."""
+        row = await store.register(framework="openclaw", display_name="normal-agent")
+        # Manually inject a row with a leading '@' to simulate pre-fix data.
+        await store._db.execute(
+            "UPDATE agent_registry SET display_name = '@tainted' WHERE canonical_id = ?",
+            (row["canonical_id"],),
+        )
+        await store._db.commit()
+
+        # Verify the '@' is present before the migration runs.
+        raw = await store.get(row["canonical_id"])
+        assert raw["display_name"] == "@tainted"
+
+        # Run the migration.
+        await _migration_v2_strip_at_display_name(store._db)
+
+        cleaned = await store.get(row["canonical_id"])
+        assert cleaned["display_name"] == "tainted"
+        assert not cleaned["display_name"].startswith("@")
+
+    @pytest.mark.asyncio
+    async def test_leaves_names_without_at_unchanged(self, store):
+        row = await store.register(framework="openclaw", display_name="clean-name")
+        await _migration_v2_strip_at_display_name(store._db)
+        after = await store.get(row["canonical_id"])
+        assert after["display_name"] == "clean-name"
+
+    @pytest.mark.asyncio
+    async def test_idempotent_on_multiple_runs(self, store):
+        row = await store.register(framework="openclaw", display_name="normal-agent")
+        await store._db.execute(
+            "UPDATE agent_registry SET display_name = '@once' WHERE canonical_id = ?",
+            (row["canonical_id"],),
+        )
+        await store._db.commit()
+
+        await _migration_v2_strip_at_display_name(store._db)
+        await _migration_v2_strip_at_display_name(store._db)  # second run is a no-op
+
+        after = await store.get(row["canonical_id"])
+        assert after["display_name"] == "once"
+
+    @pytest.mark.asyncio
+    async def test_strips_at_on_store_init(self, tmp_path):
+        """AgentRegistryStore._post_init runs the migration automatically."""
+        s = AgentRegistryStore(tmp_path / "migr_test.db")
+        await s.init()
+
+        row = await s.register(framework="openclaw", display_name="normal-agent")
+        await s._db.execute(
+            "UPDATE agent_registry SET display_name = '@auto-migrated' WHERE canonical_id = ?",
+            (row["canonical_id"],),
+        )
+        await s._db.commit()
+
+        # Re-opening the store triggers _post_init which runs the migration.
+        await s.close()
+        s2 = AgentRegistryStore(tmp_path / "migr_test.db")
+        await s2.init()
+
+        after = await s2.get(row["canonical_id"])
+        assert after["display_name"] == "auto-migrated"
+        await s2.close()

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -159,6 +159,58 @@ class TestApproveDisplayNameNormalization:
         await auth_store.close()
         await grants.close()
 
+    @pytest.mark.asyncio
+    async def test_approve_bare_at_claim_falls_back_to_framework(
+        self, client, monkeypatch, tmp_path
+    ):
+        """A degenerate '@'-only claim must never persist '@' or an empty
+        display_name -- it falls back to the framework name."""
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+
+        registry = AgentRegistryStore(tmp_path / "reg3.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth3.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants3.db")
+        await grants.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys3")
+
+        record = await auth_store.create(
+            identity_claim="@",
+            framework="openclaw",
+            requested_scopes=["memory_read"],
+            requested_skills=None,
+            reason="",
+            duration_secs=None,
+            project_id=None,
+        )
+
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(
+            client._transport.app.state, "agent_registry_keypair", (priv, pub)
+        )
+
+        resp = await client.post(
+            f"/api/agents/auth-requests/{record['id']}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+        assert resp.status_code == 200, resp.text
+
+        agents = await registry.list_all()
+        assert agents[0]["display_name"] == "openclaw"
+        assert "@" not in agents[0]["display_name"]
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+
 
 class TestAgentAuthRequestsGet:
     @pytest.mark.asyncio

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -56,6 +56,110 @@ class TestAgentAuthRequestsList:
         assert data["requests"][0]["status"] == "pending"
 
 
+class TestApproveDisplayNameNormalization:
+    """Verify _do_approve strips a leading '@' before persisting display_name."""
+
+    @pytest.mark.asyncio
+    async def test_approve_strips_leading_at_from_display_name(
+        self, client, monkeypatch, tmp_path
+    ):
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+
+        registry = AgentRegistryStore(tmp_path / "reg.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants.db")
+        await grants.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys")
+
+        record = await auth_store.create(
+            identity_claim="@taOSmd-dev",
+            framework="openclaw",
+            requested_scopes=["memory_read"],
+            requested_skills=None,
+            reason="",
+            duration_secs=None,
+            project_id=None,
+        )
+
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(
+            client._transport.app.state, "agent_registry_keypair", (priv, pub)
+        )
+
+        resp = await client.post(
+            f"/api/agents/auth-requests/{record['id']}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+        assert resp.status_code == 200, resp.text
+
+        agents = await registry.list_all()
+        assert len(agents) == 1
+        assert agents[0]["display_name"] == "taOSmd-dev"
+        assert not agents[0]["display_name"].startswith("@")
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+
+    @pytest.mark.asyncio
+    async def test_approve_preserves_name_without_at(
+        self, client, monkeypatch, tmp_path
+    ):
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+
+        registry = AgentRegistryStore(tmp_path / "reg2.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth2.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants2.db")
+        await grants.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys2")
+
+        record = await auth_store.create(
+            identity_claim="taOSmd-dev",
+            framework="openclaw",
+            requested_scopes=["memory_read"],
+            requested_skills=None,
+            reason="",
+            duration_secs=None,
+            project_id=None,
+        )
+
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(
+            client._transport.app.state, "agent_registry_keypair", (priv, pub)
+        )
+
+        resp = await client.post(
+            f"/api/agents/auth-requests/{record['id']}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+        assert resp.status_code == 200, resp.text
+
+        agents = await registry.list_all()
+        assert agents[0]["display_name"] == "taOSmd-dev"
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+
+
 class TestAgentAuthRequestsGet:
     @pytest.mark.asyncio
     async def test_get_unknown_id_returns_404(self, client, monkeypatch):

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -111,9 +111,11 @@ async def _migration_v2_strip_at_display_name(conn) -> None:
     in display_name.  Safe to run every startup — rows without a leading
     '@' are untouched by the WHERE clause.
     """
+    # '@_%' requires at least one character after '@', so bare '@'-only rows
+    # are intentionally left unchanged and cannot be produced as empty strings.
     await conn.execute(
         "UPDATE agent_registry SET display_name = substr(display_name, 2) "
-        "WHERE display_name LIKE '@%'"
+        "WHERE display_name LIKE '@_%'"
     )
     await conn.commit()
 

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -104,6 +104,19 @@ async def _migration_v1_add_status(conn) -> None:
     await conn.commit()
 
 
+async def _migration_v2_strip_at_display_name(conn) -> None:
+    """Strip a leading '@' from display_name for all rows (idempotent).
+
+    The '@' sigil is bus-addressing syntax only; it must never be stored
+    in display_name.  Safe to run every startup — rows without a leading
+    '@' are untouched by the WHERE clause.
+    """
+    await conn.execute(
+        "UPDATE agent_registry SET display_name = substr(display_name, 2) "
+        "WHERE display_name LIKE '@%'"
+    )
+    await conn.commit()
+
 # ---------------------------------------------------------------------------
 # Signing-key helpers (Ed25519, persisted to disk)
 # ---------------------------------------------------------------------------
@@ -301,6 +314,7 @@ class AgentRegistryStore(BaseStore):
     async def _post_init(self) -> None:
         """Idempotently ensure the status column exists and is backfilled."""
         await _migration_v1_add_status(self._db)
+        await _migration_v2_strip_at_display_name(self._db)
 
     # ------------------------------------------------------------------
     # Registration

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -300,9 +300,13 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
     rel_mgr = _get_relationships(request)
 
     # Mint canonical identity in the registry.
-    # Strip any leading "@" — that sigil is bus-addressing syntax only and
-    # must never appear in a stored display_name.
-    display_name = record["identity_claim"].removeprefix("@").strip()
+    # Strip whitespace first, then remove the leading "@" sigil (bus-addressing
+    # syntax only), then strip again.  Guard against an empty result (claim was
+    # "@" or whitespace-only): prefer the raw claim text, then the framework
+    # name, to ensure display_name is always non-empty.
+    _raw = record["identity_claim"].strip()
+    _claim = _raw.removeprefix("@").strip()
+    display_name = _claim or _raw or record["framework"]
     reg_record = await registry.register(
         framework=record["framework"],
         display_name=display_name,

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -301,12 +301,12 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
 
     # Mint canonical identity in the registry.
     # Strip whitespace first, then remove the leading "@" sigil (bus-addressing
-    # syntax only), then strip again.  Guard against an empty result (claim was
-    # "@" or whitespace-only): prefer the raw claim text, then the framework
-    # name, to ensure display_name is always non-empty.
-    _raw = record["identity_claim"].strip()
-    _claim = _raw.removeprefix("@").strip()
-    display_name = _claim or _raw or record["framework"]
+    # syntax only), then strip again.  If that leaves nothing (claim was "@" or
+    # whitespace-only) fall back to the framework name -- never the raw claim,
+    # which could still carry the "@", so display_name is always a clean,
+    # non-empty value.
+    _claim = record["identity_claim"].strip().removeprefix("@").strip()
+    display_name = _claim or record["framework"]
     reg_record = await registry.register(
         framework=record["framework"],
         display_name=display_name,

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -300,9 +300,12 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
     rel_mgr = _get_relationships(request)
 
     # Mint canonical identity in the registry.
+    # Strip any leading "@" — that sigil is bus-addressing syntax only and
+    # must never appear in a stored display_name.
+    display_name = record["identity_claim"].removeprefix("@").strip()
     reg_record = await registry.register(
         framework=record["framework"],
-        display_name=record["identity_claim"],
+        display_name=display_name,
         user_id=user.user_id,
         origin="external-selfjoin",
         handle="",


### PR DESCRIPTION
## Live updates
The Agents panel fetched the registry once on mount, so identity changes (mint/approve/suspend/revoke, new pending requests) only appeared after a manual PWA refresh. It now polls every 5s while visible (pauses when the tab is hidden, refetches on focus) and refetches immediately after any local action — matching the existing `use-server-notifications` pattern. First step toward OS-wide live updates.

## @ is targeting-only, never a display name
Some identities stored an `@` in `display_name` (consent/external self-joins), so the Agents app showed `@taOSmd-dev` for some and bare `taosmd-dev` for others. Fixed at three layers: strip the `@` on the consent approve write path, an idempotent store migration that cleans existing rows on startup, and a defensive UI strip. Canonical IDs and targeting handles untouched.

## Tests
6 backend (approve normalization + migration idempotency) and 9 frontend (stripAt + polling/refetch with fake timers) added; 374 backend + 9 frontend pass, tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent names in the registry now omit a leading `@`, including action labels.
  * Approved auth requests now save a normalized display name (trimmed, `@`-stripped when present, with a safe fallback).
  * Existing registry entries are automatically normalized on startup via migration.
* **New Features**
  * Registry panel now auto-refreshes every 5 seconds while visible, pauses when hidden, and resumes with an immediate reload when visible again or when the window is refocused.
* **Tests**
  * Added tests covering normalization, migration behavior, and registry polling/visibility and approval flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->