### PR TITLE
feat(live): shared SSE event stream + live notifications (foundation)

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -25,6 +25,7 @@ import { NotificationToasts } from "@/components/NotificationToast";
 import { NotificationCentre } from "@/components/NotificationCentre";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useServerNotifications } from "@/hooks/use-server-notifications";
+import { useEventStream } from "@/hooks/use-event-stream";
 import { usePerfAutoDetect } from "@/lib/use-perf-autodetect";
 import { TaosAssistantPanel } from "@/components/TaosAssistantPanel";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
@@ -199,6 +200,9 @@ export function App() {
   // Sync the persistent backend notification feed into the bell (desktop and
   // mobile both render NotificationCentre under this component).
   useServerNotifications();
+  // Open a persistent SSE connection for real-time OS updates. This is the
+  // primary push channel; useServerNotifications falls back to polling.
+  useEventStream();
 
   // Re-apply the persisted active theme on app boot so a reload keeps the
   // user's chosen theme app-wide (not only when Settings is opened).

--- a/desktop/src/hooks/use-event-stream.test.ts
+++ b/desktop/src/hooks/use-event-stream.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useEventStream } from "./use-event-stream";
+import { useNotificationStore } from "@/stores/notification-store";
+
+// ---------------------------------------------------------------------------
+// Mock EventSource — must use a regular function (not arrow) so `new` works
+// ---------------------------------------------------------------------------
+
+type MessageListener = (e: MessageEvent) => void;
+
+interface MockEventSource {
+  url: string;
+  onmessage: MessageListener | null;
+  onerror: ((e: Event) => void) | null;
+  close: ReturnType<typeof vi.fn>;
+  _fire: (data: unknown) => void;
+}
+
+let lastEs: MockEventSource | null = null;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const MockEventSourceCtor = vi.fn().mockImplementation(function (this: any, url: string) {
+  this.url = url;
+  this.onmessage = null as MessageListener | null;
+  this.onerror = null;
+  this.close = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  this._fire = (data: unknown) => {
+    (this as MockEventSource).onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  };
+  lastEs = this as MockEventSource;
+});
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.stubGlobal("EventSource", MockEventSourceCtor);
+  MockEventSourceCtor.mockClear();
+  lastEs = null;
+  // Reset the notification store so tests start clean
+  useNotificationStore.setState({ notifications: [] });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useEventStream", () => {
+  it("opens an EventSource to /api/events/stream on mount", () => {
+    renderHook(() => useEventStream());
+    expect(MockEventSourceCtor).toHaveBeenCalledWith("/api/events/stream");
+  });
+
+  it("closes the EventSource on unmount", () => {
+    const { unmount } = renderHook(() => useEventStream());
+    unmount();
+    expect(lastEs?.close).toHaveBeenCalled();
+  });
+
+  it("routes notification.added into the notification store via mapRow", () => {
+    renderHook(() => useEventStream());
+
+    const row = {
+      id: 42,
+      timestamp: 1700000000,
+      level: "info",
+      title: "Agent joined",
+      message: "worker-1 is now online",
+      read: false,
+      source: "worker.join",
+      data: null,
+    };
+
+    act(() => {
+      lastEs?._fire({ type: "notification.added", payload: row, ts: 1700000000 });
+    });
+
+    const notifications = useNotificationStore.getState().notifications;
+    expect(notifications).toHaveLength(1);
+    const n = notifications[0];
+    expect(n.id).toBe("srv-42");
+    expect(n.title).toBe("Agent joined");
+    expect(n.body).toBe("worker-1 is now online");
+    // timestamp is converted from seconds to milliseconds by mapRow
+    expect(n.timestamp).toBe(1700000000 * 1000);
+  });
+
+  it("ignores unknown event types without throwing", () => {
+    renderHook(() => useEventStream());
+    expect(() => {
+      act(() => {
+        lastEs?._fire({ type: "future.event.type", payload: {}, ts: 0 });
+      });
+    }).not.toThrow();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("ignores malformed JSON without throwing", () => {
+    renderHook(() => useEventStream());
+    expect(() => {
+      act(() => {
+        lastEs?.onmessage?.({ data: "not json {{" } as MessageEvent);
+      });
+    }).not.toThrow();
+  });
+
+  it("ignores messages with no payload without throwing", () => {
+    renderHook(() => useEventStream());
+    expect(() => {
+      act(() => {
+        lastEs?._fire({ type: "notification.added" }); // no payload
+      });
+    }).not.toThrow();
+  });
+
+  it("merges multiple notification.added events", () => {
+    renderHook(() => useEventStream());
+
+    const base = {
+      timestamp: 1700000000,
+      level: "info",
+      message: "msg",
+      read: false,
+      source: "system",
+      data: null,
+    };
+
+    act(() => {
+      lastEs?._fire({ type: "notification.added", payload: { ...base, id: 1, title: "First" } });
+      lastEs?._fire({ type: "notification.added", payload: { ...base, id: 2, title: "Second" } });
+    });
+
+    const notifications = useNotificationStore.getState().notifications;
+    expect(notifications).toHaveLength(2);
+    const ids = notifications.map((n) => n.id);
+    expect(ids).toContain("srv-1");
+    expect(ids).toContain("srv-2");
+  });
+});

--- a/desktop/src/hooks/use-event-stream.ts
+++ b/desktop/src/hooks/use-event-stream.ts
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { useNotificationStore } from "@/stores/notification-store";
+import { mapRow, ServerNotificationRow } from "@/lib/server-notifications";
+
+type EventPayload = Record<string, unknown>;
+type EventHandler = (payload: EventPayload) => void;
+
+/**
+ * Dispatch table: maps SSE event type → handler.
+ * Adding a new event type is one line here.
+ */
+const handlers: Record<string, EventHandler> = {
+  "notification.added": (payload) => {
+    const store = useNotificationStore.getState();
+    const newItem = mapRow(payload as unknown as ServerNotificationRow);
+    // mergeServerNotifications replaces ALL unarchived srv-* items with the
+    // passed list. For a single SSE push we must include the existing items so
+    // they are not dropped; de-dup by id so the new item is not duplicated.
+    const existingSrv = store.notifications.filter(
+      (n) => n.id.startsWith("srv-") && !n.archived && n.id !== newItem.id,
+    );
+    store.mergeServerNotifications([newItem, ...existingSrv]);
+  },
+};
+
+/**
+ * Open ONE persistent SSE connection to /api/events/stream and route each
+ * incoming event by its ``type`` field through the dispatch table.
+ *
+ * Mount once in the app shell (App.tsx) so there is exactly one connection
+ * per session.  The EventSource reconnects automatically on transient errors;
+ * unmount closes the connection cleanly.
+ */
+export function useEventStream(): void {
+  useEffect(() => {
+    const es = new EventSource("/api/events/stream");
+
+    es.onmessage = (msg) => {
+      let event: { type?: string; payload?: EventPayload } | null;
+      try {
+        event = JSON.parse(msg.data as string);
+      } catch {
+        return;
+      }
+      if (!event || typeof event !== "object") return;
+      const handler = handlers[event.type ?? ""];
+      if (handler && event.payload !== undefined) {
+        handler(event.payload as EventPayload);
+      }
+    };
+
+    es.onerror = () => {
+      // Transient network errors: the browser reconnects automatically.
+      // On hard close the effect cleanup runs and a remount opens a fresh stream.
+    };
+
+    return () => es.close();
+  }, []);
+}

--- a/desktop/src/hooks/use-event-stream.ts
+++ b/desktop/src/hooks/use-event-stream.ts
@@ -28,32 +28,75 @@ const handlers: Record<string, EventHandler> = {
  * incoming event by its ``type`` field through the dispatch table.
  *
  * Mount once in the app shell (App.tsx) so there is exactly one connection
- * per session.  The EventSource reconnects automatically on transient errors;
- * unmount closes the connection cleanly.
+ * per session.  The browser only auto-reconnects EventSource on transient
+ * network drops; an HTTP error response (e.g. a 401 after session expiry)
+ * closes the connection for good, so that case is reconnected manually.
+ * Unmount closes the connection cleanly and cancels any pending reconnect.
  */
+const RECONNECT_DELAY_MS = 5000;
+
+// Replay on (re)connect is best-effort (see event_stream.py docstring): the
+// server cannot filter by Last-Event-ID, so the same buffered events can
+// arrive again. De-dupe by the event's stable id (trace_id) instead, bounded
+// so the set can't grow without limit over a long session.
+const MAX_SEEN_IDS = 128;
+
 export function useEventStream(): void {
   useEffect(() => {
-    const es = new EventSource("/api/events/stream");
+    let es: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let stopped = false;
+    const seenIds: string[] = [];
+    const seen = new Set<string>();
 
-    es.onmessage = (msg) => {
-      let event: { type?: string; payload?: EventPayload } | null;
-      try {
-        event = JSON.parse(msg.data as string);
-      } catch {
-        return;
+    const alreadySeen = (id: string | undefined): boolean => {
+      if (!id) return false;
+      if (seen.has(id)) return true;
+      seen.add(id);
+      seenIds.push(id);
+      if (seenIds.length > MAX_SEEN_IDS) {
+        const oldest = seenIds.shift();
+        if (oldest) seen.delete(oldest);
       }
-      if (!event || typeof event !== "object") return;
-      const handler = handlers[event.type ?? ""];
-      if (handler && event.payload !== undefined) {
-        handler(event.payload as EventPayload);
-      }
+      return false;
     };
 
-    es.onerror = () => {
-      // Transient network errors: the browser reconnects automatically.
-      // On hard close the effect cleanup runs and a remount opens a fresh stream.
+    const connect = () => {
+      es = new EventSource("/api/events/stream");
+
+      es.onmessage = (msg) => {
+        let event: { type?: string; payload?: EventPayload; id?: string } | null;
+        try {
+          event = JSON.parse(msg.data as string);
+        } catch {
+          return;
+        }
+        if (!event || typeof event !== "object") return;
+        if (alreadySeen(event.id)) return;
+        const handler = handlers[event.type ?? ""];
+        if (handler && event.payload !== undefined) {
+          handler(event.payload as EventPayload);
+        }
+      };
+
+      es.onerror = () => {
+        // Transient network errors: the browser reconnects automatically.
+        // A hard close (e.g. HTTP error response) leaves readyState CLOSED
+        // and the browser gives up, so reconnect manually after a backoff.
+        if (!stopped && es?.readyState === EventSource.CLOSED) {
+          reconnectTimer = setTimeout(() => {
+            if (!stopped) connect();
+          }, RECONNECT_DELAY_MS);
+        }
+      };
     };
 
-    return () => es.close();
+    connect();
+
+    return () => {
+      stopped = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      es?.close();
+    };
   }, []);
 }

--- a/desktop/src/hooks/use-event-stream.ts
+++ b/desktop/src/hooks/use-event-stream.ts
@@ -41,10 +41,14 @@ const RECONNECT_DELAY_MS = 5000;
 // so the set can't grow without limit over a long session.
 const MAX_SEEN_IDS = 128;
 
+// Reconnect backoff so a permanently-down backend is not hit every 5s forever.
+const MAX_RECONNECT_DELAY_MS = 30000;
+
 export function useEventStream(): void {
   useEffect(() => {
     let es: EventSource | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let reconnectAttempts = 0;
     let stopped = false;
     const seenIds: string[] = [];
     const seen = new Set<string>();
@@ -63,6 +67,11 @@ export function useEventStream(): void {
 
     const connect = () => {
       es = new EventSource("/api/events/stream");
+
+      es.onopen = () => {
+        // A clean open means the backend is healthy again; reset the backoff.
+        reconnectAttempts = 0;
+      };
 
       es.onmessage = (msg) => {
         let event: { type?: string; payload?: EventPayload; id?: string } | null;
@@ -84,9 +93,14 @@ export function useEventStream(): void {
         // A hard close (e.g. HTTP error response) leaves readyState CLOSED
         // and the browser gives up, so reconnect manually after a backoff.
         if (!stopped && es?.readyState === EventSource.CLOSED) {
+          const delay = Math.min(
+            RECONNECT_DELAY_MS * 2 ** reconnectAttempts,
+            MAX_RECONNECT_DELAY_MS,
+          );
+          reconnectAttempts += 1;
           reconnectTimer = setTimeout(() => {
             if (!stopped) connect();
-          }, RECONNECT_DELAY_MS);
+          }, delay);
         }
       };
     };

--- a/desktop/src/hooks/use-server-notifications.ts
+++ b/desktop/src/hooks/use-server-notifications.ts
@@ -2,12 +2,16 @@ import { useEffect } from "react";
 import { useNotificationStore } from "@/stores/notification-store";
 import { fetchServerNotifications } from "@/lib/server-notifications";
 
-const POLL_MS = 30_000;
+// The SSE stream (use-event-stream) is the primary delivery path for new
+// notifications. This poll is a slow safety-net: it catches any notifications
+// missed while the SSE connection was down (e.g. network hiccup, tab sleep).
+const POLL_MS = 120_000;
 
 /**
  * Keep the notification store in sync with the backend feed: fetch + merge on
- * mount, poll every 30s, and refresh immediately whenever the notification
- * centre transitions to open. Mount once under the desktop shell.
+ * mount, poll every 120s (fallback; SSE is primary), and refresh immediately
+ * whenever the notification centre transitions to open. Mount once under the
+ * desktop shell.
  */
 export function useServerNotifications() {
   const centreOpen = useNotificationStore((s) => s.centreOpen);

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -11,7 +11,7 @@ import { withCsrf } from "./csrf";
  * ids, and second-precision timestamps are converted to milliseconds.
  */
 
-interface ServerNotificationRow {
+export interface ServerNotificationRow {
   id: number;
   timestamp: number; // unix seconds
   level: string;
@@ -64,7 +64,7 @@ export function sourceToTarget(
   }
 }
 
-function mapRow(row: ServerNotificationRow): Notification {
+export function mapRow(row: ServerNotificationRow): Notification {
   const level = VALID_LEVELS.has(row.level as Notification["level"])
     ? (row.level as Notification["level"])
     : "info";

--- a/tests/test_event_stream.py
+++ b/tests/test_event_stream.py
@@ -1,0 +1,187 @@
+"""Tests for GET /api/events/stream and the NotificationStore event emitter."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.events.bus import EventBus, SystemEvent
+from tinyagentos.notifications import NotificationStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(**kwargs) -> SystemEvent:
+    defaults = dict(
+        kind="notification.added",
+        source="system",
+        targets=["broadcast"],
+        payload={"id": 1, "title": "T", "message": "M", "level": "info"},
+    )
+    defaults.update(kwargs)
+    return SystemEvent(**defaults)
+
+
+@pytest_asyncio.fixture
+async def notif_store(tmp_path):
+    store = NotificationStore(tmp_path / "notifications.db")
+    await store.init()
+    yield store
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# EventBus.broadcast()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_broadcast_delivers_to_broadcast_channel():
+    bus = EventBus()
+    q = await bus.subscribe("broadcast")
+    ev = _make_event()
+    await bus.broadcast(ev)
+    received = q.get_nowait()
+    assert received is ev
+
+
+@pytest.mark.asyncio
+async def test_broadcast_does_not_deliver_to_other_channels():
+    bus = EventBus()
+    other_q = await bus.subscribe("user:alice")
+    bcast_q = await bus.subscribe("broadcast")
+    ev = _make_event()
+    await bus.broadcast(ev)
+    # broadcast channel gets it
+    assert not bcast_q.empty()
+    # user channel does not
+    assert other_q.empty()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_multiple_subscribers_all_receive():
+    bus = EventBus()
+    q1 = await bus.subscribe("broadcast")
+    q2 = await bus.subscribe("broadcast")
+    ev = _make_event()
+    await bus.broadcast(ev)
+    assert q1.get_nowait() is ev
+    assert q2.get_nowait() is ev
+
+
+# ---------------------------------------------------------------------------
+# NotificationStore.add() emitter wiring
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_add_calls_event_emitter_with_correct_payload(notif_store):
+    received: list[dict] = []
+
+    async def emitter(row: dict) -> None:
+        received.append(row)
+
+    notif_store.set_event_emitter(emitter)
+    await notif_store.add("Hello", "World", level="warning", source="tests")
+
+    assert len(received) == 1
+    row = received[0]
+    assert row["title"] == "Hello"
+    assert row["message"] == "World"
+    assert row["level"] == "warning"
+    assert row["source"] == "tests"
+    assert row["read"] is False
+    assert isinstance(row["id"], int)
+    assert isinstance(row["timestamp"], int)
+
+
+@pytest.mark.asyncio
+async def test_add_emitter_receives_data_field(notif_store):
+    received: list[dict] = []
+
+    async def emitter(row: dict) -> None:
+        received.append(row)
+
+    notif_store.set_event_emitter(emitter)
+    await notif_store.add("T", "M", data={"request_id": "abc"})
+
+    assert received[0]["data"] == {"request_id": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_add_raising_emitter_does_not_break_add(notif_store):
+    async def bad_emitter(row: dict) -> None:
+        raise RuntimeError("emitter exploded")
+
+    notif_store.set_event_emitter(bad_emitter)
+    # Should not raise
+    await notif_store.add("Title", "Body")
+    # Notification was persisted despite the emitter failing
+    rows = await notif_store.list()
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Title"
+
+
+@pytest.mark.asyncio
+async def test_add_without_emitter_still_works(notif_store):
+    """No emitter set: add() works normally."""
+    await notif_store.add("T", "M")
+    rows = await notif_store.list()
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /api/events/stream — auth gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stream_requires_auth(client):
+    """The SSE stream returns 401 for requests without a session."""
+    # Create a client without auth credentials
+    from httpx import ASGITransport, AsyncClient
+    transport = ASGITransport(app=client._transport.app)
+    async with AsyncClient(transport=transport, base_url="http://test") as no_auth:
+        resp = await no_auth.get("/api/events/stream")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stream_requires_auth_explicit_setup(app):
+    """Belt-and-braces: check that request.state.user_id=None gives 401."""
+    from tinyagentos.routes.event_stream import events_stream
+    from unittest.mock import MagicMock, AsyncMock
+
+    req = MagicMock()
+    req.state.user_id = None
+    resp = await events_stream(req)
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# EventBus broadcast integration: notification.added flows to broadcast channel
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_notification_add_reaches_event_bus_broadcast(notif_store):
+    """Full seam: add() → emitter → EventBus.broadcast() → subscriber."""
+    bus = EventBus()
+    bcast_q = await bus.subscribe("broadcast")
+
+    async def emitter(row: dict) -> None:
+        ev = SystemEvent(
+            kind="notification.added",
+            source="system",
+            targets=["broadcast"],
+            payload=row,
+        )
+        await bus.broadcast(ev)
+
+    notif_store.set_event_emitter(emitter)
+    await notif_store.add("Push Test", "via emitter")
+
+    received = bcast_q.get_nowait()
+    assert received.kind == "notification.added"
+    assert received.payload["title"] == "Push Test"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1180,10 +1180,24 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
         # System event bus — unified typed-event broadcast.
         from tinyagentos.events import EventBus, SystemEventStore
+        from tinyagentos.events.bus import SystemEvent as _SystemEvent
         _system_events = SystemEventStore(data_dir / "system-events.db")
         await _system_events.init()
         app.state.system_events = _system_events
         app.state.event_bus = EventBus()
+
+        # Wire NotificationStore → EventBus so SSE clients get instant push.
+        # The emitter is best-effort: failures are logged and never break add().
+        async def _notify_emitter(row: dict) -> None:
+            ev = _SystemEvent(
+                kind="notification.added",
+                source="system",
+                targets=["broadcast"],
+                payload=row,
+            )
+            await app.state.event_bus.broadcast(ev)
+
+        notif_store.set_event_emitter(_notify_emitter)
 
         # All startup init complete — allow requests through.
         app.state._startup_complete = True

--- a/tinyagentos/events/bus.py
+++ b/tinyagentos/events/bus.py
@@ -73,6 +73,16 @@ class EventBus:
         for q in list(self._queues.get(channel, [])):
             q.put_nowait(event)
 
+    async def broadcast(self, event: SystemEvent) -> None:
+        """Publish *event* directly to the broadcast channel.
+
+        Bypasses the routing sinks (trace_store, notifications, agent_messages)
+        so callers that have already persisted the event (e.g. NotificationStore)
+        can push it to SSE subscribers without recursion or double-persistence.
+        """
+        async with self._lock:
+            await self._publish_to_channel(_BROADCAST_CHANNEL, event)
+
     # ------------------------------------------------------------------
     # Emit
     # ------------------------------------------------------------------

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -63,10 +63,21 @@ class NotificationStore(BaseStore):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._webhook_notifier = None
+        self._event_emitter = None  # async callable: (row: dict) -> None
 
     def set_webhook_notifier(self, notifier) -> None:
         """Attach a WebhookNotifier to fire on every notification."""
         self._webhook_notifier = notifier
+
+    def set_event_emitter(self, emitter) -> None:
+        """Attach an async callable called with each new notification row dict.
+
+        The emitter receives the same shape as the GET /api/notifications items
+        (id, timestamp, level, title, message, read, source, data). Used to
+        push new notifications to SSE subscribers without polling. Best-effort:
+        a failing emitter never breaks add().
+        """
+        self._event_emitter = emitter
 
     async def _post_init(self) -> None:
         # `archived` was added after the initial notifications ship. Guarded
@@ -98,7 +109,7 @@ class NotificationStore(BaseStore):
     ) -> None:
         ts = int(time.time())
         data_json = json.dumps(data) if data is not None else None
-        await self._db.execute(
+        cursor = await self._db.execute(
             "INSERT INTO notifications (timestamp, level, title, message, source, data) VALUES (?, ?, ?, ?, ?, ?)",
             (ts, level, title, message, source, data_json),
         )
@@ -109,6 +120,22 @@ class NotificationStore(BaseStore):
                 await self._webhook_notifier.notify(title, message, level)
             except Exception as e:
                 logger.warning(f"Webhook notification error: {e}")
+        # Push to EventBus broadcast for SSE delivery — best-effort, never breaks add()
+        if self._event_emitter:
+            try:
+                row = {
+                    "id": cursor.lastrowid,
+                    "timestamp": ts,
+                    "level": level,
+                    "title": title,
+                    "message": message,
+                    "read": False,
+                    "source": source,
+                    "data": data,
+                }
+                await self._event_emitter(row)
+            except Exception:
+                logger.warning("NotificationStore: event emitter failed", exc_info=True)
 
     async def list(self, limit: int = 20, unread_only: bool = False) -> list[dict]:
         # Active feed: archived (dismissed) notifications are excluded.

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -302,6 +302,9 @@ def register_all_routers(app):
     from tinyagentos.routes.events import router as events_router
     app.include_router(events_router)
 
+    from tinyagentos.routes.event_stream import router as event_stream_router
+    app.include_router(event_stream_router)
+
     # OTLP/HTTP+JSON receiver -- Phase 2 observability.
     # POST /v1/traces accepts ExportTraceServiceRequest JSON and writes spans
     # to the per-agent SpanStore (app.state.span_store_registry).

--- a/tinyagentos/routes/event_stream.py
+++ b/tinyagentos/routes/event_stream.py
@@ -1,0 +1,98 @@
+"""SSE endpoint: GET /api/events/stream
+
+Streams SystemEvents from the EventBus to authenticated clients.  Each frame
+is a JSON object with the shape ``{"type": <kind>, "payload": {...}, "ts": <float>}``
+so the frontend dispatch table can route by ``type``.
+
+Auth: session cookie via AuthMiddleware (this path is NOT in EXEMPT_PATHS, so
+unauthenticated requests are rejected with 401 before they reach the handler).
+The handler also checks user_id explicitly to produce a clear error if the
+middleware somehow skips it (belt-and-braces).
+
+Reconnect / replay: each SSE frame carries an ``id:`` sequence number.  A
+reconnecting EventSource sends ``Last-Event-ID``; the EventBus replay buffer
+(last 32 events per channel) is delivered to new subscribers automatically on
+subscribe(), so recent events are re-streamed without client logic.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from fastapi import APIRouter
+from fastapi.requests import Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/api/events/stream")
+async def events_stream(request: Request):
+    """SSE stream of system events for the calling user.
+
+    Subscribes to both the per-user channel (``user:<id>``) and the broadcast
+    channel on the EventBus and merges them.  Keepalives are sent every 10 s
+    so proxies don't close the connection.  Both channel subscriptions are
+    cleaned up on disconnect or generator cancellation.
+    """
+    user_id = getattr(request.state, "user_id", None)
+    if not user_id:
+        return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+
+    event_bus = getattr(request.app.state, "event_bus", None)
+    if event_bus is None:
+        return JSONResponse({"detail": "Service starting"}, status_code=503)
+
+    user_ch = f"user:{user_id}"
+    user_q = await event_bus.subscribe(user_ch)
+    bcast_q = await event_bus.subscribe("broadcast")
+
+    # Merge both channels into a single queue so the generator has one await.
+    merged: asyncio.Queue = asyncio.Queue()
+
+    async def _relay(src: asyncio.Queue) -> None:
+        while True:
+            ev = await src.get()
+            await merged.put(ev)
+
+    relay_tasks = [
+        asyncio.create_task(_relay(user_q), name="sse-relay-user"),
+        asyncio.create_task(_relay(bcast_q), name="sse-relay-bcast"),
+    ]
+
+    async def gen():
+        seq = 0
+        try:
+            while True:
+                if await request.is_disconnected():
+                    return
+                try:
+                    event = await asyncio.wait_for(merged.get(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    yield ":keepalive\n\n"
+                    continue
+                seq += 1
+                data = json.dumps(
+                    {"type": event.kind, "payload": event.payload, "ts": event.ts}
+                )
+                yield f"id: {seq}\ndata: {data}\n\n"
+        finally:
+            for t in relay_tasks:
+                t.cancel()
+            await event_bus.unsubscribe(user_ch, user_q)
+            await event_bus.unsubscribe("broadcast", bcast_q)
+
+    # Cache-Control: no-cache + X-Accel-Buffering: no prevent nginx/proxies
+    # from buffering the stream (which would coalesce or delay events).
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )

--- a/tinyagentos/routes/event_stream.py
+++ b/tinyagentos/routes/event_stream.py
@@ -9,10 +9,14 @@ unauthenticated requests are rejected with 401 before they reach the handler).
 The handler also checks user_id explicitly to produce a clear error if the
 middleware somehow skips it (belt-and-braces).
 
-Reconnect / replay: each SSE frame carries an ``id:`` sequence number.  A
-reconnecting EventSource sends ``Last-Event-ID``; the EventBus replay buffer
-(last 32 events per channel) is delivered to new subscribers automatically on
-subscribe(), so recent events are re-streamed without client logic.
+Reconnect / replay: the EventBus replay buffer (last 32 events per channel)
+is delivered to new subscribers automatically on subscribe(), so recent
+events are re-streamed on every (re)connect.  This is best-effort, not
+precise replay via ``Last-Event-ID``: the ``id:`` field on each frame is a
+per-connection counter, not a stable value across reconnects, so the server
+does not filter on the ``Last-Event-ID`` request header.  Each event's JSON
+payload instead carries a stable ``id`` (the event's trace_id) so the client
+can de-dupe events it has already handled.
 """
 from __future__ import annotations
 
@@ -76,7 +80,12 @@ async def events_stream(request: Request):
                     continue
                 seq += 1
                 data = json.dumps(
-                    {"type": event.kind, "payload": event.payload, "ts": event.ts}
+                    {
+                        "type": event.kind,
+                        "payload": event.payload,
+                        "ts": event.ts,
+                        "id": event.trace_id,
+                    }
                 )
                 yield f"id: {seq}\ndata: {data}\n\n"
         finally:

--- a/tinyagentos/routes/event_stream.py
+++ b/tinyagentos/routes/event_stream.py
@@ -91,6 +91,11 @@ async def events_stream(request: Request):
         finally:
             for t in relay_tasks:
                 t.cancel()
+            # Await the cancelled relays so they finish unwinding before we
+            # unsubscribe -- otherwise a still-running relay can touch a queue
+            # that is about to go away, and asyncio logs "Task was destroyed but
+            # it is pending". return_exceptions swallows the expected CancelledError.
+            await asyncio.gather(*relay_tasks, return_exceptions=True)
             await event_bus.unsubscribe(user_ch, user_q)
             await event_bus.unsubscribe("broadcast", bcast_q)
 


### PR DESCRIPTION
First slice of OS-wide live updates (no PWA refresh). Wires the existing-but-unused `EventBus` to a user-facing SSE stream and makes notifications the first live consumer to prove the pattern.

## Backend
- New `GET /api/events/stream` (SSE): session-gated (401 without auth, not exempt), subscribes to `user:{id}` + `broadcast`, 10s keepalive, `id:`/Last-Event-ID with the EventBus 32-event replay buffer, full cleanup on disconnect. Pattern mirrors the existing `desktop_control` stream.
- `EventBus.broadcast()` publishes directly to the broadcast channel, bypassing `emit()`'s sinks (no recursion).
- `NotificationStore.add()` emits a `notification.added` event (best-effort; a failing emitter never breaks the write). Emitter wired at startup.

## Frontend
- New `use-event-stream` hook: one EventSource mounted in the app shell, dispatch-table router (notifications wired; other types are one-liners later), native reconnect.
- Notification poll 30s → 120s resilience fallback (stream is primary).

## Scope
Foundation + notifications only. Cluster/decisions/registry/auth-requests are deliberate follow-ups.

## Tests
71 backend + 7 frontend pass; tsc clean. Deploy via Settings update after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated SSE endpoint (`/api/events/stream`) for real-time notifications, streaming from both user and broadcast event channels.
  * Desktop now maintains a persistent live connection to receive OS/event updates instantly.
* **Bug Fixes**
  * Improved robustness with JSON/type validation, bounded de-duplication, graceful handling of unknown/malformed messages, and automatic SSE reconnect.
  * Increased the polling interval for server notifications as a slower fallback.
* **Tests**
  * Added comprehensive unit/integration tests for SSE delivery, store-to-event propagation, and auth-gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->