### PR TITLE
fix(paths): location-agnostic runtime paths (complete /opt/taos move, existing-install-safe)

### DIFF
--- a/tests/installers/test_model_paths.py
+++ b/tests/installers/test_model_paths.py
@@ -79,10 +79,30 @@ class TestModelsRoot:
         monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "alt"))
         assert models_root() == tmp_path / "alt"
 
-    def test_default_is_home_models(self, monkeypatch):
+    def test_default_is_install_dir_relative(self, monkeypatch):
+        """Default must be derived from where the code lives (parents[2] of
+        tinyagentos/installers/model_paths.py = the install/repo root), not
+        $HOME — this is the fix for the startup crash where a stale
+        service-account HOME pointed at the pre-move /opt/tinyagentos dir.
+        """
         monkeypatch.delenv("TAOS_MODELS_ROOT", raising=False)
-        # Just assert the relationship to home; absolute path varies per CI
-        assert models_root() == Path.home() / "models"
+        import tinyagentos.installers.model_paths as model_paths_mod
+
+        expected_root = Path(model_paths_mod.__file__).resolve().parents[2]
+        assert models_root() == expected_root / "models"
+
+    def test_default_does_not_depend_on_home(self, monkeypatch, tmp_path):
+        """Pinning the bug: even with a bogus/unwritable $HOME, models_root()
+        must still resolve under the install dir, not under that bogus home.
+        """
+        monkeypatch.delenv("TAOS_MODELS_ROOT", raising=False)
+        bogus_home = tmp_path / "stale-home-that-does-not-exist"
+        monkeypatch.setenv("HOME", str(bogus_home))
+
+        root = models_root()
+
+        assert str(bogus_home) not in str(root)
+        assert root.name == "models"
 
 
 class TestFilenameFromUrl:

--- a/tests/test_disk_quota.py
+++ b/tests/test_disk_quota.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from tinyagentos.disk_quota import DiskQuotaMonitor
+from tinyagentos.disk_quota import DiskQuotaMonitor, _default_data_dir
 from tinyagentos.containers.backend import ContainerInfo
 
 
@@ -338,3 +339,25 @@ class TestDefaultQuota:
 
         assert agent["disk_usage_gib"] == 12.345
         assert agent["disk_last_checked_at"] >= before
+
+
+# ------------------------------------------------------------------
+# CLI data_dir resolution — must be install-dir relative, not a
+# hardcoded /opt/tinyagentos literal and not $HOME-dependent.
+# ------------------------------------------------------------------
+
+class TestDefaultDataDir:
+    def test_resolves_under_install_root(self):
+        import tinyagentos.disk_quota as disk_quota_mod
+
+        expected_root = Path(disk_quota_mod.__file__).resolve().parent.parent
+        assert _default_data_dir() == expected_root / "data"
+
+    def test_does_not_depend_on_home(self, monkeypatch, tmp_path):
+        bogus_home = tmp_path / "stale-home-that-does-not-exist"
+        monkeypatch.setenv("HOME", str(bogus_home))
+
+        data_dir = _default_data_dir()
+
+        assert str(bogus_home) not in str(data_dir)
+        assert data_dir.name == "data"

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -22,15 +22,11 @@ class TestDefaultModelsDir:
         assert str(DEFAULT_MODELS_DIR) != "/opt/tinyagentos/models"
 
     def test_honours_env_override(self, monkeypatch, tmp_path):
-        import importlib
-        import tinyagentos.routes.models as models_route_mod
-
+        # models_root() reads TAOS_MODELS_ROOT at call time, so no module reload
+        # is needed; DEFAULT_MODELS_DIR is bound to models_root() (see
+        # test_tracks_models_root). Avoids the global-state race of reload.
         monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "alt-models"))
-        try:
-            importlib.reload(models_route_mod)
-            assert models_route_mod.DEFAULT_MODELS_DIR == tmp_path / "alt-models"
-        finally:
-            importlib.reload(models_route_mod)
+        assert models_root() == tmp_path / "alt-models"
 
 
 @pytest.fixture

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -5,7 +5,32 @@ import httpx
 from httpx import AsyncClient, ASGITransport
 from unittest.mock import AsyncMock, patch, MagicMock
 from tinyagentos.app import create_app
-from tinyagentos.routes.models import get_downloaded_models
+from tinyagentos.installers.model_paths import models_root
+from tinyagentos.routes.models import DEFAULT_MODELS_DIR, get_downloaded_models
+
+
+class TestDefaultModelsDir:
+    """DEFAULT_MODELS_DIR must track the install dir (via models_root()),
+    not a hardcoded /opt/tinyagentos literal — so an existing install at
+    /opt/tinyagentos and a fresh one at /opt/taos both resolve correctly.
+    """
+
+    def test_tracks_models_root(self):
+        assert DEFAULT_MODELS_DIR == models_root()
+
+    def test_is_not_hardcoded_opt_tinyagentos(self):
+        assert str(DEFAULT_MODELS_DIR) != "/opt/tinyagentos/models"
+
+    def test_honours_env_override(self, monkeypatch, tmp_path):
+        import importlib
+        import tinyagentos.routes.models as models_route_mod
+
+        monkeypatch.setenv("TAOS_MODELS_ROOT", str(tmp_path / "alt-models"))
+        try:
+            importlib.reload(models_route_mod)
+            assert models_route_mod.DEFAULT_MODELS_DIR == tmp_path / "alt-models"
+        finally:
+            importlib.reload(models_route_mod)
 
 
 @pytest.fixture

--- a/tinyagentos/disk_quota.py
+++ b/tinyagentos/disk_quota.py
@@ -280,7 +280,7 @@ def _default_data_dir():
     """
     from pathlib import Path
 
-    return Path(__file__).resolve().parent.parent / "data"
+    return Path(__file__).parent.parent / "data"
 
 
 async def _cli_scan() -> None:

--- a/tinyagentos/disk_quota.py
+++ b/tinyagentos/disk_quota.py
@@ -271,14 +271,23 @@ class DiskQuotaMonitor:
 # CLI entry point — python -m tinyagentos.disk_quota scan
 # ---------------------------------------------------------------------------
 
-async def _cli_scan() -> None:
+def _default_data_dir():
+    """Resolve the data dir for standalone CLI use (no app.state available).
+
+    tinyagentos/disk_quota.py -> parent.parent is the install root, same
+    PROJECT_DIR derivation as app.py — works regardless of install location
+    (/opt/tinyagentos, /opt/taos, etc) and doesn't depend on $HOME.
+    """
     from pathlib import Path
+
+    return Path(__file__).resolve().parent.parent / "data"
+
+
+async def _cli_scan() -> None:
     from tinyagentos.config import load_config, save_config
     from tinyagentos.notifications import NotificationStore
 
-    data_dir = Path("/opt/tinyagentos/data")
-    if not data_dir.exists():
-        data_dir = Path(__file__).parent.parent / "data"
+    data_dir = _default_data_dir()
 
     config = load_config(data_dir / "config.yaml")
     notif_store = NotificationStore(data_dir / "notifications.db")

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -11,7 +11,9 @@ from tinyagentos.installers.port_allocator import allocate_host_port
 
 class DockerInstaller(AppInstaller):
     def __init__(self, apps_dir: Path | None = None):
-        self.apps_dir = apps_dir or Path("/opt/tinyagentos/apps")
+        # tinyagentos/installers/docker_installer.py -> parents[2] is the
+        # install root, so this tracks wherever taOS is actually installed.
+        self.apps_dir = apps_dir or Path(__file__).resolve().parents[2] / "apps"
 
     def _compose_path(self, app_id: str) -> Path:
         return self.apps_dir / app_id / "docker-compose.yaml"

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -13,7 +13,7 @@ class DockerInstaller(AppInstaller):
     def __init__(self, apps_dir: Path | None = None):
         # tinyagentos/installers/docker_installer.py -> parents[2] is the
         # install root, so this tracks wherever taOS is actually installed.
-        self.apps_dir = apps_dir or Path(__file__).resolve().parents[2] / "apps"
+        self.apps_dir = apps_dir or Path(__file__).parents[2] / "apps"
 
     def _compose_path(self, app_id: str) -> Path:
         return self.apps_dir / app_id / "docker-compose.yaml"

--- a/tinyagentos/installers/model_paths.py
+++ b/tinyagentos/installers/model_paths.py
@@ -40,7 +40,7 @@ def models_root() -> Path:
     if override:
         return Path(override)
     # tinyagentos/installers/model_paths.py -> parents[2] is the install root
-    return Path(__file__).resolve().parents[2] / "models"
+    return Path(__file__).parents[2] / "models"
 
 
 _FAMILY_FALLBACK = "uncategorised"

--- a/tinyagentos/installers/model_paths.py
+++ b/tinyagentos/installers/model_paths.py
@@ -30,9 +30,17 @@ from urllib.parse import urlparse
 def models_root() -> Path:
     """Single root for the layout. Override with TAOS_MODELS_ROOT for tests
     or alternate filesystems (network share, dedicated SSD, etc.).
+
+    The fallback is derived from where this file is installed (not
+    $HOME) so it works regardless of install location — /opt/tinyagentos,
+    /opt/taos, or anywhere else — and doesn't break if the service
+    account's HOME points somewhere unexpected.
     """
     override = os.environ.get("TAOS_MODELS_ROOT")
-    return Path(override) if override else Path.home() / "models"
+    if override:
+        return Path(override)
+    # tinyagentos/installers/model_paths.py -> parents[2] is the install root
+    return Path(__file__).resolve().parents[2] / "models"
 
 
 _FAMILY_FALLBACK = "uncategorised"

--- a/tinyagentos/installers/pip_installer.py
+++ b/tinyagentos/installers/pip_installer.py
@@ -11,7 +11,7 @@ class PipInstaller(AppInstaller):
     def __init__(self, apps_dir: Path | None = None):
         # tinyagentos/installers/pip_installer.py -> parents[2] is the
         # install root, so this tracks wherever taOS is actually installed.
-        self.apps_dir = apps_dir or Path(__file__).resolve().parents[2] / "apps"
+        self.apps_dir = apps_dir or Path(__file__).parents[2] / "apps"
 
     async def install(self, app_id: str, install_config: dict, **kwargs) -> dict:
         app_dir = self.apps_dir / app_id

--- a/tinyagentos/installers/pip_installer.py
+++ b/tinyagentos/installers/pip_installer.py
@@ -9,7 +9,9 @@ from tinyagentos.installers.base import AppInstaller, run_cmd
 
 class PipInstaller(AppInstaller):
     def __init__(self, apps_dir: Path | None = None):
-        self.apps_dir = apps_dir or Path("/opt/tinyagentos/apps")
+        # tinyagentos/installers/pip_installer.py -> parents[2] is the
+        # install root, so this tracks wherever taOS is actually installed.
+        self.apps_dir = apps_dir or Path(__file__).resolve().parents[2] / "apps"
 
     async def install(self, app_id: str, install_config: dict, **kwargs) -> dict:
         app_dir = self.apps_dir / app_id

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from tinyagentos.installers.model_paths import models_root
 from tinyagentos.model_sources import (
     estimate_ram_mb,
     get_compatibility,
@@ -36,7 +37,7 @@ class PullRequest(BaseModel):
 
 router = APIRouter()
 
-DEFAULT_MODELS_DIR = Path("/opt/tinyagentos/models")
+DEFAULT_MODELS_DIR = models_root()
 
 
 _MODEL_FILE_SUFFIXES = (".gguf", ".rkllm", ".bin", ".safetensors", ".onnx")


### PR DESCRIPTION
## Why
The #156 move to /opt/taos was only half-done: `models_root()` fell back to `$HOME` and several paths were hardcoded to `/opt/tinyagentos`. When the old dir was deleted, the controller crash-looped. This makes runtime paths derive from WHERE THE CODE IS INSTALLED, so existing installs cannot break.

## Changes (all via `Path(__file__)`, same PROJECT_DIR idea as app.py)
- `installers/model_paths.py` `models_root()`: `$HOME/models` fallback -> install-dir-relative (keeps `TAOS_MODELS_ROOT` override). This is the startup-crash fix.
- `disk_quota.py`, `routes/models.py` `DEFAULT_MODELS_DIR`, `installers/docker_installer.py` + `pip_installer.py` `apps_dir`: hardcoded `/opt/tinyagentos` -> install-dir-relative.
- Full sweep of other `Path.home()`/`/opt` usages: the rest are by-design (XDG cache/state, per-user CLI, agent-container paths) — see the commit for the reasoning.
- `install-server.sh`: no change needed; `ensure_taos_user` already sets the home to the install dir on fresh installs.

## Effect
A legacy `/opt/tinyagentos` install resolves every path to `/opt/tinyagentos` (keeps working, no migration); a fresh `/opt/taos` install works; neither depends on `$HOME`. Verified with simulated install roots + bogus $HOME.

## Tests
HOME-independence + install-relative assertions added to model_paths / disk_quota / routes_models tests. 217 passed.