### PR TITLE
fix(shared-folders): block path traversal in folder names and upload filenames

### DIFF
--- a/tests/test_shared_folders.py
+++ b/tests/test_shared_folders.py
@@ -230,7 +230,7 @@ class TestSharedFolderTraversal:
         assert not (folder_mgr.storage_dir.parent / "evil").exists()
         # every escape variant normalizes to the same contained basename
         for variant in ("../evil", "/etc/evil", "..\\evil"):
-            assert folder_mgr._safe_label(variant).endswith("evil")
+            assert folder_mgr._safe_label(variant) == "evil"
 
     async def test_create_folder_flattens_slashy_name(self, folder_mgr):
         # A nested-looking name collapses to its basename, staying contained.

--- a/tests/test_shared_folders.py
+++ b/tests/test_shared_folders.py
@@ -210,3 +210,37 @@ async def test_api_duplicate_folder_returns_409(client):
     await client.post("/api/shared-folders", json={"name": "dup"})
     resp = await client.post("/api/shared-folders", json={"name": "dup"})
     assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+class TestSharedFolderTraversal:
+    """A folder name or filename must never escape storage_dir (path traversal)."""
+
+    async def test_create_folder_rejects_pure_traversal_name(self, folder_mgr):
+        # Names with no real basename (bare traversal) are rejected outright.
+        for bad in ("..", ".", ""):
+            with pytest.raises(ValueError):
+                await folder_mgr.create_folder(bad)
+
+    async def test_create_folder_contains_slashy_traversal(self, folder_mgr):
+        # A traversal-looking name that has a basename is flattened to it and
+        # stays inside the storage root; nothing escapes.
+        await folder_mgr.create_folder("../../etc/evil")
+        assert (folder_mgr.storage_dir / "evil").is_dir()
+        assert not (folder_mgr.storage_dir.parent / "evil").exists()
+        # every escape variant normalizes to the same contained basename
+        for variant in ("../evil", "/etc/evil", "..\\evil"):
+            assert folder_mgr._safe_label(variant).endswith("evil")
+
+    async def test_create_folder_flattens_slashy_name(self, folder_mgr):
+        # A nested-looking name collapses to its basename, staying contained.
+        await folder_mgr.create_folder("a/b/docs")
+        assert (folder_mgr.storage_dir / "docs").is_dir()
+        assert not (folder_mgr.storage_dir / "a").exists()
+
+    async def test_safe_label_blocks_escape(self, folder_mgr):
+        assert folder_mgr._safe_label("../../etc/passwd") == "passwd"
+        with pytest.raises(ValueError):
+            folder_mgr._safe_label("..")
+        with pytest.raises(ValueError):
+            folder_mgr._safe_label("")

--- a/tinyagentos/routes/shared_folders.py
+++ b/tinyagentos/routes/shared_folders.py
@@ -39,6 +39,9 @@ async def create_shared_folder(request: Request, body: CreateFolderRequest):
             description=body.description,
             agents=body.agents,
         )
+    except ValueError:
+        # _safe_label rejected a traversal name: clean 400, not a 500 + trace.
+        return JSONResponse({"error": "Invalid folder name"}, status_code=400)
     except Exception as e:
         if "UNIQUE constraint" in str(e):
             return JSONResponse({"error": f"Folder '{body.name}' already exists"}, status_code=409)
@@ -58,7 +61,10 @@ async def delete_shared_folder(request: Request, folder_id: int):
 @router.get("/api/shared-folders/{name}/files")
 async def list_shared_folder_files(request: Request, name: str):
     mgr = request.app.state.shared_folders
-    return mgr.list_files(name)
+    try:
+        return mgr.list_files(name)
+    except ValueError:
+        return JSONResponse({"error": "Invalid folder name"}, status_code=400)
 
 
 @router.post("/api/shared-folders/{name}/upload")

--- a/tinyagentos/routes/shared_folders.py
+++ b/tinyagentos/routes/shared_folders.py
@@ -64,13 +64,21 @@ async def list_shared_folder_files(request: Request, name: str):
 @router.post("/api/shared-folders/{name}/upload")
 async def upload_to_shared_folder(request: Request, name: str, file: UploadFile):
     mgr = request.app.state.shared_folders
-    folder_path = mgr.storage_dir / name
+    # Both the folder name (URL path) and the upload filename are caller
+    # controlled; sanitize each to a contained label so an uploaded file can
+    # never be written outside the shared-folder root (path traversal).
+    try:
+        folder_name = mgr._safe_label(name)
+        safe_filename = mgr._safe_label(file.filename or "")
+    except ValueError:
+        return JSONResponse({"error": "Invalid folder or file name"}, status_code=400)
+    folder_path = mgr.storage_dir / folder_name
     if not folder_path.exists():
         return JSONResponse({"error": f"Folder '{name}' not found"}, status_code=404)
-    dest = folder_path / file.filename
+    dest = folder_path / safe_filename
     content = await file.read()
     dest.write_bytes(content)
-    return {"status": "uploaded", "name": file.filename, "size": len(content)}
+    return {"status": "uploaded", "name": safe_filename, "size": len(content)}
 
 
 @router.post("/api/shared-folders/{folder_id}/access")

--- a/tinyagentos/shared_folders.py
+++ b/tinyagentos/shared_folders.py
@@ -49,7 +49,10 @@ class SharedFolderManager(BaseStore):
         etc.). A shared-folder name and an uploaded filename are both flat
         labels, so stripping to the basename is the correct, lossless guard.
         """
-        safe = Path(str(label)).name
+        # Normalize backslashes to forward slashes first: on POSIX, Path only
+        # splits on "/", so a Windows-style "..\evil" would otherwise survive
+        # as a literal name. Doing it here makes the guard platform-independent.
+        safe = Path(str(label).replace("\\", "/")).name
         if not safe or safe in (".", ".."):
             raise ValueError(f"invalid shared-folder name: {label!r}")
         return safe

--- a/tinyagentos/shared_folders.py
+++ b/tinyagentos/shared_folders.py
@@ -39,10 +39,28 @@ class SharedFolderManager(BaseStore):
         await self._db.commit()
         self.storage_dir.mkdir(parents=True, exist_ok=True)
 
+    @staticmethod
+    def _safe_label(label: str) -> str:
+        """Reduce a folder name or filename to a single flat, contained label.
+
+        Names and filenames reach the filesystem from API callers, so a "..",
+        a "/etc/..." absolute part, or an embedded "../" must never escape the
+        shared-folder root (path traversal writing to cron, authorized_keys,
+        etc.). A shared-folder name and an uploaded filename are both flat
+        labels, so stripping to the basename is the correct, lossless guard.
+        """
+        safe = Path(str(label)).name
+        if not safe or safe in (".", ".."):
+            raise ValueError(f"invalid shared-folder name: {label!r}")
+        return safe
+
     async def create_folder(self, name: str, description: str = "",
                             owner_type: str = "global", owner_name: str = "",
                             agents: list[str] | None = None) -> int:
         now = time.time()
+        # Sanitize before it reaches both the DB and the filesystem so the two
+        # stay consistent and the physical mkdir cannot escape storage_dir.
+        name = self._safe_label(name)
         cursor = await self._db.execute(
             "INSERT INTO shared_folders (name, description, owner_type, owner_name, created_at) VALUES (?, ?, ?, ?, ?)",
             (name, description, owner_type, owner_name, now))
@@ -76,7 +94,9 @@ class SharedFolderManager(BaseStore):
             row = await cursor.fetchone()
         if not row:
             return False
-        folder_path = self.storage_dir / row[0]
+        # Re-sanitize the stored name before an rmtree: defends any legacy row
+        # that predates the create-time guard.
+        folder_path = self.storage_dir / self._safe_label(row[0])
         if folder_path.exists():
             shutil.rmtree(folder_path)
         await self._db.execute("DELETE FROM shared_folders WHERE id = ?", (folder_id,))
@@ -84,7 +104,7 @@ class SharedFolderManager(BaseStore):
         return True
 
     def list_files(self, folder_name: str) -> list[dict]:
-        folder_path = self.storage_dir / folder_name
+        folder_path = self.storage_dir / self._safe_label(folder_name)
         if not folder_path.exists():
             return []
         files = []


### PR DESCRIPTION
Surgical fix for a path-traversal write found in the security audit. In shared_folders.py and its upload route, a folder name and an uploaded filename reached the filesystem unsanitized (create mkdir, delete rmtree, upload write_bytes), so a '..' name or '../' filename escaped the shared-folder root and let any authenticated caller (user or agent) write or delete arbitrary paths as the service user.

All filesystem joins now go through a _safe_label helper (basename + reject bare traversal); names and filenames are flat labels so this is lossless. delete_folder re-sanitizes the stored name so legacy rows are covered too. Traversal tests added (32 pass).

This one is worth landing now (not part of the larger public-hardening epic) because it is a genuine bug exploitable in the current single-user Pi deployment by any agent, and the fix is contained and low-risk.