### PR TITLE
fix(desktop): guard crypto.randomUUID for non-secure-context (http)

### DIFF
--- a/desktop/src/apps/officestudio/slides/deck.ts
+++ b/desktop/src/apps/officestudio/slides/deck.ts
@@ -3,6 +3,8 @@
 // serializes its workbook (see ../calc/workbook.ts) and Write stores its
 // Tiptap HTML directly as `content`.
 
+import { randomId } from "@/lib/uid";
+
 export type SlideLayout = "title" | "title-content" | "two-column" | "section-header" | "blank";
 
 export interface Slide {
@@ -32,10 +34,7 @@ export const LAYOUTS: { id: SlideLayout; label: string }[] = [
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
 function genId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return `slide-${crypto.randomUUID()}`;
-  }
-  return `slide-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  return randomId("slide-");
 }
 
 export function newSlide(layout: SlideLayout = "title-content"): Slide {

--- a/desktop/src/apps/webstudio/templates.ts
+++ b/desktop/src/apps/webstudio/templates.ts
@@ -5,10 +5,11 @@ import type {
   Site,
   Theme,
 } from "./types";
+import { randomId } from "@/lib/uid";
 
 /** Unique id for a section. */
 export function newSectionId(): string {
-  return `sec-${crypto.randomUUID()}`;
+  return randomId("sec-");
 }
 
 /** Default editable content for a freshly-added section of a given type. */

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -26,6 +26,7 @@ import {
   SCREEN_CAPTURE_CHANGED_EVENT,
 } from "@/lib/screen-capture";
 import { useProcessStore } from "@/stores/process-store";
+import { randomId } from "@/lib/uid";
 
 export interface PendingAttachment {
   id: string;
@@ -147,7 +148,7 @@ export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boole
       form.append("file", new File([resp.blob], "screenshot.png", { type: resp.mime_type }));
       const uploaded = await uploadChatAttachment(form);
       const snap: PendingAttachment = {
-        id: crypto.randomUUID(),
+        id: randomId(),
         filename: uploaded.filename,
         size: uploaded.size,
         uploading: false,
@@ -186,7 +187,7 @@ export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boole
     el.onchange = async () => {
       const files = Array.from(el.files ?? []);
       for (const file of files) {
-        const id = crypto.randomUUID();
+        const id = randomId();
         setPendingAttachments((p) => [
           ...p,
           { id, filename: file.name, size: file.size, uploading: true },

--- a/desktop/src/lib/browser-push-bootstrap.ts
+++ b/desktop/src/lib/browser-push-bootstrap.ts
@@ -6,6 +6,7 @@
  */
 
 import { getVapidPublicKey, subscribePush } from "./browser-push-api";
+import { randomId } from "./uid";
 
 const DEVICE_ID_KEY = "taos-browser:push-device-id";
 
@@ -45,7 +46,7 @@ export async function bootstrapPushSubscription(): Promise<
     // 2. Get or create stable device_id
     let device_id = localStorage.getItem(DEVICE_ID_KEY);
     if (!device_id) {
-      device_id = crypto.randomUUID();
+      device_id = randomId();
       localStorage.setItem(DEVICE_ID_KEY, device_id);
     }
 

--- a/desktop/src/lib/uid.test.ts
+++ b/desktop/src/lib/uid.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { randomId } from "./uid";
+
+describe("randomId", () => {
+  it("returns an id normally", () => {
+    const id = randomId();
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it("applies the given prefix", () => {
+    expect(randomId("sec-")).toMatch(/^sec-/);
+  });
+
+  it("still returns a valid id when crypto.randomUUID is unavailable (non-secure-context http)", () => {
+    const original = crypto.randomUUID;
+    // @ts-expect-error simulate a non-secure context where randomUUID is undefined
+    crypto.randomUUID = undefined;
+    try {
+      const id = randomId();
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+    } finally {
+      crypto.randomUUID = original;
+    }
+  });
+});

--- a/desktop/src/lib/uid.ts
+++ b/desktop/src/lib/uid.ts
@@ -1,0 +1,14 @@
+/**
+ * `crypto.randomUUID()` only exists in a secure context (https or localhost).
+ * taOS is commonly accessed over plain http (e.g. http://taos.local:6969),
+ * where `crypto.randomUUID` is undefined and calling it throws synchronously.
+ * Use this helper anywhere a unique id is needed instead of calling
+ * `crypto.randomUUID()` directly.
+ */
+export function randomId(prefix?: string): string {
+  const id =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : Date.now().toString(36) + Math.random().toString(36).slice(2);
+  return prefix ? `${prefix}${id}` : id;
+}


### PR DESCRIPTION
## Summary
- \`crypto.randomUUID()\` only exists in a secure context (https or localhost); over plain http (e.g. `http://taos.local:6969`) it is `undefined` and throws synchronously on call. This class of bug caused #1584 (Text Editor could not create notes), already patched for `officestudio/slides/deck.ts` in #1569.
- This hardens the remaining unguarded call sites the same way: adds a shared `randomId(prefix?)` helper in `desktop/src/lib/uid.ts` (falls back to a `Date.now()`/`Math.random()` id when `crypto.randomUUID` is unavailable) and switches all remaining call sites to use it instead of copy-pasting the guard.
- Also refactored `officestudio/slides/deck.ts`'s existing inline guard to use the shared helper, since it was trivial and preserves the same `slide-` prefix.

## Changed call sites
- `desktop/src/components/TaosAssistantPanel.tsx` (screenshot attachment id, file upload id)
- `desktop/src/lib/browser-push-bootstrap.ts` (push `device_id` generation — this one breaks web-push registration off secure context)
- `desktop/src/apps/webstudio/templates.ts` (`sec-` section id)
- `desktop/src/apps/officestudio/slides/deck.ts` (refactor only, already guarded)

Not touched: `desktop/src/apps/TextEditorApp.tsx` (covered by open PR #1585).

## Test plan
- [x] Added `desktop/src/lib/uid.test.ts` covering normal id generation and the fallback path when `crypto.randomUUID` is shadowed to `undefined`
- [x] `npx vitest run` — 286 files / 2368 tests pass
- [x] `npm run build` — clean (tsc + vite build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared ID generator used across several desktop workflows, supporting prefixed IDs for slides, sections, attachments, and device setup.

* **Tests**
  * Added coverage for the new ID generator, including default output, prefix handling, and fallback behavior when newer browser APIs aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->