### PR TITLE
fix(lifecycle): resume every paused agent after a controller restart (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- A controller update or restart no longer silently strands agents in a paused state: agents whose framework handled the shutdown protocol itself, hostless agents, and agents whose containers boot slower than the controller are all resumed at boot (with background retries), and anything that still cannot be resumed raises a visible warning instead of staying paused quietly.
+
 ## [1.0.0-beta.15] - 2026-07-02
 
 ### Fixed

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -61,12 +61,19 @@ class TestResumeAgentsFromNotes:
 
     @pytest.mark.asyncio
     async def test_unpauses_hostless_agent_directly(self, tmp_path):
+        """Hostless agents unpause without a /resume call, and any note on
+        disk is preserved (nothing consumed it)."""
         agent = {"name": "wkrlan1", "host": "", "paused": True}
         state = _app_state(tmp_path, [agent])
+        note_dir = tmp_path / "agent-memory" / "wkrlan1"
+        note_dir.mkdir(parents=True)
+        note_file = note_dir / "resume_note.json"
+        note_file.write_text(json.dumps({"reason": "pause"}))
 
         await ro.resume_agents_from_notes(state)
 
         assert agent["paused"] is False
+        assert note_file.exists()
 
     @pytest.mark.asyncio
     async def test_uses_existing_note_when_present(self, tmp_path, monkeypatch):

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -1,0 +1,151 @@
+"""Boot-time agent resume after a controller update/restart (#97).
+
+The graceful-shutdown pause marks every agent paused=True; these tests pin
+that the boot-time resume covers every paused agent instead of silently
+stranding them:
+  - an agent whose framework handled /prepare-for-shutdown itself (no
+    controller-side resume note) is still resumed;
+  - a hostless agent is unpaused directly (there is no /resume to call);
+  - an agent that is unreachable at boot is retried in the background and
+    resumed when it comes back;
+  - an agent that never comes back leaves a WARNING notification, not silence.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import tinyagentos.restart_orchestrator as ro
+
+
+def _app_state(tmp_path, agents):
+    notifications = SimpleNamespace(add=AsyncMock())
+    config = SimpleNamespace(agents=agents, config_path=tmp_path / "config.yaml")
+    return SimpleNamespace(
+        config=config,
+        data_dir=tmp_path,
+        notifications=notifications,
+        _background_tasks=set(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_config_write(monkeypatch):
+    import tinyagentos.config as cfg
+
+    monkeypatch.setattr(cfg, "save_config_locked", AsyncMock())
+
+
+class TestResumeAgentsFromNotes:
+    @pytest.mark.asyncio
+    async def test_resumes_agent_without_controller_note(self, tmp_path, monkeypatch):
+        """A framework that answered /prepare-for-shutdown leaves no
+        controller-side note; resume must synthesize one, not skip the agent."""
+        agent = {"name": "naira", "host": "10.0.0.5", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        posted = {}
+
+        async def fake_post(host, port, note):
+            posted["note"] = note
+            return True
+
+        monkeypatch.setattr(ro, "_post_resume", fake_post)
+        await ro.resume_agents_from_notes(state)
+
+        assert agent["paused"] is False
+        assert posted["note"]["reason"] == "restart"
+        state.notifications.add.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unpauses_hostless_agent_directly(self, tmp_path):
+        agent = {"name": "wkrlan1", "host": "", "paused": True}
+        state = _app_state(tmp_path, [agent])
+
+        await ro.resume_agents_from_notes(state)
+
+        assert agent["paused"] is False
+
+    @pytest.mark.asyncio
+    async def test_uses_existing_note_when_present(self, tmp_path, monkeypatch):
+        agent = {"name": "a1", "host": "10.0.0.6", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        note_dir = tmp_path / "agent-memory" / "a1"
+        note_dir.mkdir(parents=True)
+        (note_dir / "resume_note.json").write_text(
+            json.dumps({"reason": "pause", "next_step_hint": "carry on"})
+        )
+        posted = {}
+
+        async def fake_post(host, port, note):
+            posted["note"] = note
+            return True
+
+        monkeypatch.setattr(ro, "_post_resume", fake_post)
+        await ro.resume_agents_from_notes(state)
+
+        assert posted["note"]["next_step_hint"] == "carry on"
+        assert agent["paused"] is False
+        assert not (note_dir / "resume_note.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_unreachable_agent_resumed_by_retry_loop(self, tmp_path, monkeypatch):
+        """The agent container boots slower than the controller: the first
+        attempt fails, the background retry succeeds and unpauses it."""
+        agent = {"name": "slow", "host": "10.0.0.7", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        attempts = {"n": 0}
+
+        async def flaky_post(host, port, note):
+            attempts["n"] += 1
+            return attempts["n"] >= 2
+
+        monkeypatch.setattr(ro, "_post_resume", flaky_post)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_INTERVAL_S", 0.01)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_WINDOW_S", 5)
+
+        await ro.resume_agents_from_notes(state)
+        assert agent["paused"] is True  # first attempt failed
+        assert state._background_tasks  # retry loop spawned
+
+        for task in list(state._background_tasks):
+            await task
+
+        assert agent["paused"] is False
+        titles = [c.kwargs["title"] for c in state.notifications.add.await_args_list]
+        assert any("resumed" in t.lower() for t in titles)
+
+    @pytest.mark.asyncio
+    async def test_never_returning_agent_leaves_warning(self, tmp_path, monkeypatch):
+        agent = {"name": "gone", "host": "10.0.0.8", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+
+        async def always_fail(host, port, note):
+            return False
+
+        monkeypatch.setattr(ro, "_post_resume", always_fail)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_INTERVAL_S", 0.01)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_WINDOW_S", 0.05)
+
+        await ro.resume_agents_from_notes(state)
+        for task in list(state._background_tasks):
+            await task
+
+        assert agent["paused"] is True
+        warnings = [
+            c for c in state.notifications.add.await_args_list
+            if c.kwargs.get("level") == "warning"
+        ]
+        assert warnings and "gone" in warnings[-1].kwargs["message"]
+
+    @pytest.mark.asyncio
+    async def test_no_paused_agents_is_a_noop(self, tmp_path):
+        agent = {"name": "up", "host": "10.0.0.9", "paused": False}
+        state = _app_state(tmp_path, [agent])
+
+        await ro.resume_agents_from_notes(state)
+
+        state.notifications.add.assert_not_awaited()
+        assert not state._background_tasks

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -264,10 +264,12 @@ def _load_or_synthesize_note(note_path: Path) -> dict:
         except Exception:
             logger.warning("unreadable resume note at %s; synthesizing", note_path)
     # No controller-side note: the framework handled /prepare-for-shutdown
-    # itself and keeps its own state, so a minimal note is enough.
+    # itself and keeps its own state, so a minimal note is enough. Field
+    # shapes mirror _write_controller_note (paused_at is an int there) so a
+    # framework parsing either source sees a single contract.
     return {
         "reason": "restart",
-        "paused_at": None,
+        "paused_at": int(time.time()),
         "last_user_msg": None,
         "in_progress_task": None,
         "next_step_hint": "controller restarted; resume normal operation",
@@ -284,13 +286,16 @@ async def _post_resume(host: str, port: int, note: dict) -> bool:
         return False
 
 
-async def _unpause(app_state, agent: dict, note_path: Path) -> None:
+async def _unpause(app_state, agent: dict, note_path: Path | None) -> None:
     agent["paused"] = False
-    note_path.unlink(missing_ok=True)
     from tinyagentos.config import save_config_locked
 
     config = app_state.config
     await save_config_locked(config, config.config_path)
+    # Delete the note only AFTER the unpause is persisted: a failed config
+    # write must never leave paused=True with the recovery note already gone.
+    if note_path is not None:
+        note_path.unlink(missing_ok=True)
 
 
 async def resume_agents_from_notes(app_state) -> None:
@@ -304,6 +309,9 @@ async def resume_agents_from_notes(app_state) -> None:
 
     resumed: list[str] = []
     pending: list[str] = []
+    # (agent, note_path-to-delete) pairs; flags flip and persist in ONE locked
+    # config write below instead of one write per agent.
+    finalize: list[tuple[dict, Path | None]] = []
 
     for agent in paused:
         name = agent["name"]
@@ -313,17 +321,29 @@ async def resume_agents_from_notes(app_state) -> None:
 
         if not host:
             # Nothing to call: the pause flag is the only thing holding the
-            # agent back, so clear it.
-            await _unpause(app_state, agent, note_path)
+            # agent back, so clear it. Keep any note on disk: nothing consumed
+            # it, and it may carry state worth inspecting.
+            finalize.append((agent, None))
             resumed.append(name)
             continue
 
         note = _load_or_synthesize_note(note_path)
         if await _post_resume(host, port, note):
-            await _unpause(app_state, agent, note_path)
+            finalize.append((agent, note_path))
             resumed.append(name)
         else:
             pending.append(name)
+
+    if finalize:
+        for agent, _ in finalize:
+            agent["paused"] = False
+        from tinyagentos.config import save_config_locked
+
+        await save_config_locked(config, config.config_path)
+        # Notes go only after the unpauses are persisted (see _unpause).
+        for _, np_ in finalize:
+            if np_ is not None:
+                np_.unlink(missing_ok=True)
 
     if resumed:
         await notif.add(
@@ -354,22 +374,29 @@ async def _resume_retry_loop(app_state, names: list[str]) -> None:
 
     while remaining and time.monotonic() < deadline:
         await asyncio.sleep(_RESUME_RETRY_INTERVAL_S)
-        for agent in list(config.agents):
-            name = agent["name"]
-            if name not in remaining or not agent.get("paused", False):
-                remaining.discard(name)
-                continue
-            note_path = data_dir / "agent-memory" / name / "resume_note.json"
-            note = _load_or_synthesize_note(note_path)
-            if await _post_resume(agent.get("host", ""), agent.get("port", 8080), note):
-                await _unpause(app_state, agent, note_path)
-                remaining.discard(name)
-                await notif.add(
-                    title=f"Agent {name} resumed",
-                    message="Resumed after the controller restart (agent took a while to come back up).",
-                    level="info",
-                    source="system.lifecycle",
-                )
+        by_name = {a["name"]: a for a in config.agents}
+        for name in list(remaining):
+            # Any raise past this point (config write, notification store)
+            # would kill the loop and re-create the silent pause this fix
+            # exists to remove; log and keep going instead.
+            try:
+                agent = by_name.get(name)
+                if agent is None or not agent.get("paused", False):
+                    remaining.discard(name)
+                    continue
+                note_path = data_dir / "agent-memory" / name / "resume_note.json"
+                note = _load_or_synthesize_note(note_path)
+                if await _post_resume(agent.get("host", ""), agent.get("port", 8080), note):
+                    await _unpause(app_state, agent, note_path)
+                    remaining.discard(name)
+                    await notif.add(
+                        title=f"Agent {name} resumed",
+                        message="Resumed after the controller restart (agent took a while to come back up).",
+                        level="info",
+                        source="system.lifecycle",
+                    )
+            except Exception:
+                logger.exception("resume retry for agent %s failed; will retry", name)
 
     if remaining:
         await notif.add(

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -243,49 +243,141 @@ async def apply_pending_restart_check(app_state) -> None:
         )
 
 
+# The graceful-shutdown pause (prepare()) marks EVERY agent paused=True, so the
+# boot-time resume must cover every paused agent or a routine update/restart
+# strands agents paused with no indication (#97):
+#   - a framework that answered /prepare-for-shutdown itself leaves NO
+#     controller-side note, so a note-gated resume skipped exactly the agents
+#     that implemented the protocol correctly;
+#   - hostless agents have no /resume to call and were never unpaused;
+#   - agents whose containers boot slower than the controller failed the single
+#     resume attempt and stayed paused silently.
+
+_RESUME_RETRY_INTERVAL_S = 30
+_RESUME_RETRY_WINDOW_S = 600
+
+
+def _load_or_synthesize_note(note_path: Path) -> dict:
+    if note_path.exists():
+        try:
+            return json.loads(note_path.read_text())
+        except Exception:
+            logger.warning("unreadable resume note at %s; synthesizing", note_path)
+    # No controller-side note: the framework handled /prepare-for-shutdown
+    # itself and keeps its own state, so a minimal note is enough.
+    return {
+        "reason": "restart",
+        "paused_at": None,
+        "last_user_msg": None,
+        "in_progress_task": None,
+        "next_step_hint": "controller restarted; resume normal operation",
+        "context_snapshot": {},
+    }
+
+
+async def _post_resume(host: str, port: int, note: dict) -> bool:
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(f"http://{host}:{port}/resume", json=note)
+            return resp.status_code == 200
+    except Exception:
+        return False
+
+
+async def _unpause(app_state, agent: dict, note_path: Path) -> None:
+    agent["paused"] = False
+    note_path.unlink(missing_ok=True)
+    from tinyagentos.config import save_config_locked
+
+    config = app_state.config
+    await save_config_locked(config, config.config_path)
+
+
 async def resume_agents_from_notes(app_state) -> None:
     config = app_state.config
     data_dir: Path = app_state.data_dir
     notif = app_state.notifications
 
-    resumed = []
-    for agent in config.agents:
-        if not agent.get("paused", False):
-            continue
+    paused = [a for a in config.agents if a.get("paused", False)]
+    if not paused:
+        return
+
+    resumed: list[str] = []
+    pending: list[str] = []
+
+    for agent in paused:
         name = agent["name"]
         note_path = data_dir / "agent-memory" / name / "resume_note.json"
-        if not note_path.exists():
-            continue
-
-        try:
-            note = json.loads(note_path.read_text())
-        except Exception:
-            continue
-
         host = agent.get("host", "")
         port = agent.get("port", 8080)
+
         if not host:
+            # Nothing to call: the pause flag is the only thing holding the
+            # agent back, so clear it.
+            await _unpause(app_state, agent, note_path)
+            resumed.append(name)
             continue
 
-        try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(
-                    f"http://{host}:{port}/resume",
-                    json=note,
-                )
-                if resp.status_code == 200:
-                    agent["paused"] = False
-                    note_path.unlink(missing_ok=True)
-                    resumed.append(name)
-        except Exception:
-            pass  # leave paused=True and note in place
+        note = _load_or_synthesize_note(note_path)
+        if await _post_resume(host, port, note):
+            await _unpause(app_state, agent, note_path)
+            resumed.append(name)
+        else:
+            pending.append(name)
 
     if resumed:
-        from tinyagentos.config import save_config_locked
-        await save_config_locked(config, config.config_path)
         await notif.add(
-            title="All agents resumed",
-            message=f"Resumed {len(resumed)} agent(s) from resume notes: {', '.join(resumed)}",
+            title="Agents resumed",
+            message=f"Resumed {len(resumed)} agent(s) after restart: {', '.join(resumed)}",
             level="info",
+            source="system.lifecycle",
+        )
+
+    if pending:
+        # Agent containers can boot slower than the controller; keep retrying
+        # in the background instead of stranding them paused, and say so loudly
+        # if they never come back.
+        task = asyncio.create_task(_resume_retry_loop(app_state, pending))
+        bg = getattr(app_state, "_background_tasks", None)
+        if bg is not None:
+            bg.add(task)
+            task.add_done_callback(bg.discard)
+
+
+async def _resume_retry_loop(app_state, names: list[str]) -> None:
+    config = app_state.config
+    data_dir: Path = app_state.data_dir
+    notif = app_state.notifications
+
+    remaining = set(names)
+    deadline = time.monotonic() + _RESUME_RETRY_WINDOW_S
+
+    while remaining and time.monotonic() < deadline:
+        await asyncio.sleep(_RESUME_RETRY_INTERVAL_S)
+        for agent in list(config.agents):
+            name = agent["name"]
+            if name not in remaining or not agent.get("paused", False):
+                remaining.discard(name)
+                continue
+            note_path = data_dir / "agent-memory" / name / "resume_note.json"
+            note = _load_or_synthesize_note(note_path)
+            if await _post_resume(agent.get("host", ""), agent.get("port", 8080), note):
+                await _unpause(app_state, agent, note_path)
+                remaining.discard(name)
+                await notif.add(
+                    title=f"Agent {name} resumed",
+                    message="Resumed after the controller restart (agent took a while to come back up).",
+                    level="info",
+                    source="system.lifecycle",
+                )
+
+    if remaining:
+        await notif.add(
+            title="Some agents are still paused",
+            message=(
+                f"Could not resume after the restart: {', '.join(sorted(remaining))}. "
+                "They stay paused; check the agent containers, then unpause from the Agents app."
+            ),
+            level="warning",
             source="system.lifecycle",
         )

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -347,15 +347,20 @@ async def resume_agents_from_notes(app_state) -> None:
             await save_config_locked(config, config.config_path)
         except Exception:
             logger.exception("persisting agent unpauses failed")
-            await notif.add(
-                title="Agent resume not persisted",
-                message=(
-                    "Agents were resumed but the config write failed; they may "
-                    "show as paused again after the next restart."
-                ),
-                level="warning",
-                source="system.lifecycle",
-            )
+            try:
+                await notif.add(
+                    title="Agent resume not persisted",
+                    message=(
+                        "Agents were resumed but the config write failed; they may "
+                        "show as paused again after the next restart."
+                    ),
+                    level="warning",
+                    source="system.lifecycle",
+                )
+            except Exception:
+                # The log line above already carries the failure; a broken
+                # notification store must not abort the rest of the resume.
+                logger.exception("could not post the persist-failure warning")
         else:
             # Notes go only after the unpauses are persisted (see _unpause).
             for _, np_ in finalize:
@@ -427,9 +432,9 @@ async def _resume_retry_loop(app_state, names: list[str]) -> None:
         try:
             await notif.add(
                 title="Some agents are still paused",
-            message=(
-                f"Could not resume after the restart: {', '.join(sorted(remaining))}. "
-                "They stay paused; check the agent containers, then unpause from the Agents app."
+                message=(
+                    f"Could not resume after the restart: {', '.join(sorted(remaining))}. "
+                    "They stay paused; check the agent containers, then unpause from the Agents app."
                 ),
                 level="warning",
                 source="system.lifecycle",

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -335,15 +335,32 @@ async def resume_agents_from_notes(app_state) -> None:
             pending.append(name)
 
     if finalize:
+        # In-memory flags flip regardless of persistence: the agents were
+        # genuinely resumed over /resume, so blocking them in memory because a
+        # disk write failed would be worse than the divergence. A failed write
+        # is surfaced loudly and the recovery notes are kept.
         for agent, _ in finalize:
             agent["paused"] = False
         from tinyagentos.config import save_config_locked
 
-        await save_config_locked(config, config.config_path)
-        # Notes go only after the unpauses are persisted (see _unpause).
-        for _, np_ in finalize:
-            if np_ is not None:
-                np_.unlink(missing_ok=True)
+        try:
+            await save_config_locked(config, config.config_path)
+        except Exception:
+            logger.exception("persisting agent unpauses failed")
+            await notif.add(
+                title="Agent resume not persisted",
+                message=(
+                    "Agents were resumed but the config write failed; they may "
+                    "show as paused again after the next restart."
+                ),
+                level="warning",
+                source="system.lifecycle",
+            )
+        else:
+            # Notes go only after the unpauses are persisted (see _unpause).
+            for _, np_ in finalize:
+                if np_ is not None:
+                    np_.unlink(missing_ok=True)
 
     if resumed:
         await notif.add(
@@ -374,6 +391,9 @@ async def _resume_retry_loop(app_state, names: list[str]) -> None:
 
     while remaining and time.monotonic() < deadline:
         await asyncio.sleep(_RESUME_RETRY_INTERVAL_S)
+        # Rebuilt each tick on purpose: agents can be added or removed while
+        # the 10-minute window runs, and a stale index would resume a deleted
+        # agent or miss a re-added one.
         by_name = {a["name"]: a for a in config.agents}
         for name in list(remaining):
             # Any raise past this point (config write, notification store)
@@ -387,6 +407,9 @@ async def _resume_retry_loop(app_state, names: list[str]) -> None:
                 note_path = data_dir / "agent-memory" / name / "resume_note.json"
                 note = _load_or_synthesize_note(note_path)
                 if await _post_resume(agent.get("host", ""), agent.get("port", 8080), note):
+                    # Per-agent config write is fine here: retry successes are
+                    # rare, isolated events (one agent per 30s tick at worst),
+                    # unlike the boot pass which batches.
                     await _unpause(app_state, agent, note_path)
                     remaining.discard(name)
                     await notif.add(
@@ -399,12 +422,20 @@ async def _resume_retry_loop(app_state, names: list[str]) -> None:
                 logger.exception("resume retry for agent %s failed; will retry", name)
 
     if remaining:
-        await notif.add(
-            title="Some agents are still paused",
+        # The whole point of this warning is to make the failure visible; a
+        # notification-store error must not silently swallow it.
+        try:
+            await notif.add(
+                title="Some agents are still paused",
             message=(
                 f"Could not resume after the restart: {', '.join(sorted(remaining))}. "
                 "They stay paused; check the agent containers, then unpause from the Agents app."
-            ),
-            level="warning",
-            source="system.lifecycle",
-        )
+                ),
+                level="warning",
+                source="system.lifecycle",
+            )
+        except Exception:
+            logger.exception(
+                "could not post the still-paused warning; agents still paused: %s",
+                ", ".join(sorted(remaining)),
+            )


### PR DESCRIPTION
Fixes task #97 (controller update/restart silently pauses running agents), reproduced live minutes after the beta.15 Settings update: agent `naira` (container running) and both workers stuck `paused: true` with zero resume notes on disk.

Root cause: `prepare()` (systemd stop hook) marks EVERY agent `paused=True`, but the boot-time `resume_agents_from_notes` was note-gated, host-gated, and single-shot:
1. A framework that answers `/prepare-for-shutdown` itself (200) leaves no controller-side note, so the resume skipped exactly the agents that implemented the protocol correctly.
2. Hostless agents were never unpaused (nothing to call, flag never cleared).
3. An agent container that boots slower than the controller failed the one unretried attempt and stayed paused, silently.

Fix, all in `restart_orchestrator.py`:
- Resume iterates every `paused=True` agent; a missing note is synthesized (the framework keeps its own state in that case).
- Hostless agents are unpaused directly.
- Unreachable agents get a supervised background retry loop (30s interval, 10 minute window) with a per-agent resumed notification on late success.
- Anything still paused when the window closes raises a WARNING naming the agents, so the failure mode can never be silent again.

Six new tests pin each previously-silent path; 69 pass across the orchestrator-adjacent suites. CHANGELOG Unreleased entry included.

After merge I will unstick the three currently-paused agents on the Pi.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented paused agents from remaining stuck after controller updates/restarts.
  * On boot, automatically resumes paused agents, using any existing resume instructions when available and synthesizing safe defaults when not.
  * Retries resuming agents that aren’t reachable yet, and issues a visible warning if an agent still can’t be resumed after the retry window.
* **Tests**
  * Added coverage for boot-time resume behavior, retry handling, and warning emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->