### PR TITLE
chore(release): 1.0.0-beta.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.15] - 2026-07-02
+
 ### Fixed
-- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin now points at a commit that fresh clones can actually check out, and a stale pin fails with a clear explanation and override instructions instead of a raw git error.
+- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin now points at a commit that fresh clones can actually check out, and a stale pin fails with a clear explanation and override instructions instead of a raw git error. Reported by @mandresve (#1527).
+- Reconnecting a comms channel (Telegram/Slack/Discord/email/Matrix/webchat) after a token rotation now stops the previous connector instead of silently leaking its background task, concurrent reconnects for the same agent can no longer orphan a connector, and a malformed Matrix reconnect fails cleanly without tearing down the working connector.
+- The LLM proxy self-heal is more robust: it locates the install root at any venv layout, only trusts our own pyproject when doing so, and its pip fallback installs just the proxy requirements instead of re-resolving every dependency.
+- Seeding the internal driver agents now requires naming each pre-existing handle explicitly to adopt it; a blanket adopt flag is rejected so a handle claimed by someone else can never be vouched for as a side effect.
 
 ## [1.0.0-beta.14] - 2026-07-01
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.14"
+version = "1.0.0-beta.15"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.14"
+__version__ = "1.0.0-beta.15"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b14"
+version = "1.0.0b15"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump + CHANGELOG for 1.0.0-beta.15.

Small fix release so the #1527 installer fix reaches master, where the install one-liner clones from. Carries two merged PRs on top of beta.14:
- #1528: rknpu installer re-pins rkllama to a reachable commit + verifies the pin before checkout (fixes #1527, fresh NPU installs were failing at the rkllama checkout).
- #1526: review-finding fix-forward (channel-hub reconnect leak/race/validation order, llm-proxy self-heal robustness, explicit per-handle adoption for seed-internal).

After merge: promote dev to master, tag v1.0.0-beta.15, GitHub Release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version **1.0.0-beta.15**.

* **Bug Fixes**
  * Improved first-time setup for Rockchip NPU installations.
  * Made connector reconnects more reliable after token changes.
  * Reduced orphaned background tasks during reconnects.
  * Strengthened LLM proxy recovery for smoother self-healing.
  * Tightened driver-agent setup rules for existing handles.

* **Documentation**
  * Updated the changelog with the latest release entry and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->