### PR TITLE
chore(release): 1.0.0-beta.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - The LLM proxy now self-heals: if litellm is missing at startup (e.g. left over from an update before the fix above), it reinstalls itself once automatically and comes back online.
 - The desktop no longer breaks after an update: it reliably loads the new version after a redeploy instead of getting stuck on stale cached code or crashing when opening an app, on Chrome, Safari, and Firefox alike.
 - A failed background rebuild during boot no longer crash-loops the controller; it now falls back to the last working build and logs a warning instead.
+- Opening Settings > Account no longer flashes the login screen and bounces you back to System Info when you are not signed into a taOS cloud account; the account service's expected "not signed in" response is no longer mistaken for your device session expiring.
 
 ## [1.0.0-beta.13] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,29 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.14] - 2026-07-01
+
 ### Added
 - Channel Hub: Matrix connector. An agent can be reached over Matrix (homeserver + access token) the same way as Telegram/Slack/Discord; the connector mirrors the others and coexists with the A2A bus (channels are human-to-agent transport, A2A is agent-to-agent).
 - Secrets: SSH keys are first-class on agent deploy. A secret in the `ssh-keys` category is materialized inside the agent container as `~/.ssh/<name>` with 0600 perms (path-traversal-guarded), so tools like git and ssh can use it directly instead of only as an env var.
 - Store: the four optional social apps (Reddit, YouTube, GitHub, X) are installable again from the Store's taOS Apps section.
+- Live notifications: a shared real-time event stream now pushes updates (starting with the notification bell) straight to the desktop, no more waiting on a poll or a page refresh.
+- Observatory: per-session approval-mode control (default / accept-edits / don't-ask), the storage and API foundation for finer-grained control over how much an agent can do without asking.
+- Action receipts: every tool call an agent makes is now recorded in an append-only, content-hashed audit trail (inputs and outputs fingerprinted), the foundation for verifiable replay.
+- Agents panel now updates live as agents are minted, approved, or revoked, instead of needing a manual refresh.
+- Auth: agents authenticate to the A2A bus with their own identity/token instead of borrowing the owner's session, and an admin can now adopt a pre-existing agent identity into the registry rather than being blocked.
+- Contributor tooling: an enforced documentation-drift gate (local hook + CI) keeps README/docs in sync when scripts or install paths change.
+
+### Changed
+- Agent consent requests are now non-blocking: a bell entry and toast with inline Allow/Deny, instead of a desktop-blocking popup. Nothing is lost, decisions are archived to History.
+- In-app updates now install exactly the dependency versions pinned in the lockfile (uv sync --frozen) instead of re-resolving on every update, so an update can no longer pull in an untested dependency version.
+- The install directory moved from `/opt/tinyagentos` to `/opt/taos`; existing installs keep working with zero migration required.
+
+### Fixed
+- **Critical**: Settings > Install Update no longer uninstalls the LLM proxy (litellm); earlier updates could silently strip it and disable all agent LLM routing.
+- The LLM proxy now self-heals: if litellm is missing at startup (e.g. left over from an update before the fix above), it reinstalls itself once automatically and comes back online.
+- The desktop no longer breaks after an update: it reliably loads the new version after a redeploy instead of getting stuck on stale cached code or crashing when opening an app, on Chrome, Safari, and Firefox alike.
+- A failed background rebuild during boot no longer crash-loops the controller; it now falls back to the last working build and logs a warning instead.
 
 ## [1.0.0-beta.13] - 2026-06-28
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.13",
+  "version": "1.0.0-beta.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/lib/__tests__/auth-guard.test.ts
+++ b/desktop/src/lib/__tests__/auth-guard.test.ts
@@ -47,6 +47,25 @@ describe("auth-guard", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  it("does not dispatch on 401 from /api/account/* paths", async () => {
+    // The account proxy (taos.my cloud account) is a separate auth boundary
+    // and returns 401 when the user simply is not signed into the cloud —
+    // account-client maps that to a signed-out state. Treating it as a
+    // controller-session expiry flashed the login gate and bounced the user
+    // out of the Account pane. Reported by jay 2026-07-01.
+    vi.resetModules();
+    const { installAuthGuard: install } = await import("../auth-guard");
+    window.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    install();
+
+    const handler = vi.fn();
+    window.addEventListener(SESSION_EXPIRED_EVENT, handler);
+    await window.fetch("/api/account/me");
+    window.removeEventListener(SESSION_EXPIRED_EVENT, handler);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
   it("does not dispatch on 200", async () => {
     vi.resetModules();
     const { installAuthGuard: install } = await import("../auth-guard");

--- a/desktop/src/lib/auth-guard.ts
+++ b/desktop/src/lib/auth-guard.ts
@@ -21,6 +21,17 @@
  */
 
 const SESSION_EXPIRED_EVENT = "taos-session-expired";
+
+// API prefixes whose 401s do NOT mean the controller session expired.
+// /api/account/* proxies to the taos.my cloud account, a separate auth
+// boundary: it returns 401 whenever the user is not signed into that cloud
+// account, a normal state account-client maps to "signed-out". Firing
+// session-expired on it flashed the login gate and bounced the user out of
+// the Account pane (reported by jay 2026-07-01). Genuine controller-session
+// expiry is still caught by every other /api/* call the desktop makes.
+// (/auth/* is excluded implicitly by failing the /api/ test below.)
+const SESSION_EXPIRED_EXCLUDE = [/\/api\/account\//];
+
 let installed = false;
 
 export function installAuthGuard(): void {
@@ -43,14 +54,9 @@ export function installAuthGuard(): void {
       else if (input && typeof (input as Request).url === "string") url = (input as Request).url;
       // Only react to API paths — auth endpoints handle their own 401s.
       // Match path-prefix so absolute URLs from the same origin work too.
-      // The account proxy (/api/account/*) is a SEPARATE auth boundary: it
-      // forwards to the taos.my cloud account and returns 401 whenever the
-      // user is not signed into that cloud account, which is a normal state
-      // account-client maps to "signed-out". Firing session-expired on it
-      // flashed the login gate and bounced the user out of the Account pane
-      // (reported by jay 2026-07-01). Genuine controller-session expiry is
-      // still caught by every other /api/* call the desktop makes.
-      const isApi = /\/api\//.test(url) && !/\/api\/account\//.test(url);
+      const isApi =
+        /\/api\//.test(url) &&
+        !SESSION_EXPIRED_EXCLUDE.some((re) => re.test(url));
       if (isApi) {
         const now = Date.now();
         if (now - lastDispatch > 2000) {

--- a/desktop/src/lib/auth-guard.ts
+++ b/desktop/src/lib/auth-guard.ts
@@ -43,7 +43,14 @@ export function installAuthGuard(): void {
       else if (input && typeof (input as Request).url === "string") url = (input as Request).url;
       // Only react to API paths — auth endpoints handle their own 401s.
       // Match path-prefix so absolute URLs from the same origin work too.
-      const isApi = /\/api\//.test(url);
+      // The account proxy (/api/account/*) is a SEPARATE auth boundary: it
+      // forwards to the taos.my cloud account and returns 401 whenever the
+      // user is not signed into that cloud account, which is a normal state
+      // account-client maps to "signed-out". Firing session-expired on it
+      // flashed the login gate and bounced the user out of the Account pane
+      // (reported by jay 2026-07-01). Genuine controller-session expiry is
+      // still caught by every other /api/* call the desktop makes.
+      const isApi = /\/api\//.test(url) && !/\/api\/account\//.test(url);
       if (isApi) {
         const now = Date.now();
         if (now - lastDispatch > 2000) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.13"
+version = "1.0.0-beta.14"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.13"
+__version__ = "1.0.0-beta.14"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b13"
+version = "1.0.0b14"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump + CHANGELOG for the beta.14 release (dev -> master promotion).

**Why now:** master is still v1.0.0-beta.13, which ships the broken updater that silently uninstalls litellm on every Settings update. This release replaces it.

Bumps the 4 version files (pyproject.toml, desktop/package.json, tinyagentos/__init__.py, uv.lock) and dates the CHANGELOG section. `test_version_lock_sync` passes.

**Headline fixes in beta.14:** updater no longer strips the litellm proxy extra (#1517); proxy self-heals if missing (#1519/#1521); PWA reliably swaps to the new build after a deploy instead of crashing/looping (#1522/#1523). Full set in the CHANGELOG.

After this merges to dev, follow-up PR dev -> master, then tag v1.0.0-beta.14 + GitHub Release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live desktop notification streaming, live Agents panel updates, and per-session approval-mode (“Observatory”).
  * Introduced append-only, content-hashed action receipts/audit trail and improved A2A bus agent authentication.
  * Added a documentation-drift gate to keep changes aligned.

* **Changed**
  * Updated agent consent to be non-blocking (bell/toast) with archived history.
  * In-app updates now install exactly lockfile-pinned dependency versions.
  * Moved the install directory to a new path while preserving existing installs.

* **Bug Fixes**
  * Improved reliability/security across update/startup, including LLM proxy preservation/self-healing, fresh desktop reloads, and boot crash-loop recovery.
  * Fixed Settings > Account login behavior to prevent session-expired bounces.

* **Tests**
  * Added coverage to ensure session-expired is not dispatched for `401` responses from account endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->