### PR TITLE
chore(release): 1.0.0-beta.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 ### Changed
 - Office Suite is now Office Studio, and it is a real office suite. Write is a full rich-text word processor (bold/italic/underline, headings, lists, links); Calc is a real spreadsheet with a formula engine (cell references, SUM/AVERAGE/MIN/MAX/COUNT/IF), multiple sheets, sort/filter and CSV import/export; and Slides is a real presentation editor with layouts, images, a fullscreen present mode and PDF export. All three save to your cluster (#1565, #1568, #1569).
 
+### Fixed
+- Models: downloading a model actually downloads it now. The Models app was showing a fake progress bar and a false "installed" state without ever contacting the backend, so the model vanished on reopen and no file was fetched. Download now calls the real backend, shows true progress, reflects the backend's installed state, and surfaces a real error with a Retry button on failure. Reported by @mandresve (#1548).
+
 ## [1.0.0-beta.18] - 2026-07-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.19] - 2026-07-03
+
+### Added
+- Design Studio is now a real canvas editor. Select, move, resize and rotate elements; add editable text, shapes and images; manage layers; zoom and pan; undo and redo; and export the artboard to PNG. AI-generated images from the Magic view drop straight onto the canvas as editable elements (#1566).
+- Web Studio: a new AI-assisted, Wix-style website builder. Describe a site or start from a template, then edit it as stacked sections (hero, features, gallery, contact and more) with inline text, image swaps, live theming, and add/remove/reorder. Preview responsively across desktop, tablet and mobile, and export a self-contained static HTML page. Sites persist on your own cluster (#1567).
+
+### Changed
+- Office Suite is now Office Studio, and it is a real office suite. Write is a full rich-text word processor (bold/italic/underline, headings, lists, links); Calc is a real spreadsheet with a formula engine (cell references, SUM/AVERAGE/MIN/MAX/COUNT/IF), multiple sheets, sort/filter and CSV import/export; and Slides is a real presentation editor with layouts, images, a fullscreen present mode and PDF export. All three save to your cluster (#1565, #1568, #1569).
+
 ## [1.0.0-beta.18] - 2026-07-03
 
 ### Fixed

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.18",
+  "version": "1.0.0-beta.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.18"
+version = "1.0.0-beta.19"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.18"
+__version__ = "1.0.0-beta.19"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b18"
+version = "1.0.0b19"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Bumps to `1.0.0-beta.19` and dates the CHANGELOG.

Ships the Creative Studios buildout merged to dev overnight:
- **Office Studio** (renamed from Office Suite): real Write (Tiptap rich text), Calc (Fortune-sheet formula spreadsheet), Slides (jsPDF presentation editor) (#1565, #1568, #1569)
- **Design Studio**: real Konva canvas editor (#1566)
- **Web Studio**: new AI-assisted Wix-style website builder (#1567)

Version files: pyproject.toml, desktop/package.json, tinyagentos/__init__.py, uv.lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Design Studio canvas editing, including selection/manipulation, layers, zoom/pan, undo/redo, and PNG export, plus editable drops of AI-generated Magic view images.
  * Added Web Studio AI-assisted, section-based website building with inline editing, live theming, responsive preview, and static HTML export.
  * Renamed Office Suite to **Office Studio** and expanded Write, Calc, and Slides into full-featured editors (including exports).

* **Bug Fixes**
  * Fixed model downloads to perform real backend downloads and show actionable errors with retry.

* **Chores**
  * Updated app version to **1.0.0-beta.19**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->