### PR TITLE
fix(rknpu): re-pin rkllama to the proven production lineage (fixes #1529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 ## [1.0.0-beta.15] - 2026-07-02
 
 ### Fixed
-- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin now points at a commit that fresh clones can actually check out, and a stale pin fails with a clear explanation and override instructions instead of a raw git error. Reported by @mandresve (#1527).
+- The Rockchip NPU installer no longer fails on fresh installs with "reference is not a tree": the rkllama pin points at the proven production commit (made reachable for fresh clones again), and a stale pin fails with a clear explanation instead of a raw git error. This also keeps the generated rkllama service startable: the newer rkllama default branch dropped the preload option the service relies on. Reported by @mandresve (#1527, #1529).
 - Reconnecting a comms channel (Telegram/Slack/Discord/email/Matrix/webchat) after a token rotation now stops the previous connector instead of silently leaking its background task, concurrent reconnects for the same agent can no longer orphan a connector, and a malformed Matrix reconnect fails cleanly without tearing down the working connector.
 - The LLM proxy self-heal is more robust: it locates the install root at any venv layout, only trusts our own pyproject when doing so, and its pip fallback installs just the proxy requirements instead of re-resolving every dependency.
 - Seeding the internal driver agents now requires naming each pre-existing handle explicitly to adopt it; a blanket adopt flag is rejected so a handle claimed by someone else can never be vouched for as a side effect.

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 4f518e97d114f386a153f6c6da36270c7f692712)
+#     TAOS_RKLLAMA_REF        git ref  (default: 06cf874d8b29767729ec06547cf02fc92acd875c)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-4f518e97d114f386a153f6c6da36270c7f692712}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-06cf874d8b29767729ec06547cf02fc92acd875c}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -105,7 +105,7 @@ if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
 if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
-    log "current librknnrt=$(strings "$LIBRKNNRT_DEST" 2>/dev/null | grep -m1 -oE 'librknnrt version: [0-9.]+' || echo 'version string not found')"
+    log "current librknnrt=$(strings "$LIBRKNNRT_DEST" 2>/dev/null | grep -m1 -oE 'librknnrt version: [0-9]+\.[0-9]+\.[0-9]+' || echo 'version string not found')"
 fi
 
 # verify_sha256 <file> <expected_hex> <label>

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -65,12 +65,12 @@ log "os=$os_name arch=$arch"
 if [[ -r /etc/os-release ]]; then
     log "distro=$( . /etc/os-release; echo "${PRETTY_NAME:-$ID}" )"
 fi
-log "kernel=$(uname -r)"
+log "kernel=$(uname -r) arch=$(uname -m)"
 if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
 command -v python3 >/dev/null 2>&1 && log "python3=$(python3 --version 2>&1)"
-log "disk_free_root=$(df -Ph / | awk 'NR==2 {print $4}')"
+log "disk_free_root=$(df -Ph / 2>/dev/null | awk 'NR==2 {print $4}' || echo unknown)"
 log "install_dir=$INSTALL_DIR branch=$BRANCH port=$TAOS_PORT proxy_port=$TAOS_BROWSER_PROXY_PORT qmd_port=$TAOS_QMD_PORT"
 
 # --- system dependencies --------------------------------------------------

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -65,7 +65,7 @@ log "os=$os_name arch=$arch"
 if [[ -r /etc/os-release ]]; then
     log "distro=$( . /etc/os-release; echo "${PRETTY_NAME:-$ID}" )"
 fi
-log "kernel=$(uname -r) arch=$(uname -m)"
+log "kernel=$(uname -r)"
 if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -69,11 +69,25 @@ class TestAgentRegistryStore:
         finally:
             await store.close()
 
-    async def test_collision_appends_two_char_suffix(self, tmp_path):
+    async def test_collision_appends_two_char_suffix(self, tmp_path, monkeypatch):
         """Two registrations with the same display_name in the same second get distinct IDs."""
         store = await self._make_store(tmp_path / "reg.db")
         try:
             now = datetime.now(timezone.utc)
+
+            # Freeze the store's clock: register() mints its own timestamp, so
+            # on a slow runner the pre-inserted id and the registration could
+            # straddle a second boundary and never collide (flaked in CI with
+            # "expected suffix on collision").
+            import tinyagentos.agent_registry_store as _store_mod
+
+            class _FrozenDatetime(datetime):
+                @classmethod
+                def now(cls, tz=None):  # noqa: ARG003 - signature parity
+                    return now
+
+            monkeypatch.setattr(_store_mod, "datetime", _FrozenDatetime)
+
             slug = _slugify("Clash")
             base_id = mint_canonical_id(slug, now)
 


### PR DESCRIPTION
Fixes #1529 (found by @mandresve minutes after working around #1527 manually).

Root cause of #1529: the #1528 re-pin moved `RKLLAMA_REF` to the fork's rewritten main head, which carries the rerank endpoint but silently dropped the `--preload` server option; the systemd unit the installer generates uses `--preload`, so the service exits with `unrecognized arguments` on every fresh install.

Fix, done at the source:
- The original production pin `06cf874d` (preload + rerank + per-model locking + KV-cache fix + worker daemonize fix) is reachable again: `feat/rebase-onto-upstream` in jaylfc/rkllama was fast-forwarded one commit onto it (no history rewrite; that branch's head was the pin's direct parent). Verified with a fresh clone: `git checkout 06cf874d` works and `server.py` has `--preload`.
- `install-rknpu.sh` re-pins to `06cf874d`. The #1528 reachability guard stays, so a future orphaned pin still fails with the curated error.
- CHANGELOG beta.15 entry updated to tell the corrected story (release not yet promoted; #1531 is held for this).

Note for the fork backlog: rkllama main is missing taOS-required patches (`--preload`, and the daemonize fix exists only on the old lineage). Reconciling main is follow-up work in the rkllama repo, not this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the NPU/RKLLAMA installer’s default pinned version for fresh installs.
  * Stale version pins now fail with a clearer, more actionable error and override instructions; refreshed wording also ensures the `rkllama` service remains startable as expected.
  * Improved setup reliability by tightening installed runtime version detection to match `X.Y.Z`.
  * Enhanced server disk free logging to report `unknown` when the disk check fails.
* **Tests**
  * Stabilized an agent registry collision test by freezing time during the run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->