### PR TITLE
fix(texteditor): restore create/save of notes and documents (#1584)

### DIFF
--- a/desktop/src/apps/TextEditorApp.tsx
+++ b/desktop/src/apps/TextEditorApp.tsx
@@ -19,6 +19,17 @@ interface Note {
 
 const STORAGE_KEY = "tinyagentos-notes";
 
+// crypto.randomUUID() only exists in secure contexts (https, or localhost).
+// taOS is normally reached over plain http (e.g. http://taos.local:6969), so
+// window.crypto.randomUUID is undefined there and calling it threw inside the
+// click handler, silently killing note creation. Fall back to a non-crypto id.
+function newNoteId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `note-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function loadNotes(): Note[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -199,7 +210,7 @@ export function TextEditorApp({ windowId: _windowId }: { windowId: string }) {
 
   const createNote = useCallback(() => {
     const note: Note = {
-      id: crypto.randomUUID(),
+      id: newNoteId(),
       content: "# New Note\n\nStart writing...",
       updatedAt: Date.now(),
     };

--- a/desktop/src/apps/__tests__/TextEditorApp.test.tsx
+++ b/desktop/src/apps/__tests__/TextEditorApp.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+import { TextEditorApp } from "../TextEditorApp";
+
+describe("TextEditorApp", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(window, "fetch").mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a note and shows it in the sidebar (crypto.randomUUID available)", () => {
+    render(<TextEditorApp windowId="w1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /create your first note/i }));
+
+    // The new note becomes the active/selected entry, with a delete affordance
+    // in the sidebar keyed to its (unique) title.
+    expect(screen.getByRole("button", { name: "Delete New Note" })).toBeInTheDocument();
+
+    // Persisted to localStorage so it survives a reload.
+    const stored = JSON.parse(localStorage.getItem("tinyagentos-notes") ?? "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toContain("New Note");
+  });
+
+  it("still creates a note when crypto.randomUUID is unavailable (insecure-context regression, #1584)", () => {
+    // taOS is normally served over plain http (e.g. http://taos.local:6969),
+    // which is not a "secure context" per the spec, so window.crypto.randomUUID
+    // is undefined there. Simulate that and confirm note creation still works
+    // instead of silently throwing inside the click handler.
+    // randomUUID lives on the Crypto prototype, not as an own property, so
+    // `delete crypto.randomUUID` is a silent no-op — shadow it with an own
+    // property instead to faithfully simulate the missing API.
+    const originalRandomUUID = crypto.randomUUID;
+    Object.defineProperty(crypto, "randomUUID", { value: undefined, configurable: true });
+
+    try {
+      render(<TextEditorApp windowId="w1" />);
+
+      fireEvent.click(screen.getByRole("button", { name: /create your first note/i }));
+
+      expect(screen.getAllByText("New Note").length).toBeGreaterThan(0);
+      const stored = JSON.parse(localStorage.getItem("tinyagentos-notes") ?? "[]");
+      expect(stored).toHaveLength(1);
+      expect(typeof stored[0].id).toBe("string");
+      expect(stored[0].id.length).toBeGreaterThan(0);
+    } finally {
+      Object.defineProperty(crypto, "randomUUID", { value: originalRandomUUID, configurable: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Text Editor's "New note" / "Create your first note" buttons did nothing on beta.20 with no visible error, matching #1584.
- Root cause: `createNote()` called `crypto.randomUUID()` unguarded. That API only exists in secure contexts (https, or localhost), but taOS is normally reached over plain http (`http://taos.local:6969` or `http://<ip>:6969` per the getting-started guide), which is not a secure context — so `crypto.randomUUID` is `undefined` there and the call threw a `TypeError` synchronously inside the click handler, aborting before `setNotes`/`setActiveId` ran. No error surfaced to the user, matching the report exactly.
- Fixed with the same fallback pattern already used in `officestudio/slides/deck.ts` for this exact problem: use `crypto.randomUUID()` when available, otherwise generate an id from `Date.now()` + `Math.random()`.

## Test plan
- [x] Added `desktop/src/apps/__tests__/TextEditorApp.test.tsx`: one baseline test (crypto.randomUUID available) and one regression test that shadows `crypto.randomUUID` with `undefined` (matching the reporter's insecure-context environment) and asserts note creation still succeeds. Verified the regression test fails with the exact reported `TypeError: crypto.randomUUID is not a function` against the pre-fix code, and passes with the fix.
- [x] `cd desktop && npx vitest run` — 286 files / 2367 tests passed.
- [x] `cd desktop && npm run build` (`tsc -b && vite build`) — clean.

Fixes #1584

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Note creation now works reliably in environments where secure browser APIs aren’t available.
  * Notes continue to be created and saved even when the built-in UUID generator can’t be used.

* **Tests**
  * Added coverage for creating the first note, showing it in the sidebar, and saving it locally.
  * Added a regression test to confirm note creation still succeeds in non-secure browser contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->