### PR TITLE
Release 1.0.0-beta.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.16] - 2026-07-02
+
 ### Added
 - On Rockchip boards the setup checklist now includes an "Install the NPU backend" step: it appears only when an NPU is detected, opens the Store where the rkllama backend installs with one click, and ticks itself once the backend is running. Previously nothing in the setup flow ever surfaced the NPU install.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 ### Added
 - On Rockchip boards the setup checklist now includes an "Install the NPU backend" step: it appears only when an NPU is detected, opens the Store where the rkllama backend installs with one click, and ticks itself once the backend is running. Previously nothing in the setup flow ever surfaced the NPU install.
 
+### Fixed
+- A controller update or restart no longer silently strands agents in a paused state: agents whose framework handled the shutdown protocol itself, hostless agents, and agents whose containers boot slower than the controller are all resumed at boot (with background retries), and anything that still cannot be resumed raises a visible warning instead of staying paused quietly.
+
 ## [1.0.0-beta.15] - 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Added
+- On Rockchip boards the setup checklist now includes an "Install the NPU backend" step: it appears only when an NPU is detected, opens the Store where the rkllama backend installs with one click, and ticks itself once the backend is running. Previously nothing in the setup flow ever surfaced the NPU install.
+
 ## [1.0.0-beta.15] - 2026-07-02
 
 ### Fixed

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.15",
+  "version": "1.0.0-beta.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/components/SetupChecklist.test.tsx
+++ b/desktop/src/components/SetupChecklist.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { SetupChecklist } from "./SetupChecklist";
 
 vi.mock("@/stores/process-store", () => ({
@@ -72,15 +72,22 @@ describe("SetupChecklist", () => {
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders nothing when status.dismissed is true", () => {
+  it("renders nothing when status.dismissed is true", async () => {
     mockFetchStatus({ ...baseStatus, dismissed: true });
     const { container } = render(<SetupChecklist />);
+    // Wait for the status fetch to land, then assert against the settled
+    // render; asserting synchronously would pass trivially on the initial
+    // (status === null) render even if the hiding logic were broken.
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalledWith("/api/setup/status"));
+    await act(async () => {});
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders nothing when status.complete is true", () => {
+  it("renders nothing when status.complete is true", async () => {
     mockFetchStatus({ ...baseStatus, complete: true });
     const { container } = render(<SetupChecklist />);
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalledWith("/api/setup/status"));
+    await act(async () => {});
     expect(container.innerHTML).toBe("");
   });
 
@@ -207,7 +214,7 @@ describe("SetupChecklist", () => {
     expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
   });
 
-  it("hides once complete and the NPU backend is running", () => {
+  it("hides once complete and the NPU backend is running", async () => {
     mockFetchStatus({
       ...baseStatus,
       complete: true,
@@ -215,6 +222,8 @@ describe("SetupChecklist", () => {
       npu_backend_running: true,
     });
     const { container } = render(<SetupChecklist />);
+    await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalledWith("/api/setup/status"));
+    await act(async () => {});
     expect(container.innerHTML).toBe("");
   });
 

--- a/desktop/src/components/SetupChecklist.test.tsx
+++ b/desktop/src/components/SetupChecklist.test.tsx
@@ -175,4 +175,56 @@ describe("SetupChecklist", () => {
     render(<SetupChecklist />);
     expect(await screen.findByRole("list")).toBeInTheDocument();
   });
+
+  it("hides the NPU step on boards without an NPU", async () => {
+    mockFetchStatus(baseStatus);
+    render(<SetupChecklist />);
+    await screen.findByText("Get started");
+    expect(screen.queryByText("Install the NPU backend")).toBeNull();
+    expect(screen.getByText("0/5")).toBeInTheDocument();
+  });
+
+  it("shows the NPU step as a sixth item when an NPU is present", async () => {
+    mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: false });
+    render(<SetupChecklist />);
+    expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
+    expect(
+      screen.getByText("Install rkllama from the Store to run models on this device's NPU"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("0/6")).toBeInTheDocument();
+  });
+
+  it("stays visible when core steps are complete but the NPU step is outstanding", async () => {
+    mockFetchStatus({
+      ...baseStatus,
+      has_provider: true,
+      taos_model_set: true,
+      complete: true,
+      npu_present: true,
+      npu_backend_running: false,
+    });
+    render(<SetupChecklist />);
+    expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
+  });
+
+  it("hides once complete and the NPU backend is running", () => {
+    mockFetchStatus({
+      ...baseStatus,
+      complete: true,
+      npu_present: true,
+      npu_backend_running: true,
+    });
+    const { container } = render(<SetupChecklist />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("marks the NPU step complete when the backend is running", async () => {
+    mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: true });
+    render(<SetupChecklist />);
+    const doneStep = await screen.findByRole("button", {
+      name: "Install the NPU backend — complete",
+    });
+    expect(doneStep).toBeInTheDocument();
+    expect(screen.getByText("1/6")).toBeInTheDocument();
+  });
 });

--- a/desktop/src/components/SetupChecklist.tsx
+++ b/desktop/src/components/SetupChecklist.tsx
@@ -98,7 +98,7 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   // complete covers the two core steps only; on an NPU board the backend
   // install still deserves a surface until it is running (or the user
   // dismisses the checklist), otherwise it would never be seen (#1535).
-  const npuOutstanding = Boolean(status.npu_present) && !status.npu_backend_running;
+  const npuOutstanding = status.npu_present === true && !status.npu_backend_running;
   if (status.complete && !npuOutstanding) return null;
 
   const steps = status.npu_present ? [...STEPS, NPU_STEP] : STEPS;

--- a/desktop/src/components/SetupChecklist.tsx
+++ b/desktop/src/components/SetupChecklist.tsx
@@ -9,6 +9,8 @@ interface SetupStatus {
   taos_model_set: boolean;
   has_agent: boolean;
   memory_enabled: boolean;
+  npu_present?: boolean;
+  npu_backend_running?: boolean;
   dismissed: boolean;
   complete: boolean;
 }
@@ -52,6 +54,16 @@ const STEPS: Step[] = [
   },
 ];
 
+// Shown only when the board has a Rockchip NPU (#1535): the backend that
+// serves on-device models is a Store install, and without this step nothing
+// in the setup flow ever surfaces it.
+const NPU_STEP: Step = {
+  key: "npu_backend_running",
+  label: "Install the NPU backend",
+  detail: "Install rkllama from the Store to run models on this device's NPU",
+  appId: "store",
+};
+
 export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   const [status, setStatus] = useState<SetupStatus | null>(null);
   const [dismissing, setDismissing] = useState(false);
@@ -82,9 +94,15 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
     if (app) openWindow(step.appId, app.defaultSize);
   };
 
-  if (!status || status.dismissed || status.complete) return null;
+  if (!status || status.dismissed) return null;
+  // complete covers the two core steps only; on an NPU board the backend
+  // install still deserves a surface until it is running (or the user
+  // dismisses the checklist), otherwise it would never be seen (#1535).
+  const npuOutstanding = Boolean(status.npu_present) && !status.npu_backend_running;
+  if (status.complete && !npuOutstanding) return null;
 
-  const doneCount = STEPS.filter((s) => Boolean(status[s.key])).length;
+  const steps = status.npu_present ? [...STEPS, NPU_STEP] : STEPS;
+  const doneCount = steps.filter((s) => Boolean(status[s.key])).length;
 
   return (
     <div className="border-b border-white/10">
@@ -93,7 +111,7 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
         <div className="flex items-center gap-2">
           <span className="text-xs font-medium text-shell-text">Get started</span>
           <span className="text-[10px] text-shell-text-tertiary bg-white/5 rounded-full px-1.5 py-0.5">
-            {doneCount}/{STEPS.length}
+            {doneCount}/{steps.length}
           </span>
         </div>
         <button
@@ -109,7 +127,7 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
 
       {/* Steps */}
       <ul role="list" className="pb-2">
-        {STEPS.map((step) => {
+        {steps.map((step) => {
           const done = Boolean(status[step.key]);
           return (
             <li key={step.key}>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -38,14 +38,14 @@ After that PR merges, the install-count telemetry at taos.my starts recording th
 
 On `master`, after the merge commit:
 
-```
+```bash
 git tag v1.0.0-beta.N
 git push origin v1.0.0-beta.N
 ```
 
 Create a GitHub Release for that tag. Paste the matching CHANGELOG section as the release body:
 
-```
+```bash
 gh release create v1.0.0-beta.N --title "v1.0.0-beta.N" --notes-file <notes> --latest
 ```
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,7 +43,16 @@ git tag v1.0.0-beta.N
 git push origin v1.0.0-beta.N
 ```
 
-Create a GitHub Release for that tag. Paste the matching CHANGELOG section as the release body.
+Create a GitHub Release for that tag. Paste the matching CHANGELOG section as the release body:
+
+```
+gh release create v1.0.0-beta.N --title "v1.0.0-beta.N" --notes-file <notes> --latest
+```
+
+Do NOT pass `--prerelease`: betas are our normal releases here, and the in-app
+update check (`tinyagentos/github_releases.py`) reads `/releases/latest`, which
+skips prereleases. A release created as a prerelease leaves both the GitHub
+"Latest" badge and the update check stuck on the previous version.
 The taos.my changelog page pulls from GitHub Releases, so this is the canonical public record.
 
 ## Notes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.15"
+version = "1.0.0-beta.16"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -94,6 +94,15 @@ log()  { printf '\033[1;34m[rknpu]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[rknpu]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[rknpu]\033[0m %s\n' "$*" >&2; exit 1; }
 
+# Single source of truth for reading the installed librknnrt version; used by
+# both the environment banner below and the pin logic later so the two can
+# never drift if upstream rewords the version string.
+librknnrt_current_version() {
+    if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
+        strings "$LIBRKNNRT_DEST" | awk '/librknnrt version: / { print $3; exit }'
+    fi
+}
+
 # Environment banner: every user-posted install log should self-describe the
 # machine it ran on (distro, kernel, board, current NPU runtime) so a failure
 # report is diagnosable without a round-trip asking for these.
@@ -104,8 +113,13 @@ log "kernel=$(uname -r) arch=$(uname -m)"
 if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
-if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
-    log "current librknnrt=$(strings "$LIBRKNNRT_DEST" 2>/dev/null | grep -m1 -oE 'librknnrt version: [0-9]+\.[0-9]+\.[0-9]+' || echo 'version string not found')"
+if [[ ! -f "$LIBRKNNRT_DEST" ]]; then
+    log "current librknnrt=not installed"
+elif ! command -v strings >/dev/null 2>&1; then
+    log "current librknnrt=unknown (strings/binutils not installed yet)"
+else
+    _rt_v="$(librknnrt_current_version || true)"
+    log "current librknnrt=${_rt_v:-version string not found}"
 fi
 
 # verify_sha256 <file> <expected_hex> <label>
@@ -260,12 +274,6 @@ detect_rknpu_driver() {
 
 # -------- (3) librknnrt 2.3.0 pin ----------------------------------------
 
-librknnrt_current_version() {
-    if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
-        strings "$LIBRKNNRT_DEST" | awk '/librknnrt version: / { print $3; exit }'
-    fi
-}
-
 pin_librknnrt() {
     local current
     current="$(librknnrt_current_version || true)"
@@ -356,7 +364,8 @@ install_rkllama() {
         # refuse unadvertised objects) so the verification below sees the
         # same coverage as the re-install path; on failure fall through to
         # the curated error instead of dying on git's raw message.
-        run_as_user git -C "$RKLLAMA_DIR" fetch --quiet origin "$RKLLAMA_REF" 2>/dev/null || true
+        _fetch_err="$(run_as_user git -C "$RKLLAMA_DIR" fetch --quiet origin "$RKLLAMA_REF" 2>&1)" \
+            || log "note: direct fetch of the pinned ref failed (${_fetch_err:-no detail}); relying on the refs the clone brought down"
     fi
     # Verify the pinned ref is actually fetchable before checking it out. A
     # fresh clone only has branch/tag refs, so a pin orphaned by a history

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -73,7 +73,12 @@ command -v python3 >/dev/null 2>&1 && log "python3=$(python3 --version 2>&1)"
 # Report free space on the filesystem the install actually targets;
 # INSTALL_DIR may not exist yet on a fresh box, so walk up to its nearest
 # existing ancestor (falling back to / masks a full /opt-style volume).
+# An empty or relative INSTALL_DIR would walk to "." and report the cwd's
+# filesystem instead of the install target; fall back to / for the banner.
 _df_target="$INSTALL_DIR"
+if [[ -z "$_df_target" || "$_df_target" != /* ]]; then
+    _df_target="/"
+fi
 while [[ ! -d "$_df_target" && "$_df_target" != "/" ]]; do
     _df_target="$(dirname "$_df_target")"
 done

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -70,7 +70,14 @@ if [[ -r /proc/device-tree/model ]]; then
     log "board=$(tr -d '\0' < /proc/device-tree/model)"
 fi
 command -v python3 >/dev/null 2>&1 && log "python3=$(python3 --version 2>&1)"
-log "disk_free_root=$(df -Ph / 2>/dev/null | awk 'NR==2 {print $4}' || echo unknown)"
+# Report free space on the filesystem the install actually targets;
+# INSTALL_DIR may not exist yet on a fresh box, so walk up to its nearest
+# existing ancestor (falling back to / masks a full /opt-style volume).
+_df_target="$INSTALL_DIR"
+while [[ ! -d "$_df_target" && "$_df_target" != "/" ]]; do
+    _df_target="$(dirname "$_df_target")"
+done
+log "disk_free=$(df -Ph "$_df_target" 2>/dev/null | awk 'NR==2 {print $4}' || echo unknown) (at $_df_target)"
 log "install_dir=$INSTALL_DIR branch=$BRANCH port=$TAOS_PORT proxy_port=$TAOS_BROWSER_PROXY_PORT qmd_port=$TAOS_QMD_PORT"
 
 # --- system dependencies --------------------------------------------------

--- a/tests/test_restart_orchestrator_resume.py
+++ b/tests/test_restart_orchestrator_resume.py
@@ -1,0 +1,158 @@
+"""Boot-time agent resume after a controller update/restart (#97).
+
+The graceful-shutdown pause marks every agent paused=True; these tests pin
+that the boot-time resume covers every paused agent instead of silently
+stranding them:
+  - an agent whose framework handled /prepare-for-shutdown itself (no
+    controller-side resume note) is still resumed;
+  - a hostless agent is unpaused directly (there is no /resume to call);
+  - an agent that is unreachable at boot is retried in the background and
+    resumed when it comes back;
+  - an agent that never comes back leaves a WARNING notification, not silence.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import tinyagentos.restart_orchestrator as ro
+
+
+def _app_state(tmp_path, agents):
+    notifications = SimpleNamespace(add=AsyncMock())
+    config = SimpleNamespace(agents=agents, config_path=tmp_path / "config.yaml")
+    return SimpleNamespace(
+        config=config,
+        data_dir=tmp_path,
+        notifications=notifications,
+        _background_tasks=set(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_config_write(monkeypatch):
+    import tinyagentos.config as cfg
+
+    monkeypatch.setattr(cfg, "save_config_locked", AsyncMock())
+
+
+class TestResumeAgentsFromNotes:
+    @pytest.mark.asyncio
+    async def test_resumes_agent_without_controller_note(self, tmp_path, monkeypatch):
+        """A framework that answered /prepare-for-shutdown leaves no
+        controller-side note; resume must synthesize one, not skip the agent."""
+        agent = {"name": "naira", "host": "10.0.0.5", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        posted = {}
+
+        async def fake_post(host, port, note):
+            posted["note"] = note
+            return True
+
+        monkeypatch.setattr(ro, "_post_resume", fake_post)
+        await ro.resume_agents_from_notes(state)
+
+        assert agent["paused"] is False
+        assert posted["note"]["reason"] == "restart"
+        state.notifications.add.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unpauses_hostless_agent_directly(self, tmp_path):
+        """Hostless agents unpause without a /resume call, and any note on
+        disk is preserved (nothing consumed it)."""
+        agent = {"name": "wkrlan1", "host": "", "paused": True}
+        state = _app_state(tmp_path, [agent])
+        note_dir = tmp_path / "agent-memory" / "wkrlan1"
+        note_dir.mkdir(parents=True)
+        note_file = note_dir / "resume_note.json"
+        note_file.write_text(json.dumps({"reason": "pause"}))
+
+        await ro.resume_agents_from_notes(state)
+
+        assert agent["paused"] is False
+        assert note_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_uses_existing_note_when_present(self, tmp_path, monkeypatch):
+        agent = {"name": "a1", "host": "10.0.0.6", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        note_dir = tmp_path / "agent-memory" / "a1"
+        note_dir.mkdir(parents=True)
+        (note_dir / "resume_note.json").write_text(
+            json.dumps({"reason": "pause", "next_step_hint": "carry on"})
+        )
+        posted = {}
+
+        async def fake_post(host, port, note):
+            posted["note"] = note
+            return True
+
+        monkeypatch.setattr(ro, "_post_resume", fake_post)
+        await ro.resume_agents_from_notes(state)
+
+        assert posted["note"]["next_step_hint"] == "carry on"
+        assert agent["paused"] is False
+        assert not (note_dir / "resume_note.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_unreachable_agent_resumed_by_retry_loop(self, tmp_path, monkeypatch):
+        """The agent container boots slower than the controller: the first
+        attempt fails, the background retry succeeds and unpauses it."""
+        agent = {"name": "slow", "host": "10.0.0.7", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+        attempts = {"n": 0}
+
+        async def flaky_post(host, port, note):
+            attempts["n"] += 1
+            return attempts["n"] >= 2
+
+        monkeypatch.setattr(ro, "_post_resume", flaky_post)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_INTERVAL_S", 0.01)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_WINDOW_S", 5)
+
+        await ro.resume_agents_from_notes(state)
+        assert agent["paused"] is True  # first attempt failed
+        assert state._background_tasks  # retry loop spawned
+
+        for task in list(state._background_tasks):
+            await task
+
+        assert agent["paused"] is False
+        titles = [c.kwargs["title"] for c in state.notifications.add.await_args_list]
+        assert any("resumed" in t.lower() for t in titles)
+
+    @pytest.mark.asyncio
+    async def test_never_returning_agent_leaves_warning(self, tmp_path, monkeypatch):
+        agent = {"name": "gone", "host": "10.0.0.8", "port": 8080, "paused": True}
+        state = _app_state(tmp_path, [agent])
+
+        async def always_fail(host, port, note):
+            return False
+
+        monkeypatch.setattr(ro, "_post_resume", always_fail)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_INTERVAL_S", 0.01)
+        monkeypatch.setattr(ro, "_RESUME_RETRY_WINDOW_S", 0.05)
+
+        await ro.resume_agents_from_notes(state)
+        for task in list(state._background_tasks):
+            await task
+
+        assert agent["paused"] is True
+        warnings = [
+            c for c in state.notifications.add.await_args_list
+            if c.kwargs.get("level") == "warning"
+        ]
+        assert warnings and "gone" in warnings[-1].kwargs["message"]
+
+    @pytest.mark.asyncio
+    async def test_no_paused_agents_is_a_noop(self, tmp_path):
+        agent = {"name": "up", "host": "10.0.0.9", "paused": False}
+        state = _app_state(tmp_path, [agent])
+
+        await ro.resume_agents_from_notes(state)
+
+        state.notifications.add.assert_not_awaited()
+        assert not state._background_tasks

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -222,6 +222,47 @@ class TestSetupStatus:
         resp = await client.get("/api/setup/status")
         assert resp.json()["complete"] is False
 
+    async def test_npu_absent_by_default(self, client, app):
+        """No hardware profile (or a non-Rockchip one) hides the NPU step."""
+        # Pin the profile: another test in this class sets a Rockchip profile
+        # on the shared app fixture, and test order must not matter.
+        app.state.hardware_profile = None
+        app.state.config.backends = []
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["npu_present"] is False
+        assert data["npu_backend_running"] is False
+
+    async def test_npu_present_and_backend_state(self, client, app, monkeypatch):
+        """A Rockchip profile surfaces the step; completion mirrors a live
+        rkllama probe (#1535)."""
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+        import tinyagentos.installers.rkllama_installer as rk
+
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: True)
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["npu_present"] is True
+        assert data["npu_backend_running"] is True
+
+    async def test_npu_present_backend_not_running(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+        import tinyagentos.installers.rkllama_installer as rk
+
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["npu_present"] is True
+        assert data["npu_backend_running"] is False
+
     async def test_dismissed_false_initially(self, client):
         resp = await client.get("/api/setup/status")
         assert resp.json()["dismissed"] is False

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -242,8 +242,11 @@ class TestSetupStatus:
             npu=SimpleNamespace(type="rknpu", tops=6)
         )
         import tinyagentos.installers.rkllama_installer as rk
+        import tinyagentos.routes.setup as setup_routes
 
         monkeypatch.setattr(rk, "rkllama_is_running", lambda: True)
+        # The probe result is TTL-cached; reset so this test sees a fresh probe.
+        monkeypatch.setattr(setup_routes, "_npu_probe_cache", (0.0, False))
         resp = await client.get("/api/setup/status")
         data = resp.json()
         assert data["npu_present"] is True
@@ -256,8 +259,10 @@ class TestSetupStatus:
             npu=SimpleNamespace(type="rknpu", tops=6)
         )
         import tinyagentos.installers.rkllama_installer as rk
+        import tinyagentos.routes.setup as setup_routes
 
         monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+        monkeypatch.setattr(setup_routes, "_npu_probe_cache", (0.0, False))
         resp = await client.get("/api/setup/status")
         data = resp.json()
         assert data["npu_present"] is True

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.15"
+__version__ = "1.0.0-beta.16"

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -206,21 +206,26 @@ class LLMProxy:
         # OURS (project.name == tinyagentos): matching on the file alone
         # could latch onto an unrelated project's pyproject higher up (e.g.
         # one in $HOME) and pip-install that project's pins into our venv.
-        def _is_install_root(parent: Path) -> bool:
+        def _load_install_pyproject(parent: Path) -> dict | None:
             pj = parent / "pyproject.toml"
             if not pj.is_file():
-                return False
+                return None
             try:
                 with open(pj, "rb") as fh:
-                    name = tomllib.load(fh).get("project", {}).get("name")
+                    doc = tomllib.load(fh)
             except Exception:  # noqa: BLE001 - unreadable/foreign file: keep walking
-                return False
-            return name == "tinyagentos"
+                return None
+            return doc if doc.get("project", {}).get("name") == "tinyagentos" else None
 
-        project_root = next(
-            (p for p in Path(sys.executable).parents if _is_install_root(p)),
-            None,
-        )
+        # Keep the parsed document alongside the root so the pip fallback
+        # below reuses it instead of re-opening and re-parsing the file.
+        project_root = None
+        pyproject_doc: dict | None = None
+        for parent in Path(sys.executable).parents:
+            pyproject_doc = _load_install_pyproject(parent)
+            if pyproject_doc is not None:
+                project_root = parent
+                break
         if project_root is None:
             logger.warning(
                 "proxy self-heal: no tinyagentos pyproject.toml above %s — skipping",
@@ -253,8 +258,7 @@ class LLMProxy:
             # undo — and a later bare `uv sync --frozen` would strip the
             # extra right back out anyway.
             try:
-                with open(project_root / "pyproject.toml", "rb") as fh:
-                    optional = tomllib.load(fh)["project"]["optional-dependencies"]
+                optional = pyproject_doc["project"]["optional-dependencies"]
                 # strip(): a stray newline/whitespace in a pyproject entry
                 # would otherwise reach pip verbatim and fail opaquely.
                 reqs = [

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -260,7 +260,13 @@ _RESUME_RETRY_WINDOW_S = 600
 def _load_or_synthesize_note(note_path: Path) -> dict:
     if note_path.exists():
         try:
-            return json.loads(note_path.read_text())
+            note = json.loads(note_path.read_text())
+            # Valid JSON is not necessarily a valid note (null, [], "x");
+            # posting one of those to /resume would fail until the retry
+            # window expires, so synthesize instead.
+            if isinstance(note, dict):
+                return note
+            logger.warning("resume note at %s is not an object; synthesizing", note_path)
         except Exception:
             logger.warning("unreadable resume note at %s; synthesizing", note_path)
     # No controller-side note: the framework handled /prepare-for-shutdown
@@ -281,17 +287,33 @@ async def _post_resume(host: str, port: int, note: dict) -> bool:
     try:
         async with httpx.AsyncClient(timeout=10) as client:
             resp = await client.post(f"http://{host}:{port}/resume", json=note)
+            if resp.status_code != 200:
+                logger.warning("resume POST to %s:%s returned HTTP %s", host, port, resp.status_code)
             return resp.status_code == 200
-    except Exception:
+    except Exception as exc:
+        # The cause matters for a post-mortem (DNS vs refused vs TLS vs
+        # timeout); without this line a failed fleet resume is invisible
+        # until the final still-paused warning, which carries no cause.
+        logger.warning("resume POST to %s:%s failed: %r", host, port, exc)
         return False
 
 
 async def _unpause(app_state, agent: dict, note_path: Path | None) -> None:
+    # Same contract as the boot-time batch pass: the agent was genuinely
+    # resumed over /resume, so the in-memory flag flips even if persistence
+    # fails; the failure is surfaced and the recovery note is kept.
     agent["paused"] = False
     from tinyagentos.config import save_config_locked
 
     config = app_state.config
-    await save_config_locked(config, config.config_path)
+    try:
+        await save_config_locked(config, config.config_path)
+    except Exception:
+        logger.exception(
+            "persisting unpause of agent %s failed; keeping its resume note",
+            agent.get("name"),
+        )
+        return
     # Delete the note only AFTER the unpause is persisted: a failed config
     # write must never leave paused=True with the recovery note already gone.
     if note_path is not None:
@@ -334,6 +356,18 @@ async def resume_agents_from_notes(app_state) -> None:
         else:
             pending.append(name)
 
+    if pending:
+        # Agent containers can boot slower than the controller; keep retrying
+        # in the background instead of stranding them paused, and say so loudly
+        # if they never come back. Scheduled FIRST: the persistence and
+        # notification steps below are best-effort, and a raise there must not
+        # cost the pending agents their retry window.
+        task = asyncio.create_task(_resume_retry_loop(app_state, pending))
+        bg = getattr(app_state, "_background_tasks", None)
+        if bg is not None:
+            bg.add(task)
+            task.add_done_callback(bg.discard)
+
     if finalize:
         # In-memory flags flip regardless of persistence: the agents were
         # genuinely resumed over /resume, so blocking them in memory because a
@@ -365,7 +399,10 @@ async def resume_agents_from_notes(app_state) -> None:
             # Notes go only after the unpauses are persisted (see _unpause).
             for _, np_ in finalize:
                 if np_ is not None:
-                    np_.unlink(missing_ok=True)
+                    try:
+                        np_.unlink(missing_ok=True)
+                    except OSError:
+                        logger.warning("could not delete resume note %s", np_)
 
     if resumed:
         await notif.add(
@@ -374,16 +411,6 @@ async def resume_agents_from_notes(app_state) -> None:
             level="info",
             source="system.lifecycle",
         )
-
-    if pending:
-        # Agent containers can boot slower than the controller; keep retrying
-        # in the background instead of stranding them paused, and say so loudly
-        # if they never come back.
-        task = asyncio.create_task(_resume_retry_loop(app_state, pending))
-        bg = getattr(app_state, "_background_tasks", None)
-        if bg is not None:
-            bg.add(task)
-            task.add_done_callback(bg.discard)
 
 
 async def _resume_retry_loop(app_state, names: list[str]) -> None:

--- a/tinyagentos/restart_orchestrator.py
+++ b/tinyagentos/restart_orchestrator.py
@@ -243,49 +243,204 @@ async def apply_pending_restart_check(app_state) -> None:
         )
 
 
+# The graceful-shutdown pause (prepare()) marks EVERY agent paused=True, so the
+# boot-time resume must cover every paused agent or a routine update/restart
+# strands agents paused with no indication (#97):
+#   - a framework that answered /prepare-for-shutdown itself leaves NO
+#     controller-side note, so a note-gated resume skipped exactly the agents
+#     that implemented the protocol correctly;
+#   - hostless agents have no /resume to call and were never unpaused;
+#   - agents whose containers boot slower than the controller failed the single
+#     resume attempt and stayed paused silently.
+
+_RESUME_RETRY_INTERVAL_S = 30
+_RESUME_RETRY_WINDOW_S = 600
+
+
+def _load_or_synthesize_note(note_path: Path) -> dict:
+    if note_path.exists():
+        try:
+            return json.loads(note_path.read_text())
+        except Exception:
+            logger.warning("unreadable resume note at %s; synthesizing", note_path)
+    # No controller-side note: the framework handled /prepare-for-shutdown
+    # itself and keeps its own state, so a minimal note is enough. Field
+    # shapes mirror _write_controller_note (paused_at is an int there) so a
+    # framework parsing either source sees a single contract.
+    return {
+        "reason": "restart",
+        "paused_at": int(time.time()),
+        "last_user_msg": None,
+        "in_progress_task": None,
+        "next_step_hint": "controller restarted; resume normal operation",
+        "context_snapshot": {},
+    }
+
+
+async def _post_resume(host: str, port: int, note: dict) -> bool:
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(f"http://{host}:{port}/resume", json=note)
+            return resp.status_code == 200
+    except Exception:
+        return False
+
+
+async def _unpause(app_state, agent: dict, note_path: Path | None) -> None:
+    agent["paused"] = False
+    from tinyagentos.config import save_config_locked
+
+    config = app_state.config
+    await save_config_locked(config, config.config_path)
+    # Delete the note only AFTER the unpause is persisted: a failed config
+    # write must never leave paused=True with the recovery note already gone.
+    if note_path is not None:
+        note_path.unlink(missing_ok=True)
+
+
 async def resume_agents_from_notes(app_state) -> None:
     config = app_state.config
     data_dir: Path = app_state.data_dir
     notif = app_state.notifications
 
-    resumed = []
-    for agent in config.agents:
-        if not agent.get("paused", False):
-            continue
+    paused = [a for a in config.agents if a.get("paused", False)]
+    if not paused:
+        return
+
+    resumed: list[str] = []
+    pending: list[str] = []
+    # (agent, note_path-to-delete) pairs; flags flip and persist in ONE locked
+    # config write below instead of one write per agent.
+    finalize: list[tuple[dict, Path | None]] = []
+
+    for agent in paused:
         name = agent["name"]
         note_path = data_dir / "agent-memory" / name / "resume_note.json"
-        if not note_path.exists():
-            continue
-
-        try:
-            note = json.loads(note_path.read_text())
-        except Exception:
-            continue
-
         host = agent.get("host", "")
         port = agent.get("port", 8080)
+
         if not host:
+            # Nothing to call: the pause flag is the only thing holding the
+            # agent back, so clear it. Keep any note on disk: nothing consumed
+            # it, and it may carry state worth inspecting.
+            finalize.append((agent, None))
+            resumed.append(name)
             continue
 
+        note = _load_or_synthesize_note(note_path)
+        if await _post_resume(host, port, note):
+            finalize.append((agent, note_path))
+            resumed.append(name)
+        else:
+            pending.append(name)
+
+    if finalize:
+        # In-memory flags flip regardless of persistence: the agents were
+        # genuinely resumed over /resume, so blocking them in memory because a
+        # disk write failed would be worse than the divergence. A failed write
+        # is surfaced loudly and the recovery notes are kept.
+        for agent, _ in finalize:
+            agent["paused"] = False
+        from tinyagentos.config import save_config_locked
+
         try:
-            async with httpx.AsyncClient(timeout=10) as client:
-                resp = await client.post(
-                    f"http://{host}:{port}/resume",
-                    json=note,
-                )
-                if resp.status_code == 200:
-                    agent["paused"] = False
-                    note_path.unlink(missing_ok=True)
-                    resumed.append(name)
+            await save_config_locked(config, config.config_path)
         except Exception:
-            pass  # leave paused=True and note in place
+            logger.exception("persisting agent unpauses failed")
+            try:
+                await notif.add(
+                    title="Agent resume not persisted",
+                    message=(
+                        "Agents were resumed but the config write failed; they may "
+                        "show as paused again after the next restart."
+                    ),
+                    level="warning",
+                    source="system.lifecycle",
+                )
+            except Exception:
+                # The log line above already carries the failure; a broken
+                # notification store must not abort the rest of the resume.
+                logger.exception("could not post the persist-failure warning")
+        else:
+            # Notes go only after the unpauses are persisted (see _unpause).
+            for _, np_ in finalize:
+                if np_ is not None:
+                    np_.unlink(missing_ok=True)
 
     if resumed:
-        from tinyagentos.config import save_config_locked
-        await save_config_locked(config, config.config_path)
         await notif.add(
-            title="All agents resumed",
-            message=f"Resumed {len(resumed)} agent(s) from resume notes: {', '.join(resumed)}",
+            title="Agents resumed",
+            message=f"Resumed {len(resumed)} agent(s) after restart: {', '.join(resumed)}",
             level="info",
             source="system.lifecycle",
         )
+
+    if pending:
+        # Agent containers can boot slower than the controller; keep retrying
+        # in the background instead of stranding them paused, and say so loudly
+        # if they never come back.
+        task = asyncio.create_task(_resume_retry_loop(app_state, pending))
+        bg = getattr(app_state, "_background_tasks", None)
+        if bg is not None:
+            bg.add(task)
+            task.add_done_callback(bg.discard)
+
+
+async def _resume_retry_loop(app_state, names: list[str]) -> None:
+    config = app_state.config
+    data_dir: Path = app_state.data_dir
+    notif = app_state.notifications
+
+    remaining = set(names)
+    deadline = time.monotonic() + _RESUME_RETRY_WINDOW_S
+
+    while remaining and time.monotonic() < deadline:
+        await asyncio.sleep(_RESUME_RETRY_INTERVAL_S)
+        # Rebuilt each tick on purpose: agents can be added or removed while
+        # the 10-minute window runs, and a stale index would resume a deleted
+        # agent or miss a re-added one.
+        by_name = {a["name"]: a for a in config.agents}
+        for name in list(remaining):
+            # Any raise past this point (config write, notification store)
+            # would kill the loop and re-create the silent pause this fix
+            # exists to remove; log and keep going instead.
+            try:
+                agent = by_name.get(name)
+                if agent is None or not agent.get("paused", False):
+                    remaining.discard(name)
+                    continue
+                note_path = data_dir / "agent-memory" / name / "resume_note.json"
+                note = _load_or_synthesize_note(note_path)
+                if await _post_resume(agent.get("host", ""), agent.get("port", 8080), note):
+                    # Per-agent config write is fine here: retry successes are
+                    # rare, isolated events (one agent per 30s tick at worst),
+                    # unlike the boot pass which batches.
+                    await _unpause(app_state, agent, note_path)
+                    remaining.discard(name)
+                    await notif.add(
+                        title=f"Agent {name} resumed",
+                        message="Resumed after the controller restart (agent took a while to come back up).",
+                        level="info",
+                        source="system.lifecycle",
+                    )
+            except Exception:
+                logger.exception("resume retry for agent %s failed; will retry", name)
+
+    if remaining:
+        # The whole point of this warning is to make the failure visible; a
+        # notification-store error must not silently swallow it.
+        try:
+            await notif.add(
+                title="Some agents are still paused",
+                message=(
+                    f"Could not resume after the restart: {', '.join(sorted(remaining))}. "
+                    "They stay paused; check the agent containers, then unpause from the Agents app."
+                ),
+                level="warning",
+                source="system.lifecycle",
+            )
+        except Exception:
+            logger.exception(
+                "could not post the still-paused warning; agents still paused: %s",
+                ", ".join(sorted(remaining)),
+            )

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -41,14 +41,22 @@ async def _connect_lock(connector_key: str):
 async def _stop_prior_connector(connectors: dict, connector_key: str) -> None:
     """Stop and drop any prior connector under this key. Reconnecting (e.g.
     after a token rotation) must not silently orphan the previous connector's
-    background task/client."""
+    background task/client.
+
+    The pop happens before the await on purpose: callers hold the per-key
+    connect lock, so nothing can observe the gap, and the caller is about to
+    overwrite the slot with a fresh connector either way. If stop() raises,
+    the old connector's task may live until process restart; that is logged
+    loudly rather than blocking the reconnect, because keeping a broken
+    connector registered would be strictly worse."""
     old = connectors.pop(connector_key, None)
     if old is not None and hasattr(old, "stop"):
         try:
             await old.stop()
         except Exception:
-            logger.warning(
-                "channel-hub: failed to stop prior %s connector on reconnect",
+            logger.error(
+                "channel-hub: failed to stop prior %s connector on reconnect; "
+                "its background task may persist until restart",
                 connector_key,
                 exc_info=True,
             )

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -25,6 +25,8 @@ async def setup_status(request: Request):
       taos_model_set  — the taOS agent has a model configured
       has_agent       — at least one deployed agent exists
       memory_enabled  — user completed the taOSmd memory setup wizard
+      npu_present     — a Rockchip NPU was detected on this board (#1535)
+      npu_backend_running — a live rkllama answers on the taOS or legacy port
       dismissed       — user dismissed the checklist
       complete        — has_provider AND taos_model_set (the core two steps)
     """
@@ -49,6 +51,22 @@ async def setup_status(request: Request):
     setup_prefs = await store.get_preference("user", _PREF_NAMESPACE)
     dismissed = bool(setup_prefs.get("dismissed", False))
 
+    # NPU-conditional step (#1535): on a Rockchip board the checklist offers
+    # the rkllama backend install (via the Store), complete once a live
+    # rkllama answers. Boards without an NPU never see the step.
+    profile = getattr(request.app.state, "hardware_profile", None)
+    npu = getattr(profile, "npu", None)
+    npu_present = bool(npu is not None and getattr(npu, "type", "none") == "rknpu")
+    npu_backend_running = False
+    if npu_present:
+        import asyncio
+
+        from tinyagentos.installers.rkllama_installer import rkllama_is_running
+
+        # rkllama_is_running never raises, but its socket probes block;
+        # keep them off the event loop.
+        npu_backend_running = await asyncio.to_thread(rkllama_is_running)
+
     # complete: the two core steps done
     complete = has_provider and taos_model_set
 
@@ -58,6 +76,8 @@ async def setup_status(request: Request):
         "taos_model_set": taos_model_set,
         "has_agent": has_agent,
         "memory_enabled": memory_enabled,
+        "npu_present": npu_present,
+        "npu_backend_running": npu_backend_running,
         "dismissed": dismissed,
         "complete": complete,
     })

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -5,6 +5,8 @@ POST /api/setup/dismiss → persist user's dismissal of the checklist
 """
 from __future__ import annotations
 
+import asyncio
+import time
 from pathlib import Path
 
 from fastapi import APIRouter, Request
@@ -13,6 +15,34 @@ from fastapi.responses import JSONResponse
 router = APIRouter()
 
 _PREF_NAMESPACE = "setup"
+
+# The rkllama probe holds a worker thread while its socket connects, and
+# /api/setup/status is polled by the frontend; without a cache and a hard
+# timeout, concurrent polls could pin the default-thread executor.
+_NPU_PROBE_TTL_S = 5.0
+_NPU_PROBE_TIMEOUT_S = 5.0
+_npu_probe_cache: tuple[float, bool] = (0.0, False)
+
+
+async def _npu_backend_running() -> bool:
+    global _npu_probe_cache
+    now = time.monotonic()
+    cached_at, cached = _npu_probe_cache
+    if cached_at and now - cached_at < _NPU_PROBE_TTL_S:
+        return cached
+
+    from tinyagentos.installers.rkllama_installer import rkllama_is_running
+
+    try:
+        # rkllama_is_running never raises, but its socket probes block;
+        # keep them off the event loop and cap how long one can hang.
+        running = await asyncio.wait_for(
+            asyncio.to_thread(rkllama_is_running), _NPU_PROBE_TIMEOUT_S
+        )
+    except asyncio.TimeoutError:
+        running = False
+    _npu_probe_cache = (now, running)
+    return running
 
 
 @router.get("/api/setup/status")
@@ -59,13 +89,7 @@ async def setup_status(request: Request):
     npu_present = bool(npu is not None and getattr(npu, "type", "none") == "rknpu")
     npu_backend_running = False
     if npu_present:
-        import asyncio
-
-        from tinyagentos.installers.rkllama_installer import rkllama_is_running
-
-        # rkllama_is_running never raises, but its socket probes block;
-        # keep them off the event loop.
-        npu_backend_running = await asyncio.to_thread(rkllama_is_running)
+        npu_backend_running = await _npu_backend_running()
 
     # complete: the two core steps done
     complete = has_provider and taos_model_set

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b15"
+version = "1.0.0b16"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promote dev to master for 1.0.0-beta.16.

Both headline changes were live-verified on real hardware before this promotion:
- Fixed: a controller update or restart no longer silently strands agents in a paused state. Verified end to end on the dev Pi: the stop hook paused three agents, hostless workers auto-resumed instantly at boot, and an unreachable hosted agent got the full retry window followed by a visible warning naming it.
- Added: on Rockchip boards the setup checklist now offers an "Install the NPU backend" step (appears only when an NPU is detected, opens the Store one-click rkllama install, completes when the backend answers, stays visible until installed or dismissed).

Full details in CHANGELOG.md. All gated by CI + bot review per PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an NPU backend step to the setup checklist for supported Rockchip devices, including a one-click install option that can auto-complete once the backend is available.
* **Bug Fixes**
  * Improved controller/controller-restart recovery so paused agents resume correctly, with background retries and visible warnings when resumption still fails.
  * Enhanced setup status with `npu_present` and `npu_backend_running`, using a timed, cached backend liveness probe.
* **Documentation**
  * Updated release/publishing guidance for creating GitHub releases from tags.
* **Tests**
  * Added coverage for NPU setup status, checklist rendering, and resume-at-boot recovery scenarios.
* **Chores**
  * Refined installer behaviors (NPU runtime detection, pinned ref fetching, and disk-space checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->