### PR TITLE
fix(rknpu): re-pin rkllama to a reachable commit + verify the pin before checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin now points at a commit that fresh clones can actually check out, and a stale pin fails with a clear explanation and override instructions instead of a raw git error.
+
 ## [1.0.0-beta.14] - 2026-07-01
 
 ### Added

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -336,6 +336,13 @@ install_rkllama() {
         log "cloning $RKLLAMA_REPO -> $RKLLAMA_DIR"
         run_as_user mkdir -p "$(dirname "$RKLLAMA_DIR")"
         run_as_user git clone --quiet "$RKLLAMA_REPO" "$RKLLAMA_DIR"
+        # A clone brings down all branches and tags, but an overridden
+        # TAOS_RKLLAMA_REF can be a SHA reachable from none of them. Try to
+        # fetch the configured ref explicitly (best-effort: some servers
+        # refuse unadvertised objects) so the verification below sees the
+        # same coverage as the re-install path; on failure fall through to
+        # the curated error instead of dying on git's raw message.
+        run_as_user git -C "$RKLLAMA_DIR" fetch --quiet origin "$RKLLAMA_REF" 2>/dev/null || true
     fi
     # Verify the pinned ref is actually fetchable before checking it out. A
     # fresh clone only has branch/tag refs, so a pin orphaned by a history
@@ -344,7 +351,7 @@ install_rkllama() {
     # override, rather than silently falling back to a moving branch (which
     # would break install reproducibility).
     if ! run_as_user git -C "$RKLLAMA_DIR" cat-file -e "${RKLLAMA_REF}^{commit}" 2>/dev/null; then
-        die "pinned rkllama ref ${RKLLAMA_REF:0:12} is not reachable from any branch of $RKLLAMA_REPO (the fork's history may have been rewritten). Update taOS for a current pin, or override with TAOS_RKLLAMA_REF=<ref>."
+        die "pinned rkllama ref ${RKLLAMA_REF:0:12} is not reachable from any branch or tag of $RKLLAMA_REPO (the fork's history may have been rewritten). Update taOS for a current pin, or override with TAOS_RKLLAMA_REF=<ref>."
     fi
     run_as_user git -C "$RKLLAMA_DIR" checkout --quiet "$RKLLAMA_REF"
     log "rkllama pinned to $(run_as_user git -C "$RKLLAMA_DIR" rev-parse --short HEAD)"

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 06cf874d8b29767729ec06547cf02fc92acd875c)
+#     TAOS_RKLLAMA_REF        git ref  (default: 4f518e97d114f386a153f6c6da36270c7f692712)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-06cf874d8b29767729ec06547cf02fc92acd875c}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-4f518e97d114f386a153f6c6da36270c7f692712}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.
@@ -336,6 +336,15 @@ install_rkllama() {
         log "cloning $RKLLAMA_REPO -> $RKLLAMA_DIR"
         run_as_user mkdir -p "$(dirname "$RKLLAMA_DIR")"
         run_as_user git clone --quiet "$RKLLAMA_REPO" "$RKLLAMA_DIR"
+    fi
+    # Verify the pinned ref is actually fetchable before checking it out. A
+    # fresh clone only has branch/tag refs, so a pin orphaned by a history
+    # rewrite of the rkllama fork fails with git's opaque "reference is not a
+    # tree" (#1527). Fail with a message that says what happened and how to
+    # override, rather than silently falling back to a moving branch (which
+    # would break install reproducibility).
+    if ! run_as_user git -C "$RKLLAMA_DIR" cat-file -e "${RKLLAMA_REF}^{commit}" 2>/dev/null; then
+        die "pinned rkllama ref ${RKLLAMA_REF:0:12} is not reachable from any branch of $RKLLAMA_REPO (the fork's history may have been rewritten). Update taOS for a current pin, or override with TAOS_RKLLAMA_REF=<ref>."
     fi
     run_as_user git -C "$RKLLAMA_DIR" checkout --quiet "$RKLLAMA_REF"
     log "rkllama pinned to $(run_as_user git -C "$RKLLAMA_DIR" rev-parse --short HEAD)"


### PR DESCRIPTION
Fixes #1527.

The rkllama pin `06cf874d` still exists on GitHub as an API-visible object but is no longer reachable from any branch of the jaylfc/rkllama fork (history was rebased onto upstream), so a fresh `git clone` + `git checkout` fails with the reported `fatal: reference is not a tree`. Verified via the compare API: main is diverged from the pin and no branch head contains it.

Changes:
- Re-pin `RKLLAMA_REF` to `4f518e97d114` (current main head: the rerank endpoint plus the GET_LOGITS 1-token cap fix), which fresh clones can check out.
- After clone/fetch, verify the pinned ref resolves to a commit (`git cat-file -e <ref>^{commit}`) and fail with a descriptive error naming the orphaned-pin cause and the `TAOS_RKLLAMA_REF` override, instead of git's opaque message.
- Deliberately no auto-fallback to a moving branch: installs stay reproducible; a stale pin should fail loudly, not silently drift.

`bash -n` passes; the one shellcheck warning in the file (SC2034, line 511) is pre-existing and untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rockchip NPU installer reliability on fresh installs by updating the default pinned `rkllama` ref.
  * Added safer validation of the pinned ref and a clearer, actionable error when the ref can’t be resolved, including override instructions.
* **Changelog**
  * Updated the Unreleased → Fixed entry to reflect the installer behavior change and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->