### PR TITLE
release: promote dev to master (1.0.0-beta.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.18] - 2026-07-03
+
 ### Fixed
 - Installer: agent-container runtime install now prefers the `incus-base` package over the full `incus` metapackage, whose extras have unsatisfiable dependencies on Debian Bookworm ARM64 (held broken packages); falls back to `incus` where incus-base is not a candidate (#1555).
 - Models: a download that finishes the transfer but wrote no data (or the wrong number of bytes) is no longer marked complete. Both the torrent and HTTP paths now validate the file exists, is non-empty, matches the expected size, and passes its checksum before the model is reported installed (#1548).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- Installer: agent-container runtime install now prefers the `incus-base` package over the full `incus` metapackage, whose extras have unsatisfiable dependencies on Debian Bookworm ARM64 (held broken packages); falls back to `incus` where incus-base is not a candidate (#1555).
+
 ## [1.0.0-beta.17] - 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 ### Fixed
 - Installer: agent-container runtime install now prefers the `incus-base` package over the full `incus` metapackage, whose extras have unsatisfiable dependencies on Debian Bookworm ARM64 (held broken packages); falls back to `incus` where incus-base is not a candidate (#1555).
 - Models: a download that finishes the transfer but wrote no data (or the wrong number of bytes) is no longer marked complete. Both the torrent and HTTP paths now validate the file exists, is non-empty, matches the expected size, and passes its checksum before the model is reported installed (#1548).
+- Installer: the RK3588 NPU install no longer aborts on the first clean run on boards that have binutils. The librknnrt version check piped `strings` (a 7MB binary) into an `awk` that exited on the first match; the early exit SIGPIPEd `strings`, which under `set -o pipefail` + `set -e` killed the whole install. It succeeded on a second run only because the pin was already applied and the block was skipped. The check now reads to EOF and is guarded (#1560, #1543). Reported by @mandresve.
 
 ## [1.0.0-beta.17] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ### Fixed
 - Installer: agent-container runtime install now prefers the `incus-base` package over the full `incus` metapackage, whose extras have unsatisfiable dependencies on Debian Bookworm ARM64 (held broken packages); falls back to `incus` where incus-base is not a candidate (#1555).
+- Models: a download that finishes the transfer but wrote no data (or the wrong number of bytes) is no longer marked complete. Both the torrent and HTTP paths now validate the file exists, is non-empty, matches the expected size, and passes its checksum before the model is reported installed (#1548).
 
 ## [1.0.0-beta.17] - 2026-07-02
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.17",
+  "version": "1.0.0-beta.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/apps/AppStudioApp.test.tsx
+++ b/desktop/src/apps/AppStudioApp.test.tsx
@@ -4,11 +4,6 @@ import React from "react";
 import { AppStudioApp } from "./AppStudioApp";
 
 describe("AppStudioApp", () => {
-  it("renders the titlebar with App Studio", () => {
-    render(<AppStudioApp windowId="test" />);
-    expect(screen.getByText("App Studio")).toBeInTheDocument();
-  });
-
   it("renders all rail items", () => {
     const { container } = render(<AppStudioApp windowId="test" />);
     const nav = container.querySelector("nav[aria-label='App Studio views']");

--- a/desktop/src/apps/AppStudioApp.tsx
+++ b/desktop/src/apps/AppStudioApp.tsx
@@ -60,11 +60,6 @@ export function AppStudioApp({ windowId: _windowId }: { windowId: string }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
-      {/* titlebar */}
-      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
-        <span className="text-[13px] font-semibold tracking-[-0.01em]">App Studio</span>
-      </div>
-
       <div className="flex min-h-0 flex-1">
         {/* left rail */}
         <nav

--- a/desktop/src/apps/CodingStudioApp.test.tsx
+++ b/desktop/src/apps/CodingStudioApp.test.tsx
@@ -7,11 +7,6 @@ function renderApp() {
 }
 
 describe("CodingStudioApp", () => {
-  it("renders the app titlebar", () => {
-    renderApp();
-    expect(screen.getByText("Coding Studio")).toBeDefined();
-  });
-
   it("renders all rail items", () => {
     renderApp();
     // Rail buttons use aria-label for exact matching via the nav element

--- a/desktop/src/apps/CodingStudioApp.tsx
+++ b/desktop/src/apps/CodingStudioApp.tsx
@@ -19,11 +19,6 @@ export function CodingStudioApp({ windowId: _windowId }: { windowId: string }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
-      {/* title strip */}
-      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
-        <span className="text-[13px] font-semibold tracking-[-0.01em]">Coding Studio</span>
-      </div>
-
       <div className="flex min-h-0 flex-1">
         {/* left rail */}
         <nav

--- a/desktop/src/apps/DesignStudioApp.test.tsx
+++ b/desktop/src/apps/DesignStudioApp.test.tsx
@@ -7,11 +7,6 @@ function renderApp() {
 }
 
 describe("DesignStudioApp", () => {
-  it("renders the app titlebar", () => {
-    renderApp();
-    expect(screen.getByText("Design Studio")).toBeDefined();
-  });
-
   it("renders all rail items", () => {
     renderApp();
     const nav = screen.getByRole("navigation", { name: "Design Studio views" });

--- a/desktop/src/apps/DesignStudioApp.tsx
+++ b/desktop/src/apps/DesignStudioApp.tsx
@@ -180,10 +180,6 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
-      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
-        <span className="text-[13px] font-semibold tracking-[-0.01em]">Design Studio</span>
-      </div>
-
       <div className="flex min-h-0 flex-1">
         <nav
           aria-label="Design Studio views"

--- a/desktop/src/apps/GameStudioApp.tsx
+++ b/desktop/src/apps/GameStudioApp.tsx
@@ -62,11 +62,6 @@ export function GameStudioApp({ windowId }: { windowId: string }) {
         }
       `}</style>
 
-      {/* title strip */}
-      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
-        <span className="text-[13px] font-semibold tracking-[-0.01em]">Game Studio</span>
-      </div>
-
       <div className="flex min-h-0 flex-1">
         {/* left rail */}
         <nav

--- a/desktop/src/apps/ImagesApp.tsx
+++ b/desktop/src/apps/ImagesApp.tsx
@@ -333,13 +333,6 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
-      {/* title strip */}
-      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
-        <span className="text-[13px] font-semibold tracking-[-0.01em]">
-          Images Studio
-        </span>
-      </div>
-
       <div className="flex min-h-0 flex-1">
         {/* left rail */}
         <div className="flex w-[68px] flex-none flex-col items-center gap-1.5 border-r border-shell-border bg-shell-bg-deep py-3.5">

--- a/desktop/src/apps/MusicStudioApp.test.tsx
+++ b/desktop/src/apps/MusicStudioApp.test.tsx
@@ -7,11 +7,6 @@ function renderApp() {
 }
 
 describe("MusicStudioApp", () => {
-  it("renders the app titlebar with name", () => {
-    renderApp();
-    expect(screen.getByText("Music Studio")).toBeDefined();
-  });
-
   it("renders all rail items", () => {
     renderApp();
     const nav = screen.getByRole("navigation", { name: "Music Studio views" });

--- a/desktop/src/apps/MusicStudioApp.tsx
+++ b/desktop/src/apps/MusicStudioApp.tsx
@@ -97,10 +97,6 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
-      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
-        <span className="text-[13px] font-semibold tracking-[-0.01em]">Music Studio</span>
-      </div>
-
       <div className="flex min-h-0 flex-1">
         <nav
           aria-label="Music Studio views"

--- a/desktop/src/apps/OfficeSuiteApp.test.tsx
+++ b/desktop/src/apps/OfficeSuiteApp.test.tsx
@@ -7,11 +7,6 @@ function renderApp() {
 }
 
 describe("OfficeSuiteApp", () => {
-  it("renders the app titlebar", () => {
-    renderApp();
-    expect(screen.getByText("Office Suite")).toBeDefined();
-  });
-
   it("renders all rail items", () => {
     renderApp();
     const nav = screen.getByRole("navigation", { name: "Office Suite views" });

--- a/desktop/src/apps/OfficeSuiteApp.tsx
+++ b/desktop/src/apps/OfficeSuiteApp.tsx
@@ -18,11 +18,6 @@ export function OfficeSuiteApp({ windowId: _windowId }: { windowId: string }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
-      {/* title strip */}
-      <div className="flex h-[46px] flex-none items-center justify-center border-b border-shell-border">
-        <span className="text-[13px] font-semibold tracking-[-0.01em]">Office Suite</span>
-      </div>
-
       <div className="flex min-h-0 flex-1">
         {/* left rail */}
         <nav

--- a/desktop/src/hooks/use-desktop-control.test.ts
+++ b/desktop/src/hooks/use-desktop-control.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useDesktopControl } from "./use-desktop-control";
+import { useProcessStore } from "@/stores/process-store";
+
+const reset = () => useProcessStore.setState({ windows: [], nextZIndex: 1 });
+
+describe("useDesktopControl taos:window receiver", () => {
+  beforeEach(reset);
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("closes every window for an appId, not just the first", () => {
+    renderHook(() => useDesktopControl());
+    const first = useProcessStore.getState().openWindow("coding-studio", { w: 800, h: 600 });
+    const second = useProcessStore
+      .getState()
+      .openWindow("coding-studio", { w: 800, h: 600 }, undefined, { forceNew: true });
+    const other = useProcessStore.getState().openWindow("settings", { w: 400, h: 300 });
+
+    window.dispatchEvent(
+      new CustomEvent("taos:window", { detail: { action: "close", appId: "coding-studio" } }),
+    );
+
+    const windows = useProcessStore.getState().windows;
+    expect(windows.find((w) => w.id === first)!.closing).toBe(true);
+    expect(windows.find((w) => w.id === second)!.closing).toBe(true);
+    expect(windows.find((w) => w.id === other)!.closing).toBeFalsy();
+  });
+
+  it("closes by app id using the op/app alias payload (the reported bug shape)", () => {
+    renderHook(() => useDesktopControl());
+    const id = useProcessStore.getState().openWindow("coding-studio", { w: 800, h: 600 });
+
+    window.dispatchEvent(
+      new CustomEvent("taos:window", { detail: { op: "close", app: "coding-studio" } }),
+    );
+
+    expect(useProcessStore.getState().windows.find((w) => w.id === id)!.closing).toBe(true);
+  });
+
+  it("warns and ignores a payload with neither action nor op", () => {
+    renderHook(() => useDesktopControl());
+    const id = useProcessStore.getState().openWindow("coding-studio", { w: 800, h: 600 });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    window.dispatchEvent(
+      new CustomEvent("taos:window", { detail: { appId: "coding-studio" } }),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][1]).toEqual({ appId: "coding-studio" });
+    expect(useProcessStore.getState().windows.find((w) => w.id === id)!.closing).toBeFalsy();
+  });
+
+  it("warns and ignores an unknown action/op (not in the allowlist)", () => {
+    renderHook(() => useDesktopControl());
+    const id = useProcessStore.getState().openWindow("coding-studio", { w: 800, h: 600 });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    window.dispatchEvent(
+      new CustomEvent("taos:window", { detail: { op: "shutdown", app: "coding-studio" } }),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(useProcessStore.getState().windows.find((w) => w.id === id)!.closing).toBeFalsy();
+  });
+
+  it("removes the event listener on unmount", () => {
+    const { unmount } = renderHook(() => useDesktopControl());
+    const id = useProcessStore.getState().openWindow("coding-studio", { w: 800, h: 600 });
+    unmount();
+
+    window.dispatchEvent(
+      new CustomEvent("taos:window", { detail: { action: "close", appId: "coding-studio" } }),
+    );
+
+    expect(useProcessStore.getState().windows.find((w) => w.id === id)!.closing).toBeFalsy();
+  });
+});

--- a/desktop/src/hooks/use-desktop-control.ts
+++ b/desktop/src/hooks/use-desktop-control.ts
@@ -14,6 +14,12 @@ import { resolveApp } from "@/registry/app-registry";
  * Actions: open, close, focus, minimize, restore, maximize, move, resize, snap,
  * arrange (preset: tile-2 | tile-3 | center | cascade). Targeting precedence:
  * explicit windowId, else first window for appId, else the focused/topmost one.
+ * `close` is the one exception: given an appId with no windowId, it closes
+ * every open window for that app (an app can have more than one via forceNew).
+ * The CustomEvent also accepts `op`/`app` as aliases for `action`/`appId` (the
+ * sibling `taos:open-app` event uses `app`, so callers reasonably guess it here
+ * too); an event with neither `action` nor `op` is rejected with a console.warn
+ * so contract drift is visible instead of silently doing nothing.
  * This is the agent-tool side of the deep-navigation API (#836) and complements
  * `taos:open-app`.
  */
@@ -57,6 +63,13 @@ export interface WindowOp {
   snap?: SnapPosition;
   preset?: "tile-2" | "tile-3" | "center" | "cascade";
 }
+
+// The valid WindowOp actions, as a runtime allowlist for the event receiver
+// (the type union alone cannot guard an untrusted CustomEvent payload).
+const WINDOW_ACTIONS = new Set<WindowOp["action"]>([
+  "open", "close", "focus", "minimize", "restore",
+  "maximize", "move", "resize", "snap", "arrange",
+]);
 
 const TOP = 36; // below the 32px top bar
 const DOCK = 88; // above the dock
@@ -187,6 +200,12 @@ function run(op: WindowOp): string | void {
       return;
     }
     case "close": {
+      // appId with no explicit windowId closes every window for that app,
+      // not just the first match -- an app can have several (forceNew).
+      if (!op.windowId && op.appId) {
+        s.windows.filter((w) => w.appId === op.appId).forEach((w) => s.closeWindow(w.id));
+        return;
+      }
       const id = resolveId(op);
       if (id) s.closeWindow(id);
       return;
@@ -211,8 +230,22 @@ declare global {
 export function useDesktopControl(): void {
   useEffect(() => {
     const onWindow = (e: Event) => {
-      const detail = (e as CustomEvent).detail as WindowOp | undefined;
-      if (detail?.action) run(detail);
+      // `op`/`app` are accepted as aliases for `action`/`appId` (see module
+      // docstring) since they mirror the sibling taos:open-app payload shape.
+      const raw = (e as CustomEvent).detail as Record<string, unknown> | undefined;
+      const candidate = raw?.action ?? raw?.op;
+      // Allowlist the action so an unknown string (e.g. op: "shutdown") is
+      // rejected loudly here rather than falling through run()'s switch as a
+      // silent no-op, which is the very behaviour this receiver fixes.
+      if (typeof candidate !== "string" || !WINDOW_ACTIONS.has(candidate as WindowOp["action"])) {
+        console.warn("taos:window ignored: missing or unknown action/op", raw);
+        return;
+      }
+      const action = candidate as WindowOp["action"];
+      // appId must be a string; a non-string app silently fails the lookup.
+      const rawAppId = raw?.appId ?? raw?.app;
+      const appId = typeof rawAppId === "string" ? rawAppId : undefined;
+      run({ ...(raw as Partial<WindowOp>), action, appId });
     };
     window.addEventListener("taos:window", onWindow);
     window.taosDesktop = { getLayout, run };

--- a/docs/design/logs-app.md
+++ b/docs/design/logs-app.md
@@ -1,0 +1,81 @@
+# Logs app + Providers state model (design, v1)
+
+Closes out the two remaining halves of #1548: a fresh install where every
+provider shows "error" and a Settings log viewer that shows nothing, leaving
+users unable to self-diagnose. Principle: end users never need a terminal.
+
+## Part 1: Logs app (new platform app)
+
+A dedicated app (dock/launchpad, category `platform`) at the Store/Images
+design bar. The existing Settings viewer stays as-is for browser-side client
+errors; the Logs app links to it as one source among several.
+
+### Sources (v1)
+
+| Source | Backing | Transport |
+| --- | --- | --- |
+| Controller | journald unit (system install) or the in-process ring buffer (user-mode/dev) | REST page + SSE tail |
+| rkllama | journalctl -u rkllama | REST page + SSE tail |
+| qmd | journalctl -u qmd | REST page + SSE tail |
+| LLM proxy | its file log under the data dir | REST page + SSE tail |
+| Client errors | existing client_log_store | existing endpoint, rendered as a tab |
+| Agent containers (v2) | incus/docker logs per agent | deferred; needs per-agent scoping design |
+
+### Backend
+
+New route module `tinyagentos/routes/system_logs.py`:
+
+- `GET /api/system-logs/sources` — the sources available on THIS install
+  (journald probed once; absent units simply not listed).
+- `GET /api/system-logs/{source}?lines=N&before=cursor` — paged read,
+  newest-first, cursor = journald cursor or byte offset.
+- `GET /api/system-logs/{source}/stream` — SSE live tail.
+- `GET /api/system-logs/bundle` — the copy-for-bug-report payload: the
+  installer-style environment banner + last N lines of every source, as one
+  redacted text blob.
+
+Rules:
+- Session-auth only (operator surface), same middleware as the rest of the API.
+- journalctl runs via asyncio subprocess with `--no-pager -o json`, hard line
+  caps, and a per-source concurrency guard of one tail per client.
+- REDACTION is mandatory and applied server-side before anything leaves the
+  box: mask values for key/token/secret/password/authorization patterns,
+  bearer headers, and anything matching the secrets store's known names.
+  Redaction is a pure function with its own tests; logs never bypass it.
+
+### Frontend
+
+`desktop/src/apps/LogsApp.tsx` + `logs/` per the studio layout conventions:
+left rail = sources with live badges, main pane = virtualised log list with
+level colouring, follow-tail toggle, search-in-buffer, and a top bar with
+"Copy bug report" (calls /bundle, copies to clipboard, toasts). Client-errors
+tab reuses the existing feed. Mobile: single-column, source picker as a sheet.
+
+## Part 2: Providers state model
+
+Today `/api/providers` flattens every probe outcome to `status: "error"`,
+so a fresh box or a slow-starting service looks broken (#1548 screenshot:
+every row red).
+
+Replace the boolean-ish status with an explicit state enum carried per entry:
+
+- `ok` — probe answered.
+- `starting` — the backend's lifecycle state says installed/managed but the
+  socket is not answering yet (connection refused within the grace window,
+  default 120s after controller boot or lifecycle start).
+- `unreachable` — probe failed after the grace window; carry `detail` with
+  the exception class + target so the UI can show WHY.
+- `unconfigured` — cloud type present but no key resolvable.
+
+Frontend: empty list renders a first-run card ("No providers yet") with an
+Add Provider CTA instead of an error wall; `starting` renders an amber badge
+with auto-refresh; `unreachable` renders red with the detail line and a
+Retry probe button. No more undifferentiated red.
+
+## Build order
+
+1. Redaction function + tests (the security core, nothing ships without it).
+2. system_logs.py routes + tests (fake journalctl via injected runner).
+3. Providers state enum in providers.py + tests + ModelBrowser/Providers UI states.
+4. LogsApp frontend + tests.
+5. Live verify on the Pi via the control API with screenshots, both surfaces.

--- a/docs/design/logs-app.md
+++ b/docs/design/logs-app.md
@@ -25,12 +25,12 @@ errors; the Logs app links to it as one source among several.
 
 New route module `tinyagentos/routes/system_logs.py`:
 
-- `GET /api/system-logs/sources` — the sources available on THIS install
+- `GET /api/system-logs/sources`: the sources available on THIS install
   (journald probed once; absent units simply not listed).
-- `GET /api/system-logs/{source}?lines=N&before=cursor` — paged read,
+- `GET /api/system-logs/{source}?lines=N&before=cursor`: paged read,
   newest-first, cursor = journald cursor or byte offset.
-- `GET /api/system-logs/{source}/stream` — SSE live tail.
-- `GET /api/system-logs/bundle` — the copy-for-bug-report payload: the
+- `GET /api/system-logs/{source}/stream`: SSE live tail.
+- `GET /api/system-logs/bundle`: the copy-for-bug-report payload: the
   installer-style environment banner + last N lines of every source, as one
   redacted text blob.
 
@@ -59,13 +59,13 @@ every row red).
 
 Replace the boolean-ish status with an explicit state enum carried per entry:
 
-- `ok` — probe answered.
-- `starting` — the backend's lifecycle state says installed/managed but the
+- `ok`: probe answered.
+- `starting`: the backend's lifecycle state says installed/managed but the
   socket is not answering yet (connection refused within the grace window,
   default 120s after controller boot or lifecycle start).
-- `unreachable` — probe failed after the grace window; carry `detail` with
+- `unreachable`: probe failed after the grace window; carry `detail` with
   the exception class + target so the UI can show WHY.
-- `unconfigured` — cloud type present but no key resolvable.
+- `unconfigured`: cloud type present but no key resolvable.
 
 Frontend: empty list renders a first-run card ("No providers yet") with an
 Add Provider CTA instead of an error wall; `starting` renders an amber badge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.17"
+version = "1.0.0-beta.18"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -99,7 +99,14 @@ die()  { printf '\033[1;31m[rknpu]\033[0m %s\n' "$*" >&2; exit 1; }
 # never drift if upstream rewords the version string.
 librknnrt_current_version() {
     if [[ -f "$LIBRKNNRT_DEST" ]] && command -v strings >/dev/null 2>&1; then
-        strings "$LIBRKNNRT_DEST" | awk '/librknnrt version: / { print $3; exit }'
+        # No early awk exit: it SIGPIPEs strings and trips pipefail (see the
+        # note at the version-verify site). Read to EOF and print the first
+        # match only. Do not swallow strings' stderr: if it fails on the
+        # installed library (vendor perms, corrupted ELF) the real error should
+        # surface in the log rather than the banner silently dropping the
+        # runtime line. Both callers guard the call with `|| true`, so a probe
+        # failure cannot abort the install.
+        strings "$LIBRKNNRT_DEST" | awk '/librknnrt version: / && !seen { print $3; seen=1 }'
     fi
 }
 
@@ -337,7 +344,28 @@ pin_librknnrt() {
     # when the tool is unavailable; only die on a genuine version mismatch.
     local verified=""
     if command -v strings >/dev/null 2>&1; then
-        verified="$(strings "$tmp" | awk '/librknnrt version: / { print $3; exit }')"
+        # awk must NOT exit early here: an early `exit` closes the pipe and
+        # SIGPIPEs `strings`, which under `set -o pipefail` fails the whole
+        # command substitution, and with `set -e` that aborted the ENTIRE
+        # install on the first clean run wherever binutils was present (#1560,
+        # #1543). The second run only worked because librknnrt was already at
+        # 2.3.0 and this whole pin block was skipped. Read to EOF (no early
+        # exit) and guard the assignment so a strings/awk hiccup is never fatal.
+        # Capture the substitution status so a genuine strings/awk failure is
+        # not silently indistinguishable from "no version string" (which used
+        # to mean only "binutils missing"); warn so a future first-run failure
+        # stays diagnosable.
+        # Do NOT swallow strings' stderr: if the probe fails (truncated
+        # download, bad perms, corrupted ELF) its real error is the diagnostic,
+        # so let it through to the log alongside the warn below. On a valid
+        # runtime strings is quiet on stderr, so this adds no normal-path noise.
+        if verified="$(strings "$tmp" | awk '/librknnrt version: / && !seen { print $3; seen=1 }')"; then
+            :
+        else
+            # A failed substitution already leaves $verified empty, so no reset
+            # is needed; the fallback below re-reads the installed path.
+            warn "strings/awk version probe failed on the downloaded runtime; falling back to the installed path"
+        fi
         if [[ -z "$verified" ]]; then
             # Fall back to re-reading the installed path (legacy behaviour).
             verified="$(librknnrt_current_version || true)"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -729,6 +729,7 @@ ensure_container_runtime() {
     fi
 
     local installed=0
+    local _incus_pkg=""
     if command -v apt-get >/dev/null 2>&1; then
         # Try the distro's default repos first (Ubuntu 24.04+ ships incus in
         # universe; some Debian unstable releases also have it). Fall back
@@ -736,13 +737,26 @@ ensure_container_runtime() {
         # apt-cache madison is the lightest "is the package available?"
         # probe — empty output means no candidate, which is what we want.
         sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq 2>/dev/null || true
-        if [[ -n "$(apt-cache madison incus 2>/dev/null)" ]]; then
-            log "incus available in default apt repos — installing"
-            if sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq incus; then
+        # Prefer incus-base: the full `incus` metapackage pulls incus-ui and
+        # other extras whose dependencies are unsatisfiable on Debian Bookworm
+        # ARM64 ("held broken packages"), whereas incus-base is the minimal
+        # daemon+CLI and installs cleanly there (#1555). Use the full package
+        # only where incus-base is not a candidate. Gate on EITHER package so a
+        # repo shipping incus-base but not the metapackage still takes this
+        # native path instead of a wasted Zabbly round trip.
+        _incus_pkg=""
+        [[ -n "$(apt-cache madison incus-base 2>/dev/null)" ]] && _incus_pkg="incus-base"
+        [[ -z "$_incus_pkg" && -n "$(apt-cache madison incus 2>/dev/null)" ]] && _incus_pkg="incus"
+        if [[ -n "$_incus_pkg" ]]; then
+            log "incus available in default apt repos — installing $_incus_pkg"
+            # No metapackage fallback: the exact failure this fix targets is the
+            # full `incus` package being broken on the vendor image, so retrying
+            # it would fail identically. The warn below covers the failure path.
+            if sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$_incus_pkg"; then
                 installed=1
-                log "container runtime: incus installed from default apt repos"
+                log "container runtime: $_incus_pkg installed from default apt repos"
             else
-                warn "default apt install of incus failed — see /var/log/apt/term.log"
+                warn "default apt install of $_incus_pkg failed — see /var/log/apt/term.log"
             fi
         else
             # Detect distro codename for Zabbly repo line.

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -315,6 +315,23 @@ class TestDownloadHttp:
         assert dest.read_bytes() == data
 
     @pytest.mark.asyncio
+    async def test_download_empty_body_marks_error_not_complete(self, dm, tmp_path):
+        """A 0-byte response body (e.g. an error page served with a 200,
+        or a stream that closes immediately) must not be reported as a
+        complete download."""
+        dest = tmp_path / "out.bin"
+        task = DownloadTask(id="dl", url="http://example.com/f.bin", dest=dest)
+        mock_resp = self._make_async_context_manager_mock(b"", None)
+        mock_client = self._make_mock_client(mock_resp)
+
+        with patch("tinyagentos.download_manager.httpx.AsyncClient", return_value=mock_client):
+            await dm._download(task, expected_sha256=None)
+
+        assert task.status == "error"
+        assert task.error == "download produced no data"
+        assert not dest.exists()
+
+    @pytest.mark.asyncio
     async def test_download_no_content_length(self, dm, tmp_path):
         data = b"no content length"
         dest = tmp_path / "out.bin"
@@ -391,6 +408,7 @@ class TestDownloadWithFallback:
     async def test_torrent_success_path(self, dm, tmp_path):
         dest = tmp_path / "model.bin"
         task = DownloadTask(id="dl", url="http://example.com/m.bin", dest=dest)
+        data = b"z" * 999
 
         fake_torrent = AsyncMock()
         fake_progress_task = MagicMock()
@@ -398,6 +416,7 @@ class TestDownloadWithFallback:
         fake_progress_task.downloaded_bytes = 999
 
         async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+            dest.write_bytes(data)
             progress_cb(fake_progress_task)
 
         fake_torrent.download = mock_download
@@ -414,6 +433,62 @@ class TestDownloadWithFallback:
         assert task.total_bytes == 999
         assert task.downloaded_bytes == 999
         assert task.completed_at > 0
+        assert dest.read_bytes() == data
+
+    @pytest.mark.asyncio
+    async def test_torrent_success_reported_but_no_file_marks_error(self, dm, tmp_path):
+        """Guards against the false-complete bug: the torrent swarm can
+        report a clean finish via progress_cb while writing nothing (or
+        an empty file) to dest. That must not be reported as complete."""
+        dest = tmp_path / "model.bin"
+        task = DownloadTask(id="dl", url="http://example.com/m.bin", dest=dest)
+
+        fake_torrent = AsyncMock()
+        fake_progress_task = MagicMock()
+        fake_progress_task.total_bytes = 999
+        fake_progress_task.downloaded_bytes = 999
+
+        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+            # never writes dest, just reports progress as if it finished
+            progress_cb(fake_progress_task)
+
+        fake_torrent.download = mock_download
+
+        with patch.object(dm, "_get_torrent_downloader", return_value=fake_torrent):
+            await dm._download_with_fallback(
+                task,
+                expected_sha256=None,
+                magnet="magnet:?xt=urn:btih:abc",
+                license_allows_redistribution=True,
+            )
+
+        assert task.status == "error"
+        assert task.error == "download produced no data"
+        assert not dest.exists()
+
+    @pytest.mark.asyncio
+    async def test_torrent_success_reported_but_empty_file_marks_error(self, dm, tmp_path):
+        dest = tmp_path / "model.bin"
+        task = DownloadTask(id="dl", url="http://example.com/m.bin", dest=dest)
+
+        fake_torrent = AsyncMock()
+
+        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+            dest.write_bytes(b"")
+
+        fake_torrent.download = mock_download
+
+        with patch.object(dm, "_get_torrent_downloader", return_value=fake_torrent):
+            await dm._download_with_fallback(
+                task,
+                expected_sha256=None,
+                magnet="magnet:?xt=urn:btih:abc",
+                license_allows_redistribution=True,
+            )
+
+        assert task.status == "error"
+        assert task.error == "download produced no data"
+        assert not dest.exists()
 
     @pytest.mark.asyncio
     async def test_torrent_failure_falls_back_to_http(self, dm, tmp_path):

--- a/tests/test_log_redaction.py
+++ b/tests/test_log_redaction.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from tinyagentos.log_redaction import PLACEHOLDER, redact, redact_lines
+
+
+class TestKeyValue:
+    def test_equals_form(self):
+        assert redact("api_key=sk-abc123def456ghi789") == f"api_key={PLACEHOLDER}"
+
+    def test_colon_form(self):
+        assert redact("password: hunter2secret") == f"password: {PLACEHOLDER}"
+
+    def test_json_form(self):
+        out = redact('{"secret": "topsecretvalue123"}')
+        assert "topsecretvalue123" not in out
+        assert PLACEHOLDER in out
+
+    def test_flag_form(self):
+        assert redact("--token deadbeefcafebabe01") == f"--token {PLACEHOLDER}"
+
+    def test_case_insensitive(self):
+        assert redact("PASSWORD=SuperSecret99") == f"PASSWORD={PLACEHOLDER}"
+
+    def test_does_not_match_substring_key(self):
+        # "monkey" must not trip the "key" rule.
+        assert redact("monkey=banana") == "monkey=banana"
+
+    def test_preserves_surrounding_text(self):
+        out = redact("connecting with token=abcdef123456 to host db1")
+        assert out == f"connecting with token={PLACEHOLDER} to host db1"
+
+
+class TestBearer:
+    def test_header(self):
+        assert redact("Authorization: Bearer abc123def456ghi") == \
+            f"Authorization: Bearer {PLACEHOLDER}"
+
+
+class TestTokenShapes:
+    def test_openai_style(self):
+        assert redact("using sk-taos-abcdefghij0123456789 now").count(PLACEHOLDER) == 1
+        assert "abcdefghij0123456789" not in redact("sk-taos-abcdefghij0123456789")
+
+    def test_github_pat(self):
+        assert PLACEHOLDER in redact("ghp_EXAMPLEEXAMPLEEXAMPLEEXAMPLE00")
+
+    def test_slack(self):
+        assert PLACEHOLDER in redact("xoxb-EXAMPLEEXAMPLE-EXAMPLEEXAMPLETOKEN")
+
+    def test_aws_akia(self):
+        assert PLACEHOLDER in redact("AKIAEXAMPLEEXAMPLE00")
+
+
+class TestPem:
+    def test_private_key_block(self):
+        block = (
+            "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+            "b3BlbnNzaC1rZXktdjEAAAAABG5vbmU\nAAAAAAAA\n"
+            "-----END OPENSSH PRIVATE KEY-----"
+        )
+        out = redact(f"key material:\n{block}\ndone")
+        assert "b3BlbnNz" not in out
+        assert out.startswith("key material:")
+        assert out.endswith("done")
+
+
+class TestConnectionString:
+    def test_masks_only_password(self):
+        out = redact("dsn=postgres://taos:s3cr3tpw@db.internal:5432/app")
+        assert "s3cr3tpw" not in out
+        assert "postgres://taos:" in out
+        assert "@db.internal:5432/app" in out
+
+
+class TestKnownValues:
+    def test_literal_value_masked(self):
+        out = redact("the model returned plainlookingkey987", known_values=["plainlookingkey987"])
+        assert "plainlookingkey987" not in out
+        assert PLACEHOLDER in out
+
+    def test_short_known_value_ignored(self):
+        # too short to safely mask -> left alone (no runaway redaction)
+        assert redact("abc appears here", known_values=["abc"]) == "abc appears here"
+
+    def test_empty_known_values_noop(self):
+        assert redact("nothing sensitive here", known_values=[]) == "nothing sensitive here"
+
+    def test_none_known_values(self):
+        assert redact("nothing sensitive here") == "nothing sensitive here"
+
+
+class TestSafety:
+    def test_empty_string(self):
+        assert redact("") == ""
+
+    def test_clean_line_untouched(self):
+        line = "2026-07-02 19:00:00 INFO controller ready on port 6969"
+        assert redact(line) == line
+
+    def test_redact_lines(self):
+        out = redact_lines(["password=abcdef123456", "all good here"])
+        assert out[0] == f"password={PLACEHOLDER}"
+        assert out[1] == "all good here"
+
+
+class TestFoldedFindings:
+    """Negative/regression tests for the review folds (base64 bearer, JWT,
+    partial-leak known values, PEM framing, coercion)."""
+
+    def test_base64_bearer_masked_whole(self):
+        # + / = must not truncate the value (AWS/OAuth2 token shape).
+        out = redact("Authorization: Bearer abc123+def/456ghi789=")
+        assert "abc123" not in out
+        assert out == f"Authorization: Bearer {PLACEHOLDER}"
+
+    def test_bare_jwt_masked(self):
+        # Bare in prose: no key= prefix and no Bearer word, so only the
+        # standalone JWT shape rule can catch it.
+        jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4"
+        out = redact(f"decoded session {jwt} from the proxy header")
+        assert "SflKxwRJSMeKKF2QT4" not in out
+        assert PLACEHOLDER in out
+
+    def test_google_api_key(self):
+        assert PLACEHOLDER in redact("AIzaSyA0000000000000000000000000000000X")
+
+    def test_stripe_live_key(self):
+        assert PLACEHOLDER in redact("sk_live_0000000000000000abcdef")
+
+    def test_known_value_masks_whole_token(self):
+        # secret is a prefix of a longer id: the whole token must vanish, no
+        # trailing leak, no garbled placeholder.
+        out = redact("request_id=abcdef1234560000", known_values=["abcdef123456"])
+        assert "0000" not in out
+        assert "[REDACTED]0" not in out
+        assert PLACEHOLDER in out
+
+    def test_pem_keeps_framing(self):
+        block = (
+            "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+            "b3BlbnNzaC1rZXktdjEAAAAA\n"
+            "-----END OPENSSH PRIVATE KEY-----"
+        )
+        out = redact(block)
+        assert "b3BlbnNz" not in out
+        assert "-----BEGIN OPENSSH PRIVATE KEY-----" in out
+        assert "-----END OPENSSH PRIVATE KEY-----" in out
+
+    def test_redact_lines_coerces_non_str(self):
+        out = redact_lines(["password=abcdef123456", None, 42])
+        assert out[0] == f"password={PLACEHOLDER}"
+        assert out[1] == "None"
+        assert out[2] == "42"

--- a/tests/test_shared_folders.py
+++ b/tests/test_shared_folders.py
@@ -210,3 +210,37 @@ async def test_api_duplicate_folder_returns_409(client):
     await client.post("/api/shared-folders", json={"name": "dup"})
     resp = await client.post("/api/shared-folders", json={"name": "dup"})
     assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+class TestSharedFolderTraversal:
+    """A folder name or filename must never escape storage_dir (path traversal)."""
+
+    async def test_create_folder_rejects_pure_traversal_name(self, folder_mgr):
+        # Names with no real basename (bare traversal) are rejected outright.
+        for bad in ("..", ".", ""):
+            with pytest.raises(ValueError):
+                await folder_mgr.create_folder(bad)
+
+    async def test_create_folder_contains_slashy_traversal(self, folder_mgr):
+        # A traversal-looking name that has a basename is flattened to it and
+        # stays inside the storage root; nothing escapes.
+        await folder_mgr.create_folder("../../etc/evil")
+        assert (folder_mgr.storage_dir / "evil").is_dir()
+        assert not (folder_mgr.storage_dir.parent / "evil").exists()
+        # every escape variant normalizes to the same contained basename
+        for variant in ("../evil", "/etc/evil", "..\\evil"):
+            assert folder_mgr._safe_label(variant) == "evil"
+
+    async def test_create_folder_flattens_slashy_name(self, folder_mgr):
+        # A nested-looking name collapses to its basename, staying contained.
+        await folder_mgr.create_folder("a/b/docs")
+        assert (folder_mgr.storage_dir / "docs").is_dir()
+        assert not (folder_mgr.storage_dir / "a").exists()
+
+    async def test_safe_label_blocks_escape(self, folder_mgr):
+        assert folder_mgr._safe_label("../../etc/passwd") == "passwd"
+        with pytest.raises(ValueError):
+            folder_mgr._safe_label("..")
+        with pytest.raises(ValueError):
+            folder_mgr._safe_label("")

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.17"
+__version__ = "1.0.0-beta.18"

--- a/tinyagentos/download_manager.py
+++ b/tinyagentos/download_manager.py
@@ -97,6 +97,38 @@ class DownloadManager:
     def list_all(self) -> list[DownloadTask]:
         return list(self._tasks.values())
 
+    async def _validate_download(
+        self,
+        task: DownloadTask,
+        expected_sha256: str | None = None,
+        computed_sha256: str | None = None,
+    ) -> str | None:
+        """Check a finished download before it is marked complete.
+
+        Returns None if the download is valid, or an error message
+        describing why it isn't. Applies to both the torrent and HTTP
+        paths so neither can mark a task complete when nothing (or the
+        wrong thing) was actually written to disk.
+        """
+        if not task.dest.exists() or task.dest.stat().st_size == 0:
+            return "download produced no data"
+        if task.total_bytes and task.dest.stat().st_size != task.total_bytes:
+            return "size mismatch"
+        if expected_sha256:
+            digest = computed_sha256
+            if digest is None:
+                # Fallback for a caller that did not stream the hash. Reading a
+                # potentially multi-GB model is offloaded to a thread so it
+                # never blocks the event loop.
+                digest = await asyncio.to_thread(
+                    lambda: hashlib.sha256(task.dest.read_bytes()).hexdigest()
+                )
+            # Hex digests are case-insensitive; a caller passing an uppercase
+            # expected value must not be treated as a mismatch.
+            if digest.lower() != expected_sha256.lower():
+                return "SHA256 mismatch"
+        return None
+
     async def _download_with_fallback(
         self,
         task: DownloadTask,
@@ -133,6 +165,21 @@ class DownloadManager:
                     expected_sha256=expected_sha256,
                     progress_cb=_progress,
                 )
+                # torrent.download() already SHA-verified the file internally
+                # (and raised on mismatch), so re-hashing here would just re-read
+                # a multi-GB file to no benefit. Only the cheap non-empty / size
+                # floor is needed on this path.
+                error = await self._validate_download(task)
+                if error:
+                    task.dest.unlink(missing_ok=True)
+                    task.status = "error"
+                    task.error = error
+                    logger.error(
+                        "Torrent download for %s produced an invalid result (%s)",
+                        task.id,
+                        error,
+                    )
+                    return
                 task.status = "complete"
                 task.completed_at = time.time()
                 logger.info("Downloaded %s via torrent swarm", task.id)
@@ -160,17 +207,29 @@ class DownloadManager:
             async with httpx.AsyncClient(timeout=None, follow_redirects=True) as client:
                 async with client.stream("GET", task.url) as resp:
                     resp.raise_for_status()
+                    # Content-Length is the size of the ON-THE-WIRE body. When
+                    # the response is content-encoded (gzip/br/deflate/zstd),
+                    # httpx's aiter_bytes() transparently decompresses, so the
+                    # bytes we write to disk are LARGER than Content-Length.
+                    # Treating that as the expected on-disk size would make
+                    # _validate_download flag a perfectly good download as a
+                    # "size mismatch" and delete it, so leave total_bytes at 0
+                    # (unknown) for encoded responses and rely on the SHA check.
                     total = resp.headers.get("content-length")
-                    task.total_bytes = int(total) if total else 0
+                    if total and not resp.headers.get("content-encoding"):
+                        task.total_bytes = int(total)
+                    else:
+                        task.total_bytes = 0
                     with open(task.dest, "wb") as f:
                         async for chunk in resp.aiter_bytes(chunk_size=65536):
                             f.write(chunk)
                             sha.update(chunk)
                             task.downloaded_bytes += len(chunk)
-            if expected_sha256 and sha.hexdigest() != expected_sha256:
+            error = await self._validate_download(task, expected_sha256, computed_sha256=sha.hexdigest())
+            if error:
                 task.dest.unlink(missing_ok=True)
                 task.status = "error"
-                task.error = "SHA256 mismatch"
+                task.error = error
             else:
                 task.status = "complete"
                 task.completed_at = time.time()

--- a/tinyagentos/log_redaction.py
+++ b/tinyagentos/log_redaction.py
@@ -1,0 +1,144 @@
+"""Redaction for operator-facing log output (Logs app, bug-report bundle).
+
+Every log line that leaves the box through the system-logs API passes through
+`redact()` first. The threat is a well-meaning operator copying a log bundle
+into a public GitHub issue and leaking a live credential that happened to be
+logged by a dependency, a stack trace, or an env dump.
+
+Design choices:
+- Pure functions, no I/O, exhaustively tested. Nothing in the logs path may
+  bypass this.
+- Redact by PATTERN (key=value, bearer tokens, connection strings, private-key
+  blocks, high-entropy provider-key shapes) AND by KNOWN SECRET VALUE (the
+  literal values from the secrets store, so a secret logged verbatim is caught
+  even if it does not match a generic shape).
+- Fail closed on the value side: an empty or too-short known value is ignored
+  rather than redacting everything.
+- Never widen a match to swallow surrounding context; replace only the secret
+  span with a fixed placeholder so the log stays readable.
+"""
+from __future__ import annotations
+
+import re
+
+PLACEHOLDER = "[REDACTED]"
+
+# Keys whose value must be masked when they appear as key=value / key: value /
+# "key": "value" / --key value. Case-insensitive, matched as whole words so
+# "monkey" does not trip "key".
+_SENSITIVE_KEYS = (
+    "password", "passwd", "secret", "token", "api_key", "apikey", "api-key",
+    "access_key", "access-key", "secret_key", "secret-key", "private_key",
+    "private-key", "client_secret", "client-secret", "authorization", "auth",
+    "bearer", "session", "cookie", "credential", "credentials", "passphrase",
+    "id_token", "refresh_token", "access_token", "jwt", "assertion",
+)
+_KEY_ALT = "|".join(sorted((re.escape(k) for k in _SENSITIVE_KEYS), key=len, reverse=True))
+
+# key = value  /  key: value  /  "key": "value". The value runs until a quote,
+# whitespace, or comma; brackets/URLs are kept in the value so a token is not
+# truncated mid-string (leaving a readable tail). Capped to avoid runaway
+# matches on pathological single-line input.
+_KV_RE = re.compile(
+    r'(?P<pre>["\']?(?:' + _KEY_ALT + r')["\']?\s*[:=]\s*)'
+    r'(?P<quote>["\']?)(?P<val>[^\s,"\']{1,4096})(?P=quote)',
+    re.IGNORECASE,
+)
+
+# --key value  (CLI flag form, space-separated).
+_FLAG_RE = re.compile(r'(?P<pre>--(?:' + _KEY_ALT + r')\s+)(?P<val>\S+)', re.IGNORECASE)
+
+# Auth SCHEME words that legitimately follow "authorization:"; the real secret
+# is the NEXT token (handled by the bearer rule), so the KV rule must not treat
+# the scheme word itself as the value and stop there, leaving the token exposed.
+_AUTH_SCHEMES = {"bearer", "basic", "digest", "token", "negotiate"}
+
+# Authorization: Bearer <token>  (header form). The value class includes the
+# base64/base64url trailing set (+ / =) so AWS session tokens and OAuth2
+# access tokens are masked whole, not truncated at the first + or /.
+_BEARER_RE = re.compile(r'(?P<pre>bearer\s+)(?P<val>[A-Za-z0-9._\-+/=]{8,})', re.IGNORECASE)
+
+# Bare secret shapes that carry no key= prefix. JWTs (three base64url segments)
+# are common in logs with no Bearer word, so they get their own rule.
+_TOKEN_SHAPE_RE = re.compile(
+    r'(?:'
+    r'\bsk-[A-Za-z0-9._\-]{16,}'          # OpenAI / sk-taos
+    r'|\bsk_(?:live|test)_[0-9A-Za-z]{16,}'  # Stripe
+    r'|\bgh[posru]_[A-Za-z0-9]{20,}'      # GitHub PAT
+    r'|\bxox[baprs]-[A-Za-z0-9\-]{10,}'   # Slack
+    r'|\bAKIA[0-9A-Z]{16}\b'              # AWS access key id
+    r'|\bAIza[0-9A-Za-z_\-]{35}\b'        # Google API key
+    r'|\bnpm_[A-Za-z0-9]{20,}'            # npm token
+    r'|\bSG\.[A-Za-z0-9_\-]{16,}\.[A-Za-z0-9_\-]{16,}\b'  # SendGrid
+    # JWT: base64url segments, but tolerate non-strict encoders that emit
+    # standard base64 (+ / =) so a real token is masked whole, not truncated
+    # at the first +, / or = padding char.
+    r'|\beyJ[A-Za-z0-9_\-+/=]{8,}\.eyJ[A-Za-z0-9_\-+/=]{6,}\.[A-Za-z0-9_\-+/=]{6,}'  # JWT
+    r')'
+)
+
+# PEM private-key blocks (SSH keys materialized on deploy, TLS keys). Keep the
+# BEGIN/END markers so a key logged inside a stack trace still shows WHAT was
+# redacted; only the base64 body is masked.
+_PEM_RE = re.compile(
+    r'(?P<begin>-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----).*?(?P<end>-----END [A-Z0-9 ]*PRIVATE KEY-----)',
+    re.DOTALL,
+)
+
+# postgres://user:pass@host, mysql://..., redis://..., amqp:// -- mask the
+# password component only.
+_CONN_STR_RE = re.compile(r'(?P<pre>[a-zA-Z][a-zA-Z0-9+.\-]*://[^:/\s]+:)(?P<val>[^@\s]+)(?P<post>@)')
+
+# A known secret value shorter than this is not masked: too likely to be a
+# common substring and cause runaway redaction of unrelated text.
+_MIN_KNOWN_VALUE_LEN = 6
+
+
+def redact(text: str, known_values: "list[str] | None" = None) -> str:
+    """Return `text` with credential-shaped spans replaced by PLACEHOLDER.
+
+    known_values: exact secret strings (e.g. from the secrets store) to mask
+    wherever they appear verbatim, in addition to the pattern rules.
+    """
+    if not text:
+        return text
+
+    # Structural rules first (they anchor on keys/prefixes, least likely to
+    # over-match), then the bare token shapes.
+    text = _PEM_RE.sub(lambda m: m.group("begin") + PLACEHOLDER + m.group("end"), text)
+    text = _CONN_STR_RE.sub(lambda m: m.group("pre") + PLACEHOLDER + m.group("post"), text)
+    # Bearer BEFORE the key-value rule so "authorization: Bearer <tok>" has its
+    # token masked; the KV rule then leaves the bare scheme word alone.
+    text = _BEARER_RE.sub(lambda m: m.group("pre") + PLACEHOLDER, text)
+    text = _FLAG_RE.sub(lambda m: m.group("pre") + PLACEHOLDER, text)
+
+    def _kv_repl(m: "re.Match[str]") -> str:
+        if m.group("val").lower() in _AUTH_SCHEMES:
+            return m.group(0)  # e.g. "authorization: Bearer" -> leave for bearer rule
+        return m.group("pre") + PLACEHOLDER
+
+    text = _KV_RE.sub(_kv_repl, text)
+    text = _TOKEN_SHAPE_RE.sub(PLACEHOLDER, text)
+
+    # Known literal secret values last: mask any that survived the shape rules
+    # (e.g. a plain-looking API key logged without a key= prefix). Mask the
+    # WHOLE surrounding non-whitespace token, not just the substring, so a
+    # secret that is a prefix of a longer identifier (request_id=<secret>0000)
+    # does not leak the trailing part or produce garbled "[REDACTED]0000"
+    # output. Longest first so a value containing a shorter one is fully masked.
+    if known_values:
+        for val in sorted((v for v in known_values if v), key=len, reverse=True):
+            if len(val) < _MIN_KNOWN_VALUE_LEN:
+                continue
+            text = re.sub(r'\S*' + re.escape(val) + r'\S*', PLACEHOLDER, text)
+
+    return text
+
+
+def redact_lines(lines: "list[str]", known_values: "list[str] | None" = None) -> "list[str]":
+    """Redact a list of log lines (convenience for the paged log reader).
+
+    Coerces non-string elements to str so one malformed line (e.g. a None from
+    a buggy upstream parser) cannot take down the whole page response.
+    """
+    return [redact(line if isinstance(line, str) else str(line), known_values) for line in lines]

--- a/tinyagentos/routes/desktop_control.py
+++ b/tinyagentos/routes/desktop_control.py
@@ -6,6 +6,17 @@ desktop/src/hooks/use-desktop-command-stream.ts). Agent tools push commands via
 POST /api/desktop/command, scoped to the calling user so a user only ever drives
 their own desktop. This is the backend half of the agent-OS-control layer (#836);
 the browser receivers already exist and are tested.
+
+kind="open-app" payload: {"app": "<appId>", "props"?: {...}}.
+
+kind="window" payload (see desktop/src/hooks/use-desktop-control.ts for the
+receiver): {"action": "<op>", "windowId"?, "appId"?, "props"?, "x"?, "y"?,
+"w"?, "h"?, "snap"?, "preset"?}. `op`/`app` are also accepted as aliases for
+`action`/`appId`. Ops: open, close, focus, minimize, restore, maximize, move,
+resize, snap, arrange (preset: tile-2 | tile-3 | center | cascade). Targeting
+precedence: explicit windowId, else first window for appId, else the
+focused/topmost window -- except close, which given an appId with no windowId
+closes every open window for that app.
 """
 from __future__ import annotations
 
@@ -140,10 +151,11 @@ async def get_layout(request: Request):
     """Read the calling user's live desktop layout: screen size + every window's
     bounds and state. This is the "screen-aware" read half of the agent window-
     management API -- the agent fetches the layout to decide placement, then
-    drives windows via POST /api/desktop/command kind="window" (move/resize/snap/
-    arrange). Mirrors the screenshot round-trip: emit a `layout` command, the
-    first desktop to answer POSTs its getLayout() to /api/desktop/layout-result.
-    409 if no desktop is connected, 504 if none responds in time.
+    drives windows via POST /api/desktop/command kind="window" (see the module
+    docstring for the full op/payload contract). Mirrors the screenshot
+    round-trip: emit a `layout` command, the first desktop to answer POSTs its
+    getLayout() to /api/desktop/layout-result. 409 if no desktop is connected,
+    504 if none responds in time.
     """
     broker = request.app.state.desktop_command_broker
     user_id = _user_id(request)

--- a/tinyagentos/routes/shared_folders.py
+++ b/tinyagentos/routes/shared_folders.py
@@ -39,6 +39,9 @@ async def create_shared_folder(request: Request, body: CreateFolderRequest):
             description=body.description,
             agents=body.agents,
         )
+    except ValueError:
+        # _safe_label rejected a traversal name: clean 400, not a 500 + trace.
+        return JSONResponse({"error": "Invalid folder name"}, status_code=400)
     except Exception as e:
         if "UNIQUE constraint" in str(e):
             return JSONResponse({"error": f"Folder '{body.name}' already exists"}, status_code=409)
@@ -58,19 +61,30 @@ async def delete_shared_folder(request: Request, folder_id: int):
 @router.get("/api/shared-folders/{name}/files")
 async def list_shared_folder_files(request: Request, name: str):
     mgr = request.app.state.shared_folders
-    return mgr.list_files(name)
+    try:
+        return mgr.list_files(name)
+    except ValueError:
+        return JSONResponse({"error": "Invalid folder name"}, status_code=400)
 
 
 @router.post("/api/shared-folders/{name}/upload")
 async def upload_to_shared_folder(request: Request, name: str, file: UploadFile):
     mgr = request.app.state.shared_folders
-    folder_path = mgr.storage_dir / name
+    # Both the folder name (URL path) and the upload filename are caller
+    # controlled; sanitize each to a contained label so an uploaded file can
+    # never be written outside the shared-folder root (path traversal).
+    try:
+        folder_name = mgr._safe_label(name)
+        safe_filename = mgr._safe_label(file.filename or "")
+    except ValueError:
+        return JSONResponse({"error": "Invalid folder or file name"}, status_code=400)
+    folder_path = mgr.storage_dir / folder_name
     if not folder_path.exists():
         return JSONResponse({"error": f"Folder '{name}' not found"}, status_code=404)
-    dest = folder_path / file.filename
+    dest = folder_path / safe_filename
     content = await file.read()
     dest.write_bytes(content)
-    return {"status": "uploaded", "name": file.filename, "size": len(content)}
+    return {"status": "uploaded", "name": safe_filename, "size": len(content)}
 
 
 @router.post("/api/shared-folders/{folder_id}/access")

--- a/tinyagentos/shared_folders.py
+++ b/tinyagentos/shared_folders.py
@@ -39,10 +39,31 @@ class SharedFolderManager(BaseStore):
         await self._db.commit()
         self.storage_dir.mkdir(parents=True, exist_ok=True)
 
+    @staticmethod
+    def _safe_label(label: str) -> str:
+        """Reduce a folder name or filename to a single flat, contained label.
+
+        Names and filenames reach the filesystem from API callers, so a "..",
+        a "/etc/..." absolute part, or an embedded "../" must never escape the
+        shared-folder root (path traversal writing to cron, authorized_keys,
+        etc.). A shared-folder name and an uploaded filename are both flat
+        labels, so stripping to the basename is the correct, lossless guard.
+        """
+        # Normalize backslashes to forward slashes first: on POSIX, Path only
+        # splits on "/", so a Windows-style "..\evil" would otherwise survive
+        # as a literal name. Doing it here makes the guard platform-independent.
+        safe = Path(str(label).replace("\\", "/")).name
+        if not safe or safe in (".", ".."):
+            raise ValueError(f"invalid shared-folder name: {label!r}")
+        return safe
+
     async def create_folder(self, name: str, description: str = "",
                             owner_type: str = "global", owner_name: str = "",
                             agents: list[str] | None = None) -> int:
         now = time.time()
+        # Sanitize before it reaches both the DB and the filesystem so the two
+        # stay consistent and the physical mkdir cannot escape storage_dir.
+        name = self._safe_label(name)
         cursor = await self._db.execute(
             "INSERT INTO shared_folders (name, description, owner_type, owner_name, created_at) VALUES (?, ?, ?, ?, ?)",
             (name, description, owner_type, owner_name, now))
@@ -76,7 +97,9 @@ class SharedFolderManager(BaseStore):
             row = await cursor.fetchone()
         if not row:
             return False
-        folder_path = self.storage_dir / row[0]
+        # Re-sanitize the stored name before an rmtree: defends any legacy row
+        # that predates the create-time guard.
+        folder_path = self.storage_dir / self._safe_label(row[0])
         if folder_path.exists():
             shutil.rmtree(folder_path)
         await self._db.execute("DELETE FROM shared_folders WHERE id = ?", (folder_id,))
@@ -84,7 +107,7 @@ class SharedFolderManager(BaseStore):
         return True
 
     def list_files(self, folder_name: str) -> list[dict]:
-        folder_path = self.storage_dir / folder_name
+        folder_path = self.storage_dir / self._safe_label(folder_name)
         if not folder_path.exists():
             return []
         files = []

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b17"
+version = "1.0.0b18"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotes dev to master for the 1.0.0-beta.18 release.

Installer + model-download fixes from @mandresve's beta.17 retest:
- Installer: prefer `incus-base` over the full `incus` metapackage on Debian Bookworm ARM64 (#1555)
- Models: reject false-complete downloads that wrote no data / wrong size before marking installed (#1548)
- Installer: fix the rknpu first-run SIGPIPE abort in the librknnrt version check (#1560, #1543)

Plus internal groundwork (no user-facing surface yet): secret-redaction core for the Logs app (#1558).

----
## Summary by Gitar

- **Security & Path Traversal:**
  - Added `_safe_label` validation to `SharedFolderManager` and routes to block path traversal via folder names or upload filenames.
- **Log Privacy:**
  - Introduced `log_redaction.py` to mask credentials (keys, tokens, passwords) in logs before they leave the system.
- **Desktop Control:**
  - Added an allowlist to `useDesktopControl` to reject invalid actions and allow `close` to target multiple windows by `appId`.
- **Cleanup:**
  - Removed redundant title stripping from several studio app components.


<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download reliability by checking that completed downloads actually produce a valid file.
  * Fixed container/runtime installation so supported packages are chosen more reliably.
  * Resolved an NPU installer issue that could incorrectly stop after a clean first run.
  * Strengthened shared folder handling to prevent invalid folder/file paths and return clearer errors.
  * Updated desktop window control behavior so close actions work consistently across all matching windows.
  * Removed redundant title bars from several studio apps for a cleaner layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->