### PR TITLE
fix(doc-gate): fold Qodo findings (glob precision, CONTRIBUTING drift, single-source trailer)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -8,10 +8,11 @@
 # configures for CI (default: "Docs-Reviewed:").
 set -euo pipefail
 
-trailer="Docs-Reviewed:"
 msg_file="$1"
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
+
+trailer="$(python3 "$repo_root/scripts/check_doc_gate.py" print-trailer 2>/dev/null || echo 'Docs-Reviewed:')"
 
 if python3 scripts/check_doc_gate.py diff-gate --staged >/dev/null 2>&1; then
     exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,7 @@ A gate blocks PRs that add or remove certain feature code without a matching doc
 | Change | Requires editing one of |
 |--------|--------------------------|
 | A desktop app under `desktop/src/apps/` is added or removed | `README.md` |
-| A route module under `tinyagentos/routes/` is added or removed | `docs/agent-coordination.md` or `docs/AGENT_HANDOFF.md` |
+| A route module under `tinyagentos/routes/` is added or removed | `docs/agent-coordination.md` |
 | An installer under `tinyagentos/installers/` or `scripts/install*` is added or removed | `README.md` |
 | A manifest under `app-catalog/` is added or removed | `README.md` |
 

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -104,10 +104,10 @@ def check_referenced_paths(repo_root: Path, files_to_scan: list[str], config: di
 def _glob_match(path: str, pattern: str) -> bool:
     """Path-segment-aware glob match, unlike fnmatch (where `*` crosses `/`).
 
-    `**` matches across path separators (translates to `.*`), a single `*`
-    matches within one path segment only (`[^/]*`), `?` matches one
-    non-separator character (`[^/]`), and every other character is matched
-    literally.
+    `**` matches zero or more path segments (so a trailing `/**` also matches
+    the bare parent, e.g. `a/**` matches `a`), a single `*` matches within one
+    path segment only (`[^/]*`), `?` matches one non-separator character
+    (`[^/]`), and every other character is matched literally.
     """
     regex_parts = []
     i = 0
@@ -116,7 +116,12 @@ def _glob_match(path: str, pattern: str) -> bool:
         char = pattern[i]
         if char == "*":
             if i + 1 < length and pattern[i + 1] == "*":
-                regex_parts.append(".*")
+                # A trailing `/**` should also match the bare parent path, so
+                # fold the preceding literal `/` into an optional group.
+                if regex_parts and regex_parts[-1] == "/" and i + 2 == length:
+                    regex_parts[-1] = "(?:/.*)?"
+                else:
+                    regex_parts.append(".*")
                 i += 2
             else:
                 regex_parts.append("[^/]*")
@@ -150,7 +155,7 @@ def evaluate_rules(
     commit_messages: full text of each commit message in range (empty list
     when there is no finalized commit yet, i.e. --staged mode).
     """
-    trailer = config.get("gate", {}).get("trailer", DEFAULT_TRAILER)
+    trailer = get_trailer(config)
     rules = config.get("rules", [])
 
     all_paths = [path for _status, path in changed_status]

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -27,7 +27,6 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import re
 import subprocess
 import sys
@@ -102,8 +101,37 @@ def check_referenced_paths(repo_root: Path, files_to_scan: list[str], config: di
     return failures
 
 
+def _glob_match(path: str, pattern: str) -> bool:
+    """Path-segment-aware glob match, unlike fnmatch (where `*` crosses `/`).
+
+    `**` matches across path separators (translates to `.*`), a single `*`
+    matches within one path segment only (`[^/]*`), `?` matches one
+    non-separator character (`[^/]`), and every other character is matched
+    literally.
+    """
+    regex_parts = []
+    i = 0
+    length = len(pattern)
+    while i < length:
+        char = pattern[i]
+        if char == "*":
+            if i + 1 < length and pattern[i + 1] == "*":
+                regex_parts.append(".*")
+                i += 2
+            else:
+                regex_parts.append("[^/]*")
+                i += 1
+        elif char == "?":
+            regex_parts.append("[^/]")
+            i += 1
+        else:
+            regex_parts.append(re.escape(char))
+            i += 1
+    return re.fullmatch("".join(regex_parts), path) is not None
+
+
 def _match_any(path: str, patterns: list[str]) -> bool:
-    return any(fnmatch.fnmatch(path, pat) for pat in patterns)
+    return any(_glob_match(path, pat) for pat in patterns)
 
 
 def evaluate_rules(
@@ -190,6 +218,12 @@ def _git_commit_messages(base_ref: str) -> list[str]:
     return [m for m in out.split("\x00") if m.strip()]
 
 
+def get_trailer(config: dict) -> str:
+    """Single source of truth for the commit-message trailer prefix, shared
+    by the diff-gate check and the hooks (via the print-trailer command)."""
+    return config.get("gate", {}).get("trailer", DEFAULT_TRAILER)
+
+
 def _report(failures: list[str]) -> int:
     if not failures:
         print("doc-gate: clean")
@@ -204,6 +238,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("invariants", help="Run Layer-A deterministic checks")
+    sub.add_parser("print-trailer", help="Print the configured commit trailer prefix")
 
     diff_parser = sub.add_parser("diff-gate", help="Run Layer-B path->doc rule engine")
     group = diff_parser.add_mutually_exclusive_group(required=True)
@@ -217,6 +252,10 @@ def main(argv: list[str] | None = None) -> int:
         files_to_scan = config.get("invariants", {}).get("referenced_paths_scan", [])
         failures = check_referenced_paths(REPO_ROOT, files_to_scan, config)
         return _report(failures)
+
+    if args.command == "print-trailer":
+        print(get_trailer(config))
+        return 0
 
     # diff-gate
     if args.staged:

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -167,3 +167,15 @@ class TestCheckReferencedPaths:
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))
+
+
+def test_glob_double_star_matches_bare_parent():
+    """A trailing `/**` matches the bare parent path as well as anything under
+    it (folds a Kilo review note that `**` was one-or-more, not zero-or-more)."""
+    from check_doc_gate import _glob_match
+
+    assert _glob_match("app-catalog", "app-catalog/**") is True
+    assert _glob_match("app-catalog/foo/bar.json", "app-catalog/**") is True
+    # A single `*` still does not cross a separator.
+    assert _glob_match("tinyagentos/routes/desktop_browser/__init__.py",
+                       "tinyagentos/routes/*.py") is False

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -91,6 +91,47 @@ class TestEvaluateRules:
         assert failures[0].startswith("routes -- ")
 
 
+class TestGlobMatch:
+    def test_single_star_stays_within_segment(self):
+        assert dg._glob_match("tinyagentos/routes/settings.py", "tinyagentos/routes/*.py")
+        assert not dg._glob_match(
+            "tinyagentos/routes/desktop_browser/__init__.py",
+            "tinyagentos/routes/*.py",
+        )
+
+    def test_double_star_crosses_segments(self):
+        assert dg._glob_match(
+            "desktop/src/apps/Foo/sub/x.ts", "desktop/src/apps/*/**"
+        )
+
+    def test_trailing_star_matches_within_segment(self):
+        assert dg._glob_match("scripts/install-server.sh", "scripts/install*")
+
+    def test_double_star_matches_nested_manifest(self):
+        assert dg._glob_match("app-catalog/foo/bar.json", "app-catalog/**")
+
+
+class TestEvaluateRulesRoutesGlobPrecision:
+    def test_nested_route_file_does_not_trigger_routes_rule(self):
+        changed = [("A", "tinyagentos/routes/desktop_browser/newmod.py")]
+        assert dg.evaluate_rules(changed, [], APPS_RULE_CONFIG) == []
+
+    def test_top_level_route_file_triggers_routes_rule(self):
+        changed = [("A", "tinyagentos/routes/newroute.py")]
+        failures = dg.evaluate_rules(changed, [], APPS_RULE_CONFIG)
+        assert len(failures) == 1
+        assert failures[0].startswith("routes -- ")
+
+
+class TestGetTrailer:
+    def test_returns_configured_trailer(self):
+        config = {"gate": {"trailer": "Docs-Reviewed:"}}
+        assert dg.get_trailer(config) == "Docs-Reviewed:"
+
+    def test_falls_back_to_default_when_missing(self):
+        assert dg.get_trailer({}) == dg.DEFAULT_TRAILER
+
+
 class TestCheckReferencedPaths:
     def test_dead_path_token_fails(self, tmp_path: Path):
         readme = tmp_path / "README.md"


### PR DESCRIPTION
Folds all three Qodo findings on the merged doc-gate (#1518):

1. **Glob crossed directory separators (correctness).** `_match_any` used `fnmatch`, where `*` matches `/`, so `tinyagentos/routes/*.py` wrongly matched nested files like `tinyagentos/routes/desktop_browser/__init__.py`, over-triggering the routes rule. Added `_glob_match` (path-segment-aware: `**`→across `/`, `*`→within a segment, `?`→one non-sep char); `_match_any` uses it.
2. **CONTRIBUTING drift (correctness).** The routes-rule row listed `docs/AGENT_HANDOFF.md` as a satisfying doc, but it is gitignored/untracked and not in `doc-gate.toml`, so following CONTRIBUTING would still fail CI. Now lists only `docs/agent-coordination.md`.
3. **Trailer hardcoded in hooks (maintainability).** `.githooks/commit-msg` now sources the trailer from config via a new `print-trailer` subcommand (fallback preserved), so it cannot desync from CI.

Tests: `tests/test_doc_gate.py` gains glob-precision + evaluate_rules + trailer tests; 20 pass. `invariants` + `diff-gate --base origin/dev` clean; hooks `bash -n` + shellcheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation gate checks so path matching is more precise and nested files are handled correctly.
  * Commit messages now pick up the required documentation trailer automatically when available, with a safe fallback if not.

* **Documentation**
  * Updated contribution guidance for route changes: only the main agent coordination docs are now required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->