### PR TITLE
fix(llm-proxy): self-heal the litellm proxy extra on the bootstrap update

### DIFF
--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -537,3 +537,71 @@ class TestInhouseKeys:
         assert proxy._keystore().lookup(key)["allowed_models"] == ["b", "c"]
         assert await proxy.delete_agent_key(key) is True
         assert proxy._keystore().lookup(key) is None
+
+
+class TestProxySelfHeal:
+    """The proxy self-installs the litellm extra once if a pre-fix update
+    stripped it (bounded + non-fatal), so agents are not left without a route."""
+
+    @pytest.mark.asyncio
+    async def test_selfheal_uses_uv_sync_extra_proxy(self, tmp_path, monkeypatch):
+        import sys
+        import tinyagentos.llm_proxy as mod
+
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        binp = tmp_path / ".local" / "bin"
+        binp.mkdir(parents=True)
+        (binp / "uv").write_text("x")
+        monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"ok", None)
+
+        async def fake_exec(*cmd, **kw):
+            captured["cmd"] = list(cmd)
+            captured["cwd"] = kw.get("cwd")
+            captured["home"] = (kw.get("env") or {}).get("HOME")
+            return FakeProc()
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+
+        ok = await LLMProxy()._selfheal_proxy_extra()
+        assert ok is True
+        assert captured["cmd"][:4] == [str(binp / "uv"), "sync", "--frozen", "--extra"]
+        assert "proxy" in captured["cmd"]
+        assert captured["cwd"] == str(tmp_path)
+        assert captured["home"] == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_selfheal_nonzero_returns_false(self, tmp_path, monkeypatch):
+        import sys
+        import tinyagentos.llm_proxy as mod
+
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / ".local" / "bin").mkdir(parents=True)
+        (tmp_path / ".local" / "bin" / "uv").write_text("x")
+        monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+
+        class FakeProc:
+            returncode = 1
+
+            async def communicate(self):
+                return (b"boom", None)
+
+        async def fake_exec(*cmd, **kw):
+            return FakeProc()
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+        assert await LLMProxy()._selfheal_proxy_extra() is False
+
+    @pytest.mark.asyncio
+    async def test_selfheal_skips_when_no_install_root(self, tmp_path, monkeypatch):
+        import sys
+        monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+        # No pyproject.toml under tmp_path -> cannot locate install root.
+        assert await LLMProxy()._selfheal_proxy_extra() is False

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -605,3 +605,47 @@ class TestProxySelfHeal:
         monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
         # No pyproject.toml under tmp_path -> cannot locate install root.
         assert await LLMProxy()._selfheal_proxy_extra() is False
+
+    @pytest.mark.asyncio
+    async def test_selfheal_kills_subprocess_on_timeout(self, tmp_path, monkeypatch):
+        import asyncio as aio
+        import sys
+        import tinyagentos.llm_proxy as mod
+
+        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / ".local" / "bin").mkdir(parents=True)
+        (tmp_path / ".local" / "bin" / "uv").write_text("x")
+        monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+
+        killed = {"called": False}
+
+        class FakeProc:
+            returncode = None
+
+            async def communicate(self):
+                return (b"", None)
+
+            def kill(self):
+                killed["called"] = True
+
+            async def wait(self):
+                return 0
+
+        async def fake_exec(*a, **k):
+            return FakeProc()
+
+        calls = {"n": 0}
+
+        async def fake_wait_for(aw, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                if hasattr(aw, "close"):
+                    aw.close()
+                raise aio.TimeoutError()
+            return await aw
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr(mod.asyncio, "wait_for", fake_wait_for)
+
+        assert await LLMProxy()._selfheal_proxy_extra() is False
+        assert killed["called"] is True

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -113,6 +113,10 @@ class LLMProxy:
         self._data_dir = data_dir
         self._process: subprocess.Popen | None = None
         self._keystore_cache = None
+        # One-shot guard: if litellm is missing at start() (e.g. a pre-fix
+        # update stripped the proxy extra), self-install it once per process
+        # rather than retry the slow install on every start() call.
+        self._selfheal_attempted = False
 
     def _keystore(self):
         """Lazily open the in-house key store (controller side)."""
@@ -178,6 +182,74 @@ class LLMProxy:
                 "from tinyagentos.litellm_auth import user_api_key_auth\n"
             )
         return config_path
+
+    async def _selfheal_proxy_extra(self) -> bool:
+        """One-time attempt to install the missing litellm proxy extra.
+
+        install-server.sh installs ``.[proxy]`` (litellm + prisma), but any
+        update run by a pre-fix updater ran a bare ``uv sync --frozen`` and
+        pruned the extra out of the venv, so a fresh boot finds litellm gone
+        and every agent loses its LLM route. Since the proxy is core, install
+        it once here rather than leave it disabled. Bounded + non-fatal: on any
+        failure the proxy just stays disabled and the box keeps running.
+        """
+        import shutil
+        import sys
+
+        # The install dir is the venv's grandparent (<root>/.venv/bin/python).
+        project_root = Path(sys.executable).resolve().parents[2]
+        if not (project_root / "pyproject.toml").is_file():
+            logger.warning(
+                "proxy self-heal: cannot locate the install root at %s — skipping",
+                project_root,
+            )
+            return False
+
+        # Single source of truth for the extras (matches the updater); fall
+        # back to the literal if the import is unavailable for any reason.
+        try:
+            from tinyagentos.routes.settings import UPDATE_EXTRAS
+        except Exception:
+            UPDATE_EXTRAS = ("proxy",)
+
+        # HOME=install dir so uv resolves its cache under the service user.
+        env = {**os.environ, "HOME": str(project_root)}
+        uv = None
+        cand = project_root / ".local" / "bin" / "uv"
+        if cand.exists():
+            uv = str(cand)
+        uv = uv or shutil.which("uv")
+        if uv:
+            extra_args = [a for e in UPDATE_EXTRAS for a in ("--extra", e)]
+            cmd = [uv, "sync", "--frozen", *extra_args]
+        else:
+            pip = str(Path(sys.executable).parent / "pip")
+            cmd = [pip, "install", "-e", f".[{','.join(UPDATE_EXTRAS)}]"]
+
+        logger.warning(
+            "proxy self-heal: litellm missing, installing the proxy extra: %s",
+            " ".join(cmd),
+        )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=str(project_root),
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            out, _ = await asyncio.wait_for(proc.communicate(), timeout=900)
+            if proc.returncode == 0:
+                logger.info("proxy self-heal: install succeeded")
+                return True
+            tail = (out or b"").decode(errors="replace")[-400:]
+            logger.warning(
+                "proxy self-heal: install failed (rc=%s): %s", proc.returncode, tail
+            )
+            return False
+        except Exception as exc:  # noqa: BLE001 - non-fatal by design
+            logger.warning("proxy self-heal: install error: %s", exc)
+            return False
 
     async def start(
         self,
@@ -255,6 +327,16 @@ class LLMProxy:
         import sys
         venv_bin = Path(sys.executable).parent / "litellm"
         litellm_cmd = str(venv_bin) if venv_bin.exists() else shutil.which("litellm")
+        if not litellm_cmd and not self._selfheal_attempted:
+            # The proxy is a core dependency. A pre-fix update ran a bare
+            # `uv sync --frozen` and stripped the proxy extra, so a fresh boot
+            # finds litellm gone. Self-install it once (bounded, non-fatal);
+            # this runs inside the background litellm-bringup task so a slow
+            # install does not block controller startup.
+            self._selfheal_attempted = True
+            if await self._selfheal_proxy_extra():
+                venv_bin = Path(sys.executable).parent / "litellm"
+                litellm_cmd = str(venv_bin) if venv_bin.exists() else shutil.which("litellm")
         if not litellm_cmd:
             logger.warning("LiteLLM not installed — proxy disabled. Install with: pip install litellm[proxy]")
             return False

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -238,18 +238,36 @@ class LLMProxy:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
             )
+        except Exception as exc:  # noqa: BLE001 - non-fatal by design
+            logger.warning("proxy self-heal: could not spawn install: %s", exc)
+            return False
+
+        try:
             out, _ = await asyncio.wait_for(proc.communicate(), timeout=900)
-            if proc.returncode == 0:
-                logger.info("proxy self-heal: install succeeded")
-                return True
-            tail = (out or b"").decode(errors="replace")[-400:]
-            logger.warning(
-                "proxy self-heal: install failed (rc=%s): %s", proc.returncode, tail
-            )
+        except asyncio.TimeoutError:
+            # Kill the runaway install so it does not leak past the timeout.
+            logger.warning("proxy self-heal: install timed out after 900s — killing")
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+                pass
             return False
         except Exception as exc:  # noqa: BLE001 - non-fatal by design
             logger.warning("proxy self-heal: install error: %s", exc)
             return False
+
+        if proc.returncode == 0:
+            logger.info("proxy self-heal: install succeeded")
+            return True
+        tail = (out or b"").decode(errors="replace")[-400:]
+        logger.warning(
+            "proxy self-heal: install failed (rc=%s): %s", proc.returncode, tail
+        )
+        return False
 
     async def start(
         self,


### PR DESCRIPTION
## Why

#1517 stops *future* updates from stripping litellm, but the transitional update that **delivers** that fix is executed by the **old** updater code (bare `uv sync --frozen`), which prunes the `proxy` extra before the new code takes over. Verified live on the Pi: updating to the fix commit left `:4000` down and litellm not importable. Without this, every user updating to the fix-release loses their LLM proxy once.

## Fix

When `LLMProxy.start()` finds litellm missing, self-install the proxy extra once:
- `uv sync --frozen --extra proxy` (pip fallback `-e .[proxy]`), extras single-sourced from `settings.UPDATE_EXTRAS`.
- Guarded to run **once per process** (`_selfheal_attempted`), **bounded** (900s timeout), **non-fatal** (any failure just leaves the proxy disabled and the box running).
- Runs inside the existing **background** litellm-bringup task, so a slow install never blocks controller startup - the proxy simply arrives a minute or two after boot.

## Tests

3 new tests in `tests/test_llm_proxy.py` (command construction, non-zero handling, missing-root guard); full file 41/41 pass.

## Verification plan

After merge + Settings-update to the Pi: deliberately strip litellm, restart, and confirm the self-heal reinstalls it and the proxy binds - the definitive proof before the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery during startup when a required proxy component is missing, helping the app continue without manual repair.

* **Bug Fixes**
  * Improved startup behavior so failed recovery no longer blocks the app; it now safely stays disabled if recovery cannot complete.

* **Tests**
  * Added coverage for successful recovery, failed recovery, and cases where recovery is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->