### PR TITLE
feat(userspace): install-time permission consent UI (App Runtime M3)

### DIFF
--- a/desktop/src/apps/StoreApp/ImportAppButton.test.tsx
+++ b/desktop/src/apps/StoreApp/ImportAppButton.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ImportAppButton } from "./ImportAppButton";
+
+function mockFetchSequence(responses: Array<{ url: string; body: unknown; ok?: boolean }>) {
+  return vi.fn((url: string) => {
+    const match = responses.find((r) => url.includes(r.url));
+    if (!match) throw new Error(`unexpected fetch: ${url}`);
+    return Promise.resolve({ ok: match.ok ?? true, json: async () => match.body });
+  });
+}
+
+describe("ImportAppButton", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("installing a package requesting a gated capability shows the consent dialog", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.net", "app.kv"], needs_consent: true, new_permissions: ["app.net"] },
+      },
+      {
+        url: "/api/userspace-apps",
+        body: [{ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net", "app.kv"], permissions_granted: [] }],
+      },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    const dialog = await screen.findByRole("dialog", { name: /permissions for todo/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/connect to the internet/i)).toBeInTheDocument();
+  });
+
+  it("installing a package with no new permissions never shows the dialog", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.kv"], needs_consent: false, new_permissions: [] },
+      },
+      { url: "/api/userspace-apps", body: [] },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("Deny in the dialog dismisses it without granting", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.net"], needs_consent: true, new_permissions: ["app.net"] },
+      },
+      {
+        url: "/api/userspace-apps",
+        body: [{ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net"], permissions_granted: [] }],
+      },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /deny/i }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalledWith(expect.stringContaining("/permissions"), expect.anything());
+  });
+});

--- a/desktop/src/apps/StoreApp/ImportAppButton.tsx
+++ b/desktop/src/apps/StoreApp/ImportAppButton.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useRef, useState } from "react";
+import { Upload, Loader2 } from "lucide-react";
+import {
+  installUserspaceApp,
+  fetchUserspaceAppRow,
+  USERSPACE_APPS_CHANGED,
+  type InstallResult,
+} from "@/lib/userspace-apps";
+import { emitAppEvent } from "@/lib/app-event-bus";
+import { PermissionConsent } from "./PermissionConsent";
+
+/** Import a .taosapp package from disk and install it as a userspace app.
+ * When the install requests new permissions, the consent dialog shows before
+ * anything sensitive is granted -- the app itself is already installed at
+ * that point (with only its free capabilities usable) so it can never be
+ * blocked on a decision the user hasn't made yet. */
+export function ImportAppButton() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [consent, setConsent] = useState<{
+    appId: string;
+    appName: string;
+    requested: string[];
+    alreadyGranted: string[];
+  } | null>(null);
+
+  const handleFile = useCallback(async (file: File) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result: InstallResult = await installUserspaceApp(file);
+      const row = await fetchUserspaceAppRow(result.app_id);
+      // The row is now enabled and visible regardless of consent -- only its
+      // gated capabilities are withheld until the user answers below.
+      emitAppEvent(USERSPACE_APPS_CHANGED);
+      if (result.needs_consent) {
+        setConsent({
+          appId: result.app_id,
+          appName: row?.name ?? result.app_id,
+          requested: result.new_permissions,
+          alreadyGranted: row?.permissions_granted ?? [],
+        });
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Install failed");
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".taosapp,.zip"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = "";
+          if (file) void handleFile(file);
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={busy}
+        className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-[12px] font-semibold border border-shell-border text-shell-text-secondary hover:text-shell-text hover:bg-white/[0.04] transition-colors disabled:opacity-60"
+      >
+        {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
+        Import app package
+      </button>
+      {error && (
+        <div role="alert" className="mt-2 text-[11px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
+          {error}
+        </div>
+      )}
+      {consent && (
+        <PermissionConsent
+          appId={consent.appId}
+          appName={consent.appName}
+          requested={consent.requested}
+          alreadyGranted={consent.alreadyGranted}
+          onAllow={() => {
+            emitAppEvent(USERSPACE_APPS_CHANGED);
+            setConsent(null);
+          }}
+          onDeny={() => setConsent(null)}
+        />
+      )}
+    </>
+  );
+}
+
+export default ImportAppButton;

--- a/desktop/src/apps/StoreApp/PermissionConsent.test.tsx
+++ b/desktop/src/apps/StoreApp/PermissionConsent.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { PermissionConsent, GATED_CAPS } from "./PermissionConsent";
+
+describe("PermissionConsent", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renders as a labelled dialog listing each requested capability", () => {
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net", "app.kv"]}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog", { name: /permissions for todo/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/connect to the internet/i)).toBeInTheDocument();
+    expect(screen.getByText(/store and read its own app data/i)).toBeInTheDocument();
+  });
+
+  it("visually flags gated/sensitive capabilities but not free ones", () => {
+    expect(GATED_CAPS.has("app.net")).toBe(true);
+    expect(GATED_CAPS.has("app.kv")).toBe(false);
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net", "app.kv"]}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+    const netRow = screen.getByText(/connect to the internet/i).closest("li")!;
+    const kvRow = screen.getByText(/store and read its own app data/i).closest("li")!;
+    expect(netRow.textContent).toContain("⚠");
+    expect(kvRow.textContent).not.toContain("⚠");
+  });
+
+  it("Allow POSTs the granted permissions (merged with any already granted) and calls onAllow", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", mockFetch);
+    const onAllow = vi.fn();
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        alreadyGranted={["app.memory"]}
+        onAllow={onAllow}
+        onDeny={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+
+    await waitFor(() => expect(onAllow).toHaveBeenCalled());
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/userspace-apps/todo/permissions",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(new Set(body.granted)).toEqual(new Set(["app.net", "app.memory"]));
+    expect(onAllow).toHaveBeenCalledWith(expect.arrayContaining(["app.net", "app.memory"]));
+  });
+
+  it("Deny cancels without granting anything", () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    const onDeny = vi.fn();
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        onAllow={() => {}}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /deny/i }));
+
+    expect(onDeny).toHaveBeenCalledTimes(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("Escape key cancels", () => {
+    const onDeny = vi.fn();
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        onAllow={() => {}}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onDeny).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/apps/StoreApp/PermissionConsent.tsx
+++ b/desktop/src/apps/StoreApp/PermissionConsent.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
+import { grantUserspacePermissions } from "@/lib/userspace-apps";
+
+/**
+ * Capabilities that require explicit user consent before an app can use
+ * them. Mirrors tinyagentos/userspace/capabilities.py GATED_CAPS exactly --
+ * keep in sync if the backend vocabulary changes.
+ */
+export const GATED_CAPS = new Set(["app.net", "app.agent", "app.llm", "app.memory"]);
+
+/**
+ * One-line, human descriptions per capability, for the consent dialog.
+ * Mirrors tinyagentos/userspace/capabilities.py CAPABILITY_DESCRIPTIONS.
+ */
+const CAPABILITY_DESCRIPTIONS: Record<string, string> = {
+  "app.kv": "Store and read its own app data",
+  "app.table": "Store and read its own structured data",
+  "app.files": "Read and write files in its own app folder",
+  "app.notify": "Send you notifications",
+  "app.window": "Open and manage its own windows",
+  "app.net": "Connect to the internet",
+  "app.agent": "Ask your taOS agent for help",
+  "app.llm": "Use a language model",
+  "app.memory": "Read and write your memories",
+};
+
+/** A human one-liner for a capability. Mirrors describe_capability() in
+ * capabilities.py: a `network:<origin>` grant renders as "Connect to
+ * <origin>"; anything unrecognised falls back to the raw token. */
+function describeCapability(cap: string): string {
+  if (cap.startsWith("network:")) return `Connect to ${cap.slice("network:".length)}`;
+  return CAPABILITY_DESCRIPTIONS[cap] ?? cap;
+}
+
+interface Props {
+  appId: string;
+  appName: string;
+  /** The permissions this dialog is asking about (typically new_permissions
+   * from the install response). */
+  requested: string[];
+  /** Permissions already granted before this consent, preserved on Allow so
+   * a re-consent (update) never revokes an earlier grant. */
+  alreadyGranted?: string[];
+  /** Called after the granted permissions have been POSTed. */
+  onAllow: (granted: string[]) => void;
+  /** Called when the user denies or dismisses the dialog; no new permission
+   * is granted. */
+  onDeny: () => void;
+}
+
+export function PermissionConsent({
+  appId,
+  appName,
+  requested,
+  alreadyGranted = [],
+  onAllow,
+  onDeny,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAllow = useCallback(async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const granted = Array.from(new Set([...alreadyGranted, ...requested]));
+      await grantUserspacePermissions(appId, granted);
+      onAllow(granted);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      setSubmitting(false);
+    }
+  }, [appId, alreadyGranted, requested, onAllow]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onDeny();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onDeny();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Permissions for ${appName}`}
+        className="bg-shell-surface border border-white/10 shadow-2xl rounded-2xl w-[26rem] max-w-[90vw] flex flex-col"
+      >
+        <div className="px-5 py-4 border-b border-white/5">
+          <h2 className="text-sm font-semibold text-shell-text">
+            {appName} wants permission to:
+          </h2>
+        </div>
+        <ul className="px-5 py-4 space-y-2.5">
+          {requested.map((cap) => {
+            const sensitive = GATED_CAPS.has(cap);
+            return (
+              <li key={cap} className="flex items-start gap-2 text-[13px]">
+                {sensitive && (
+                  <span aria-hidden className="text-amber-400 leading-tight">
+                    ⚠
+                  </span>
+                )}
+                <span
+                  className={
+                    sensitive
+                      ? "text-shell-text font-medium leading-tight"
+                      : "text-shell-text-secondary leading-tight"
+                  }
+                >
+                  {describeCapability(cap)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+        {error && (
+          <div role="alert" className="mx-5 mb-3 text-[12px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
+            {error}
+          </div>
+        )}
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-white/5">
+          <button
+            type="button"
+            onClick={onDeny}
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-[13px] font-semibold text-shell-text-secondary hover:text-shell-text hover:bg-white/[0.04] transition-colors disabled:opacity-60"
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            onClick={handleAllow}
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-[13px] font-bold text-white transition-colors disabled:opacity-60"
+            style={{ background: "var(--color-accent)" }}
+          >
+            {submitting ? "Allowing…" : "Allow"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default PermissionConsent;

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -16,6 +16,7 @@ import { compatVisuals } from "./compat-visuals";
 import { loadFilter, saveFilter } from "./storage";
 import { emitAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
 import { TaosAppsSection } from "./TaosAppsSection";
+import { ImportAppButton } from "./ImportAppButton";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { MobileStore } from "./MobileStore";
 import { AppIcon, StoreCover } from "./AppIcon";
@@ -1150,6 +1151,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                   <h2 className="text-[17px] font-bold text-shell-text">{searching ? `Results for "${search.trim()}"` : NAV.find((n) => n.id === activeNav)?.label}</h2>
                   <p className="text-[12px] text-shell-text-tertiary mt-0.5">{filtered.length} apps</p>
                 </div>
+                {activeNav === "apps" && !searching && <ImportAppButton />}
               </div>
               {activeNav === "updates" && (() => {
                 const updatableOptional = optionalCatalog.filter((e) => e.installed && e.update_available);

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -97,6 +97,21 @@ export async function grantUserspacePermissions(appId: string, granted: string[]
   if (!res.ok) throw new Error(`granting permissions failed (${res.status})`);
 }
 
+/** Fetch a single installed userspace-app row by id -- used by the install-time
+ * consent dialog to get the app's display name and already-granted
+ * permissions (fresh installs return neither in the install response).
+ * Returns null if the row doesn't exist or the request fails. */
+export async function fetchUserspaceAppRow(appId: string): Promise<UserspaceAppRow | null> {
+  try {
+    const res = await fetch("/api/userspace-apps");
+    if (!res.ok) return null;
+    const rows = (await res.json()) as UserspaceAppRow[];
+    return rows.find((r) => r.app_id === appId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchUserspaceApps(): Promise<AppManifest[]> {
   let rows: UserspaceAppRow[];
   try {


### PR DESCRIPTION
## Summary
- Adds `PermissionConsent` — the install-time consent dialog for userspace apps. Lists each requested capability with a plain-English description mirrored from `tinyagentos/userspace/capabilities.py`, visually flags the gated ones (`app.net`, `app.agent`, `app.llm`, `app.memory`), and Allow/Deny posts the granted set (or nothing) to `POST /api/userspace-apps/{app_id}/permissions`.
- Adds `ImportAppButton` in the Store's Apps tab (next to taOS Apps) so a `.taosapp` package can actually be installed from the UI, and wires the dialog to show whenever the install response has `needs_consent: true`.
- Adds `fetchUserspaceAppRow` to `lib/userspace-apps.ts` so the dialog can show the app's real name and merge with any already-granted permissions (the permissions column is replaced wholesale server-side, not patched).

Completes the M3 frontend for the App Runtime epic (#196); backend permission plumbing was already on `dev`.

## Test plan
- [x] `npx vitest run src/apps/StoreApp/PermissionConsent.test.tsx src/apps/StoreApp/ImportAppButton.test.tsx` — 8 passed
- [x] `npx vitest run` (full desktop suite) — 2365 passed, 285 files
- [x] `npm run build` (tsc -b && vite build) — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an app import button in the Store app so users can install `.taosapp` or `.zip` files directly.
  * Added a permissions consent dialog for apps that request new or sensitive capabilities, with clear allow/deny actions.
* **Bug Fixes**
  * Improved install feedback with loading and error states.
  * Ensured permission prompts only appear when needed, and dismissal behaves consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->