### PR TITLE
chore(release): 1.0.0-beta.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.18] - 2026-07-03
+
 ### Fixed
 - Installer: agent-container runtime install now prefers the `incus-base` package over the full `incus` metapackage, whose extras have unsatisfiable dependencies on Debian Bookworm ARM64 (held broken packages); falls back to `incus` where incus-base is not a candidate (#1555).
 - Models: a download that finishes the transfer but wrote no data (or the wrong number of bytes) is no longer marked complete. Both the torrent and HTTP paths now validate the file exists, is non-empty, matches the expected size, and passes its checksum before the model is reported installed (#1548).

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.17"
+version = "1.0.0-beta.18"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.17"
+__version__ = "1.0.0-beta.18"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b17"
+version = "1.0.0b18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bumps to `1.0.0-beta.18` and dates the CHANGELOG.

Bundles the user-facing installer + model-download fixes from @mandresve's beta.17 retest, all merged to dev:
- Installer: prefer `incus-base` over the full `incus` metapackage on Debian Bookworm ARM64 (#1555, was #1559)
- Models: reject false-complete downloads that wrote no data / wrong size before marking installed (#1548, was #1562)
- Installer: fix the rknpu first-run SIGPIPE abort in the librknnrt version check (#1560, #1543, was #1561)

Also on dev but intentionally not in the CHANGELOG: the secret-redaction core for the Logs app (#1558) is internal groundwork with no user-facing surface yet (the Logs app UI/routes are not shipped), so it carries no user-facing changelog entry.

Version files: pyproject.toml, desktop/package.json, tinyagentos/__init__.py, uv.lock.