### PR TITLE
fix: fold the post-beta.15 review batch (promotion + banner findings)

### DIFF
--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -113,8 +113,14 @@ log "kernel=$(uname -r) arch=$(uname -m)"
 if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
-_rt_v="$(librknnrt_current_version || true)"
-log "current librknnrt=${_rt_v:-none}"
+if [[ ! -f "$LIBRKNNRT_DEST" ]]; then
+    log "current librknnrt=not installed"
+elif ! command -v strings >/dev/null 2>&1; then
+    log "current librknnrt=unknown (strings/binutils not installed yet)"
+else
+    _rt_v="$(librknnrt_current_version || true)"
+    log "current librknnrt=${_rt_v:-version string not found}"
+fi
 
 # verify_sha256 <file> <expected_hex> <label>
 # Hard-fails on mismatch: a corrupted download or a tampered mirror must
@@ -358,8 +364,8 @@ install_rkllama() {
         # refuse unadvertised objects) so the verification below sees the
         # same coverage as the re-install path; on failure fall through to
         # the curated error instead of dying on git's raw message.
-        run_as_user git -C "$RKLLAMA_DIR" fetch --quiet origin "$RKLLAMA_REF" 2>/dev/null \
-            || log "note: direct fetch of the pinned ref was refused (normal when the server does not serve unadvertised objects); relying on the refs the clone brought down"
+        _fetch_err="$(run_as_user git -C "$RKLLAMA_DIR" fetch --quiet origin "$RKLLAMA_REF" 2>&1)" \
+            || log "note: direct fetch of the pinned ref failed (${_fetch_err:-no detail}); relying on the refs the clone brought down"
     fi
     # Verify the pinned ref is actually fetchable before checking it out. A
     # fresh clone only has branch/tag refs, so a pin orphaned by a history

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -94,6 +94,15 @@ log()  { printf '\033[1;34m[rknpu]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[rknpu]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[rknpu]\033[0m %s\n' "$*" >&2; exit 1; }
 
+# Single source of truth for reading the installed librknnrt version; used by
+# both the environment banner below and the pin logic later so the two can
+# never drift if upstream rewords the version string.
+librknnrt_current_version() {
+    if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
+        strings "$LIBRKNNRT_DEST" | awk '/librknnrt version: / { print $3; exit }'
+    fi
+}
+
 # Environment banner: every user-posted install log should self-describe the
 # machine it ran on (distro, kernel, board, current NPU runtime) so a failure
 # report is diagnosable without a round-trip asking for these.
@@ -104,9 +113,8 @@ log "kernel=$(uname -r) arch=$(uname -m)"
 if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
-if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
-    log "current librknnrt=$(strings "$LIBRKNNRT_DEST" 2>/dev/null | grep -m1 -oE 'librknnrt version: [0-9]+\.[0-9]+\.[0-9]+' || echo 'version string not found')"
-fi
+_rt_v="$(librknnrt_current_version || true)"
+log "current librknnrt=${_rt_v:-none}"
 
 # verify_sha256 <file> <expected_hex> <label>
 # Hard-fails on mismatch: a corrupted download or a tampered mirror must
@@ -260,12 +268,6 @@ detect_rknpu_driver() {
 
 # -------- (3) librknnrt 2.3.0 pin ----------------------------------------
 
-librknnrt_current_version() {
-    if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
-        strings "$LIBRKNNRT_DEST" | awk '/librknnrt version: / { print $3; exit }'
-    fi
-}
-
 pin_librknnrt() {
     local current
     current="$(librknnrt_current_version || true)"
@@ -356,7 +358,8 @@ install_rkllama() {
         # refuse unadvertised objects) so the verification below sees the
         # same coverage as the re-install path; on failure fall through to
         # the curated error instead of dying on git's raw message.
-        run_as_user git -C "$RKLLAMA_DIR" fetch --quiet origin "$RKLLAMA_REF" 2>/dev/null || true
+        run_as_user git -C "$RKLLAMA_DIR" fetch --quiet origin "$RKLLAMA_REF" 2>/dev/null \
+            || log "note: direct fetch of the pinned ref was refused (normal when the server does not serve unadvertised objects); relying on the refs the clone brought down"
     fi
     # Verify the pinned ref is actually fetchable before checking it out. A
     # fresh clone only has branch/tag refs, so a pin orphaned by a history

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -70,7 +70,11 @@ if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
 command -v python3 >/dev/null 2>&1 && log "python3=$(python3 --version 2>&1)"
-log "disk_free_root=$(df -Ph / 2>/dev/null | awk 'NR==2 {print $4}' || echo unknown)"
+# Report free space on the filesystem the install actually targets;
+# INSTALL_DIR may not exist yet on a fresh box, so fall back to /.
+_df_target="$INSTALL_DIR"
+[[ -d "$_df_target" ]] || _df_target="/"
+log "disk_free=$(df -Ph "$_df_target" 2>/dev/null | awk 'NR==2 {print $4}' || echo unknown) (at $_df_target)"
 log "install_dir=$INSTALL_DIR branch=$BRANCH port=$TAOS_PORT proxy_port=$TAOS_BROWSER_PROXY_PORT qmd_port=$TAOS_QMD_PORT"
 
 # --- system dependencies --------------------------------------------------

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -71,9 +71,12 @@ if [[ -r /proc/device-tree/model ]]; then
 fi
 command -v python3 >/dev/null 2>&1 && log "python3=$(python3 --version 2>&1)"
 # Report free space on the filesystem the install actually targets;
-# INSTALL_DIR may not exist yet on a fresh box, so fall back to /.
+# INSTALL_DIR may not exist yet on a fresh box, so walk up to its nearest
+# existing ancestor (falling back to / masks a full /opt-style volume).
 _df_target="$INSTALL_DIR"
-[[ -d "$_df_target" ]] || _df_target="/"
+while [[ ! -d "$_df_target" && "$_df_target" != "/" ]]; do
+    _df_target="$(dirname "$_df_target")"
+done
 log "disk_free=$(df -Ph "$_df_target" 2>/dev/null | awk 'NR==2 {print $4}' || echo unknown) (at $_df_target)"
 log "install_dir=$INSTALL_DIR branch=$BRANCH port=$TAOS_PORT proxy_port=$TAOS_BROWSER_PROXY_PORT qmd_port=$TAOS_QMD_PORT"
 

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -206,21 +206,26 @@ class LLMProxy:
         # OURS (project.name == tinyagentos): matching on the file alone
         # could latch onto an unrelated project's pyproject higher up (e.g.
         # one in $HOME) and pip-install that project's pins into our venv.
-        def _is_install_root(parent: Path) -> bool:
+        def _load_install_pyproject(parent: Path) -> dict | None:
             pj = parent / "pyproject.toml"
             if not pj.is_file():
-                return False
+                return None
             try:
                 with open(pj, "rb") as fh:
-                    name = tomllib.load(fh).get("project", {}).get("name")
+                    doc = tomllib.load(fh)
             except Exception:  # noqa: BLE001 - unreadable/foreign file: keep walking
-                return False
-            return name == "tinyagentos"
+                return None
+            return doc if doc.get("project", {}).get("name") == "tinyagentos" else None
 
-        project_root = next(
-            (p for p in Path(sys.executable).parents if _is_install_root(p)),
-            None,
-        )
+        # Keep the parsed document alongside the root so the pip fallback
+        # below reuses it instead of re-opening and re-parsing the file.
+        project_root = None
+        pyproject_doc: dict | None = None
+        for parent in Path(sys.executable).parents:
+            pyproject_doc = _load_install_pyproject(parent)
+            if pyproject_doc is not None:
+                project_root = parent
+                break
         if project_root is None:
             logger.warning(
                 "proxy self-heal: no tinyagentos pyproject.toml above %s — skipping",
@@ -253,8 +258,7 @@ class LLMProxy:
             # undo — and a later bare `uv sync --frozen` would strip the
             # extra right back out anyway.
             try:
-                with open(project_root / "pyproject.toml", "rb") as fh:
-                    optional = tomllib.load(fh)["project"]["optional-dependencies"]
+                optional = pyproject_doc["project"]["optional-dependencies"]
                 # strip(): a stray newline/whitespace in a pyproject entry
                 # would otherwise reach pip verbatim and fail opaquely.
                 reqs = [

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -41,14 +41,22 @@ async def _connect_lock(connector_key: str):
 async def _stop_prior_connector(connectors: dict, connector_key: str) -> None:
     """Stop and drop any prior connector under this key. Reconnecting (e.g.
     after a token rotation) must not silently orphan the previous connector's
-    background task/client."""
+    background task/client.
+
+    The pop happens before the await on purpose: callers hold the per-key
+    connect lock, so nothing can observe the gap, and the caller is about to
+    overwrite the slot with a fresh connector either way. If stop() raises,
+    the old connector's task may live until process restart; that is logged
+    loudly rather than blocking the reconnect, because keeping a broken
+    connector registered would be strictly worse."""
     old = connectors.pop(connector_key, None)
     if old is not None and hasattr(old, "stop"):
         try:
             await old.stop()
         except Exception:
-            logger.warning(
-                "channel-hub: failed to stop prior %s connector on reconnect",
+            logger.error(
+                "channel-hub: failed to stop prior %s connector on reconnect; "
+                "its background task may persist until restart",
                 connector_key,
                 exc_info=True,
             )


### PR DESCRIPTION
Folds the five outstanding review findings queued during the beta.15 train (three from Kilo's #1531 promotion-diff review, two from its final banner pass), per the fold-everything rule:

1. Server banner df now reports the filesystem `INSTALL_DIR` actually targets (fallback to `/` pre-creation) and names the path.
2. One shared librknnrt version extractor for the rknpu banner and the pin logic (helper moved above the banner), with an explicit `none` when absent.
3. The best-effort pinned-ref fetch logs a note when refused instead of failing silently.
4. `_selfheal_proxy_extra` keeps the parsed pyproject from the root walk and reuses it in the pip fallback (no second open/parse).
5. `_stop_prior_connector` documents the deliberate pop-before-await (the per-key lock covers the gap) and logs a failed stop at error level since the old task may persist until restart.

Findings assessed as needing no code change, with reasons: the pyproject walk runs only on the self-heal path, not every proxy boot; holding the connect lock across `start()` is the intended per-key serialization (it only serializes the same platform:agent); the webchat stop wrapping is deliberate consistency (its stop() is a no-op today but connectors change).

163 tests pass across the affected suites; bash -n clean on both scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer disk-space reporting to show free space for the actual installation target when available.
  * Strengthened reconnect behavior so a failed prior connector stop won’t prevent reconnection, with clearer logs.
  * Improved upgrade/install resilience when repository fetch or object references are restricted, continuing with existing references when needed.
  * Streamlined installer version detection for more consistent setup output.
* **Refactor**
  * Enhanced upgrade/self-heal logic to reuse parsed project metadata, reducing redundant reads during optional dependency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->