### PR TITLE
fix(updater): install the proxy extra so updates never strip litellm

### DIFF
--- a/tests/test_updater_dep_install.py
+++ b/tests/test_updater_dep_install.py
@@ -5,8 +5,10 @@ Settings "Install Update" flow:
 
   * `_find_uv` resolves uv robustly (uv is not always on PATH; on the Pi it
     lives at <install_dir>/.local/bin/uv).
-  * `_install_dependencies` prefers a lockfile-pinned `uv sync --frozen` and
-    falls back to `pip install -e .` only when uv is absent.
+  * `_install_dependencies` prefers a lockfile-pinned `uv sync --frozen
+    --extra proxy` and falls back to `pip install -e .[proxy]` only when uv is
+    absent. The proxy extra (litellm + prisma) is a core dep, so both paths
+    carry it to match install-server.sh.
   * a non-zero install return code aborts the update WITHOUT writing the
     pending-restart marker (the crash-loop safety net stays intact).
 
@@ -53,7 +55,7 @@ def test_find_uv_not_found_returns_none(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_install_uses_uv_sync_frozen(monkeypatch):
-    """uv found -> runs `uv sync --frozen` with cwd + HOME=project_dir."""
+    """uv found -> runs `uv sync --frozen --extra proxy` with cwd + HOME=project_dir."""
     project = Path("/srv/taos")
     monkeypatch.setattr(settings_mod, "_find_uv", lambda pd: "/opt/uv")
 
@@ -71,14 +73,14 @@ async def test_install_uses_uv_sync_frozen(monkeypatch):
 
     assert rc == 0
     assert out == "synced"
-    assert captured["cmd"] == ["/opt/uv", "sync", "--frozen"]
+    assert captured["cmd"] == ["/opt/uv", "sync", "--frozen", "--extra", "proxy"]
     assert captured["cwd"] == str(project)
     assert captured["env"]["HOME"] == str(project)
 
 
 @pytest.mark.asyncio
 async def test_install_falls_back_to_pip(monkeypatch):
-    """uv absent -> runs `pip install -e .` (legacy path unchanged)."""
+    """uv absent -> runs `pip install -e .[proxy]` (legacy path)."""
     project = Path("/srv/taos")
     monkeypatch.setattr(settings_mod, "_find_uv", lambda pd: None)
     # No venv pip on disk -> bare "pip".
@@ -97,7 +99,7 @@ async def test_install_falls_back_to_pip(monkeypatch):
     rc, out = await settings_mod._install_dependencies(project)
 
     assert rc == 0
-    assert captured["cmd"] == ["pip", "install", "-e", "."]
+    assert captured["cmd"] == ["pip", "install", "-e", ".[proxy]"]
     assert captured["cwd"] == str(project)
     # pip path inherits the parent env (no override).
     assert captured["env"] is None
@@ -120,7 +122,7 @@ async def test_install_uses_venv_pip_when_present(monkeypatch):
     monkeypatch.setattr(settings_mod, "_run_capture", fake_run)
 
     await settings_mod._install_dependencies(project)
-    assert captured["cmd"] == [str(venv_pip), "install", "-e", "."]
+    assert captured["cmd"] == [str(venv_pip), "install", "-e", ".[proxy]"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_updater_dep_install.py
+++ b/tests/test_updater_dep_install.py
@@ -125,6 +125,27 @@ async def test_install_uses_venv_pip_when_present(monkeypatch):
     assert captured["cmd"] == [str(venv_pip), "install", "-e", ".[proxy]"]
 
 
+def test_updater_extras_match_install_server():
+    """The updater's UPDATE_EXTRAS must equal install-server.sh's pip extras.
+
+    Both install paths carry the same optional extras; if install-server.sh
+    later adds one (e.g. `.[proxy,gpu]`) the updater must too, or a bare-set
+    `uv sync --frozen` will strip it on the next update. This binds the two
+    so a drift fails CI instead of silently breaking a live box.
+    """
+    import re
+
+    repo_root = Path(__file__).resolve().parents[1]
+    script = (repo_root / "scripts" / "install-server.sh").read_text()
+    matches = re.findall(r'pip install[^\n]*-e\s+["\']?\.\[([^\]]+)\]', script)
+    assert matches, "could not find a `pip install -e .[extras]` line in install-server.sh"
+    script_extras = {e.strip() for e in matches[-1].split(",") if e.strip()}
+    assert script_extras == set(settings_mod.UPDATE_EXTRAS), (
+        f"install-server.sh installs extras {script_extras} but the updater installs "
+        f"{set(settings_mod.UPDATE_EXTRAS)}; keep them in parity (settings.UPDATE_EXTRAS)"
+    )
+
+
 @pytest.mark.asyncio
 async def test_install_nonzero_rc_is_propagated(monkeypatch):
     """A failed install returns (rc, output) so the caller aborts safely."""

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -672,6 +672,12 @@ async def _install_dependencies(project_dir: Path) -> tuple[int, str]:
     deps onto a user's box. When uv is not present we fall back to the legacy
     ``pip install -e .`` so installs without uv still update.
 
+    Both paths carry the ``proxy`` extra (litellm + prisma) to match
+    ``install-server.sh``'s ``pip install -e ".[proxy]"``. The LLM proxy is a
+    core dependency, not optional: a bare ``uv sync --frozen`` prunes the venv
+    to the locked default set and silently uninstalls litellm, disabling the
+    proxy on every update and breaking basic agent functionality.
+
     Capture output and surface failures -- silently swallowing a failed install
     lands users on a grey-screen the next time they restart, because the new
     code imports a module that's not on disk. See issue #323's sibling failure
@@ -687,7 +693,7 @@ async def _install_dependencies(project_dir: Path) -> tuple[int, str]:
         # service user whose HOME is the install dir (the Pi layout).
         env = {**os.environ, "HOME": str(project_dir)}
         return await _run_capture(
-            [uv_cmd, "sync", "--frozen"],
+            [uv_cmd, "sync", "--frozen", "--extra", "proxy"],
             cwd=str(project_dir),
             env=env,
         )
@@ -697,9 +703,9 @@ async def _install_dependencies(project_dir: Path) -> tuple[int, str]:
         if candidate.exists():
             pip_cmd = str(candidate)
             break
-    logger.info("Updater dependency install: uv not found, using %s install -e .", pip_cmd)
+    logger.info("Updater dependency install: uv not found, using %s install -e .[proxy]", pip_cmd)
     return await _run_capture(
-        [pip_cmd, "install", "-e", "."],
+        [pip_cmd, "install", "-e", ".[proxy]"],
         cwd=str(project_dir),
     )
 

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -664,6 +664,14 @@ def _find_uv(project_dir: Path) -> str | None:
     return None
 
 
+# Optional-dependency extras the updater must install so a `uv sync --frozen`
+# does not prune them out of the venv. Single source of truth for the Python
+# side; `scripts/install-server.sh` installs the same set via
+# `pip install -e ".[proxy]"`, and `test_updater_dep_install.py` asserts the two
+# stay in parity so they cannot silently drift (the bug that stripped litellm).
+UPDATE_EXTRAS: tuple[str, ...] = ("proxy",)
+
+
 async def _install_dependencies(project_dir: Path) -> tuple[int, str]:
     """Install/sync the update's Python deps, preferring a pinned uv sync.
 
@@ -692,8 +700,9 @@ async def _install_dependencies(project_dir: Path) -> tuple[int, str]:
         # HOME=project_dir so uv resolves its data/cache dir correctly under the
         # service user whose HOME is the install dir (the Pi layout).
         env = {**os.environ, "HOME": str(project_dir)}
+        extra_args = [arg for extra in UPDATE_EXTRAS for arg in ("--extra", extra)]
         return await _run_capture(
-            [uv_cmd, "sync", "--frozen", "--extra", "proxy"],
+            [uv_cmd, "sync", "--frozen", *extra_args],
             cwd=str(project_dir),
             env=env,
         )
@@ -703,9 +712,10 @@ async def _install_dependencies(project_dir: Path) -> tuple[int, str]:
         if candidate.exists():
             pip_cmd = str(candidate)
             break
-    logger.info("Updater dependency install: uv not found, using %s install -e .[proxy]", pip_cmd)
+    pip_target = f".[{','.join(UPDATE_EXTRAS)}]"
+    logger.info("Updater dependency install: uv not found, using %s install -e %s", pip_cmd, pip_target)
     return await _run_capture(
-        [pip_cmd, "install", "-e", ".[proxy]"],
+        [pip_cmd, "install", "-e", pip_target],
         cwd=str(project_dir),
     )
 

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -696,16 +696,13 @@ async def _install_dependencies(project_dir: Path) -> tuple[int, str]:
     """
     uv_cmd = _find_uv(project_dir)
     if uv_cmd is not None:
-        logger.info("Updater dependency install: uv sync --frozen (%s)", uv_cmd)
         # HOME=project_dir so uv resolves its data/cache dir correctly under the
         # service user whose HOME is the install dir (the Pi layout).
         env = {**os.environ, "HOME": str(project_dir)}
         extra_args = [arg for extra in UPDATE_EXTRAS for arg in ("--extra", extra)]
-        return await _run_capture(
-            [uv_cmd, "sync", "--frozen", *extra_args],
-            cwd=str(project_dir),
-            env=env,
-        )
+        cmd = [uv_cmd, "sync", "--frozen", *extra_args]
+        logger.info("Updater dependency install: %s", " ".join(cmd))
+        return await _run_capture(cmd, cwd=str(project_dir), env=env)
 
     pip_cmd = "pip"
     for candidate in (project_dir / ".venv" / "bin" / "pip", project_dir / "venv" / "bin" / "pip"):


### PR DESCRIPTION
## Problem

The Settings-update dependency install (`_install_dependencies`) ran a bare `uv sync --frozen`. `uv sync` prunes the venv to the locked **default** dependency set, so it silently **uninstalls `litellm[proxy]` + `prisma`** — which live in the optional `proxy` extra — on every update.

`install-server.sh` installs the extra (`pip install -e ".[proxy]"`), so a **fresh** box has the LLM proxy, but **every subsequent Settings update disabled it**. The controller then logs `LiteLLM not installed — proxy disabled` and the proxy never binds. The LLM proxy is a **core** dependency — basic agent functionality fails without it.

Discovered on the live Pi: after a clean reconcile + Settings update, `:4000` wasn't listening and litellm wasn't importable in the venv, despite being present in `uv.lock`. Restored on the box with `uv sync --frozen --extra proxy`.

## Fix

Carry the `proxy` extra on both updater paths, matching install-server.sh:
- uv path: `uv sync --frozen --extra proxy`
- pip fallback: `pip install -e ".[proxy]"`

## Tests

`tests/test_updater_dep_install.py` updated to pin the new commands; all 8 pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the in-app “Install Update” flow to install the complete dependency set needed for proxy functionality.
  * Made the dependency set consistent across both update install methods to prevent missing capabilities after an update.
  * Preserved existing handling for failed installs and pending-restart behavior.
* **Tests**
  * Strengthened update-install coverage to verify the installed extras match the official install script, including the proxy extra.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->