### PR TITLE
feat(install): environment banner at the top of both installers

### DIFF
--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -94,6 +94,20 @@ log()  { printf '\033[1;34m[rknpu]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[rknpu]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[rknpu]\033[0m %s\n' "$*" >&2; exit 1; }
 
+# Environment banner: every user-posted install log should self-describe the
+# machine it ran on (distro, kernel, board, current NPU runtime) so a failure
+# report is diagnosable without a round-trip asking for these.
+if [[ -r /etc/os-release ]]; then
+    log "distro=$( . /etc/os-release; echo "${PRETTY_NAME:-$ID}" )"
+fi
+log "kernel=$(uname -r) arch=$(uname -m)"
+if [[ -r /proc/device-tree/model ]]; then
+    log "board=$(tr -d '\0' < /proc/device-tree/model)"
+fi
+if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
+    log "current librknnrt=$(strings "$LIBRKNNRT_DEST" 2>/dev/null | grep -m1 -oE 'librknnrt version: [0-9.]+' || echo 'version string not found')"
+fi
+
 # verify_sha256 <file> <expected_hex> <label>
 # Hard-fails on mismatch: a corrupted download or a tampered mirror must
 # never be silently accepted.

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -59,6 +59,18 @@ warn() { printf '\033[1;33m[server-install]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[server-install]\033[0m %s\n' "$*" >&2; exit 1; }
 
 log "os=$os_name arch=$arch"
+# Environment banner: every user-posted install log should self-describe the
+# machine it ran on (distro, kernel, board, python, free disk) so a failure
+# report is diagnosable without a round-trip asking for these.
+if [[ -r /etc/os-release ]]; then
+    log "distro=$( . /etc/os-release; echo "${PRETTY_NAME:-$ID}" )"
+fi
+log "kernel=$(uname -r)"
+if [[ -r /proc/device-tree/model ]]; then
+    log "board=$(tr -d '\0' < /proc/device-tree/model)"
+fi
+command -v python3 >/dev/null 2>&1 && log "python3=$(python3 --version 2>&1)"
+log "disk_free_root=$(df -Ph / | awk 'NR==2 {print $4}')"
 log "install_dir=$INSTALL_DIR branch=$BRANCH port=$TAOS_PORT proxy_port=$TAOS_BROWSER_PROXY_PORT qmd_port=$TAOS_QMD_PORT"
 
 # --- system dependencies --------------------------------------------------


### PR DESCRIPTION
First output of the installer hardening audit (vendor-image support push, context in #2/#1527):

Both install-server.sh and install-rknpu.sh now log an environment banner before doing anything: distro (os-release PRETTY_NAME), kernel, board (device-tree model), python3 version, free root disk, and (rknpu) the currently installed librknnrt version.

Why: community testers are starting to run fresh installs on OSes we have not verified (official Orange Pi Debian Bookworm on an Orange Pi 5 Pro is in flight). Their pasted logs should self-describe the machine so failures are diagnosable without a round-trip asking for uname -a and /etc/os-release.

bash -n passes on both scripts; banner logic smoke-tested for the no-os-release and no-device-tree paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installer output now includes a clearer environment summary before setup begins.
  * Displays detected OS, kernel version, architecture, board model, Python 3 version, disk space, and available runtime details when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->