### PR TITLE
fix(sw): network-first for the SPA shell (stops redeploys breaking open PWA sessions)

### DIFF
--- a/desktop/src/sw.ts
+++ b/desktop/src/sw.ts
@@ -107,19 +107,26 @@ self.addEventListener("fetch", (event: FetchEvent) => {
     return;
   }
 
+  // isShellHTML is checked BEFORE isPrecachedStatic on purpose: /desktop/,
+  // /desktop/index.html and /chat-pwa are in PRECACHE_URLS but must use
+  // network-first, not the SWR branch below -- a stale cached index
+  // reintroduces the ChunkLoadError loop. Keep this branch first.
   if (isShellHTML(url)) {
-    // Network-first for the SPA shell: a stale cached index references old
-    // hashed chunk URLs that 404 after a redeploy -> ChunkLoadError -> reload
-    // loop. Always try the network so the served index matches the deployed
-    // assets; fall back to cache only when the network fails (offline /
-    // mid-restart). For chat-pwa subpaths, key on /chat-pwa.
+    // Network-first (bounded) for the SPA shell: fetch the current index when
+    // the backend is healthy so its chunk refs match the deployed assets. Fall
+    // back to the cached shell on a non-OK response (503 mid-restart), a
+    // network failure (offline), or a stall (aborted after the timeout),
+    // preserving the Install-Update reconnect UX. cache:"no-store" bypasses the
+    // browser HTTP cache so a 304-with-empty-body cannot slip through.
     const cacheKey = url.pathname.startsWith("/chat-pwa")
       ? new Request("/chat-pwa")
       : (url.pathname !== "/desktop/index.html" ? new Request("/desktop/") : req);
     event.respondWith(
       caches.open(STATIC_CACHE).then(async (cache) => {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 4000);
         try {
-          const fresh = await fetch(req);
+          const fresh = await fetch(req, { cache: "no-store", signal: controller.signal });
           if (fresh.ok) {
             cache.put(cacheKey, fresh.clone());
             return fresh;
@@ -129,10 +136,12 @@ self.addEventListener("fetch", (event: FetchEvent) => {
           const hit = await cache.match(cacheKey);
           return hit || fresh;
         } catch (err) {
-          // Offline / network failure: fall back to the cached shell.
+          // Offline / stall (aborted) / network failure: fall back to cache.
           const hit = await cache.match(cacheKey);
           if (hit) return hit;
           throw err;
+        } finally {
+          clearTimeout(timer);
         }
       })
     );

--- a/desktop/src/sw.ts
+++ b/desktop/src/sw.ts
@@ -7,8 +7,12 @@
  * (e.g. mid-restart after Install Update). Scope: '/' — covers both
  * /desktop and /chat-pwa. Strategy:
  *  - cache-first for /desktop/assets/* (immutable hashed URLs)
- *  - stale-while-revalidate for /desktop/index.html, /chat-pwa,
- *    static manifests and icons
+ *  - network-first for the SPA shell HTML (/desktop/index.html, /chat-pwa):
+ *    a stale cached index references old hashed chunk URLs that 404 after a
+ *    redeploy, which crashes lazy imports (ChunkLoadError) and forces a reload
+ *    loop. Always fetch the current index when online; fall back to cache only
+ *    when the network fails (offline / mid-restart).
+ *  - stale-while-revalidate for static manifests and icons
  *  - passes everything else through (/api/*, /ws/*, ...)
  *
  * No app logic, no postMessage, no polling. The reconnect / version
@@ -103,29 +107,52 @@ self.addEventListener("fetch", (event: FetchEvent) => {
     return;
   }
 
-  if (isShellHTML(url) || isPrecachedStatic(url)) {
-    // Stale-while-revalidate: serve cache instantly, refresh in background.
-    // For chat-pwa subpaths (e.g. /chat-pwa/foo), serve cached /chat-pwa.
-    const cacheKey = isShellHTML(url) && url.pathname.startsWith("/chat-pwa")
+  if (isShellHTML(url)) {
+    // Network-first for the SPA shell: a stale cached index references old
+    // hashed chunk URLs that 404 after a redeploy -> ChunkLoadError -> reload
+    // loop. Always try the network so the served index matches the deployed
+    // assets; fall back to cache only when the network fails (offline /
+    // mid-restart). For chat-pwa subpaths, key on /chat-pwa.
+    const cacheKey = url.pathname.startsWith("/chat-pwa")
       ? new Request("/chat-pwa")
-      : (isShellHTML(url) && url.pathname !== "/desktop/index.html"
-          ? new Request("/desktop/")
-          : req);
+      : (url.pathname !== "/desktop/index.html" ? new Request("/desktop/") : req);
     event.respondWith(
       caches.open(STATIC_CACHE).then(async (cache) => {
-        const hit = await cache.match(cacheKey);
+        try {
+          const fresh = await fetch(req);
+          if (fresh.ok) {
+            cache.put(cacheKey, fresh.clone());
+            return fresh;
+          }
+          // Non-OK (e.g. 503 mid-restart after Install Update): prefer the
+          // cached shell so the UI still loads and the reconnect banner shows.
+          const hit = await cache.match(cacheKey);
+          return hit || fresh;
+        } catch (err) {
+          // Offline / network failure: fall back to the cached shell.
+          const hit = await cache.match(cacheKey);
+          if (hit) return hit;
+          throw err;
+        }
+      })
+    );
+    return;
+  }
+
+  if (isPrecachedStatic(url)) {
+    // Stale-while-revalidate for icons/manifests (no hashed-chunk coupling):
+    // serve cache instantly, refresh in background.
+    event.respondWith(
+      caches.open(STATIC_CACHE).then(async (cache) => {
+        const hit = await cache.match(req);
         const network = fetch(req).then((r) => {
-          if (r.ok) cache.put(cacheKey, r.clone());
+          if (r.ok) cache.put(req, r.clone());
           return r;
         }).catch((err) => {
-          // If we have a cached copy, fall back to it. Otherwise propagate
-          // the network error so the browser shows a normal failure rather
-          // than crashing the SW handler with an undefined Response.
           if (hit) return hit;
           throw err;
         });
-        if (hit) return hit;
-        return network;
+        return hit || network;
       })
     );
     return;


### PR DESCRIPTION
## Problem

The service worker served the SPA shell HTML **stale-while-revalidate** (cached index first). After a redeploy, the cached index references old hashed chunk URLs that 404, so lazy imports throw `ChunkLoadError`, the error boundary auto-reloads, and it lands on the default pane. Repro (Jay): Settings > Account after several rebuilds -> `fatal: Importing a module script failed` in client logs -> reload loop back to System Info.

## Fix

Serve the shell **network-first**: fetch the current index when the backend is healthy so its chunk refs match the deployed assets. Fall back to the cached shell only on a **non-OK response** (503 mid-restart after Install Update) or a **network failure** (offline) - preserving the reconnect UX the SW cache exists for. Immutable hashed assets stay cache-first; icons/manifests stay stale-while-revalidate.

## Notes
- HTTP-layer was already correct (`index.html` is `no-cache`); the SW cache was the remaining stale layer.
- Existing open sessions need one refresh to pick up the new SW (skipWaiting + clients.claim then take over); after that, redeploys no longer strip sessions.
- `desktop/tests/e2e/sw-and-reconnect.spec.ts` covers precache + offline-shell; the non-OK/offline fallback preserves both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app loading reliability by reducing stale cached shell pages after updates.
  * The app now prefers the latest online shell for smoother navigation and fewer reload loops caused by outdated cached files.
  * When offline or during restarts, it falls back to the last known cached shell to keep the UI accessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->