### PR TITLE
fix(models): wire the Models app download to the real backend (was a frontend mock) (#1548)

### DIFF
--- a/desktop/src/apps/ModelsApp.download.test.tsx
+++ b/desktop/src/apps/ModelsApp.download.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ModelsApp } from "./ModelsApp";
+
+// Pins #1548: the Models app download flow used to be a pure frontend mock —
+// a setInterval + Math.random progress bar that never called the backend,
+// then fabricated a "downloaded" entry that vanished on reopen. These tests
+// fail against that mock and only pass once Download really calls
+// POST /api/models/download, polls GET /api/models/downloads/{id}, and
+// refetches /api/models on completion instead of fabricating state.
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const CATALOG_NOT_DOWNLOADED = {
+  models: [
+    {
+      id: "test-model",
+      name: "Test Model",
+      description: "a model for testing",
+      compatibility: "green",
+      capabilities: ["chat"],
+      has_downloaded_variant: false,
+      variants: [{ id: "q4", size_mb: 500 }],
+    },
+  ],
+  downloaded_files: [],
+  hardware_profile_id: "profile-1",
+};
+
+const CATALOG_DOWNLOADED = {
+  ...CATALOG_NOT_DOWNLOADED,
+  models: [
+    {
+      ...CATALOG_NOT_DOWNLOADED.models[0],
+      has_downloaded_variant: true,
+    },
+  ],
+};
+
+function mockFetch(routes: Record<string, () => Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      for (const [prefix, make] of Object.entries(routes)) {
+        if (url.startsWith(prefix)) return Promise.resolve(make());
+      }
+      return Promise.resolve(json([]));
+    }) as unknown as typeof fetch,
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ModelsApp download wiring (#1548)", () => {
+  it("issues POST /api/models/download with {app_id, variant_id} on click", async () => {
+    const calls = mockFetch({
+      "/api/models/downloads/": () => json({ status: "downloading", percent: 0 }),
+      "/api/models/download": () =>
+        json({ status: "started", download_id: "test-model-q4" }),
+      "/api/models": () => json(CATALOG_NOT_DOWNLOADED),
+    });
+
+    render(<ModelsApp windowId="w1" />);
+
+    const btn = await screen.findByRole("button", { name: "Download Test Model" });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      const call = calls.find((c) => c.url === "/api/models/download");
+      expect(call).toBeTruthy();
+      const body = JSON.parse(call!.init!.body as string);
+      expect(body).toEqual({ app_id: "test-model", variant_id: "q4" });
+    });
+  });
+
+  it("drives the progress bar from the polled percent, not a fake timer", async () => {
+    let pollCount = 0;
+    mockFetch({
+      "/api/models/downloads/": () => {
+        pollCount += 1;
+        return json({ status: "downloading", percent: 42 });
+      },
+      "/api/models/download": () =>
+        json({ status: "started", download_id: "test-model-q4" }),
+      "/api/models": () => json(CATALOG_NOT_DOWNLOADED),
+    });
+
+    render(<ModelsApp windowId="w1" />);
+    fireEvent.click(await screen.findByRole("button", { name: "Download Test Model" }));
+
+    const bar = await screen.findByRole("progressbar", {}, { timeout: 5000 });
+    await waitFor(
+      () => {
+        expect(pollCount).toBeGreaterThan(0);
+        expect(bar.getAttribute("aria-valuenow")).toBe("42");
+      },
+      { timeout: 5000 },
+    );
+  }, 10000);
+
+  it("surfaces a polled status:error with a Retry button instead of fake success", async () => {
+    mockFetch({
+      "/api/models/downloads/": () =>
+        json({ status: "error", percent: 0, error: "checksum mismatch" }),
+      "/api/models/download": () =>
+        json({ status: "started", download_id: "test-model-q4" }),
+      "/api/models": () => json(CATALOG_NOT_DOWNLOADED),
+    });
+
+    render(<ModelsApp windowId="w1" />);
+    fireEvent.click(await screen.findByRole("button", { name: "Download Test Model" }));
+
+    const alert = await screen.findByRole("alert", {}, { timeout: 5000 });
+    expect(alert.textContent).toContain("checksum mismatch");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  }, 10000);
+
+  it("refetches the model list on complete instead of fabricating a downloaded entry", async () => {
+    let modelsCallCount = 0;
+    mockFetch({
+      "/api/models/downloads/": () => json({ status: "complete", percent: 100 }),
+      "/api/models/download": () =>
+        json({ status: "started", download_id: "test-model-q4" }),
+      "/api/models": () => {
+        modelsCallCount += 1;
+        return json(modelsCallCount === 1 ? CATALOG_NOT_DOWNLOADED : CATALOG_DOWNLOADED);
+      },
+    });
+
+    render(<ModelsApp windowId="w1" />);
+    fireEvent.click(await screen.findByRole("button", { name: "Download Test Model" }));
+
+    // The real signal of completion is a second /api/models fetch driving
+    // the "Downloaded" label — never a client-fabricated entry.
+    await waitFor(
+      () => {
+        expect(modelsCallCount).toBeGreaterThanOrEqual(2);
+        expect(screen.getByText("Downloaded")).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+    expect(
+      screen.queryByRole("button", { name: "Download Test Model" }),
+    ).not.toBeInTheDocument();
+  }, 10000);
+
+  it("shows a clear error instead of fake success when a model has no downloadable variant", async () => {
+    // Force the offline MOCK_AVAILABLE fallback (no variantId on any model)
+    // by making /api/models fail while a worker is reachable — this is the
+    // path that surfaces isFallback with real cards to click.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.startsWith("/api/models")) {
+          return Promise.resolve(new Response("not json", { status: 500 }));
+        }
+        if (url.startsWith("/api/cluster/workers")) {
+          return Promise.resolve(
+            json([{ name: "worker1", url: "http://worker1", models: ["some-model"] }]),
+          );
+        }
+        return Promise.resolve(json([]));
+      }) as unknown as typeof fetch,
+    );
+
+    render(<ModelsApp windowId="w1" />);
+
+    const btn = await screen.findByRole("button", { name: /Download Llama 3 8B/i });
+    fireEvent.click(btn);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/no downloadable variant/i);
+  });
+});

--- a/desktop/src/apps/ModelsApp.tsx
+++ b/desktop/src/apps/ModelsApp.tsx
@@ -120,27 +120,45 @@ function DownloadProgress({
   onComplete: () => void;
   onRetry: () => void;
 }) {
-  const timer = useRef<ReturnType<typeof setInterval>>(undefined);
+  const timer = useRef<ReturnType<typeof setTimeout>>(undefined);
   const { downloadId, status } = state;
 
   useEffect(() => {
     if (!downloadId || status === "complete" || status === "error") return undefined;
 
+    // A running backend download must not be flipped to error by a single
+    // transient poll miss (a proxy hiccup, a momentary 502). Only give up
+    // after several CONSECUTIVE failures; a real backend status of "error"
+    // is authoritative and stops immediately.
+    const MAX_POLL_FAILURES = 3;
+    let consecutiveFailures = 0;
+    let cancelled = false;
+    const controller = new AbortController();
+
+    const schedule = () => {
+      timer.current = setTimeout(() => void poll(), 1000);
+    };
+
+    // Self-scheduling recursive poll rather than setInterval, so a slow poll
+    // never overlaps a newer one and a stale response can't clobber fresher
+    // state.
     const poll = async () => {
+      if (cancelled) return;
       try {
         const res = await fetch(`/api/models/downloads/${downloadId}`, {
           credentials: "include",
+          signal: controller.signal,
         });
         const data = await res.json().catch(() => null);
         if (!res.ok || !data || typeof data !== "object") {
           throw new Error("invalid poll response");
         }
+        consecutiveFailures = 0;
+        if (cancelled) return;
         if (data.status === "complete") {
-          clearInterval(timer.current);
           onUpdate({ downloadId, percent: 100, status: "complete" });
           onComplete();
         } else if (data.status === "error") {
-          clearInterval(timer.current);
           onUpdate({
             downloadId,
             percent: data.percent ?? state.percent,
@@ -155,22 +173,30 @@ function DownloadProgress({
             percent: data.percent ?? state.percent,
             status: "downloading",
           });
+          schedule();
         }
-      } catch {
-        // Losing the poll (network blip, proxy error page) must not strand
-        // a spinner with no outcome — surface it as an error.
-        clearInterval(timer.current);
-        onUpdate({
-          downloadId,
-          percent: state.percent,
-          status: "error",
-          error: "Lost contact with the download; retry to continue",
-        });
+      } catch (e) {
+        if (cancelled || (e as { name?: string })?.name === "AbortError") return;
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= MAX_POLL_FAILURES) {
+          onUpdate({
+            downloadId,
+            percent: state.percent,
+            status: "error",
+            error: "Lost contact with the download; retry to continue",
+          });
+          return;
+        }
+        schedule();
       }
     };
 
-    timer.current = setInterval(poll, 1000);
-    return () => clearInterval(timer.current);
+    void poll();
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (timer.current) clearTimeout(timer.current);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [downloadId, status]);
 
@@ -744,7 +770,12 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                     const compat = COMPAT_STYLES[model.compatibility] ?? { dot: "bg-emerald-400", label: "Recommended" };
                     const isDownloaded =
                       model.installed || downloaded.some((d) => d.id === model.id);
-                    const isDownloading = model.id in downloading;
+                    const dlState = downloading[model.id];
+                    // Only treat a download as in-progress while it is actually
+                    // running. On error the card button must return to an
+                    // actionable Retry, not a stuck disabled "Downloading...".
+                    const isDownloading = dlState != null && dlState.status !== "error";
+                    const isErrored = dlState != null && dlState.status === "error";
 
                     return (
                       <Card key={model.id}>
@@ -788,10 +819,10 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                               size="sm"
                               onClick={() => handleDownload(model)}
                               disabled={isDownloading}
-                              aria-label={`Download ${model.name}`}
+                              aria-label={`${isErrored ? "Retry download of" : "Download"} ${model.name}`}
                             >
                               <Download size={12} />
-                              {isDownloading ? "Downloading..." : "Download"}
+                              {isDownloading ? "Downloading..." : isErrored ? "Retry" : "Download"}
                             </Button>
                           )}
                         </CardFooter>

--- a/desktop/src/apps/ModelsApp.tsx
+++ b/desktop/src/apps/ModelsApp.tsx
@@ -42,6 +42,21 @@ interface AvailableModel {
   compatibility: "green" | "yellow" | "red";
   capabilities: string[];
   size: string;
+  /** Default variant to request from POST /api/models/download. Undefined
+   * when the model has no variants (e.g. the offline MOCK_AVAILABLE
+   * fallback) — Download must then surface an error, not fake success. */
+  variantId?: string;
+  /** Backend's own verdict (has_downloaded_variant) — the authoritative
+   * source for "already installed", since the union `downloaded` list
+   * below is keyed by filename/host, not by catalog model id. */
+  installed?: boolean;
+}
+
+interface DownloadState {
+  downloadId?: string;
+  percent: number;
+  status: "starting" | "downloading" | "complete" | "error";
+  error?: string;
 }
 
 type SourceFilter = "all" | "local" | "workers" | "cloud";
@@ -89,28 +104,90 @@ const CAPABILITY_COLORS: Record<string, string> = {
 };
 
 /* ------------------------------------------------------------------ */
-/*  DownloadProgress                                                   */
+/*  DownloadProgress — polls the real backend, no fake timer           */
 /* ------------------------------------------------------------------ */
 
-function DownloadProgress({ name, onDone }: { name: string; onDone: () => void }) {
-  const [pct, setPct] = useState(0);
+function DownloadProgress({
+  name,
+  state,
+  onUpdate,
+  onComplete,
+  onRetry,
+}: {
+  name: string;
+  state: DownloadState;
+  onUpdate: (next: DownloadState) => void;
+  onComplete: () => void;
+  onRetry: () => void;
+}) {
   const timer = useRef<ReturnType<typeof setInterval>>(undefined);
+  const { downloadId, status } = state;
 
   useEffect(() => {
-    timer.current = setInterval(() => {
-      setPct((prev) => {
-        if (prev >= 100) {
-          clearInterval(timer.current);
-          setTimeout(onDone, 400);
-          return 100;
-        }
-        return prev + Math.random() * 8 + 2;
-      });
-    }, 300);
-    return () => clearInterval(timer.current);
-  }, [onDone]);
+    if (!downloadId || status === "complete" || status === "error") return undefined;
 
-  const progress = Math.min(100, Math.round(pct));
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/models/downloads/${downloadId}`, {
+          credentials: "include",
+        });
+        const data = await res.json().catch(() => null);
+        if (!res.ok || !data || typeof data !== "object") {
+          throw new Error("invalid poll response");
+        }
+        if (data.status === "complete") {
+          clearInterval(timer.current);
+          onUpdate({ downloadId, percent: 100, status: "complete" });
+          onComplete();
+        } else if (data.status === "error") {
+          clearInterval(timer.current);
+          onUpdate({
+            downloadId,
+            percent: data.percent ?? state.percent,
+            status: "error",
+            // || not ?? — the backend initialises error to "", and an
+            // empty alert helps nobody.
+            error: data.error || "Download failed",
+          });
+        } else {
+          onUpdate({
+            downloadId,
+            percent: data.percent ?? state.percent,
+            status: "downloading",
+          });
+        }
+      } catch {
+        // Losing the poll (network blip, proxy error page) must not strand
+        // a spinner with no outcome — surface it as an error.
+        clearInterval(timer.current);
+        onUpdate({
+          downloadId,
+          percent: state.percent,
+          status: "error",
+          error: "Lost contact with the download; retry to continue",
+        });
+      }
+    };
+
+    timer.current = setInterval(poll, 1000);
+    return () => clearInterval(timer.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [downloadId, status]);
+
+  const progress = Math.min(100, Math.round(state.percent));
+
+  if (state.status === "error") {
+    return (
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-red-400 truncate" role="alert">
+          {name}: {state.error || "Download failed"}
+        </span>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-1.5">
@@ -139,7 +216,7 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
   const [search, setSearch] = useState("");
   const [source, setSource] = useState<SourceFilter>("all");
   const [subFilter, setSubFilter] = useState<string | null>(null);
-  const [downloading, setDownloading] = useState<Set<string>>(new Set());
+  const [downloading, setDownloading] = useState<Record<string, DownloadState>>({});
 
   const [isFallback, setIsFallback] = useState(false);
 
@@ -210,14 +287,26 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
             const variants = Array.isArray(m.variants)
               ? (m.variants as Array<Record<string, unknown>>)
               : [];
-            // Pick smallest variant for display size estimate.
+            // Pick the smallest variant (by size_mb) as both the display
+            // size estimate and the default download target, falling back
+            // to the first variant when none carry a usable size_mb.
             let sizeLabel = "\u2014";
+            let variantId: string | undefined;
             if (variants.length > 0) {
-              const sizes = variants
-                .map((v) => (v.size_mb as number) ?? 0)
-                .filter((n) => n > 0);
-              if (sizes.length > 0) {
-                sizeLabel = fmtSize(Math.min(...sizes));
+              const sized = variants.filter(
+                (v) => typeof v.size_mb === "number" && (v.size_mb as number) > 0,
+              );
+              const smallest =
+                sized.length > 0
+                  ? sized.reduce((a, b) =>
+                      (b.size_mb as number) < (a.size_mb as number) ? b : a,
+                    )
+                  : variants[0];
+              variantId = (smallest?.id as string) || undefined;
+              if (sized.length > 0) {
+                sizeLabel = fmtSize(
+                  Math.min(...sized.map((v) => v.size_mb as number)),
+                );
               }
             }
             const compat =
@@ -234,6 +323,8 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                 ? (m.capabilities as string[])
                 : [],
               size: sizeLabel,
+              variantId,
+              installed: Boolean(m.has_downloaded_variant),
             };
           });
 
@@ -288,29 +379,80 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
     setDownloaded((prev) => prev.filter((m) => m.id !== id));
   };
 
-  const handleDownload = (model: AvailableModel) => {
-    setDownloading((prev) => new Set(prev).add(model.id));
-  };
-
-  const handleDownloadDone = (model: AvailableModel) => {
-    setDownloading((prev) => {
-      const next = new Set(prev);
-      next.delete(model.id);
-      return next;
-    });
-    setDownloaded((prev) => [
+  const handleDownload = useCallback(async (model: AvailableModel) => {
+    if (!model.variantId) {
+      setDownloading((prev) => ({
+        ...prev,
+        [model.id]: {
+          percent: 0,
+          status: "error",
+          error: "No downloadable variant for this model",
+        },
+      }));
+      return;
+    }
+    setDownloading((prev) => ({
       ...prev,
-      {
-        id: model.id,
-        filename: `${model.id}-q4_k_m.gguf`,
-        size: model.size,
-        format: "GGUF",
-        quantization: "Q4_K_M",
-        host: "controller",
-        hostKind: "controller",
-      },
-    ]);
-  };
+      [model.id]: { percent: 0, status: "starting" },
+    }));
+    try {
+      const res = await fetch("/api/models/download", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          app_id: model.id,
+          variant_id: model.variantId,
+        }),
+      });
+      const data = await res.json().catch(() => ({}) as Record<string, unknown>);
+      if (!res.ok || !data.download_id) {
+        setDownloading((prev) => ({
+          ...prev,
+          [model.id]: {
+            percent: 0,
+            status: "error",
+            error:
+              (data.error as string) ||
+              (data.detail as string) ||
+              "The download could not be started",
+          },
+        }));
+        return;
+      }
+      setDownloading((prev) => ({
+        ...prev,
+        [model.id]: {
+          percent: 0,
+          status: "downloading",
+          downloadId: data.download_id as string,
+        },
+      }));
+    } catch {
+      setDownloading((prev) => ({
+        ...prev,
+        [model.id]: {
+          percent: 0,
+          status: "error",
+          error: "Could not reach the backend to start the download",
+        },
+      }));
+    }
+  }, []);
+
+  const handleDownloadComplete = useCallback(
+    async (modelId: string) => {
+      setDownloading((prev) => {
+        const next = { ...prev };
+        delete next[modelId];
+        return next;
+      });
+      // Re-fetch the real catalog instead of fabricating a downloaded
+      // entry, so the Downloaded Models list reflects backend truth.
+      await fetchModels();
+    },
+    [fetchModels],
+  );
 
   const q = search.toLowerCase();
 
@@ -556,17 +698,25 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
             )}
 
             {/* Downloading */}
-            {downloading.size > 0 && (
+            {Object.keys(downloading).length > 0 && (
               <section aria-label="Downloads in progress">
                 <h2 className="text-sm font-semibold mb-3">Downloading</h2>
                 <div className="space-y-2">
-                  {[...downloading].map((id) => {
+                  {Object.entries(downloading).map(([id, state]) => {
                     const model = available.find((m) => m.id === id);
                     if (!model) return null;
                     return (
                       <Card key={id}>
                         <CardContent className="p-3.5">
-                          <DownloadProgress name={model.name} onDone={() => handleDownloadDone(model)} />
+                          <DownloadProgress
+                            name={model.name}
+                            state={state}
+                            onUpdate={(next) =>
+                              setDownloading((prev) => ({ ...prev, [id]: next }))
+                            }
+                            onComplete={() => handleDownloadComplete(id)}
+                            onRetry={() => handleDownload(model)}
+                          />
                         </CardContent>
                       </Card>
                     );
@@ -592,8 +742,9 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   {filteredAvailable.map((model) => {
                     const compat = COMPAT_STYLES[model.compatibility] ?? { dot: "bg-emerald-400", label: "Recommended" };
-                    const isDownloaded = downloaded.some((d) => d.id === model.id);
-                    const isDownloading = downloading.has(model.id);
+                    const isDownloaded =
+                      model.installed || downloaded.some((d) => d.id === model.id);
+                    const isDownloading = model.id in downloading;
 
                     return (
                       <Card key={model.id}>


### PR DESCRIPTION
## Root cause

The Models app's download flow in `desktop/src/apps/ModelsApp.tsx` never called the backend at all:

- `DownloadProgress` animated a fake percentage with `setInterval` + `Math.random()` and called `onDone` on a timer, with no network call.
- `handleDownload` just added the model id to a local `downloading` Set.
- `handleDownloadDone` pushed a fabricated entry (filename `${model.id}-q4_k_m.gguf`) into local `downloaded` state. Nothing was persisted, so on the next `/api/models` refetch (e.g. reopening the app) the entry vanished, no files were ever written, and the "complete" state was purely cosmetic.

The real backend endpoints already existed and worked (`POST /api/models/download`, `GET /api/models/downloads/{id}`, `GET /api/models` with `variants[].size_mb`/`has_downloaded_variant`) — the frontend simply never called them.

## Fix

- `AvailableModel` now carries a `variantId`, chosen in the `/api/models` mapping as the smallest variant by `size_mb` (falls back to the first variant; `undefined` if a model has no variants, e.g. the offline `MOCK_AVAILABLE` list).
- `handleDownload` now does `POST /api/models/download` with `{ app_id, variant_id }` (`credentials: "include"`). A missing `variantId` or a failed/erroring response surfaces a clear message instead of pretending to succeed.
- `DownloadProgress` polls `GET /api/models/downloads/{download_id}` every second and drives the bar from the real `percent`. `status: "complete"` stops polling and refetches `/api/models` (no fabricated entry — the Downloaded Models list now reflects backend truth and survives reopening the app). `status: "error"` stops polling and shows the backend's error with a Retry button that re-invokes `handleDownload`.
- The `downloading` state changed from a `Set<string>` to a `Record<string, DownloadState>` so each in-flight download tracks its own `download_id`, `percent`, `status`, and `error`.
- `isDownloaded` now also honours the backend's own `has_downloaded_variant` verdict, since the existing union of controller/worker/cloud downloads is keyed by filename/host, not catalog model id, and would otherwise never mark a freshly-completed local download as installed.

## Tests

Added `desktop/src/apps/ModelsApp.download.test.tsx`, mocking `fetch` to assert:
- Download issues `POST /api/models/download` with the correct `{app_id, variant_id}`
- the progress bar reflects the polled `percent`
- a polled `status: "error"` surfaces the error text with a Retry button
- a polled `status: "complete"` triggers a real `/api/models` refetch (asserted via a second catalog fetch flipping `has_downloaded_variant`), not a fabricated entry
- a model with no variant shows a clear "no downloadable variant" error

## Test plan

- [x] `cd desktop && npm install && npm run build` succeeds
- [x] `cd desktop && npx vitest run` — 278 files / 2320 tests pass
- [x] New `ModelsApp.download.test.tsx` suite passes (5/5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model downloads now reflect real backend progress via polling, with accurate complete and error outcomes.
  * After completion, the downloaded/installed state is refreshed from the server (no client-fabricated entries).
  * Improved messaging when no downloadable variant exists, avoiding false success states.
  * Download requests now use the selected variant for both size display and download initiation.
* **Tests**
  * Added end-to-end coverage for the model download lifecycle: success, retry after error, error display, and missing-variant handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->