### PR TITLE
feat(security): provenance-keyed sandbox tiers for the app capability model

### DIFF
--- a/desktop/src/apps/SandboxedAppWindow.tsx
+++ b/desktop/src/apps/SandboxedAppWindow.tsx
@@ -36,14 +36,28 @@ const PROVENANCE_LABELS: Record<AppProvenance, string> = {
   unknown: "Unknown origin",
 };
 
+/** The `a.b` namespace of a capability, e.g. `app.kv.get` -> `app.kv`.
+ * Mirrors _namespace in tinyagentos/userspace/capabilities.py. */
+function namespaceOf(capability: string): string {
+  const parts = capability.split(".");
+  return parts.length >= 2 ? parts.slice(0, 2).join(".") : capability;
+}
+
 /** True if `capability`'s namespace is free for this tier or was explicitly
- * granted -- the same "ceiling OR grant" rule the backend enforces. */
+ * granted -- the same namespace-based "ceiling OR grant" rule the backend's
+ * capability_allowed enforces (so a sub-capability like `app.kv.get` matches
+ * the `app.kv` ceiling entry, not just an exact string). */
 function hasCapability(
   provenance: AppProvenance,
   capability: string,
   granted: readonly string[],
 ): boolean {
-  return PROVENANCE_CEILINGS[provenance].includes(capability) || granted.includes(capability);
+  const ns = namespaceOf(capability);
+  return (
+    PROVENANCE_CEILINGS[provenance].includes(ns) ||
+    granted.includes(ns) ||
+    granted.includes(capability)
+  );
 }
 
 /**

--- a/desktop/src/apps/SandboxedAppWindow.tsx
+++ b/desktop/src/apps/SandboxedAppWindow.tsx
@@ -1,12 +1,88 @@
 // desktop/src/apps/SandboxedAppWindow.tsx
 import { useEffect, useRef } from "react";
+import { ShieldAlert } from "lucide-react";
 import { useThemeStore } from "@/stores/theme-store";
 import { ALLOWED_TOKENS } from "@/theme/theme-config";
+import { defaultProvenanceForTrust, type AppProvenance } from "@/lib/userspace-apps";
 
 interface Props {
   windowId: string;
   appId: string;
   trust?: "community" | "first-party";
+  /** Where the app's code came from. Falls back to defaultProvenanceForTrust(trust)
+   * when omitted, so a caller that only knows the legacy `trust` field still
+   * gets a sensible classification. */
+  provenance?: AppProvenance;
+  /** Capabilities the user has explicitly granted this app -- drives the
+   * network-blocked badge and mirrors what the broker actually enforces. */
+  grantedCapabilities?: string[];
+}
+
+/** Mirrors tinyagentos/userspace/capabilities.py PROVENANCE_CEILINGS -- the
+ * default (no-consent) capability ceiling per tier. Only used here to decide
+ * what the badge shows; the backend broker is the actual enforcement point. */
+const PROVENANCE_CEILINGS: Record<AppProvenance, readonly string[]> = {
+  "first-party": ["app.kv", "app.table", "app.files", "app.notify", "app.window",
+    "app.net", "app.agent", "app.llm", "app.memory"],
+  "ai-generated": ["app.notify", "app.window"],
+  "user-uploaded": ["app.notify", "app.window"],
+  unknown: [],
+};
+
+const PROVENANCE_LABELS: Record<AppProvenance, string> = {
+  "first-party": "Built-in",
+  "ai-generated": "AI-generated",
+  "user-uploaded": "User-uploaded",
+  unknown: "Unknown origin",
+};
+
+/** True if `capability`'s namespace is free for this tier or was explicitly
+ * granted -- the same "ceiling OR grant" rule the backend enforces. */
+function hasCapability(
+  provenance: AppProvenance,
+  capability: string,
+  granted: readonly string[],
+): boolean {
+  return PROVENANCE_CEILINGS[provenance].includes(capability) || granted.includes(capability);
+}
+
+/**
+ * The iframe `sandbox` attribute, derived from provenance. Every tier
+ * resolves to the same minimal "allow-scripts" today: it is already the
+ * tightest value that still lets the app's own script run, and adding tokens
+ * like allow-forms/allow-popups/allow-same-origin would LOOSEN the existing
+ * restriction for whichever tier got them (allow-same-origin in particular
+ * would let a sandboxed app execute on the core origin -- never acceptable).
+ * The function exists (rather than a bare constant) so the derivation is a
+ * single, provenance-aware, testable place to tighten further per tier later.
+ */
+function computeSandboxAttr(_provenance: AppProvenance): string {
+  return "allow-scripts";
+}
+
+/** Small corner badge showing an app's provenance + whether it can reach the
+ * network. Skipped for first-party apps (built-in, nothing to warn about). */
+function ProvenanceBadge({
+  provenance,
+  networkAllowed,
+}: {
+  provenance: AppProvenance;
+  networkAllowed: boolean;
+}) {
+  if (provenance === "first-party") return null;
+  return (
+    <div
+      data-testid="provenance-badge"
+      data-provenance={provenance}
+      className="pointer-events-none absolute right-2 top-2 z-10 flex items-center gap-1 rounded-full bg-black/60 px-2 py-1 text-[10px] font-semibold text-white/90 backdrop-blur-sm"
+    >
+      <ShieldAlert size={11} />
+      <span>{PROVENANCE_LABELS[provenance]}</span>
+      <span className="text-white/60">
+        {networkAllowed ? "· Network allowed" : "· Network blocked"}
+      </span>
+    </div>
+  );
 }
 
 interface BrokerRequest {
@@ -28,9 +104,16 @@ function readThemeTokens(): Record<string, string> {
   return tokens;
 }
 
-export function SandboxedAppWindow({ appId, trust = "community" }: Props) {
+export function SandboxedAppWindow({
+  appId,
+  trust = "community",
+  provenance,
+  grantedCapabilities = [],
+}: Props) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const isFirstParty = trust === "first-party";
+  const resolvedProvenance: AppProvenance = provenance ?? defaultProvenanceForTrust(trust);
+  const networkAllowed = hasCapability(resolvedProvenance, "app.net", grantedCapabilities);
   // Subscribe to scheme changes (which fire on any applyThemeConfig call) so we
   // can push updated tokens when the theme changes. The selector is minimal to
   // avoid re-renders on unrelated store updates.
@@ -90,13 +173,17 @@ export function SandboxedAppWindow({ appId, trust = "community" }: Props) {
   }, [appId]);
 
   return (
-    <iframe
-      ref={iframeRef}
-      title={appId}
-      src={`/api/userspace-apps/${encodeURIComponent(appId)}/bundle/index.html?app=${encodeURIComponent(appId)}`}
-      sandbox="allow-scripts"
-      className="w-full h-full border-0 bg-white"
-      onLoad={handleLoad}
-    />
+    <div className="relative h-full w-full">
+      <ProvenanceBadge provenance={resolvedProvenance} networkAllowed={networkAllowed} />
+      <iframe
+        ref={iframeRef}
+        title={appId}
+        src={`/api/userspace-apps/${encodeURIComponent(appId)}/bundle/index.html?app=${encodeURIComponent(appId)}`}
+        sandbox={computeSandboxAttr(resolvedProvenance)}
+        data-provenance={resolvedProvenance}
+        className="w-full h-full border-0 bg-white"
+        onLoad={handleLoad}
+      />
+    </div>
   );
 }

--- a/desktop/src/apps/__tests__/SandboxedAppWindow.test.tsx
+++ b/desktop/src/apps/__tests__/SandboxedAppWindow.test.tsx
@@ -123,6 +123,58 @@ describe("SandboxedAppWindow -- theme injection", () => {
   });
 });
 
+describe("SandboxedAppWindow -- provenance tiers", () => {
+  it("never widens the sandbox attribute beyond allow-scripts for any tier", () => {
+    for (const provenance of ["first-party", "ai-generated", "user-uploaded", "unknown"] as const) {
+      const { unmount } = render(
+        <SandboxedAppWindow windowId="w1" appId={`app-${provenance}`} provenance={provenance} />
+      );
+      const iframe = screen.getByTitle(`app-${provenance}`) as HTMLIFrameElement;
+      expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+      expect(iframe.getAttribute("data-provenance")).toBe(provenance);
+      unmount();
+    }
+  });
+
+  it("shows no badge for a first-party app", () => {
+    render(<SandboxedAppWindow windowId="w1" appId="fp" provenance="first-party" />);
+    expect(screen.queryByTestId("provenance-badge")).toBeNull();
+  });
+
+  it("shows an AI-generated badge with network blocked by default", () => {
+    render(<SandboxedAppWindow windowId="w1" appId="agent-app" provenance="ai-generated" />);
+    const badge = screen.getByTestId("provenance-badge");
+    expect(badge.textContent).toContain("AI-generated");
+    expect(badge.textContent).toContain("Network blocked");
+  });
+
+  it("shows network allowed once app.net is granted", () => {
+    render(
+      <SandboxedAppWindow
+        windowId="w1"
+        appId="agent-app"
+        provenance="ai-generated"
+        grantedCapabilities={["app.net"]}
+      />
+    );
+    const badge = screen.getByTestId("provenance-badge");
+    expect(badge.textContent).toContain("Network allowed");
+  });
+
+  it("shows the unknown-origin badge as network blocked", () => {
+    render(<SandboxedAppWindow windowId="w1" appId="mystery" provenance="unknown" />);
+    const badge = screen.getByTestId("provenance-badge");
+    expect(badge.textContent).toContain("Unknown origin");
+    expect(badge.textContent).toContain("Network blocked");
+  });
+
+  it("falls back to defaultProvenanceForTrust when provenance is omitted", () => {
+    render(<SandboxedAppWindow windowId="w1" appId="legacy-fp" trust="first-party" />);
+    expect(screen.getByTitle("legacy-fp").getAttribute("data-provenance")).toBe("first-party");
+    expect(screen.queryByTestId("provenance-badge")).toBeNull();
+  });
+});
+
 describe("SDK theme API (mirrors taos-app-sdk.js handler)", () => {
   // The SDK ships as a plain IIFE loaded inside the sandbox iframe, so it cannot
   // be imported here without eval/new-Function (a flagged pattern). These tests

--- a/desktop/src/apps/__tests__/SandboxedAppWindow.test.tsx
+++ b/desktop/src/apps/__tests__/SandboxedAppWindow.test.tsx
@@ -161,6 +161,16 @@ describe("SandboxedAppWindow -- provenance tiers", () => {
     expect(badge.textContent).toContain("Network allowed");
   });
 
+  it("treats network as allowed for a first-party app via its ceiling namespace", () => {
+    // app.net is in the first-party ceiling, so the namespace check reports
+    // network allowed with no explicit grant -- exercises the ceiling branch
+    // of the namespace-aware hasCapability.
+    render(<SandboxedAppWindow windowId="w1" appId="fp" provenance="first-party" />);
+    // First-party shows no badge, but the underlying capability check is what
+    // drives it; assert the badge is absent (network-allowed first-party path).
+    expect(screen.queryByTestId("provenance-badge")).toBeNull();
+  });
+
   it("shows the unknown-origin badge as network blocked", () => {
     render(<SandboxedAppWindow windowId="w1" appId="mystery" provenance="unknown" />);
     const badge = screen.getByTestId("provenance-badge");

--- a/desktop/src/apps/appstudio/PublishView.tsx
+++ b/desktop/src/apps/appstudio/PublishView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Folder, Bell, Users, Shield, Upload, Share2, Download, CheckSquare } from "lucide-react";
+import { Folder, Bell, Users, Shield, Sparkles, Upload, Share2, Download, CheckSquare } from "lucide-react";
 
 /* ------------------------------------------------------------------ */
 /*  PublishView -- app identity + capabilities + side publish panel    */
@@ -66,7 +66,17 @@ export function PublishView() {
                 <CheckSquare size={30} />
               </div>
               <div>
-                <div className="text-[19px] font-extrabold tracking-[-0.02em]">Chore Quest</div>
+                <div className="flex items-center gap-[8px]">
+                  <span className="text-[19px] font-extrabold tracking-[-0.02em]">Chore Quest</span>
+                  <span
+                    data-testid="provenance-badge"
+                    data-provenance="ai-generated"
+                    className="flex items-center gap-1 rounded-full border border-shell-border bg-shell-surface px-[8px] py-[2px] text-[10px] font-semibold text-shell-text-secondary"
+                  >
+                    <Sparkles size={11} />
+                    AI-generated
+                  </span>
+                </div>
                 <div className="mt-[3px] text-[12.5px] text-shell-text-secondary">
                   A weekly chore tracker with points and a family leaderboard.
                 </div>

--- a/desktop/src/apps/appstudio/__tests__/PublishView.test.tsx
+++ b/desktop/src/apps/appstudio/__tests__/PublishView.test.tsx
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PublishView } from "../PublishView";
+
+describe("PublishView -- provenance badge", () => {
+  it("shows an AI-generated provenance badge next to the app name", () => {
+    render(<PublishView />);
+    const badge = screen.getByTestId("provenance-badge");
+    expect(badge.getAttribute("data-provenance")).toBe("ai-generated");
+    expect(badge.textContent).toContain("AI-generated");
+  });
+});

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -6,6 +6,10 @@ import type { AppManifest } from "@/registry/app-registry";
  */
 export const USERSPACE_APPS_CHANGED = "taos:userspace-apps-changed";
 
+/** Where an app's code came from. See tinyagentos/userspace/capabilities.py
+ * PROVENANCE_TIERS for the single source of truth this mirrors. */
+export type AppProvenance = "first-party" | "ai-generated" | "user-uploaded" | "unknown";
+
 export interface UserspaceAppRow {
   app_id: string;
   name: string;
@@ -16,10 +20,19 @@ export interface UserspaceAppRow {
   permissions_requested: string[];
   permissions_granted: string[];
   trust?: "community" | "first-party";
+  provenance?: AppProvenance;
+}
+
+/** Back-compat default for a row with no provenance recorded: legacy
+ * first-party built-ins classify first-party, everything else user-uploaded
+ * -- mirrors default_provenance_for_trust in the backend. */
+export function defaultProvenanceForTrust(trust?: string): AppProvenance {
+  return trust === "first-party" ? "first-party" : "user-uploaded";
 }
 
 export function toAppManifest(row: UserspaceAppRow): AppManifest {
   const trust = row.trust ?? "community";
+  const provenance = row.provenance ?? defaultProvenanceForTrust(trust);
   return {
     // Registry id is namespaced (mirrors "service:") so a community app cannot
     // shadow a built-in app id. The broker/bundle still use the raw app_id.
@@ -30,7 +43,13 @@ export function toAppManifest(row: UserspaceAppRow): AppManifest {
     component: () =>
       import("@/apps/SandboxedAppWindow").then((m) => ({
         default: (props: { windowId: string }) =>
-          m.SandboxedAppWindow({ ...props, appId: row.app_id, trust }),
+          m.SandboxedAppWindow({
+            ...props,
+            appId: row.app_id,
+            trust,
+            provenance,
+            grantedCapabilities: row.permissions_granted,
+          }),
       })),
     defaultSize: { w: 900, h: 600 },
     minSize: { w: 360, h: 280 },

--- a/tests/test_app_provenance.py
+++ b/tests/test_app_provenance.py
@@ -1,0 +1,117 @@
+"""The provenance -> capability ceiling model (provenance-keyed sandbox tiers).
+
+Every userspace app is classified into one of four provenance tiers
+(first-party/ai-generated/user-uploaded/unknown); the tier is a CEILING --
+the capabilities the app holds automatically, before any user consent.
+"""
+import pytest
+
+from tinyagentos.userspace.capabilities import (
+    DEFAULT_PROVENANCE,
+    FREE_CAPS,
+    GATED_CAPS,
+    KNOWN_CAPS,
+    PROVENANCE_CEILINGS,
+    PROVENANCE_DESCRIPTIONS,
+    PROVENANCE_TIERS,
+    capability_allowed,
+    capability_ceiling,
+    default_provenance_for_trust,
+    is_known_provenance,
+)
+
+
+def test_provenance_tiers_are_exactly_four():
+    assert PROVENANCE_TIERS == ("first-party", "ai-generated", "user-uploaded", "unknown")
+
+
+def test_every_tier_has_a_ceiling_and_description():
+    for tier in PROVENANCE_TIERS:
+        assert tier in PROVENANCE_CEILINGS
+        assert PROVENANCE_DESCRIPTIONS.get(tier), f"no description for {tier}"
+
+
+def test_default_provenance_is_unknown_the_most_restricted():
+    assert DEFAULT_PROVENANCE == "unknown"
+    assert capability_ceiling(DEFAULT_PROVENANCE) == frozenset()
+
+
+def test_is_known_provenance():
+    for tier in PROVENANCE_TIERS:
+        assert is_known_provenance(tier) is True
+    assert is_known_provenance("community") is False
+    assert is_known_provenance("") is False
+    assert is_known_provenance(None) is False
+
+
+def test_first_party_ceiling_is_every_known_capability():
+    assert capability_ceiling("first-party") == KNOWN_CAPS
+
+
+def test_ai_generated_and_user_uploaded_have_no_network_or_storage_by_default():
+    for tier in ("ai-generated", "user-uploaded"):
+        ceiling = capability_ceiling(tier)
+        # No storage, no network, no cross-app data.
+        assert "app.kv" not in ceiling
+        assert "app.table" not in ceiling
+        assert "app.files" not in ceiling
+        assert "app.net" not in ceiling
+        assert "app.agent" not in ceiling
+        assert "app.llm" not in ceiling
+        assert "app.memory" not in ceiling
+        # Only the inert, app-local UI capabilities are free.
+        assert ceiling == frozenset({"app.notify", "app.window"})
+
+
+def test_unknown_is_more_restricted_than_ai_generated_or_user_uploaded():
+    unknown_ceiling = capability_ceiling("unknown")
+    assert unknown_ceiling == frozenset()
+    for tier in ("ai-generated", "user-uploaded"):
+        assert unknown_ceiling < capability_ceiling(tier)
+
+
+def test_unrecognised_provenance_falls_back_to_default():
+    assert capability_ceiling("bogus-tier") == capability_ceiling(DEFAULT_PROVENANCE)
+    assert capability_ceiling(None) == capability_ceiling(DEFAULT_PROVENANCE)
+
+
+@pytest.mark.parametrize("cap", sorted(GATED_CAPS))
+def test_gated_caps_never_free_below_first_party(cap):
+    for tier in ("ai-generated", "user-uploaded", "unknown"):
+        assert not capability_allowed(tier, cap, granted=[])
+
+
+@pytest.mark.parametrize("cap", sorted(FREE_CAPS))
+def test_first_party_ceiling_covers_every_free_cap(cap):
+    assert capability_allowed("first-party", cap, granted=[])
+
+
+def test_capability_allowed_within_ceiling_needs_no_grant():
+    assert capability_allowed("ai-generated", "app.notify", granted=[]) is True
+    assert capability_allowed("ai-generated", "app.window.open", granted=[]) is True
+
+
+def test_capability_allowed_outside_ceiling_denied_without_grant():
+    assert capability_allowed("ai-generated", "app.kv", granted=[]) is False
+    assert capability_allowed("user-uploaded", "app.net", granted=[]) is False
+    assert capability_allowed("unknown", "app.notify", granted=[]) is False
+
+
+def test_an_explicit_grant_lets_an_app_exceed_its_ceiling():
+    # This is the whole point of the ceiling: it is a default, not a cap. An
+    # app can always exceed it via the existing consent/grant flow.
+    assert capability_allowed("ai-generated", "app.kv", granted=["app.kv"]) is True
+    assert capability_allowed("user-uploaded", "app.net", granted=["app.net"]) is True
+    assert capability_allowed("unknown", "app.memory.search", granted=["app.memory"]) is True
+    # A grant recorded as the exact sub-capability string also counts.
+    assert capability_allowed("unknown", "app.memory.search", granted=["app.memory.search"]) is True
+
+
+def test_default_provenance_for_trust_back_compat_mapping():
+    # Legacy first-party built-ins classify as first-party; everything else
+    # (community, missing, or any other value) defaults to user-uploaded --
+    # the only other way an app reaches the userspace store today.
+    assert default_provenance_for_trust("first-party") == "first-party"
+    assert default_provenance_for_trust("community") == "user-uploaded"
+    assert default_provenance_for_trust(None) == "user-uploaded"
+    assert default_provenance_for_trust("") == "user-uploaded"

--- a/tests/test_provenance_enforcement.py
+++ b/tests/test_provenance_enforcement.py
@@ -1,0 +1,263 @@
+"""Route-level enforcement of the provenance -> capability ceiling.
+
+Complements tests/test_app_provenance.py (the pure ceiling table) by checking
+the ceiling is actually wired into the userspace broker, the bundle CSP, and
+the app_permissions consent flow, without changing behaviour for the
+pre-existing first-party / community trust levels.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+async def _init_userspace_stores(app):
+    store = app.state.userspace_apps
+    if store._db is not None:
+        await store.close()
+    await store.init()
+    data_store = app.state.userspace_data
+    if data_store._db is not None:
+        await data_store.close()
+    await data_store.init()
+
+
+async def _install(store, app_id, *, trust="community", provenance=None, permissions=None):
+    await store.install(
+        app_id=app_id, name=app_id, version="1.0.0", app_type="web",
+        entry="index.html", icon="", permissions_requested=permissions or [],
+        trust=trust, provenance=provenance,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Store -- provenance column
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_default_provenance_is_user_uploaded(app, tmp_data_dir):
+    await _init_userspace_stores(app)
+    store = app.state.userspace_apps
+    await _install(store, "a")
+    row = await store.get("a")
+    assert row["provenance"] == "user-uploaded"
+
+
+@pytest.mark.asyncio
+async def test_install_first_party_trust_defaults_to_first_party_provenance(app, tmp_data_dir):
+    await _init_userspace_stores(app)
+    store = app.state.userspace_apps
+    await _install(store, "studio", trust="first-party")
+    row = await store.get("studio")
+    assert row["provenance"] == "first-party"
+
+
+@pytest.mark.asyncio
+async def test_install_explicit_provenance_is_honoured(app, tmp_data_dir):
+    await _init_userspace_stores(app)
+    store = app.state.userspace_apps
+    await _install(store, "agent-app", provenance="ai-generated")
+    row = await store.get("agent-app")
+    assert row["provenance"] == "ai-generated"
+
+
+@pytest.mark.asyncio
+async def test_migration_backfills_provenance_from_legacy_trust(tmp_path):
+    """A pre-existing DB with a trust column but no provenance column gets one
+    backfilled sensibly, matching the back-compat requirement: legacy
+    first-party rows classify first-party, everything else user-uploaded."""
+    import aiosqlite
+    from tinyagentos.userspace.store import UserspaceAppStore
+
+    db_path = tmp_path / "legacy.db"
+    async with aiosqlite.connect(str(db_path)) as db:
+        await db.executescript("""
+            CREATE TABLE IF NOT EXISTS userspace_apps (
+                app_id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                version TEXT NOT NULL DEFAULT '',
+                app_type TEXT NOT NULL,
+                entry TEXT NOT NULL DEFAULT 'index.html',
+                icon TEXT NOT NULL DEFAULT '',
+                permissions_requested TEXT NOT NULL DEFAULT '[]',
+                permissions_granted TEXT NOT NULL DEFAULT '[]',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                installed_at INTEGER NOT NULL,
+                container_host TEXT,
+                container_port INTEGER,
+                trust TEXT NOT NULL DEFAULT 'community'
+            );
+        """)
+        await db.execute(
+            "INSERT INTO userspace_apps "
+            "(app_id, name, version, app_type, entry, icon, permissions_requested, "
+            "permissions_granted, enabled, installed_at, trust) "
+            "VALUES ('legacy-fp', 'FP', '1', 'web', 'index.html', '', '[]', '[]', 1, 0, 'first-party')"
+        )
+        await db.execute(
+            "INSERT INTO userspace_apps "
+            "(app_id, name, version, app_type, entry, icon, permissions_requested, "
+            "permissions_granted, enabled, installed_at, trust) "
+            "VALUES ('legacy-community', 'C', '1', 'web', 'index.html', '', '[]', '[]', 1, 0, 'community')"
+        )
+        await db.commit()
+
+    store = UserspaceAppStore(db_path)
+    await store.init()
+    assert (await store.get("legacy-fp"))["provenance"] == "first-party"
+    assert (await store.get("legacy-community"))["provenance"] == "user-uploaded"
+    await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Broker -- ceiling honoured per tier, existing behaviour preserved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broker_storage_dispatch_scope_is_unchanged_by_ceiling(app, tmp_data_dir, client):
+    """Documents a deliberate scope boundary: the raw broker dispatch
+    (handle_capability) still treats app.kv/app.table/app.files as always-on
+    for every provenance, exactly as it did before this change, for every
+    tier including ai-generated/user-uploaded. Tightening that shared,
+    heavily-tested dispatch path would break existing installed-app behaviour
+    that several pre-existing tests rely on (e.g. tests/userspace/test_e2e.py
+    and tests/userspace/test_routes.py::test_broker_enforces_granted both
+    exercise free app.kv/app.table access with no grant on a community-trust
+    app). The ceiling IS enforced for this tier at the consent-request layer
+    (see test_request_consent_flags_storage_for_ai_generated_app below) and
+    for the gated network/agent/llm/memory namespaces at the broker layer
+    (see the first-party/user-uploaded tests above); closing this last gap so
+    an ai-generated app's storage calls are denied at the broker itself,
+    not just flagged for consent, is a follow-up."""
+    await _init_userspace_stores(app)
+    store = app.state.userspace_apps
+    await _install(store, "agent-app", provenance="ai-generated", permissions=["app.kv"])
+
+    r = await client.post(
+        "/api/userspace-apps/agent-app/broker",
+        json={"capability": "app.kv.set", "args": {"key": "k", "value": 1}},
+    )
+    assert r.json()["result"] is True
+
+
+@pytest.mark.asyncio
+async def test_broker_first_party_still_bypasses_gated_caps(app, tmp_data_dir, client):
+    """Generalising trust -> provenance must not change the existing
+    first-party bypass of gated capabilities (network/agent/llm/memory)."""
+    await _init_userspace_stores(app)
+    store = app.state.userspace_apps
+    await _install(store, "studio", trust="first-party", provenance="first-party")
+
+    r = await client.post(
+        "/api/userspace-apps/studio/broker",
+        json={"capability": "app.memory.search", "args": {"q": "x"}},
+    )
+    assert r.json().get("error") != "permission_denied"
+
+
+@pytest.mark.asyncio
+async def test_broker_user_uploaded_still_needs_grant_for_gated_caps(app, tmp_data_dir, client):
+    """Unchanged from the pre-existing community behaviour: gated caps always
+    need an explicit grant below first-party."""
+    await _init_userspace_stores(app)
+    store = app.state.userspace_apps
+    await _install(store, "side-loaded", provenance="user-uploaded")
+
+    r = await client.post(
+        "/api/userspace-apps/side-loaded/broker",
+        json={"capability": "app.net", "args": {"path": "/ping"}},
+    )
+    assert r.json()["error"] == "permission_denied"
+
+
+# ---------------------------------------------------------------------------
+# Bundle CSP -- tightened further for the unknown tier only
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_provenance_gets_a_tighter_img_src(app, tmp_data_dir, client, tmp_path):
+    await _init_userspace_stores(app)
+    apps_dir = tmp_path / "apps" / "mystery"
+    apps_dir.mkdir(parents=True)
+    (apps_dir / "index.html").write_text("<h1>mystery</h1>")
+
+    store = app.state.userspace_apps
+    await _install(store, "mystery", provenance="unknown")
+
+    r = await client.get("/api/userspace-apps/mystery/bundle/index.html")
+    assert r.status_code == 200
+    csp = r.headers.get("content-security-policy", "")
+    assert "img-src 'self' data: blob:" in csp
+    assert "https:" not in csp.split("img-src")[1].split(";")[0]
+
+
+@pytest.mark.asyncio
+async def test_user_uploaded_keeps_the_existing_img_src(app, tmp_data_dir, client, tmp_path):
+    await _init_userspace_stores(app)
+    apps_dir = tmp_path / "apps" / "normal"
+    apps_dir.mkdir(parents=True)
+    (apps_dir / "index.html").write_text("<h1>normal</h1>")
+
+    store = app.state.userspace_apps
+    await _install(store, "normal", provenance="user-uploaded")
+
+    r = await client.get("/api/userspace-apps/normal/bundle/index.html")
+    csp = r.headers.get("content-security-policy", "")
+    assert "img-src 'self' https: data: blob:" in csp
+
+
+# ---------------------------------------------------------------------------
+# app_permissions -- provenance surfaced + honoured for classified apps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_permissions_reports_provenance_and_ceiling(app, tmp_data_dir, client):
+    await _init_userspace_stores(app)
+    store = app.state.userspace_apps
+    await _install(store, "agent-app", provenance="ai-generated")
+
+    r = await client.get("/api/apps/agent-app/permissions")
+    data = r.json()
+    assert data["provenance"] == "ai-generated"
+    assert data["ceiling"] == ["app.notify", "app.window"]
+
+
+@pytest.mark.asyncio
+async def test_get_permissions_provenance_null_for_untracked_app_id(app, tmp_data_dir, client):
+    await _init_userspace_stores(app)
+    r = await client.get("/api/apps/some-native-feature/permissions")
+    data = r.json()
+    assert data["provenance"] is None
+    assert data["ceiling"] is None
+
+
+@pytest.mark.asyncio
+async def test_request_consent_flags_storage_for_ai_generated_app(app, tmp_data_dir, client):
+    await _init_userspace_stores(app)
+    store = app.state.userspace_apps
+    await _install(store, "agent-app", provenance="ai-generated")
+
+    r = await client.post(
+        "/api/apps/agent-app/request-consent",
+        json={"capabilities": ["app.kv", "app.notify", "app.net"]},
+    )
+    data = r.json()
+    # app.notify is within the ai-generated ceiling (free); app.kv and app.net
+    # are not, so both need consent -- unlike the untracked-app-id path, which
+    # still treats app.kv as free (see test_routes_app_permissions.py).
+    assert set(data["pending"]) == {"app.kv", "app.net"}
+
+
+@pytest.mark.asyncio
+async def test_request_consent_untracked_app_id_behaviour_unchanged(app, tmp_data_dir, client):
+    """An app_id that isn't a classified userspace app keeps the exact
+    pre-existing rule: free caps skip consent regardless of provenance."""
+    await _init_userspace_stores(app)
+    r = await client.post(
+        "/api/apps/some-native-feature/request-consent",
+        json={"capabilities": ["app.kv", "app.net"]},
+    )
+    assert r.json()["pending"] == ["app.net"]

--- a/tinyagentos/routes/app_permissions.py
+++ b/tinyagentos/routes/app_permissions.py
@@ -20,12 +20,35 @@ from tinyagentos.auth_context import CurrentUser, current_user
 from tinyagentos.userspace.capabilities import (
     FREE_CAPS,
     NET_PREFIX,
+    capability_allowed,
+    capability_ceiling,
+    default_provenance_for_trust,
     describe_capability,
     is_known_capability,
     is_valid_network_grant,
 )
 
 router = APIRouter()
+
+
+async def _resolve_provenance(request: Request, app_id: str) -> str | None:
+    """The app's provenance tier, if `app_id` is a classified userspace app.
+
+    None if `app_id` doesn't match any row in the userspace apps store -- most
+    callers of this generic grant ledger are not sandboxed userspace apps at
+    all (native features requesting a capability on their own behalf), so
+    their pending-consent computation is left exactly as before rather than
+    guessed at.
+    """
+    store = getattr(request.app.state, "userspace_apps", None)
+    # Uninitialised (e.g. a test app that never ran the userspace lifespan) is
+    # treated the same as "no store" -- best effort, never a 500.
+    if store is None or getattr(store, "_db", None) is None:
+        return None
+    row = await store.get(app_id)
+    if row is None:
+        return None
+    return row.get("provenance") or default_provenance_for_trust(row.get("trust"))
 
 
 def app_grant_decision_payload(app_id: str, capabilities: list[str]) -> dict:
@@ -65,11 +88,21 @@ class RevokeIn(BaseModel):
 async def list_app_permissions(
     app_id: str, request: Request, user: CurrentUser = Depends(current_user)
 ):
-    """The current user's capability decisions for an app, plus the granted set."""
+    """The current user's capability decisions for an app, plus the granted set.
+
+    Also reports `provenance` (null if `app_id` isn't a classified userspace
+    app) and `ceiling` -- the capabilities that tier holds without any of
+    `grants` -- so a UI can show why a capability needs consent.
+    """
     store = request.app.state.app_grants
     grants = await store.list_grants(user.user_id, app_id)
     granted = sorted(await store.granted_capabilities(user.user_id, app_id))
-    return {"app_id": app_id, "grants": grants, "granted": granted}
+    provenance = await _resolve_provenance(request, app_id)
+    ceiling = sorted(capability_ceiling(provenance)) if provenance else None
+    return {
+        "app_id": app_id, "grants": grants, "granted": granted,
+        "provenance": provenance, "ceiling": ceiling,
+    }
 
 
 @router.post("/api/apps/{app_id}/permissions")
@@ -140,8 +173,21 @@ async def request_app_consent(
             return JSONResponse({"error": f"invalid network origin: {cap}"}, status_code=400)
         caps.append(cap)
 
-    # Free caps are granted without consent; caps the user already granted or
-    # denied for this app are not re-prompted (the Permissions app revisits).
+    # Which caps are auto-free (no consent needed) depends on the app's
+    # provenance tier. Only a classified userspace app (found in the
+    # userspace_apps store) gets tier-aware treatment; every other caller of
+    # this generic ledger (a native feature requesting a capability on its own
+    # behalf, not a sandboxed app) keeps the plain FREE_CAPS-are-free rule it
+    # always had, unchanged.
+    provenance = await _resolve_provenance(request, app_id)
+
+    def _auto_free(cap: str) -> bool:
+        if provenance is not None:
+            return capability_allowed(provenance, cap, set())
+        return cap in FREE_CAPS
+
+    # Caps the user already granted or denied for this app are not re-prompted
+    # (the Permissions app revisits).
     decided = {g["capability"] for g in await grants.list_grants(user.user_id, app_id)}
     # Caps that already have an unanswered app_grant Decision for this app: the
     # lazy first-use path re-fires on every denied access until the user answers,
@@ -156,7 +202,7 @@ async def request_app_consent(
     # a colliding option whose value the dedup suffixer rewrites to a non-cap.
     pending: list[str] = []
     for c in caps:
-        if c in FREE_CAPS or c in decided or c in awaiting or c in pending:
+        if _auto_free(c) or c in decided or c in awaiting or c in pending:
             continue
         pending.append(c)
     if not pending:

--- a/tinyagentos/routes/apps.py
+++ b/tinyagentos/routes/apps.py
@@ -59,6 +59,21 @@ APP_TRUST: dict[str, str] = {
     "web-studio": "first-party",
 }
 
+# Provenance tier for each optional app (see tinyagentos/userspace/capabilities.py
+# for the full tier -> capability model). Every app bundled here ships in the
+# core repo and is built by taOS itself, so they are all "first-party" today;
+# this is a separate dict from APP_TRUST because provenance is the broader,
+# 4-tier classification (first-party/ai-generated/user-uploaded/unknown) while
+# trust remains the older first-party/community binary used elsewhere.
+APP_PROVENANCE: dict[str, str] = {
+    "coding-studio": "first-party",
+    "design-studio": "first-party",
+    "music-studio": "first-party",
+    "app-studio": "first-party",
+    "office-studio": "first-party",
+    "web-studio": "first-party",
+}
+
 
 def _semver_tuple(version: str) -> tuple[int, int, int]:
     """Parse a semver string into a fixed-length (major, minor, patch) tuple.
@@ -213,6 +228,7 @@ async def optional_app_catalog(request: Request):
                     "id": "reddit",
                     "version": "1.0.0",
                     "trust": "first-party",
+                    "provenance": "first-party",
                     "source": "core",
                     "installed": true,
                     "update_available": false
@@ -253,10 +269,18 @@ async def optional_app_catalog(request: Request):
             if recorded:
                 update_available = _semver_tuple(recorded) < _semver_tuple(current_version)
 
+        # Legacy install rows (from before provenance was recorded) fall back to
+        # the APP_PROVENANCE allowlist -- every optional app shipped in-core is
+        # first-party, so this is always a safe, non-elevating default.
+        provenance = (
+            (row.get("metadata") or {}).get("provenance") if row is not None else None
+        ) or APP_PROVENANCE.get(app_id, "first-party")
+
         result.append({
             "id": app_id,
             "version": current_version,
             "trust": APP_TRUST.get(app_id, "first-party"),
+            "provenance": provenance,
             "source": "core",
             "installed": is_installed,
             "update_available": update_available,
@@ -280,7 +304,10 @@ async def install_optional_app(app_id: str, request: Request):
     await store.install(
         app_id,
         version=APP_VERSIONS.get(app_id, "1.0.0"),
-        metadata={"kind": _FRONTEND_APP_KIND},
+        metadata={
+            "kind": _FRONTEND_APP_KIND,
+            "provenance": APP_PROVENANCE.get(app_id, "first-party"),
+        },
     )
     return {"status": "installed", "app_id": app_id}
 

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -6,12 +6,19 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import APIRouter, Request, UploadFile, File
+from fastapi import APIRouter, Form, Request, UploadFile, File
 from fastapi.responses import JSONResponse, FileResponse, Response
 
-from tinyagentos.userspace.broker import handle_capability, GATED_CAPS
+from tinyagentos.userspace.broker import handle_capability
+from tinyagentos.userspace.capabilities import capability_ceiling, default_provenance_for_trust
 from tinyagentos.userspace.package import extract_package, PackageError
 from tinyagentos.userspace.url_guard import resolve_safe_public_ip
+
+# Provenance values a caller may set through the PUBLIC install endpoint. Never
+# includes "first-party" -- that tier is only reachable via the internal
+# boot-seeding path (seed.py) or a verified signature (P2), matching the
+# existing trust="community"-only invariant this endpoint already enforces.
+_PUBLIC_PROVENANCES = {"ai-generated", "user-uploaded"}
 
 logger = logging.getLogger(__name__)
 
@@ -29,14 +36,21 @@ _SDK_PATH = Path(__file__).resolve().parent.parent / "userspace" / "sdk" / "taos
 # user has granted `network:<origin>` permissions gets exactly those origins
 # added to connect-src and nothing else (each origin is strictly validated at
 # manifest-parse time, so it cannot inject other CSP directives).
-def _bundle_csp(net_origins: list[str]) -> str:
+#
+# `provenance` only ever TIGHTENS this baseline further -- it never grants back
+# a directive every tier already gets. Today that means the "unknown" tier (an
+# app that could not be classified at all) also loses the permissive
+# `img-src https:` catch-all, so it cannot even passively load images from an
+# arbitrary origin. Every other tier keeps the existing img-src.
+def _bundle_csp(net_origins: list[str], provenance: str = "user-uploaded") -> str:
     connect = "connect-src 'self'" + "".join(" " + o for o in net_origins)
+    img_src = "img-src 'self' data: blob:" if provenance == "unknown" else "img-src 'self' https: data: blob:"
     return (
         "sandbox allow-scripts allow-forms allow-popups; "
         "default-src 'none'; "
         "script-src 'self' 'unsafe-inline' blob:; "
         "style-src 'self' 'unsafe-inline'; "
-        "img-src 'self' https: data: blob:; "
+        f"{img_src}; "
         "font-src 'self' data:; "
         f"{connect}; "
         "frame-ancestors 'self'; base-uri 'none'"
@@ -64,7 +78,11 @@ _MAX_PACKAGE_BYTES = 64 * 1024 * 1024
 
 
 @router.post("/api/userspace-apps/install")
-async def install_app(request: Request, package: UploadFile | None = File(default=None)):
+async def install_app(
+    request: Request,
+    package: UploadFile | None = File(default=None),
+    provenance: str | None = Form(default=None),
+):
     store = request.app.state.userspace_apps
     if package is not None:
         data = await package.read(_MAX_PACKAGE_BYTES + 1)
@@ -76,6 +94,7 @@ async def install_app(request: Request, package: UploadFile | None = File(defaul
         url = body.get("source_url")
         if not url:
             return JSONResponse({"error": "source_url or package required"}, status_code=400)
+        provenance = body.get("provenance") or provenance
         # SSRF guard: resolve + validate the host ONCE, then pin the connection
         # to that validated IP. Re-resolving at fetch time would reopen a
         # DNS-rebinding TOCTOU window. follow_redirects stays off so a 3xx
@@ -139,11 +158,18 @@ async def install_app(request: Request, package: UploadFile | None = File(defaul
     # trust is always 'community' through this public endpoint -- no manifest
     # field can elevate it. first-party trust is set only through the internal
     # boot-seeding path (P4) or after package signature verification (P2).
+    #
+    # provenance defaults to "user-uploaded" (a public install IS a side-load,
+    # by definition) but a caller can tag it "ai-generated" instead, e.g. once
+    # App Studio's publish flow posts here -- "first-party" is never accepted,
+    # same invariant as trust above.
+    resolved_provenance = provenance if provenance in _PUBLIC_PROVENANCES else "user-uploaded"
     await store.install(
         app_id=manifest["id"], name=manifest["name"], version=manifest["version"],
         app_type=manifest["app_type"], entry=manifest["entry"], icon=manifest["icon"],
         permissions_requested=manifest["permissions"],
         trust="community",
+        provenance=resolved_provenance,
     )
     return {
         "app_id": manifest["id"],
@@ -204,8 +230,9 @@ async def serve_bundle(request: Request, app_id: str, path: str):
     granted = (app or {}).get("permissions_granted") or []
     net_origins = [p[len("network:"):] for p in granted
                    if isinstance(p, str) and p.startswith("network:")]
+    provenance = (app or {}).get("provenance") or default_provenance_for_trust((app or {}).get("trust"))
     resp = FileResponse(target)
-    resp.headers["Content-Security-Policy"] = _bundle_csp(net_origins)
+    resp.headers["Content-Security-Policy"] = _bundle_csp(net_origins, provenance)
     resp.headers["X-Content-Type-Options"] = "nosniff"
     return resp
 
@@ -245,31 +272,30 @@ async def broker(request: Request, app_id: str):
     if app is None or not app["enabled"]:
         return JSONResponse({"error": "app not found or disabled"}, status_code=404)
     body = await request.json()
-    # First-party apps have all gated capabilities pre-authorised -- no per-cap
-    # consent step is needed. Community apps use only their explicitly granted set.
-    if app.get("trust") == "first-party":
-        granted = set(GATED_CAPS)
-    else:
-        # The userspace broker stays the runtime enforcer; the app_grants ledger
-        # feeds it (decision 24). A capability the current user granted this app
-        # via the consent flow also authorises it, on top of the per-app granted
-        # set. Additive and best-effort: no auth session or no ledger falls back
-        # to the per-app set, so nothing that worked before changes.
-        granted = set(app["permissions_granted"])
-        uid = getattr(request.state, "user_id", None)
-        grants_store = getattr(request.app.state, "app_grants", None)
-        if uid and grants_store is not None:
-            try:
-                granted |= await grants_store.granted_capabilities(uid, app_id)
-            except Exception:
-                # Genuinely best-effort: an uninitialised store or a query error
-                # must not turn a previously-working broker call into a 500. Fall
-                # back to the per-app granted set.
-                logger.warning(
-                    "app_grants lookup failed for app %s; using per-app grants only",
-                    app_id,
-                    exc_info=True,
-                )
+    # granted starts at the app's provenance ceiling (#PROV): first-party's
+    # ceiling is every known capability, so it behaves exactly like the old
+    # trust="first-party" bypass; every other tier's ceiling excludes the
+    # gated namespaces (network/agent/llm/memory), so those still need an
+    # explicit grant exactly as "community" apps always required. On top of
+    # the ceiling, the app's own declared+granted permissions and the
+    # app_grants consent ledger are additive, same as before.
+    provenance = app.get("provenance") or default_provenance_for_trust(app.get("trust"))
+    granted = set(capability_ceiling(provenance))
+    granted |= set(app["permissions_granted"])
+    uid = getattr(request.state, "user_id", None)
+    grants_store = getattr(request.app.state, "app_grants", None)
+    if uid and grants_store is not None:
+        try:
+            granted |= await grants_store.granted_capabilities(uid, app_id)
+        except Exception:
+            # Genuinely best-effort: an uninitialised store or a query error
+            # must not turn a previously-working broker call into a 500. Fall
+            # back to the ceiling + per-app granted set.
+            logger.warning(
+                "app_grants lookup failed for app %s; using per-app grants only",
+                app_id,
+                exc_info=True,
+            )
     out = await handle_capability(
         app_id, body.get("capability", ""), body.get("args") or {},
         granted=granted,

--- a/tinyagentos/userspace/capabilities.py
+++ b/tinyagentos/userspace/capabilities.py
@@ -85,3 +85,109 @@ def describe_capability(perm: str) -> str:
     if isinstance(perm, str) and perm.startswith(NET_PREFIX):
         return f"Connect to {perm[len(NET_PREFIX):]}"
     return CAPABILITY_DESCRIPTIONS.get(perm, perm)
+
+
+# ---------------------------------------------------------------------------
+# Provenance tiers -- where an installed app's code came from.
+# ---------------------------------------------------------------------------
+#
+# Every app is classified into exactly one tier. The tier is the CEILING: the
+# set of capabilities the app holds automatically, before the user has made
+# any decision. Anything in KNOWN_CAPS not on a tier's ceiling still exists
+# and can be granted through the existing consent flow (routes/app_permissions.py,
+# the app_grant Decision, routes/userspace_apps.py's /permissions endpoint) --
+# a tier never blocks a capability outright, it only decides whether holding
+# it requires an explicit user grant. This is the single source of truth for
+# the provenance -> capability model; the broker and the app_permissions API
+# both read PROVENANCE_CEILINGS rather than hard-coding a tier's defaults.
+PROVENANCE_TIERS = ("first-party", "ai-generated", "user-uploaded", "unknown")
+
+# Fallback for an app whose provenance was never recorded or could not be
+# classified -- the most restricted tier, so an unclassified app never
+# accidentally inherits a permissive default.
+DEFAULT_PROVENANCE = "unknown"
+
+# The default (no-consent-required) capability ceiling per tier:
+#
+#  - first-party: built-in / signed taOS apps. Full trust -- every known
+#    capability, matching the pre-existing trust="first-party" broker bypass.
+#  - ai-generated: authored by an agent in App Studio. No network, no
+#    storage, no cross-app data by default -- only the inert UI-local caps
+#    (notify/window, no data leaves the app) are free. Everything else
+#    (app.kv/app.table/app.files/app.net/app.agent/app.llm/app.memory) must
+#    be explicitly requested and granted.
+#  - user-uploaded: imported/side-loaded by the user. Same floor as
+#    ai-generated -- imported code is exactly as untrusted as agent-authored
+#    code, regardless of who clicked "install".
+#  - unknown: default fallback for anything not classified. The most
+#    restricted tier -- nothing is free, not even notify/window.
+PROVENANCE_CEILINGS: dict[str, frozenset[str]] = {
+    "first-party": KNOWN_CAPS,
+    "ai-generated": frozenset({"app.notify", "app.window"}),
+    "user-uploaded": frozenset({"app.notify", "app.window"}),
+    "unknown": frozenset(),
+}
+
+# One-line description per tier, for the app_permissions API / UI badge.
+PROVENANCE_DESCRIPTIONS: dict[str, str] = {
+    "first-party": "Built into taOS",
+    "ai-generated": "Built by an agent in App Studio",
+    "user-uploaded": "Imported by you",
+    "unknown": "Origin not verified",
+}
+
+
+def is_known_provenance(value: object) -> bool:
+    """True if `value` is one of the four classified provenance tiers."""
+    return isinstance(value, str) and value in PROVENANCE_TIERS
+
+
+def capability_ceiling(provenance: str) -> frozenset[str]:
+    """The tier's default (no-consent) capability ceiling.
+
+    Falls back to DEFAULT_PROVENANCE's ceiling for an unrecognised value, so a
+    typo'd or legacy provenance never resolves to an undefined (and possibly
+    permissive) ceiling.
+    """
+    return PROVENANCE_CEILINGS.get(provenance, PROVENANCE_CEILINGS[DEFAULT_PROVENANCE])
+
+
+def default_provenance_for_trust(trust: str | None) -> str:
+    """Back-compat mapping from the legacy binary `trust` field to a tier.
+
+    Used to classify rows written before the provenance column existed:
+    trust="first-party" -> "first-party" (unchanged meaning); anything else
+    (trust="community", or missing) -> "user-uploaded", since every app that
+    reaches the userspace store today arrives either through the public
+    install endpoint (side-loaded by the user) or boot-seeding (first-party).
+    """
+    return "first-party" if trust == "first-party" else "user-uploaded"
+
+
+def capability_allowed(provenance: str, capability: str, granted: object) -> bool:
+    """True if `capability` is available to an app of this provenance.
+
+    An app can never exceed its tier's ceiling without an explicit grant: a
+    capability namespace within the tier's ceiling is always available; one
+    outside it is only available if it (or its namespace) appears in
+    `granted`, the app's explicit grants (declared manifest permissions plus
+    whatever the user has approved through the consent flow).
+    """
+    ns = _namespace(capability)
+    if ns in capability_ceiling(provenance):
+        return True
+    granted_set = set(granted) if not isinstance(granted, (set, frozenset)) else granted
+    return ns in granted_set or capability in granted_set
+
+
+def _namespace(capability: str) -> str:
+    """The `a.b` namespace of a capability, e.g. `app.kv.get` -> `app.kv`.
+
+    Mirrors tinyagentos.userspace.broker._namespace; duplicated here (rather
+    than imported) because broker.py imports FREE_CAPS/GATED_CAPS from this
+    module, and this module must stay free of a reverse dependency on it.
+    """
+    if not isinstance(capability, str):
+        return capability
+    parts = capability.split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else capability

--- a/tinyagentos/userspace/capabilities.py
+++ b/tinyagentos/userspace/capabilities.py
@@ -176,7 +176,7 @@ def capability_allowed(provenance: str, capability: str, granted: object) -> boo
     ns = _namespace(capability)
     if ns in capability_ceiling(provenance):
         return True
-    granted_set = set(granted) if not isinstance(granted, (set, frozenset)) else granted
+    granted_set = set(granted)
     return ns in granted_set or capability in granted_set
 
 

--- a/tinyagentos/userspace/seed.py
+++ b/tinyagentos/userspace/seed.py
@@ -37,7 +37,7 @@ async def seed_bundled_apps(store, apps_root: Path, seed_dir: Path | None = None
     1. Parse the manifest to get id + version.
     2. Skip if the app is already installed at the same version.
     3. Otherwise build a .taosapp zip in memory, extract it, then call
-       store.install(..., trust="first-party").
+       store.install(..., trust="first-party", provenance="first-party").
 
     All errors for a single app are caught and logged; they do not abort seeding
     of subsequent apps or crash startup.
@@ -80,6 +80,7 @@ async def seed_bundled_apps(store, apps_root: Path, seed_dir: Path | None = None
                 icon=manifest.get("icon", ""),
                 permissions_requested=manifest.get("permissions", []),
                 trust="first-party",
+                provenance="first-party",
             )
             logger.info("seeded bundled app %s v%s", app_id, version)
         except Exception:

--- a/tinyagentos/userspace/store.py
+++ b/tinyagentos/userspace/store.py
@@ -4,6 +4,7 @@ import json
 import time
 
 from tinyagentos.base_store import BaseStore
+from tinyagentos.userspace.capabilities import default_provenance_for_trust
 
 
 class UserspaceAppStore(BaseStore):
@@ -32,7 +33,7 @@ class UserspaceAppStore(BaseStore):
     """
 
     async def _post_init(self) -> None:
-        """Add the trust column to databases created before it was introduced.
+        """Add the trust/provenance columns to databases created before they existed.
 
         SQLite has no IF NOT EXISTS for ADD COLUMN prior to 3.37, so we check
         PRAGMA table_info for broad compatibility (same pattern used by
@@ -49,27 +50,45 @@ class UserspaceAppStore(BaseStore):
                 "ALTER TABLE userspace_apps ADD COLUMN trust TEXT NOT NULL DEFAULT 'community'"
             )
             await self._db.commit()
+        if "provenance" not in existing_cols:
+            # Empty default (rather than a real tier) so the backfill below can
+            # tell "never classified" apart from an explicitly-set tier, then
+            # derive a sensible value per row from its existing trust column.
+            await self._db.execute(
+                "ALTER TABLE userspace_apps ADD COLUMN provenance TEXT NOT NULL DEFAULT ''"
+            )
+            await self._db.execute(
+                "UPDATE userspace_apps SET provenance = CASE "
+                "WHEN trust = 'first-party' THEN 'first-party' ELSE 'user-uploaded' END "
+                "WHERE provenance = ''"
+            )
+            await self._db.commit()
 
     async def install(self, app_id, name, version, app_type, entry, icon,
-                      permissions_requested, *, trust: str = "community"):
+                      permissions_requested, *, trust: str = "community",
+                      provenance: str | None = None):
         assert self._db is not None
+        if provenance is None:
+            provenance = default_provenance_for_trust(trust)
         await self._db.execute(
             """INSERT INTO userspace_apps
                (app_id, name, version, app_type, entry, icon,
-                permissions_requested, permissions_granted, enabled, installed_at, trust)
-               VALUES (?,?,?,?,?,?,?,'[]',1,?,?)
+                permissions_requested, permissions_granted, enabled, installed_at, trust, provenance)
+               VALUES (?,?,?,?,?,?,?,'[]',1,?,?,?)
                ON CONFLICT(app_id) DO UPDATE SET
                  name=excluded.name, version=excluded.version,
                  app_type=excluded.app_type, entry=excluded.entry,
                  icon=excluded.icon,
                  permissions_requested=excluded.permissions_requested,
-                 trust=excluded.trust""",
+                 trust=excluded.trust,
+                 provenance=excluded.provenance""",
             (app_id, name, version, app_type, entry, icon,
-             json.dumps(permissions_requested), int(time.time()), trust),
+             json.dumps(permissions_requested), int(time.time()), trust, provenance),
         )
         await self._db.commit()
 
     def _row_to_dict(self, row) -> dict:
+        trust = row[12] if len(row) > 12 else "community"
         return {
             "app_id": row[0], "name": row[1], "version": row[2],
             "app_type": row[3], "entry": row[4], "icon": row[5],
@@ -77,7 +96,8 @@ class UserspaceAppStore(BaseStore):
             "permissions_granted": json.loads(row[7]),
             "enabled": row[8], "installed_at": row[9],
             "container_host": row[10], "container_port": row[11],
-            "trust": row[12] if len(row) > 12 else "community",
+            "trust": trust,
+            "provenance": row[13] if len(row) > 13 and row[13] else default_provenance_for_trust(trust),
         }
 
     async def get(self, app_id) -> dict | None:

--- a/tinyagentos/userspace/store.py
+++ b/tinyagentos/userspace/store.py
@@ -54,9 +54,12 @@ class UserspaceAppStore(BaseStore):
             # Empty default (rather than a real tier) so the backfill below can
             # tell "never classified" apart from an explicitly-set tier, then
             # derive a sensible value per row from its existing trust column.
+            # Commit the ALTER before the backfill UPDATE, matching the trust
+            # column's pattern above (keep DDL and DML in separate transactions).
             await self._db.execute(
                 "ALTER TABLE userspace_apps ADD COLUMN provenance TEXT NOT NULL DEFAULT ''"
             )
+            await self._db.commit()
             await self._db.execute(
                 "UPDATE userspace_apps SET provenance = CASE "
                 "WHEN trust = 'first-party' THEN 'first-party' ELSE 'user-uploaded' END "


### PR DESCRIPTION
## Summary

Classifies every app into one of four provenance tiers -- `first-party`, `ai-generated`, `user-uploaded`, `unknown` -- and maps each tier to a default capability ceiling, so an app's sandbox is shaped by where its code came from, not just a binary trusted/community flag.

- `tinyagentos/userspace/capabilities.py`: single source of truth. `PROVENANCE_TIERS`, `PROVENANCE_CEILINGS` (the default, no-consent capability set per tier), `capability_ceiling()`, `capability_allowed()`, and `default_provenance_for_trust()` for back-compat.
- `tinyagentos/userspace/store.py`: new `provenance` column on `userspace_apps`, migrated in from the existing `trust` column for pre-existing rows (first-party stays first-party, everything else becomes user-uploaded).
- `tinyagentos/routes/userspace_apps.py`: the broker's granted-capability set is now built from the app's provenance ceiling instead of a hard-coded `trust == "first-party"` check (same effective behaviour for first-party and for the gated network/agent/llm/memory capabilities, now expressed as one of four tiers instead of two). The public install endpoint accepts an optional `provenance` (`ai-generated` or `user-uploaded` only) and defaults to `user-uploaded`. The bundle CSP tightens `img-src` further for the `unknown` tier.
- `tinyagentos/routes/app_permissions.py`: `GET /api/apps/{id}/permissions` now reports `provenance` and `ceiling`; `request-consent` now correctly flags storage capabilities as needing consent for a classified ai-generated/user-uploaded app (previously free for everyone). Untracked app ids (native features using the same ledger) keep their exact previous behaviour.
- `tinyagentos/routes/apps.py`: the optional first-party frontend apps also carry `provenance` in their `installed_apps` metadata and catalog response.
- `desktop/src/apps/SandboxedAppWindow.tsx`: accepts `provenance` + `grantedCapabilities`, renders a small corner badge for non-first-party apps ("AI-generated - Network blocked" etc). The iframe `sandbox` attribute stays `allow-scripts` for every tier (already the tightest value; widening it for any tier would loosen an existing restriction).
- `desktop/src/apps/appstudio/PublishView.tsx`: an AI-generated badge next to the app identity, where its requested capabilities are already listed.

## Known scope boundary (disclosed, not a gap I missed)

The raw broker dispatch (`handle_capability`) still treats `app.kv`/`app.table`/`app.files` as always-on for every tier, unchanged from before. Several pre-existing tests (`tests/userspace/test_e2e.py`, `tests/userspace/test_routes.py::test_broker_enforces_granted`) exercise free storage access with no grant on a community-trust app installed through the public endpoint -- tightening that shared dispatch path would break those already-working installs. The ceiling IS enforced there for storage at the consent-request layer (`request-consent` now flags it) and at the broker layer for the gated network/agent/llm/memory capabilities. Fully closing the storage gap at the broker dispatch layer is a natural follow-up once App Studio's publish flow is wired to actually use `provenance=ai-generated`.

## Test plan

- [x] `pytest tests/test_app_provenance.py tests/test_provenance_enforcement.py` -- new tests for the ceiling table and route-level enforcement
- [x] `pytest tests/userspace tests/test_app_capabilities.py tests/test_routes_app_permissions.py tests/test_routes_userspace_apps.py tests/test_userspace_seed.py tests/test_userspace_store.py tests/test_routes_apps.py` -- zero regressions across every affected existing suite
- [x] `cd desktop && npx vitest run` -- full suite (278 files / 2322 tests) passes
- [x] `cd desktop && npm run build` -- succeeds
- [x] `python scripts/check_doc_gate.py diff-gate --base origin/dev` -- clean (Docs-Reviewed trailer on the commit that adds a co-located test under desktop/src/apps/appstudio/**; no app was actually added/removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app provenance labels and badges, showing whether an app is first-party, AI-generated, user-uploaded, or unknown.
  * App install, catalog, and permissions flows now carry provenance data end-to-end.
  * Network access indicators and app sandbox behavior now reflect an app’s provenance.

* **Bug Fixes**
  * Improved handling for older app records by backfilling provenance from existing trust values.
  * Tightened permission prompts and content policies for apps with lower trust levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->