### PR TITLE
fix(installer): vendor-image clean-install batch (Orange Pi 5 Pro report)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- Installer: the Docker Compose v2 plugin now installs on Debian (including vendor Pi images) by trying the Debian package name (`docker-compose-plugin`) before the Ubuntu one (`docker-compose-v2`), and the engine + plugin install in separate apt transactions so a missing plugin name can no longer prevent Docker itself from installing (#1541).
+- Installer: install-rknpu.sh no longer aborts right after replacing librknnrt.so when `ldconfig` exits non-zero on vendor images with merged /lib layouts; the cache refresh is best-effort and rkllama now installs in the same run (#1543).
+- Installer: the prebuilt desktop bundle is used on re-runs again. Re-runs as root over the taos-owned checkout tripped git's dubious-ownership check, which silently disabled the prebuilt path and forced a local vite build every time; the tree check now runs as the owning user, logs say whether the bundle channel was unreachable or genuinely mismatched, and installs pinned to a release tag fall back to the bundle attached to that release (#1544).
+- Installer: install-rknpu.sh now installs the OpenCV runtime libraries rkllama needs (libGL, GLib, libSM, libXext); vendor Debian images ship without them and rkllama.service crashlooped on "ImportError: libGL.so.1" (#1545).
+- Installer: when a vendor image ships with Docker preinstalled, incus is now installed as well (it is the preferred runtime for agent containers; skip with TAOS_NO_INCUS=1). Previously the installer treated the pre-existing Docker as sufficient and only a later warning told the user to install incus by hand and re-run (#1546).
+
 ## [1.0.0-beta.16] - 2026-07-02
 
 ### Added

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -324,7 +324,7 @@ pin_librknnrt() {
     # the whole install right after the library was correctly replaced and
     # rkllama never got installed (#1543). The cache refresh is best-effort:
     # the library is already at its canonical path.
-    sudo ldconfig || warn "ldconfig exited non-zero after installing librknnrt (harmless on merged /lib layouts; continuing)"
+    sudo ldconfig || warn "ldconfig exited $? after installing librknnrt (its stderr above has the cause; harmless on merged /lib layouts where the runtime resolves by absolute path; continuing)"
 
     # Verify the version string as a belt-and-braces check. The SHA256 above
     # already proved $tmp is byte-for-byte the pinned runtime, so this is
@@ -400,7 +400,15 @@ install_rkllama() {
         # libs; vendor Debian images ship without them and the service then
         # crashloops on "ImportError: libGL.so.1" (#1545). Bookworm+ names the
         # GL runtime libgl1; older releases only have libgl1-mesa-glx.
-        dpkg-query -W libglib2.0-0 >/dev/null 2>&1 || _need+=("libglib2.0-0")
+        # GLib was renamed libglib2.0-0t64 in Ubuntu 24.04 / Debian Trixie;
+        # probe both installed names and add whichever the repos carry.
+        if ! dpkg-query -W libglib2.0-0 >/dev/null 2>&1 && ! dpkg-query -W libglib2.0-0t64 >/dev/null 2>&1; then
+            if [[ -n "$(apt-cache madison libglib2.0-0 2>/dev/null)" ]]; then
+                _need+=("libglib2.0-0")
+            else
+                _need+=("libglib2.0-0t64")
+            fi
+        fi
         dpkg-query -W libsm6 >/dev/null 2>&1 || _need+=("libsm6")
         dpkg-query -W libxext6 >/dev/null 2>&1 || _need+=("libxext6")
         if ! dpkg-query -W libgl1 >/dev/null 2>&1 && ! dpkg-query -W libgl1-mesa-glx >/dev/null 2>&1; then

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -319,7 +319,12 @@ pin_librknnrt() {
     # Install the new one.
     sudo install -m 0644 "$tmp" "$LIBRKNNRT_DEST"
     LIBRKNNRT_REPLACED=1
-    sudo ldconfig
+    # ldconfig can exit non-zero on vendor images (e.g. "/lib/librknnrt.so is
+    # not a symbolic link" on merged-/lib layouts), which under set -e killed
+    # the whole install right after the library was correctly replaced and
+    # rkllama never got installed (#1543). The cache refresh is best-effort:
+    # the library is already at its canonical path.
+    sudo ldconfig || warn "ldconfig exited non-zero after installing librknnrt (harmless on merged /lib layouts; continuing)"
 
     # Verify the version string as a belt-and-braces check. The SHA256 above
     # already proved $tmp is byte-for-byte the pinned runtime, so this is
@@ -391,6 +396,20 @@ install_rkllama() {
         # `strings` (binutils) is used by the librknnrt version checks; minimal
         # Pi images can lack it (#783). Ensure it is present.
         command -v strings >/dev/null 2>&1 || _need+=("binutils")
+        # rkllama imports OpenCV (cv2), which needs the OpenGL/GLib/X runtime
+        # libs; vendor Debian images ship without them and the service then
+        # crashloops on "ImportError: libGL.so.1" (#1545). Bookworm+ names the
+        # GL runtime libgl1; older releases only have libgl1-mesa-glx.
+        dpkg-query -W libglib2.0-0 >/dev/null 2>&1 || _need+=("libglib2.0-0")
+        dpkg-query -W libsm6 >/dev/null 2>&1 || _need+=("libsm6")
+        dpkg-query -W libxext6 >/dev/null 2>&1 || _need+=("libxext6")
+        if ! dpkg-query -W libgl1 >/dev/null 2>&1 && ! dpkg-query -W libgl1-mesa-glx >/dev/null 2>&1; then
+            if [[ -n "$(apt-cache madison libgl1 2>/dev/null)" ]]; then
+                _need+=("libgl1")
+            else
+                _need+=("libgl1-mesa-glx")
+            fi
+        fi
         if (( ${#_need[@]} )); then
             log "installing build deps for rkllama wheel compilation: ${_need[*]}"
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${_need[@]}" \

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -909,8 +909,18 @@ PY
 # docker-compose-v2. Trying only the Ubuntu name broke Debian Bookworm
 # (vendor Pi images included) with "Unable to locate package" (#1541).
 _apt_install_compose() {
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-plugin 2>/dev/null \
-        || sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2
+    local _err
+    if _err=$(sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-plugin 2>&1); then
+        return 0
+    fi
+    # Only fall through to the Ubuntu name when the Debian name simply is not
+    # in the repos; any other apt failure (locks, held packages, resolver)
+    # is real and must reach the operator, not be masked by a second attempt.
+    if ! grep -qi "unable to locate package" <<<"$_err"; then
+        printf '%s\n' "$_err" >&2
+        return 1
+    fi
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2
 }
 
 ensure_docker_for_apps() {
@@ -1286,10 +1296,12 @@ _bundle_base="https://github.com/jaylfc/taOS/releases/download/bundle-latest"
 # (#1544). Drop to the owning user, matching the checkout-update logic above.
 _tree_owner="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
 _git_ro() {
+    # safe.directory is passed explicitly so a TOCTOU owner change between the
+    # stat above and this call cannot re-trip the dubious-ownership guard.
     if [[ "$(id -u)" == "0" && -n "$_tree_owner" && "$_tree_owner" != "root" ]]; then
-        sudo -u "$_tree_owner" git -C "$INSTALL_DIR" "$@"
+        sudo -u "$_tree_owner" git -c safe.directory="$INSTALL_DIR" -C "$INSTALL_DIR" "$@"
     else
-        git -C "$INSTALL_DIR" "$@"
+        git -c safe.directory="$INSTALL_DIR" -C "$INSTALL_DIR" "$@"
     fi
 }
 _desktop_tree="$(_git_ro rev-parse HEAD:desktop 2>/dev/null || echo "")"
@@ -1300,7 +1312,7 @@ _desktop_tree="$(_git_ro rev-parse HEAD:desktop 2>/dev/null || echo "")"
 # for logs). Returns 0 only when a tree-matching, checksum-verified bundle was
 # installed into static/desktop/.
 _try_prebuilt_bundle() {
-    local _base="$1" _label="$2" _remote_tree _stage _tarball _exp_sha _sha_cmd _own
+    local _base="$1" _label="$2" _remote_tree _stage _tarball _exp_sha _sha_cmd _own _old
     _remote_tree="$(curl -fsSL --max-time 20 "$_base/desktop-tree.txt" 2>/dev/null | tr -d '[:space:]' || echo "")"
     if [[ -z "$_remote_tree" ]]; then
         # Say WHY there is no prebuilt: a transient network failure here used
@@ -1319,18 +1331,45 @@ _try_prebuilt_bundle() {
     # rename and avoids writing through an attacker-planted symlink while
     # running as root in the common `curl | sudo bash` invocation.
     _stage="$(mktemp -d "$INSTALL_DIR/static/.taos-bundle.XXXXXX")"
-    _tarball="$(mktemp "$INSTALL_DIR/static/.taos-bundle.XXXXXX.tgz")"
+    # BSD/macOS mktemp requires the template to END in Xs (no suffix allowed).
+    _tarball="$(mktemp "$INSTALL_DIR/static/.taos-bundle-tar.XXXXXX")"
     # Verify the download against the CI-published SHA256 before extracting,
     # so a corrupted or tampered tarball is rejected (we fall back to a local
-    # build). sha256sum on Linux, shasum -a 256 on macOS.
+    # build). sha256sum on Linux, shasum -a 256 on macOS; with neither, say
+    # explicitly that VERIFICATION was impossible (not "download failed").
     _exp_sha="$(curl -fsSL --max-time 20 "$_base/desktop-bundle.sha256" 2>/dev/null | tr -d '[:space:]' || echo "")"
-    _sha_cmd="sha256sum"; command -v sha256sum >/dev/null 2>&1 || _sha_cmd="shasum -a 256"
+    _sha_cmd="sha256sum"
+    if ! command -v sha256sum >/dev/null 2>&1; then
+        if command -v shasum >/dev/null 2>&1; then
+            _sha_cmd="shasum -a 256"
+        else
+            warn "no sha256 tool available — cannot verify the prebuilt bundle, skipping it"
+            rm -rf "$_stage" "$_tarball"
+            return 1
+        fi
+    fi
     if curl -fsSL --max-time 120 "$_base/desktop-bundle.tar.gz" -o "$_tarball" \
        && [[ -n "$_exp_sha" && "$($_sha_cmd "$_tarball" | awk '{print $1}')" == "$_exp_sha" ]] \
        && tar -C "$_stage" -xzf "$_tarball" \
        && [[ -f "$_stage/desktop/index.html" ]]; then
-        rm -rf "$INSTALL_DIR/static/desktop"
-        mv "$_stage/desktop" "$INSTALL_DIR/static/desktop"
+        # Swap via rename-out / rename-in (same filesystem, so each mv is an
+        # atomic rename): a failed swap must never leave the install with NO
+        # desktop at all, which is what delete-then-move risked.
+        _old=""
+        if [[ -d "$INSTALL_DIR/static/desktop" ]]; then
+            _old="$_stage/desktop.old"
+            if ! mv "$INSTALL_DIR/static/desktop" "$_old"; then
+                warn "could not move the current desktop aside — leaving it in place"
+                rm -rf "$_stage" "$_tarball"
+                return 1
+            fi
+        fi
+        if ! mv "$_stage/desktop" "$INSTALL_DIR/static/desktop"; then
+            [[ -n "$_old" ]] && mv "$_old" "$INSTALL_DIR/static/desktop" 2>/dev/null
+            warn "installing the prebuilt bundle failed during the swap — previous desktop restored"
+            rm -rf "$_stage" "$_tarball"
+            return 1
+        fi
         # Match the repo owner so a later in-app rebuild (run as that user) can
         # still write here; only meaningful when installing as root. Trailing
         # colon sets the owner's primary group (do not assume a group named
@@ -1343,7 +1382,7 @@ _try_prebuilt_bundle() {
         log "prebuilt desktop bundle installed into static/desktop/ (from $_label)"
         return 0
     fi
-    warn "prebuilt bundle download/extract from $_label failed"
+    warn "prebuilt bundle from $_label failed (download error, checksum mismatch, or bad archive)"
     rm -rf "$_stage" "$_tarball"
     return 1
 }
@@ -1366,6 +1405,7 @@ fi
 if [[ "$_prebuilt_done" == "0" ]]; then
     if command -v npm >/dev/null 2>&1; then
         log "building desktop SPA locally (no matching prebuilt bundle for this source)"
+        log "  note: the vite build needs roughly 2-4GB of free memory; on small boards close other services first"
         if ! (cd "$INSTALL_DIR/desktop" && npm install --silent && npm run build); then
             die "desktop SPA build failed. This almost always means the machine ran out of memory: the vite build needs roughly 2-4GB free. On WSL the Linux VM is capped at about half of Windows RAM by default, so add to C:\\Users\\<you>\\.wslconfig:
     [wsl2]

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1367,7 +1367,9 @@ _try_prebuilt_bundle() {
         if ! mv "$_stage/desktop" "$INSTALL_DIR/static/desktop"; then
             # Do not claim the restore worked unless it actually did: a failed
             # rename-back would otherwise leave no desktop while saying otherwise.
-            if [[ -n "$_old" ]] && mv "$_old" "$INSTALL_DIR/static/desktop"; then
+            if [[ -z "$_old" ]]; then
+                warn "installing the prebuilt bundle failed during the swap — no previous desktop existed; the local build below (or a re-run) will create static/desktop"
+            elif mv "$_old" "$INSTALL_DIR/static/desktop"; then
                 warn "installing the prebuilt bundle failed during the swap — previous desktop restored"
             else
                 warn "installing the prebuilt bundle failed during the swap AND the previous desktop could not be restored — static/desktop is missing; the local build below (or a re-run) will recreate it"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -700,16 +700,33 @@ ensure_container_runtime() {
         esac
         return 0
     fi
+    # A pre-existing Docker/podman (vendor Pi images often ship Docker) is a
+    # usable runtime, but agent LXC deploys prefer incus — and returning early
+    # here meant incus was never installed on such images, leaving the user to
+    # discover it from a later group-setup warning and install it by hand
+    # (#1546). Install incus as well, except on WSL (where Docker is the sane
+    # default) or with TAOS_NO_INCUS=1.
+    local _other_runtime=""
     if command -v docker >/dev/null 2>&1; then
+        _other_runtime="docker"
         log "container runtime: docker $(docker --version 2>/dev/null | head -1) — ok"
-        return 0
-    fi
-    if command -v podman >/dev/null 2>&1; then
+    elif command -v podman >/dev/null 2>&1; then
+        _other_runtime="podman"
         log "container runtime: podman $(podman --version 2>/dev/null | head -1) — ok"
-        return 0
     fi
-
-    log "no container runtime found — installing Incus"
+    if [[ -n "$_other_runtime" ]]; then
+        if [[ "${TAOS_NO_INCUS:-0}" == "1" ]]; then
+            log "TAOS_NO_INCUS=1 — not installing incus; agent containers will use $_other_runtime"
+            return 0
+        fi
+        if grep -qi microsoft /proc/version 2>/dev/null; then
+            log "WSL detected — using $_other_runtime; skipping the incus install"
+            return 0
+        fi
+        log "incus not found — installing it as well (preferred runtime for agent containers; set TAOS_NO_INCUS=1 to skip)"
+    else
+        log "no container runtime found — installing Incus"
+    fi
 
     local installed=0
     if command -v apt-get >/dev/null 2>&1; then
@@ -887,6 +904,15 @@ PY
 # including compose-style stacks like SearXNG / Perplexica. incus runs agent
 # LXCs; Docker runs Docker apps. Installed by default — set TAOS_SKIP_DOCKER=1
 # to opt out (Store Docker apps then stay unavailable).
+# The Compose v2 plugin has two apt names: Debian and Docker's own repo call
+# it docker-compose-plugin; Ubuntu's universe archive calls it
+# docker-compose-v2. Trying only the Ubuntu name broke Debian Bookworm
+# (vendor Pi images included) with "Unable to locate package" (#1541).
+_apt_install_compose() {
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-plugin 2>/dev/null \
+        || sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2
+}
+
 ensure_docker_for_apps() {
     if [[ "${TAOS_SKIP_DOCKER:-0}" == "1" ]]; then
         log "TAOS_SKIP_DOCKER=1 — skipping Docker (Store Docker apps will be unavailable)"
@@ -925,8 +951,14 @@ ensure_docker_for_apps() {
         # with "unknown command: docker compose".
         log "installing Docker Engine + Compose plugin (for Store Docker apps)"
         if command -v apt-get >/dev/null 2>&1; then
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io docker-compose-v2 \
-                || warn "apt install docker.io/docker-compose-v2 failed — Store Docker apps will be unavailable"
+            # Install the engine and the compose plugin in SEPARATE apt
+            # transactions: bundling them meant a missing compose package name
+            # (see _apt_install_compose below) failed the whole transaction and
+            # left the box without Docker at all (#1541).
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io \
+                || warn "apt install docker.io failed — Store Docker apps will be unavailable"
+            _apt_install_compose \
+                || warn "apt install of the compose plugin failed — Store Docker apps will be unavailable"
         elif command -v dnf >/dev/null 2>&1; then
             sudo dnf install -y -q moby-engine docker-compose \
                 || warn "dnf install moby-engine/docker-compose failed — Store Docker apps will be unavailable"
@@ -949,7 +981,7 @@ ensure_docker_for_apps() {
     if ! docker compose version >/dev/null 2>&1; then
         log "installing the Docker Compose v2 plugin"
         if command -v apt-get >/dev/null 2>&1; then
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2 || true
+            _apt_install_compose || true
         elif command -v dnf >/dev/null 2>&1; then
             sudo dnf install -y -q docker-compose || true
         elif command -v pacman >/dev/null 2>&1; then
@@ -1246,44 +1278,88 @@ ensure_litellm_postgres || warn "litellm postgres setup did not complete -- virt
 # old UI. Fall back to a local build only when no matching prebuilt is available.
 
 _bundle_base="https://github.com/jaylfc/taOS/releases/download/bundle-latest"
-_desktop_tree="$(git -C "$INSTALL_DIR" rev-parse HEAD:desktop 2>/dev/null || echo "")"
-_prebuilt_done=0
-if [[ -n "$_desktop_tree" ]]; then
-    _remote_tree="$(curl -fsSL --max-time 20 "$_bundle_base/desktop-tree.txt" 2>/dev/null | tr -d '[:space:]')"
-    if [[ -n "$_remote_tree" && "$_remote_tree" == "$_desktop_tree" ]]; then
-        log "fetching prebuilt desktop bundle (matches source; no local build needed)"
-        mkdir -p "$INSTALL_DIR/static"
-        # Stage INSIDE the install tree (private, same filesystem) rather than a
-        # fixed world-writable /tmp path: this makes the final swap an atomic
-        # rename and avoids writing through an attacker-planted symlink while
-        # running as root in the common `curl | sudo bash` invocation.
-        _stage="$(mktemp -d "$INSTALL_DIR/static/.taos-bundle.XXXXXX")"
-        _tarball="$(mktemp "$INSTALL_DIR/static/.taos-bundle.XXXXXX.tgz")"
-        # Verify the download against the CI-published SHA256 before extracting,
-        # so a corrupted or tampered tarball is rejected (we fall back to a local
-        # build). sha256sum on Linux, shasum -a 256 on macOS.
-        _exp_sha="$(curl -fsSL --max-time 20 "$_bundle_base/desktop-bundle.sha256" 2>/dev/null | tr -d '[:space:]')"
-        _sha_cmd="sha256sum"; command -v sha256sum >/dev/null 2>&1 || _sha_cmd="shasum -a 256"
-        if curl -fsSL --max-time 120 "$_bundle_base/desktop-bundle.tar.gz" -o "$_tarball" \
-           && [[ -n "$_exp_sha" && "$($_sha_cmd "$_tarball" | awk '{print $1}')" == "$_exp_sha" ]] \
-           && tar -C "$_stage" -xzf "$_tarball" \
-           && [[ -f "$_stage/desktop/index.html" ]]; then
-            rm -rf "$INSTALL_DIR/static/desktop"
-            mv "$_stage/desktop" "$INSTALL_DIR/static/desktop"
-            # Match the repo owner so a later in-app rebuild (run as that user) can
-            # still write here; only meaningful when installing as root. Trailing
-            # colon sets the owner's primary group (do not assume a group named
-            # after the user exists).
-            _own="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
-            if [[ "$(id -u)" == "0" && -n "$_own" && "$_own" != "root" ]]; then
-                chown -R "$_own:" "$INSTALL_DIR/static/desktop" 2>/dev/null || true
-            fi
-            _prebuilt_done=1
-            log "prebuilt desktop bundle installed into static/desktop/"
-        else
-            warn "prebuilt bundle download/extract failed; falling back to a local build"
+
+# The repo is chowned to the 'taos' service user at the end of a system
+# install, so on a re-run as root a plain `git rev-parse` here trips git's
+# dubious-ownership check, returned empty, and silently disabled the prebuilt
+# path — every re-run then fell back to the memory-heavy local vite build
+# (#1544). Drop to the owning user, matching the checkout-update logic above.
+_tree_owner="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
+_git_ro() {
+    if [[ "$(id -u)" == "0" && -n "$_tree_owner" && "$_tree_owner" != "root" ]]; then
+        sudo -u "$_tree_owner" git -C "$INSTALL_DIR" "$@"
+    else
+        git -C "$INSTALL_DIR" "$@"
+    fi
+}
+_desktop_tree="$(_git_ro rev-parse HEAD:desktop 2>/dev/null || echo "")"
+[[ -z "$_desktop_tree" ]] \
+    && warn "could not read the desktop/ tree SHA from $INSTALL_DIR — prebuilt bundles unavailable this run"
+
+# Try one prebuilt-bundle source ($1 = release download base URL, $2 = label
+# for logs). Returns 0 only when a tree-matching, checksum-verified bundle was
+# installed into static/desktop/.
+_try_prebuilt_bundle() {
+    local _base="$1" _label="$2" _remote_tree _stage _tarball _exp_sha _sha_cmd _own
+    _remote_tree="$(curl -fsSL --max-time 20 "$_base/desktop-tree.txt" 2>/dev/null | tr -d '[:space:]' || echo "")"
+    if [[ -z "$_remote_tree" ]]; then
+        # Say WHY there is no prebuilt: a transient network failure here used
+        # to be indistinguishable from a genuine source mismatch (#1544).
+        log "prebuilt bundle: $_label unreachable or missing its manifest — skipping"
+        return 1
+    fi
+    if [[ "$_remote_tree" != "$_desktop_tree" ]]; then
+        log "prebuilt bundle: $_label was built from a different desktop/ source — skipping"
+        return 1
+    fi
+    log "fetching prebuilt desktop bundle from $_label (matches source; no local build needed)"
+    mkdir -p "$INSTALL_DIR/static"
+    # Stage INSIDE the install tree (private, same filesystem) rather than a
+    # fixed world-writable /tmp path: this makes the final swap an atomic
+    # rename and avoids writing through an attacker-planted symlink while
+    # running as root in the common `curl | sudo bash` invocation.
+    _stage="$(mktemp -d "$INSTALL_DIR/static/.taos-bundle.XXXXXX")"
+    _tarball="$(mktemp "$INSTALL_DIR/static/.taos-bundle.XXXXXX.tgz")"
+    # Verify the download against the CI-published SHA256 before extracting,
+    # so a corrupted or tampered tarball is rejected (we fall back to a local
+    # build). sha256sum on Linux, shasum -a 256 on macOS.
+    _exp_sha="$(curl -fsSL --max-time 20 "$_base/desktop-bundle.sha256" 2>/dev/null | tr -d '[:space:]' || echo "")"
+    _sha_cmd="sha256sum"; command -v sha256sum >/dev/null 2>&1 || _sha_cmd="shasum -a 256"
+    if curl -fsSL --max-time 120 "$_base/desktop-bundle.tar.gz" -o "$_tarball" \
+       && [[ -n "$_exp_sha" && "$($_sha_cmd "$_tarball" | awk '{print $1}')" == "$_exp_sha" ]] \
+       && tar -C "$_stage" -xzf "$_tarball" \
+       && [[ -f "$_stage/desktop/index.html" ]]; then
+        rm -rf "$INSTALL_DIR/static/desktop"
+        mv "$_stage/desktop" "$INSTALL_DIR/static/desktop"
+        # Match the repo owner so a later in-app rebuild (run as that user) can
+        # still write here; only meaningful when installing as root. Trailing
+        # colon sets the owner's primary group (do not assume a group named
+        # after the user exists).
+        _own="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
+        if [[ "$(id -u)" == "0" && -n "$_own" && "$_own" != "root" ]]; then
+            chown -R "$_own:" "$INSTALL_DIR/static/desktop" 2>/dev/null || true
         fi
         rm -rf "$_stage" "$_tarball"
+        log "prebuilt desktop bundle installed into static/desktop/ (from $_label)"
+        return 0
+    fi
+    warn "prebuilt bundle download/extract from $_label failed"
+    rm -rf "$_stage" "$_tarball"
+    return 1
+}
+
+_prebuilt_done=0
+if [[ -n "$_desktop_tree" ]]; then
+    # bundle-latest tracks the newest master build, so an install pinned to an
+    # older release tag only matches it until the next master push. Fall back
+    # to the bundle attached to the release tag itself, which matches that
+    # tag's source forever (#1544).
+    _try_prebuilt_bundle "$_bundle_base" "bundle-latest" && _prebuilt_done=1
+    if [[ "$_prebuilt_done" == "0" ]]; then
+        _rel_tag="$(_git_ro describe --exact-match --tags HEAD 2>/dev/null || echo "")"
+        if [[ -n "$_rel_tag" ]]; then
+            _try_prebuilt_bundle "${_bundle_base%bundle-latest}$_rel_tag" "release $_rel_tag" && _prebuilt_done=1
+        fi
     fi
 fi
 
@@ -1559,7 +1635,7 @@ ensure_taos_user() {
             && log "added 'taos' to the 'incus' group" \
             || warn "could not add 'taos' to the 'incus' group — agent container deploys may fail"
     else
-        warn "'incus' group not found — skipping (install Incus first, then re-run to add 'taos' to the group)"
+        warn "'incus' group not found — incus is not installed, so agent LXC deploys are unavailable (Docker apps still work). Install incus and re-run this installer to finish the group setup."
     fi
 
     # Mirror the existing docker-group handling: add 'taos' to docker so the

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1365,8 +1365,13 @@ _try_prebuilt_bundle() {
             fi
         fi
         if ! mv "$_stage/desktop" "$INSTALL_DIR/static/desktop"; then
-            [[ -n "$_old" ]] && mv "$_old" "$INSTALL_DIR/static/desktop" 2>/dev/null
-            warn "installing the prebuilt bundle failed during the swap — previous desktop restored"
+            # Do not claim the restore worked unless it actually did: a failed
+            # rename-back would otherwise leave no desktop while saying otherwise.
+            if [[ -n "$_old" ]] && mv "$_old" "$INSTALL_DIR/static/desktop"; then
+                warn "installing the prebuilt bundle failed during the swap — previous desktop restored"
+            else
+                warn "installing the prebuilt bundle failed during the swap AND the previous desktop could not be restored — static/desktop is missing; the local build below (or a re-run) will recreate it"
+            fi
             rm -rf "$_stage" "$_tarball"
             return 1
         fi


### PR DESCRIPTION
Fixes the five bugs from the clean-install report on an official Orange Pi 5 Pro Debian Bookworm vendor image (#1540), each root-caused from the attached logs:

- **#1541** Compose plugin: Debian names it `docker-compose-plugin`; we only tried Ubuntu's `docker-compose-v2`. Now tries both, and installs engine + plugin in separate apt transactions so a missing plugin name cannot block Docker itself on fresh boxes.
- **#1543** install-rknpu.sh died right after replacing librknnrt.so: `ldconfig` exits non-zero on merged-/lib vendor layouts and `set -e` killed the run before rkllama ever installed. The cache refresh is now best-effort.
- **#1544** Prebuilt SPA bundle silently skipped on re-runs: the tree check ran as root over the taos-owned checkout, tripped git's dubious-ownership protection, and returned empty. It now drops to the owning user (same pattern as the checkout update), logs unreachable-channel vs tree-mismatch distinctly, and falls back to the bundle attached to the release tag (assets already published per release by CI).
- **#1545** rkllama.service crashlooped on `ImportError: libGL.so.1`: cv2's runtime libraries (libGL/GLib/libSM/libXext) are now installed with the other rkllama deps, with the bookworm/legacy libgl package-name split handled.
- **#1546** Vendor images ship Docker preinstalled, which made the runtime setup return early and never install incus; the user was left to decode a warning and install it manually. Incus now installs alongside a pre-existing Docker (`TAOS_NO_INCUS=1` opts out; WSL stays Docker-only), and the group warning explains the actual state.

Verified: bash -n + shellcheck on both scripts (no new findings).

Fixes #1541. Fixes #1543. Fixes #1544. Fixes #1545. Fixes #1546.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer reliability for the desktop prebuilt bundle on re-runs, including ownership-safe Git operations, SHA256-verified downloads, and safe fallback when pinned bundle references can’t be reached.
  * Fixed Docker Compose v2 installation on Debian/Ubuntu by handling Debian vs Ubuntu package-name ordering and installing Docker Engine and Compose in separate apt transactions.
  * Made `ldconfig` handling best-effort during the driver install so non-critical failures don’t abort the overall process.
  * Prevented rkllama crashes on vendor Debian images by installing missing OpenCV/OpenGL runtime libraries (`libGL`/GLib/X/SM).
  * Ensured Incus is installed alongside preinstalled Docker images when appropriate, with WSL handling and `TAOS_NO_INCUS=1` to skip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->