### PR TITLE
fix(installer): prefer incus-base on Debian Bookworm ARM64 (#1555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- Installer: agent-container runtime install now prefers the `incus-base` package over the full `incus` metapackage, whose extras have unsatisfiable dependencies on Debian Bookworm ARM64 (held broken packages); falls back to `incus` where incus-base is not a candidate (#1555).
+
 ## [1.0.0-beta.17] - 2026-07-02
 
 ### Fixed

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -729,6 +729,7 @@ ensure_container_runtime() {
     fi
 
     local installed=0
+    local _incus_pkg=""
     if command -v apt-get >/dev/null 2>&1; then
         # Try the distro's default repos first (Ubuntu 24.04+ ships incus in
         # universe; some Debian unstable releases also have it). Fall back
@@ -737,10 +738,21 @@ ensure_container_runtime() {
         # probe — empty output means no candidate, which is what we want.
         sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>/dev/null || true
         if [[ -n "$(apt-cache madison incus 2>/dev/null)" ]]; then
-            log "incus available in default apt repos — installing"
-            if sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus; then
+            # Prefer incus-base: the full `incus` metapackage pulls incus-ui and
+            # other extras whose dependencies are unsatisfiable on Debian
+            # Bookworm ARM64 ("held broken packages"), whereas incus-base is the
+            # minimal daemon+CLI and installs cleanly there (#1555). Fall back to
+            # the full package where incus-base is not a candidate.
+            log "incus available in default apt repos — installing (incus-base preferred)"
+            _incus_pkg="incus"
+            [[ -n "$(apt-cache madison incus-base 2>/dev/null)" ]] && _incus_pkg="incus-base"
+            if sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$_incus_pkg"; then
                 installed=1
-                log "container runtime: incus installed from default apt repos"
+                log "container runtime: $_incus_pkg installed from default apt repos"
+            elif [[ "$_incus_pkg" == "incus-base" ]] \
+                 && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus; then
+                installed=1
+                log "container runtime: incus installed from default apt repos (incus-base unavailable)"
             else
                 warn "default apt install of incus failed — see /var/log/apt/term.log"
             fi

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -737,24 +737,26 @@ ensure_container_runtime() {
         # apt-cache madison is the lightest "is the package available?"
         # probe — empty output means no candidate, which is what we want.
         sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>/dev/null || true
-        if [[ -n "$(apt-cache madison incus 2>/dev/null)" ]]; then
-            # Prefer incus-base: the full `incus` metapackage pulls incus-ui and
-            # other extras whose dependencies are unsatisfiable on Debian
-            # Bookworm ARM64 ("held broken packages"), whereas incus-base is the
-            # minimal daemon+CLI and installs cleanly there (#1555). Fall back to
-            # the full package where incus-base is not a candidate.
-            log "incus available in default apt repos — installing (incus-base preferred)"
-            _incus_pkg="incus"
-            [[ -n "$(apt-cache madison incus-base 2>/dev/null)" ]] && _incus_pkg="incus-base"
+        # Prefer incus-base: the full `incus` metapackage pulls incus-ui and
+        # other extras whose dependencies are unsatisfiable on Debian Bookworm
+        # ARM64 ("held broken packages"), whereas incus-base is the minimal
+        # daemon+CLI and installs cleanly there (#1555). Use the full package
+        # only where incus-base is not a candidate. Gate on EITHER package so a
+        # repo shipping incus-base but not the metapackage still takes this
+        # native path instead of a wasted Zabbly round trip.
+        _incus_pkg=""
+        [[ -n "$(apt-cache madison incus-base 2>/dev/null)" ]] && _incus_pkg="incus-base"
+        [[ -z "$_incus_pkg" && -n "$(apt-cache madison incus 2>/dev/null)" ]] && _incus_pkg="incus"
+        if [[ -n "$_incus_pkg" ]]; then
+            log "incus available in default apt repos — installing $_incus_pkg"
+            # No metapackage fallback: the exact failure this fix targets is the
+            # full `incus` package being broken on the vendor image, so retrying
+            # it would fail identically. The warn below covers the failure path.
             if sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$_incus_pkg"; then
                 installed=1
                 log "container runtime: $_incus_pkg installed from default apt repos"
-            elif [[ "$_incus_pkg" == "incus-base" ]] \
-                 && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus; then
-                installed=1
-                log "container runtime: incus installed from default apt repos (incus-base unavailable)"
             else
-                warn "default apt install of incus failed — see /var/log/apt/term.log"
+                warn "default apt install of $_incus_pkg failed — see /var/log/apt/term.log"
             fi
         else
             # Detect distro codename for Zabbly repo line.


### PR DESCRIPTION
The incus auto-install added in #1546 (beta.17) regressed on the exact vendor image it targeted: on Debian Bookworm ARM64, `apt-get install incus` pulls the full metapackage (incus-ui etc.) whose deps are unsatisfiable, failing with held broken packages. @mandresve confirmed on a second clean install (#1555) that `incus-base` installs cleanly.

Fix: install `incus-base` (minimal daemon + CLI) when it is an apt candidate, falling back to the full `incus` package where it is not. Verified with bash -n; the change is confined to the default-repos branch of ensure_container_runtime.

Fixes #1555.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer reliability on Debian/Ubuntu by preferring the `incus-base` package when available, falling back to `incus` when it isn’t.
  * Fixed an installation failure on Debian Bookworm ARM64 caused by unsatisfiable dependencies when using the broader package.
  * Enhanced installer logging to clearly indicate which package is being installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->