### PR TITLE
fix(deploy): boot rebuild must not brick the controller

### DIFF
--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -30,8 +30,11 @@ ExecStartPre=/bin/sh -c '\
     echo "[taos] desktop source newer than bundle — rebuilding..."; \
     if (cd desktop && npm install --silent && npm run build); then \
       echo "[taos] desktop rebuild succeeded"; \
+    elif [ -f static/desktop/index.html ]; then \
+      echo "[taos] desktop rebuild FAILED -- starting with the existing (stale) bundle (see journalctl -u tinyagentos)"; \
     else \
-      echo "[taos] desktop rebuild FAILED — starting with the existing bundle (see journalctl -u tinyagentos)"; \
+      echo "[taos] desktop rebuild FAILED and no existing bundle -- cannot start"; \
+      exit 1; \
     fi; \
   fi'
 # Launch via the module entrypoint (not uvicorn directly) so the dual-port

--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -27,8 +27,12 @@ ExecStartPre=+/bin/sh -c '\
 ExecStartPre=/bin/sh -c '\
   cd TAOS_INSTALL_DIR && \
   if [ -d desktop ] && { [ ! -f static/desktop/index.html ] || [ -n "$(find desktop/src -type f -newer static/desktop/index.html -print -quit 2>/dev/null)" ]; }; then \
-    echo "[taos] desktop source newer than bundle — rebuilding..." && \
-    cd desktop && npm install --silent && npm run build; \
+    echo "[taos] desktop source newer than bundle — rebuilding..."; \
+    if (cd desktop && npm install --silent && npm run build); then \
+      echo "[taos] desktop rebuild succeeded"; \
+    else \
+      echo "[taos] desktop rebuild FAILED — starting with the existing bundle (see journalctl -u tinyagentos)"; \
+    fi; \
   fi'
 # Launch via the module entrypoint (not uvicorn directly) so the dual-port
 # browser-proxy origin starts. __main__.main() reads TAOS_HOST/TAOS_PORT and


### PR DESCRIPTION
## Incident
An in-app update triggered a desktop rebuild in the systemd `ExecStartPre`. The rebuild failed (a type error from drifted frontend deps on the device), and because the step chained `... && npm run build`, the non-zero exit failed the unit -> the controller crash-looped 26 times until manual recovery.

## Fix
Wrap the rebuild so it is non-fatal: on failure it logs `[taos] desktop rebuild FAILED -- starting with the existing bundle` and the unit still starts with the last good bundle. The staleness check and rebuild-on-success behavior are unchanged.

CI already type-checks (its build runs `npm ci && npm run build` = `tsc -b`); the device failure was `npm install` dep drift, addressed separately. This is the safety net so a build failure can never take the box down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop bundle rebuild handling during startup for more reliable recovery.
  * Added clearer status messages for rebuild success and failure.
  * If rebuilding fails, the service now starts using the existing (stale) desktop bundle when available; if no existing bundle is present, startup is blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->