### PR TITLE
fix(models): surface download failures instead of silently clearing them (#1548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- Models: a failed model download no longer looks like an instant successful install. The failure now stays on the model card with the actual cause from the backend (for example a checksum mismatch or an unreachable download host) and a Retry button, instead of the progress UI silently disappearing (#1548).
+
 ## [1.0.0-beta.16] - 2026-07-02
 
 ### Added

--- a/desktop/src/components/ModelBrowser.test.tsx
+++ b/desktop/src/components/ModelBrowser.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ModelBrowser } from "./ModelBrowser";
+
+// Pins the #1548 fix: a download that fails must stay visible with its
+// backend error and a Retry button, not silently vanish (which made an
+// instant failure look like a completed install).
+
+const CATALOG = {
+  models: [
+    {
+      id: "qwen-test",
+      name: "Qwen Test",
+      description: "test model",
+      capabilities: ["chat"],
+      variants: [
+        {
+          id: "q4",
+          name: "Q4",
+          size_mb: 500,
+          compatibility: "green",
+          downloaded: false,
+        },
+      ],
+    },
+  ],
+};
+
+function mockFetch(routes: Record<string, () => Response>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      for (const [prefix, make] of Object.entries(routes)) {
+        if (url.startsWith(prefix)) return Promise.resolve(make());
+      }
+      return Promise.resolve(
+        new Response("[]", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as unknown as typeof fetch,
+  );
+}
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("ModelBrowser download errors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("shows the backend error and a Retry button when a download fails", async () => {
+    mockFetch({
+      "/api/models/downloads/": () =>
+        json({ status: "error", percent: 0, error: "SHA256 mismatch" }),
+      "/api/models/download": () => json({ download_id: "dl-1" }),
+      "/api/models/loaded": () => json({ models: [] }),
+      "/api/models": () => json(CATALOG),
+      "/api/providers": () => json([]),
+    });
+
+    render(
+      <ModelBrowser open={true} onClose={() => {}} capability="chat" />,
+    );
+
+    const btn = await screen.findByRole("button", { name: "Download" });
+    fireEvent.click(btn);
+
+    // Poll interval is 2s; the error must surface, not be cleared.
+    const alert = await screen.findByRole(
+      "alert",
+      {},
+      { timeout: 5000 },
+    );
+    expect(alert.textContent).toContain("SHA256 mismatch");
+    expect(
+      screen.getByRole("button", { name: "Retry" }),
+    ).toBeInTheDocument();
+  }, 10000);
+
+  it("shows an error when the download cannot even be started", async () => {
+    mockFetch({
+      "/api/models/download": () => json({ error: "no download_url for variant" }),
+      "/api/models/loaded": () => json({ models: [] }),
+      "/api/models": () => json(CATALOG),
+      "/api/providers": () => json([]),
+    });
+
+    render(
+      <ModelBrowser open={true} onClose={() => {}} capability="chat" />,
+    );
+
+    const btn = await screen.findByRole("button", { name: "Download" });
+    fireEvent.click(btn);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("no download_url for variant");
+  });
+});

--- a/desktop/src/components/ModelBrowser.tsx
+++ b/desktop/src/components/ModelBrowser.tsx
@@ -103,7 +103,7 @@ export function ModelBrowser({
     "compatible",
   );
   const [downloading, setDownloading] = useState<
-    Record<string, { percent: number; status: string }>
+    Record<string, { percent: number; status: string; error?: string }>
   >({});
   const [loadedModels, setLoadedModels] = useState<LoadedModel[]>([]);
 
@@ -243,11 +243,16 @@ export function ModelBrowser({
         });
         const data = await res.json();
         if (!data.download_id) {
-          setDownloading((prev) => {
-            const n = { ...prev };
-            delete n[key];
-            return n;
-          });
+          // Keep the failure on screen: silently clearing here made a
+          // rejected install look like an instant success (#1548).
+          setDownloading((prev) => ({
+            ...prev,
+            [key]: {
+              percent: 0,
+              status: "error",
+              error: data.error || data.detail || "The download could not be started",
+            },
+          }));
           return;
         }
         const interval = setInterval(async () => {
@@ -272,11 +277,17 @@ export function ModelBrowser({
               onModelDownloaded?.(modelId, variantId);
             } else if (task.status === "error") {
               clearInterval(interval);
-              setDownloading((prev) => {
-                const n = { ...prev };
-                delete n[key];
-                return n;
-              });
+              // A failed download must stay visible with its cause; clearing
+              // it made an immediate failure indistinguishable from a
+              // completed install (#1548).
+              setDownloading((prev) => ({
+                ...prev,
+                [key]: {
+                  percent: task.percent ?? 0,
+                  status: "error",
+                  error: task.error || "Download failed",
+                },
+              }));
             }
           } catch {
             clearInterval(interval);
@@ -515,7 +526,31 @@ export function ModelBrowser({
                               </div>
                             </div>
                             <div className="shrink-0">
-                              {dl ? (
+                              {dl && dl.status === "error" ? (
+                                <div
+                                  className="flex items-center gap-2 max-w-[260px]"
+                                  role="alert"
+                                >
+                                  <span
+                                    className="text-[10px] text-red-400 flex items-center gap-1 truncate"
+                                    title={dl.error}
+                                  >
+                                    <AlertTriangle size={10} className="shrink-0" />
+                                    <span className="truncate">
+                                      {dl.error || "Download failed"}
+                                    </span>
+                                  </span>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() =>
+                                      startDownload(model.id, variant.id)
+                                    }
+                                  >
+                                    Retry
+                                  </Button>
+                                </div>
+                              ) : dl ? (
                                 <div className="flex items-center gap-2 text-xs text-shell-text-secondary">
                                   <Loader2
                                     size={12}


### PR DESCRIPTION
Addresses the silent-failure half of #1548 (clean Debian Bookworm vendor image, Orange Pi 5 Pro): clicking Install appeared to complete instantly but the model never installed.

Root cause of the confusing UX: in ModelBrowser the download poll loop deleted the progress entry when the task reported status=error, and discarded the backend's task.error string; a rejected download-start did the same. An immediate failure therefore rendered exactly like an instant success.

Now:
- a failed download stays on the variant row with the backend's real error text (checksum mismatch, unreachable host, permission error, and so on) and a Retry button
- a download that cannot even be started shows the API's error instead of vanishing
- two vitest cases pin both paths

This intentionally does not guess at the underlying download failure on the reporter's board: with the error finally visible, their next attempt tells us the exact cause. The Providers-page error states and the empty log viewer from #1548 are being handled separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed model downloads now remain on the model card with the backend-provided error reason, instead of disappearing.
  * Added clearer failure states, including an inline error message and a **Retry** button when downloads fail or can’t be started.
  * Improved resilience when polling download status to avoid leaving silent or confusing states.
* **Tests**
  * Added UI tests covering model download error handling and **Retry** behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->