### PR TITLE
fix(installer): rknpu version check SIGPIPEs strings, aborting the first clean install (#1560)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 ### Fixed
 - Installer: agent-container runtime install now prefers the `incus-base` package over the full `incus` metapackage, whose extras have unsatisfiable dependencies on Debian Bookworm ARM64 (held broken packages); falls back to `incus` where incus-base is not a candidate (#1555).
 - Models: a download that finishes the transfer but wrote no data (or the wrong number of bytes) is no longer marked complete. Both the torrent and HTTP paths now validate the file exists, is non-empty, matches the expected size, and passes its checksum before the model is reported installed (#1548).
+- Installer: the RK3588 NPU install no longer aborts on the first clean run on boards that have binutils. The librknnrt version check piped `strings` (a 7MB binary) into an `awk` that exited on the first match; the early exit SIGPIPEd `strings`, which under `set -o pipefail` + `set -e` killed the whole install. It succeeded on a second run only because the pin was already applied and the block was skipped. The check now reads to EOF and is guarded (#1560, #1543). Reported by @mandresve.
 
 ## [1.0.0-beta.17] - 2026-07-02
 

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -101,8 +101,12 @@ librknnrt_current_version() {
     if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
         # No early awk exit: it SIGPIPEs strings and trips pipefail (see the
         # note at the version-verify site). Read to EOF and print the first
-        # match only.
-        strings "$LIBRKNNRT_DEST" 2>/dev/null | awk '/librknnrt version: / && !seen { print $3; seen=1 }'
+        # match only. Do not swallow strings' stderr: if it fails on the
+        # installed library (vendor perms, corrupted ELF) the real error should
+        # surface in the log rather than the banner silently dropping the
+        # runtime line. Both callers guard the call with `|| true`, so a probe
+        # failure cannot abort the install.
+        strings "$LIBRKNNRT_DEST" | awk '/librknnrt version: / && !seen { print $3; seen=1 }'
     fi
 }
 

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -351,11 +351,16 @@ pin_librknnrt() {
         # not silently indistinguishable from "no version string" (which used
         # to mean only "binutils missing"); warn so a future first-run failure
         # stays diagnosable.
-        if verified="$(strings "$tmp" 2>/dev/null | awk '/librknnrt version: / && !seen { print $3; seen=1 }')"; then
+        # Do NOT swallow strings' stderr: if the probe fails (truncated
+        # download, bad perms, corrupted ELF) its real error is the diagnostic,
+        # so let it through to the log alongside the warn below. On a valid
+        # runtime strings is quiet on stderr, so this adds no normal-path noise.
+        if verified="$(strings "$tmp" | awk '/librknnrt version: / && !seen { print $3; seen=1 }')"; then
             :
         else
+            # A failed substitution already leaves $verified empty, so no reset
+            # is needed; the fallback below re-reads the installed path.
             warn "strings/awk version probe failed on the downloaded runtime; falling back to the installed path"
-            verified=""
         fi
         if [[ -z "$verified" ]]; then
             # Fall back to re-reading the installed path (legacy behaviour).

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -99,7 +99,10 @@ die()  { printf '\033[1;31m[rknpu]\033[0m %s\n' "$*" >&2; exit 1; }
 # never drift if upstream rewords the version string.
 librknnrt_current_version() {
     if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
-        strings "$LIBRKNNRT_DEST" | awk '/librknnrt version: / { print $3; exit }'
+        # No early awk exit: it SIGPIPEs strings and trips pipefail (see the
+        # note at the version-verify site). Read to EOF and print the first
+        # match only.
+        strings "$LIBRKNNRT_DEST" 2>/dev/null | awk '/librknnrt version: / && !seen { print $3; seen=1 }'
     fi
 }
 
@@ -337,7 +340,14 @@ pin_librknnrt() {
     # when the tool is unavailable; only die on a genuine version mismatch.
     local verified=""
     if command -v strings >/dev/null 2>&1; then
-        verified="$(strings "$tmp" | awk '/librknnrt version: / { print $3; exit }')"
+        # awk must NOT exit early here: an early `exit` closes the pipe and
+        # SIGPIPEs `strings`, which under `set -o pipefail` fails the whole
+        # command substitution, and with `set -e` that aborted the ENTIRE
+        # install on the first clean run wherever binutils was present (#1560,
+        # #1543). The second run only worked because librknnrt was already at
+        # 2.3.0 and this whole pin block was skipped. Read to EOF (no early
+        # exit) and guard the assignment so a strings/awk hiccup is never fatal.
+        verified="$(strings "$tmp" 2>/dev/null | awk '/librknnrt version: / && !seen { print $3; seen=1 }')" || true
         if [[ -z "$verified" ]]; then
             # Fall back to re-reading the installed path (legacy behaviour).
             verified="$(librknnrt_current_version || true)"

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -347,7 +347,16 @@ pin_librknnrt() {
         # #1543). The second run only worked because librknnrt was already at
         # 2.3.0 and this whole pin block was skipped. Read to EOF (no early
         # exit) and guard the assignment so a strings/awk hiccup is never fatal.
-        verified="$(strings "$tmp" 2>/dev/null | awk '/librknnrt version: / && !seen { print $3; seen=1 }')" || true
+        # Capture the substitution status so a genuine strings/awk failure is
+        # not silently indistinguishable from "no version string" (which used
+        # to mean only "binutils missing"); warn so a future first-run failure
+        # stays diagnosable.
+        if verified="$(strings "$tmp" 2>/dev/null | awk '/librknnrt version: / && !seen { print $3; seen=1 }')"; then
+            :
+        else
+            warn "strings/awk version probe failed on the downloaded runtime; falling back to the installed path"
+            verified=""
+        fi
         if [[ -z "$verified" ]]; then
             # Fall back to re-reading the installed path (legacy behaviour).
             verified="$(librknnrt_current_version || true)"


### PR DESCRIPTION
Root-causes the deterministic first-run abort of install-rknpu.sh that @mandresve reported across two clean Bookworm installs (#1560, formerly #1543). It was **not** ldconfig.

The librknnrt version check ran `strings $tmp | awk '/librknnrt version: / { print $3; exit }'`. awk exits on the first match and closes the pipe while `strings` still has ~7MB of the binary left to write, so `strings` takes SIGPIPE. Under `set -o pipefail` the substitution exits 141, and with `set -e` that aborts the whole install. It only triggers where binutils is present (mandresve's vendor image has it) and only on the first run: the second run finds librknnrt already at 2.3.0 and skips the entire pin block, which is exactly the reported deterministic-first / working-second pattern.

Fix: awk reads to EOF (first match, no early exit) and the assignment is guarded so a strings/awk hiccup is never fatal; the same early-exit pattern is removed from `librknnrt_current_version`. Proven with a `set -e -o pipefail` repro (old pattern exits 141, new returns the version, exits 0).

Fixes #1560.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an installer issue that could interrupt the first clean run when checking the RK3588 NPU runtime version with `binutils` installed.
  * Improved runtime version detection to prevent premature failures during version probe checks.
  * Strengthened pinned-runtime verification so installation continues when a version can’t be confirmed, using an automatic fallback.
* **Documentation**
  * Added an Unreleased changelog entry describing the RK3588 NPU installer fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->