### PR TITLE
feat(office-studio): real Slides presentation editor (layouts, images, present mode, PDF export, persistence)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -46,6 +46,7 @@
         "clsx": "^2.1.1",
         "emoji-picker-react": "^4.19.1",
         "highlight.js": "^11.11.1",
+        "jspdf": "^4.2.1",
         "konva": "^10.3.0",
         "lucide-react": "^0.577.0",
         "mathjs": "^15.2.0",
@@ -7476,6 +7477,19 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -7967,6 +7981,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/bessel": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bessel/-/bessel-1.0.2.tgz",
@@ -8021,6 +8045,33 @@
       "resolved": "https://registry.npmjs.org/canvas-roundrect-polyfill/-/canvas-roundrect-polyfill-0.0.1.tgz",
       "integrity": "sha512-yWq+R3U3jE+coOeEb3a3GgE2j/0MMiDKM/QpLb6h9ihf5fGY9UXtvK9o4vNqjWXoZz7/3EaSVU3IX53TvFFUOw==",
       "license": "MIT"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -8284,6 +8335,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -9081,6 +9142,33 @@
       "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -9103,7 +9191,6 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fill-range": {
@@ -9377,6 +9464,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -9463,6 +9564,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -9719,6 +9826,23 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+      "integrity": "sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.6",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.3.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jstat": {
@@ -11442,6 +11566,13 @@
       "integrity": "sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==",
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/pica": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/pica/-/pica-7.1.1.tgz",
@@ -12191,6 +12322,16 @@
         }
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/rangetouch": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rangetouch/-/rangetouch-2.0.1.tgz",
@@ -12659,6 +12800,16 @@
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "license": "MIT"
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
@@ -12844,6 +12995,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -12908,6 +13069,16 @@
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -12944,6 +13115,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/three": {
@@ -13361,6 +13542,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -50,6 +50,7 @@
     "clsx": "^2.1.1",
     "emoji-picker-react": "^4.19.1",
     "highlight.js": "^11.11.1",
+    "jspdf": "^4.2.1",
     "konva": "^10.3.0",
     "lucide-react": "^0.577.0",
     "mathjs": "^15.2.0",

--- a/desktop/src/apps/OfficeStudioApp.test.tsx
+++ b/desktop/src/apps/OfficeStudioApp.test.tsx
@@ -68,21 +68,37 @@ describe("OfficeStudioApp", () => {
     expect(screen.getByRole("button", { name: /Save/ })).toBeDefined();
   });
 
-  it("switches to Slides view and shows slide thumbnails", () => {
+  it("switches to Slides view and shows a real, editable deck", () => {
     renderApp();
     fireEvent.click(screen.getByRole("button", { name: "Slides" }));
     expect(screen.getByRole("button", { name: "Slides" }).getAttribute("aria-current")).toBe(
       "page",
     );
-    // thumbnail rail
+    // thumbnail rail starts with a single default slide
     expect(screen.getByRole("complementary", { name: "Slide thumbnails" })).toBeDefined();
-    // all 5 slide thumbnails
-    expect(screen.getByLabelText("Slide 1: Build it your way")).toBeDefined();
-    expect(screen.getByLabelText("Slide 2: Ready today")).toBeDefined();
-    expect(screen.getByLabelText("Slide 3: On the way")).toBeDefined();
-    expect(screen.getByLabelText("Slide 4: Your hardware")).toBeDefined();
-    expect(screen.getByLabelText("Slide 5: Get started")).toBeDefined();
-    // slide content
-    expect(screen.getByText("Build it your way.")).toBeDefined();
+    expect(screen.getByLabelText("Slide 1: Untitled slide")).toBeDefined();
+    // deck title + layout picker + edit fields are real controls, not a mock
+    expect(screen.getByLabelText("Deck title")).toBeDefined();
+    expect(screen.getByRole("group", { name: "Slide layout" })).toBeDefined();
+    expect(screen.getByLabelText("Slide title")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Present" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Export PDF" })).toBeDefined();
+  });
+
+  it("editing the slide title updates the thumbnail label and preview", () => {
+    renderApp();
+    fireEvent.click(screen.getByRole("button", { name: "Slides" }));
+    const titleInput = screen.getByLabelText("Slide title");
+    fireEvent.change(titleInput, { target: { value: "Welcome" } });
+    expect(screen.getByLabelText("Slide 1: Welcome")).toBeDefined();
+  });
+
+  it("adds and deletes slides from the rail", () => {
+    renderApp();
+    fireEvent.click(screen.getByRole("button", { name: "Slides" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add slide" }));
+    expect(screen.getByLabelText("Slide 2: Untitled slide")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Delete slide 2" }));
+    expect(screen.queryByLabelText("Slide 2: Untitled slide")).toBeNull();
   });
 });

--- a/desktop/src/apps/officestudio/SlidesView.tsx
+++ b/desktop/src/apps/officestudio/SlidesView.tsx
@@ -1,160 +1,628 @@
-import { Sparkles } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlignLeft,
+  ChevronDown,
+  ChevronUp,
+  Columns2,
+  Download,
+  Heading1,
+  ImagePlus,
+  Play,
+  Plus,
+  Save,
+  Square,
+  SquareStack,
+  Trash2,
+  X,
+} from "lucide-react";
+import {
+  blankDeck,
+  insertSlideAfter,
+  LAYOUTS,
+  MAX_IMAGE_BYTES,
+  moveSlideBy,
+  newSlide,
+  parseDeckContent,
+  removeSlide,
+  serializeDeck,
+  updateSlide,
+  type Deck,
+  type Slide,
+  type SlideLayout,
+} from "./slides/deck";
+import { SlideCanvas } from "./slides/SlideCanvas";
+import { PresentMode } from "./slides/PresentMode";
+import { exportDeckToPdf, EXPORT_PAGE_HEIGHT, EXPORT_PAGE_WIDTH } from "./slides/pdfExport";
 
-const SLIDES = [
-  {
-    idx: 1,
-    label: "Build it your way",
-    bg: "radial-gradient(120% 130% at 18% 14%,#4a5572,transparent 55%),linear-gradient(150deg,#262c3b,#14161f)",
-  },
-  { idx: 2, label: "Ready today", bg: "linear-gradient(150deg,#1d3a33,#0f1f1b)" },
-  { idx: 3, label: "On the way", bg: "linear-gradient(150deg,#3a2f1d,#1f190f)" },
-  { idx: 4, label: "Your hardware", bg: "linear-gradient(150deg,#2c2436,#16111d)" },
-  { idx: 5, label: "Get started", bg: "linear-gradient(150deg,#23303f,#121b24)" },
-] as const;
+type OfficeDocListItem = {
+  id: string;
+  kind: string;
+  title: string;
+  updated_at?: number;
+};
 
-const LAYOUTS = [
-  { id: "title", active: true, barWidths: ["70%", "90%"] },
-  { id: "split", active: false, barWidths: ["50%", "90%"] },
-  { id: "center", active: false, barWidths: ["40%"] },
-] as const;
+type OfficeDoc = OfficeDocListItem & {
+  content: string;
+};
+
+const LAYOUT_ICONS: Record<SlideLayout, typeof Heading1> = {
+  title: Heading1,
+  "title-content": AlignLeft,
+  "two-column": Columns2,
+  "section-header": SquareStack,
+  blank: Square,
+};
+
+function formatUpdated(ts?: number): string {
+  if (!ts) return "Draft";
+  const d = new Date(ts * 1000);
+  return `Updated ${d.toLocaleString()}`;
+}
 
 export function SlidesView() {
-  return (
-    <div className="flex min-h-0 flex-1">
-      {/* slide thumbnail rail */}
-      <aside
-        className="flex w-[150px] flex-none flex-col gap-2.5 overflow-auto border-r border-shell-border bg-shell-bg-deep p-3"
-        aria-label="Slide thumbnails"
-      >
-        {SLIDES.map((s) => (
-          <div
-            key={s.idx}
-            role="button"
-            tabIndex={0}
-            aria-label={`Slide ${s.idx}: ${s.label}`}
-            className="relative flex aspect-video cursor-pointer items-center justify-center overflow-hidden rounded-lg border px-1.5 text-center text-[10px] font-bold text-white"
-            style={{
-              background: s.bg,
-              borderColor:
-                s.idx === 1 ? "var(--color-accent, #8b92a3)" : "rgba(255,255,255,0.08)",
-              outline: s.idx === 1 ? "2px solid #a9b0c2" : undefined,
-              outlineOffset: s.idx === 1 ? 1 : undefined,
-            }}
-          >
-            <span
-              className="absolute left-1.5 top-1 text-[8px]"
-              style={{ color: "rgba(255,255,255,0.7)" }}
-            >
-              {s.idx}
-            </span>
-            {s.label}
-          </div>
-        ))}
-      </aside>
+  const [docs, setDocs] = useState<OfficeDocListItem[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [deck, setDeck] = useState<Deck>(() => blankDeck());
+  const [selectedSlideId, setSelectedSlideId] = useState<string>(() => deck.slides[0]?.id ?? "");
+  const [updatedAt, setUpdatedAt] = useState<number | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-      {/* slide canvas stage */}
-      <div className="flex flex-1 flex-col items-center justify-center bg-shell-bg-deep p-5">
-        <div
-          className="relative flex w-[560px] flex-col justify-center overflow-hidden rounded-[10px] px-[52px] py-[46px] text-white"
-          style={{
-            aspectRatio: "16/9",
-            background:
-              "radial-gradient(120% 130% at 18% 14%,#4a5572,transparent 55%),linear-gradient(150deg,#262c3b,#14161f)",
-            boxShadow: "0 22px 50px -16px rgba(0,0,0,0.6)",
-          }}
-        >
-          <div
-            className="text-[12px] font-bold tracking-[2px] uppercase"
-            style={{ color: "rgba(255,255,255,0.6)" }}
+  const [isPresenting, setIsPresenting] = useState(false);
+  const [presentIndex, setPresentIndex] = useState(0);
+  const presentStageRef = useRef<HTMLDivElement | null>(null);
+  const hadFullscreenRef = useRef(false);
+
+  const exportContainerRef = useRef<HTMLDivElement | null>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+
+  // deck.slides is never empty: blankDeck/parseDeckContent always seed one
+  // slide, and removeSlide refuses to drop the last one.
+  const selectedSlide: Slide =
+    deck.slides.find((s) => s.id === selectedSlideId) ?? (deck.slides[0] as Slide);
+
+  /* ------------------------------- doc list ------------------------------ */
+
+  const loadList = useCallback(async () => {
+    const res = await fetch("/api/office/docs", { credentials: "include" });
+    if (!res.ok) throw new Error("Could not load decks");
+    const items = (await res.json()) as OfficeDocListItem[];
+    setDocs(items.filter((d) => d.kind === "slides"));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await loadList();
+        if (!cancelled) setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Load failed");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadList]);
+
+  const applyDeck = useCallback((next: Deck) => {
+    setDeck(next);
+    setSelectedSlideId(next.slides[0]?.id ?? "");
+  }, []);
+
+  const openDoc = async (docId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/office/docs/${encodeURIComponent(docId)}`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Could not open deck");
+      const doc = (await res.json()) as OfficeDoc;
+      setActiveId(doc.id);
+      setUpdatedAt(doc.updated_at);
+      applyDeck(parseDeckContent(doc.content));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Open failed");
+    }
+  };
+
+  const newDoc = () => {
+    setActiveId(null);
+    setUpdatedAt(undefined);
+    setError(null);
+    applyDeck(blankDeck());
+  };
+
+  const saveDoc = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        kind: "slides",
+        title: deck.title.trim() || "Untitled deck",
+        content: serializeDeck(deck),
+      };
+      const url = activeId
+        ? `/api/office/docs/${encodeURIComponent(activeId)}`
+        : "/api/office/docs";
+      const res = await fetch(url, {
+        method: activeId ? "PUT" : "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error || "Save failed");
+      }
+      const saved = (await res.json()) as OfficeDoc;
+      setActiveId(saved.id);
+      setUpdatedAt(saved.updated_at);
+      applyDeck(parseDeckContent(saved.content));
+      await loadList();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /* ------------------------------- slide ops ------------------------------ */
+
+  const patchSelected = useCallback(
+    (patch: Partial<Omit<Slide, "id">>) => {
+      setDeck((d) => ({ ...d, slides: updateSlide(d.slides, selectedSlideId, patch) }));
+    },
+    [selectedSlideId],
+  );
+
+  const handleAddSlide = useCallback(() => {
+    const slide = newSlide();
+    setDeck((d) => ({ ...d, slides: insertSlideAfter(d.slides, selectedSlideId, slide) }));
+    setSelectedSlideId(slide.id);
+  }, [selectedSlideId]);
+
+  const handleDeleteSlide = useCallback(
+    (id: string) => {
+      if (deck.slides.length <= 1) return;
+      const index = deck.slides.findIndex((s) => s.id === id);
+      const slides = removeSlide(deck.slides, id);
+      setDeck((d) => ({ ...d, slides }));
+      if (id === selectedSlideId) {
+        const nextIndex = Math.min(index, slides.length - 1);
+        setSelectedSlideId(slides[nextIndex]?.id ?? "");
+      }
+    },
+    [deck.slides, selectedSlideId],
+  );
+
+  const handleMoveSlide = useCallback((id: string, delta: number) => {
+    setDeck((d) => ({ ...d, slides: moveSlideBy(d.slides, id, delta) }));
+  }, []);
+
+  /* ------------------------------- image insert ---------------------------- */
+
+  const handleImageFile = useCallback(
+    (file: File) => {
+      if (!file.type.startsWith("image/")) {
+        setError("That file isn't an image. Choose a PNG, JPG, GIF, or WEBP file.");
+        return;
+      }
+      if (file.size > MAX_IMAGE_BYTES) {
+        setError(
+          `That image is too large (${Math.round(file.size / 1024 / 1024)}MB). Max size is ${MAX_IMAGE_BYTES / 1024 / 1024}MB.`,
+        );
+        return;
+      }
+      setError(null);
+      const reader = new FileReader();
+      reader.onload = () => {
+        patchSelected({ imageDataUri: String(reader.result) });
+      };
+      reader.onerror = () => setError("Could not read that image file.");
+      reader.readAsDataURL(file);
+    },
+    [patchSelected],
+  );
+
+  /* ------------------------------- present mode ---------------------------- */
+
+  // Native Fullscreen is best-effort: if the browser grants it we track that
+  // in hadFullscreenRef, and only auto-exit present mode if we genuinely had
+  // it and it ended (e.g. the user's own Escape or F11). If the browser never
+  // grants it (unsupported, or denied), present mode still works windowed —
+  // the user is never blocked by a fullscreen failure.
+  useEffect(() => {
+    const onFsChange = () => {
+      const isOurs = document.fullscreenElement === presentStageRef.current;
+      if (isOurs) {
+        hadFullscreenRef.current = true;
+        return;
+      }
+      if (hadFullscreenRef.current) {
+        hadFullscreenRef.current = false;
+        setIsPresenting(false);
+      }
+    };
+    document.addEventListener("fullscreenchange", onFsChange);
+    return () => document.removeEventListener("fullscreenchange", onFsChange);
+  }, []);
+
+  const startPresenting = useCallback(() => {
+    const idx = Math.max(0, deck.slides.findIndex((s) => s.id === selectedSlideId));
+    setPresentIndex(idx);
+    setIsPresenting(true);
+    presentStageRef.current?.requestFullscreen?.().catch(() => {});
+  }, [deck.slides, selectedSlideId]);
+
+  const exitPresenting = useCallback(() => {
+    setIsPresenting(false);
+    if (document.fullscreenElement) document.exitFullscreen?.().catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!isPresenting) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        exitPresenting();
+      } else if (e.key === "ArrowRight" || e.key === "ArrowDown" || e.key === " ") {
+        e.preventDefault();
+        setPresentIndex((i) => Math.min(i + 1, deck.slides.length - 1));
+      } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setPresentIndex((i) => Math.max(i - 1, 0));
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isPresenting, exitPresenting, deck.slides.length]);
+
+  /* ------------------------------- export ---------------------------------- */
+
+  const exportPdf = useCallback(async () => {
+    const container = exportContainerRef.current;
+    if (!container) return;
+    setExporting(true);
+    setError(null);
+    try {
+      await exportDeckToPdf(deck, container);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }, [deck]);
+
+  const layoutIcons = useMemo(
+    () => LAYOUTS.map((l) => ({ ...l, Icon: LAYOUT_ICONS[l.id] })),
+    [],
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* view header */}
+      <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
+        <h2 className="text-[17px] font-bold tracking-[-0.02em]">Slides</h2>
+        <input
+          value={deck.title}
+          onChange={(e) => setDeck((d) => ({ ...d, title: e.target.value }))}
+          aria-label="Deck title"
+          className="w-52 truncate border-0 bg-transparent text-[13px] font-semibold text-shell-text outline-none placeholder:text-shell-text-tertiary"
+        />
+        <span className="truncate text-[12px] text-shell-text-tertiary">
+          {docs.length} deck{docs.length === 1 ? "" : "s"} &middot;{" "}
+          {activeId ? formatUpdated(updatedAt) : "New deck"}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={startPresenting}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] border border-shell-border px-3 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           >
-            taOS Studios
-          </div>
-          <h1
-            className="mt-2.5 font-extrabold leading-[1.05] tracking-tight"
-            style={{ fontSize: 38, letterSpacing: -1 }}
+            <Play size={14} />
+            Present
+          </button>
+          <button
+            type="button"
+            onClick={exportPdf}
+            disabled={exporting}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] border border-shell-border px-3 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
           >
-            Build it your way.
-          </h1>
-          <p
-            className="mt-3.5 max-w-[80%] text-[15px] leading-[1.5]"
-            style={{ color: "rgba(255,255,255,0.82)" }}
+            <Download size={14} />
+            {exporting ? "Exporting..." : "Export PDF"}
+          </button>
+          <button
+            type="button"
+            onClick={newDoc}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] border border-shell-border px-3 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           >
-            Dedicated studios for every project, running on hardware you already own.
-          </p>
-          {/* selection box */}
-          <div
-            className="pointer-events-none absolute rounded-[4px]"
-            style={{
-              border: "1.5px solid #a9b0c2",
-              left: 46,
-              top: 96,
-              right: 120,
-              height: 88,
-            }}
-          />
+            <Plus size={14} />
+            New
+          </button>
+          <button
+            type="button"
+            onClick={saveDoc}
+            disabled={saving}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] bg-gradient-to-br from-accent to-accent/70 px-3.5 text-[12px] font-bold text-white disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Save size={14} />
+            {saving ? "Saving..." : "Save"}
+          </button>
         </div>
       </div>
 
-      {/* right panel */}
-      <aside className="flex w-[248px] flex-none flex-col gap-3.5 border-l border-shell-border bg-shell-bg p-[18px]">
-        {/* generate a deck */}
-        <div
-          className="rounded-[13px] border p-3.5"
-          style={{
-            borderColor: "rgba(139,146,163,0.35)",
-            background:
-              "radial-gradient(120% 130% at 12% 10%, rgba(139,146,163,0.35), transparent 60%), var(--color-shell-surface, rgba(255,255,255,0.045))",
-          }}
+      {error && (
+        <p className="border-b border-shell-border px-3.5 py-1.5 text-[12px] text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex min-h-0 flex-1">
+        {/* slide thumbnail rail */}
+        <aside
+          className="flex w-[180px] flex-none flex-col gap-2 overflow-auto border-r border-shell-border bg-shell-bg-deep p-3"
+          aria-label="Slide thumbnails"
         >
-          <div className="flex items-center gap-1.5 text-[13px] font-bold text-shell-text">
-            <Sparkles size={15} className="text-accent" />
-            Generate a deck
-          </div>
-          <p className="mb-2.5 mt-1.5 text-[11.5px] leading-[1.45] text-shell-text-secondary">
-            Describe the talk and taOS drafts the slides, on brand.
-          </p>
-          <div className="mb-2 rounded-[10px] border border-shell-border bg-shell-bg-deep px-3 py-2.5 text-[11.5px] text-shell-text-tertiary">
-            a 5-slide intro to taOS Studios for new users&hellip;
-          </div>
+          {loading && <p className="px-1 py-1 text-[12px] text-shell-text-tertiary">Loading...</p>}
+          {deck.slides.map((s, i) => (
+            <div key={s.id} className="group relative">
+              <button
+                type="button"
+                aria-label={`Slide ${i + 1}: ${s.title || "Untitled slide"}`}
+                aria-current={s.id === selectedSlideId ? "true" : undefined}
+                onClick={() => setSelectedSlideId(s.id)}
+                className={`relative w-full overflow-hidden rounded-lg border text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  s.id === selectedSlideId ? "outline outline-2 outline-offset-1" : ""
+                }`}
+                style={{
+                  borderColor:
+                    s.id === selectedSlideId ? "var(--color-accent, #8b92a3)" : "rgba(255,255,255,0.08)",
+                  outlineColor: s.id === selectedSlideId ? "#a9b0c2" : undefined,
+                }}
+              >
+                <SlideCanvas slide={s} className="pointer-events-none w-full" />
+                <span
+                  className="absolute left-1.5 top-1 rounded bg-black/40 px-1 text-[9px] text-white"
+                  aria-hidden="true"
+                >
+                  {i + 1}
+                </span>
+              </button>
+              <div className="absolute right-1 top-1 flex flex-col gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+                <button
+                  type="button"
+                  aria-label={`Move slide ${i + 1} up`}
+                  disabled={i === 0}
+                  onClick={() => handleMoveSlide(s.id, -1)}
+                  className="grid h-5 w-5 place-items-center rounded bg-black/55 text-white hover:bg-black/75 disabled:pointer-events-none disabled:opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+                >
+                  <ChevronUp size={12} />
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Move slide ${i + 1} down`}
+                  disabled={i === deck.slides.length - 1}
+                  onClick={() => handleMoveSlide(s.id, 1)}
+                  className="grid h-5 w-5 place-items-center rounded bg-black/55 text-white hover:bg-black/75 disabled:pointer-events-none disabled:opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+                >
+                  <ChevronDown size={12} />
+                </button>
+                <button
+                  type="button"
+                  aria-label={`Delete slide ${i + 1}`}
+                  disabled={deck.slides.length <= 1}
+                  onClick={() => handleDeleteSlide(s.id)}
+                  className="grid h-5 w-5 place-items-center rounded bg-black/55 text-white hover:bg-red-500/80 disabled:pointer-events-none disabled:opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+                >
+                  <Trash2 size={12} />
+                </button>
+              </div>
+            </div>
+          ))}
           <button
             type="button"
-            className="flex w-full items-center justify-center gap-2 rounded-[11px] border-none bg-gradient-to-br from-accent to-accent/70 py-2.5 text-[12.5px] font-bold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            onClick={handleAddSlide}
+            aria-label="Add slide"
+            className="flex h-9 flex-none items-center justify-center gap-1.5 rounded-lg border border-dashed border-shell-border text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
           >
-            <Sparkles size={15} />
-            Generate
+            <Plus size={14} />
+            Add slide
           </button>
+        </aside>
+
+        {/* live preview stage */}
+        <div className="flex flex-1 flex-col items-center justify-center overflow-auto bg-shell-bg-deep p-6">
+          <SlideCanvas slide={selectedSlide} className="w-full max-w-[640px] rounded-[10px] shadow-card" />
         </div>
 
-        {/* layout picker */}
-        <div className="text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
-          Layout
-        </div>
-        <div className="grid grid-cols-3 gap-2">
-          {LAYOUTS.map((lay) => (
-            <button
-              key={lay.id}
-              type="button"
-              aria-label={`Layout ${lay.id}`}
-              className="flex aspect-[16/10] cursor-pointer flex-col gap-1 rounded-lg border bg-shell-surface p-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-              style={{
-                borderColor: lay.active ? "#a9b0c2" : "rgba(255,255,255,0.08)",
-              }}
-            >
-              {lay.barWidths.map((w, i) => (
-                <div
-                  key={i}
-                  className="h-[3px] rounded-sm"
-                  style={{
-                    width: w,
-                    background: i === 0 ? "rgba(255,255,255,0.40)" : "rgba(255,255,255,0.14)",
-                    alignSelf: lay.id === "center" ? "center" : undefined,
-                  }}
-                />
+        {/* right panel: layout + edit form */}
+        <aside className="flex w-[280px] flex-none flex-col gap-4 overflow-auto border-l border-shell-border bg-shell-bg p-[18px]">
+          <div>
+            <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
+              Layout
+            </div>
+            <div className="grid grid-cols-2 gap-2" role="group" aria-label="Slide layout">
+              {layoutIcons.map(({ id, label, Icon }) => (
+                <button
+                  key={id}
+                  type="button"
+                  aria-pressed={selectedSlide.layout === id}
+                  onClick={() => patchSelected({ layout: id })}
+                  className={`flex items-center gap-1.5 rounded-lg border px-2 py-2 text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                    selectedSlide.layout === id
+                      ? "border-accent/60 bg-accent-soft text-shell-text"
+                      : "border-shell-border bg-shell-surface text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text"
+                  }`}
+                >
+                  <Icon size={14} />
+                  {label}
+                </button>
               ))}
-            </button>
-          ))}
+            </div>
+          </div>
+
+          <label className="flex flex-col gap-1 text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
+            Title
+            <input
+              value={selectedSlide.title}
+              onChange={(e) => patchSelected({ title: e.target.value })}
+              aria-label="Slide title"
+              className="rounded-lg border border-shell-border bg-shell-surface px-2.5 py-2 text-[12.5px] font-normal normal-case tracking-normal text-shell-text outline-none placeholder:text-shell-text-tertiary focus-visible:ring-2 focus-visible:ring-accent/40"
+            />
+          </label>
+
+          {selectedSlide.layout !== "blank" && (
+            <label className="flex flex-col gap-1 text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
+              Body
+              <textarea
+                value={selectedSlide.body}
+                onChange={(e) => patchSelected({ body: e.target.value })}
+                aria-label="Slide body"
+                rows={3}
+                className="resize-none rounded-lg border border-shell-border bg-shell-surface px-2.5 py-2 text-[12.5px] font-normal normal-case tracking-normal text-shell-text outline-none placeholder:text-shell-text-tertiary focus-visible:ring-2 focus-visible:ring-accent/40"
+              />
+            </label>
+          )}
+
+          {(selectedSlide.layout === "title-content" || selectedSlide.layout === "two-column") && (
+            <label className="flex flex-col gap-1 text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
+              Bullets (one per line)
+              <textarea
+                value={selectedSlide.bullets.join("\n")}
+                onChange={(e) => patchSelected({ bullets: e.target.value.split("\n") })}
+                onBlur={(e) =>
+                  patchSelected({
+                    bullets: e.target.value.split("\n").filter((b) => b.trim() !== ""),
+                  })
+                }
+                aria-label="Slide bullets, one per line"
+                rows={4}
+                className="resize-none rounded-lg border border-shell-border bg-shell-surface px-2.5 py-2 text-[12.5px] font-normal normal-case tracking-normal text-shell-text outline-none placeholder:text-shell-text-tertiary focus-visible:ring-2 focus-visible:ring-accent/40"
+              />
+            </label>
+          )}
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
+              Image
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => imageInputRef.current?.click()}
+                className="flex h-8 items-center gap-1.5 rounded-lg border border-shell-border bg-shell-surface px-2.5 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                <ImagePlus size={14} />
+                {selectedSlide.imageDataUri ? "Replace" : "Insert"}
+              </button>
+              {selectedSlide.imageDataUri && (
+                <button
+                  type="button"
+                  aria-label="Remove image"
+                  onClick={() => patchSelected({ imageDataUri: undefined })}
+                  className="grid h-8 w-8 place-items-center rounded-lg border border-shell-border text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+            <input
+              ref={imageInputRef}
+              type="file"
+              accept="image/*"
+              aria-label="Insert slide image"
+              className="sr-only"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                e.target.value = "";
+                if (file) handleImageFile(file);
+              }}
+            />
+          </div>
+
+          <label className="flex flex-col gap-1 text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
+            Speaker notes
+            <textarea
+              value={selectedSlide.notes ?? ""}
+              onChange={(e) => patchSelected({ notes: e.target.value })}
+              aria-label="Speaker notes"
+              rows={3}
+              className="resize-none rounded-lg border border-shell-border bg-shell-surface px-2.5 py-2 text-[12.5px] font-normal normal-case tracking-normal text-shell-text outline-none placeholder:text-shell-text-tertiary focus-visible:ring-2 focus-visible:ring-accent/40"
+            />
+          </label>
+        </aside>
+      </div>
+
+      {/* documents sidebar row (below body, matching Write/Calc's saved-docs list) */}
+      <div className="flex h-[132px] flex-none border-t border-shell-border bg-shell-bg-deep">
+        <div className="flex w-full flex-col overflow-hidden">
+          <div className="border-b border-shell-border px-3 py-1.5 text-[11px] font-bold uppercase tracking-wide text-shell-text-tertiary">
+            Saved decks
+          </div>
+          <div className="flex flex-1 items-center gap-2 overflow-x-auto p-2">
+            {!loading && docs.length === 0 && (
+              <p className="px-2 text-[12px] text-shell-text-tertiary">No saved decks yet</p>
+            )}
+            {docs.map((doc) => (
+              <button
+                key={doc.id}
+                type="button"
+                onClick={() => openDoc(doc.id)}
+                className={`h-full w-[140px] flex-none rounded-lg px-2.5 py-2 text-left text-[12px] transition-colors hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  activeId === doc.id ? "bg-shell-surface text-shell-text" : "text-shell-text-secondary"
+                }`}
+              >
+                <div className="truncate font-semibold">{doc.title}</div>
+                <div className="truncate text-[10px] text-shell-text-tertiary">
+                  {formatUpdated(doc.updated_at)}
+                </div>
+              </button>
+            ))}
+          </div>
         </div>
-      </aside>
+      </div>
+
+      {/* present mode overlay: always mounted (not display:none) so
+          requestFullscreen can be called synchronously from the Present
+          button's click handler; sized to 0 while inactive. */}
+      <div
+        ref={presentStageRef}
+        aria-hidden={!isPresenting}
+        className={isPresenting ? "fixed inset-0 z-[999]" : "fixed left-0 top-0 h-0 w-0 overflow-hidden"}
+      >
+        {isPresenting && (
+          <PresentMode
+            deck={deck}
+            index={Math.min(presentIndex, deck.slides.length - 1)}
+            onNext={() => setPresentIndex((i) => Math.min(i + 1, deck.slides.length - 1))}
+            onPrev={() => setPresentIndex((i) => Math.max(i - 1, 0))}
+            onExit={exitPresenting}
+          />
+        )}
+      </div>
+
+      {/* offscreen export capture surface: one fixed-size render per slide,
+          always kept in sync with the deck so exportPdf can rasterize
+          without a mount-timing race. */}
+      <div
+        ref={exportContainerRef}
+        aria-hidden="true"
+        style={{ position: "fixed", top: 0, left: -100000, pointerEvents: "none" }}
+      >
+        {deck.slides.map((s) => (
+          <div
+            key={s.id}
+            data-export-slide
+            style={{ width: EXPORT_PAGE_WIDTH, height: EXPORT_PAGE_HEIGHT }}
+          >
+            <SlideCanvas slide={s} fixedScale={EXPORT_PAGE_WIDTH / 640} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/desktop/src/apps/officestudio/slides/PresentMode.tsx
+++ b/desktop/src/apps/officestudio/slides/PresentMode.tsx
@@ -1,0 +1,75 @@
+import { ChevronLeft, ChevronRight, LogOut } from "lucide-react";
+import { SlideCanvas } from "./SlideCanvas";
+import type { Deck } from "./deck";
+
+// The fullscreen presentation surface. HARD REQUIREMENT (matching Game
+// Studio's PlayView): an always-visible "Exit" control is layered on top
+// whenever this is showing, and Escape exits (wired by the caller), so the
+// user is never trapped.
+
+export interface PresentModeProps {
+  deck: Deck;
+  index: number;
+  onNext: () => void;
+  onPrev: () => void;
+  onExit: () => void;
+}
+
+export function PresentMode({ deck, index, onNext, onPrev, onExit }: PresentModeProps) {
+  const slide = deck.slides[index];
+  const total = deck.slides.length;
+  if (!slide) return null;
+
+  return (
+    <div
+      className="relative flex h-full w-full items-center justify-center bg-black"
+      role="dialog"
+      aria-label={`Presenting ${deck.title || "deck"}`}
+    >
+      <div className="w-full" style={{ maxWidth: "min(92vw, 163.5vh)" }}>
+        <SlideCanvas slide={slide} className="w-full" />
+      </div>
+
+      {/* persistent Exit control, never hidden while presenting */}
+      <button
+        type="button"
+        onClick={onExit}
+        aria-label="Exit presentation"
+        className="absolute z-50 inline-flex items-center gap-1.5 rounded-full border border-accent/45 bg-[rgba(16,18,24,0.62)] px-3 py-1.5 text-[12px] font-bold text-white shadow-lg backdrop-blur-md transition-all hover:-translate-y-0.5 hover:bg-[rgba(28,32,42,0.82)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+        style={{
+          top: "max(12px, env(safe-area-inset-top, 12px))",
+          left: "max(12px, env(safe-area-inset-left, 12px))",
+        }}
+      >
+        <LogOut size={15} className="-scale-x-100" />
+        Exit
+        <span className="ml-0.5 rounded border border-white/25 px-1.5 py-px text-[9.5px] font-bold tracking-wide text-white/60">
+          ESC
+        </span>
+      </button>
+
+      <div className="absolute bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full bg-black/50 px-3 py-1 text-[12px] font-semibold text-white/80 backdrop-blur-sm">
+        {index + 1} / {total}
+      </div>
+
+      <button
+        type="button"
+        onClick={onPrev}
+        disabled={index === 0}
+        aria-label="Previous slide"
+        className="absolute left-4 top-1/2 z-50 grid h-10 w-10 -translate-y-1/2 place-items-center rounded-full bg-black/45 text-white backdrop-blur-sm transition-colors hover:bg-black/65 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:pointer-events-none disabled:opacity-30"
+      >
+        <ChevronLeft size={20} />
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={index === total - 1}
+        aria-label="Next slide"
+        className="absolute right-4 top-1/2 z-50 grid h-10 w-10 -translate-y-1/2 place-items-center rounded-full bg-black/45 text-white backdrop-blur-sm transition-colors hover:bg-black/65 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 disabled:pointer-events-none disabled:opacity-30"
+      >
+        <ChevronRight size={20} />
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/apps/officestudio/slides/SlideCanvas.tsx
+++ b/desktop/src/apps/officestudio/slides/SlideCanvas.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useRef, useState } from "react";
+import type { Slide } from "./deck";
+
+// Fixed "design" size the slide is authored at. The outer wrapper is a
+// responsive 16:9 box (thumbnail rail, editor preview, present mode, and PDF
+// export all use this same component); the inner slide is rendered at this
+// exact pixel size and scaled to fit, so every surface shows identical
+// proportions instead of separately-tuned layouts per size.
+const BASE_WIDTH = 640;
+const BASE_HEIGHT = 360;
+
+export interface SlideCanvasProps {
+  slide: Slide;
+  className?: string;
+  /** Skip the ResizeObserver and scale by this factor directly (offscreen export capture, where the container never mounts in the visible DOM). */
+  fixedScale?: number;
+}
+
+export function SlideCanvas({ slide, className, fixedScale }: SlideCanvasProps) {
+  const outerRef = useRef<HTMLDivElement | null>(null);
+  const [scale, setScale] = useState(fixedScale ?? 1);
+
+  useEffect(() => {
+    if (fixedScale != null) return;
+    const el = outerRef.current;
+    // jsdom (unit tests) has no ResizeObserver at all; fall back to the
+    // default scale rather than crashing the render.
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const update = () => {
+      if (el.clientWidth > 0) setScale(el.clientWidth / BASE_WIDTH);
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [fixedScale]);
+
+  return (
+    <div
+      ref={outerRef}
+      className={className}
+      style={{ position: "relative", aspectRatio: "16 / 9", overflow: "hidden" }}
+    >
+      <div
+        data-slide-stage
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          width: BASE_WIDTH,
+          height: BASE_HEIGHT,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+        }}
+      >
+        <SlideBody slide={slide} />
+      </div>
+    </div>
+  );
+}
+
+function SlideBody({ slide }: { slide: Slide }) {
+  const base: React.CSSProperties = {
+    width: BASE_WIDTH,
+    height: BASE_HEIGHT,
+    background:
+      "radial-gradient(120% 130% at 18% 14%,#4a5572,transparent 55%),linear-gradient(150deg,#262c3b,#14161f)",
+    color: "#fff",
+    display: "flex",
+    flexDirection: "column",
+    boxSizing: "border-box",
+    overflow: "hidden",
+  };
+
+  if (slide.layout === "blank") {
+    if (slide.imageDataUri) {
+      return (
+        <div style={{ ...base, alignItems: "center", justifyContent: "center", padding: 0 }}>
+          <img
+            src={slide.imageDataUri}
+            alt={slide.title || "Slide image"}
+            style={{ width: "100%", height: "100%", objectFit: "cover" }}
+          />
+        </div>
+      );
+    }
+    return (
+      <div style={{ ...base, alignItems: "center", justifyContent: "center", padding: 40 }}>
+        {slide.title && (
+          <h1 style={{ margin: 0, fontSize: 26, fontWeight: 700, textAlign: "center" }}>
+            {slide.title}
+          </h1>
+        )}
+        {slide.body && (
+          <p
+            style={{
+              margin: "10px 0 0",
+              fontSize: 14,
+              textAlign: "center",
+              color: "rgba(255,255,255,0.75)",
+            }}
+          >
+            {slide.body}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  if (slide.layout === "section-header") {
+    return (
+      <div style={{ ...base, alignItems: "center", justifyContent: "center", padding: 48 }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+            color: "rgba(255,255,255,0.55)",
+          }}
+        >
+          Section
+        </div>
+        <h1
+          style={{
+            margin: "10px 0 0",
+            fontSize: 34,
+            fontWeight: 800,
+            letterSpacing: -1,
+            textAlign: "center",
+          }}
+        >
+          {slide.title || "Untitled section"}
+        </h1>
+        {slide.body && (
+          <p
+            style={{
+              margin: "12px 0 0",
+              maxWidth: "80%",
+              fontSize: 14,
+              textAlign: "center",
+              color: "rgba(255,255,255,0.75)",
+            }}
+          >
+            {slide.body}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  if (slide.layout === "title") {
+    return (
+      <div style={{ ...base, justifyContent: "center", padding: "0 52px" }}>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            letterSpacing: 2,
+            textTransform: "uppercase",
+            color: "rgba(255,255,255,0.6)",
+          }}
+        >
+          taOS Studios
+        </div>
+        <h1 style={{ margin: "10px 0 0", fontSize: 38, fontWeight: 800, letterSpacing: -1 }}>
+          {slide.title || "Untitled slide"}
+        </h1>
+        {slide.body && (
+          <p
+            style={{
+              margin: "14px 0 0",
+              maxWidth: "80%",
+              fontSize: 15,
+              lineHeight: 1.5,
+              color: "rgba(255,255,255,0.82)",
+            }}
+          >
+            {slide.body}
+          </p>
+        )}
+        {slide.imageDataUri && (
+          <img
+            src={slide.imageDataUri}
+            alt=""
+            style={{ marginTop: 16, maxHeight: 90, borderRadius: 6, objectFit: "cover" }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  if (slide.layout === "two-column") {
+    return (
+      <div style={{ ...base, padding: "36px 44px" }}>
+        <h2 style={{ margin: 0, fontSize: 24, fontWeight: 800, letterSpacing: -0.5 }}>
+          {slide.title || "Untitled slide"}
+        </h2>
+        <div style={{ marginTop: 18, display: "flex", flex: 1, gap: 28, minHeight: 0 }}>
+          <ul style={{ flex: 1, margin: 0, paddingLeft: 18, fontSize: 13, lineHeight: 1.7 }}>
+            {slide.bullets.length === 0 && (
+              <li style={{ color: "rgba(255,255,255,0.4)", listStyle: "none", marginLeft: -18 }}>
+                No bullets yet
+              </li>
+            )}
+            {slide.bullets.map((b, i) => <li key={i}>{b}</li>)}
+          </ul>
+          <div style={{ flex: 1, minHeight: 0, display: "flex", alignItems: "center" }}>
+            {slide.imageDataUri ? (
+              <img
+                src={slide.imageDataUri}
+                alt=""
+                style={{ width: "100%", maxHeight: 220, objectFit: "cover", borderRadius: 8 }}
+              />
+            ) : (
+              <p style={{ margin: 0, fontSize: 13, lineHeight: 1.6, color: "rgba(255,255,255,0.75)" }}>
+                {slide.body}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // title-content (default)
+  return (
+    <div style={{ ...base, padding: "36px 44px" }}>
+      <h2 style={{ margin: 0, fontSize: 24, fontWeight: 800, letterSpacing: -0.5 }}>
+        {slide.title || "Untitled slide"}
+      </h2>
+      {slide.body && (
+        <p
+          style={{
+            margin: "12px 0 0",
+            fontSize: 14,
+            lineHeight: 1.6,
+            color: "rgba(255,255,255,0.82)",
+          }}
+        >
+          {slide.body}
+        </p>
+      )}
+      {slide.bullets.length > 0 && (
+        <ul style={{ margin: "10px 0 0", paddingLeft: 18, fontSize: 13, lineHeight: 1.7 }}>
+          {slide.bullets.map((b, i) => <li key={i}>{b}</li>)}
+        </ul>
+      )}
+      {slide.imageDataUri && (
+        <img
+          src={slide.imageDataUri}
+          alt=""
+          style={{
+            marginTop: 12,
+            width: "100%",
+            maxHeight: 130,
+            objectFit: "cover",
+            borderRadius: 8,
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/desktop/src/apps/officestudio/slides/__tests__/deck.test.ts
+++ b/desktop/src/apps/officestudio/slides/__tests__/deck.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  addSlide,
+  blankDeck,
+  insertSlideAfter,
+  moveSlideBy,
+  newSlide,
+  parseDeckContent,
+  reorderSlide,
+  removeSlide,
+  serializeDeck,
+  updateSlide,
+  type Deck,
+  type Slide,
+} from "../deck";
+
+function makeSlides(n: number): Slide[] {
+  return Array.from({ length: n }, (_, i) => ({
+    ...newSlide("title-content"),
+    id: `s${i + 1}`,
+    title: `Slide ${i + 1}`,
+  }));
+}
+
+describe("blankDeck", () => {
+  it("starts with exactly one slide", () => {
+    const deck = blankDeck();
+    expect(deck.slides).toHaveLength(1);
+    expect(deck.title).toBe("Untitled deck");
+  });
+});
+
+describe("addSlide / insertSlideAfter", () => {
+  it("appends a slide when afterId is null", () => {
+    const slides = makeSlides(2);
+    const next = addSlide(slides, null);
+    expect(next).toHaveLength(3);
+    expect(next[2].id).not.toBe(slides[0].id);
+    expect(next[2].id).not.toBe(slides[1].id);
+  });
+
+  it("inserts right after the given slide", () => {
+    const slides = makeSlides(3);
+    const slide = newSlide();
+    const next = insertSlideAfter(slides, "s1", slide);
+    expect(next.map((s) => s.id)).toEqual(["s1", slide.id, "s2", "s3"]);
+  });
+
+  it("falls back to appending when afterId is not found", () => {
+    const slides = makeSlides(2);
+    const slide = newSlide();
+    const next = insertSlideAfter(slides, "missing", slide);
+    expect(next.map((s) => s.id)).toEqual(["s1", "s2", slide.id]);
+  });
+});
+
+describe("removeSlide", () => {
+  it("removes the slide with the given id", () => {
+    const slides = makeSlides(3);
+    const next = removeSlide(slides, "s2");
+    expect(next.map((s) => s.id)).toEqual(["s1", "s3"]);
+  });
+
+  it("refuses to remove the last remaining slide", () => {
+    const slides = makeSlides(1);
+    const next = removeSlide(slides, "s1");
+    expect(next).toHaveLength(1);
+    expect(next).toBe(slides);
+  });
+});
+
+describe("updateSlide", () => {
+  it("patches the title/body/bullets/layout of the target slide only", () => {
+    const slides = makeSlides(2);
+    const next = updateSlide(slides, "s1", {
+      title: "New title",
+      body: "New body",
+      bullets: ["a", "b"],
+      layout: "two-column",
+    });
+    expect(next[0]).toMatchObject({
+      title: "New title",
+      body: "New body",
+      bullets: ["a", "b"],
+      layout: "two-column",
+    });
+    expect(next[1]).toBe(slides[1]);
+  });
+
+  it("does not mutate the source array", () => {
+    const slides = makeSlides(2);
+    const before = JSON.stringify(slides);
+    updateSlide(slides, "s1", { title: "changed" });
+    expect(JSON.stringify(slides)).toBe(before);
+  });
+});
+
+describe("reorderSlide / moveSlideBy", () => {
+  it("moves a slide from one index to another", () => {
+    const slides = makeSlides(4);
+    const next = reorderSlide(slides, 0, 2);
+    expect(next.map((s) => s.id)).toEqual(["s2", "s3", "s1", "s4"]);
+  });
+
+  it("clamps an out-of-range target index instead of throwing", () => {
+    const slides = makeSlides(3);
+    const next = reorderSlide(slides, 0, 99);
+    expect(next.map((s) => s.id)).toEqual(["s2", "s3", "s1"]);
+  });
+
+  it("is a no-op for an out-of-range source index", () => {
+    const slides = makeSlides(3);
+    const next = reorderSlide(slides, 10, 0);
+    expect(next).toBe(slides);
+  });
+
+  it("moveSlideBy moves the slide with the given id by a relative delta", () => {
+    const slides = makeSlides(3);
+    const next = moveSlideBy(slides, "s3", -2);
+    expect(next.map((s) => s.id)).toEqual(["s3", "s1", "s2"]);
+  });
+
+  it("moveSlideBy is a no-op for an unknown id", () => {
+    const slides = makeSlides(3);
+    const next = moveSlideBy(slides, "missing", 1);
+    expect(next).toBe(slides);
+  });
+});
+
+describe("serializeDeck / parseDeckContent round trip", () => {
+  it("round-trips a deck with multiple slides and fields untouched", () => {
+    const deck: Deck = {
+      version: 1,
+      title: "Quarterly review",
+      slides: [
+        {
+          id: "s1",
+          layout: "title",
+          title: "Q3 results",
+          body: "A strong quarter",
+          bullets: [],
+          notes: "Smile",
+        },
+        {
+          id: "s2",
+          layout: "two-column",
+          title: "Breakdown",
+          body: "",
+          bullets: ["Revenue up", "Costs down"],
+          imageDataUri: "data:image/png;base64,AAAA",
+        },
+      ],
+    };
+    const json = serializeDeck(deck);
+    const parsed = parseDeckContent(json);
+    expect(parsed).toEqual(deck);
+  });
+
+  // blankDeck() mints a fresh random slide id each call, so a fallback deck
+  // can't be compared with toEqual(blankDeck()) directly; check its shape
+  // instead (single untitled "title" slide).
+  function expectBlankDeckShape(deck: Deck) {
+    expect(deck.title).toBe("Untitled deck");
+    expect(deck.slides).toHaveLength(1);
+    expect(deck.slides[0]).toMatchObject({ layout: "title", title: "", body: "", bullets: [] });
+  }
+
+  it("falls back to a blank deck for empty content", () => {
+    expectBlankDeckShape(parseDeckContent(""));
+    expectBlankDeckShape(parseDeckContent("   "));
+  });
+
+  it("falls back to a blank deck for malformed JSON", () => {
+    expectBlankDeckShape(parseDeckContent("{not json"));
+  });
+
+  it("falls back to a blank deck when a slide is missing required fields", () => {
+    const corrupted = JSON.stringify({
+      version: 1,
+      title: "Broken",
+      slides: [{ id: "s1", layout: "title" }],
+    });
+    expectBlankDeckShape(parseDeckContent(corrupted));
+  });
+
+  it("falls back to a blank deck when slides is empty", () => {
+    const empty = JSON.stringify({ version: 1, title: "Empty", slides: [] });
+    expectBlankDeckShape(parseDeckContent(empty));
+  });
+});

--- a/desktop/src/apps/officestudio/slides/__tests__/pdfExport.test.ts
+++ b/desktop/src/apps/officestudio/slides/__tests__/pdfExport.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { blankDeck } from "../deck";
+import { EXPORT_PAGE_HEIGHT, EXPORT_PAGE_WIDTH, exportDeckToPdf } from "../pdfExport";
+
+const domToPngMock = vi.fn(async () => "data:image/png;base64,mock");
+const addImageMock = vi.fn();
+const addPageMock = vi.fn();
+const saveMock = vi.fn();
+
+vi.mock("modern-screenshot", () => ({
+  domToPng: (...args: unknown[]) => domToPngMock(...args),
+}));
+
+vi.mock("jspdf", () => ({
+  // A plain function (not an arrow function) so it can be invoked with
+  // `new`; returning an object from a constructor call overrides `this`
+  // with that object, which is all exportDeckToPdf needs from jsPDF.
+  jsPDF: vi.fn().mockImplementation(function jsPDFMock() {
+    return { addImage: addImageMock, addPage: addPageMock, save: saveMock };
+  }),
+}));
+
+function makeExportContainer(slideCount: number): HTMLElement {
+  const container = document.createElement("div");
+  for (let i = 0; i < slideCount; i++) {
+    const node = document.createElement("div");
+    node.setAttribute("data-export-slide", "");
+    container.appendChild(node);
+  }
+  document.body.appendChild(container);
+  return container;
+}
+
+describe("exportDeckToPdf", () => {
+  afterEach(() => {
+    domToPngMock.mockClear();
+    addImageMock.mockClear();
+    addPageMock.mockClear();
+    saveMock.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  it("rasterizes each marked slide node and adds one PDF page per slide", async () => {
+    const deck = { ...blankDeck(), title: "My Deck" };
+    const container = makeExportContainer(3);
+
+    await exportDeckToPdf(deck, container);
+
+    expect(domToPngMock).toHaveBeenCalledTimes(3);
+    // first slide does not call addPage (the jsPDF constructor already made page 1)
+    expect(addPageMock).toHaveBeenCalledTimes(2);
+    expect(addImageMock).toHaveBeenCalledTimes(3);
+    expect(addImageMock).toHaveBeenCalledWith(
+      "data:image/png;base64,mock",
+      "PNG",
+      0,
+      0,
+      EXPORT_PAGE_WIDTH,
+      EXPORT_PAGE_HEIGHT,
+    );
+    expect(saveMock).toHaveBeenCalledWith("My-Deck.pdf");
+  });
+
+  it("does nothing when there are no export-marked slide nodes", async () => {
+    const deck = blankDeck();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    await exportDeckToPdf(deck, container);
+
+    expect(domToPngMock).not.toHaveBeenCalled();
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a generic filename when the deck has no title", async () => {
+    const deck = { ...blankDeck(), title: "   " };
+    const container = makeExportContainer(1);
+
+    await exportDeckToPdf(deck, container);
+
+    expect(saveMock).toHaveBeenCalledWith("deck.pdf");
+  });
+});

--- a/desktop/src/apps/officestudio/slides/deck.ts
+++ b/desktop/src/apps/officestudio/slides/deck.ts
@@ -1,0 +1,136 @@
+// Deck model for the Slides view. Persisted as the office doc's `content`
+// (kind "slides"): the whole deck is serialized to JSON, mirroring how Calc
+// serializes its workbook (see ../calc/workbook.ts) and Write stores its
+// Tiptap HTML directly as `content`.
+
+export type SlideLayout = "title" | "title-content" | "two-column" | "section-header" | "blank";
+
+export interface Slide {
+  id: string;
+  layout: SlideLayout;
+  title: string;
+  body: string;
+  bullets: string[];
+  imageDataUri?: string;
+  notes?: string;
+}
+
+export interface Deck {
+  version: 1;
+  title: string;
+  slides: Slide[];
+}
+
+export const LAYOUTS: { id: SlideLayout; label: string }[] = [
+  { id: "title", label: "Title" },
+  { id: "title-content", label: "Title + content" },
+  { id: "two-column", label: "Two column" },
+  { id: "section-header", label: "Section header" },
+  { id: "blank", label: "Blank" },
+];
+
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+function genId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `slide-${crypto.randomUUID()}`;
+  }
+  return `slide-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function newSlide(layout: SlideLayout = "title-content"): Slide {
+  return { id: genId(), layout, title: "", body: "", bullets: [] };
+}
+
+export function blankDeck(): Deck {
+  return { version: 1, title: "Untitled deck", slides: [newSlide("title")] };
+}
+
+// Inserts an already-constructed slide after `afterId` (or at the end, if
+// `afterId` is null or not found). Split out from addSlide so a caller that
+// needs to know the new slide's id (e.g. to select it) can build the slide
+// first, instead of diffing the before/after arrays to find it.
+export function insertSlideAfter(slides: Slide[], afterId: string | null, slide: Slide): Slide[] {
+  if (afterId == null) return [...slides, slide];
+  const index = slides.findIndex((s) => s.id === afterId);
+  if (index === -1) return [...slides, slide];
+  const next = [...slides];
+  next.splice(index + 1, 0, slide);
+  return next;
+}
+
+export function addSlide(slides: Slide[], afterId: string | null, layout?: SlideLayout): Slide[] {
+  return insertSlideAfter(slides, afterId, newSlide(layout));
+}
+
+export function removeSlide(slides: Slide[], id: string): Slide[] {
+  if (slides.length <= 1) return slides;
+  return slides.filter((s) => s.id !== id);
+}
+
+export function updateSlide(slides: Slide[], id: string, patch: Partial<Omit<Slide, "id">>): Slide[] {
+  return slides.map((s) => (s.id === id ? { ...s, ...patch } : s));
+}
+
+// Moves the slide at `fromIndex` to `toIndex`, clamping so an out-of-range
+// index is a no-op-safe move to the nearest valid end rather than throwing or
+// silently dropping the slide.
+export function reorderSlide(slides: Slide[], fromIndex: number, toIndex: number): Slide[] {
+  if (fromIndex < 0 || fromIndex >= slides.length) return slides;
+  const clampedTo = Math.max(0, Math.min(toIndex, slides.length - 1));
+  if (clampedTo === fromIndex) return slides;
+  const next = [...slides];
+  // fromIndex was already bounds-checked above, so this splice always
+  // returns the removed element.
+  const moved = next.splice(fromIndex, 1)[0] as Slide;
+  next.splice(clampedTo, 0, moved);
+  return next;
+}
+
+export function moveSlideBy(slides: Slide[], id: string, delta: number): Slide[] {
+  const index = slides.findIndex((s) => s.id === id);
+  if (index === -1) return slides;
+  return reorderSlide(slides, index, index + delta);
+}
+
+export function serializeDeck(deck: Deck): string {
+  return JSON.stringify(deck);
+}
+
+function isValidSlide(value: unknown): value is Slide {
+  if (!value || typeof value !== "object") return false;
+  const s = value as Partial<Slide>;
+  if (typeof s.id !== "string") return false;
+  if (typeof s.title !== "string") return false;
+  if (typeof s.body !== "string") return false;
+  if (!Array.isArray(s.bullets) || !s.bullets.every((b) => typeof b === "string")) return false;
+  if (s.imageDataUri !== undefined && typeof s.imageDataUri !== "string") return false;
+  if (s.notes !== undefined && typeof s.notes !== "string") return false;
+  const validLayouts: SlideLayout[] = [
+    "title",
+    "title-content",
+    "two-column",
+    "section-header",
+    "blank",
+  ];
+  if (!validLayouts.includes(s.layout as SlideLayout)) return false;
+  return true;
+}
+
+// Parses saved content into a Deck, falling back to a fresh blank deck on
+// any malformed or corrupted content instead of crashing the view.
+export function parseDeckContent(content: string): Deck {
+  if (!content || !content.trim()) return blankDeck();
+  try {
+    const parsed = JSON.parse(content) as Partial<Deck>;
+    if (!parsed || typeof parsed.title !== "string" || !Array.isArray(parsed.slides)) {
+      return blankDeck();
+    }
+    if (parsed.slides.length === 0 || !parsed.slides.every(isValidSlide)) {
+      return blankDeck();
+    }
+    return { version: 1, title: parsed.title, slides: parsed.slides };
+  } catch {
+    return blankDeck();
+  }
+}

--- a/desktop/src/apps/officestudio/slides/pdfExport.ts
+++ b/desktop/src/apps/officestudio/slides/pdfExport.ts
@@ -1,0 +1,44 @@
+import type { Deck } from "./deck";
+
+// Renders the deck to a single downloadable PDF. Each page is a raster of
+// one slide, captured from an offscreen DOM node the caller has already
+// rendered (one child per slide, marked with data-export-slide, in deck
+// order) via SlideCanvas at a fixed 1280x720 scale — see SlidesView's hidden
+// export container.
+//
+// modern-screenshot (MIT, already a dependency, used elsewhere for desktop
+// screenshots) rasterizes each node to a PNG data URL; jsPDF (MIT) composes
+// those into pages. Both are dynamically imported so the cost is only paid
+// when a user actually exports.
+export const EXPORT_PAGE_WIDTH = 1280;
+export const EXPORT_PAGE_HEIGHT = 720;
+
+export async function exportDeckToPdf(deck: Deck, container: HTMLElement): Promise<void> {
+  const nodes = Array.from(container.querySelectorAll<HTMLElement>("[data-export-slide]"));
+  if (nodes.length === 0) return;
+
+  const [{ domToPng }, { jsPDF }] = await Promise.all([
+    import("modern-screenshot"),
+    import("jspdf"),
+  ]);
+
+  const doc = new jsPDF({
+    orientation: "landscape",
+    unit: "px",
+    format: [EXPORT_PAGE_WIDTH, EXPORT_PAGE_HEIGHT],
+  });
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    if (!node) continue;
+    const dataUrl = await domToPng(node, {
+      width: EXPORT_PAGE_WIDTH,
+      height: EXPORT_PAGE_HEIGHT,
+    });
+    if (i > 0) doc.addPage([EXPORT_PAGE_WIDTH, EXPORT_PAGE_HEIGHT], "landscape");
+    doc.addImage(dataUrl, "PNG", 0, 0, EXPORT_PAGE_WIDTH, EXPORT_PAGE_HEIGHT);
+  }
+
+  const filename = `${(deck.title || "deck").trim().replace(/\s+/g, "-") || "deck"}.pdf`;
+  doc.save(filename);
+}


### PR DESCRIPTION
## Summary
- Replaces the static 5-slide Slides mock with a real presentation editor: a `Deck`/`Slide` data model (5 layouts: title, title+content, two-column, section-header, blank), a thumbnail rail with add/delete/move-up/move-down, a live editor (title/body/bullets/notes fields, image insert with MIME + size validation), and a layout picker that switches the preview live.
- Adds fullscreen Present mode (arrow-key/on-screen nav, always-visible Exit control + Escape, matching Game Studio's PlayView fullscreen-exit pattern) and single-click Export to PDF.
- Persists the deck as JSON through the existing `/api/office/docs` endpoints with `kind: "slides"` (no backend changes needed -- `content` is already opaque TEXT and `slides` was already a valid kind). Mirrors Write/Calc's doc sidebar list/new/open/save pattern.
- Write and Calc views are untouched.

## Libraries added
- `jspdf` (MIT) -- composes rasterized slide pages into one downloadable PDF.
- Rasterization reuses `modern-screenshot` (MIT), already a dependency used elsewhere in the desktop app.

## Test plan
- [x] `cd desktop && npm install && npm run build` succeeds
- [x] `cd desktop && npx vitest run` -- 277 files / 2315 tests pass, including new coverage: slide add/delete/reorder mutations, title/body/layout updates, deck JSON round-trip + corrupted-content fallback, and the PDF export path (mocked `modern-screenshot`/`jspdf`, asserts one page per slide + save filename)
- [x] `python3 scripts/check_doc_gate.py diff-gate --base origin/dev` -- clean (via `Docs-Reviewed` trailer: new files are internal to the existing Office Studio app, not a new app)

## Deferred
- Drag-and-drop slide reordering (up/down buttons cover the same requirement, fully keyboard accessible)
- AI "Generate a deck" (was already an inert affordance in the old mock; out of scope for this phase)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Office Studio now includes a full slide editor with slide thumbnails, live preview, slide layouts, image insertion, speaker notes, and deck management.
  * Added presentation mode for fullscreen slideshow navigation.
  * Added PDF export for slide decks.
* **Bug Fixes**
  * Improved slide editing and thumbnail updates when titles, slides, or ordering change.
  * Deck loading now handles invalid or empty saved content more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->