### PR TITLE
fix: fold the four Kilo findings from the beta.14 promotion review

### DIFF
--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -245,14 +245,16 @@ class TestMintInternalRoute:
         assert kwargs["actor_user_id"]
 
     async def test_seed_internal_adopt_handles_preexisting(self, mint_client):
-        """seed-internal?adopt=true vouches for a pre-existing driver handle and
-        still seeds the rest."""
+        """seed-internal?adopt=@handle vouches for THAT pre-existing driver
+        handle explicitly and still seeds the rest."""
         rec = await mint_client._app.state.agent_registry.register(
             framework="claude-code", display_name="taos-dev",
             origin="external-selfjoin", handle="@taOS-dev",
         )
         await mint_client._app.state.agent_registry.set_status(rec["canonical_id"], "active")
-        resp = await mint_client.post("/api/agents/registry/seed-internal?adopt=true")
+        resp = await mint_client.post(
+            "/api/agents/registry/seed-internal?adopt=@taOS-dev"
+        )
         assert resp.status_code == 200, resp.text
         seeded = {s["handle"]: s for s in resp.json()["seeded"]}
         assert seeded["@taOS-dev"]["adopted"] is True and seeded["@taOS-dev"]["created"] is False
@@ -260,6 +262,31 @@ class TestMintInternalRoute:
         # Without adopt it would have 409d on @taOS-dev:
         resp2 = await mint_client.post("/api/agents/registry/seed-internal")
         assert resp2.status_code == 409
+
+    async def test_seed_internal_rejects_blanket_adopt(self, mint_client):
+        """A bare adopt=true (or any non-handle value) is a 400: adoption
+        grants driver scopes + a token to a pre-existing identity, so each
+        handle must be vouched for explicitly, never all four at once."""
+        resp = await mint_client.post(
+            "/api/agents/registry/seed-internal?adopt=true"
+        )
+        assert resp.status_code == 400
+        assert "explicitly" in resp.json()["detail"]
+
+    async def test_seed_internal_adopt_only_covers_listed_handles(self, mint_client):
+        """A pre-existing handle NOT named in adopt still 409s even when
+        another handle is being adopted."""
+        reg = mint_client._app.state.agent_registry
+        for handle, name in (("@taOS-dev", "taos-dev"), ("@Hermes", "hermes")):
+            rec = await reg.register(
+                framework="claude-code", display_name=name,
+                origin="external-selfjoin", handle=handle,
+            )
+            await reg.set_status(rec["canonical_id"], "active")
+        resp = await mint_client.post(
+            "/api/agents/registry/seed-internal?adopt=@taOS-dev"
+        )
+        assert resp.status_code == 409
 
     async def test_mint_requires_auth(self, mint_client):
         """An unauthenticated caller cannot mint (route is admin-only and not on

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -263,6 +263,26 @@ class TestMintInternalRoute:
         resp2 = await mint_client.post("/api/agents/registry/seed-internal")
         assert resp2.status_code == 409
 
+    async def test_seed_internal_adopt_multiple_listed(self, mint_client):
+        """Multiple handles (with copy-paste spacing and a duplicate) adopt in
+        one call; each named row comes back adopted."""
+        reg = mint_client._app.state.agent_registry
+        for handle, name in (("@taOS-dev", "taos-dev"), ("@Hermes", "hermes")):
+            rec = await reg.register(
+                framework="claude-code", display_name=name,
+                origin="external-selfjoin", handle=handle,
+            )
+            await reg.set_status(rec["canonical_id"], "active")
+        resp = await mint_client.post(
+            "/api/agents/registry/seed-internal"
+            "?adopt=@taOS-dev,%20@Hermes,@taOS-dev"
+        )
+        assert resp.status_code == 200, resp.text
+        seeded = {s["handle"]: s for s in resp.json()["seeded"]}
+        assert seeded["@taOS-dev"]["adopted"] is True
+        assert seeded["@Hermes"]["adopted"] is True
+        assert seeded["@taOSmd-dev"]["created"] is True
+
     async def test_seed_internal_rejects_blanket_adopt(self, mint_client):
         """A bare adopt=true (or any non-handle value) is a 400: adoption
         grants driver scopes + a token to a pre-existing identity, so each

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -548,7 +548,7 @@ class TestProxySelfHeal:
         import sys
         import tinyagentos.llm_proxy as mod
 
-        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         binp = tmp_path / ".local" / "bin"
         binp.mkdir(parents=True)
         (binp / "uv").write_text("x")
@@ -582,7 +582,7 @@ class TestProxySelfHeal:
         import sys
         import tinyagentos.llm_proxy as mod
 
-        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         (tmp_path / ".local" / "bin").mkdir(parents=True)
         (tmp_path / ".local" / "bin" / "uv").write_text("x")
         monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
@@ -612,7 +612,7 @@ class TestProxySelfHeal:
         import sys
         import tinyagentos.llm_proxy as mod
 
-        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         (tmp_path / ".local" / "bin").mkdir(parents=True)
         (tmp_path / ".local" / "bin" / "uv").write_text("x")
         monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
@@ -660,7 +660,7 @@ class TestProxySelfHeal:
 
         root = tmp_path / "install"
         (root / ".venv" / "bin").mkdir(parents=True)
-        (root / "pyproject.toml").write_text("[project]\n")
+        (root / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         (root / ".local" / "bin").mkdir(parents=True)
         (root / ".local" / "bin" / "uv").write_text("x")
         base = tmp_path / "usr" / "local" / "bin"
@@ -702,7 +702,7 @@ class TestProxySelfHeal:
         root = tmp_path / "install"
         deep = root / "envs" / ".venv" / "bin"
         deep.mkdir(parents=True)
-        (root / "pyproject.toml").write_text("[project]\n")
+        (root / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         (root / ".local" / "bin").mkdir(parents=True)
         (root / ".local" / "bin" / "uv").write_text("x")
         monkeypatch.setattr(sys, "executable", str(deep / "python3.12"))
@@ -737,9 +737,11 @@ class TestProxySelfHeal:
         import tinyagentos.llm_proxy as mod
 
         (tmp_path / "pyproject.toml").write_text(
-            "[project]\nname = \"x\"\nversion = \"0\"\n"
+            "[project]\nname = \"tinyagentos\"\nversion = \"0\"\n"
             "[project.optional-dependencies]\n"
-            "proxy = [\"litellm[proxy]>=1.90.0\", \"prisma>=0.11.0\"]\n"
+            # trailing whitespace/newline in an entry must be stripped, not
+            # reach pip verbatim
+            "proxy = [\"litellm[proxy]>=1.90.0\", \"prisma>=0.11.0\\n\"]\n"
         )
         (tmp_path / ".venv" / "bin").mkdir(parents=True)
         monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
@@ -763,7 +765,23 @@ class TestProxySelfHeal:
         assert captured["cmd"] == [
             str(tmp_path / ".venv" / "bin" / "pip"),
             "install",
+            "--no-input",
+            "--disable-pip-version-check",
             "litellm[proxy]>=1.90.0",
             "prisma>=0.11.0",
         ]
         assert "-e" not in captured["cmd"]
+
+    @pytest.mark.asyncio
+    async def test_selfheal_ignores_foreign_pyproject(self, tmp_path, monkeypatch):
+        """The root walk must not trust just any pyproject.toml above the
+        interpreter: a foreign project's file (e.g. one in $HOME) would make
+        the self-heal pip-install THAT project's pins into our venv. Only a
+        pyproject whose project.name is tinyagentos counts."""
+        import sys
+
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "someone-else"\n')
+        (tmp_path / ".venv" / "bin").mkdir(parents=True)
+        monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+
+        assert await LLMProxy()._selfheal_proxy_extra() is False

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -690,3 +690,80 @@ class TestProxySelfHeal:
         assert ok is True
         # cwd must be the install root (venv grandparent), not tmp_path/usr.
         assert captured["cwd"] == str(root)
+
+    @pytest.mark.asyncio
+    async def test_selfheal_locates_root_at_other_venv_depths(self, tmp_path, monkeypatch):
+        """The root walk must not assume <root>/.venv/bin/python exactly: a
+        python3.x-named binary or nested layout still finds the first ancestor
+        holding pyproject.toml instead of silently no-opping."""
+        import sys
+        import tinyagentos.llm_proxy as mod
+
+        root = tmp_path / "install"
+        deep = root / "envs" / ".venv" / "bin"
+        deep.mkdir(parents=True)
+        (root / "pyproject.toml").write_text("[project]\n")
+        (root / ".local" / "bin").mkdir(parents=True)
+        (root / ".local" / "bin" / "uv").write_text("x")
+        monkeypatch.setattr(sys, "executable", str(deep / "python3.12"))
+
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"", None)
+
+        async def fake_exec(*cmd, **kw):
+            captured["cwd"] = kw.get("cwd")
+            return FakeProc()
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+
+        assert await LLMProxy()._selfheal_proxy_extra() is True
+        assert captured["cwd"] == str(root)
+
+    @pytest.mark.asyncio
+    async def test_selfheal_pip_fallback_installs_only_extra_requirements(
+        self, tmp_path, monkeypatch
+    ):
+        """Without uv, the fallback installs the extras' pinned requirements
+        from pyproject, never an editable reinstall of the project: pip
+        install -e .[proxy] re-resolves every dependency, the exact churn the
+        self-heal exists to undo."""
+        import shutil
+        import sys
+        import tinyagentos.llm_proxy as mod
+
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = \"x\"\nversion = \"0\"\n"
+            "[project.optional-dependencies]\n"
+            "proxy = [\"litellm[proxy]>=1.90.0\", \"prisma>=0.11.0\"]\n"
+        )
+        (tmp_path / ".venv" / "bin").mkdir(parents=True)
+        monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+        monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"", None)
+
+        async def fake_exec(*cmd, **kw):
+            captured["cmd"] = list(cmd)
+            return FakeProc()
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+
+        assert await LLMProxy()._selfheal_proxy_extra() is True
+        assert captured["cmd"] == [
+            str(tmp_path / ".venv" / "bin" / "pip"),
+            "install",
+            "litellm[proxy]>=1.90.0",
+            "prisma>=0.11.0",
+        ]
+        assert "-e" not in captured["cmd"]

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -196,24 +196,34 @@ class LLMProxy:
         import shutil
         import sys
 
+        import tomllib
+
         # The install dir is an ancestor of the venv python (normally the
         # venv's grandparent: <root>/.venv/bin/python). Do NOT resolve(): the
         # venv python is a symlink to the base interpreter (e.g.
         # /usr/local/bin/python3.x), so resolving walks out of the install
-        # tree. Walk upward to the first ancestor holding pyproject.toml so a
-        # different venv depth (python3.x binary name, nested layouts) still
-        # finds the root instead of silently no-opping.
+        # tree. Walk upward to the first ancestor whose pyproject.toml is
+        # OURS (project.name == tinyagentos): matching on the file alone
+        # could latch onto an unrelated project's pyproject higher up (e.g.
+        # one in $HOME) and pip-install that project's pins into our venv.
+        def _is_install_root(parent: Path) -> bool:
+            pj = parent / "pyproject.toml"
+            if not pj.is_file():
+                return False
+            try:
+                with open(pj, "rb") as fh:
+                    name = tomllib.load(fh).get("project", {}).get("name")
+            except Exception:  # noqa: BLE001 - unreadable/foreign file: keep walking
+                return False
+            return name == "tinyagentos"
+
         project_root = next(
-            (
-                parent
-                for parent in Path(sys.executable).parents
-                if (parent / "pyproject.toml").is_file()
-            ),
+            (p for p in Path(sys.executable).parents if _is_install_root(p)),
             None,
         )
         if project_root is None:
             logger.warning(
-                "proxy self-heal: no pyproject.toml above %s — skipping",
+                "proxy self-heal: no tinyagentos pyproject.toml above %s — skipping",
                 sys.executable,
             )
             return False
@@ -242,12 +252,17 @@ class LLMProxy:
             # project dependency — the exact churn this self-heal exists to
             # undo — and a later bare `uv sync --frozen` would strip the
             # extra right back out anyway.
-            import tomllib
-
             try:
                 with open(project_root / "pyproject.toml", "rb") as fh:
                     optional = tomllib.load(fh)["project"]["optional-dependencies"]
-                reqs = [r for e in UPDATE_EXTRAS for r in optional.get(e, [])]
+                # strip(): a stray newline/whitespace in a pyproject entry
+                # would otherwise reach pip verbatim and fail opaquely.
+                reqs = [
+                    r.strip()
+                    for e in UPDATE_EXTRAS
+                    for r in optional.get(e, [])
+                    if r.strip()
+                ]
             except Exception as exc:  # noqa: BLE001 - non-fatal by design
                 logger.warning(
                     "proxy self-heal: cannot read extras from pyproject: %s", exc
@@ -260,7 +275,16 @@ class LLMProxy:
                 )
                 return False
             pip = str(Path(sys.executable).parent / "pip")
-            cmd = [pip, "install", *reqs]
+            # --no-input: never block the 900s window on a TTY prompt.
+            # --disable-pip-version-check: no upgrade nag in the captured
+            # stream. (No --quiet: failure output must stay in the logs.)
+            cmd = [
+                pip,
+                "install",
+                "--no-input",
+                "--disable-pip-version-check",
+                *reqs,
+            ]
 
         logger.warning(
             "proxy self-heal: litellm missing, installing the proxy extra: %s",

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -196,16 +196,25 @@ class LLMProxy:
         import shutil
         import sys
 
-        # The install dir is the venv's grandparent (<root>/.venv/bin/python).
-        # Do NOT resolve(): the venv python is a symlink to the base
-        # interpreter (e.g. /usr/local/bin/python3.x), so resolving walks out
-        # of the install tree and lands parents[2] on /usr. start() derives the
-        # venv bin the same non-resolved way.
-        project_root = Path(sys.executable).parents[2]
-        if not (project_root / "pyproject.toml").is_file():
+        # The install dir is an ancestor of the venv python (normally the
+        # venv's grandparent: <root>/.venv/bin/python). Do NOT resolve(): the
+        # venv python is a symlink to the base interpreter (e.g.
+        # /usr/local/bin/python3.x), so resolving walks out of the install
+        # tree. Walk upward to the first ancestor holding pyproject.toml so a
+        # different venv depth (python3.x binary name, nested layouts) still
+        # finds the root instead of silently no-opping.
+        project_root = next(
+            (
+                parent
+                for parent in Path(sys.executable).parents
+                if (parent / "pyproject.toml").is_file()
+            ),
+            None,
+        )
+        if project_root is None:
             logger.warning(
-                "proxy self-heal: cannot locate the install root at %s — skipping",
-                project_root,
+                "proxy self-heal: no pyproject.toml above %s — skipping",
+                sys.executable,
             )
             return False
 
@@ -227,8 +236,31 @@ class LLMProxy:
             extra_args = [a for e in UPDATE_EXTRAS for a in ("--extra", e)]
             cmd = [uv, "sync", "--frozen", *extra_args]
         else:
+            # Without uv, install ONLY the extras' requirements (read from
+            # pyproject so the pins stay single-sourced). An editable
+            # reinstall (pip install -e .[proxy]) would re-resolve every
+            # project dependency — the exact churn this self-heal exists to
+            # undo — and a later bare `uv sync --frozen` would strip the
+            # extra right back out anyway.
+            import tomllib
+
+            try:
+                with open(project_root / "pyproject.toml", "rb") as fh:
+                    optional = tomllib.load(fh)["project"]["optional-dependencies"]
+                reqs = [r for e in UPDATE_EXTRAS for r in optional.get(e, [])]
+            except Exception as exc:  # noqa: BLE001 - non-fatal by design
+                logger.warning(
+                    "proxy self-heal: cannot read extras from pyproject: %s", exc
+                )
+                return False
+            if not reqs:
+                logger.warning(
+                    "proxy self-heal: no requirements found for extras %s",
+                    UPDATE_EXTRAS,
+                )
+                return False
             pip = str(Path(sys.executable).parent / "pip")
-            cmd = [pip, "install", "-e", f".[{','.join(UPDATE_EXTRAS)}]"]
+            cmd = [pip, "install", *reqs]
 
         logger.warning(
             "proxy self-heal: litellm missing, installing the proxy extra: %s",

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -360,19 +360,34 @@ async def mint_internal_agent(
 async def seed_internal_agents(
     request: Request,
     user: CurrentUser = Depends(current_user),
-    adopt: bool = False,
+    adopt: str = "",
 ):
     """Idempotently mint the four internal driver agents and return their tokens.
 
     Admin only.  Each of @taOS-dev, @taOS-website-dev, @taOSmd-dev, @Hermes is
     minted with the a2a_send + a2a_receive scopes.  Re-running creates no
-    duplicate rows.  ``adopt=true`` (query param) vouches for any of those
-    handles that already exist under a non-internal origin (e.g. a driver that
-    self-joined earlier) instead of 409ing.  Response: {"seeded": [{handle,
-    canonical_id, created, adopted, scopes, token}, ...]}.
+    duplicate rows.  ``adopt`` (query param) is a comma-separated list of the
+    specific handles to vouch for when they already exist under a non-internal
+    origin (e.g. ``?adopt=@taOS-dev``); each adoption grants driver scopes and
+    a token to a pre-existing identity, so it must name each handle explicitly
+    rather than blanket-vouch for all four (a driver handle claimed by someone
+    else via the consent flow must not be adopted as a side effect).  A bare
+    ``adopt=true`` is rejected.  Response: {"seeded": [{handle, canonical_id,
+    created, adopted, scopes, token}, ...]}.
     """
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="forbidden")
+    known = {spec["handle"] for spec in _INTERNAL_AGENTS}
+    adopt_handles = {h.strip() for h in adopt.split(",") if h.strip()}
+    if adopt_handles - known:
+        bad = ", ".join(sorted(adopt_handles - known))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"adopt must list internal driver handles explicitly "
+                f"(one or more of: {', '.join(sorted(known))}); got: {bad}"
+            ),
+        )
     seeded = []
     for spec in _INTERNAL_AGENTS:
         seeded.append(
@@ -382,7 +397,7 @@ async def seed_internal_agents(
                 handle=spec["handle"],
                 slug=spec["slug"],
                 scopes=list(_INTERNAL_AGENT_SCOPES),
-                adopt=adopt,
+                adopt=spec["handle"] in adopt_handles,
             )
         )
     return {"seeded": seeded}

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -380,12 +380,14 @@ async def seed_internal_agents(
     known = {spec["handle"] for spec in _INTERNAL_AGENTS}
     adopt_handles = {h.strip() for h in adopt.split(",") if h.strip()}
     if adopt_handles - known:
+        # Echo only the caller's own bad input; do not enumerate the internal
+        # handle set in an error body (the docstring documents it for admins).
         bad = ", ".join(sorted(adopt_handles - known))
         raise HTTPException(
             status_code=400,
             detail=(
-                f"adopt must list internal driver handles explicitly "
-                f"(one or more of: {', '.join(sorted(known))}); got: {bad}"
+                "adopt must list internal driver handles explicitly, "
+                f"never true/blanket values; got: {bad}"
             ),
         )
     seeded = []

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, Request, WebSocket
@@ -8,6 +9,32 @@ from fastapi.responses import JSONResponse
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["channel-hub"])
+
+# One lock per connector key, held across stop-old + start-new + map-assign.
+# Two concurrent connects for the same key would otherwise both pop (second
+# gets None), both start, and the loser's connector stays alive but
+# unreachable via the map, so it could never be stopped.
+_connect_locks: dict[str, asyncio.Lock] = {}
+
+
+def _connect_lock(connector_key: str) -> asyncio.Lock:
+    return _connect_locks.setdefault(connector_key, asyncio.Lock())
+
+
+async def _stop_prior_connector(connectors: dict, connector_key: str) -> None:
+    """Stop and drop any prior connector under this key. Reconnecting (e.g.
+    after a token rotation) must not silently orphan the previous connector's
+    background task/client."""
+    old = connectors.pop(connector_key, None)
+    if old is not None and hasattr(old, "stop"):
+        try:
+            await old.stop()
+        except Exception:
+            logger.warning(
+                "channel-hub: failed to stop prior %s connector on reconnect",
+                connector_key,
+                exc_info=True,
+            )
 
 
 @router.get("/api/channel-hub/status")
@@ -46,9 +73,11 @@ async def connect_bot(request: Request):
         connector_key = f"webchat:{agent_name}"
 
         from tinyagentos.channel_hub.webchat_connector import WebChatConnector
-        connector = WebChatConnector(agent_name=agent_name, router=router_obj)
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
+        async with _connect_lock(connector_key):
+            await _stop_prior_connector(connectors, connector_key)
+            connector = WebChatConnector(agent_name=agent_name, router=router_obj)
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
         return {"status": "connected", "platform": "webchat", "agent_name": agent_name}
 
     bot_token_secret = body.get("bot_token_secret", "")
@@ -68,107 +97,96 @@ async def connect_bot(request: Request):
 
     connector_key = f"{platform}:{agent_name}"
 
-    # Reconnecting under the same key (e.g. after a token rotation) must not
-    # silently orphan the previous connector's background task/client: stop it
-    # before the new one replaces it in the map.
-    old = connectors.pop(connector_key, None)
-    if old is not None and hasattr(old, "stop"):
-        try:
-            await old.stop()
-        except Exception:
-            logger.warning(
-                "channel-hub: failed to stop prior %s connector on reconnect",
-                connector_key,
-                exc_info=True,
-            )
+    async with _connect_lock(connector_key):
+        await _stop_prior_connector(connectors, connector_key)
 
-    if platform == "telegram":
-        from tinyagentos.channel_hub.telegram_connector import TelegramConnector
-        connector = TelegramConnector(bot_token=bot_token, agent_name=agent_name, router=router_obj)
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "discord":
-        channel_ids = body.get("channel_ids", [])
-        from tinyagentos.channel_hub.discord_connector import DiscordConnector
-        connector = DiscordConnector(
-            bot_token=bot_token, agent_name=agent_name,
-            router=router_obj, channel_ids=channel_ids,
-        )
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "slack":
-        channel_ids = body.get("channel_ids", [])
-        from tinyagentos.channel_hub.slack_connector import SlackConnector
-        connector = SlackConnector(
-            bot_token=bot_token, agent_name=agent_name,
-            router=router_obj, channel_ids=channel_ids,
-        )
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "email":
-        imap_host = body.get("imap_host", "")
-        imap_port = body.get("imap_port", 993)
-        smtp_host = body.get("smtp_host", "")
-        smtp_port = body.get("smtp_port", 587)
-        # bot_token holds "username:password" for email
-        parts = bot_token.split(":", 1)
-        email_user = parts[0]
-        email_pass = parts[1] if len(parts) > 1 else ""
-        from tinyagentos.channel_hub.email_connector import EmailConnector
-        connector = EmailConnector(
-            agent_name=agent_name, router=router_obj,
-            imap_host=imap_host, imap_port=imap_port,
-            smtp_host=smtp_host, smtp_port=smtp_port,
-            username=email_user, password=email_pass,
-        )
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "github":
-        if not agent_name:
-            return JSONResponse({"error": "agent_name is required"}, status_code=400)
-        repo = body.get("repo")
-        event_kinds = body.get("event_kinds", [])
-        pr_number = body.get("pr_number")
-        from tinyagentos.channel_hub.adapters.github import GithubConnector
-        connector = GithubConnector(
-            agent_name=agent_name, router=router_obj,
-            repo=repo, event_kinds=event_kinds, pr_number=pr_number,
-        )
-        router_obj.assign_channel(platform, agent_name, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "matrix":
-        homeserver = body.get("homeserver", "")
-        if not homeserver:
-            return JSONResponse({"error": "homeserver is required for matrix"}, status_code=400)
-        from tinyagentos.channel_hub.matrix_connector import MatrixConnector
-        connector = MatrixConnector(
-            homeserver=homeserver,
-            access_token=bot_token,
-            agent_name=agent_name,
-            router=router_obj,
-        )
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    else:
-        return JSONResponse({"error": f"Platform '{platform}' not yet supported"}, status_code=400)
+        if platform == "telegram":
+            from tinyagentos.channel_hub.telegram_connector import TelegramConnector
+            connector = TelegramConnector(bot_token=bot_token, agent_name=agent_name, router=router_obj)
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "discord":
+            channel_ids = body.get("channel_ids", [])
+            from tinyagentos.channel_hub.discord_connector import DiscordConnector
+            connector = DiscordConnector(
+                bot_token=bot_token, agent_name=agent_name,
+                router=router_obj, channel_ids=channel_ids,
+            )
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "slack":
+            channel_ids = body.get("channel_ids", [])
+            from tinyagentos.channel_hub.slack_connector import SlackConnector
+            connector = SlackConnector(
+                bot_token=bot_token, agent_name=agent_name,
+                router=router_obj, channel_ids=channel_ids,
+            )
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "email":
+            imap_host = body.get("imap_host", "")
+            imap_port = body.get("imap_port", 993)
+            smtp_host = body.get("smtp_host", "")
+            smtp_port = body.get("smtp_port", 587)
+            # bot_token holds "username:password" for email
+            parts = bot_token.split(":", 1)
+            email_user = parts[0]
+            email_pass = parts[1] if len(parts) > 1 else ""
+            from tinyagentos.channel_hub.email_connector import EmailConnector
+            connector = EmailConnector(
+                agent_name=agent_name, router=router_obj,
+                imap_host=imap_host, imap_port=imap_port,
+                smtp_host=smtp_host, smtp_port=smtp_port,
+                username=email_user, password=email_pass,
+            )
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "github":
+            if not agent_name:
+                return JSONResponse({"error": "agent_name is required"}, status_code=400)
+            repo = body.get("repo")
+            event_kinds = body.get("event_kinds", [])
+            pr_number = body.get("pr_number")
+            from tinyagentos.channel_hub.adapters.github import GithubConnector
+            connector = GithubConnector(
+                agent_name=agent_name, router=router_obj,
+                repo=repo, event_kinds=event_kinds, pr_number=pr_number,
+            )
+            router_obj.assign_channel(platform, agent_name, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "matrix":
+            homeserver = body.get("homeserver", "")
+            if not homeserver:
+                return JSONResponse({"error": "homeserver is required for matrix"}, status_code=400)
+            from tinyagentos.channel_hub.matrix_connector import MatrixConnector
+            connector = MatrixConnector(
+                homeserver=homeserver,
+                access_token=bot_token,
+                agent_name=agent_name,
+                router=router_obj,
+            )
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        else:
+            return JSONResponse({"error": f"Platform '{platform}' not yet supported"}, status_code=400)
 
 
 @router.post("/api/channel-hub/disconnect")

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import asynccontextmanager
 
 from fastapi import APIRouter, Request, WebSocket
 from fastapi.responses import JSONResponse
@@ -10,15 +11,31 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["channel-hub"])
 
-# One lock per connector key, held across stop-old + start-new + map-assign.
-# Two concurrent connects for the same key would otherwise both pop (second
-# gets None), both start, and the loser's connector stays alive but
-# unreachable via the map, so it could never be stopped.
+# One lock per connector key, held across stop-old + start-new + map-assign
+# (and around disconnects). Two concurrent connects for the same key would
+# otherwise both pop (second gets None), both start, and the loser's
+# connector stays alive but unreachable via the map, so it could never be
+# stopped. Refcounted so an entry is evicted once no task holds or awaits it
+# (the map must not grow forever); the bookkeeping has no awaits, so it is
+# atomic under asyncio's single-threaded scheduling.
 _connect_locks: dict[str, asyncio.Lock] = {}
+_connect_lock_refs: dict[str, int] = {}
 
 
-def _connect_lock(connector_key: str) -> asyncio.Lock:
-    return _connect_locks.setdefault(connector_key, asyncio.Lock())
+@asynccontextmanager
+async def _connect_lock(connector_key: str):
+    _connect_lock_refs[connector_key] = _connect_lock_refs.get(connector_key, 0) + 1
+    lock = _connect_locks.setdefault(connector_key, asyncio.Lock())
+    try:
+        async with lock:
+            yield
+    finally:
+        remaining = _connect_lock_refs[connector_key] - 1
+        if remaining:
+            _connect_lock_refs[connector_key] = remaining
+        else:
+            del _connect_lock_refs[connector_key]
+            _connect_locks.pop(connector_key, None)
 
 
 async def _stop_prior_connector(connectors: dict, connector_key: str) -> None:
@@ -97,6 +114,13 @@ async def connect_bot(request: Request):
 
     connector_key = f"{platform}:{agent_name}"
 
+    # Validate required per-platform inputs BEFORE stopping the live
+    # connector: a malformed reconnect must fail without tearing down the
+    # working one.
+    homeserver = body.get("homeserver", "") if platform == "matrix" else ""
+    if platform == "matrix" and not homeserver:
+        return JSONResponse({"error": "homeserver is required for matrix"}, status_code=400)
+
     async with _connect_lock(connector_key):
         await _stop_prior_connector(connectors, connector_key)
 
@@ -170,9 +194,7 @@ async def connect_bot(request: Request):
             request.app.state.channel_hub_connectors = connectors
             return {"status": "connected", "platform": platform, "agent_name": agent_name}
         elif platform == "matrix":
-            homeserver = body.get("homeserver", "")
-            if not homeserver:
-                return JSONResponse({"error": "homeserver is required for matrix"}, status_code=400)
+            # homeserver validated above, before the destructive stop.
             from tinyagentos.channel_hub.matrix_connector import MatrixConnector
             connector = MatrixConnector(
                 homeserver=homeserver,
@@ -199,14 +221,17 @@ async def disconnect_bot(request: Request):
     connectors = getattr(request.app.state, "channel_hub_connectors", {})
     connector_key = f"{platform}:{agent_name}"
 
-    connector = connectors.pop(connector_key, None)
-    if connector:
-        if hasattr(connector, "stop"):
-            await connector.stop()
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "disconnected", "platform": platform, "agent_name": agent_name}
-    else:
-        return JSONResponse({"error": "Connector not found"}, status_code=404)
+    # Same per-key lock as connect_bot: a disconnect racing a reconnect must
+    # not pop the old connector mid-swap (404ing while the new one lands).
+    async with _connect_lock(connector_key):
+        connector = connectors.pop(connector_key, None)
+        if connector:
+            if hasattr(connector, "stop"):
+                await connector.stop()
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "disconnected", "platform": platform, "agent_name": agent_name}
+        else:
+            return JSONResponse({"error": "Connector not found"}, status_code=404)
 
 
 @router.get("/api/channel-hub/adapters")

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Request, WebSocket
 from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["channel-hub"])
 
@@ -63,6 +67,20 @@ async def connect_bot(request: Request):
     connectors = getattr(request.app.state, "channel_hub_connectors", {})
 
     connector_key = f"{platform}:{agent_name}"
+
+    # Reconnecting under the same key (e.g. after a token rotation) must not
+    # silently orphan the previous connector's background task/client: stop it
+    # before the new one replaces it in the map.
+    old = connectors.pop(connector_key, None)
+    if old is not None and hasattr(old, "stop"):
+        try:
+            await old.stop()
+        except Exception:
+            logger.warning(
+                "channel-hub: failed to stop prior %s connector on reconnect",
+                connector_key,
+                exc_info=True,
+            )
 
     if platform == "telegram":
         from tinyagentos.channel_hub.telegram_connector import TelegramConnector


### PR DESCRIPTION
Immediate fix-forward for the four inline findings Kilo raised on the #1525 promotion diff (all pre-existing on dev, none introduced by the release):

1. **llm_proxy self-heal, pip fallback** (`llm_proxy.py`): no longer runs `pip install -e .[proxy]` (which re-resolves every project dependency, the exact churn the self-heal exists to undo). It now installs only the extras' pinned requirement strings read from `pyproject.toml`, keeping the pins single-sourced. Deliberately NOT the reviewer's `--no-deps` variant: that would skip the extra's dependencies entirely and install nothing useful.
2. **llm_proxy self-heal, root discovery**: walks up from `sys.executable` to the first ancestor holding `pyproject.toml` instead of hard-coding `parents[2]`, so `python3.x`-named binaries and nested venv layouts still self-heal instead of silently no-opping.
3. **agent registry, seed-internal adoption**: `adopt` is now an explicit comma-separated handle list (`?adopt=@taOS-dev`); a bare `adopt=true` returns 400. A driver handle claimed by someone else via the consent flow can no longer be vouched for as a side effect of seeding the others. New tests cover the 400 and that unlisted pre-existing handles still 409.
4. **channel hub, reconnect leak**: `connect_bot` stops a prior connector under the same `platform:agent` key before replacing it (single fix above the platform dispatch, covering every token-based branch), so reconnecting after a token rotation no longer orphans the old background task/client.

163 tests pass across the affected suites; the 4 new tests pin the changed behaviours. Ruff findings in these files are pre-existing on dev (identical before/after).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Internal agent seeding now supports handle-specific adoption via a comma-separated `adopt` list, rejecting blanket/invalid values with HTTP 400 and ensuring conflicts occur for unlisted handles.
  * Channel hub reconnects/disconnects are now synchronized per connector key, ensuring the previous connector is cleanly stopped/replaced and preventing race conditions.
  * LLM proxy self-healing more reliably finds the correct project root and improves the non-`uv` fallback by installing only the needed extras.
* **Tests**
  * Expanded self-heal and internal seeding scenarios, and updated fixture metadata to match expected project naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->