### PR TITLE
feat(doc-gate): enforced documentation-drift gate (commit + CI)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Documentation-drift gate: commit-msg escape hatch.
+#
+# The pre-commit hook already checked the staged diff. If it failed only
+# because a rule wants a doc edit that isn't in this commit, this hook still
+# accepts the commit when the message carries a non-empty
+# "Docs-Reviewed: <why>" trailer line. Matches the trailer docs/doc-gate.toml
+# configures for CI (default: "Docs-Reviewed:").
+set -euo pipefail
+
+trailer="Docs-Reviewed:"
+msg_file="$1"
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if python3 scripts/check_doc_gate.py diff-gate --staged >/dev/null 2>&1; then
+    exit 0
+fi
+
+trim() {
+    local s="$1"
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "$s"
+}
+
+while IFS= read -r line; do
+    line="$(trim "$line")"
+    case "$line" in
+        "$trailer"*)
+            rest="$(trim "${line#"$trailer"}")"
+            if [ -n "$rest" ]; then
+                exit 0
+            fi
+            ;;
+    esac
+done < "$msg_file"
+
+python3 scripts/check_doc_gate.py diff-gate --staged || true
+echo ""
+echo "This commit changes feature code without a matching doc update."
+echo "Fix the docs listed above, or add a line to your commit message:"
+echo "  Docs-Reviewed: <why this needs no doc change / what you checked>"
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Documentation-drift gate: local pre-commit hook.
+#
+# Runs the same two checks CI runs, against the staged index. This is a
+# convenience/fast-feedback layer only -- .github/workflows/doc-gate.yml is
+# the authoritative gate and cannot be bypassed with --no-verify.
+#
+# Enable with: scripts/install-git-hooks.sh
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+fail=0
+
+if ! python3 scripts/check_doc_gate.py invariants; then
+    fail=1
+fi
+
+if ! python3 scripts/check_doc_gate.py diff-gate --staged; then
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo ""
+    echo "Fix the docs, or add a 'Docs-Reviewed: <why>' line to your commit message (the commit-msg hook accepts that). CI enforces this regardless of --no-verify."
+    exit 1
+fi
+
+exit 0

--- a/.github/workflows/doc-gate.yml
+++ b/.github/workflows/doc-gate.yml
@@ -1,0 +1,37 @@
+name: Doc drift gate
+
+# Authoritative documentation-drift gate. Blocks PRs that change feature code
+# (a desktop app, an API route module, an installer, a catalog manifest)
+# without touching the doc that covers it, unless a commit in the PR carries
+# a "Docs-Reviewed: <why>" trailer. See docs/doc-gate.toml for the rules and
+# scripts/check_doc_gate.py for the implementation. This job is authoritative
+# regardless of local hooks (--no-verify does not skip it).
+
+on:
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  doc-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF"
+
+      - name: Invariants (Layer A)
+        run: python scripts/check_doc_gate.py invariants
+
+      - name: Diff gate (Layer B)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: python scripts/check_doc_gate.py diff-gate --base "origin/$BASE_REF"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,31 @@ When adding a feature, add tests that cover the new behaviour. When fixing a bug
 
 ---
 
+## Documentation gate
+
+A gate blocks PRs that add or remove certain feature code without a matching doc update. It only fires on structural changes (a file added or deleted), never on a plain edit, and only for a small set of conservative rules configured in `docs/doc-gate.toml`:
+
+| Change | Requires editing one of |
+|--------|--------------------------|
+| A desktop app under `desktop/src/apps/` is added or removed | `README.md` |
+| A route module under `tinyagentos/routes/` is added or removed | `docs/agent-coordination.md` or `docs/AGENT_HANDOFF.md` |
+| An installer under `tinyagentos/installers/` or `scripts/install*` is added or removed | `README.md` |
+| A manifest under `app-catalog/` is added or removed | `README.md` |
+
+If your PR trips a rule and there is genuinely nothing to document (or you already covered it elsewhere), add a trailer line to a commit message instead of editing a doc:
+
+```
+Docs-Reviewed: no user-facing change, internal refactor only
+```
+
+The trailer must have non-empty text after the colon; a bare `Docs-Reviewed:` does not count.
+
+Run `scripts/install-git-hooks.sh` once to enable local hooks (`.githooks/pre-commit` and `.githooks/commit-msg`) so the gate runs before you push instead of after you open the PR. Local hooks are a convenience only: `.github/workflows/doc-gate.yml` is the authoritative check and runs on every PR regardless of local setup or `--no-verify`.
+
+To add a new rule, edit `docs/doc-gate.toml` -- rules are data, no code changes needed.
+
+---
+
 ## Architecture Overview
 
 ```

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -13,7 +13,7 @@
 trailer = "Docs-Reviewed:"
 
 [invariants]
-referenced_paths_scan = ["README.md", "docs/agent-coordination.md", "docs/AGENT_HANDOFF.md"]
+referenced_paths_scan = ["README.md", "docs/agent-coordination.md"]
 
 [[rules]]
 name = "apps"
@@ -24,7 +24,7 @@ hint = "a desktop app was added or removed"
 [[rules]]
 name = "routes"
 when_changed = ["tinyagentos/routes/*.py"]
-require_doc = ["docs/agent-coordination.md", "docs/AGENT_HANDOFF.md"]
+require_doc = ["docs/agent-coordination.md"]
 hint = "an API route module was added or removed"
 
 [[rules]]

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -1,0 +1,43 @@
+# Documentation-drift gate configuration.
+#
+# Read by scripts/check_doc_gate.py. Rules are data: add more [[rules]]
+# entries here to cover new feature areas without touching the script.
+#
+# Precision over recall: `when_changed` only triggers a rule on a structural
+# change (a file added or deleted), never a plain modification, and every
+# glob below is scoped to the specific tree it names. This is deliberate --
+# a noisy gate gets disabled, so false positives are worse than an occasional
+# missed doc update.
+
+[gate]
+trailer = "Docs-Reviewed:"
+
+[invariants]
+referenced_paths_scan = ["README.md", "docs/agent-coordination.md", "docs/AGENT_HANDOFF.md"]
+
+[[rules]]
+name = "apps"
+when_changed = ["desktop/src/apps/*/**"]
+require_doc = ["README.md"]
+hint = "a desktop app was added or removed"
+
+[[rules]]
+name = "routes"
+when_changed = ["tinyagentos/routes/*.py"]
+require_doc = ["docs/agent-coordination.md", "docs/AGENT_HANDOFF.md"]
+hint = "an API route module was added or removed"
+
+[[rules]]
+name = "installers"
+when_changed = ["tinyagentos/installers/*", "scripts/install*"]
+require_doc = ["README.md"]
+hint = "an installer was added or removed"
+
+[[rules]]
+# The repo's catalog tree is app-catalog/, not catalog/ (there is no
+# catalog/ directory in this repo). Scoped to the real path so the rule can
+# actually fire instead of being permanently dead config.
+name = "catalog"
+when_changed = ["app-catalog/**"]
+require_doc = ["README.md"]
+hint = "a catalog manifest was added or removed"

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Documentation-drift gate.
+
+Blocks commits/PRs that change feature code without a matching doc update,
+unless the change carries an explicit "Docs-Reviewed: <why>" trailer.
+
+Two layers:
+  invariants  -- deterministic sanity checks (Layer A). Currently: every
+                 scripts/, tinyagentos/, docs/, desktop/ path mentioned in the
+                 configured doc set actually exists on disk.
+  diff-gate   -- path -> doc rule engine (Layer B). A configured rule fires
+                 when a *structural* change (a file added or deleted, never a
+                 plain modification) matches one of its `when_changed` globs.
+                 A fired rule is satisfied by either editing one of its
+                 `require_doc` files in the same changeset, or by a commit
+                 message trailer line starting with the configured trailer
+                 (default "Docs-Reviewed:") with non-empty text after it.
+
+Config lives in docs/doc-gate.toml. Rules are data, not code: add more by
+editing the TOML, no changes to this file required.
+
+Usage:
+    python scripts/check_doc_gate.py invariants
+    python scripts/check_doc_gate.py diff-gate --staged
+    python scripts/check_doc_gate.py diff-gate --base origin/dev
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = REPO_ROOT / "docs" / "doc-gate.toml"
+DEFAULT_TRAILER = "Docs-Reviewed:"
+
+# A path-like token: one of the four known repo prefixes followed by a run of
+# non-whitespace / non-quoting characters. The negative lookbehind stops us
+# matching a prefix that is actually embedded inside a larger path (e.g. the
+# "tinyagentos/" inside "/home/<user>/tinyagentos/data/" in a deploy-layout
+# table), which would otherwise falsely flag deploy-time paths that never
+# exist in the repo itself.
+_TOKEN_RE = re.compile(r"(?<![\w/])(?:scripts|tinyagentos|docs|desktop)/[^\s`\"'|]+")
+
+# Chars that mark a token as a glob pattern or a <placeholder> rather than a
+# concrete repo path -- these are never asserted to exist.
+_GLOB_OR_PLACEHOLDER_CHARS = set("*?[]{}<>$~")
+
+# Trailing punctuation that is prose/markdown decoration, not part of the path.
+_TRAILING_PUNCT = ".,;:!?)]}'\"`"
+
+
+def _clean_token(raw: str) -> str | None:
+    """Normalize a raw regex match into a bare repo-relative path, or None
+    if it should be ignored (glob, placeholder, anchor/query fragment)."""
+    token = raw
+    for sep in ("#", "?"):
+        if sep in token:
+            token = token.split(sep, 1)[0]
+    while token and token[-1] in _TRAILING_PUNCT:
+        token = token[:-1]
+    if not token:
+        return None
+    if any(c in _GLOB_OR_PLACEHOLDER_CHARS for c in token):
+        return None
+    return token
+
+
+def extract_path_tokens(text: str) -> list[str]:
+    """Pull candidate repo-relative path tokens out of doc prose."""
+    tokens = []
+    for m in _TOKEN_RE.finditer(text):
+        cleaned = _clean_token(m.group(0))
+        if cleaned:
+            tokens.append(cleaned)
+    return tokens
+
+
+def load_config(path: Path) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def check_referenced_paths(repo_root: Path, files_to_scan: list[str], config: dict) -> list[str]:
+    """Layer A: every scripts/tinyagentos/docs/desktop path token mentioned in
+    the configured doc set must exist on disk. A scan-target file that itself
+    does not exist (e.g. a local-only, gitignored doc) is silently skipped
+    rather than treated as a failure."""
+    failures: list[str] = []
+    for rel in files_to_scan:
+        doc_path = repo_root / rel
+        if not doc_path.is_file():
+            continue
+        text = doc_path.read_text(encoding="utf-8", errors="ignore")
+        for token in extract_path_tokens(text):
+            if not (repo_root / token).exists():
+                failures.append(f"{rel} references '{token}' which does not exist in the repo")
+    return failures
+
+
+def _match_any(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pat) for pat in patterns)
+
+
+def evaluate_rules(
+    changed_status: list[tuple[str, str]],
+    commit_messages: list[str],
+    config: dict,
+) -> list[str]:
+    """Layer B: run every configured rule against a changeset.
+
+    changed_status: list of (status, path) pairs as from `git diff
+    --name-status`, e.g. [("A", "desktop/src/apps/Foo/Foo.tsx"), ("M", "x")].
+    Only status "A" (added) or "D" (deleted) files count as structural change
+    for the purposes of *triggering* a rule; plain modifications ("M") are
+    ignored to keep the gate precise. Any changed file (any status) can
+    *satisfy* a rule if it matches a require_doc glob.
+    commit_messages: full text of each commit message in range (empty list
+    when there is no finalized commit yet, i.e. --staged mode).
+    """
+    trailer = config.get("gate", {}).get("trailer", DEFAULT_TRAILER)
+    rules = config.get("rules", [])
+
+    all_paths = [path for _status, path in changed_status]
+    structural_paths = [path for status, path in changed_status if status in ("A", "D")]
+
+    trailer_present = any(
+        line.strip().startswith(trailer) and line.strip()[len(trailer):].strip()
+        for message in commit_messages
+        for line in message.splitlines()
+    )
+
+    failures: list[str] = []
+    for rule in rules:
+        name = rule.get("name", "?")
+        when_changed = rule.get("when_changed", [])
+        require_doc = rule.get("require_doc", [])
+        hint = rule.get("hint", "")
+
+        triggered = any(_match_any(p, when_changed) for p in structural_paths)
+        if not triggered:
+            continue
+
+        doc_edited = any(_match_any(p, require_doc) for p in all_paths)
+        if doc_edited or trailer_present:
+            continue
+
+        failures.append(
+            f"{name} -- {hint} (edit one of: {', '.join(require_doc)}, "
+            f"or add a 'Docs-Reviewed: <why>' trailer)"
+        )
+    return failures
+
+
+def _run_git(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def _parse_name_status(output: str) -> list[tuple[str, str]]:
+    changed: list[tuple[str, str]] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        # Renames/copies (R100, C100, ...) carry old + new path; the new path
+        # is what matters for both triggering and satisfying a rule.
+        path = parts[-1]
+        changed.append((status[0], path))
+    return changed
+
+
+def _git_changed_staged() -> list[tuple[str, str]]:
+    return _parse_name_status(_run_git(["diff", "--cached", "--name-status"]))
+
+
+def _git_changed_base(base_ref: str) -> list[tuple[str, str]]:
+    return _parse_name_status(_run_git(["diff", "--name-status", f"{base_ref}...HEAD"]))
+
+
+def _git_commit_messages(base_ref: str) -> list[str]:
+    out = _run_git(["log", f"{base_ref}..HEAD", "--format=%B%x00"])
+    return [m for m in out.split("\x00") if m.strip()]
+
+
+def _report(failures: list[str]) -> int:
+    if not failures:
+        print("doc-gate: clean")
+        return 0
+    for failure in failures:
+        print(f"DOC-GATE FAIL: {failure}")
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("invariants", help="Run Layer-A deterministic checks")
+
+    diff_parser = sub.add_parser("diff-gate", help="Run Layer-B path->doc rule engine")
+    group = diff_parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--staged", action="store_true", help="Check the git index (pre-commit)")
+    group.add_argument("--base", help="Compare <base>...HEAD (CI / commit-msg)")
+
+    args = parser.parse_args(argv)
+    config = load_config(args.config)
+
+    if args.command == "invariants":
+        files_to_scan = config.get("invariants", {}).get("referenced_paths_scan", [])
+        failures = check_referenced_paths(REPO_ROOT, files_to_scan, config)
+        return _report(failures)
+
+    # diff-gate
+    if args.staged:
+        changed = _git_changed_staged()
+        commit_messages: list[str] = []
+    else:
+        changed = _git_changed_base(args.base)
+        commit_messages = _git_commit_messages(args.base)
+
+    failures = evaluate_rules(changed, commit_messages, config)
+    return _report(failures)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Enable the repo's local git hooks (currently: the documentation-drift
+# gate). Idempotent -- safe to re-run.
+#
+# Usage: scripts/install-git-hooks.sh
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit .githooks/commit-msg
+
+echo "git hooks enabled: core.hooksPath = $(git config core.hooksPath)"
+echo "  .githooks/pre-commit  -- runs the doc-gate against staged changes"
+echo "  .githooks/commit-msg  -- accepts a 'Docs-Reviewed: <why>' trailer as an escape hatch"
+echo "CI (.github/workflows/doc-gate.yml) enforces the same gate regardless of local hooks."

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -1,0 +1,128 @@
+"""Unit tests for scripts/check_doc_gate.py.
+
+These call evaluate_rules() and check_referenced_paths() directly with
+synthetic inputs -- no shelling out to git, no dependence on the state of
+this checkout's actual history.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not a package; make it importable the same way the other
+# scripts/*.py unit tests do (see tests/test_kv_quant_validator.py).
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import check_doc_gate as dg  # noqa: E402 -- path manipulation must precede
+
+
+APPS_RULE_CONFIG = {
+    "gate": {"trailer": "Docs-Reviewed:"},
+    "rules": [
+        {
+            "name": "apps",
+            "when_changed": ["desktop/src/apps/*/**"],
+            "require_doc": ["README.md"],
+            "hint": "a desktop app was added or removed",
+        },
+        {
+            "name": "routes",
+            "when_changed": ["tinyagentos/routes/*.py"],
+            "require_doc": ["docs/agent-coordination.md", "docs/AGENT_HANDOFF.md"],
+            "hint": "an API route module was added or removed",
+        },
+    ],
+}
+
+
+class TestEvaluateRules:
+    def test_no_changes_passes(self):
+        assert dg.evaluate_rules([], [], APPS_RULE_CONFIG) == []
+
+    def test_added_app_file_no_doc_no_trailer_fails(self):
+        changed = [("A", "desktop/src/apps/Foo/Foo.tsx")]
+        failures = dg.evaluate_rules(changed, [], APPS_RULE_CONFIG)
+        assert len(failures) == 1
+        assert failures[0].startswith("apps -- ")
+
+    def test_added_app_file_with_readme_edit_passes(self):
+        changed = [
+            ("A", "desktop/src/apps/Foo/Foo.tsx"),
+            ("M", "README.md"),
+        ]
+        assert dg.evaluate_rules(changed, [], APPS_RULE_CONFIG) == []
+
+    def test_added_app_file_with_trailer_passes(self):
+        changed = [("A", "desktop/src/apps/Foo/Foo.tsx")]
+        messages = ["feat: add Foo app\n\nDocs-Reviewed: reworded the apps table\n"]
+        assert dg.evaluate_rules(changed, messages, APPS_RULE_CONFIG) == []
+
+    def test_trailer_with_no_text_after_it_does_not_satisfy(self):
+        changed = [("A", "desktop/src/apps/Foo/Foo.tsx")]
+        messages = ["feat: add Foo app\n\nDocs-Reviewed:\n"]
+        failures = dg.evaluate_rules(changed, messages, APPS_RULE_CONFIG)
+        assert len(failures) == 1
+
+    def test_plain_modification_does_not_trigger(self):
+        """Editing an existing route file (status M) must not fire the
+        'routes' rule -- only structural add/delete counts, to keep the gate
+        precise."""
+        changed = [("M", "tinyagentos/routes/agents.py")]
+        assert dg.evaluate_rules(changed, [], APPS_RULE_CONFIG) == []
+
+    def test_deleted_route_file_triggers_routes_rule(self):
+        changed = [("D", "tinyagentos/routes/old_routes.py")]
+        failures = dg.evaluate_rules(changed, [], APPS_RULE_CONFIG)
+        assert len(failures) == 1
+        assert failures[0].startswith("routes -- ")
+
+    def test_unrelated_rule_is_unaffected_by_other_rule_satisfaction(self):
+        """Two rules fire in the same changeset; satisfying only one (via a
+        doc edit that doesn't match the other rule's require_doc) still
+        leaves the other rule failing."""
+        changed = [
+            ("A", "desktop/src/apps/Foo/Foo.tsx"),
+            ("A", "tinyagentos/routes/new_routes.py"),
+            ("M", "README.md"),
+        ]
+        failures = dg.evaluate_rules(changed, [], APPS_RULE_CONFIG)
+        assert len(failures) == 1
+        assert failures[0].startswith("routes -- ")
+
+
+class TestCheckReferencedPaths:
+    def test_dead_path_token_fails(self, tmp_path: Path):
+        readme = tmp_path / "README.md"
+        readme.write_text("See `scripts/nope.sh` for details.\n")
+        failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
+        assert len(failures) == 1
+        assert "scripts/nope.sh" in failures[0]
+
+    def test_only_real_paths_passes(self, tmp_path: Path):
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "real.sh").write_text("#!/bin/sh\n")
+        readme = tmp_path / "README.md"
+        readme.write_text("See `scripts/real.sh` for details.\n")
+        failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
+        assert failures == []
+
+    def test_missing_scan_target_is_skipped_not_failed(self, tmp_path: Path):
+        """A configured scan target that doesn't exist on disk (e.g. a
+        local-only, gitignored doc absent from a fresh checkout) must not
+        itself be treated as a failure."""
+        failures = dg.check_referenced_paths(tmp_path, ["docs/AGENT_HANDOFF.md"], {})
+        assert failures == []
+
+    def test_glob_and_placeholder_tokens_are_ignored(self, tmp_path: Path):
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "Wildcard install scripts live under `scripts/install*`.\n"
+            "Per-framework bridges: `tinyagentos/scripts/install_<framework>.sh`.\n"
+        )
+        failures = dg.check_referenced_paths(tmp_path, ["README.md"], {})
+        assert failures == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

An enforced doc-drift gate so feature changes cannot land without touching the docs. Two layers, low false-positive by design:

- **Layer A - deterministic invariants** (`scripts/check_doc_gate.py invariants`): scans README + agent-coordination.md for path-like tokens (`scripts/...`, `tinyagentos/...`, etc.) and asserts they exist on disk. Catches dead references.
- **Layer B - structural rules** (`diff-gate`): when a commit/PR **adds or removes** an app, route module, installer, or catalog manifest (never a plain edit - precision over recall), it must also edit the mapped doc OR carry a `Docs-Reviewed: <why>` trailer. Rules are data in `docs/doc-gate.toml`.

**Authoritative in CI** (`.github/workflows/doc-gate.yml`, on pull_request) since agents commit in worktrees and can `--no-verify`. Local `.githooks/` (pre-commit + commit-msg) mirror it for fast feedback; `scripts/install-git-hooks.sh` wires them up (`core.hooksPath`).

## Design choices
- Hard-block triggers only on **structural** changes, so the `Docs-Reviewed:` trailer stays meaningful rather than reflexive.
- Config gates on **tracked** docs only (gitignored files can't satisfy a CI diff check).

## Tests
`tests/test_doc_gate.py` - 12 tests (rule engine + referenced-paths, no git shelling). All pass. `invariants` + `diff-gate --base origin/dev` both clean on this branch.

## HELD for review
Flagging for your eyes before merge since it changes every contributor's commit flow. Nothing merges without your go-ahead.