### PR TITLE
feat(userspace): container app tier (App Runtime M4)

### DIFF
--- a/desktop/src/apps/SandboxedAppWindow.tsx
+++ b/desktop/src/apps/SandboxedAppWindow.tsx
@@ -8,6 +8,9 @@ import { defaultProvenanceForTrust, type AppProvenance } from "@/lib/userspace-a
 interface Props {
   windowId: string;
   appId: string;
+  /** "container" apps run their own HTTP backend and are loaded via the
+   * server-side proxy instead of the static bundle. Defaults to "web". */
+  appType?: "web" | "container";
   trust?: "community" | "first-party";
   /** Where the app's code came from. Falls back to defaultProvenanceForTrust(trust)
    * when omitted, so a caller that only knows the legacy `trust` field still
@@ -120,11 +123,16 @@ function readThemeTokens(): Record<string, string> {
 
 export function SandboxedAppWindow({
   appId,
+  appType = "web",
   trust = "community",
   provenance,
   grantedCapabilities = [],
 }: Props) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const iframeSrc =
+    appType === "container"
+      ? `/api/userspace-apps/${encodeURIComponent(appId)}/proxy/`
+      : `/api/userspace-apps/${encodeURIComponent(appId)}/bundle/index.html?app=${encodeURIComponent(appId)}`;
   const isFirstParty = trust === "first-party";
   const resolvedProvenance: AppProvenance = provenance ?? defaultProvenanceForTrust(trust);
   const networkAllowed = hasCapability(resolvedProvenance, "app.net", grantedCapabilities);
@@ -192,7 +200,7 @@ export function SandboxedAppWindow({
       <iframe
         ref={iframeRef}
         title={appId}
-        src={`/api/userspace-apps/${encodeURIComponent(appId)}/bundle/index.html?app=${encodeURIComponent(appId)}`}
+        src={iframeSrc}
         sandbox={computeSandboxAttr(resolvedProvenance)}
         data-provenance={resolvedProvenance}
         className="w-full h-full border-0 bg-white"

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -46,6 +46,7 @@ export function toAppManifest(row: UserspaceAppRow): AppManifest {
           m.SandboxedAppWindow({
             ...props,
             appId: row.app_id,
+            appType: row.app_type,
             trust,
             provenance,
             grantedCapabilities: row.permissions_granted,

--- a/tests/test_container_docker.py
+++ b/tests/test_container_docker.py
@@ -56,6 +56,33 @@ class TestDockerCreate:
             result = await backend.create_container("agent-test", "ubuntu:22.04")
             assert result["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_publishes_ports_bound_to_localhost_only(self):
+        """App Runtime M4: a published port must bind to 127.0.0.1, never
+        0.0.0.0 -- only the controller may reach a container app's backend."""
+        backend = DockerBackend()
+        with patch.object(backend, "_run", new_callable=AsyncMock) as mock:
+            mock.return_value = (0, "container_id")
+            result = await backend.create_container(
+                "taos-app-echo", "myimage:latest", ports=[(13042, 5678)],
+            )
+            assert result["success"] is True
+            call_args = mock.call_args[0][0]
+            assert "-p" in call_args
+            assert "127.0.0.1:13042:5678" in call_args
+            # never publish on all interfaces
+            assert not any(a.startswith("0.0.0.0:") for a in call_args)
+
+    @pytest.mark.asyncio
+    async def test_no_ports_argument_publishes_nothing(self):
+        """Backward compatible: existing agent-deploy callers never pass ports."""
+        backend = DockerBackend()
+        with patch.object(backend, "_run", new_callable=AsyncMock) as mock:
+            mock.return_value = (0, "container_id")
+            await backend.create_container("agent-test", "ubuntu:22.04")
+            call_args = mock.call_args[0][0]
+            assert "-p" not in call_args
+
 
 class TestDockerLifecycle:
     @pytest.mark.asyncio

--- a/tests/test_routes_userspace_apps.py
+++ b/tests/test_routes_userspace_apps.py
@@ -233,8 +233,10 @@ async def test_install_private_url_returns_400(client):
 
 
 @pytest.mark.asyncio
-async def test_install_container_package_returns_501(client):
-    """Container app_type must be rejected with 501."""
+async def test_install_container_package_succeeds(client):
+    """Container app_type installs successfully (App Runtime M4 lifted the old
+    web-only 501 gate). Install does NOT auto-deploy -- the backend container
+    is created on enable -- so no Docker is touched here."""
     await _init_userspace_stores(
         client._transport.app,
         client._transport.app.state.data_dir,
@@ -260,12 +262,25 @@ async def test_install_container_package_returns_501(client):
         zf.writestr("manifest.yaml", manifest)
     pkg = buf.getvalue()
 
-    resp = await client.post(
-        "/api/userspace-apps/install",
-        files={"package": ("container.taosapp", pkg, "application/zip")},
-    )
-    assert resp.status_code == 501
-    assert "container packages are not supported" in resp.json()["error"]
+    # Guard: even though install must not deploy, patch the deployer so a
+    # regression that starts deploying at install time would fail loudly here.
+    with patch(
+        "tinyagentos.routes.userspace_apps.deploy_app_container",
+        new_callable=AsyncMock,
+    ) as deploy:
+        resp = await client.post(
+            "/api/userspace-apps/install",
+            files={"package": ("container.taosapp", pkg, "application/zip")},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["app_id"] == "container-app"
+        deploy.assert_not_awaited()
+
+    # App is recorded as a container app, with no runtime location yet.
+    rows = (await client.get("/api/userspace-apps")).json()
+    row = next(a for a in rows if a["app_id"] == "container-app")
+    assert row["app_type"] == "container"
+    assert row["container_host"] is None and row["container_port"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/userspace/test_container_app.py
+++ b/tests/userspace/test_container_app.py
@@ -1,0 +1,194 @@
+"""App Runtime M4: container app lifecycle -- deploy on enable, destroy on
+disable/uninstall, and the enable/disable route contracts around it.
+
+deploy_app_container / destroy_app_container are patched at the point they
+are imported into tinyagentos.routes.userspace_apps so these tests never
+touch a real Docker daemon.
+"""
+import io
+import zipfile
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+CONTAINER_MANIFEST = (
+    "id: echo\nname: Echo\nversion: 1.0.0\napp_type: container\n"
+    "entry: index.html\nicon: ''\npermissions: []\n"
+    "container:\n  image: docker.io/hashicorp/http-echo:latest\n  ports: [5678]\n"
+)
+
+
+def _zip(manifest=CONTAINER_MANIFEST):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("manifest.yaml", manifest)
+        z.writestr("index.html", "x")
+    return buf.getvalue()
+
+
+async def _install(client):
+    r = await client.post(
+        "/api/userspace-apps/install",
+        files={"package": ("echo.taosapp", _zip(), "application/zip")},
+    )
+    assert r.status_code == 200, r.text
+    return r
+
+
+@pytest.mark.asyncio
+async def test_install_does_not_deploy_a_container(client):
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        await _install(client)
+        deploy.assert_not_awaited()
+    apps = (await client.get("/api/userspace-apps")).json()
+    echo = next(a for a in apps if a["app_id"] == "echo")
+    assert echo["container_host"] is None and echo["container_port"] is None
+
+
+@pytest.mark.asyncio
+async def test_enable_deploys_backend_and_records_runtime_location(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        r = await client.post("/api/userspace-apps/echo/enable")
+        assert r.status_code == 200, r.text
+        deploy.assert_awaited_once()
+        # the image from the manifest's container block reached deploy_app_container
+        assert "http-echo" in str(deploy.await_args)
+
+    apps = (await client.get("/api/userspace-apps")).json()
+    echo = next(a for a in apps if a["app_id"] == "echo")
+    assert echo["container_host"] == "127.0.0.1" and echo["container_port"] == 13042
+    assert echo["enabled"]
+
+
+@pytest.mark.asyncio
+async def test_enable_failure_keeps_app_disabled_and_reports_error(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": False, "error": "image not found"}
+        r = await client.post("/api/userspace-apps/echo/enable")
+        assert r.status_code == 502
+        assert r.json()["error"] == "image not found"
+
+    apps = (await client.get("/api/userspace-apps")).json()
+    echo = next(a for a in apps if a["app_id"] == "echo")
+    # Not left half-enabled: enabled flips back off, no runtime location.
+    assert not echo["enabled"]
+    assert echo["container_host"] is None and echo["container_port"] is None
+
+
+@pytest.mark.asyncio
+async def test_docker_missing_is_graceful_on_enable(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {
+            "success": False,
+            "error": "Docker is required to run container apps but was not found.",
+        }
+        r = await client.post("/api/userspace-apps/echo/enable")
+        assert r.status_code == 502
+        assert "Docker" in r.json()["error"]
+    apps = (await client.get("/api/userspace-apps")).json()
+    assert not next(a for a in apps if a["app_id"] == "echo")["enabled"]
+
+
+@pytest.mark.asyncio
+async def test_disable_destroys_backend_and_clears_runtime_location(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        await client.post("/api/userspace-apps/echo/enable")
+
+    with patch("tinyagentos.routes.userspace_apps.destroy_app_container",
+               new_callable=AsyncMock) as destroy:
+        r = await client.post("/api/userspace-apps/echo/disable")
+        assert r.status_code == 200
+        destroy.assert_awaited_once()
+        assert destroy.await_args.args[0] == "echo"
+
+    apps = (await client.get("/api/userspace-apps")).json()
+    echo = next(a for a in apps if a["app_id"] == "echo")
+    assert not echo["enabled"]
+    assert echo["container_host"] is None and echo["container_port"] is None
+
+
+@pytest.mark.asyncio
+async def test_uninstall_destroys_container_app_backend_first(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        await client.post("/api/userspace-apps/echo/enable")
+
+    with patch("tinyagentos.routes.userspace_apps.destroy_app_container",
+               new_callable=AsyncMock) as destroy:
+        r = await client.delete("/api/userspace-apps/echo")
+        assert r.status_code == 200
+        destroy.assert_awaited_once()
+        assert destroy.await_args.args[0] == "echo"
+
+    apps = (await client.get("/api/userspace-apps")).json()
+    assert all(a["app_id"] != "echo" for a in apps)
+
+
+@pytest.mark.asyncio
+async def test_web_app_enable_never_touches_container_deploy(client):
+    web = "id: w\nname: W\nversion: 1\napp_type: web\nentry: index.html\nicon: ''\npermissions: []\n"
+    r = await client.post("/api/userspace-apps/install",
+                          files={"package": ("w.taosapp", _zip(web), "application/zip")})
+    assert r.status_code == 200
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        r = await client.post("/api/userspace-apps/w/enable")
+        assert r.status_code == 200
+        deploy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwards_only_to_recorded_runtime_location(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        await client.post("/api/userspace-apps/echo/enable")
+
+    captured = {}
+
+    class _FakeUpstreamResponse:
+        status_code = 200
+        headers = {"content-type": "text/plain"}
+
+        async def aiter_bytes(self):
+            yield b"hello from echo"
+
+        async def aclose(self):
+            pass
+
+    async def _fake_send(req, **kwargs):
+        captured["url"] = str(req.url)
+        return _FakeUpstreamResponse()
+
+    # Patch only the proxy's own client instance -- patching AsyncClient.send
+    # on the class would also intercept the test client's ASGI requests.
+    with patch("tinyagentos.routes.userspace_apps._container_proxy_client.send", new=_fake_send):
+        r = await client.get("/api/userspace-apps/echo/proxy/status")
+
+    assert r.status_code == 200
+    assert r.content == b"hello from echo"
+    # the proxy only ever targets the exact recorded 127.0.0.1:<port> location
+    assert captured["url"] == "http://127.0.0.1:13042/status"
+    # sandbox CSP is applied to the proxied response too
+    assert "sandbox" in r.headers.get("content-security-policy", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_proxy_404s_when_no_runtime_location(client):
+    await _install(client)  # installed, but never enabled -- no runtime location
+    r = await client.get("/api/userspace-apps/echo/proxy/")
+    assert r.status_code == 404

--- a/tests/userspace/test_container_app.py
+++ b/tests/userspace/test_container_app.py
@@ -192,3 +192,49 @@ async def test_proxy_404s_when_no_runtime_location(client):
     await _install(client)  # installed, but never enabled -- no runtime location
     r = await client.get("/api/userspace-apps/echo/proxy/")
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_proxy_strips_taos_session_even_from_malformed_cookie(client):
+    # A malformed Cookie header must NOT leak the taos_session credential to
+    # the untrusted container backend, even when it is not valid cookie
+    # grammar (the scrub is textual, never SimpleCookie-dependent).
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        await client.post("/api/userspace-apps/echo/enable")
+
+    captured = {}
+
+    class _FakeUpstreamResponse:
+        status_code = 200
+        headers = {"content-type": "text/plain"}
+
+        async def aiter_bytes(self):
+            yield b"ok"
+
+        async def aclose(self):
+            pass
+
+    async def _fake_send(req, **kwargs):
+        captured["cookie"] = req.headers.get("cookie", "")
+        return _FakeUpstreamResponse()
+
+    # Include the REAL session cookie (so auth passes) inside an otherwise
+    # malformed Cookie header that would trip SimpleCookie.load. taos_session
+    # is exactly what must be scrubbed before the request reaches the backend.
+    session_token = client.cookies.get("taos_session")
+    malformed = f"taos_session={session_token}; bad==value; keep=1; ;;"
+    with patch("tinyagentos.routes.userspace_apps._container_proxy_client.send", new=_fake_send):
+        r = await client.get(
+            "/api/userspace-apps/echo/proxy/status",
+            headers={"Cookie": malformed},
+        )
+
+    assert r.status_code == 200
+    # taos_session (and its value) must never reach the backend...
+    assert "taos_session" not in captured["cookie"]
+    assert session_token not in captured["cookie"]
+    # ...while an unrelated cookie is still forwarded.
+    assert "keep=1" in captured["cookie"]

--- a/tests/userspace/test_container_deploy.py
+++ b/tests/userspace/test_container_deploy.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from tinyagentos.userspace import container_deploy as cd
+
+
+@pytest.mark.asyncio
+async def test_deploy_publishes_first_port_bound_to_localhost_and_applies_caps():
+    with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
+         patch.object(cd, "_find_free_port", return_value=13042), \
+         patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
+        create.return_value = {"success": True, "name": "taos-app-echo"}
+        out = await cd.deploy_app_container("echo", {"image": "hashicorp/http-echo:latest", "ports": [5678]})
+        assert out == {"success": True, "host": "127.0.0.1", "port": 13042}
+        kwargs = create.call_args.kwargs
+        args = create.call_args.args
+        assert args[0] == "taos-app-echo"
+        assert kwargs["image"] == "hashicorp/http-echo:latest"
+        # (host_port, container_port) tuple reached the backend -- the actual
+        # 127.0.0.1-only binding is enforced inside DockerBackend.create_container
+        # (see test_docker_backend.py), not re-verified here.
+        assert kwargs["ports"] == [(13042, 5678)]
+        # untrusted app backend gets a conservative, fixed resource cap
+        assert kwargs["memory_limit"] == "512m"
+        assert kwargs["cpu_limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_deploy_fails_cleanly_without_docker():
+    with patch.object(cd.shutil, "which", return_value=None):
+        out = await cd.deploy_app_container("echo", {"image": "x", "ports": [5678]})
+        assert out["success"] is False
+        assert "Docker" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_deploy_propagates_backend_error():
+    with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
+         patch.object(cd, "_find_free_port", return_value=13042), \
+         patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
+        create.return_value = {"success": False, "error": "image not found"}
+        out = await cd.deploy_app_container("echo", {"image": "nope", "ports": [5678]})
+        assert out["success"] is False and out["error"] == "image not found"
+
+
+@pytest.mark.asyncio
+async def test_deploy_retries_on_port_race():
+    with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
+         patch.object(cd, "_find_free_port", side_effect=[13042, 13043]), \
+         patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
+        create.side_effect = [
+            {"success": False, "error": "port is already allocated"},
+            {"success": True, "name": "taos-app-echo"},
+        ]
+        out = await cd.deploy_app_container("echo", {"image": "x", "ports": [5678]})
+        assert out == {"success": True, "host": "127.0.0.1", "port": 13043}
+        assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_destroy_calls_backend_remove():
+    with patch.object(cd.DockerBackend, "destroy_container", new_callable=AsyncMock) as rm:
+        await cd.destroy_app_container("echo")
+        rm.assert_awaited_once()
+        assert rm.call_args.args[-1] == "taos-app-echo"

--- a/tests/userspace/test_container_manifest.py
+++ b/tests/userspace/test_container_manifest.py
@@ -1,0 +1,46 @@
+import pytest
+from tinyagentos.userspace.package import parse_manifest, PackageError
+
+VALID_CONTAINER = (
+    "id: echo\nname: Echo\nversion: 1.0.0\napp_type: container\n"
+    "container:\n  image: docker.io/hashicorp/http-echo:latest\n  ports: [5678]\n"
+)
+
+
+def test_valid_container_manifest_roundtrip():
+    m = parse_manifest(VALID_CONTAINER)
+    assert m["container"]["image"] == "docker.io/hashicorp/http-echo:latest"
+    assert m["container"]["ports"] == [5678]
+
+
+def test_container_app_no_container_block():
+    with pytest.raises(PackageError, match="container"):
+        parse_manifest("id: x\nname: X\nversion: 1\napp_type: container\n")
+
+
+def test_container_block_missing_image():
+    with pytest.raises(PackageError, match="container.image"):
+        parse_manifest(
+            "id: x\nname: X\nversion: 1\napp_type: container\n"
+            "container:\n  ports: [8080]\n"
+        )
+
+
+@pytest.mark.parametrize("ports_yaml,label", [
+    ("", "missing"),
+    ("  ports: []\n", "empty list"),
+    ("  ports: [x]\n", "non-int element"),
+    ("  ports: [true]\n", "bool element"),
+])
+def test_container_block_bad_ports(ports_yaml, label):
+    yaml_text = (
+        "id: x\nname: X\nversion: 1\napp_type: container\n"
+        "container:\n  image: foo\n" + ports_yaml
+    )
+    with pytest.raises(PackageError, match="container.ports"):
+        parse_manifest(yaml_text)
+
+
+def test_web_app_no_container_block_parses_fine():
+    m = parse_manifest("id: t\nname: T\nversion: 1\napp_type: web\n")
+    assert m["app_type"] == "web"

--- a/tests/userspace/test_routes.py
+++ b/tests/userspace/test_routes.py
@@ -110,7 +110,7 @@ async def test_install_pins_connection_to_resolved_ip(client):
 def _container_zip():
     manifest = (
         "id: ctapp\nname: ContainerApp\nversion: 1.0.0\napp_type: container\n"
-        "entry: index.html\nicon: \npermissions: []\n"
+        "entry: index.html\nicon: ''\npermissions: []\n"
         "container:\n  image: myimage:latest\n  ports: [8080]\n"
     )
     buf = io.BytesIO()
@@ -121,19 +121,22 @@ def _container_zip():
 
 
 @pytest.mark.asyncio
-async def test_container_install_rejected_with_no_stored_state(client):
-    # Finding 3: installing a container package must return 501 before
-    # persisting anything -- no app row and no extracted directory must remain.
+async def test_container_install_no_longer_gated(client):
+    # App Runtime M4: container packages are no longer rejected at install --
+    # see tests/userspace/test_container_app.py for the full deploy/enable/
+    # disable/uninstall lifecycle. This just confirms the old 501 gate is gone
+    # and the app is stored (not auto-deployed at install time).
     r = await client.post(
         "/api/userspace-apps/install",
         files={"package": ("ctapp.taosapp", _container_zip(), "application/zip")},
     )
-    assert r.status_code == 501
-    assert "container" in r.json()["error"].lower()
+    assert r.status_code == 200, r.text
+    assert r.json()["app_id"] == "ctapp"
 
-    # No app row stored.
     rows = (await client.get("/api/userspace-apps")).json()
-    assert all(a["app_id"] != "ctapp" for a in rows)
+    row = next(a for a in rows if a["app_id"] == "ctapp")
+    assert row["app_type"] == "container"
+    assert row["container_host"] is None and row["container_port"] is None
 
 
 def _net_zip():

--- a/tinyagentos/containers/docker.py
+++ b/tinyagentos/containers/docker.py
@@ -133,6 +133,7 @@ class DockerBackend(ContainerBackend):
         env: dict[str, str] | None = None,
         host_uid: int | None = None,
         root_size_gib: int | None = None,
+        ports: list[tuple[int, int]] | None = None,
     ) -> dict:
         """Create and start a new container.
 
@@ -142,6 +143,11 @@ class DockerBackend(ContainerBackend):
         root_size_gib: when set, call set_root_quota after the container
         is created. Enforcement depends on the Docker storage driver;
         on overlay2 without pquota this is accounting-only.
+
+        ports: list of (host_port, container_port) pairs to publish. Each is
+        bound to 127.0.0.1 ONLY -- never 0.0.0.0 -- so a published port is
+        reachable from this host alone (the controller proxies to it); it
+        must never be reachable off-host.
         """
         args = [
             self.binary, "run", "-d",
@@ -155,6 +161,8 @@ class DockerBackend(ContainerBackend):
             args += ["-v", f"{host_path}:{container_path}"]
         for key, value in (env or {}).items():
             args += ["-e", f"{key}={value}"]
+        for host_port, container_port in ports or []:
+            args += ["-p", f"127.0.0.1:{host_port}:{container_port}"]
         args.append(image)
         code, output = await self._run(args, timeout=300)
         if code != 0:

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -8,12 +8,14 @@ from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Form, Request, UploadFile, File
-from fastapi.responses import JSONResponse, FileResponse, Response
+from fastapi.responses import JSONResponse, FileResponse, RedirectResponse, Response, StreamingResponse
+from starlette.background import BackgroundTask
 
 from tinyagentos.code_analyzer import analyze_app_source, has_critical
 from tinyagentos.userspace.broker import handle_capability, GATED_CAPS
 from tinyagentos.userspace.capabilities import capability_ceiling, default_provenance_for_trust
-from tinyagentos.userspace.package import extract_package, PackageError
+from tinyagentos.userspace.container_deploy import deploy_app_container, destroy_app_container
+from tinyagentos.userspace.package import extract_package, parse_manifest, PackageError
 from tinyagentos.userspace.url_guard import resolve_safe_public_ip
 
 # Provenance values a caller may set through the PUBLIC install endpoint. Never
@@ -171,36 +173,32 @@ async def install_app(
         manifest = extract_package(data, apps_root=_apps_root(request))
     except PackageError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
-    # Reject container packages before persisting anything -- no partial state.
-    if manifest["app_type"] == "container":
-        return JSONResponse(
-            {"error": "container packages are not supported in this release (web-only)"},
-            status_code=501,
-        )
     apps_root = _apps_root(request).resolve()
     app_dir = (apps_root / manifest["id"]).resolve()
     # Static security gate: this runs server-side on every install regardless
-    # of how the package was submitted (upload or source_url) or its
-    # app_type, so a modified/bypassed client can never skip it and a future
-    # app_type can never silently bypass it. Unconditional is also cheap and
-    # correct here -- "container" is already rejected above, and "tui"
-    # packages ship no _ANALYZABLE_EXTENSIONS files (just a manifest.yaml +
-    # command spec), so _collect_source_files() naturally finds nothing to
-    # scan for them. A critical finding blocks the install outright -- the
-    # extracted files are removed so nothing scanned-and-rejected is left
-    # reachable via serve_bundle. This is defense in depth in FRONT of the
-    # sandbox iframe, not a replacement for it.
-    findings = analyze_app_source(_collect_source_files(app_dir))
-    if has_critical(findings):
-        if app_dir.is_relative_to(apps_root) and app_dir != apps_root:
-            shutil.rmtree(app_dir, ignore_errors=True)
-        return JSONResponse(
-            {
-                "error": "blocked_by_security_analysis",
-                "findings": [f.to_dict() for f in findings],
-            },
-            status_code=422,
-        )
+    # of how the package was submitted (upload or source_url), so a
+    # modified/bypassed client can never skip it. Container apps ship an
+    # opaque Docker image (not analyzable source) and are skipped here --
+    # their isolation comes from the container boundary, not this scanner.
+    # "tui" packages ship no _ANALYZABLE_EXTENSIONS files (just a
+    # manifest.yaml + command spec), so _collect_source_files() naturally
+    # finds nothing to scan for them. A critical finding blocks the install
+    # outright -- the extracted files are removed so nothing
+    # scanned-and-rejected is left reachable via serve_bundle. This is
+    # defense in depth in FRONT of the sandbox iframe, not a replacement
+    # for it.
+    if manifest["app_type"] != "container":
+        findings = analyze_app_source(_collect_source_files(app_dir))
+        if has_critical(findings):
+            if app_dir.is_relative_to(apps_root) and app_dir != apps_root:
+                shutil.rmtree(app_dir, ignore_errors=True)
+            return JSONResponse(
+                {
+                    "error": "blocked_by_security_analysis",
+                    "findings": [f.to_dict() for f in findings],
+                },
+                status_code=422,
+            )
     existing = await store.get(manifest["id"])
     # A public install must never replace an app installed as first-party: that
     # would let an attacker overwrite a trusted studio's bundle (and, before the
@@ -309,21 +307,67 @@ async def set_permissions(request: Request, app_id: str):
     return {"status": "ok", "granted": safe}
 
 
+def _load_container_spec(app_dir: Path) -> dict | None:
+    """Re-parse the installed package's manifest.yaml to recover its
+    container block (image + ports). Not persisted in the store row --
+    extract_package already wrote manifest.yaml alongside the app's other
+    files, so it's re-read here rather than adding new store columns."""
+    manifest_path = app_dir / "manifest.yaml"
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = parse_manifest(manifest_path.read_text(encoding="utf-8"))
+    except (PackageError, OSError):
+        return None
+    return manifest.get("container")
+
+
 @router.post("/api/userspace-apps/{app_id}/enable")
 async def enable_app(request: Request, app_id: str):
-    await request.app.state.userspace_apps.set_enabled(app_id, True)
+    store = request.app.state.userspace_apps
+    app = await store.get(app_id)
+    if app is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.set_enabled(app_id, True)
+    if app["app_type"] == "container":
+        container_spec = _load_container_spec(_apps_root(request) / app_id)
+        if container_spec is None:
+            await store.set_enabled(app_id, False)
+            return JSONResponse(
+                {"error": "container app manifest missing or invalid"}, status_code=500
+            )
+        result = await deploy_app_container(app_id, container_spec)
+        if not result.get("success"):
+            # Do not leave a half-enabled app claiming to run.
+            await store.set_enabled(app_id, False)
+            return JSONResponse(
+                {"error": result.get("error", "container deploy failed")}, status_code=502
+            )
+        await store.set_runtime_location(app_id, result["host"], result["port"])
     return {"status": "ok"}
 
 
 @router.post("/api/userspace-apps/{app_id}/disable")
 async def disable_app(request: Request, app_id: str):
-    await request.app.state.userspace_apps.set_enabled(app_id, False)
+    store = request.app.state.userspace_apps
+    app = await store.get(app_id)
+    if app is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if app["app_type"] == "container":
+        await destroy_app_container(app_id)
+        await store.set_runtime_location(app_id, None, None)
+    await store.set_enabled(app_id, False)
     return {"status": "ok"}
 
 
 @router.delete("/api/userspace-apps/{app_id}")
 async def uninstall_app(request: Request, app_id: str):
     store = request.app.state.userspace_apps
+    app = await store.get(app_id)
+    if app is not None and app["app_type"] == "container":
+        # Best-effort: tear down the backend container before removing the
+        # store record and files, so nothing is left running unreferenced.
+        await destroy_app_container(app_id)
     removed = await store.uninstall(app_id)
     root = _apps_root(request).resolve()
     app_dir = (root / app_id).resolve()
@@ -357,6 +401,121 @@ async def serve_bundle(request: Request, app_id: str, path: str):
     resp.headers["Content-Security-Policy"] = _bundle_csp(net_origins, provenance)
     resp.headers["X-Content-Type-Options"] = "nosniff"
     return resp
+
+
+# Hop-by-hop headers must not be forwarded between the proxy and the
+# upstream/client (RFC 2616 §13.5.1). Authorization is stripped too, and the
+# taos_session cookie is scrubbed out of Cookie -- an untrusted container-app
+# backend must never see the controller session credential.
+_PROXY_HOP_BY_HOP = frozenset({
+    "connection", "keep-alive", "proxy-authorization", "te",
+    "trailer", "transfer-encoding", "upgrade", "host",
+})
+_PROXY_SENSITIVE_HEADERS = frozenset({"authorization"})
+_PROXY_STRIPPED_COOKIES = frozenset({"taos_session"})
+
+# Module-level HTTP client for the container-app proxy -- avoids per-request
+# connection churn, mirrors service_proxy.py's pattern.
+_container_proxy_client = httpx.AsyncClient(timeout=60.0)
+
+
+def _strip_taos_session_cookie(cookie_header: str) -> str:
+    if not cookie_header:
+        return ""
+    from http.cookies import SimpleCookie
+    jar = SimpleCookie()
+    try:
+        jar.load(cookie_header)
+    except Exception:
+        return cookie_header
+    for name in _PROXY_STRIPPED_COOKIES:
+        jar.pop(name, None)
+    return "; ".join(f"{k}={m.value}" for k, m in jar.items())
+
+
+def _filter_proxy_headers(headers: dict) -> dict:
+    filtered: dict[str, str] = {}
+    for k, v in headers.items():
+        kl = k.lower()
+        if kl in _PROXY_HOP_BY_HOP or kl in _PROXY_SENSITIVE_HEADERS:
+            continue
+        if kl == "cookie":
+            stripped = _strip_taos_session_cookie(v)
+            if not stripped:
+                continue
+            filtered[k] = stripped
+            continue
+        filtered[k] = v
+    return filtered
+
+
+@router.get("/api/userspace-apps/{app_id}/proxy", include_in_schema=False)
+async def proxy_no_slash_redirect(app_id: str):
+    """Redirect /proxy -> /proxy/ so the container app's relative links work."""
+    return RedirectResponse(url=f"/api/userspace-apps/{app_id}/proxy/", status_code=307)
+
+
+@router.api_route(
+    "/api/userspace-apps/{app_id}/proxy/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+    include_in_schema=False,
+)
+async def proxy_container_app(request: Request, app_id: str, path: str):
+    # Store lookup FIRST (same reasoning as serve_bundle): nothing is
+    # forwarded until the app is installed, enabled, a container app, and has
+    # a recorded runtime location.
+    app = await request.app.state.userspace_apps.get(app_id)
+    if (
+        app is None
+        or app["app_type"] != "container"
+        or not app["enabled"]
+        or not app.get("container_host")
+        or not app.get("container_port")
+    ):
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    # SECURITY: the proxy target is built ONLY from the recorded runtime
+    # location (always 127.0.0.1:<port>, set by deploy_app_container) -- never
+    # from client-controlled input. This is what rules out SSRF here.
+    host = app["container_host"]
+    port = app["container_port"]
+    upstream = f"http://{host}:{port}/{path}"
+    if request.url.query:
+        upstream = f"{upstream}?{request.url.query}"
+
+    fwd_headers = _filter_proxy_headers(dict(request.headers))
+
+    async def _stream_body():
+        async for chunk in request.stream():
+            yield chunk
+
+    try:
+        req = _container_proxy_client.build_request(
+            method=request.method, url=upstream, headers=fwd_headers, content=_stream_body(),
+        )
+        upstream_resp = await _container_proxy_client.send(req, stream=True, follow_redirects=False)
+    except httpx.ConnectError:
+        return JSONResponse(
+            {"error": f"cannot reach app '{app_id}' -- it may be stopped or still starting"},
+            status_code=502,
+        )
+    except httpx.TimeoutException:
+        return JSONResponse({"error": f"app '{app_id}' timed out"}, status_code=504)
+
+    resp_headers = _filter_proxy_headers(dict(upstream_resp.headers))
+    granted = app.get("permissions_granted") or []
+    net_origins = [p[len("network:"):] for p in granted
+                   if isinstance(p, str) and p.startswith("network:")]
+    provenance = app.get("provenance") or default_provenance_for_trust(app.get("trust"))
+    resp_headers["Content-Security-Policy"] = _bundle_csp(net_origins, provenance)
+    resp_headers["X-Content-Type-Options"] = "nosniff"
+
+    return StreamingResponse(
+        upstream_resp.aiter_bytes(),
+        status_code=upstream_resp.status_code,
+        headers=resp_headers,
+        background=BackgroundTask(upstream_resp.aclose),
+    )
 
 
 @router.get("/api/userspace-apps/{app_id}/icon")

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -420,17 +420,21 @@ _container_proxy_client = httpx.AsyncClient(timeout=60.0)
 
 
 def _strip_taos_session_cookie(cookie_header: str) -> str:
+    # Textual scrub that does not depend on SimpleCookie's grammar: a
+    # malformed Cookie header must still have taos_session removed, never
+    # forwarded whole (SimpleCookie.load could raise and leak the credential).
     if not cookie_header:
         return ""
-    from http.cookies import SimpleCookie
-    jar = SimpleCookie()
-    try:
-        jar.load(cookie_header)
-    except Exception:
-        return cookie_header
-    for name in _PROXY_STRIPPED_COOKIES:
-        jar.pop(name, None)
-    return "; ".join(f"{k}={m.value}" for k, m in jar.items())
+    kept = []
+    for part in cookie_header.split(";"):
+        stripped = part.strip()
+        if not stripped:
+            continue
+        name = stripped.split("=", 1)[0].strip()
+        if name in _PROXY_STRIPPED_COOKIES:
+            continue
+        kept.append(stripped)
+    return "; ".join(kept)
 
 
 def _filter_proxy_headers(headers: dict) -> dict:

--- a/tinyagentos/userspace/container_deploy.py
+++ b/tinyagentos/userspace/container_deploy.py
@@ -1,0 +1,80 @@
+"""Generic container-app deploy — SEPARATE from the agent deployer.
+
+Launches a userspace app's backend as a Docker container. No agent
+environment (no LiteLLM / skills / AGENTS.md / bridge). Shares only the
+low-level tinyagentos.containers Docker primitive. The agent deploy path
+(deployer.py, incus) is intentionally not reused here.
+"""
+from __future__ import annotations
+
+import shutil
+import socket
+from contextlib import closing
+
+from tinyagentos.containers.docker import DockerBackend
+
+# Untrusted third-party app backends get a conservative, fixed resource cap --
+# there is no per-app config for this today and these apps are not vetted the
+# way agent containers are.
+_MEMORY_LIMIT = "512m"
+_CPU_LIMIT = 1
+
+
+def _find_free_port(start: int = 13000, end: int = 14000) -> int:
+    for port in range(start, end):
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("no free port available in range")
+
+
+def _app_container_name(app_id: str) -> str:
+    return f"taos-app-{app_id}"
+
+
+async def deploy_app_container(app_id: str, container_spec: dict) -> dict:
+    """Deploy a userspace app's backend container via Docker.
+
+    container_spec: {"image": str, "ports": [int, ...]} (already validated
+    at manifest-parse time). The first port is the app's service port.
+    Returns {"success": True, "host": "127.0.0.1", "port": <host_port>}
+    or {"success": False, "error": str}.
+    """
+    if shutil.which("docker") is None:
+        return {"success": False,
+                "error": "Docker is required to run container apps but was not found. "
+                         "Install Docker (taOS installs it by default) and retry."}
+    image = container_spec["image"]
+    container_port = int(container_spec["ports"][0])
+    name = _app_container_name(app_id)
+    backend = DockerBackend("docker")
+
+    # Find a free host port and publish container_port to it, bound to
+    # 127.0.0.1 only (enforced inside DockerBackend.create_container). Retry
+    # on the narrow TOCTOU window where the chosen port gets taken before
+    # docker binds.
+    last_error = "deploy failed"
+    for _ in range(3):
+        host_port = _find_free_port()
+        result = await backend.create_container(
+            name,
+            image=image,
+            ports=[(host_port, container_port)],
+            memory_limit=_MEMORY_LIMIT,
+            cpu_limit=_CPU_LIMIT,
+        )
+        if result.get("success"):
+            return {"success": True, "host": "127.0.0.1", "port": host_port}
+        last_error = result.get("error", "container create failed")
+        if "port is already allocated" not in last_error and "address already in use" not in last_error:
+            break  # a non-port error won't be fixed by retrying
+    return {"success": False, "error": last_error}
+
+
+async def destroy_app_container(app_id: str) -> None:
+    """Remove an app's backend container (idempotent). Best-effort."""
+    backend = DockerBackend("docker")
+    await backend.destroy_container(_app_container_name(app_id))


### PR DESCRIPTION
## Summary
- Lifts the `501 "container packages are not supported in this release (web-only)"` gate on install: container-type `.taosapp` packages are now parsed, extracted, and registered like web apps. The static security analyzer (`analyze_app_source`) still runs unconditionally for web packages -- it is only skipped for container packages, which ship an opaque Docker image rather than analyzable source.
- Container apps are installed but **not** auto-deployed. `POST /{app_id}/enable` re-reads the app's `manifest.yaml` for its `container` block and calls the new `deploy_app_container()`, recording the resulting `container_host`/`container_port` via the existing `set_runtime_location`. A failed deploy (bad image, Docker missing) flips the app back to `enabled=false` and returns the error -- it never leaves a half-enabled app claiming to run. `disable`/`uninstall` call `destroy_app_container()` (best-effort) and clear the runtime location.
- New `tinyagentos/userspace/container_deploy.py`: finds a free `127.0.0.1` port (retrying on the create/bind TOCTOU race), deploys via `DockerBackend.create_container(..., ports=[(host_port, container_port)])`, and applies fixed resource caps (`memory_limit="512m"`, `cpu_limit=1`) since these are untrusted third-party backends with no per-app resource config today. Gracefully reports an error (no raise) when `docker` isn't on `PATH`.
- `DockerBackend.create_container` gains an optional `ports: list[tuple[int, int]] | None` parameter. Each pair is published with `-p 127.0.0.1:{host}:{container}` -- **never `0.0.0.0`** -- so a container app's backend is reachable only from the host itself; the controller is the only thing that proxies to it. Backward compatible (`None` default, existing agent-deploy callers unaffected).
- New proxy route `GET/POST/PUT/DELETE/PATCH/HEAD/OPTIONS /api/userspace-apps/{app_id}/proxy/{path:path}`: looks up the app in the store first (404 if not installed/enabled/no runtime location), then forwards only to the exact recorded `container_host:container_port` (always `127.0.0.1:<port>`) -- never built from client input, so there's no SSRF surface here. Strips hop-by-hop headers, `Authorization`, and the `taos_session` cookie before forwarding (an untrusted container backend must never see the controller session credential), and applies the same sandbox CSP `serve_bundle` uses to the proxied response.
- Frontend: `SandboxedAppWindow` takes an `appType` prop; container apps load their iframe from the proxy URL (`/api/userspace-apps/{id}/proxy/`) instead of the static bundle. Touched only the minimal lines needed for URL selection.

### Security posture
- Container app backends are reachable **only** via `127.0.0.1` on the host -- never `0.0.0.0` -- and only the controller's proxy route talks to them.
- Fixed resource caps (`512m` memory, `1` CPU) on every container-app deploy.
- The proxy target is always the store's recorded runtime location, never client-supplied, closing off SSRF via this route.
- Session cookie and `Authorization` are stripped before any request reaches a container-app backend.
- The static source security analyzer intentionally does **not** scan container images -- that boundary is the container itself, not text-based static analysis. A known gap: there's no network-egress restriction on a container app's outbound connections yet; that's a natural follow-up rather than something this PR claims to solve.

This completes M4 of the App Runtime plan (#196).

## Test plan
- [x] `pytest tests/userspace/ -q` -- 148 passed (includes 3 new files: `test_container_app.py`, `test_container_deploy.py`, `test_container_manifest.py`, plus updated `test_routes.py` and `tests/test_container_docker.py`)
- [x] `python -c "import tinyagentos.userspace.container_deploy, tinyagentos.routes.userspace_apps, tinyagentos.containers.docker"` -- clean
- [x] `cd desktop && npm run build` -- clean (tsc + vite)
- [x] `npx vitest run` on `SandboxedAppWindow` + `userspace-apps` -- 24 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for container-based apps, including install, enable/disable, uninstall, and proxy access.
  * Apps now select the correct iframe source URL based on app type, and container apps can be proxied via `/proxy/*`.
* **Bug Fixes**
  * Published container ports are now bound to `127.0.0.1` only; proxy forwarding is limited to recorded runtime locations.
  * Proxy strips `taos_session` from cookies and applies safer response headers with improved 502/504 handling.
* **Tests**
  * Added/extended coverage for container port binding, deployment/teardown, manifest parsing, install behavior, and proxy cookie scrubbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->