### PR TITLE
Release 1.0.0-beta.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- Installer: the Docker Compose v2 plugin now installs on Debian (including vendor Pi images) by trying the Debian package name (`docker-compose-plugin`) before the Ubuntu one (`docker-compose-v2`), and the engine + plugin install in separate apt transactions so a missing plugin name can no longer prevent Docker itself from installing (#1541).
+- Installer: install-rknpu.sh no longer aborts right after replacing librknnrt.so when `ldconfig` exits non-zero on vendor images with merged /lib layouts; the cache refresh is best-effort and rkllama now installs in the same run (#1543).
+- Installer: the prebuilt desktop bundle is used on re-runs again. Re-runs as root over the taos-owned checkout tripped git's dubious-ownership check, which silently disabled the prebuilt path and forced a local vite build every time; the tree check now runs as the owning user, logs say whether the bundle channel was unreachable or genuinely mismatched, and installs pinned to a release tag fall back to the bundle attached to that release (#1544).
+- Installer: install-rknpu.sh now installs the OpenCV runtime libraries rkllama needs (libGL, GLib, libSM, libXext); vendor Debian images ship without them and rkllama.service crashlooped on "ImportError: libGL.so.1" (#1545).
+- Installer: when a vendor image ships with Docker preinstalled, incus is now installed as well (it is the preferred runtime for agent containers; skip with TAOS_NO_INCUS=1). Previously the installer treated the pre-existing Docker as sufficient and only a later warning told the user to install incus by hand and re-run (#1546).
+
 ## [1.0.0-beta.16] - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.17] - 2026-07-02
+
 ### Fixed
 - Models: a failed model download no longer looks like an instant successful install. The failure now stays on the model card with the actual cause from the backend (for example a checksum mismatch or an unreachable download host) and a Retry button, instead of the progress UI silently disappearing (#1548).
 - Installer: the Docker Compose v2 plugin now installs on Debian (including vendor Pi images) by trying the Debian package name (`docker-compose-plugin`) before the Ubuntu one (`docker-compose-v2`), and the engine + plugin install in separate apt transactions so a missing plugin name can no longer prevent Docker itself from installing (#1541).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 ## [Unreleased]
 
 ### Fixed
+- Models: a failed model download no longer looks like an instant successful install. The failure now stays on the model card with the actual cause from the backend (for example a checksum mismatch or an unreachable download host) and a Retry button, instead of the progress UI silently disappearing (#1548).
 - Installer: the Docker Compose v2 plugin now installs on Debian (including vendor Pi images) by trying the Debian package name (`docker-compose-plugin`) before the Ubuntu one (`docker-compose-v2`), and the engine + plugin install in separate apt transactions so a missing plugin name can no longer prevent Docker itself from installing (#1541).
 - Installer: install-rknpu.sh no longer aborts right after replacing librknnrt.so when `ldconfig` exits non-zero on vendor images with merged /lib layouts; the cache refresh is best-effort and rkllama now installs in the same run (#1543).
 - Installer: the prebuilt desktop bundle is used on re-runs again. Re-runs as root over the taos-owned checkout tripped git's dubious-ownership check, which silently disabled the prebuilt path and forced a local vite build every time; the tree check now runs as the owning user, logs say whether the bundle channel was unreachable or genuinely mismatched, and installs pinned to a release tag fall back to the bundle attached to that release (#1544).

--- a/README.md
+++ b/README.md
@@ -78,7 +78,15 @@ curl -fsSL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-
 
 Run without `sudo` to install as a user-mode systemd unit instead. The script is idempotent, safe to re-run on an existing install. Supports env-var overrides for install path, branch, and port.
 
-Tested on WSL2 (Windows 11) with the default Ubuntu image, including the current Python 3.14 default: the installer provisions a compatible Python automatically, so a clean box needs nothing more than the one line above.
+### Verified installs
+
+Platforms where a clean controller install has been verified end to end. Ran it somewhere else? Open an issue with your install log (the installer prints an environment banner for exactly this) and it gets added here.
+
+| Hardware | OS | Verified |
+| --- | --- | --- |
+| Orange Pi 5 Plus 16GB (RK3588) | Armbian (Debian trixie base) | Runs the maintainer's stack daily, including the RK3588 NPU memory/embedding path |
+| Orange Pi 5 Pro (RK3588S) | Official Orange Pi Debian 12 (Bookworm) vendor image | Clean-install community report (#1540); fixes shipped in v1.0.0-beta.17, including the RK3588 NPU backend with preloaded models |
+| WSL2 on Windows 11 | Default Ubuntu image (incl. Python 3.14) | Clean install; the installer provisions a compatible Python automatically |
 
 **Manual / development:**
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ Platforms where a clean controller install has been verified end to end. Ran it 
 | --- | --- | --- |
 | Orange Pi 5 Plus 16GB (RK3588) | Armbian (Debian trixie base) | Runs the maintainer's stack daily, including the RK3588 NPU memory/embedding path |
 | Orange Pi 5 Pro (RK3588S) | Official Orange Pi Debian 12 (Bookworm) vendor image | Clean-install community report (#1540); fixes shipped in v1.0.0-beta.17, including the RK3588 NPU backend with preloaded models |
+| x86_64 PC | Fedora | Maintainer-verified install (also serves as a GPU cluster worker with an RTX 3060) |
+| x86_64 PC | Debian | Maintainer-verified install |
 | WSL2 on Windows 11 | Default Ubuntu image (incl. Python 3.14) | Clean install; the installer provisions a compatible Python automatically |
+| Mac | macOS | Installer verified in early betas; the dedicated macOS app (Apple Containerization) is a separate track |
 
 **Manual / development:**
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.16",
+  "version": "1.0.0-beta.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/components/ModelBrowser.test.tsx
+++ b/desktop/src/components/ModelBrowser.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ModelBrowser } from "./ModelBrowser";
+
+// Pins the #1548 fix: a download that fails must stay visible with its
+// backend error and a Retry button, not silently vanish (which made an
+// instant failure look like a completed install).
+
+const CATALOG = {
+  models: [
+    {
+      id: "qwen-test",
+      name: "Qwen Test",
+      description: "test model",
+      capabilities: ["chat"],
+      variants: [
+        {
+          id: "q4",
+          name: "Q4",
+          size_mb: 500,
+          compatibility: "green",
+          downloaded: false,
+        },
+      ],
+    },
+  ],
+};
+
+function mockFetch(routes: Record<string, () => Response>) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      for (const [prefix, make] of Object.entries(routes)) {
+        if (url.startsWith(prefix)) return Promise.resolve(make());
+      }
+      return Promise.resolve(
+        new Response("[]", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as unknown as typeof fetch,
+  );
+}
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("ModelBrowser download errors", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("shows the backend error and a Retry button when a download fails", async () => {
+    mockFetch({
+      "/api/models/downloads/": () =>
+        json({ status: "error", percent: 0, error: "SHA256 mismatch" }),
+      "/api/models/download": () => json({ download_id: "dl-1" }),
+      "/api/models/loaded": () => json({ models: [] }),
+      "/api/models": () => json(CATALOG),
+      "/api/providers": () => json([]),
+    });
+
+    render(
+      <ModelBrowser open={true} onClose={() => {}} capability="chat" />,
+    );
+
+    const btn = await screen.findByRole("button", { name: "Download" });
+    fireEvent.click(btn);
+
+    // Poll interval is 2s; the error must surface, not be cleared.
+    const alert = await screen.findByRole(
+      "alert",
+      {},
+      { timeout: 5000 },
+    );
+    expect(alert.textContent).toContain("SHA256 mismatch");
+    expect(
+      screen.getByRole("button", { name: "Retry" }),
+    ).toBeInTheDocument();
+  }, 10000);
+
+  it("shows an error when the download cannot even be started", async () => {
+    mockFetch({
+      "/api/models/download": () => json({ error: "no download_url for variant" }),
+      "/api/models/loaded": () => json({ models: [] }),
+      "/api/models": () => json(CATALOG),
+      "/api/providers": () => json([]),
+    });
+
+    render(
+      <ModelBrowser open={true} onClose={() => {}} capability="chat" />,
+    );
+
+    const btn = await screen.findByRole("button", { name: "Download" });
+    fireEvent.click(btn);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("no download_url for variant");
+  });
+});

--- a/desktop/src/components/ModelBrowser.tsx
+++ b/desktop/src/components/ModelBrowser.tsx
@@ -103,7 +103,7 @@ export function ModelBrowser({
     "compatible",
   );
   const [downloading, setDownloading] = useState<
-    Record<string, { percent: number; status: string }>
+    Record<string, { percent: number; status: string; error?: string }>
   >({});
   const [loadedModels, setLoadedModels] = useState<LoadedModel[]>([]);
 
@@ -243,17 +243,27 @@ export function ModelBrowser({
         });
         const data = await res.json();
         if (!data.download_id) {
-          setDownloading((prev) => {
-            const n = { ...prev };
-            delete n[key];
-            return n;
-          });
+          // Keep the failure on screen: silently clearing here made a
+          // rejected install look like an instant success (#1548).
+          setDownloading((prev) => ({
+            ...prev,
+            [key]: {
+              percent: 0,
+              status: "error",
+              error: data.error || data.detail || "The download could not be started",
+            },
+          }));
           return;
         }
         const interval = setInterval(async () => {
           try {
             const pr = await fetch(`/api/models/downloads/${data.download_id}`);
             const task = await pr.json();
+            // A proxy error page or empty body must land in the catch below
+            // (which surfaces an error), not TypeError into a stuck spinner.
+            if (!task || typeof task !== "object") {
+              throw new Error("invalid poll response");
+            }
             setDownloading((prev) => ({
               ...prev,
               [key]: {
@@ -272,14 +282,32 @@ export function ModelBrowser({
               onModelDownloaded?.(modelId, variantId);
             } else if (task.status === "error") {
               clearInterval(interval);
-              setDownloading((prev) => {
-                const n = { ...prev };
-                delete n[key];
-                return n;
-              });
+              // A failed download must stay visible with its cause; clearing
+              // it made an immediate failure indistinguishable from a
+              // completed install (#1548).
+              setDownloading((prev) => ({
+                ...prev,
+                [key]: {
+                  percent: task.percent ?? 0,
+                  status: "error",
+                  // || not ??: the backend initialises error to an empty
+                  // string, and an empty alert helps nobody.
+                  error: task.error || "Download failed",
+                },
+              }));
             }
           } catch {
+            // Losing the poll (network blip, proxy error page) must not
+            // strand a spinner with no outcome; surface it as an error.
             clearInterval(interval);
+            setDownloading((prev) => ({
+              ...prev,
+              [key]: {
+                percent: 0,
+                status: "error",
+                error: "Lost contact with the download; retry to continue",
+              },
+            }));
           }
         }, 2000);
       } catch {
@@ -515,7 +543,31 @@ export function ModelBrowser({
                               </div>
                             </div>
                             <div className="shrink-0">
-                              {dl ? (
+                              {dl && dl.status === "error" ? (
+                                <div
+                                  className="flex items-center gap-2 max-w-[260px]"
+                                  role="alert"
+                                >
+                                  <span
+                                    className="text-[10px] text-red-400 flex items-center gap-1 truncate"
+                                    title={dl.error}
+                                  >
+                                    <AlertTriangle size={10} className="shrink-0" />
+                                    <span className="truncate">
+                                      {dl.error || "Download failed"}
+                                    </span>
+                                  </span>
+                                  <Button
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={() =>
+                                      startDownload(model.id, variant.id)
+                                    }
+                                  >
+                                    Retry
+                                  </Button>
+                                </div>
+                              ) : dl ? (
                                 <div className="flex items-center gap-2 text-xs text-shell-text-secondary">
                                   <Loader2
                                     size={12}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.16"
+version = "1.0.0-beta.17"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -319,7 +319,12 @@ pin_librknnrt() {
     # Install the new one.
     sudo install -m 0644 "$tmp" "$LIBRKNNRT_DEST"
     LIBRKNNRT_REPLACED=1
-    sudo ldconfig
+    # ldconfig can exit non-zero on vendor images (e.g. "/lib/librknnrt.so is
+    # not a symbolic link" on merged-/lib layouts), which under set -e killed
+    # the whole install right after the library was correctly replaced and
+    # rkllama never got installed (#1543). The cache refresh is best-effort:
+    # the library is already at its canonical path.
+    sudo ldconfig || warn "ldconfig exited $? after installing librknnrt (its stderr above has the cause; harmless on merged /lib layouts where the runtime resolves by absolute path; continuing)"
 
     # Verify the version string as a belt-and-braces check. The SHA256 above
     # already proved $tmp is byte-for-byte the pinned runtime, so this is
@@ -391,6 +396,28 @@ install_rkllama() {
         # `strings` (binutils) is used by the librknnrt version checks; minimal
         # Pi images can lack it (#783). Ensure it is present.
         command -v strings >/dev/null 2>&1 || _need+=("binutils")
+        # rkllama imports OpenCV (cv2), which needs the OpenGL/GLib/X runtime
+        # libs; vendor Debian images ship without them and the service then
+        # crashloops on "ImportError: libGL.so.1" (#1545). Bookworm+ names the
+        # GL runtime libgl1; older releases only have libgl1-mesa-glx.
+        # GLib was renamed libglib2.0-0t64 in Ubuntu 24.04 / Debian Trixie;
+        # probe both installed names and add whichever the repos carry.
+        if ! dpkg-query -W libglib2.0-0 >/dev/null 2>&1 && ! dpkg-query -W libglib2.0-0t64 >/dev/null 2>&1; then
+            if [[ -n "$(apt-cache madison libglib2.0-0 2>/dev/null)" ]]; then
+                _need+=("libglib2.0-0")
+            else
+                _need+=("libglib2.0-0t64")
+            fi
+        fi
+        dpkg-query -W libsm6 >/dev/null 2>&1 || _need+=("libsm6")
+        dpkg-query -W libxext6 >/dev/null 2>&1 || _need+=("libxext6")
+        if ! dpkg-query -W libgl1 >/dev/null 2>&1 && ! dpkg-query -W libgl1-mesa-glx >/dev/null 2>&1; then
+            if [[ -n "$(apt-cache madison libgl1 2>/dev/null)" ]]; then
+                _need+=("libgl1")
+            else
+                _need+=("libgl1-mesa-glx")
+            fi
+        fi
         if (( ${#_need[@]} )); then
             log "installing build deps for rkllama wheel compilation: ${_need[*]}"
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "${_need[@]}" \

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -402,6 +402,9 @@ install_rkllama() {
         # GL runtime libgl1; older releases only have libgl1-mesa-glx.
         # GLib was renamed libglib2.0-0t64 in Ubuntu 24.04 / Debian Trixie;
         # probe both installed names and add whichever the repos carry.
+        # The madison probes below read the local package lists; refresh them
+        # first (best-effort) so a stale image cannot steer the name choice.
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>/dev/null || true
         if ! dpkg-query -W libglib2.0-0 >/dev/null 2>&1 && ! dpkg-query -W libglib2.0-0t64 >/dev/null 2>&1; then
             if [[ -n "$(apt-cache madison libglib2.0-0 2>/dev/null)" ]]; then
                 _need+=("libglib2.0-0")

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -403,8 +403,11 @@ install_rkllama() {
         # GLib was renamed libglib2.0-0t64 in Ubuntu 24.04 / Debian Trixie;
         # probe both installed names and add whichever the repos carry.
         # The madison probes below read the local package lists; refresh them
-        # first (best-effort) so a stale image cannot steer the name choice.
-        sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>/dev/null || true
+        # first so a stale image cannot steer the name choice. Best-effort,
+        # but say so when it fails: with stale lists the probes may pick the
+        # wrong package name, and the operator needs that context.
+        sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq \
+            || warn "apt-get update failed — package lists may be stale and the library package-name detection below may be wrong"
         if ! dpkg-query -W libglib2.0-0 >/dev/null 2>&1 && ! dpkg-query -W libglib2.0-0t64 >/dev/null 2>&1; then
             if [[ -n "$(apt-cache madison libglib2.0-0 2>/dev/null)" ]]; then
                 _need+=("libglib2.0-0")

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -909,18 +909,17 @@ PY
 # docker-compose-v2. Trying only the Ubuntu name broke Debian Bookworm
 # (vendor Pi images included) with "Unable to locate package" (#1541).
 _apt_install_compose() {
-    local _err
-    if _err=$(sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-plugin 2>&1); then
-        return 0
+    # Probe availability with apt-cache madison instead of grepping apt's
+    # stderr: the error text is locale-dependent (so string matching broke
+    # the fallback on any non-English system) and "no installation candidate"
+    # was a second phrasing the match missed; an empty madison covers both.
+    # Any real apt failure (locks, held packages, resolver) then surfaces
+    # from the single install attempt itself.
+    if [[ -n "$(apt-cache madison docker-compose-plugin 2>/dev/null)" ]]; then
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-plugin
+    else
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2
     fi
-    # Only fall through to the Ubuntu name when the Debian name simply is not
-    # in the repos; any other apt failure (locks, held packages, resolver)
-    # is real and must reach the operator, not be masked by a second attempt.
-    if ! grep -qi "unable to locate package" <<<"$_err"; then
-        printf '%s\n' "$_err" >&2
-        return 1
-    fi
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2
 }
 
 ensure_docker_for_apps() {

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -700,16 +700,33 @@ ensure_container_runtime() {
         esac
         return 0
     fi
+    # A pre-existing Docker/podman (vendor Pi images often ship Docker) is a
+    # usable runtime, but agent LXC deploys prefer incus — and returning early
+    # here meant incus was never installed on such images, leaving the user to
+    # discover it from a later group-setup warning and install it by hand
+    # (#1546). Install incus as well, except on WSL (where Docker is the sane
+    # default) or with TAOS_NO_INCUS=1.
+    local _other_runtime=""
     if command -v docker >/dev/null 2>&1; then
+        _other_runtime="docker"
         log "container runtime: docker $(docker --version 2>/dev/null | head -1) — ok"
-        return 0
-    fi
-    if command -v podman >/dev/null 2>&1; then
+    elif command -v podman >/dev/null 2>&1; then
+        _other_runtime="podman"
         log "container runtime: podman $(podman --version 2>/dev/null | head -1) — ok"
-        return 0
     fi
-
-    log "no container runtime found — installing Incus"
+    if [[ -n "$_other_runtime" ]]; then
+        if [[ "${TAOS_NO_INCUS:-0}" == "1" ]]; then
+            log "TAOS_NO_INCUS=1 — not installing incus; agent containers will use $_other_runtime"
+            return 0
+        fi
+        if grep -qi microsoft /proc/version 2>/dev/null; then
+            log "WSL detected — using $_other_runtime; skipping the incus install"
+            return 0
+        fi
+        log "incus not found — installing it as well (preferred runtime for agent containers; set TAOS_NO_INCUS=1 to skip)"
+    else
+        log "no container runtime found — installing Incus"
+    fi
 
     local installed=0
     if command -v apt-get >/dev/null 2>&1; then
@@ -887,6 +904,25 @@ PY
 # including compose-style stacks like SearXNG / Perplexica. incus runs agent
 # LXCs; Docker runs Docker apps. Installed by default — set TAOS_SKIP_DOCKER=1
 # to opt out (Store Docker apps then stay unavailable).
+# The Compose v2 plugin has two apt names: Debian and Docker's own repo call
+# it docker-compose-plugin; Ubuntu's universe archive calls it
+# docker-compose-v2. Trying only the Ubuntu name broke Debian Bookworm
+# (vendor Pi images included) with "Unable to locate package" (#1541).
+_apt_install_compose() {
+    local _err
+    if _err=$(sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-plugin 2>&1); then
+        return 0
+    fi
+    # Only fall through to the Ubuntu name when the Debian name simply is not
+    # in the repos; any other apt failure (locks, held packages, resolver)
+    # is real and must reach the operator, not be masked by a second attempt.
+    if ! grep -qi "unable to locate package" <<<"$_err"; then
+        printf '%s\n' "$_err" >&2
+        return 1
+    fi
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2
+}
+
 ensure_docker_for_apps() {
     if [[ "${TAOS_SKIP_DOCKER:-0}" == "1" ]]; then
         log "TAOS_SKIP_DOCKER=1 — skipping Docker (Store Docker apps will be unavailable)"
@@ -925,8 +961,14 @@ ensure_docker_for_apps() {
         # with "unknown command: docker compose".
         log "installing Docker Engine + Compose plugin (for Store Docker apps)"
         if command -v apt-get >/dev/null 2>&1; then
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io docker-compose-v2 \
-                || warn "apt install docker.io/docker-compose-v2 failed — Store Docker apps will be unavailable"
+            # Install the engine and the compose plugin in SEPARATE apt
+            # transactions: bundling them meant a missing compose package name
+            # (see _apt_install_compose below) failed the whole transaction and
+            # left the box without Docker at all (#1541).
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io \
+                || warn "apt install docker.io failed — Store Docker apps will be unavailable"
+            _apt_install_compose \
+                || warn "apt install of the compose plugin failed — Store Docker apps will be unavailable"
         elif command -v dnf >/dev/null 2>&1; then
             sudo dnf install -y -q moby-engine docker-compose \
                 || warn "dnf install moby-engine/docker-compose failed — Store Docker apps will be unavailable"
@@ -949,7 +991,7 @@ ensure_docker_for_apps() {
     if ! docker compose version >/dev/null 2>&1; then
         log "installing the Docker Compose v2 plugin"
         if command -v apt-get >/dev/null 2>&1; then
-            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-compose-v2 || true
+            _apt_install_compose || true
         elif command -v dnf >/dev/null 2>&1; then
             sudo dnf install -y -q docker-compose || true
         elif command -v pacman >/dev/null 2>&1; then
@@ -1246,50 +1288,131 @@ ensure_litellm_postgres || warn "litellm postgres setup did not complete -- virt
 # old UI. Fall back to a local build only when no matching prebuilt is available.
 
 _bundle_base="https://github.com/jaylfc/taOS/releases/download/bundle-latest"
-_desktop_tree="$(git -C "$INSTALL_DIR" rev-parse HEAD:desktop 2>/dev/null || echo "")"
-_prebuilt_done=0
-if [[ -n "$_desktop_tree" ]]; then
-    _remote_tree="$(curl -fsSL --max-time 20 "$_bundle_base/desktop-tree.txt" 2>/dev/null | tr -d '[:space:]')"
-    if [[ -n "$_remote_tree" && "$_remote_tree" == "$_desktop_tree" ]]; then
-        log "fetching prebuilt desktop bundle (matches source; no local build needed)"
-        mkdir -p "$INSTALL_DIR/static"
-        # Stage INSIDE the install tree (private, same filesystem) rather than a
-        # fixed world-writable /tmp path: this makes the final swap an atomic
-        # rename and avoids writing through an attacker-planted symlink while
-        # running as root in the common `curl | sudo bash` invocation.
-        _stage="$(mktemp -d "$INSTALL_DIR/static/.taos-bundle.XXXXXX")"
-        _tarball="$(mktemp "$INSTALL_DIR/static/.taos-bundle.XXXXXX.tgz")"
-        # Verify the download against the CI-published SHA256 before extracting,
-        # so a corrupted or tampered tarball is rejected (we fall back to a local
-        # build). sha256sum on Linux, shasum -a 256 on macOS.
-        _exp_sha="$(curl -fsSL --max-time 20 "$_bundle_base/desktop-bundle.sha256" 2>/dev/null | tr -d '[:space:]')"
-        _sha_cmd="sha256sum"; command -v sha256sum >/dev/null 2>&1 || _sha_cmd="shasum -a 256"
-        if curl -fsSL --max-time 120 "$_bundle_base/desktop-bundle.tar.gz" -o "$_tarball" \
-           && [[ -n "$_exp_sha" && "$($_sha_cmd "$_tarball" | awk '{print $1}')" == "$_exp_sha" ]] \
-           && tar -C "$_stage" -xzf "$_tarball" \
-           && [[ -f "$_stage/desktop/index.html" ]]; then
-            rm -rf "$INSTALL_DIR/static/desktop"
-            mv "$_stage/desktop" "$INSTALL_DIR/static/desktop"
-            # Match the repo owner so a later in-app rebuild (run as that user) can
-            # still write here; only meaningful when installing as root. Trailing
-            # colon sets the owner's primary group (do not assume a group named
-            # after the user exists).
-            _own="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
-            if [[ "$(id -u)" == "0" && -n "$_own" && "$_own" != "root" ]]; then
-                chown -R "$_own:" "$INSTALL_DIR/static/desktop" 2>/dev/null || true
-            fi
-            _prebuilt_done=1
-            log "prebuilt desktop bundle installed into static/desktop/"
+
+# The repo is chowned to the 'taos' service user at the end of a system
+# install, so on a re-run as root a plain `git rev-parse` here trips git's
+# dubious-ownership check, returned empty, and silently disabled the prebuilt
+# path — every re-run then fell back to the memory-heavy local vite build
+# (#1544). Drop to the owning user, matching the checkout-update logic above.
+_tree_owner="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
+_git_ro() {
+    # safe.directory is passed explicitly so a TOCTOU owner change between the
+    # stat above and this call cannot re-trip the dubious-ownership guard.
+    if [[ "$(id -u)" == "0" && -n "$_tree_owner" && "$_tree_owner" != "root" ]]; then
+        sudo -u "$_tree_owner" git -c safe.directory="$INSTALL_DIR" -C "$INSTALL_DIR" "$@"
+    else
+        git -c safe.directory="$INSTALL_DIR" -C "$INSTALL_DIR" "$@"
+    fi
+}
+_desktop_tree="$(_git_ro rev-parse HEAD:desktop 2>/dev/null || echo "")"
+[[ -z "$_desktop_tree" ]] \
+    && warn "could not read the desktop/ tree SHA from $INSTALL_DIR — prebuilt bundles unavailable this run"
+
+# Try one prebuilt-bundle source ($1 = release download base URL, $2 = label
+# for logs). Returns 0 only when a tree-matching, checksum-verified bundle was
+# installed into static/desktop/.
+_try_prebuilt_bundle() {
+    local _base="$1" _label="$2" _remote_tree _stage _tarball _exp_sha _sha_cmd _own _old
+    _remote_tree="$(curl -fsSL --max-time 20 "$_base/desktop-tree.txt" 2>/dev/null | tr -d '[:space:]' || echo "")"
+    if [[ -z "$_remote_tree" ]]; then
+        # Say WHY there is no prebuilt: a transient network failure here used
+        # to be indistinguishable from a genuine source mismatch (#1544).
+        log "prebuilt bundle: $_label unreachable or missing its manifest — skipping"
+        return 1
+    fi
+    if [[ "$_remote_tree" != "$_desktop_tree" ]]; then
+        log "prebuilt bundle: $_label was built from a different desktop/ source — skipping"
+        return 1
+    fi
+    log "fetching prebuilt desktop bundle from $_label (matches source; no local build needed)"
+    mkdir -p "$INSTALL_DIR/static"
+    # Stage INSIDE the install tree (private, same filesystem) rather than a
+    # fixed world-writable /tmp path: this makes the final swap an atomic
+    # rename and avoids writing through an attacker-planted symlink while
+    # running as root in the common `curl | sudo bash` invocation.
+    _stage="$(mktemp -d "$INSTALL_DIR/static/.taos-bundle.XXXXXX")"
+    # BSD/macOS mktemp requires the template to END in Xs (no suffix allowed).
+    _tarball="$(mktemp "$INSTALL_DIR/static/.taos-bundle-tar.XXXXXX")"
+    # Verify the download against the CI-published SHA256 before extracting,
+    # so a corrupted or tampered tarball is rejected (we fall back to a local
+    # build). sha256sum on Linux, shasum -a 256 on macOS; with neither, say
+    # explicitly that VERIFICATION was impossible (not "download failed").
+    _exp_sha="$(curl -fsSL --max-time 20 "$_base/desktop-bundle.sha256" 2>/dev/null | tr -d '[:space:]' || echo "")"
+    _sha_cmd="sha256sum"
+    if ! command -v sha256sum >/dev/null 2>&1; then
+        if command -v shasum >/dev/null 2>&1; then
+            _sha_cmd="shasum -a 256"
         else
-            warn "prebuilt bundle download/extract failed; falling back to a local build"
+            warn "no sha256 tool available — cannot verify the prebuilt bundle, skipping it"
+            rm -rf "$_stage" "$_tarball"
+            return 1
+        fi
+    fi
+    if curl -fsSL --max-time 120 "$_base/desktop-bundle.tar.gz" -o "$_tarball" \
+       && [[ -n "$_exp_sha" && "$($_sha_cmd "$_tarball" | awk '{print $1}')" == "$_exp_sha" ]] \
+       && tar -C "$_stage" -xzf "$_tarball" \
+       && [[ -f "$_stage/desktop/index.html" ]]; then
+        # Swap via rename-out / rename-in (same filesystem, so each mv is an
+        # atomic rename): a failed swap must never leave the install with NO
+        # desktop at all, which is what delete-then-move risked.
+        _old=""
+        if [[ -d "$INSTALL_DIR/static/desktop" ]]; then
+            _old="$_stage/desktop.old"
+            if ! mv "$INSTALL_DIR/static/desktop" "$_old"; then
+                warn "could not move the current desktop aside — leaving it in place"
+                rm -rf "$_stage" "$_tarball"
+                return 1
+            fi
+        fi
+        if ! mv "$_stage/desktop" "$INSTALL_DIR/static/desktop"; then
+            # Do not claim the restore worked unless it actually did: a failed
+            # rename-back would otherwise leave no desktop while saying otherwise.
+            if [[ -z "$_old" ]]; then
+                warn "installing the prebuilt bundle failed during the swap — no previous desktop existed; the local build below (or a re-run) will create static/desktop"
+            elif mv "$_old" "$INSTALL_DIR/static/desktop"; then
+                warn "installing the prebuilt bundle failed during the swap — previous desktop restored"
+            else
+                warn "installing the prebuilt bundle failed during the swap AND the previous desktop could not be restored — static/desktop is missing; the local build below (or a re-run) will recreate it"
+            fi
+            rm -rf "$_stage" "$_tarball"
+            return 1
+        fi
+        # Match the repo owner so a later in-app rebuild (run as that user) can
+        # still write here; only meaningful when installing as root. Trailing
+        # colon sets the owner's primary group (do not assume a group named
+        # after the user exists).
+        _own="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
+        if [[ "$(id -u)" == "0" && -n "$_own" && "$_own" != "root" ]]; then
+            chown -R "$_own:" "$INSTALL_DIR/static/desktop" 2>/dev/null || true
         fi
         rm -rf "$_stage" "$_tarball"
+        log "prebuilt desktop bundle installed into static/desktop/ (from $_label)"
+        return 0
+    fi
+    warn "prebuilt bundle from $_label failed (download error, checksum mismatch, or bad archive)"
+    rm -rf "$_stage" "$_tarball"
+    return 1
+}
+
+_prebuilt_done=0
+if [[ -n "$_desktop_tree" ]]; then
+    # bundle-latest tracks the newest master build, so an install pinned to an
+    # older release tag only matches it until the next master push. Fall back
+    # to the bundle attached to the release tag itself, which matches that
+    # tag's source forever (#1544).
+    _try_prebuilt_bundle "$_bundle_base" "bundle-latest" && _prebuilt_done=1
+    if [[ "$_prebuilt_done" == "0" ]]; then
+        _rel_tag="$(_git_ro describe --exact-match --tags HEAD 2>/dev/null || echo "")"
+        if [[ -n "$_rel_tag" ]]; then
+            _try_prebuilt_bundle "${_bundle_base%bundle-latest}$_rel_tag" "release $_rel_tag" && _prebuilt_done=1
+        fi
     fi
 fi
 
 if [[ "$_prebuilt_done" == "0" ]]; then
     if command -v npm >/dev/null 2>&1; then
         log "building desktop SPA locally (no matching prebuilt bundle for this source)"
+        log "  note: the vite build needs roughly 2-4GB of free memory; on small boards close other services first"
         if ! (cd "$INSTALL_DIR/desktop" && npm install --silent && npm run build); then
             die "desktop SPA build failed. This almost always means the machine ran out of memory: the vite build needs roughly 2-4GB free. On WSL the Linux VM is capped at about half of Windows RAM by default, so add to C:\\Users\\<you>\\.wslconfig:
     [wsl2]
@@ -1559,7 +1682,7 @@ ensure_taos_user() {
             && log "added 'taos' to the 'incus' group" \
             || warn "could not add 'taos' to the 'incus' group — agent container deploys may fail"
     else
-        warn "'incus' group not found — skipping (install Incus first, then re-run to add 'taos' to the group)"
+        warn "'incus' group not found — incus is not installed, so agent LXC deploys are unavailable (Docker apps still work). Install incus and re-run this installer to finish the group setup."
     fi
 
     # Mirror the existing docker-group handling: add 'taos' to docker so the

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.16"
+__version__ = "1.0.0-beta.17"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b16"
+version = "1.0.0b17"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promote dev to master for 1.0.0-beta.17.

This release closes out the Orange Pi 5 Pro clean-install report (#1540):
- Fixed: Docker Compose plugin installs on Debian, and a missing plugin name can no longer block Docker itself (#1541)
- Fixed: install-rknpu.sh survives ldconfig exiting non-zero on merged /lib vendor layouts, so rkllama installs on the first run (#1543)
- Fixed: the prebuilt desktop bundle works on installer re-runs (dubious-ownership tree check), with honest logging and a release-tag bundle fallback (#1544)
- Fixed: rkllama's OpenCV runtime libraries (libGL and friends) are installed, ending the service crashloop (#1545)
- Fixed: incus installs alongside a vendor-preinstalled Docker instead of a confusing manual step (#1546)
- Fixed: a failed model download now shows its actual cause and a Retry button instead of looking like an instant successful install (#1548)

Full details in CHANGELOG.md. All changes CI + bot-review gated per PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model download error handling so failures stay visible with details and a **Retry** option (including backend error messages when a download can’t start).
  * Fixed installer issues: Docker Compose v2 plugin installation, ensuring Incus is set up even when Docker/Podman is already present (except on WSL or when disabled), safer re-runs for prebuilt desktop bundles, and installation of missing runtime libraries (including OpenCV-related).
  * Made the RKNPU install script more resilient by treating `ldconfig` as best-effort.
* **Tests**
  * Added UI tests for model download failure states and **Retry** behavior.
* **Chores**
  * Bumped version to **1.0.0-beta.17** across desktop and backend.
* **Documentation**
  * Updated “Verified installs” with a platform verification table.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->