### PR TITLE
fix(sw-register): reload on new SW control so redeploys swap open sessions

### DIFF
--- a/desktop/src/lib/__tests__/sw-register.test.ts
+++ b/desktop/src/lib/__tests__/sw-register.test.ts
@@ -86,4 +86,20 @@ describe("registerServiceWorker", () => {
     await registerServiceWorker();
     expect(addEventListener).not.toHaveBeenCalled();
   });
+
+  it("wires the controllerchange listener at most once across calls", async () => {
+    const addEventListener = vi.fn();
+    const register = vi.fn().mockResolvedValue({ update: vi.fn() });
+    // Same container instance across both calls (StrictMode / remount).
+    const swMock = { register, addEventListener, controller: {} };
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: swMock, writable: true, configurable: true,
+    });
+    await registerServiceWorker();
+    await registerServiceWorker();
+    const controllerChangeCalls = addEventListener.mock.calls.filter(
+      ([type]: [string]) => type === "controllerchange",
+    );
+    expect(controllerChangeCalls).toHaveLength(1);
+  });
 });

--- a/desktop/src/lib/__tests__/sw-register.test.ts
+++ b/desktop/src/lib/__tests__/sw-register.test.ts
@@ -38,4 +38,52 @@ describe("registerServiceWorker", () => {
     await expect(registerServiceWorker()).resolves.toBeUndefined();
     expect(consoleErr).toHaveBeenCalled();
   });
+
+  it("proactively calls registration.update() to check for a new SW", async () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const register = vi.fn().mockResolvedValue({ update });
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: { register, controller: null }, writable: true, configurable: true,
+    });
+    await registerServiceWorker();
+    expect(update).toHaveBeenCalled();
+  });
+
+  it("reloads once when a new SW takes control on a returning session", async () => {
+    let handler: (() => void) | null = null;
+    const addEventListener = vi.fn((type: string, h: () => void) => {
+      if (type === "controllerchange") handler = h;
+    });
+    const register = vi.fn().mockResolvedValue({ update: vi.fn() });
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: { register, addEventListener, controller: {} }, // controller present = returning session
+      writable: true, configurable: true,
+    });
+    const originalLocation = window.location;
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { reload }, writable: true, configurable: true,
+    });
+
+    await registerServiceWorker();
+    expect(addEventListener).toHaveBeenCalledWith("controllerchange", expect.any(Function));
+    handler?.();
+    handler?.(); // second fire must not double-reload
+    expect(reload).toHaveBeenCalledTimes(1);
+
+    Object.defineProperty(window, "location", {
+      value: originalLocation, writable: true, configurable: true,
+    });
+  });
+
+  it("does not wire the reload on a first-ever visit (no controller)", async () => {
+    const addEventListener = vi.fn();
+    const register = vi.fn().mockResolvedValue({ update: vi.fn() });
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: { register, addEventListener, controller: null },
+      writable: true, configurable: true,
+    });
+    await registerServiceWorker();
+    expect(addEventListener).not.toHaveBeenCalled();
+  });
 });

--- a/desktop/src/lib/sw-register.ts
+++ b/desktop/src/lib/sw-register.ts
@@ -1,12 +1,40 @@
 /**
  * Register the SPA's service worker once on boot.
- * Safe to call from a useEffect — does nothing on browsers without
+ * Safe to call from a useEffect - does nothing on browsers without
  * service worker support and never throws.
+ *
+ * On a returning session (already controlled by a SW), reload once when a new
+ * SW takes control. A redeploy ships a new hashed bundle; the old page keeps
+ * referencing now-404 chunk URLs until it reloads, which otherwise surfaces as
+ * a ChunkLoadError loop (e.g. opening an app after a deploy). skipWaiting +
+ * clients.claim in sw.ts make the new SW activate promptly; this reload swaps
+ * the page onto the fresh index so its chunk refs match the deployed assets.
  */
 export async function registerServiceWorker(): Promise<void> {
   if (typeof navigator === "undefined" || !navigator.serviceWorker) return;
   try {
-    await navigator.serviceWorker.register("/sw.js");
+    // Only wire the auto-reload for a session that ALREADY has a controller.
+    // On a first-ever visit the SW claims control with no stale page to fix,
+    // so reloading there would just be a wasted refresh.
+    if (
+      navigator.serviceWorker.controller &&
+      typeof navigator.serviceWorker.addEventListener === "function"
+    ) {
+      let reloading = false;
+      navigator.serviceWorker.addEventListener("controllerchange", () => {
+        if (reloading) return;
+        reloading = true;
+        window.location.reload();
+      });
+    }
+
+    const registration = await navigator.serviceWorker.register("/sw.js");
+
+    // Proactively check for a new SW now (browsers otherwise only check on
+    // navigation / ~24h), so a fresh deploy is picked up without waiting.
+    if (registration && typeof registration.update === "function") {
+      registration.update().catch(() => {});
+    }
   } catch (err) {
     console.warn("[taos] service worker registration failed:", err);
   }

--- a/desktop/src/lib/sw-register.ts
+++ b/desktop/src/lib/sw-register.ts
@@ -13,15 +13,29 @@
 export async function registerServiceWorker(): Promise<void> {
   if (typeof navigator === "undefined" || !navigator.serviceWorker) return;
   try {
-    // Only wire the auto-reload for a session that ALREADY has a controller.
-    // On a first-ever visit the SW claims control with no stale page to fix,
-    // so reloading there would just be a wasted refresh.
+    // Wire the controllerchange -> reload listener at most once per SW
+    // container, even if registerServiceWorker is called again (React
+    // StrictMode double-invokes effects in dev, HMR, remounts). The marker
+    // lives on the container instance so it resets naturally per test.
+    const swc = navigator.serviceWorker as ServiceWorkerContainer & {
+      __taosReloadWired?: boolean;
+    };
+    // Only wire it for a session that ALREADY has a controller: a first-ever
+    // visit claims control with no stale page to fix, so a reload there is just
+    // a wasted refresh.
     if (
-      navigator.serviceWorker.controller &&
-      typeof navigator.serviceWorker.addEventListener === "function"
+      !swc.__taosReloadWired &&
+      swc.controller &&
+      typeof swc.addEventListener === "function"
     ) {
+      swc.__taosReloadWired = true;
       let reloading = false;
-      navigator.serviceWorker.addEventListener("controllerchange", () => {
+      // controllerchange fires whenever the controlling SW changes. This app
+      // registers one SW at one scope and never unregisters, so in practice it
+      // means a newly-activated version took control -> reload once onto the
+      // fresh index. (A manual unregister would also trigger it, which we do
+      // not do.)
+      swc.addEventListener("controllerchange", () => {
         if (reloading) return;
         reloading = true;
         window.location.reload();
@@ -31,9 +45,13 @@ export async function registerServiceWorker(): Promise<void> {
     const registration = await navigator.serviceWorker.register("/sw.js");
 
     // Proactively check for a new SW now (browsers otherwise only check on
-    // navigation / ~24h), so a fresh deploy is picked up without waiting.
+    // navigation / ~24h) so a fresh deploy is picked up without waiting.
     if (registration && typeof registration.update === "function") {
-      registration.update().catch(() => {});
+      registration.update().catch((err) => {
+        // Surface update failures (SW 404 / scope mismatch / offline) rather
+        // than swallowing them, so deploy issues are visible in the console.
+        console.debug("[taos] service worker update check failed:", err);
+      });
     }
   } catch (err) {
     console.warn("[taos] service worker registration failed:", err);


### PR DESCRIPTION
Completes the SW cache fix. #1522 made the SW network-first (so a reload gets the fresh index), but nothing reloaded an already-open session, so the page kept running old code with now-404 chunk refs -> ChunkLoadError loop on opening an app (repro: Settings > Account after a deploy; client log: `Importing a module script failed`, stack shows a lazy app chunk failing under Suspense).

`registerServiceWorker` now, on a returning session (an existing controller), listens for `controllerchange` and reloads once when the new SW takes control (sw.ts already does skipWaiting + clients.claim), and calls `registration.update()` on boot to pick up a fresh deploy promptly. First-ever visits skip the reload. 6/6 sw-register tests pass; tsc clean.

Note: an already-open session still needs one manual reset to get ONTO this new code; after that, future deploys swap seamlessly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Returning sessions now auto-reload when service worker control changes, helping users access the latest version sooner.
  * Service worker registration now checks for updates immediately after setup.
* **Bug Fixes**
  * Prevents repeated reloads from happening multiple times for the same control change.
  * Avoids enabling reload behavior on first-time visits when there is no existing service worker controller.
* **Tests**
  * Expanded service worker registration tests to cover update calls, reload wiring, and “reload only once” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->