### PR TITLE
feat(office-studio): real spreadsheet Calc view (formula engine, multi-sheet, CSV, persistence)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -15,6 +15,8 @@
         "@codemirror/view": "^6.43.1",
         "@excalidraw/excalidraw": "^0.18.1",
         "@excalidraw/mermaid-to-excalidraw": "^2.2.2",
+        "@fortune-sheet/core": "^1.0.4",
+        "@fortune-sheet/react": "^1.0.4",
         "@milkdown/kit": "^7.21.2",
         "@milkdown/react": "^7.21.2",
         "@milkdown/theme-nord": "^7.21.2",
@@ -1792,6 +1794,70 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@formulajs/formulajs": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@formulajs/formulajs/-/formulajs-2.9.3.tgz",
+      "integrity": "sha512-WpgiuJaBl/Hcda9Ti8a7mlnw/vUZkJrtjABvojz6P6mo6d8EscudyA7iAt/kTLsgi0c8zfmzQd/Yjb4ASFkw+g==",
+      "license": "MIT",
+      "dependencies": {
+        "bessel": "^1.0.2",
+        "jstat": "^1.9.2"
+      },
+      "bin": {
+        "implementation-stats": "bin/implementation-stats"
+      }
+    },
+    "node_modules/@fortune-sheet/core": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@fortune-sheet/core/-/core-1.0.4.tgz",
+      "integrity": "sha512-CDnUVebfvtT++CymNRw0qnY4sz6zYO3KZazlH+nG6otkRkZ05Bvt7NXqVhmKKSSxIvJR4R6h50abu/dVGBpjpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortune-sheet/formula-parser": "^0.2.13",
+        "dayjs": "^1.11.0",
+        "immer": "^9.0.12",
+        "lodash": "^4.17.21",
+        "numeral": "^2.0.6",
+        "uuid": "^8.3.2"
+      }
+    },
+    "node_modules/@fortune-sheet/core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@fortune-sheet/formula-parser": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@fortune-sheet/formula-parser/-/formula-parser-0.2.13.tgz",
+      "integrity": "sha512-za2ZVQ5ZfMSPCtL8MdqhCthPip7AoeU4MPyd5UDo4RCl9/arrv1Jz0y755mACVVi4suSZxrzWoJGDkLmofoSmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formulajs/formulajs": "^2.9.3",
+        "tiny-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/@fortune-sheet/react": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@fortune-sheet/react/-/react-1.0.4.tgz",
+      "integrity": "sha512-v+BU5mmp2hhUe4gRF+vOJ3j8zZkzHU0kzhTZzp+Nn00wA/RArMr+CO+SAluKlCPAsTZgPwmgOEK685WPqJ5XNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortune-sheet/core": "^1.0.4",
+        "@types/regenerator-runtime": "^0.13.6",
+        "immer": "^9.0.12",
+        "lodash": "^4.17.21",
+        "regenerator-runtime": "^0.14.1"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2",
+        "react-dom": ">= 18.2"
+      }
     },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
@@ -7437,6 +7503,12 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/regenerator-runtime": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/@types/regenerator-runtime/-/regenerator-runtime-0.13.8.tgz",
+      "integrity": "sha512-jjKoBekfYDH331060tZhosdJVDnXIXx+T8Iw2h2T4HEds6Ddb2lr0JxD15+XPKlXwRHRNgZoY+4Fb2ykoqzHBg==",
+      "license": "MIT"
+    },
     "node_modules/@types/stats.js": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
@@ -7893,6 +7965,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bessel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bessel/-/bessel-1.0.2.tgz",
+      "integrity": "sha512-Al3nHGQGqDYqqinXhQzmwmcRToe/3WyBv4N8aZc5Pef8xw2neZlR9VPi84Sa23JtgWcucu18HxVZrnI0fn2etw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/bidi-js": {
@@ -9323,6 +9404,16 @@
         "pica": "^7.1.0"
       }
     },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.7.tgz",
@@ -9629,6 +9720,11 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/jstat": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/jstat/-/jstat-1.9.6.tgz",
+      "integrity": "sha512-rPBkJbK2TnA8pzs93QcDDPlKcrtZWuuCo2dVR0TFLOJSxhqfWOVCSp8aV3/oSbn+4uY4yw1URtLpHQedtmXfug=="
     },
     "node_modules/katex": {
       "version": "0.17.0",
@@ -9964,6 +10060,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-4.3.0.tgz",
       "integrity": "sha512-vNX4ZZLJBeDEOBvdr2v/F+0aN5oMuPu7JTqrMwp+DtgK+AryOlpy6Xtm2/HpNr+azEa828oQjOtWsB6iDtSfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -11221,6 +11323,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/numeral": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+      "integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -12378,6 +12489,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/rehype-highlight": {
       "version": "7.0.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -19,6 +19,8 @@
     "@codemirror/view": "^6.43.1",
     "@excalidraw/excalidraw": "^0.18.1",
     "@excalidraw/mermaid-to-excalidraw": "^2.2.2",
+    "@fortune-sheet/core": "^1.0.4",
+    "@fortune-sheet/react": "^1.0.4",
     "@milkdown/kit": "^7.21.2",
     "@milkdown/react": "^7.21.2",
     "@milkdown/theme-nord": "^7.21.2",

--- a/desktop/src/apps/OfficeStudioApp.test.tsx
+++ b/desktop/src/apps/OfficeStudioApp.test.tsx
@@ -54,17 +54,18 @@ describe("OfficeStudioApp", () => {
     expect(body.textContent).toContain("Hello world");
   });
 
-  it("switches to Calc view and shows spreadsheet grid with Total row", () => {
+  it("switches to Calc view and shows the real spreadsheet chrome", () => {
     renderApp();
     fireEvent.click(screen.getByRole("button", { name: "Calc" }));
     expect(screen.getByRole("button", { name: "Calc" }).getAttribute("aria-current")).toBe("page");
-    // spreadsheet table
-    expect(screen.getByRole("table", { name: "Spreadsheet" })).toBeDefined();
-    // total row value
-    expect(screen.getByTestId("total-revenue")).toBeDefined();
-    expect(screen.getByTestId("total-revenue").textContent).toBe("28,900");
-    // Total label
-    expect(screen.getByText("Total")).toBeDefined();
+    // formula bar reflects the active cell (A1 on a fresh workbook)
+    expect(screen.getByLabelText("Formula for cell A1")).toBeDefined();
+    // default sheet tab
+    expect(screen.getByRole("button", { name: "Sheet1" })).toBeDefined();
+    expect(screen.getByLabelText("Add sheet")).toBeDefined();
+    // workbook title + save/new actions
+    expect(screen.getByLabelText("Workbook title")).toBeDefined();
+    expect(screen.getByRole("button", { name: /Save/ })).toBeDefined();
   });
 
   it("switches to Slides view and shows slide thumbnails", () => {

--- a/desktop/src/apps/officestudio/CalcView.tsx
+++ b/desktop/src/apps/officestudio/CalcView.tsx
@@ -1,194 +1,599 @@
-import { Sparkles } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Workbook, type WorkbookInstance } from "@fortune-sheet/react";
+import "@fortune-sheet/react/dist/index.css";
+import type { Selection, Sheet } from "@fortune-sheet/core";
+import {
+  ArrowDownZA,
+  ArrowUpAZ,
+  Download,
+  Plus,
+  Save,
+  Sparkles,
+  Upload,
+  X,
+} from "lucide-react";
+import { cellAddress } from "./calc/address";
+import { parseCsv, sheetToCsv } from "./calc/csv";
+import { blankWorkbook, parseWorkbookContent, serializeWorkbook } from "./calc/workbook";
 
-const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May"] as const;
-const BAR_HEIGHTS = [48, 60, 78, 70, 92] as const;
+type OfficeDocListItem = {
+  id: string;
+  kind: string;
+  title: string;
+  updated_at?: number;
+};
 
-const ROWS: { month: string; revenue: string; costs: string; profit: string }[] = [
-  { month: "January", revenue: "4,200", costs: "2,100", profit: "2,100" },
-  { month: "February", revenue: "5,100", costs: "2,300", profit: "2,800" },
-  { month: "March", revenue: "6,400", costs: "2,800", profit: "3,600" },
-  { month: "April", revenue: "5,900", costs: "2,600", profit: "3,300" },
-  { month: "May", revenue: "7,300", costs: "3,100", profit: "4,200" },
-];
+type OfficeDoc = OfficeDocListItem & {
+  content: string;
+};
+
+type SheetTab = { id: string; name: string };
+
+function formatUpdated(ts?: number): string {
+  if (!ts) return "Draft";
+  const d = new Date(ts * 1000);
+  return `Updated ${d.toLocaleString()}`;
+}
+
+function sortTabsByOrder(sheets: Sheet[]): SheetTab[] {
+  return [...sheets]
+    .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+    .map((s) => ({ id: s.id ?? "", name: s.name }));
+}
 
 export function CalcView() {
+  const [docs, setDocs] = useState<OfficeDocListItem[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [title, setTitle] = useState("Untitled workbook");
+  const [updatedAt, setUpdatedAt] = useState<number | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [workbookData, setWorkbookData] = useState<Sheet[]>(() => blankWorkbook().sheets);
+  const [mountKey, setMountKey] = useState(0);
+  const [sheetTabs, setSheetTabs] = useState<SheetTab[]>(() => sortTabsByOrder(workbookData));
+  const [activeSheetId, setActiveSheetId] = useState<string>(workbookData[0]?.id ?? "");
+  const [selection, setSelection] = useState<{ row: [number, number]; column: [number, number] }>(
+    { row: [0, 0], column: [0, 0] },
+  );
+  const [formulaValue, setFormulaValue] = useState("");
+  const [filterValue, setFilterValue] = useState("");
+  const [hiddenRows, setHiddenRows] = useState<string[]>([]);
+
+  const workbookRef = useRef<WorkbookInstance>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const refreshFormulaBar = useCallback((row: number, column: number) => {
+    const wb = workbookRef.current;
+    if (!wb) return;
+    const cells = wb.getCellsByRange({ row: [row, row], column: [column, column] });
+    const cell = cells?.[0]?.[0];
+    if (!cell) {
+      setFormulaValue("");
+      return;
+    }
+    setFormulaValue(cell.f ?? (cell.v == null ? "" : String(cell.v)));
+  }, []);
+
+  const refreshSheetTabs = useCallback(() => {
+    const wb = workbookRef.current;
+    if (!wb) return;
+    setSheetTabs(sortTabsByOrder(wb.getAllSheets()));
+  }, []);
+
+  const applyWorkbook = useCallback((sheets: Sheet[]) => {
+    setWorkbookData(sheets);
+    setMountKey((k) => k + 1);
+    const tabs = sortTabsByOrder(sheets);
+    setSheetTabs(tabs);
+    setActiveSheetId(tabs[0]?.id ?? "");
+    setSelection({ row: [0, 0], column: [0, 0] });
+    setFormulaValue("");
+    setFilterValue("");
+    setHiddenRows([]);
+  }, []);
+
+  const loadList = useCallback(async () => {
+    const res = await fetch("/api/office/docs", { credentials: "include" });
+    if (!res.ok) throw new Error("Could not load sheets");
+    const items = (await res.json()) as OfficeDocListItem[];
+    setDocs(items.filter((d) => d.kind === "calc"));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await loadList();
+        if (!cancelled) setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Load failed");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadList]);
+
+  const openDoc = async (docId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/office/docs/${encodeURIComponent(docId)}`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Could not open sheet");
+      const doc = (await res.json()) as OfficeDoc;
+      const workbook = parseWorkbookContent(doc.content);
+      setActiveId(doc.id);
+      setTitle(doc.title);
+      setUpdatedAt(doc.updated_at);
+      applyWorkbook(workbook.sheets);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Open failed");
+    }
+  };
+
+  const newDoc = () => {
+    setActiveId(null);
+    setTitle("Untitled workbook");
+    setUpdatedAt(undefined);
+    setError(null);
+    applyWorkbook(blankWorkbook().sheets);
+  };
+
+  const saveDoc = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const sheets = workbookRef.current?.getAllSheets() ?? workbookData;
+      const content = serializeWorkbook(sheets);
+      const payload = { kind: "calc", title: title.trim() || "Untitled workbook", content };
+      const url = activeId
+        ? `/api/office/docs/${encodeURIComponent(activeId)}`
+        : "/api/office/docs";
+      const res = await fetch(url, {
+        method: activeId ? "PUT" : "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error || "Save failed");
+      }
+      const saved = (await res.json()) as OfficeDoc;
+      setActiveId(saved.id);
+      setTitle(saved.title);
+      setUpdatedAt(saved.updated_at);
+      await loadList();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /* ------------------------------ formula bar ---------------------- */
+
+  const commitFormula = useCallback(() => {
+    const wb = workbookRef.current;
+    if (!wb) return;
+    const [row] = selection.row;
+    const [column] = selection.column;
+    wb.setCellValue(row, column, formulaValue);
+    wb.calculateFormula();
+    refreshFormulaBar(row, column);
+  }, [selection, formulaValue, refreshFormulaBar]);
+
+  /* -------------------------------- sheets --------------------------- */
+
+  const addSheetTab = useCallback(() => {
+    workbookRef.current?.addSheet();
+  }, []);
+
+  const renameSheetTab = useCallback((id: string, current: string) => {
+    const name = window.prompt("Sheet name", current);
+    if (!name || !name.trim()) return;
+    workbookRef.current?.setSheetName(name.trim(), { id });
+  }, []);
+
+  const deleteSheetTab = useCallback(
+    (id: string) => {
+      if (sheetTabs.length <= 1) return;
+      if (!window.confirm("Delete this sheet? This cannot be undone.")) return;
+      workbookRef.current?.deleteSheet({ id });
+    },
+    [sheetTabs.length],
+  );
+
+  /* -------------------------------- sort / filter --------------------- */
+
+  const sortColumn = useCallback(
+    (direction: "asc" | "desc") => {
+      const wb = workbookRef.current;
+      if (!wb) return;
+      const sheet = wb.getSheet();
+      const rowCount = sheet.row ?? 0;
+      const colCount = sheet.column ?? 0;
+      const col = selection.column[0];
+      if (rowCount < 3 || colCount < 1) return;
+      const cells = wb.getCellsByRange({ row: [1, rowCount - 1], column: [0, colCount - 1] }) ?? [];
+      const indexed = cells.map((row, i) => ({ row, i }));
+      indexed.sort((a, b) => {
+        const av = a.row?.[col]?.v;
+        const bv = b.row?.[col]?.v;
+        const an = typeof av === "number" ? av : Number(av);
+        const bn = typeof bv === "number" ? bv : Number(bv);
+        let cmp: number;
+        if (!Number.isNaN(an) && !Number.isNaN(bn)) {
+          cmp = an - bn;
+        } else {
+          cmp = String(av ?? "").localeCompare(String(bv ?? ""));
+        }
+        return direction === "asc" ? cmp : -cmp;
+      });
+      const values = indexed.map(({ row }) =>
+        Array.from({ length: colCount }, (_, c) => row?.[c]?.f ?? row?.[c]?.v ?? ""),
+      );
+      wb.setCellValuesByRange(values, { row: [1, rowCount - 1], column: [0, colCount - 1] });
+      wb.calculateFormula();
+    },
+    [selection],
+  );
+
+  const applyFilter = useCallback(() => {
+    const wb = workbookRef.current;
+    const needle = filterValue.trim().toLowerCase();
+    if (!wb || !needle) return;
+    const sheet = wb.getSheet();
+    const rowCount = sheet.row ?? 0;
+    const col = selection.column[0];
+    if (rowCount < 2) return;
+    const cells = wb.getCellsByRange({ row: [1, rowCount - 1], column: [col, col] }) ?? [];
+    const toHide: string[] = [];
+    const toShow: string[] = [];
+    cells.forEach((rowArr, i) => {
+      const rowIndex = i + 1;
+      const cell = rowArr?.[0];
+      const text = String(cell?.m ?? cell?.v ?? "").toLowerCase();
+      (text.includes(needle) ? toShow : toHide).push(String(rowIndex));
+    });
+    if (toHide.length) wb.hideRowOrColumn(toHide, "row");
+    if (toShow.length) wb.showRowOrColumn(toShow, "row");
+    setHiddenRows(toHide);
+  }, [filterValue, selection]);
+
+  const clearFilter = useCallback(() => {
+    const wb = workbookRef.current;
+    if (wb && hiddenRows.length) wb.showRowOrColumn(hiddenRows, "row");
+    setHiddenRows([]);
+    setFilterValue("");
+  }, [hiddenRows]);
+
+  /* ---------------------------------- csv ------------------------------ */
+
+  const exportCsv = useCallback(() => {
+    const wb = workbookRef.current;
+    if (!wb) return;
+    const sheet = wb.getSheet();
+    const csv = sheetToCsv(sheet.celldata ?? []);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    const sheetName = sheetTabs.find((t) => t.id === activeSheetId)?.name ?? "Sheet1";
+    a.href = url;
+    a.download = `${(title || "Untitled workbook").replace(/\s+/g, "-")}-${sheetName}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [activeSheetId, sheetTabs, title]);
+
+  const importCsv = useCallback(async (file: File) => {
+    const wb = workbookRef.current;
+    if (!wb) return;
+    const text = await file.text();
+    const rows = parseCsv(text);
+    if (rows.length === 0) return;
+    const width = Math.max(...rows.map((r) => r.length));
+    const padded = rows.map((r) => {
+      const copy = [...r];
+      while (copy.length < width) copy.push("");
+      return copy;
+    });
+    wb.setCellValuesByRange(padded, { row: [0, padded.length - 1], column: [0, width - 1] });
+    wb.calculateFormula();
+  }, []);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      e.target.value = "";
+      if (file) void importCsv(file);
+    },
+    [importCsv],
+  );
+
+  /* ------------------------------------- hooks -------------------------- */
+
+  // Passed to the Workbook component as part of its Settings prop. Memoized
+  // so its identity is stable across renders: Workbook treats a new settings
+  // object as a real config change, and recreating this on every render
+  // (e.g. from our own setSelection calls) causes a render/settings-change
+  // feedback loop.
+  const hooks = useMemo(
+    () => ({
+      afterSelectionChange: (_sheetId: string, sel: Selection) => {
+        const row: [number, number] = [sel.row[0] ?? 0, sel.row[1] ?? sel.row[0] ?? 0];
+        const column: [number, number] = [sel.column[0] ?? 0, sel.column[1] ?? sel.column[0] ?? 0];
+        setSelection({ row, column });
+        refreshFormulaBar(row[0], column[0]);
+      },
+      afterUpdateCell: (row: number, column: number) => {
+        setSelection((cur) => {
+          if (cur.row[0] === row && cur.column[0] === column) refreshFormulaBar(row, column);
+          return cur;
+        });
+      },
+      afterActivateSheet: (id: string) => {
+        setActiveSheetId(id);
+        setSelection({ row: [0, 0], column: [0, 0] });
+        refreshFormulaBar(0, 0);
+      },
+      afterAddSheet: (sheet: Sheet) => {
+        if (sheet.id) workbookRef.current?.activateSheet({ id: sheet.id });
+        refreshSheetTabs();
+      },
+      afterDeleteSheet: () => {
+        refreshSheetTabs();
+        const all = workbookRef.current?.getAllSheets() ?? [];
+        setActiveSheetId((cur) => {
+          if (all.some((s) => s.id === cur)) return cur;
+          return all[0]?.id ?? cur;
+        });
+      },
+      afterUpdateSheetName: () => {
+        refreshSheetTabs();
+      },
+    }),
+    [refreshFormulaBar, refreshSheetTabs],
+  );
+
+  const address = cellAddress(selection.row[0], selection.column[0]);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* formula bar */}
-      <div className="flex h-[34px] flex-none items-center gap-2.5 border-b border-shell-border bg-shell-bg-deep px-3.5">
-        <span className="w-[46px] text-[11.5px] font-bold text-shell-text-secondary">B7</span>
-        <span className="text-[11.5px] text-shell-text-tertiary">
-          <span className="font-mono font-semibold text-accent">=SUM(B2:B6)</span>
+      {/* view header */}
+      <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
+        <h2 className="text-[17px] font-bold tracking-[-0.02em]">Calc</h2>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          aria-label="Workbook title"
+          className="w-52 truncate border-0 bg-transparent text-[13px] font-semibold text-shell-text outline-none placeholder:text-shell-text-tertiary"
+        />
+        <span className="truncate text-[12px] text-shell-text-tertiary">
+          {docs.length} sheet{docs.length === 1 ? "" : "s"} &middot;{" "}
+          {activeId ? formatUpdated(updatedAt) : "New workbook"}
         </span>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={newDoc}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] border border-shell-border px-3 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Plus size={14} />
+            New
+          </button>
+          <button
+            type="button"
+            onClick={saveDoc}
+            disabled={saving}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] bg-gradient-to-br from-accent to-accent/70 px-3.5 text-[12px] font-bold text-white disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Save size={14} />
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
       </div>
 
-      <div className="flex min-h-0 flex-1">
-        {/* spreadsheet */}
-        <div className="flex-1 overflow-auto" style={{ background: "#f7f7f9" }}>
-          <table
-            className="w-full border-collapse text-[12px]"
-            style={{ color: "#23232a" }}
-            aria-label="Spreadsheet"
+      {/* formula bar */}
+      <div className="flex h-[34px] flex-none items-center gap-2.5 border-b border-shell-border bg-shell-bg-deep px-3.5">
+        <span
+          className="w-[46px] text-[11.5px] font-bold text-shell-text-secondary"
+          aria-hidden="true"
+        >
+          {address}
+        </span>
+        <span className="font-mono text-[11.5px] text-shell-text-tertiary" aria-hidden="true">
+          fx
+        </span>
+        <input
+          value={formulaValue}
+          onChange={(e) => setFormulaValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commitFormula();
+            }
+          }}
+          onBlur={commitFormula}
+          aria-label={`Formula for cell ${address}`}
+          placeholder="Enter a value or formula, e.g. =SUM(A1:A3)"
+          className="flex-1 bg-transparent font-mono text-[12px] text-shell-text outline-none placeholder:text-shell-text-tertiary"
+        />
+      </div>
+
+      {/* toolbar: sort / filter / csv */}
+      <div className="flex h-[42px] flex-none items-center gap-1.5 overflow-x-auto border-b border-shell-border bg-shell-bg-deep px-3">
+        <button
+          type="button"
+          aria-label="Sort column ascending"
+          onClick={() => sortColumn("asc")}
+          className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <ArrowUpAZ size={15} />
+        </button>
+        <button
+          type="button"
+          aria-label="Sort column descending"
+          onClick={() => sortColumn("desc")}
+          className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <ArrowDownZA size={15} />
+        </button>
+        <div className="mx-1 h-5 w-px flex-none bg-shell-border" />
+        <input
+          value={filterValue}
+          onChange={(e) => setFilterValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              applyFilter();
+            }
+          }}
+          aria-label="Filter column"
+          placeholder="Filter column..."
+          className="h-8 w-40 flex-none rounded-lg border border-shell-border bg-shell-surface px-2.5 text-[12px] text-shell-text outline-none placeholder:text-shell-text-tertiary focus-visible:ring-2 focus-visible:ring-accent/40"
+        />
+        <button
+          type="button"
+          onClick={applyFilter}
+          className="h-8 flex-none rounded-lg px-2.5 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          Filter
+        </button>
+        {hiddenRows.length > 0 && (
+          <button
+            type="button"
+            onClick={clearFilter}
+            className="h-8 flex-none rounded-lg px-2.5 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           >
-            <thead>
-              <tr>
-                <th
-                  className="sticky top-0 h-6 w-[34px] border"
-                  style={{
-                    background: "#ededf1",
-                    color: "#7a7a85",
-                    fontSize: 10.5,
-                    fontWeight: 600,
-                    borderColor: "#e6e6ea",
-                  }}
-                />
-                {["A", "B", "C", "D"].map((col) => (
-                  <th
-                    key={col}
-                    className="sticky top-0 h-6 border px-2"
-                    style={{
-                      background: "#ededf1",
-                      color: "#7a7a85",
-                      fontSize: 10.5,
-                      fontWeight: 600,
-                      borderColor: "#e6e6ea",
-                    }}
-                  >
-                    {col}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {/* header row */}
-              <tr>
-                <td
-                  className="h-[27px] border px-2 text-center text-[10.5px] font-semibold"
-                  style={{ background: "#ededf1", color: "#7a7a85", borderColor: "#e6e6ea" }}
-                >
-                  1
-                </td>
-                <td
-                  className="h-[27px] border px-2 font-semibold"
-                  style={{ color: "#23232a", borderColor: "#e6e6ea" }}
-                >
-                  Month
-                </td>
-                <td
-                  className="h-[27px] border px-2 text-right font-semibold"
-                  style={{ color: "#23232a", borderColor: "#e6e6ea" }}
-                >
-                  Revenue
-                </td>
-                <td
-                  className="h-[27px] border px-2 text-right font-semibold"
-                  style={{ color: "#23232a", borderColor: "#e6e6ea" }}
-                >
-                  Costs
-                </td>
-                <td
-                  className="h-[27px] border px-2 text-right font-semibold"
-                  style={{ color: "#23232a", borderColor: "#e6e6ea" }}
-                >
-                  Profit
-                </td>
-              </tr>
+            Clear filter
+          </button>
+        )}
+        <div className="mx-1 h-5 w-px flex-none bg-shell-border" />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="flex h-8 flex-none items-center gap-1.5 rounded-lg px-2.5 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <Upload size={14} />
+          Import CSV
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".csv,text/csv"
+          aria-label="Import CSV file"
+          className="hidden"
+          onChange={handleFileChange}
+        />
+        <button
+          type="button"
+          onClick={exportCsv}
+          className="flex h-8 flex-none items-center gap-1.5 rounded-lg px-2.5 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <Download size={14} />
+          Export CSV
+        </button>
+      </div>
 
-              {/* data rows */}
-              {ROWS.map((row, i) => (
-                <tr key={row.month}>
-                  <td
-                    className="h-[27px] border px-2 text-center text-[10.5px] font-semibold"
-                    style={{ background: "#ededf1", color: "#7a7a85", borderColor: "#e6e6ea" }}
-                  >
-                    {i + 2}
-                  </td>
-                  <td className="h-[27px] border px-2" style={{ borderColor: "#e6e6ea", color: "#33333c" }}>
-                    {row.month}
-                  </td>
-                  <td className="h-[27px] border px-2 text-right tabular-nums" style={{ borderColor: "#e6e6ea", color: "#33333c" }}>
-                    {row.revenue}
-                  </td>
-                  <td className="h-[27px] border px-2 text-right tabular-nums" style={{ borderColor: "#e6e6ea", color: "#33333c" }}>
-                    {row.costs}
-                  </td>
-                  <td className="h-[27px] border px-2 text-right tabular-nums" style={{ borderColor: "#e6e6ea", color: "#33333c" }}>
-                    {row.profit}
-                  </td>
-                </tr>
-              ))}
+      {error && (
+        <p className="border-b border-shell-border px-3.5 py-1.5 text-[12px] text-red-400" role="alert">
+          {error}
+        </p>
+      )}
 
-              {/* total row */}
-              <tr>
-                <td
-                  className="h-[27px] border px-2 text-center text-[10.5px] font-semibold"
-                  style={{ background: "#ededf1", color: "#7a7a85", borderColor: "#e6e6ea" }}
+      <div className="flex min-h-0 flex-1">
+        {/* documents sidebar */}
+        <aside className="flex w-[200px] flex-none flex-col border-r border-shell-border bg-shell-bg-deep">
+          <div className="border-b border-shell-border px-3 py-2 text-[11px] font-bold uppercase tracking-wide text-shell-text-tertiary">
+            Sheets
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto p-2">
+            {loading && (
+              <p className="px-2 py-1 text-[12px] text-shell-text-tertiary">Loading...</p>
+            )}
+            {!loading && docs.length === 0 && (
+              <p className="px-2 py-1 text-[12px] text-shell-text-tertiary">No saved sheets yet</p>
+            )}
+            {docs.map((doc) => (
+              <button
+                key={doc.id}
+                type="button"
+                onClick={() => openDoc(doc.id)}
+                className={`mb-1 w-full rounded-lg px-2 py-2 text-left text-[12px] transition-colors hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  activeId === doc.id
+                    ? "bg-shell-surface text-shell-text"
+                    : "text-shell-text-secondary"
+                }`}
+              >
+                <div className="truncate font-semibold">{doc.title}</div>
+                <div className="truncate text-[10px] text-shell-text-tertiary">
+                  {formatUpdated(doc.updated_at)}
+                </div>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="relative min-h-0 flex-1 overflow-hidden">
+            <Workbook
+              key={mountKey}
+              ref={workbookRef}
+              data={workbookData}
+              showToolbar={false}
+              showFormulaBar={false}
+              showSheetTabs={false}
+              hooks={hooks}
+            />
+          </div>
+
+          {/* sheet tabs */}
+          <div className="flex h-9 flex-none items-center gap-1 overflow-x-auto border-t border-shell-border bg-shell-bg-deep px-2">
+            {sheetTabs.map((tab) => (
+              <div key={tab.id} className="group relative flex flex-none items-center">
+                <button
+                  type="button"
+                  aria-current={tab.id === activeSheetId ? "true" : undefined}
+                  onClick={() => workbookRef.current?.activateSheet({ id: tab.id })}
+                  onDoubleClick={() => renameSheetTab(tab.id, tab.name)}
+                  className={`h-7 rounded-lg px-2.5 pr-6 text-[12px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                    tab.id === activeSheetId
+                      ? "bg-shell-surface text-shell-text"
+                      : "text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text"
+                  }`}
                 >
-                  7
-                </td>
-                <td
-                  className="h-[27px] border px-2 font-bold"
-                  style={{ background: "#f0f0f4", color: "#23232a", borderColor: "#e6e6ea" }}
-                >
-                  Total
-                </td>
-                <td
-                  className="h-[27px] border px-2 text-right font-bold tabular-nums"
-                  style={{
-                    background: "#f0f0f4",
-                    color: "#23232a",
-                    borderColor: "#e6e6ea",
-                    outline: "2px solid #a9b0c2",
-                    outlineOffset: -2,
-                  }}
-                  data-testid="total-revenue"
-                >
-                  28,900
-                </td>
-                <td
-                  className="h-[27px] border px-2 text-right font-bold tabular-nums"
-                  style={{ background: "#f0f0f4", color: "#23232a", borderColor: "#e6e6ea" }}
-                >
-                  12,900
-                </td>
-                <td
-                  className="h-[27px] border px-2 text-right font-bold tabular-nums"
-                  style={{ background: "#f0f0f4", color: "#23232a", borderColor: "#e6e6ea" }}
-                >
-                  16,000
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  {tab.name}
+                </button>
+                {sheetTabs.length > 1 && (
+                  <button
+                    type="button"
+                    aria-label={`Delete sheet ${tab.name}`}
+                    onClick={() => deleteSheetTab(tab.id)}
+                    className="absolute right-1 flex h-5 w-5 items-center justify-center rounded text-shell-text-tertiary opacity-0 hover:bg-shell-surface-active hover:text-shell-text focus-visible:opacity-100 focus-visible:outline-none group-hover:opacity-100"
+                  >
+                    <X size={12} />
+                  </button>
+                )}
+              </div>
+            ))}
+            <button
+              type="button"
+              aria-label="Add sheet"
+              onClick={addSheetTab}
+              className="flex h-7 w-7 flex-none items-center justify-center rounded-lg text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            >
+              <Plus size={14} />
+            </button>
+          </div>
         </div>
 
         {/* right sidebar */}
         <aside className="flex w-[262px] flex-none flex-col gap-3.5 border-l border-shell-border bg-shell-bg p-[18px]">
-          {/* bar chart card */}
-          <div className="rounded-[13px] border border-shell-border bg-shell-surface p-3.5">
-            <div className="mb-3 text-[12px] font-bold text-shell-text">Revenue by month</div>
-            <div className="flex h-24 items-end gap-2">
-              {BAR_HEIGHTS.map((h, i) => (
-                <div
-                  key={MONTHS[i]}
-                  className="flex-1 rounded-t"
-                  style={{
-                    height: `${h}%`,
-                    background: "linear-gradient(180deg,#a9b0c2,#8b92a3)",
-                  }}
-                />
-              ))}
-            </div>
-            <div className="mt-1.5 flex gap-2">
-              {MONTHS.map((m) => (
-                <span key={m} className="flex-1 text-center text-[9px] text-shell-text-tertiary">
-                  {m}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          {/* ask your data */}
           <div
             className="rounded-[13px] border p-3"
             style={{

--- a/desktop/src/apps/officestudio/CalcView.tsx
+++ b/desktop/src/apps/officestudio/CalcView.tsx
@@ -65,6 +65,15 @@ export function CalcView() {
 
   const workbookRef = useRef<WorkbookInstance>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Pending afterActivateSheet deferral; cleared on the next activation and on
+  // unmount so it can never setState after the component is gone.
+  const activateTimerRef = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (activateTimerRef.current != null) clearTimeout(activateTimerRef.current);
+    },
+    [],
+  );
 
   // Hook callbacks below run outside React's render cycle, so they read the
   // latest selection off this ref rather than closing over the `selection`
@@ -358,7 +367,7 @@ export function CalcView() {
         const column: [number, number] = [sel.column[0] ?? 0, sel.column[1] ?? sel.column[0] ?? 0];
         setSelection({ row, column });
         refreshFormulaBar(row[0], column[0]);
-        const rows = workbookRef.current?.getSheet().row;
+        const rows = workbookRef.current?.getSheet()?.row;
         if (rows != null) setRowCount(rows);
       },
       afterUpdateCell: (row: number, column: number) => {
@@ -377,11 +386,13 @@ export function CalcView() {
         // reflected everywhere the imperative API reads from. Defer to the
         // next tick and confirm the workbook actually reports this sheet as
         // active before trusting getCellsByRange for it.
-        setTimeout(() => {
+        if (activateTimerRef.current != null) clearTimeout(activateTimerRef.current);
+        activateTimerRef.current = window.setTimeout(() => {
+          activateTimerRef.current = null;
           const wb = workbookRef.current;
           if (wb?.getSheet()?.id === id) {
             refreshFormulaBar(0, 0);
-            const rows = wb.getSheet().row;
+            const rows = wb.getSheet()?.row;
             if (rows != null) setRowCount(rows);
           }
         }, 0);

--- a/desktop/src/apps/officestudio/CalcView.tsx
+++ b/desktop/src/apps/officestudio/CalcView.tsx
@@ -14,7 +14,8 @@ import {
 } from "lucide-react";
 import { cellAddress } from "./calc/address";
 import { parseCsv, sheetToCsv } from "./calc/csv";
-import { blankWorkbook, parseWorkbookContent, serializeWorkbook } from "./calc/workbook";
+import { compareCellValues } from "./calc/sort";
+import { blankWorkbook, DEFAULT_SHEET_ROWS, parseWorkbookContent, serializeWorkbook } from "./calc/workbook";
 
 type OfficeDocListItem = {
   id: string;
@@ -60,9 +61,19 @@ export function CalcView() {
   const [formulaValue, setFormulaValue] = useState("");
   const [filterValue, setFilterValue] = useState("");
   const [hiddenRows, setHiddenRows] = useState<string[]>([]);
+  const [rowCount, setRowCount] = useState<number>(() => workbookData[0]?.row ?? DEFAULT_SHEET_ROWS);
 
   const workbookRef = useRef<WorkbookInstance>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Hook callbacks below run outside React's render cycle, so they read the
+  // latest selection off this ref rather than closing over the `selection`
+  // state (which would be stale) or calling setSelection's functional-updater
+  // form to peek at it (which isn't a pure state transition).
+  const selectionRef = useRef(selection);
+  useEffect(() => {
+    selectionRef.current = selection;
+  }, [selection]);
 
   const refreshFormulaBar = useCallback((row: number, column: number) => {
     const wb = workbookRef.current;
@@ -92,6 +103,7 @@ export function CalcView() {
     setFormulaValue("");
     setFilterValue("");
     setHiddenRows([]);
+    setRowCount(sheets[0]?.row ?? DEFAULT_SHEET_ROWS);
   }, []);
 
   const loadList = useCallback(async () => {
@@ -148,6 +160,11 @@ export function CalcView() {
     setSaving(true);
     setError(null);
     try {
+      // getAllSheets() from the live ref is the source of truth for
+      // in-progress edits; workbookData only ever holds what was last
+      // *loaded* into the component. It's a fallback for the narrow window
+      // where the Workbook hasn't mounted yet (ref still null), not a
+      // general substitute for live data.
       const sheets = workbookRef.current?.getAllSheets() ?? workbookData;
       const content = serializeWorkbook(sheets);
       const payload = { kind: "calc", title: title.trim() || "Untitled workbook", content };
@@ -197,7 +214,13 @@ export function CalcView() {
   const renameSheetTab = useCallback((id: string, current: string) => {
     const name = window.prompt("Sheet name", current);
     if (!name || !name.trim()) return;
-    workbookRef.current?.setSheetName(name.trim(), { id });
+    const wb = workbookRef.current;
+    if (!wb) return;
+    wb.setSheetName(name.trim(), { id });
+    // Read the tab list back from the workbook (source of truth) instead of
+    // relying solely on the afterUpdateSheetName hook firing to keep the
+    // sidebar tabs in sync with the grid.
+    setSheetTabs(sortTabsByOrder(wb.getAllSheets()));
   }, []);
 
   const deleteSheetTab = useCallback(
@@ -216,29 +239,21 @@ export function CalcView() {
       const wb = workbookRef.current;
       if (!wb) return;
       const sheet = wb.getSheet();
-      const rowCount = sheet.row ?? 0;
+      const sheetRows = sheet.row ?? 0;
       const colCount = sheet.column ?? 0;
       const col = selection.column[0];
-      if (rowCount < 3 || colCount < 1) return;
-      const cells = wb.getCellsByRange({ row: [1, rowCount - 1], column: [0, colCount - 1] }) ?? [];
+      if (sheetRows < 3 || colCount < 1) return;
+      const cells = wb.getCellsByRange({ row: [1, sheetRows - 1], column: [0, colCount - 1] }) ?? [];
       const indexed = cells.map((row, i) => ({ row, i }));
       indexed.sort((a, b) => {
         const av = a.row?.[col]?.v;
         const bv = b.row?.[col]?.v;
-        const an = typeof av === "number" ? av : Number(av);
-        const bn = typeof bv === "number" ? bv : Number(bv);
-        let cmp: number;
-        if (!Number.isNaN(an) && !Number.isNaN(bn)) {
-          cmp = an - bn;
-        } else {
-          cmp = String(av ?? "").localeCompare(String(bv ?? ""));
-        }
-        return direction === "asc" ? cmp : -cmp;
+        return compareCellValues(av, bv, direction);
       });
       const values = indexed.map(({ row }) =>
         Array.from({ length: colCount }, (_, c) => row?.[c]?.f ?? row?.[c]?.v ?? ""),
       );
-      wb.setCellValuesByRange(values, { row: [1, rowCount - 1], column: [0, colCount - 1] });
+      wb.setCellValuesByRange(values, { row: [1, sheetRows - 1], column: [0, colCount - 1] });
       wb.calculateFormula();
     },
     [selection],
@@ -249,10 +264,10 @@ export function CalcView() {
     const needle = filterValue.trim().toLowerCase();
     if (!wb || !needle) return;
     const sheet = wb.getSheet();
-    const rowCount = sheet.row ?? 0;
+    const sheetRows = sheet.row ?? 0;
     const col = selection.column[0];
-    if (rowCount < 2) return;
-    const cells = wb.getCellsByRange({ row: [1, rowCount - 1], column: [col, col] }) ?? [];
+    if (sheetRows < 2) return;
+    const cells = wb.getCellsByRange({ row: [1, sheetRows - 1], column: [col, col] }) ?? [];
     const toHide: string[] = [];
     const toShow: string[] = [];
     cells.forEach((rowArr, i) => {
@@ -268,42 +283,56 @@ export function CalcView() {
 
   const clearFilter = useCallback(() => {
     const wb = workbookRef.current;
-    if (wb && hiddenRows.length) wb.showRowOrColumn(hiddenRows, "row");
+    if (wb) {
+      // Recompute the currently-hidden rows from the workbook (source of
+      // truth) rather than trusting the hiddenRows state, which can go
+      // stale relative to the grid (e.g. after switching sheets or
+      // re-filtering).
+      const currentlyHidden = Object.keys(wb.getSheet().config?.rowhidden ?? {});
+      if (currentlyHidden.length) wb.showRowOrColumn(currentlyHidden, "row");
+    }
     setHiddenRows([]);
     setFilterValue("");
-  }, [hiddenRows]);
+  }, []);
 
   /* ---------------------------------- csv ------------------------------ */
 
   const exportCsv = useCallback(() => {
     const wb = workbookRef.current;
     if (!wb) return;
+    // Read the sheet name and its cell data from the same workbook snapshot
+    // so they can't disagree (e.g. with sheetTabs/activeSheetId state that
+    // may not have caught up yet).
     const sheet = wb.getSheet();
     const csv = sheetToCsv(sheet.celldata ?? []);
     const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
-    const sheetName = sheetTabs.find((t) => t.id === activeSheetId)?.name ?? "Sheet1";
+    const sheetName = sheet.name || "Sheet1";
     a.href = url;
     a.download = `${(title || "Untitled workbook").replace(/\s+/g, "-")}-${sheetName}.csv`;
     a.click();
     URL.revokeObjectURL(url);
-  }, [activeSheetId, sheetTabs, title]);
+  }, [title]);
 
   const importCsv = useCallback(async (file: File) => {
     const wb = workbookRef.current;
     if (!wb) return;
-    const text = await file.text();
-    const rows = parseCsv(text);
-    if (rows.length === 0) return;
-    const width = Math.max(...rows.map((r) => r.length));
-    const padded = rows.map((r) => {
-      const copy = [...r];
-      while (copy.length < width) copy.push("");
-      return copy;
-    });
-    wb.setCellValuesByRange(padded, { row: [0, padded.length - 1], column: [0, width - 1] });
-    wb.calculateFormula();
+    try {
+      const text = await file.text();
+      const rows = parseCsv(text);
+      if (rows.length === 0) return;
+      const width = Math.max(...rows.map((r) => r.length));
+      const padded = rows.map((r) => {
+        const copy = [...r];
+        while (copy.length < width) copy.push("");
+        return copy;
+      });
+      wb.setCellValuesByRange(padded, { row: [0, padded.length - 1], column: [0, width - 1] });
+      wb.calculateFormula();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Import failed");
+    }
   }, []);
 
   const handleFileChange = useCallback(
@@ -329,20 +358,42 @@ export function CalcView() {
         const column: [number, number] = [sel.column[0] ?? 0, sel.column[1] ?? sel.column[0] ?? 0];
         setSelection({ row, column });
         refreshFormulaBar(row[0], column[0]);
+        const rows = workbookRef.current?.getSheet().row;
+        if (rows != null) setRowCount(rows);
       },
       afterUpdateCell: (row: number, column: number) => {
-        setSelection((cur) => {
-          if (cur.row[0] === row && cur.column[0] === column) refreshFormulaBar(row, column);
-          return cur;
-        });
+        // Read the latest selection off the ref rather than the
+        // setSelection functional-updater form: state updaters must be
+        // pure, and refreshFormulaBar is a side effect (it calls
+        // setFormulaValue), so it can't live inside one.
+        const cur = selectionRef.current;
+        if (cur.row[0] === row && cur.column[0] === column) refreshFormulaBar(row, column);
       },
       afterActivateSheet: (id: string) => {
         setActiveSheetId(id);
         setSelection({ row: [0, 0], column: [0, 0] });
-        refreshFormulaBar(0, 0);
+        // The engine fires this hook (via its own setTimeout) right after
+        // it flips the active sheet id, but before that's necessarily
+        // reflected everywhere the imperative API reads from. Defer to the
+        // next tick and confirm the workbook actually reports this sheet as
+        // active before trusting getCellsByRange for it.
+        setTimeout(() => {
+          const wb = workbookRef.current;
+          if (wb?.getSheet()?.id === id) {
+            refreshFormulaBar(0, 0);
+            const rows = wb.getSheet().row;
+            if (rows != null) setRowCount(rows);
+          }
+        }, 0);
       },
       afterAddSheet: (sheet: Sheet) => {
-        if (sheet.id) workbookRef.current?.activateSheet({ id: sheet.id });
+        // addSheet() already activates the new sheet internally; only
+        // activate it ourselves if that somehow didn't happen, so we don't
+        // double-activate.
+        const wb = workbookRef.current;
+        if (sheet.id && wb && wb.getSheet()?.id !== sheet.id) {
+          wb.activateSheet({ id: sheet.id });
+        }
         refreshSheetTabs();
       },
       afterDeleteSheet: () => {
@@ -430,16 +481,20 @@ export function CalcView() {
         <button
           type="button"
           aria-label="Sort column ascending"
+          title={rowCount < 3 ? "Add at least 2 data rows to sort" : undefined}
+          disabled={rowCount < 3}
           onClick={() => sortColumn("asc")}
-          className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:pointer-events-none disabled:opacity-40"
         >
           <ArrowUpAZ size={15} />
         </button>
         <button
           type="button"
           aria-label="Sort column descending"
+          title={rowCount < 3 ? "Add at least 2 data rows to sort" : undefined}
+          disabled={rowCount < 3}
           onClick={() => sortColumn("desc")}
-          className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          className="flex h-8 w-8 flex-none items-center justify-center rounded-lg text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:pointer-events-none disabled:opacity-40"
         >
           <ArrowDownZA size={15} />
         </button>
@@ -487,7 +542,7 @@ export function CalcView() {
           type="file"
           accept=".csv,text/csv"
           aria-label="Import CSV file"
-          className="hidden"
+          className="sr-only"
           onChange={handleFileChange}
         />
         <button

--- a/desktop/src/apps/officestudio/calc/__tests__/address.test.ts
+++ b/desktop/src/apps/officestudio/calc/__tests__/address.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { colToLetters, cellAddress } from "../address";
+
+describe("colToLetters", () => {
+  it("converts single-letter columns", () => {
+    expect(colToLetters(0)).toBe("A");
+    expect(colToLetters(1)).toBe("B");
+    expect(colToLetters(25)).toBe("Z");
+  });
+
+  it("converts multi-letter columns", () => {
+    expect(colToLetters(26)).toBe("AA");
+    expect(colToLetters(27)).toBe("AB");
+    expect(colToLetters(51)).toBe("AZ");
+  });
+});
+
+describe("cellAddress", () => {
+  it("combines column letters with a 1-indexed row number", () => {
+    expect(cellAddress(0, 0)).toBe("A1");
+    expect(cellAddress(6, 1)).toBe("B7");
+    expect(cellAddress(9, 26)).toBe("AA10");
+  });
+});

--- a/desktop/src/apps/officestudio/calc/__tests__/csv.test.ts
+++ b/desktop/src/apps/officestudio/calc/__tests__/csv.test.ts
@@ -3,7 +3,7 @@ import type { CellWithRowAndCol } from "@fortune-sheet/core";
 import { sheetToCsv, parseCsv } from "../csv";
 
 describe("sheetToCsv", () => {
-  it("produces expected CSV text for a small sheet", () => {
+  it("produces expected CSV text for a small sheet, with a trailing CRLF", () => {
     const celldata: CellWithRowAndCol[] = [
       { r: 0, c: 0, v: { v: "Month" } },
       { r: 0, c: 1, v: { v: "Revenue" } },
@@ -13,7 +13,7 @@ describe("sheetToCsv", () => {
       { r: 2, c: 1, v: { v: 5100 } },
     ];
     expect(sheetToCsv(celldata)).toBe(
-      "Month,Revenue\r\nJanuary,4200\r\nFebruary,5100",
+      "Month,Revenue\r\nJanuary,4200\r\nFebruary,5100\r\n",
     );
   });
 
@@ -22,12 +22,12 @@ describe("sheetToCsv", () => {
       { r: 0, c: 0, v: { v: "Smith, Jane" } },
       { r: 0, c: 1, v: { v: 'She said "hi"' } },
     ];
-    expect(sheetToCsv(celldata)).toBe('"Smith, Jane","She said ""hi"""');
+    expect(sheetToCsv(celldata)).toBe('"Smith, Jane","She said ""hi"""\r\n');
   });
 
   it("prefers the formatted display value over the raw value", () => {
     const celldata: CellWithRowAndCol[] = [{ r: 0, c: 0, v: { v: 3, m: "$3.00" } }];
-    expect(sheetToCsv(celldata)).toBe("$3.00");
+    expect(sheetToCsv(celldata)).toBe("$3.00\r\n");
   });
 
   it("returns an empty string for an empty sheet", () => {
@@ -49,6 +49,13 @@ describe("parseCsv", () => {
     ]);
   });
 
+  it("handles a quoted field containing an embedded newline", () => {
+    expect(parseCsv('a,"line one\nline two",c\n1,2,3')).toEqual([
+      ["a", "line one\nline two", "c"],
+      ["1", "2", "3"],
+    ]);
+  });
+
   it("handles CRLF line endings and a trailing newline", () => {
     expect(parseCsv("a,b\r\n1,2\r\n")).toEqual([
       ["a", "b"],
@@ -58,5 +65,23 @@ describe("parseCsv", () => {
 
   it("returns an empty array for empty input", () => {
     expect(parseCsv("")).toEqual([]);
+  });
+
+  it("round-trips through sheetToCsv for values with commas and quotes", () => {
+    const celldata: CellWithRowAndCol[] = [
+      { r: 0, c: 0, v: { v: "Smith, Jane" } },
+      { r: 0, c: 1, v: { v: 'She said "hi"' } },
+      { r: 1, c: 0, v: { v: "Doe, John" } },
+      { r: 1, c: 1, v: { v: "plain text" } },
+    ];
+    const csv = sheetToCsv(celldata);
+    expect(parseCsv(csv)).toEqual([
+      ["Smith, Jane", 'She said "hi"'],
+      ["Doe, John", "plain text"],
+    ]);
+  });
+
+  it("throws a descriptive error for an unterminated quoted field instead of swallowing the rest of the file", () => {
+    expect(() => parseCsv('a,"unterminated\nb,c')).toThrow(/unterminated/i);
   });
 });

--- a/desktop/src/apps/officestudio/calc/__tests__/csv.test.ts
+++ b/desktop/src/apps/officestudio/calc/__tests__/csv.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import type { CellWithRowAndCol } from "@fortune-sheet/core";
+import { sheetToCsv, parseCsv } from "../csv";
+
+describe("sheetToCsv", () => {
+  it("produces expected CSV text for a small sheet", () => {
+    const celldata: CellWithRowAndCol[] = [
+      { r: 0, c: 0, v: { v: "Month" } },
+      { r: 0, c: 1, v: { v: "Revenue" } },
+      { r: 1, c: 0, v: { v: "January" } },
+      { r: 1, c: 1, v: { v: 4200 } },
+      { r: 2, c: 0, v: { v: "February" } },
+      { r: 2, c: 1, v: { v: 5100 } },
+    ];
+    expect(sheetToCsv(celldata)).toBe(
+      "Month,Revenue\r\nJanuary,4200\r\nFebruary,5100",
+    );
+  });
+
+  it("quotes fields containing commas or quotes", () => {
+    const celldata: CellWithRowAndCol[] = [
+      { r: 0, c: 0, v: { v: "Smith, Jane" } },
+      { r: 0, c: 1, v: { v: 'She said "hi"' } },
+    ];
+    expect(sheetToCsv(celldata)).toBe('"Smith, Jane","She said ""hi"""');
+  });
+
+  it("prefers the formatted display value over the raw value", () => {
+    const celldata: CellWithRowAndCol[] = [{ r: 0, c: 0, v: { v: 3, m: "$3.00" } }];
+    expect(sheetToCsv(celldata)).toBe("$3.00");
+  });
+
+  it("returns an empty string for an empty sheet", () => {
+    expect(sheetToCsv([])).toBe("");
+  });
+});
+
+describe("parseCsv", () => {
+  it("parses simple rows", () => {
+    expect(parseCsv("a,b,c\n1,2,3")).toEqual([
+      ["a", "b", "c"],
+      ["1", "2", "3"],
+    ]);
+  });
+
+  it("handles quoted fields with embedded commas and escaped quotes", () => {
+    expect(parseCsv('"Smith, Jane","She said ""hi"""')).toEqual([
+      ["Smith, Jane", 'She said "hi"'],
+    ]);
+  });
+
+  it("handles CRLF line endings and a trailing newline", () => {
+    expect(parseCsv("a,b\r\n1,2\r\n")).toEqual([
+      ["a", "b"],
+      ["1", "2"],
+    ]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseCsv("")).toEqual([]);
+  });
+});

--- a/desktop/src/apps/officestudio/calc/__tests__/formulaEngine.test.tsx
+++ b/desktop/src/apps/officestudio/calc/__tests__/formulaEngine.test.tsx
@@ -12,6 +12,15 @@ import { useEffect, useRef, useState, type RefObject } from "react";
 import { Workbook, type WorkbookInstance } from "@fortune-sheet/react";
 import "@fortune-sheet/react/dist/index.css";
 
+// Re-reads ref.current at the point of use instead of caching it in a local
+// variable, since the exposed API instance can be replaced across internal
+// re-renders; the RefObject itself is the stable handle to hold on to.
+function currentWb(ref: RefObject<WorkbookInstance | null>): WorkbookInstance {
+  const wb = ref.current;
+  if (!wb) throw new Error("workbook ref not ready");
+  return wb;
+}
+
 function Harness({
   id,
   setup,
@@ -57,7 +66,7 @@ describe("spreadsheet formula engine", () => {
         }}
       />,
     );
-    await waitFor(() => expect(wbRef!.current!.getCellValue(3, 0)).toBe(6));
+    await waitFor(() => expect(currentWb(wbRef!).getCellValue(3, 0)).toBe(6));
   });
 
   it("recomputes a dependent cell after the cell it references changes", async () => {
@@ -74,11 +83,11 @@ describe("spreadsheet formula engine", () => {
         }}
       />,
     );
-    await waitFor(() => expect(wbRef!.current!.getCellValue(0, 1)).toBe(10));
+    await waitFor(() => expect(currentWb(wbRef!).getCellValue(0, 1)).toBe(10));
 
-    wbRef!.current!.setCellValue(0, 0, 7); // A1 changes
-    wbRef!.current!.calculateFormula();
-    await waitFor(() => expect(wbRef!.current!.getCellValue(0, 1)).toBe(14));
+    currentWb(wbRef!).setCellValue(0, 0, 7); // A1 changes
+    currentWb(wbRef!).calculateFormula();
+    await waitFor(() => expect(currentWb(wbRef!).getCellValue(0, 1)).toBe(14));
   });
 
   it("supports AVERAGE, MIN, MAX, COUNT and IF over a range", async () => {
@@ -102,11 +111,11 @@ describe("spreadsheet formula engine", () => {
       />,
     );
     await waitFor(() => {
-      expect(wbRef!.current!.getCellValue(0, 1)).toBe(4);
-      expect(wbRef!.current!.getCellValue(1, 1)).toBe(2);
-      expect(wbRef!.current!.getCellValue(2, 1)).toBe(6);
-      expect(wbRef!.current!.getCellValue(3, 1)).toBe(3);
-      expect(wbRef!.current!.getCellValue(4, 1)).toBe("yes");
+      expect(currentWb(wbRef!).getCellValue(0, 1)).toBe(4);
+      expect(currentWb(wbRef!).getCellValue(1, 1)).toBe(2);
+      expect(currentWb(wbRef!).getCellValue(2, 1)).toBe(6);
+      expect(currentWb(wbRef!).getCellValue(3, 1)).toBe(3);
+      expect(currentWb(wbRef!).getCellValue(4, 1)).toBe("yes");
     });
   });
 
@@ -123,6 +132,6 @@ describe("spreadsheet formula engine", () => {
         }}
       />,
     );
-    await waitFor(() => expect(wbRef!.current!.getCellValue(0, 0)).toBe(19));
+    await waitFor(() => expect(currentWb(wbRef!).getCellValue(0, 0)).toBe(19));
   });
 });

--- a/desktop/src/apps/officestudio/calc/__tests__/formulaEngine.test.tsx
+++ b/desktop/src/apps/officestudio/calc/__tests__/formulaEngine.test.tsx
@@ -1,0 +1,128 @@
+// Regression tests for the formula engine we rely on (@fortune-sheet/react's
+// built-in formula parser). These mount the Workbook component headlessly
+// (jsdom has no canvas, so the grid paints nothing, but the underlying data
+// model and formula evaluation run independent of rendering) and drive it
+// through the imperative ref API the same way CalcView does. The ref object
+// itself (not a snapshot of ref.current) is captured, and always
+// dereferenced fresh, since the exposed API instance can be replaced across
+// internal re-renders.
+import { render, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { Workbook, type WorkbookInstance } from "@fortune-sheet/react";
+import "@fortune-sheet/react/dist/index.css";
+
+function Harness({
+  id,
+  setup,
+  onReady,
+}: {
+  id: string;
+  setup: (wb: WorkbookInstance) => void;
+  onReady: (ref: RefObject<WorkbookInstance | null>) => void;
+}) {
+  const ref = useRef<WorkbookInstance>(null);
+  const [done, setDone] = useState(false);
+  useEffect(() => {
+    if (!ref.current || done) return;
+    setDone(true);
+    setup(ref.current);
+    onReady(ref);
+  }, [done, setup, onReady]);
+  return (
+    <Workbook
+      ref={ref}
+      data={[{ name: "Sheet1", id, celldata: [], row: 20, column: 10 }]}
+      showToolbar={false}
+      showFormulaBar={false}
+      showSheetTabs={false}
+    />
+  );
+}
+
+describe("spreadsheet formula engine", () => {
+  it("computes =SUM(A1:A3)", async () => {
+    let wbRef: RefObject<WorkbookInstance | null> | undefined;
+    render(
+      <Harness
+        id="sum"
+        setup={(wb) => {
+          wb.setCellValue(0, 0, 1);
+          wb.setCellValue(1, 0, 2);
+          wb.setCellValue(2, 0, 3);
+          wb.setCellValue(3, 0, "=SUM(A1:A3)");
+        }}
+        onReady={(ref) => {
+          wbRef = ref;
+        }}
+      />,
+    );
+    await waitFor(() => expect(wbRef!.current!.getCellValue(3, 0)).toBe(6));
+  });
+
+  it("recomputes a dependent cell after the cell it references changes", async () => {
+    let wbRef: RefObject<WorkbookInstance | null> | undefined;
+    render(
+      <Harness
+        id="dependent"
+        setup={(wb) => {
+          wb.setCellValue(0, 0, 5); // A1
+          wb.setCellValue(0, 1, "=A1*2"); // B1
+        }}
+        onReady={(ref) => {
+          wbRef = ref;
+        }}
+      />,
+    );
+    await waitFor(() => expect(wbRef!.current!.getCellValue(0, 1)).toBe(10));
+
+    wbRef!.current!.setCellValue(0, 0, 7); // A1 changes
+    wbRef!.current!.calculateFormula();
+    await waitFor(() => expect(wbRef!.current!.getCellValue(0, 1)).toBe(14));
+  });
+
+  it("supports AVERAGE, MIN, MAX, COUNT and IF over a range", async () => {
+    let wbRef: RefObject<WorkbookInstance | null> | undefined;
+    render(
+      <Harness
+        id="functions"
+        setup={(wb) => {
+          wb.setCellValue(0, 0, 2);
+          wb.setCellValue(1, 0, 4);
+          wb.setCellValue(2, 0, 6);
+          wb.setCellValue(0, 1, "=AVERAGE(A1:A3)");
+          wb.setCellValue(1, 1, "=MIN(A1:A3)");
+          wb.setCellValue(2, 1, "=MAX(A1:A3)");
+          wb.setCellValue(3, 1, "=COUNT(A1:A3)");
+          wb.setCellValue(4, 1, '=IF(A1>1,"yes","no")');
+        }}
+        onReady={(ref) => {
+          wbRef = ref;
+        }}
+      />,
+    );
+    await waitFor(() => {
+      expect(wbRef!.current!.getCellValue(0, 1)).toBe(4);
+      expect(wbRef!.current!.getCellValue(1, 1)).toBe(2);
+      expect(wbRef!.current!.getCellValue(2, 1)).toBe(6);
+      expect(wbRef!.current!.getCellValue(3, 1)).toBe(3);
+      expect(wbRef!.current!.getCellValue(4, 1)).toBe("yes");
+    });
+  });
+
+  it("evaluates basic arithmetic formulas", async () => {
+    let wbRef: RefObject<WorkbookInstance | null> | undefined;
+    render(
+      <Harness
+        id="arithmetic"
+        setup={(wb) => {
+          wb.setCellValue(0, 0, "=(2+3)*4-1");
+        }}
+        onReady={(ref) => {
+          wbRef = ref;
+        }}
+      />,
+    );
+    await waitFor(() => expect(wbRef!.current!.getCellValue(0, 0)).toBe(19));
+  });
+});

--- a/desktop/src/apps/officestudio/calc/__tests__/sort.test.ts
+++ b/desktop/src/apps/officestudio/calc/__tests__/sort.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { compareCellValues } from "../sort";
+
+describe("compareCellValues", () => {
+  it("sorts numbers numerically, not lexically", () => {
+    const values = [10, 2, 33, 4];
+    const sorted = [...values].sort((a, b) => compareCellValues(a, b, "asc"));
+    expect(sorted).toEqual([2, 4, 10, 33]);
+  });
+
+  it("sorts numeric strings numerically", () => {
+    const values = ["10", "2", "33", "4"];
+    const sorted = [...values].sort((a, b) => compareCellValues(a, b, "asc"));
+    expect(sorted).toEqual(["2", "4", "10", "33"]);
+  });
+
+  it("falls back to locale string compare for mixed number/text values", () => {
+    // "5" is numeric, "hi" is not: one side fails to parse as a finite
+    // number, so the whole comparison falls back to string compare rather
+    // than mixing numeric and lexical ordering.
+    expect(compareCellValues("5", "hi", "asc")).toBe("5".localeCompare("hi"));
+    expect(compareCellValues("hi", "5", "asc")).toBe("hi".localeCompare("5"));
+  });
+
+  it("treats scientific-notation strings as numbers", () => {
+    expect(compareCellValues("1e3", "500", "asc")).toBeGreaterThan(0);
+    expect(compareCellValues("1e3", "2000", "asc")).toBeLessThan(0);
+  });
+
+  it("does not coerce blank cells to zero", () => {
+    // Number("") is 0, which would otherwise sort an empty cell among
+    // numeric values instead of alongside other text.
+    expect(compareCellValues("", 5, "asc")).toBe("".localeCompare("5"));
+    expect(compareCellValues("", "", "asc")).toBe(0);
+  });
+
+  it("reverses order for descending sorts", () => {
+    expect(compareCellValues(1, 2, "desc")).toBeGreaterThan(0);
+    expect(compareCellValues("a", "b", "desc")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for equal values so sorts remain stable", () => {
+    expect(compareCellValues(5, 5, "asc")).toBe(0);
+    expect(compareCellValues("x", "x", "asc")).toBe(0);
+  });
+
+  it("keeps a mixed number/text column in a deterministic, repeatable order", () => {
+    const values: unknown[] = [5, "hi", 2, "apple", 10, ""];
+    const sorted = [...values].sort((a, b) => compareCellValues(a, b, "asc"));
+    const resorted = [...values].sort((a, b) => compareCellValues(a, b, "asc"));
+    // Sorting the same input twice must give the same result.
+    expect(sorted).toEqual(resorted);
+    // Numeric values keep their numeric relative order...
+    expect(sorted.filter((v) => typeof v === "number")).toEqual([2, 5, 10]);
+    // ...and text values (including the blank) keep their locale-compare
+    // relative order.
+    expect(sorted.filter((v) => typeof v === "string")).toEqual(["", "apple", "hi"]);
+  });
+});

--- a/desktop/src/apps/officestudio/calc/__tests__/workbook.test.ts
+++ b/desktop/src/apps/officestudio/calc/__tests__/workbook.test.ts
@@ -43,4 +43,26 @@ describe("workbook serialization round trip", () => {
       blankWorkbook(),
     );
   });
+
+  it("falls back to a blank workbook when a sheet element is corrupted", () => {
+    expect(
+      parseWorkbookContent(JSON.stringify({ version: 1, sheets: [null] })),
+    ).toEqual(blankWorkbook());
+    expect(
+      parseWorkbookContent(JSON.stringify({ version: 1, sheets: [{ notASheet: true }] })),
+    ).toEqual(blankWorkbook());
+    expect(
+      parseWorkbookContent(
+        JSON.stringify({ version: 1, sheets: [{ name: "Sheet1", celldata: "not-an-array" }] }),
+      ),
+    ).toEqual(blankWorkbook());
+    expect(
+      parseWorkbookContent(
+        JSON.stringify({ version: 1, sheets: [{ name: "Sheet1", row: "100" }] }),
+      ),
+    ).toEqual(blankWorkbook());
+    expect(parseWorkbookContent(JSON.stringify({ version: 1, sheets: "not-an-array" }))).toEqual(
+      blankWorkbook(),
+    );
+  });
 });

--- a/desktop/src/apps/officestudio/calc/__tests__/workbook.test.ts
+++ b/desktop/src/apps/officestudio/calc/__tests__/workbook.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import type { Sheet } from "@fortune-sheet/core";
+import { blankWorkbook, serializeWorkbook, parseWorkbookContent } from "../workbook";
+
+describe("workbook serialization round trip", () => {
+  it("round-trips a multi-sheet workbook with formulas through JSON", () => {
+    const sheets: Sheet[] = [
+      {
+        id: "sheet-1",
+        name: "Sheet1",
+        order: 0,
+        row: 100,
+        column: 26,
+        celldata: [
+          { r: 0, c: 0, v: { v: 1 } },
+          { r: 1, c: 0, v: { v: 2 } },
+          { r: 2, c: 0, v: { v: 3 } },
+          { r: 3, c: 0, v: { v: 6, f: "=SUM(A1:A3)" } },
+        ],
+      },
+      {
+        id: "sheet-2",
+        name: "Notes",
+        order: 1,
+        row: 100,
+        column: 26,
+        celldata: [{ r: 0, c: 0, v: { v: "hello" } }],
+      },
+    ];
+
+    const content = serializeWorkbook(sheets);
+    const restored = parseWorkbookContent(content);
+
+    expect(restored.version).toBe(1);
+    expect(restored.sheets).toEqual(sheets);
+    expect(restored.sheets[0].celldata?.[3].v?.f).toBe("=SUM(A1:A3)");
+  });
+
+  it("falls back to a blank workbook for empty or invalid content", () => {
+    expect(parseWorkbookContent("")).toEqual(blankWorkbook());
+    expect(parseWorkbookContent("not json")).toEqual(blankWorkbook());
+    expect(parseWorkbookContent(JSON.stringify({ version: 1, sheets: [] }))).toEqual(
+      blankWorkbook(),
+    );
+  });
+});

--- a/desktop/src/apps/officestudio/calc/address.ts
+++ b/desktop/src/apps/officestudio/calc/address.ts
@@ -1,0 +1,16 @@
+// Cell address helpers (0-indexed row/column <-> "A1" style labels).
+
+export function colToLetters(col: number): string {
+  let n = col + 1;
+  let letters = "";
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    letters = String.fromCharCode(65 + rem) + letters;
+    n = Math.floor((n - 1) / 26);
+  }
+  return letters;
+}
+
+export function cellAddress(row: number, col: number): string {
+  return `${colToLetters(col)}${row + 1}`;
+}

--- a/desktop/src/apps/officestudio/calc/csv.ts
+++ b/desktop/src/apps/officestudio/calc/csv.ts
@@ -38,11 +38,15 @@ export function sheetToCsv(celldata: CellWithRowAndCol[]): string {
     const row = grid[entry.r];
     if (row) row[entry.c] = cellDisplayValue(entry.v);
   }
-  return grid.map((row) => row.map(csvEscape).join(",")).join("\r\n");
+  // RFC 4180 line endings (CRLF), including a trailing CRLF after the last
+  // row, matching what Excel/Sheets emit.
+  return grid.map((row) => row.map(csvEscape).join(",")).join("\r\n") + "\r\n";
 }
 
 // Minimal RFC 4180 CSV parser: handles quoted fields, escaped quotes ("")
-// inside quoted fields, and both \n and \r\n line endings.
+// inside quoted fields, and both \n and \r\n line endings. Throws if a
+// quoted field is never closed, rather than silently swallowing the rest of
+// the file into a single field.
 export function parseCsv(text: string): string[][] {
   const rows: string[][] = [];
   let row: string[] = [];
@@ -78,6 +82,10 @@ export function parseCsv(text: string): string[][] {
       field += ch;
     }
   }
+  if (inQuotes) {
+    throw new Error("Unterminated quoted field in CSV file");
+  }
+
   row.push(field);
   rows.push(row);
 

--- a/desktop/src/apps/officestudio/calc/csv.ts
+++ b/desktop/src/apps/officestudio/calc/csv.ts
@@ -1,0 +1,91 @@
+import type { Cell, CellWithRowAndCol } from "@fortune-sheet/core";
+
+// CSV import/export for a single sheet. Values are exported using the
+// cell's formatted display text (m) when present, falling back to the raw
+// value (v). Formulas are exported as their computed value, not the formula
+// text, matching what a user sees on screen and what Excel/Sheets export.
+
+export function cellDisplayValue(cell: Cell | null | undefined): string {
+  if (!cell) return "";
+  if (cell.m != null) return String(cell.m);
+  if (cell.v != null) return String(cell.v);
+  return "";
+}
+
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+export function sheetToCsv(celldata: CellWithRowAndCol[]): string {
+  let maxRow = -1;
+  let maxCol = -1;
+  for (const entry of celldata) {
+    if (entry.v == null) continue;
+    if (cellDisplayValue(entry.v) === "") continue;
+    maxRow = Math.max(maxRow, entry.r);
+    maxCol = Math.max(maxCol, entry.c);
+  }
+  if (maxRow < 0 || maxCol < 0) return "";
+
+  const grid: string[][] = Array.from({ length: maxRow + 1 }, () =>
+    Array.from({ length: maxCol + 1 }, () => ""),
+  );
+  for (const entry of celldata) {
+    if (entry.r > maxRow || entry.c > maxCol) continue;
+    const row = grid[entry.r];
+    if (row) row[entry.c] = cellDisplayValue(entry.v);
+  }
+  return grid.map((row) => row.map(csvEscape).join(",")).join("\r\n");
+}
+
+// Minimal RFC 4180 CSV parser: handles quoted fields, escaped quotes ("")
+// inside quoted fields, and both \n and \r\n line endings.
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  for (let i = 0; i < normalized.length; i++) {
+    const ch = normalized[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (normalized[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ",") {
+      row.push(field);
+      field = "";
+    } else if (ch === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += ch;
+    }
+  }
+  row.push(field);
+  rows.push(row);
+
+  // A trailing newline produces one bogus final row of a single empty field.
+  const lastRow = rows[rows.length - 1];
+  if (rows.length > 1 && lastRow?.length === 1 && lastRow[0] === "") {
+    rows.pop();
+  }
+  if (text.trim() === "") return [];
+  return rows;
+}

--- a/desktop/src/apps/officestudio/calc/sort.ts
+++ b/desktop/src/apps/officestudio/calc/sort.ts
@@ -1,0 +1,29 @@
+// Comparator used to sort a spreadsheet column. Numbers and numeric-looking
+// strings (including scientific notation, e.g. "1e3") compare numerically
+// when both sides parse as finite numbers; otherwise we fall back to a
+// locale-aware string compare. Blank cells never coerce to 0 (Number("")
+// would otherwise treat an empty cell as numeric zero), so they fall back to
+// string compare and sort with the text values instead of among numbers.
+
+export type SortDirection = "asc" | "desc";
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+// Returns 0 for equal values, so the native (stable, ES2019+) Array.sort
+// preserves the original relative order of equal rows.
+export function compareCellValues(a: unknown, b: unknown, direction: SortDirection): number {
+  const an = toFiniteNumber(a);
+  const bn = toFiniteNumber(b);
+  const cmp =
+    an != null && bn != null ? an - bn : String(a ?? "").localeCompare(String(b ?? ""));
+  return direction === "asc" ? cmp : -cmp;
+}

--- a/desktop/src/apps/officestudio/calc/workbook.ts
+++ b/desktop/src/apps/officestudio/calc/workbook.ts
@@ -31,11 +31,28 @@ export function serializeWorkbook(sheets: Sheet[]): string {
   return JSON.stringify(file);
 }
 
+// Checks that a parsed value has the minimal shape a Sheet needs before we
+// hand it to the Workbook component: corrupted or truncated saved content
+// (e.g. a non-object entry, or celldata/row/column of the wrong type) would
+// otherwise crash the renderer downstream instead of failing safely here.
+function isValidSheet(value: unknown): value is Sheet {
+  if (!value || typeof value !== "object") return false;
+  const s = value as Partial<Sheet>;
+  if (typeof s.name !== "string") return false;
+  if (s.celldata !== undefined && !Array.isArray(s.celldata)) return false;
+  if (s.row !== undefined && typeof s.row !== "number") return false;
+  if (s.column !== undefined && typeof s.column !== "number") return false;
+  return true;
+}
+
 export function parseWorkbookContent(content: string): CalcWorkbookFile {
   if (!content || !content.trim()) return blankWorkbook();
   try {
     const parsed = JSON.parse(content) as Partial<CalcWorkbookFile>;
     if (!parsed || !Array.isArray(parsed.sheets) || parsed.sheets.length === 0) {
+      return blankWorkbook();
+    }
+    if (!parsed.sheets.every(isValidSheet)) {
       return blankWorkbook();
     }
     return { version: 1, sheets: parsed.sheets };

--- a/desktop/src/apps/officestudio/calc/workbook.ts
+++ b/desktop/src/apps/officestudio/calc/workbook.ts
@@ -1,0 +1,45 @@
+import type { Sheet } from "@fortune-sheet/core";
+
+// Persisted shape saved as the office doc's `content` (kind "calc"). The
+// workbook is the full multi-sheet state used to initialize the Workbook
+// component on load, so a save/load round trip is just JSON stringify/parse.
+export type CalcWorkbookFile = {
+  version: 1;
+  sheets: Sheet[];
+};
+
+export const DEFAULT_SHEET_ROWS = 100;
+export const DEFAULT_SHEET_COLUMNS = 26;
+
+export function blankSheet(id: string, name: string, order = 0): Sheet {
+  return {
+    id,
+    name,
+    order,
+    celldata: [],
+    row: DEFAULT_SHEET_ROWS,
+    column: DEFAULT_SHEET_COLUMNS,
+  };
+}
+
+export function blankWorkbook(): CalcWorkbookFile {
+  return { version: 1, sheets: [blankSheet("sheet-1", "Sheet1", 0)] };
+}
+
+export function serializeWorkbook(sheets: Sheet[]): string {
+  const file: CalcWorkbookFile = { version: 1, sheets };
+  return JSON.stringify(file);
+}
+
+export function parseWorkbookContent(content: string): CalcWorkbookFile {
+  if (!content || !content.trim()) return blankWorkbook();
+  try {
+    const parsed = JSON.parse(content) as Partial<CalcWorkbookFile>;
+    if (!parsed || !Array.isArray(parsed.sheets) || parsed.sheets.length === 0) {
+      return blankWorkbook();
+    }
+    return { version: 1, sheets: parsed.sheets };
+  } catch {
+    return blankWorkbook();
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 of Office Studio: the Calc view is now a real spreadsheet instead of a static mock.

**Library: @fortune-sheet/react v1.0.4, license MIT** (verified via `npm view` and the upstream `LICENSE` file). Evaluated first per the brief; it integrated cleanly (DOM-rendered chrome, canvas only for the grid paint, a real ref API, a built-in formula engine), so the jspreadsheet-ce fallback wasn't needed. `@fortune-sheet/core` is pinned alongside it since its types are imported directly.

## What works

- Real editable grid: cell editing, keyboard navigation, range selection (fortune-sheet's Workbook component). Its own toolbar/formula bar/sheet tabs are hidden (`showToolbar/showFormulaBar/showSheetTabs={false}`) and replaced with chrome that matches the shell-* design tokens.
- Formulas: cell refs (`A1`, `B2:B6`), `SUM`, `AVERAGE`, `MIN`, `MAX`, `COUNT`, `IF`, and arithmetic. The formula bar reflects and edits the active cell's formula/value and recomputes dependents on commit (Enter/blur triggers `setCellValue` + `calculateFormula`).
- Multiple sheets: add, rename (double-click a tab), delete (guarded so the last sheet can't be removed), switch, via a custom tab bar.
- Sort ascending/descending on the selected column (rows below row 1, which is treated as a header).
- Text filter on the selected column (hide/show rows), with a clear-filter action.
- CSV export of the active sheet (RFC 4180 quoting) and CSV import into it.
- Persistence: the whole workbook (all sheets, cell data, formulas) serializes to JSON and saves via the existing `POST`/`PUT /api/office/docs` with `kind: "calc"` — no backend changes, since `content` was already opaque TEXT and `"calc"` was already a valid kind. Reuses the Write view's doc sidebar (list/new/open/save) pattern, filtered to `kind === "calc"`.
- Write and Slides views are unchanged.

## Deferred / known limitations

- Sort assumes row 1 is a header and only reorders rows below it; it doesn't remap relative formula references (values/formulas are copied as-is).
- CSV import writes into the sheet's existing bounds (100 rows × 26 cols by default); very large imports beyond that aren't auto-expanded.
- No cross-sheet formula references, pivot tables, charts, or conditional formatting UI (fortune-sheet supports some of this internally, but it's out of scope for this pass).
- The grid's own canvas-painted cell content isn't independently screen-reader-addressable (an inherent tradeoff of canvas-rendered spreadsheet grids); the surrounding chrome (formula bar, toolbar, tabs, sidebar) is fully labeled/keyboard-accessible.

## Notable bug caught during testing

Passing a freshly-constructed `hooks` object to `Workbook` on every render put it into a render/settings-change feedback loop — confirmed as a real runaway CPU spin (100%+ CPU, never settling) when mounted inside the full app shell. Fixed by memoizing `hooks` with `useMemo` so its identity is stable across renders. This would have affected the real app too, not just tests.

## Test plan

- [x] `cd desktop && npm install && npm run build` succeeds
- [x] `cd desktop && npx vitest run` passes (274 files / 2280 tests, including new coverage: `=SUM(A1:A3)` computes, editing a cell recomputes a dependent formula, `AVERAGE/MIN/MAX/COUNT/IF` and arithmetic, workbook JSON round-trips through save/load, CSV export produces expected text)
- [x] `npx tsc -b` clean
- [ ] Manual browser verification (not performed this pass — needs the FastAPI backend running; the frontend build/tests above are the verification gate for this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Fortune-sheet based Calc experience with sheet management, formula bar editing, sorting, filtering, and CSV import/export.
  * Loaded and saved Calc documents, including creating blank workbooks and persisting edits.
  * Updated Office Studio navigation and expanded writing/editor interaction coverage.
* **Bug Fixes**
  * Improved spreadsheet robustness for formulas, cell addressing, CSV parsing/formatting, and safer workbook parsing.
  * Refined sorting behavior for numeric, text, blank, and mixed-value cases.
* **Tests**
  * Added coverage for address helpers, CSV conversion/parsing, workbook round-tripping, and formula engine evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->