### PR TITLE
chore(release): 1.0.0-beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.16] - 2026-07-02
+
 ### Added
 - On Rockchip boards the setup checklist now includes an "Install the NPU backend" step: it appears only when an NPU is detected, opens the Store where the rkllama backend installs with one click, and ticks itself once the backend is running. Previously nothing in the setup flow ever surfaced the NPU install.
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.15",
+  "version": "1.0.0-beta.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.15"
+version = "1.0.0-beta.16"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.15"
+__version__ = "1.0.0-beta.16"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b15"
+version = "1.0.0b16"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump + CHANGELOG for 1.0.0-beta.16.

Carries two merged PRs on top of beta.15, both live-verified on the dev Pi today:
- #1536: a controller update/restart no longer silently strands agents paused. Verified end to end on hardware: stop hook paused 3 agents, hostless workers auto-resumed instantly at boot, the unreachable hosted agent got the full retry window and then a visible warning naming it.
- #1537: NPU-conditional setup checklist step for the rkllama backend (verified live: npu_present=true on the Pi, step gating correct).

After merge: promote dev to master, tag v1.0.0-beta.16, GitHub Release marked latest.