### PR TITLE
feat(setup): NPU-conditional checklist step for the rkllama backend (#1535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Added
+- On Rockchip boards the setup checklist now includes an "Install the NPU backend" step: it appears only when an NPU is detected, opens the Store where the rkllama backend installs with one click, and ticks itself once the backend is running. Previously nothing in the setup flow ever surfaced the NPU install.
+
 ## [1.0.0-beta.15] - 2026-07-02
 
 ### Fixed

--- a/desktop/src/components/SetupChecklist.test.tsx
+++ b/desktop/src/components/SetupChecklist.test.tsx
@@ -175,4 +175,32 @@ describe("SetupChecklist", () => {
     render(<SetupChecklist />);
     expect(await screen.findByRole("list")).toBeInTheDocument();
   });
+
+  it("hides the NPU step on boards without an NPU", async () => {
+    mockFetchStatus(baseStatus);
+    render(<SetupChecklist />);
+    await screen.findByText("Get started");
+    expect(screen.queryByText("Install the NPU backend")).toBeNull();
+    expect(screen.getByText("0/5")).toBeInTheDocument();
+  });
+
+  it("shows the NPU step as a sixth item when an NPU is present", async () => {
+    mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: false });
+    render(<SetupChecklist />);
+    expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
+    expect(
+      screen.getByText("Install rkllama from the Store to run models on this device's NPU"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("0/6")).toBeInTheDocument();
+  });
+
+  it("marks the NPU step complete when the backend is running", async () => {
+    mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: true });
+    render(<SetupChecklist />);
+    const doneStep = await screen.findByRole("button", {
+      name: "Install the NPU backend — complete",
+    });
+    expect(doneStep).toBeInTheDocument();
+    expect(screen.getByText("1/6")).toBeInTheDocument();
+  });
 });

--- a/desktop/src/components/SetupChecklist.test.tsx
+++ b/desktop/src/components/SetupChecklist.test.tsx
@@ -194,6 +194,30 @@ describe("SetupChecklist", () => {
     expect(screen.getByText("0/6")).toBeInTheDocument();
   });
 
+  it("stays visible when core steps are complete but the NPU step is outstanding", async () => {
+    mockFetchStatus({
+      ...baseStatus,
+      has_provider: true,
+      taos_model_set: true,
+      complete: true,
+      npu_present: true,
+      npu_backend_running: false,
+    });
+    render(<SetupChecklist />);
+    expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
+  });
+
+  it("hides once complete and the NPU backend is running", () => {
+    mockFetchStatus({
+      ...baseStatus,
+      complete: true,
+      npu_present: true,
+      npu_backend_running: true,
+    });
+    const { container } = render(<SetupChecklist />);
+    expect(container.innerHTML).toBe("");
+  });
+
   it("marks the NPU step complete when the backend is running", async () => {
     mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: true });
     render(<SetupChecklist />);

--- a/desktop/src/components/SetupChecklist.tsx
+++ b/desktop/src/components/SetupChecklist.tsx
@@ -94,7 +94,12 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
     if (app) openWindow(step.appId, app.defaultSize);
   };
 
-  if (!status || status.dismissed || status.complete) return null;
+  if (!status || status.dismissed) return null;
+  // complete covers the two core steps only; on an NPU board the backend
+  // install still deserves a surface until it is running (or the user
+  // dismisses the checklist), otherwise it would never be seen (#1535).
+  const npuOutstanding = Boolean(status.npu_present) && !status.npu_backend_running;
+  if (status.complete && !npuOutstanding) return null;
 
   const steps = status.npu_present ? [...STEPS, NPU_STEP] : STEPS;
   const doneCount = steps.filter((s) => Boolean(status[s.key])).length;

--- a/desktop/src/components/SetupChecklist.tsx
+++ b/desktop/src/components/SetupChecklist.tsx
@@ -9,6 +9,8 @@ interface SetupStatus {
   taos_model_set: boolean;
   has_agent: boolean;
   memory_enabled: boolean;
+  npu_present?: boolean;
+  npu_backend_running?: boolean;
   dismissed: boolean;
   complete: boolean;
 }
@@ -52,6 +54,16 @@ const STEPS: Step[] = [
   },
 ];
 
+// Shown only when the board has a Rockchip NPU (#1535): the backend that
+// serves on-device models is a Store install, and without this step nothing
+// in the setup flow ever surfaces it.
+const NPU_STEP: Step = {
+  key: "npu_backend_running",
+  label: "Install the NPU backend",
+  detail: "Install rkllama from the Store to run models on this device's NPU",
+  appId: "store",
+};
+
 export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   const [status, setStatus] = useState<SetupStatus | null>(null);
   const [dismissing, setDismissing] = useState(false);
@@ -84,7 +96,8 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
 
   if (!status || status.dismissed || status.complete) return null;
 
-  const doneCount = STEPS.filter((s) => Boolean(status[s.key])).length;
+  const steps = status.npu_present ? [...STEPS, NPU_STEP] : STEPS;
+  const doneCount = steps.filter((s) => Boolean(status[s.key])).length;
 
   return (
     <div className="border-b border-white/10">
@@ -93,7 +106,7 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
         <div className="flex items-center gap-2">
           <span className="text-xs font-medium text-shell-text">Get started</span>
           <span className="text-[10px] text-shell-text-tertiary bg-white/5 rounded-full px-1.5 py-0.5">
-            {doneCount}/{STEPS.length}
+            {doneCount}/{steps.length}
           </span>
         </div>
         <button
@@ -109,7 +122,7 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
 
       {/* Steps */}
       <ul role="list" className="pb-2">
-        {STEPS.map((step) => {
+        {steps.map((step) => {
           const done = Boolean(status[step.key]);
           return (
             <li key={step.key}>

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -224,6 +224,9 @@ class TestSetupStatus:
 
     async def test_npu_absent_by_default(self, client, app):
         """No hardware profile (or a non-Rockchip one) hides the NPU step."""
+        # Pin the profile: another test in this class sets a Rockchip profile
+        # on the shared app fixture, and test order must not matter.
+        app.state.hardware_profile = None
         app.state.config.backends = []
         resp = await client.get("/api/setup/status")
         data = resp.json()

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -222,6 +222,44 @@ class TestSetupStatus:
         resp = await client.get("/api/setup/status")
         assert resp.json()["complete"] is False
 
+    async def test_npu_absent_by_default(self, client, app):
+        """No hardware profile (or a non-Rockchip one) hides the NPU step."""
+        app.state.config.backends = []
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["npu_present"] is False
+        assert data["npu_backend_running"] is False
+
+    async def test_npu_present_and_backend_state(self, client, app, monkeypatch):
+        """A Rockchip profile surfaces the step; completion mirrors a live
+        rkllama probe (#1535)."""
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+        import tinyagentos.installers.rkllama_installer as rk
+
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: True)
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["npu_present"] is True
+        assert data["npu_backend_running"] is True
+
+    async def test_npu_present_backend_not_running(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+        import tinyagentos.installers.rkllama_installer as rk
+
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["npu_present"] is True
+        assert data["npu_backend_running"] is False
+
     async def test_dismissed_false_initially(self, client):
         resp = await client.get("/api/setup/status")
         assert resp.json()["dismissed"] is False

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -49,6 +49,21 @@ async def setup_status(request: Request):
     setup_prefs = await store.get_preference("user", _PREF_NAMESPACE)
     dismissed = bool(setup_prefs.get("dismissed", False))
 
+    # NPU-conditional step (#1535): on a Rockchip board the checklist offers
+    # the rkllama backend install (via the Store), complete once a live
+    # rkllama answers. Boards without an NPU never see the step.
+    profile = getattr(request.app.state, "hardware_profile", None)
+    npu = getattr(profile, "npu", None)
+    npu_present = bool(npu is not None and getattr(npu, "type", "none") == "rknpu")
+    npu_backend_running = False
+    if npu_present:
+        import asyncio
+
+        from tinyagentos.installers.rkllama_installer import rkllama_is_running
+
+        # Socket probes are blocking; keep them off the event loop.
+        npu_backend_running = await asyncio.to_thread(rkllama_is_running)
+
     # complete: the two core steps done
     complete = has_provider and taos_model_set
 
@@ -58,6 +73,8 @@ async def setup_status(request: Request):
         "taos_model_set": taos_model_set,
         "has_agent": has_agent,
         "memory_enabled": memory_enabled,
+        "npu_present": npu_present,
+        "npu_backend_running": npu_backend_running,
         "dismissed": dismissed,
         "complete": complete,
     })

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -25,6 +25,8 @@ async def setup_status(request: Request):
       taos_model_set  — the taOS agent has a model configured
       has_agent       — at least one deployed agent exists
       memory_enabled  — user completed the taOSmd memory setup wizard
+      npu_present     — a Rockchip NPU was detected on this board (#1535)
+      npu_backend_running — a live rkllama answers on the taOS or legacy port
       dismissed       — user dismissed the checklist
       complete        — has_provider AND taos_model_set (the core two steps)
     """
@@ -61,7 +63,8 @@ async def setup_status(request: Request):
 
         from tinyagentos.installers.rkllama_installer import rkllama_is_running
 
-        # Socket probes are blocking; keep them off the event loop.
+        # rkllama_is_running never raises, but its socket probes block;
+        # keep them off the event loop.
         npu_backend_running = await asyncio.to_thread(rkllama_is_running)
 
     # complete: the two core steps done


### PR DESCRIPTION
Implements the recommended option from #1535 (the smallest honest fix, explicit consent kept).

- `/api/setup/status` gains `npu_present` (cached hardware profile, `npu.type == rknpu`) and `npu_backend_running` (live rkllama probe via `rkllama_is_running`, run in a thread so the socket probes stay off the event loop). Probe only runs when an NPU is present.
- `SetupChecklist` appends a sixth step on NPU boards: "Install the NPU backend", detail pointing at the Store (where the existing one-click rkllama install lives, #844), completing once the backend answers. Step count adapts (0/6 etc.). Non-NPU boards render exactly as before.
- Tests: 3 new backend cases (absent by default, present+running, present+not-running) and 3 new component cases (hidden without NPU, shown as sixth item, complete state). 22 + 15 pass; tsc clean.

Closes #1535. The longer-term hardware-optimized setup surface (#332) can grow out of this step later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “Install the NPU backend” step for compatible Rockchip devices, with a one-click Store flow.
  * Updated the setup status response to report NPU presence and whether the NPU backend is running.
* **Bug Fixes**
  * Improved checklist visibility/completion so the checklist remains until the NPU backend is actually running on NPU devices.
* **Tests**
  * Expanded checklist tests for NPU step visibility, progress counters, and completion behavior.
  * Added API tests validating NPU fields for default and Rockchip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->