### PR TITLE
fix(llm-proxy): self-heal must not resolve() the venv python (lands install root on /usr)

### DIFF
--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -649,3 +649,44 @@ class TestProxySelfHeal:
 
         assert await LLMProxy()._selfheal_proxy_extra() is False
         assert killed["called"] is True
+
+    @pytest.mark.asyncio
+    async def test_selfheal_locates_root_through_venv_symlink(self, tmp_path, monkeypatch):
+        """sys.executable is a venv symlink to the base interpreter; the install
+        root must be the venv's grandparent, NOT the symlink target's (regression:
+        an earlier .resolve() walked out of the install tree onto /usr)."""
+        import sys
+        import tinyagentos.llm_proxy as mod
+
+        root = tmp_path / "install"
+        (root / ".venv" / "bin").mkdir(parents=True)
+        (root / "pyproject.toml").write_text("[project]\n")
+        (root / ".local" / "bin").mkdir(parents=True)
+        (root / ".local" / "bin" / "uv").write_text("x")
+        base = tmp_path / "usr" / "local" / "bin"
+        base.mkdir(parents=True)
+        real_py = base / "python3"
+        real_py.write_text("#!/bin/sh\n")
+        venv_py = root / ".venv" / "bin" / "python"
+        venv_py.symlink_to(real_py)
+        monkeypatch.setattr(sys, "executable", str(venv_py))
+
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"", None)
+
+        async def fake_exec(*cmd, **kw):
+            captured["cwd"] = kw.get("cwd")
+            captured["cmd"] = list(cmd)
+            return FakeProc()
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+
+        ok = await LLMProxy()._selfheal_proxy_extra()
+        assert ok is True
+        # cwd must be the install root (venv grandparent), not tmp_path/usr.
+        assert captured["cwd"] == str(root)

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -197,7 +197,11 @@ class LLMProxy:
         import sys
 
         # The install dir is the venv's grandparent (<root>/.venv/bin/python).
-        project_root = Path(sys.executable).resolve().parents[2]
+        # Do NOT resolve(): the venv python is a symlink to the base
+        # interpreter (e.g. /usr/local/bin/python3.x), so resolving walks out
+        # of the install tree and lands parents[2] on /usr. start() derives the
+        # venv bin the same non-resolved way.
+        project_root = Path(sys.executable).parents[2]
         if not (project_root / "pyproject.toml").is_file():
             logger.warning(
                 "proxy self-heal: cannot locate the install root at %s — skipping",


### PR DESCRIPTION
Follow-up to #1519. The self-heal derived the install root via `Path(sys.executable).resolve().parents[2]`, but the venv python is a symlink to the base interpreter (`/usr/local/bin/python3.x`), so `resolve()` walked out of the install tree and `parents[2]` became `/usr` -> logged `cannot locate the install root at /usr` and skipped, leaving the proxy disabled.

**Caught by the live strip-and-restart test on the Pi** (unit tests used a non-symlink path and missed it). Drop `resolve()` to match how `start()` resolves the venv bin, and add `test_selfheal_locates_root_through_venv_symlink` (real symlink) as a regression guard. 43/43 proxy tests pass. Will re-run the live self-heal test after merge + redeploy before releasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app recovery behavior so it correctly finds the install root even when the Python executable inside a virtual environment is a symlink.
  * Fixed subprocess execution to use the proper working directory during self-heal, preventing it from targeting the wrong location in symlinked setups.
  * Added regression coverage for this symlink-based environment scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->