### PR TITLE
Release 1.0.0-beta.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 ## [1.0.0-beta.15] - 2026-07-02
 
 ### Fixed
-- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin now points at a commit that fresh clones can actually check out, and a stale pin fails with a clear explanation and override instructions instead of a raw git error. Reported by @mandresve (#1527).
+- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin points at the proven production commit (made reachable for fresh clones again), and a stale pin fails with a clear explanation instead of a raw git error. This also keeps the generated rkllama service startable: the newer rkllama default branch dropped the preload option the service relies on. Reported by @mandresve (#1527, #1529).
 - Reconnecting a comms channel (Telegram/Slack/Discord/email/Matrix/webchat) after a token rotation now stops the previous connector instead of silently leaking its background task, concurrent reconnects for the same agent can no longer orphan a connector, and a malformed Matrix reconnect fails cleanly without tearing down the working connector.
 - The LLM proxy self-heal is more robust: it locates the install root at any venv layout, only trusts our own pyproject when doing so, and its pip fallback installs just the proxy requirements instead of re-resolving every dependency.
 - Seeding the internal driver agents now requires naming each pre-existing handle explicitly to adopt it; a blanket adopt flag is rejected so a handle claimed by someone else can never be vouched for as a side effect.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.15] - 2026-07-02
+
 ### Fixed
-- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin now points at a commit that fresh clones can actually check out, and a stale pin fails with a clear explanation and override instructions instead of a raw git error.
+- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin now points at a commit that fresh clones can actually check out, and a stale pin fails with a clear explanation and override instructions instead of a raw git error. Reported by @mandresve (#1527).
+- Reconnecting a comms channel (Telegram/Slack/Discord/email/Matrix/webchat) after a token rotation now stops the previous connector instead of silently leaking its background task, concurrent reconnects for the same agent can no longer orphan a connector, and a malformed Matrix reconnect fails cleanly without tearing down the working connector.
+- The LLM proxy self-heal is more robust: it locates the install root at any venv layout, only trusts our own pyproject when doing so, and its pip fallback installs just the proxy requirements instead of re-resolving every dependency.
+- Seeding the internal driver agents now requires naming each pre-existing handle explicitly to adopt it; a blanket adopt flag is rejected so a handle claimed by someone else can never be vouched for as a side effect.
 
 ## [1.0.0-beta.14] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin now points at a commit that fresh clones can actually check out, and a stale pin fails with a clear explanation and override instructions instead of a raw git error.
+
 ## [1.0.0-beta.14] - 2026-07-01
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.14",
+  "version": "1.0.0-beta.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.14"
+version = "1.0.0-beta.15"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 06cf874d8b29767729ec06547cf02fc92acd875c)
+#     TAOS_RKLLAMA_REF        git ref  (default: 4f518e97d114f386a153f6c6da36270c7f692712)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-06cf874d8b29767729ec06547cf02fc92acd875c}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-4f518e97d114f386a153f6c6da36270c7f692712}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.
@@ -336,6 +336,22 @@ install_rkllama() {
         log "cloning $RKLLAMA_REPO -> $RKLLAMA_DIR"
         run_as_user mkdir -p "$(dirname "$RKLLAMA_DIR")"
         run_as_user git clone --quiet "$RKLLAMA_REPO" "$RKLLAMA_DIR"
+        # A clone brings down all branches and tags, but an overridden
+        # TAOS_RKLLAMA_REF can be a SHA reachable from none of them. Try to
+        # fetch the configured ref explicitly (best-effort: some servers
+        # refuse unadvertised objects) so the verification below sees the
+        # same coverage as the re-install path; on failure fall through to
+        # the curated error instead of dying on git's raw message.
+        run_as_user git -C "$RKLLAMA_DIR" fetch --quiet origin "$RKLLAMA_REF" 2>/dev/null || true
+    fi
+    # Verify the pinned ref is actually fetchable before checking it out. A
+    # fresh clone only has branch/tag refs, so a pin orphaned by a history
+    # rewrite of the rkllama fork fails with git's opaque "reference is not a
+    # tree" (#1527). Fail with a message that says what happened and how to
+    # override, rather than silently falling back to a moving branch (which
+    # would break install reproducibility).
+    if ! run_as_user git -C "$RKLLAMA_DIR" cat-file -e "${RKLLAMA_REF}^{commit}" 2>/dev/null; then
+        die "pinned rkllama ref ${RKLLAMA_REF:0:12} is not reachable from any branch or tag of $RKLLAMA_REPO (the fork's history may have been rewritten). Update taOS for a current pin, or override with TAOS_RKLLAMA_REF=<ref>."
     fi
     run_as_user git -C "$RKLLAMA_DIR" checkout --quiet "$RKLLAMA_REF"
     log "rkllama pinned to $(run_as_user git -C "$RKLLAMA_DIR" rev-parse --short HEAD)"

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 4f518e97d114f386a153f6c6da36270c7f692712)
+#     TAOS_RKLLAMA_REF        git ref  (default: 06cf874d8b29767729ec06547cf02fc92acd875c)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-4f518e97d114f386a153f6c6da36270c7f692712}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-06cf874d8b29767729ec06547cf02fc92acd875c}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.
@@ -105,7 +105,7 @@ if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
 if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
-    log "current librknnrt=$(strings "$LIBRKNNRT_DEST" 2>/dev/null | grep -m1 -oE 'librknnrt version: [0-9.]+' || echo 'version string not found')"
+    log "current librknnrt=$(strings "$LIBRKNNRT_DEST" 2>/dev/null | grep -m1 -oE 'librknnrt version: [0-9]+\.[0-9]+\.[0-9]+' || echo 'version string not found')"
 fi
 
 # verify_sha256 <file> <expected_hex> <label>

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -94,6 +94,20 @@ log()  { printf '\033[1;34m[rknpu]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[rknpu]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[rknpu]\033[0m %s\n' "$*" >&2; exit 1; }
 
+# Environment banner: every user-posted install log should self-describe the
+# machine it ran on (distro, kernel, board, current NPU runtime) so a failure
+# report is diagnosable without a round-trip asking for these.
+if [[ -r /etc/os-release ]]; then
+    log "distro=$( . /etc/os-release; echo "${PRETTY_NAME:-$ID}" )"
+fi
+log "kernel=$(uname -r) arch=$(uname -m)"
+if [[ -r /proc/device-tree/model ]]; then
+    log "board=$(tr -d '\0' < /proc/device-tree/model)"
+fi
+if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
+    log "current librknnrt=$(strings "$LIBRKNNRT_DEST" 2>/dev/null | grep -m1 -oE 'librknnrt version: [0-9.]+' || echo 'version string not found')"
+fi
+
 # verify_sha256 <file> <expected_hex> <label>
 # Hard-fails on mismatch: a corrupted download or a tampered mirror must
 # never be silently accepted.

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -70,7 +70,7 @@ if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
 command -v python3 >/dev/null 2>&1 && log "python3=$(python3 --version 2>&1)"
-log "disk_free_root=$(df -Ph / | awk 'NR==2 {print $4}')"
+log "disk_free_root=$(df -Ph / 2>/dev/null | awk 'NR==2 {print $4}' || echo unknown)"
 log "install_dir=$INSTALL_DIR branch=$BRANCH port=$TAOS_PORT proxy_port=$TAOS_BROWSER_PROXY_PORT qmd_port=$TAOS_QMD_PORT"
 
 # --- system dependencies --------------------------------------------------

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -59,6 +59,18 @@ warn() { printf '\033[1;33m[server-install]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[server-install]\033[0m %s\n' "$*" >&2; exit 1; }
 
 log "os=$os_name arch=$arch"
+# Environment banner: every user-posted install log should self-describe the
+# machine it ran on (distro, kernel, board, python, free disk) so a failure
+# report is diagnosable without a round-trip asking for these.
+if [[ -r /etc/os-release ]]; then
+    log "distro=$( . /etc/os-release; echo "${PRETTY_NAME:-$ID}" )"
+fi
+log "kernel=$(uname -r)"
+if [[ -r /proc/device-tree/model ]]; then
+    log "board=$(tr -d '\0' < /proc/device-tree/model)"
+fi
+command -v python3 >/dev/null 2>&1 && log "python3=$(python3 --version 2>&1)"
+log "disk_free_root=$(df -Ph / | awk 'NR==2 {print $4}')"
 log "install_dir=$INSTALL_DIR branch=$BRANCH port=$TAOS_PORT proxy_port=$TAOS_BROWSER_PROXY_PORT qmd_port=$TAOS_QMD_PORT"
 
 # --- system dependencies --------------------------------------------------

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -245,14 +245,16 @@ class TestMintInternalRoute:
         assert kwargs["actor_user_id"]
 
     async def test_seed_internal_adopt_handles_preexisting(self, mint_client):
-        """seed-internal?adopt=true vouches for a pre-existing driver handle and
-        still seeds the rest."""
+        """seed-internal?adopt=@handle vouches for THAT pre-existing driver
+        handle explicitly and still seeds the rest."""
         rec = await mint_client._app.state.agent_registry.register(
             framework="claude-code", display_name="taos-dev",
             origin="external-selfjoin", handle="@taOS-dev",
         )
         await mint_client._app.state.agent_registry.set_status(rec["canonical_id"], "active")
-        resp = await mint_client.post("/api/agents/registry/seed-internal?adopt=true")
+        resp = await mint_client.post(
+            "/api/agents/registry/seed-internal?adopt=@taOS-dev"
+        )
         assert resp.status_code == 200, resp.text
         seeded = {s["handle"]: s for s in resp.json()["seeded"]}
         assert seeded["@taOS-dev"]["adopted"] is True and seeded["@taOS-dev"]["created"] is False
@@ -260,6 +262,51 @@ class TestMintInternalRoute:
         # Without adopt it would have 409d on @taOS-dev:
         resp2 = await mint_client.post("/api/agents/registry/seed-internal")
         assert resp2.status_code == 409
+
+    async def test_seed_internal_adopt_multiple_listed(self, mint_client):
+        """Multiple handles (with copy-paste spacing and a duplicate) adopt in
+        one call; each named row comes back adopted."""
+        reg = mint_client._app.state.agent_registry
+        for handle, name in (("@taOS-dev", "taos-dev"), ("@Hermes", "hermes")):
+            rec = await reg.register(
+                framework="claude-code", display_name=name,
+                origin="external-selfjoin", handle=handle,
+            )
+            await reg.set_status(rec["canonical_id"], "active")
+        resp = await mint_client.post(
+            "/api/agents/registry/seed-internal"
+            "?adopt=@taOS-dev,%20@Hermes,@taOS-dev"
+        )
+        assert resp.status_code == 200, resp.text
+        seeded = {s["handle"]: s for s in resp.json()["seeded"]}
+        assert seeded["@taOS-dev"]["adopted"] is True
+        assert seeded["@Hermes"]["adopted"] is True
+        assert seeded["@taOSmd-dev"]["created"] is True
+
+    async def test_seed_internal_rejects_blanket_adopt(self, mint_client):
+        """A bare adopt=true (or any non-handle value) is a 400: adoption
+        grants driver scopes + a token to a pre-existing identity, so each
+        handle must be vouched for explicitly, never all four at once."""
+        resp = await mint_client.post(
+            "/api/agents/registry/seed-internal?adopt=true"
+        )
+        assert resp.status_code == 400
+        assert "explicitly" in resp.json()["detail"]
+
+    async def test_seed_internal_adopt_only_covers_listed_handles(self, mint_client):
+        """A pre-existing handle NOT named in adopt still 409s even when
+        another handle is being adopted."""
+        reg = mint_client._app.state.agent_registry
+        for handle, name in (("@taOS-dev", "taos-dev"), ("@Hermes", "hermes")):
+            rec = await reg.register(
+                framework="claude-code", display_name=name,
+                origin="external-selfjoin", handle=handle,
+            )
+            await reg.set_status(rec["canonical_id"], "active")
+        resp = await mint_client.post(
+            "/api/agents/registry/seed-internal?adopt=@taOS-dev"
+        )
+        assert resp.status_code == 409
 
     async def test_mint_requires_auth(self, mint_client):
         """An unauthenticated caller cannot mint (route is admin-only and not on

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -69,11 +69,25 @@ class TestAgentRegistryStore:
         finally:
             await store.close()
 
-    async def test_collision_appends_two_char_suffix(self, tmp_path):
+    async def test_collision_appends_two_char_suffix(self, tmp_path, monkeypatch):
         """Two registrations with the same display_name in the same second get distinct IDs."""
         store = await self._make_store(tmp_path / "reg.db")
         try:
             now = datetime.now(timezone.utc)
+
+            # Freeze the store's clock: register() mints its own timestamp, so
+            # on a slow runner the pre-inserted id and the registration could
+            # straddle a second boundary and never collide (flaked in CI with
+            # "expected suffix on collision").
+            import tinyagentos.agent_registry_store as _store_mod
+
+            class _FrozenDatetime(datetime):
+                @classmethod
+                def now(cls, tz=None):  # noqa: ARG003 - signature parity
+                    return now
+
+            monkeypatch.setattr(_store_mod, "datetime", _FrozenDatetime)
+
             slug = _slugify("Clash")
             base_id = mint_canonical_id(slug, now)
 

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -548,7 +548,7 @@ class TestProxySelfHeal:
         import sys
         import tinyagentos.llm_proxy as mod
 
-        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         binp = tmp_path / ".local" / "bin"
         binp.mkdir(parents=True)
         (binp / "uv").write_text("x")
@@ -582,7 +582,7 @@ class TestProxySelfHeal:
         import sys
         import tinyagentos.llm_proxy as mod
 
-        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         (tmp_path / ".local" / "bin").mkdir(parents=True)
         (tmp_path / ".local" / "bin" / "uv").write_text("x")
         monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
@@ -612,7 +612,7 @@ class TestProxySelfHeal:
         import sys
         import tinyagentos.llm_proxy as mod
 
-        (tmp_path / "pyproject.toml").write_text("[project]\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         (tmp_path / ".local" / "bin").mkdir(parents=True)
         (tmp_path / ".local" / "bin" / "uv").write_text("x")
         monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
@@ -660,7 +660,7 @@ class TestProxySelfHeal:
 
         root = tmp_path / "install"
         (root / ".venv" / "bin").mkdir(parents=True)
-        (root / "pyproject.toml").write_text("[project]\n")
+        (root / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
         (root / ".local" / "bin").mkdir(parents=True)
         (root / ".local" / "bin" / "uv").write_text("x")
         base = tmp_path / "usr" / "local" / "bin"
@@ -690,3 +690,98 @@ class TestProxySelfHeal:
         assert ok is True
         # cwd must be the install root (venv grandparent), not tmp_path/usr.
         assert captured["cwd"] == str(root)
+
+    @pytest.mark.asyncio
+    async def test_selfheal_locates_root_at_other_venv_depths(self, tmp_path, monkeypatch):
+        """The root walk must not assume <root>/.venv/bin/python exactly: a
+        python3.x-named binary or nested layout still finds the first ancestor
+        holding pyproject.toml instead of silently no-opping."""
+        import sys
+        import tinyagentos.llm_proxy as mod
+
+        root = tmp_path / "install"
+        deep = root / "envs" / ".venv" / "bin"
+        deep.mkdir(parents=True)
+        (root / "pyproject.toml").write_text('[project]\nname = "tinyagentos"\n')
+        (root / ".local" / "bin").mkdir(parents=True)
+        (root / ".local" / "bin" / "uv").write_text("x")
+        monkeypatch.setattr(sys, "executable", str(deep / "python3.12"))
+
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"", None)
+
+        async def fake_exec(*cmd, **kw):
+            captured["cwd"] = kw.get("cwd")
+            return FakeProc()
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+
+        assert await LLMProxy()._selfheal_proxy_extra() is True
+        assert captured["cwd"] == str(root)
+
+    @pytest.mark.asyncio
+    async def test_selfheal_pip_fallback_installs_only_extra_requirements(
+        self, tmp_path, monkeypatch
+    ):
+        """Without uv, the fallback installs the extras' pinned requirements
+        from pyproject, never an editable reinstall of the project: pip
+        install -e .[proxy] re-resolves every dependency, the exact churn the
+        self-heal exists to undo."""
+        import shutil
+        import sys
+        import tinyagentos.llm_proxy as mod
+
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\nname = \"tinyagentos\"\nversion = \"0\"\n"
+            "[project.optional-dependencies]\n"
+            # trailing whitespace/newline in an entry must be stripped, not
+            # reach pip verbatim
+            "proxy = [\"litellm[proxy]>=1.90.0\", \"prisma>=0.11.0\\n\"]\n"
+        )
+        (tmp_path / ".venv" / "bin").mkdir(parents=True)
+        monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+        monkeypatch.setattr(shutil, "which", lambda _name: None)
+
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+            async def communicate(self):
+                return (b"", None)
+
+        async def fake_exec(*cmd, **kw):
+            captured["cmd"] = list(cmd)
+            return FakeProc()
+
+        monkeypatch.setattr(mod.asyncio, "create_subprocess_exec", fake_exec)
+
+        assert await LLMProxy()._selfheal_proxy_extra() is True
+        assert captured["cmd"] == [
+            str(tmp_path / ".venv" / "bin" / "pip"),
+            "install",
+            "--no-input",
+            "--disable-pip-version-check",
+            "litellm[proxy]>=1.90.0",
+            "prisma>=0.11.0",
+        ]
+        assert "-e" not in captured["cmd"]
+
+    @pytest.mark.asyncio
+    async def test_selfheal_ignores_foreign_pyproject(self, tmp_path, monkeypatch):
+        """The root walk must not trust just any pyproject.toml above the
+        interpreter: a foreign project's file (e.g. one in $HOME) would make
+        the self-heal pip-install THAT project's pins into our venv. Only a
+        pyproject whose project.name is tinyagentos counts."""
+        import sys
+
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "someone-else"\n')
+        (tmp_path / ".venv" / "bin").mkdir(parents=True)
+        monkeypatch.setattr(sys, "executable", str(tmp_path / ".venv" / "bin" / "python"))
+
+        assert await LLMProxy()._selfheal_proxy_extra() is False

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.14"
+__version__ = "1.0.0-beta.15"

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -196,16 +196,35 @@ class LLMProxy:
         import shutil
         import sys
 
-        # The install dir is the venv's grandparent (<root>/.venv/bin/python).
-        # Do NOT resolve(): the venv python is a symlink to the base
-        # interpreter (e.g. /usr/local/bin/python3.x), so resolving walks out
-        # of the install tree and lands parents[2] on /usr. start() derives the
-        # venv bin the same non-resolved way.
-        project_root = Path(sys.executable).parents[2]
-        if not (project_root / "pyproject.toml").is_file():
+        import tomllib
+
+        # The install dir is an ancestor of the venv python (normally the
+        # venv's grandparent: <root>/.venv/bin/python). Do NOT resolve(): the
+        # venv python is a symlink to the base interpreter (e.g.
+        # /usr/local/bin/python3.x), so resolving walks out of the install
+        # tree. Walk upward to the first ancestor whose pyproject.toml is
+        # OURS (project.name == tinyagentos): matching on the file alone
+        # could latch onto an unrelated project's pyproject higher up (e.g.
+        # one in $HOME) and pip-install that project's pins into our venv.
+        def _is_install_root(parent: Path) -> bool:
+            pj = parent / "pyproject.toml"
+            if not pj.is_file():
+                return False
+            try:
+                with open(pj, "rb") as fh:
+                    name = tomllib.load(fh).get("project", {}).get("name")
+            except Exception:  # noqa: BLE001 - unreadable/foreign file: keep walking
+                return False
+            return name == "tinyagentos"
+
+        project_root = next(
+            (p for p in Path(sys.executable).parents if _is_install_root(p)),
+            None,
+        )
+        if project_root is None:
             logger.warning(
-                "proxy self-heal: cannot locate the install root at %s — skipping",
-                project_root,
+                "proxy self-heal: no tinyagentos pyproject.toml above %s — skipping",
+                sys.executable,
             )
             return False
 
@@ -227,8 +246,45 @@ class LLMProxy:
             extra_args = [a for e in UPDATE_EXTRAS for a in ("--extra", e)]
             cmd = [uv, "sync", "--frozen", *extra_args]
         else:
+            # Without uv, install ONLY the extras' requirements (read from
+            # pyproject so the pins stay single-sourced). An editable
+            # reinstall (pip install -e .[proxy]) would re-resolve every
+            # project dependency — the exact churn this self-heal exists to
+            # undo — and a later bare `uv sync --frozen` would strip the
+            # extra right back out anyway.
+            try:
+                with open(project_root / "pyproject.toml", "rb") as fh:
+                    optional = tomllib.load(fh)["project"]["optional-dependencies"]
+                # strip(): a stray newline/whitespace in a pyproject entry
+                # would otherwise reach pip verbatim and fail opaquely.
+                reqs = [
+                    r.strip()
+                    for e in UPDATE_EXTRAS
+                    for r in optional.get(e, [])
+                    if r.strip()
+                ]
+            except Exception as exc:  # noqa: BLE001 - non-fatal by design
+                logger.warning(
+                    "proxy self-heal: cannot read extras from pyproject: %s", exc
+                )
+                return False
+            if not reqs:
+                logger.warning(
+                    "proxy self-heal: no requirements found for extras %s",
+                    UPDATE_EXTRAS,
+                )
+                return False
             pip = str(Path(sys.executable).parent / "pip")
-            cmd = [pip, "install", "-e", f".[{','.join(UPDATE_EXTRAS)}]"]
+            # --no-input: never block the 900s window on a TTY prompt.
+            # --disable-pip-version-check: no upgrade nag in the captured
+            # stream. (No --quiet: failure output must stay in the logs.)
+            cmd = [
+                pip,
+                "install",
+                "--no-input",
+                "--disable-pip-version-check",
+                *reqs,
+            ]
 
         logger.warning(
             "proxy self-heal: litellm missing, installing the proxy extra: %s",

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -360,19 +360,36 @@ async def mint_internal_agent(
 async def seed_internal_agents(
     request: Request,
     user: CurrentUser = Depends(current_user),
-    adopt: bool = False,
+    adopt: str = "",
 ):
     """Idempotently mint the four internal driver agents and return their tokens.
 
     Admin only.  Each of @taOS-dev, @taOS-website-dev, @taOSmd-dev, @Hermes is
     minted with the a2a_send + a2a_receive scopes.  Re-running creates no
-    duplicate rows.  ``adopt=true`` (query param) vouches for any of those
-    handles that already exist under a non-internal origin (e.g. a driver that
-    self-joined earlier) instead of 409ing.  Response: {"seeded": [{handle,
-    canonical_id, created, adopted, scopes, token}, ...]}.
+    duplicate rows.  ``adopt`` (query param) is a comma-separated list of the
+    specific handles to vouch for when they already exist under a non-internal
+    origin (e.g. ``?adopt=@taOS-dev``); each adoption grants driver scopes and
+    a token to a pre-existing identity, so it must name each handle explicitly
+    rather than blanket-vouch for all four (a driver handle claimed by someone
+    else via the consent flow must not be adopted as a side effect).  A bare
+    ``adopt=true`` is rejected.  Response: {"seeded": [{handle, canonical_id,
+    created, adopted, scopes, token}, ...]}.
     """
     if not user.is_admin:
         raise HTTPException(status_code=403, detail="forbidden")
+    known = {spec["handle"] for spec in _INTERNAL_AGENTS}
+    adopt_handles = {h.strip() for h in adopt.split(",") if h.strip()}
+    if adopt_handles - known:
+        # Echo only the caller's own bad input; do not enumerate the internal
+        # handle set in an error body (the docstring documents it for admins).
+        bad = ", ".join(sorted(adopt_handles - known))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "adopt must list internal driver handles explicitly, "
+                f"never true/blanket values; got: {bad}"
+            ),
+        )
     seeded = []
     for spec in _INTERNAL_AGENTS:
         seeded.append(
@@ -382,7 +399,7 @@ async def seed_internal_agents(
                 handle=spec["handle"],
                 slug=spec["slug"],
                 scopes=list(_INTERNAL_AGENT_SCOPES),
-                adopt=adopt,
+                adopt=spec["handle"] in adopt_handles,
             )
         )
     return {"seeded": seeded}

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -1,9 +1,57 @@
 from __future__ import annotations
 
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import APIRouter, Request, WebSocket
 from fastapi.responses import JSONResponse
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(tags=["channel-hub"])
+
+# One lock per connector key, held across stop-old + start-new + map-assign
+# (and around disconnects). Two concurrent connects for the same key would
+# otherwise both pop (second gets None), both start, and the loser's
+# connector stays alive but unreachable via the map, so it could never be
+# stopped. Refcounted so an entry is evicted once no task holds or awaits it
+# (the map must not grow forever); the bookkeeping has no awaits, so it is
+# atomic under asyncio's single-threaded scheduling.
+_connect_locks: dict[str, asyncio.Lock] = {}
+_connect_lock_refs: dict[str, int] = {}
+
+
+@asynccontextmanager
+async def _connect_lock(connector_key: str):
+    _connect_lock_refs[connector_key] = _connect_lock_refs.get(connector_key, 0) + 1
+    lock = _connect_locks.setdefault(connector_key, asyncio.Lock())
+    try:
+        async with lock:
+            yield
+    finally:
+        remaining = _connect_lock_refs[connector_key] - 1
+        if remaining:
+            _connect_lock_refs[connector_key] = remaining
+        else:
+            del _connect_lock_refs[connector_key]
+            _connect_locks.pop(connector_key, None)
+
+
+async def _stop_prior_connector(connectors: dict, connector_key: str) -> None:
+    """Stop and drop any prior connector under this key. Reconnecting (e.g.
+    after a token rotation) must not silently orphan the previous connector's
+    background task/client."""
+    old = connectors.pop(connector_key, None)
+    if old is not None and hasattr(old, "stop"):
+        try:
+            await old.stop()
+        except Exception:
+            logger.warning(
+                "channel-hub: failed to stop prior %s connector on reconnect",
+                connector_key,
+                exc_info=True,
+            )
 
 
 @router.get("/api/channel-hub/status")
@@ -42,9 +90,11 @@ async def connect_bot(request: Request):
         connector_key = f"webchat:{agent_name}"
 
         from tinyagentos.channel_hub.webchat_connector import WebChatConnector
-        connector = WebChatConnector(agent_name=agent_name, router=router_obj)
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
+        async with _connect_lock(connector_key):
+            await _stop_prior_connector(connectors, connector_key)
+            connector = WebChatConnector(agent_name=agent_name, router=router_obj)
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
         return {"status": "connected", "platform": "webchat", "agent_name": agent_name}
 
     bot_token_secret = body.get("bot_token_secret", "")
@@ -64,93 +114,101 @@ async def connect_bot(request: Request):
 
     connector_key = f"{platform}:{agent_name}"
 
-    if platform == "telegram":
-        from tinyagentos.channel_hub.telegram_connector import TelegramConnector
-        connector = TelegramConnector(bot_token=bot_token, agent_name=agent_name, router=router_obj)
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "discord":
-        channel_ids = body.get("channel_ids", [])
-        from tinyagentos.channel_hub.discord_connector import DiscordConnector
-        connector = DiscordConnector(
-            bot_token=bot_token, agent_name=agent_name,
-            router=router_obj, channel_ids=channel_ids,
-        )
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "slack":
-        channel_ids = body.get("channel_ids", [])
-        from tinyagentos.channel_hub.slack_connector import SlackConnector
-        connector = SlackConnector(
-            bot_token=bot_token, agent_name=agent_name,
-            router=router_obj, channel_ids=channel_ids,
-        )
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "email":
-        imap_host = body.get("imap_host", "")
-        imap_port = body.get("imap_port", 993)
-        smtp_host = body.get("smtp_host", "")
-        smtp_port = body.get("smtp_port", 587)
-        # bot_token holds "username:password" for email
-        parts = bot_token.split(":", 1)
-        email_user = parts[0]
-        email_pass = parts[1] if len(parts) > 1 else ""
-        from tinyagentos.channel_hub.email_connector import EmailConnector
-        connector = EmailConnector(
-            agent_name=agent_name, router=router_obj,
-            imap_host=imap_host, imap_port=imap_port,
-            smtp_host=smtp_host, smtp_port=smtp_port,
-            username=email_user, password=email_pass,
-        )
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "github":
-        if not agent_name:
-            return JSONResponse({"error": "agent_name is required"}, status_code=400)
-        repo = body.get("repo")
-        event_kinds = body.get("event_kinds", [])
-        pr_number = body.get("pr_number")
-        from tinyagentos.channel_hub.adapters.github import GithubConnector
-        connector = GithubConnector(
-            agent_name=agent_name, router=router_obj,
-            repo=repo, event_kinds=event_kinds, pr_number=pr_number,
-        )
-        router_obj.assign_channel(platform, agent_name, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    elif platform == "matrix":
-        homeserver = body.get("homeserver", "")
-        if not homeserver:
-            return JSONResponse({"error": "homeserver is required for matrix"}, status_code=400)
-        from tinyagentos.channel_hub.matrix_connector import MatrixConnector
-        connector = MatrixConnector(
-            homeserver=homeserver,
-            access_token=bot_token,
-            agent_name=agent_name,
-            router=router_obj,
-        )
-        router_obj.assign_channel(platform, bot_token_secret, agent_name)
-        await connector.start()
-        connectors[connector_key] = connector
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "connected", "platform": platform, "agent_name": agent_name}
-    else:
-        return JSONResponse({"error": f"Platform '{platform}' not yet supported"}, status_code=400)
+    # Validate required per-platform inputs BEFORE stopping the live
+    # connector: a malformed reconnect must fail without tearing down the
+    # working one.
+    homeserver = body.get("homeserver", "") if platform == "matrix" else ""
+    if platform == "matrix" and not homeserver:
+        return JSONResponse({"error": "homeserver is required for matrix"}, status_code=400)
+
+    async with _connect_lock(connector_key):
+        await _stop_prior_connector(connectors, connector_key)
+
+        if platform == "telegram":
+            from tinyagentos.channel_hub.telegram_connector import TelegramConnector
+            connector = TelegramConnector(bot_token=bot_token, agent_name=agent_name, router=router_obj)
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "discord":
+            channel_ids = body.get("channel_ids", [])
+            from tinyagentos.channel_hub.discord_connector import DiscordConnector
+            connector = DiscordConnector(
+                bot_token=bot_token, agent_name=agent_name,
+                router=router_obj, channel_ids=channel_ids,
+            )
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "slack":
+            channel_ids = body.get("channel_ids", [])
+            from tinyagentos.channel_hub.slack_connector import SlackConnector
+            connector = SlackConnector(
+                bot_token=bot_token, agent_name=agent_name,
+                router=router_obj, channel_ids=channel_ids,
+            )
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "email":
+            imap_host = body.get("imap_host", "")
+            imap_port = body.get("imap_port", 993)
+            smtp_host = body.get("smtp_host", "")
+            smtp_port = body.get("smtp_port", 587)
+            # bot_token holds "username:password" for email
+            parts = bot_token.split(":", 1)
+            email_user = parts[0]
+            email_pass = parts[1] if len(parts) > 1 else ""
+            from tinyagentos.channel_hub.email_connector import EmailConnector
+            connector = EmailConnector(
+                agent_name=agent_name, router=router_obj,
+                imap_host=imap_host, imap_port=imap_port,
+                smtp_host=smtp_host, smtp_port=smtp_port,
+                username=email_user, password=email_pass,
+            )
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "github":
+            if not agent_name:
+                return JSONResponse({"error": "agent_name is required"}, status_code=400)
+            repo = body.get("repo")
+            event_kinds = body.get("event_kinds", [])
+            pr_number = body.get("pr_number")
+            from tinyagentos.channel_hub.adapters.github import GithubConnector
+            connector = GithubConnector(
+                agent_name=agent_name, router=router_obj,
+                repo=repo, event_kinds=event_kinds, pr_number=pr_number,
+            )
+            router_obj.assign_channel(platform, agent_name, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        elif platform == "matrix":
+            # homeserver validated above, before the destructive stop.
+            from tinyagentos.channel_hub.matrix_connector import MatrixConnector
+            connector = MatrixConnector(
+                homeserver=homeserver,
+                access_token=bot_token,
+                agent_name=agent_name,
+                router=router_obj,
+            )
+            router_obj.assign_channel(platform, bot_token_secret, agent_name)
+            await connector.start()
+            connectors[connector_key] = connector
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "connected", "platform": platform, "agent_name": agent_name}
+        else:
+            return JSONResponse({"error": f"Platform '{platform}' not yet supported"}, status_code=400)
 
 
 @router.post("/api/channel-hub/disconnect")
@@ -163,14 +221,17 @@ async def disconnect_bot(request: Request):
     connectors = getattr(request.app.state, "channel_hub_connectors", {})
     connector_key = f"{platform}:{agent_name}"
 
-    connector = connectors.pop(connector_key, None)
-    if connector:
-        if hasattr(connector, "stop"):
-            await connector.stop()
-        request.app.state.channel_hub_connectors = connectors
-        return {"status": "disconnected", "platform": platform, "agent_name": agent_name}
-    else:
-        return JSONResponse({"error": "Connector not found"}, status_code=404)
+    # Same per-key lock as connect_bot: a disconnect racing a reconnect must
+    # not pop the old connector mid-swap (404ing while the new one lands).
+    async with _connect_lock(connector_key):
+        connector = connectors.pop(connector_key, None)
+        if connector:
+            if hasattr(connector, "stop"):
+                await connector.stop()
+            request.app.state.channel_hub_connectors = connectors
+            return {"status": "disconnected", "platform": platform, "agent_name": agent_name}
+        else:
+            return JSONResponse({"error": "Connector not found"}, status_code=404)
 
 
 @router.get("/api/channel-hub/adapters")

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b14"
+version = "1.0.0b15"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promote dev to master for 1.0.0-beta.15.

Small fix release so the fresh-install fix reaches master, where the install one-liner clones from.

Headlines (full details in CHANGELOG.md):
- Fixed: the Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree" (stale rkllama pin); the pin is verified after fetch with a clear error on failure. Fixes #1527, reported by @mandresve.
- Fixed: comms-channel reconnects no longer leak the previous connector, concurrent reconnects cannot orphan one, and a malformed Matrix reconnect fails without tearing down the working connector.
- Fixed: LLM proxy self-heal robustness (any venv layout, only trusts our own pyproject, pip fallback installs just the proxy requirements).
- Changed: seeding internal driver agents requires explicit per-handle adoption; blanket adopt is rejected.

3 commits from dev; all gated by CI + bot review per PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate tasks, leaked connections, and race conditions by serializing connect/disconnect per connector key during reconnects.
  * Improved LLM proxy self-heal by more reliably finding the install root across virtualenv layouts and tightening non-uv fallback installs.
  * Enhanced Rockchip NPU installer output and safer rkllama ref handling with clearer errors when pinned refs are unavailable.
  * Tightened internal driver adoption so it applies only to explicitly listed handles (rejecting blanket/invalid values).
* **Tests**
  * Expanded internal adoption and self-heal scenarios; made a registry collision test deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->