### PR TITLE
fix(models): real delete endpoint + auto-refresh installed state after download

### DIFF
--- a/desktop/src/apps/ModelsApp.test.tsx
+++ b/desktop/src/apps/ModelsApp.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ModelsApp } from "./ModelsApp";
+
+// Pins #1581 (delete was UI-only, never hit the backend) and the #1548
+// remainder (the Models dialog didn't reliably show a model as installed
+// right after its download completed).
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const CATALOG_WITH_DOWNLOADED_FILE = {
+  models: [
+    {
+      id: "test-model",
+      name: "Test Model",
+      description: "a model for testing",
+      compatibility: "green",
+      capabilities: ["chat"],
+      has_downloaded_variant: true,
+      variants: [{ id: "q4", size_mb: 500 }],
+    },
+  ],
+  downloaded_files: [
+    {
+      filename: "test-model-q4.gguf",
+      size_mb: 500,
+      format: "gguf",
+      model_id: "test-model",
+    },
+  ],
+  hardware_profile_id: "profile-1",
+};
+
+function mockFetch(routes: Record<string, () => Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      for (const [prefix, make] of Object.entries(routes)) {
+        if (url.startsWith(prefix)) return Promise.resolve(make());
+      }
+      return Promise.resolve(json([]));
+    }) as unknown as typeof fetch,
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ModelsApp delete wiring (#1581)", () => {
+  it("issues DELETE /api/models/{model_id} and removes the row only on success", async () => {
+    let modelsCallCount = 0;
+    const calls = mockFetch({
+      "/api/models/test-model": () => json({ status: "deleted", deleted_files: ["test-model-q4.gguf"] }),
+      "/api/models": () => {
+        modelsCallCount += 1;
+        return json(
+          modelsCallCount === 1
+            ? CATALOG_WITH_DOWNLOADED_FILE
+            : { ...CATALOG_WITH_DOWNLOADED_FILE, models: [{ ...CATALOG_WITH_DOWNLOADED_FILE.models[0], has_downloaded_variant: false }], downloaded_files: [] },
+        );
+      },
+    });
+
+    render(<ModelsApp windowId="w1" />);
+
+    const deleteBtn = await screen.findByRole("button", { name: "Delete test-model-q4.gguf" });
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      const deleteCall = calls.find((c) => c.url === "/api/models/test-model" && c.init?.method === "DELETE");
+      expect(deleteCall).toBeTruthy();
+    });
+
+    // Row disappears only after the backend confirms deletion via a refetch,
+    // never optimistically before the DELETE call resolves.
+    await waitFor(() => {
+      expect(screen.queryByText("test-model-q4.gguf")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the row and surfaces an error when the backend delete fails", async () => {
+    mockFetch({
+      "/api/models/test-model": () =>
+        new Response(JSON.stringify({ error: "permission denied" }), { status: 500 }),
+      "/api/models": () => json(CATALOG_WITH_DOWNLOADED_FILE),
+    });
+
+    render(<ModelsApp windowId="w1" />);
+
+    const deleteBtn = await screen.findByRole("button", { name: "Delete test-model-q4.gguf" });
+    fireEvent.click(deleteBtn);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("permission denied");
+    // The row must still be there — a failed delete is not silently treated
+    // as a success.
+    expect(screen.getByText("test-model-q4.gguf")).toBeInTheDocument();
+  });
+});
+
+describe("ModelsApp post-download refresh (#1548 remainder)", () => {
+  it("a slow download-complete refetch must not clobber a later, faster refetch", async () => {
+    // model-a: not yet downloaded, will be downloaded during the test.
+    // model-b: already downloaded, will be deleted during the test — its
+    // Delete action triggers its own fetchModels() call, giving us a SECOND
+    // real (not synthetic) refetch to race against the download's.
+    const INITIAL = {
+      models: [
+        {
+          id: "model-a",
+          name: "Model A",
+          description: "",
+          compatibility: "green",
+          capabilities: ["chat"],
+          has_downloaded_variant: false,
+          variants: [{ id: "q4", size_mb: 500 }],
+        },
+      ],
+      downloaded_files: [
+        { filename: "model-b-default.gguf", size_mb: 100, format: "gguf", model_id: "model-b" },
+      ],
+      hardware_profile_id: "profile-1",
+    };
+
+    // What the download-complete refetch would see — STALE, because it
+    // still lists model-b as downloaded even though it's about to be
+    // deleted by the time this call actually resolves.
+    let resolveDownloadRefetch: (r: Response) => void = () => {};
+    const downloadRefetchPromise = new Promise<Response>((resolve) => {
+      resolveDownloadRefetch = resolve;
+    });
+
+    // What the delete refetch sees — the TRUE latest state: model-a
+    // installed, model-b gone. This call is issued AFTER the download's
+    // refetch but resolves FIRST.
+    const AFTER_DELETE = {
+      models: [{ ...INITIAL.models[0], has_downloaded_variant: true }],
+      downloaded_files: [],
+      hardware_profile_id: "profile-1",
+    };
+
+    let modelsCallCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (url.startsWith("/api/models/downloads/")) {
+          return Promise.resolve(json({ status: "complete", percent: 100 }));
+        }
+        if (url === "/api/models/download") {
+          return Promise.resolve(json({ status: "started", download_id: "model-a-q4" }));
+        }
+        if (url === "/api/models/model-b" && init?.method === "DELETE") {
+          return Promise.resolve(json({ status: "deleted", deleted_files: ["model-b-default.gguf"] }));
+        }
+        if (url === "/api/models") {
+          modelsCallCount += 1;
+          if (modelsCallCount === 1) return Promise.resolve(json(INITIAL));
+          if (modelsCallCount === 2) return downloadRefetchPromise; // stale, resolves last
+          return Promise.resolve(json(AFTER_DELETE)); // 3rd+ call: the true latest state
+        }
+        return Promise.resolve(json([]));
+      }) as unknown as typeof fetch,
+    );
+
+    render(<ModelsApp windowId="w1" />);
+
+    // Kick off the download — its completion will fire the (stale, slow)
+    // 2nd /api/models call.
+    const downloadBtn = await screen.findByRole("button", { name: "Download Model A" });
+    fireEvent.click(downloadBtn);
+    await waitFor(() => expect(modelsCallCount).toBeGreaterThanOrEqual(2));
+
+    // While that's still pending, delete model-b — its completion fires the
+    // (fresh, fast) 3rd /api/models call, which resolves immediately.
+    const deleteBtn = await screen.findByRole("button", { name: "Delete model-b-default.gguf" });
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(modelsCallCount).toBeGreaterThanOrEqual(3);
+      expect(screen.getByText("Downloaded")).toBeInTheDocument();
+      expect(screen.queryByText("model-b-default.gguf")).not.toBeInTheDocument();
+    });
+
+    // Now the stale download-refetch (started before the delete-refetch)
+    // finally resolves. Its data must be discarded — model-b must not
+    // reappear, and model-a must stay "Downloaded".
+    resolveDownloadRefetch(json(INITIAL));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.getByText("Downloaded")).toBeInTheDocument();
+    expect(screen.queryByText("model-b-default.gguf")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Download Model A" })).not.toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/ModelsApp.tsx
+++ b/desktop/src/apps/ModelsApp.tsx
@@ -33,6 +33,9 @@ interface DownloadedModel {
   host: string;
   hostKind: "controller" | "worker" | "cloud";
   backend?: string;
+  /** Catalog manifest id — set when the backend could match this file to a
+   *  manifest variant. Delete calls DELETE /api/models/{modelId} using this. */
+  modelId?: string;
 }
 
 interface AvailableModel {
@@ -75,6 +78,7 @@ function aggregatedToDownloaded(a: AggregatedModel): DownloadedModel {
     host: a.host,
     hostKind: a.hostKind,
     backend: a.backend,
+    modelId: a.modelId,
   };
 }
 
@@ -252,7 +256,17 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
     if (app) openWindow("providers", app.defaultSize);
   };
 
+  // fetchModels is called both on mount and right after a download/delete
+  // completes. Those calls can overlap (the mount fetch is still in flight
+  // when a fast download finishes) and network responses can resolve out of
+  // order, so a stale response must never clobber a fresher one — the same
+  // problem DownloadProgress's poll() solves with cancellation below. A
+  // monotonically increasing sequence number lets only the LAST call's
+  // response commit state.
+  const fetchSeqRef = useRef(0);
+
   const fetchModels = useCallback(async () => {
+    const seq = ++fetchSeqRef.current;
     // Kick off cluster workers + providers in parallel with /api/models so the
     // union (controller + workers + cloud) is ready in a single state flip.
     const workersPromise = fetchClusterWorkers();
@@ -288,6 +302,7 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                 filename: (d.filename as string) ?? "unknown",
                 size_mb: (d.size_mb as number) ?? 0,
                 format: (d.format as string) ?? "bin",
+                model_id: d.model_id as string | undefined,
               }),
             ),
           );
@@ -354,6 +369,10 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
             };
           });
 
+          // A newer fetchModels() call has already started (or finished) —
+          // committing this stale response would clobber fresher state, e.g.
+          // flipping a just-completed download back to "not installed".
+          if (seq !== fetchSeqRef.current) return;
           setDownloaded(downloadedList);
           setAvailable(availableList);
           setIsFallback(false);
@@ -377,6 +396,7 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
       const cloudList = cloudProvidersToAggregated(providers).map(
         aggregatedToDownloaded,
       );
+      if (seq !== fetchSeqRef.current) return;
       if (workerList.length > 0 || cloudList.length > 0) {
         setDownloaded([...workerList, ...cloudList]);
         setAvailable(MOCK_AVAILABLE);
@@ -387,6 +407,7 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
     } catch {
       /* ignore */
     }
+    if (seq !== fetchSeqRef.current) return;
     // No real models reachable anywhere (backend down AND no providers/workers
     // configured) — leave the lists empty so the clear "No models yet" empty
     // state renders instead of misleading mock cards. This is what makes the
@@ -401,9 +422,54 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
     fetchModels();
   }, [fetchModels]);
 
-  const handleDelete = (id: string) => {
-    setDownloaded((prev) => prev.filter((m) => m.id !== id));
-  };
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<Record<string, string>>({});
+
+  const handleDelete = useCallback(
+    async (model: DownloadedModel) => {
+      if (!model.modelId) {
+        setDeleteError((prev) => ({
+          ...prev,
+          [model.id]: "Cannot delete: unrecognised model file",
+        }));
+        return;
+      }
+      setDeletingId(model.id);
+      setDeleteError((prev) => {
+        const next = { ...prev };
+        delete next[model.id];
+        return next;
+      });
+      try {
+        const res = await fetch(`/api/models/${encodeURIComponent(model.modelId)}`, {
+          method: "DELETE",
+          credentials: "include",
+        });
+        const data = await res.json().catch(() => ({}) as Record<string, unknown>);
+        if (!res.ok) {
+          setDeleteError((prev) => ({
+            ...prev,
+            [model.id]:
+              (data.error as string) ||
+              (data.detail as string) ||
+              "The model could not be deleted",
+          }));
+          return;
+        }
+        // Re-fetch the real catalog instead of assuming success locally, so
+        // the list reflects backend truth (mirrors handleDownloadComplete).
+        await fetchModels();
+      } catch {
+        setDeleteError((prev) => ({
+          ...prev,
+          [model.id]: "Could not reach the backend to delete the model",
+        }));
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [fetchModels],
+  );
 
   const handleDownload = useCallback(async (model: AvailableModel) => {
     if (!model.variantId) {
@@ -664,7 +730,8 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                onClick={() => handleDelete(model.id)}
+                                onClick={() => handleDelete(model)}
+                                disabled={deletingId === model.id}
                                 className="h-7 w-7 hover:text-red-400 hover:bg-red-500/15"
                                 aria-label={`Delete ${model.filename}`}
                                 title="Delete model"
@@ -687,6 +754,11 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                               <span className="ml-auto tabular-nums">{model.size}</span>
                             )}
                           </div>
+                          {deleteError[model.id] && (
+                            <p className="text-[11px] text-red-400" role="alert">
+                              {deleteError[model.id]}
+                            </p>
+                          )}
                         </CardContent>
                       </Card>
                     );

--- a/desktop/src/lib/models.ts
+++ b/desktop/src/lib/models.ts
@@ -33,6 +33,10 @@ export interface AggregatedModel {
   /** Optional format (GGUF, etc.). */
   format?: string;
   quantization?: string;
+  /** Catalog manifest id — set for controller-local files the backend could
+   *  match against a manifest variant's naming convention. Lets Delete call
+   *  DELETE /api/models/{modelId} instead of guessing it from the filename. */
+  modelId?: string;
 }
 
 const SIZE_RE = /[Qq]\d[_A-Za-z0-9]*/;
@@ -46,6 +50,7 @@ export interface ControllerDownloaded {
   filename: string;
   size_mb?: number;
   format?: string;
+  model_id?: string;
 }
 
 /** Map a controller /api/models downloaded_files entry to an AggregatedModel. */
@@ -64,6 +69,7 @@ export function controllerDownloadedToAggregated(
     size: fmtSize(d.size_mb ?? 0),
     format: (d.format ?? "bin").toUpperCase(),
     quantization: quant,
+    modelId: d.model_id,
   };
 }
 

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -156,6 +156,34 @@ class TestModelsAPI:
         for m in data["models"]:
             assert m["has_downloaded_variant"] is False
 
+    async def test_downloaded_file_carries_model_id(self, models_app, models_client):
+        """A downloaded file whose name matches the
+        {manifest.id}-{variant.id}.{format} convention used by
+        POST /api/models/download must carry that manifest id in
+        downloaded_files, so the frontend can wire per-file Delete to
+        DELETE /api/models/{model_id} without reverse-engineering the
+        naming convention itself (#1581)."""
+        models_dir = models_app.state.models_dir
+        (models_dir / "test-model-small.gguf").write_bytes(b"x" * 100)
+
+        resp = await models_client.get("/api/models")
+        data = resp.json()
+        entry = next(f for f in data["downloaded_files"] if f["filename"] == "test-model-small.gguf")
+        assert entry["model_id"] == "test-model"
+
+    async def test_downloaded_file_without_manifest_match_has_no_model_id(
+        self, models_app, models_client
+    ):
+        """A file that doesn't match any manifest's naming convention (e.g. a
+        legacy/manually-placed file) must not get a fabricated model_id."""
+        models_dir = models_app.state.models_dir
+        (models_dir / "some-legacy-file.gguf").write_bytes(b"x" * 100)
+
+        resp = await models_client.get("/api/models")
+        data = resp.json()
+        entry = next(f for f in data["downloaded_files"] if f["filename"] == "some-legacy-file.gguf")
+        assert "model_id" not in entry
+
     async def test_registry_installed_with_disk_evidence_marks_downloaded(
         self, models_client, models_app, tmp_path
     ):
@@ -220,6 +248,25 @@ class TestModelsDelete:
         data = resp.json()
         assert data["status"] == "deleted"
         assert data["deleted_files"] == []
+
+    async def test_delete_using_model_id_surfaced_in_list(self, models_app, models_client):
+        """End-to-end: the model_id GET /api/models attaches to a downloaded
+        file is exactly the id DELETE /api/models/{model_id} needs to remove
+        it — this is the wiring the frontend Delete button now relies on."""
+        models_dir = models_app.state.models_dir
+        (models_dir / "test-model-small.gguf").write_bytes(b"x" * 100)
+
+        list_resp = await models_client.get("/api/models")
+        entry = next(
+            f for f in list_resp.json()["downloaded_files"]
+            if f["filename"] == "test-model-small.gguf"
+        )
+        model_id = entry["model_id"]
+
+        delete_resp = await models_client.delete(f"/api/models/{model_id}")
+        assert delete_resp.status_code == 200
+        assert "test-model-small.gguf" in delete_resp.json()["deleted_files"]
+        assert not (models_dir / "test-model-small.gguf").exists()
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -109,6 +109,27 @@ def _scan_all_roots(roots: list[Path]) -> list[dict]:
     return merged
 
 
+def _attach_model_ids(downloaded_files: list[dict], models) -> None:
+    """Attach the catalog manifest id to each downloaded file entry.
+
+    Matches on the ``{manifest.id}-{variant.id}.{format}`` naming convention
+    that POST /api/models/download uses when writing a variant to disk (see
+    ``_model_to_dict``'s own ``expected_filename`` check below, which this
+    mirrors). Lets the frontend wire a per-file Delete button to
+    DELETE /api/models/{model_id} without having to reverse-engineer that
+    naming convention itself.
+    """
+    by_filename: dict[str, str] = {}
+    for m in models:
+        for v in m.variants:
+            expected = f"{m.id}-{v['id']}.{v.get('format', 'bin')}"
+            by_filename.setdefault(expected, m.id)
+    for entry in downloaded_files:
+        model_id = by_filename.get(entry["filename"])
+        if model_id:
+            entry["model_id"] = model_id
+
+
 def _is_service_installed(variant: dict) -> bool:
     """Detect whether a multi-file service-backed variant is installed on disk
     outside the ``data/models`` tree.
@@ -284,6 +305,7 @@ async def list_models(request: Request):
 
     models = registry.list_available(type_filter="model")
     downloaded = _scan_all_roots(_scan_roots(request))
+    _attach_model_ids(downloaded, models)
     live_models = catalog.all_models() if catalog is not None else []
     # Build {app_id: True} from the install registry so backend-installed
     # models (e.g. rk-llama.cpp GGUFs at ~/rk-llama.cpp/models/) still show


### PR DESCRIPTION
## Summary

Fixes two related Models app bugs reported by mandresve:

- **#1581** — Delete only updated local state; the backend never removed the file, so it reappeared on reopen. `DELETE /api/models/{model_id}` already existed but nothing called it, and the frontend had no way to know which catalog `model_id` a downloaded file belonged to (only its filename). The backend now attaches `model_id` to each `downloaded_files` entry when the filename matches a manifest variant's naming convention, and `handleDelete` calls the real endpoint, only dropping the row once the backend confirms — on failure it surfaces an error and keeps the row.

- **#1548 (remainder)** — After a download completed, the dialog kept showing "not installed" until closed and reopened. `fetchModels()` already re-fetched `/api/models` on completion, but with no sequencing guard a slower, earlier in-flight fetch (e.g. the initial mount call) could resolve *after* a newer one and clobber the just-installed state — the same class of stale-response race `DownloadProgress`'s poll already guarded against. `fetchModels` now tags each call with a sequence number and discards any response that isn't from the latest call.

## Test plan

- [x] `cd desktop && npm run build` — clean
- [x] `npx vitest run src/apps/ModelsApp.test.tsx` — 3/3 passing (delete success/failure, stale-refetch race)
- [x] `npx vitest run src/apps/ModelsApp.download.test.tsx src/lib/models.test.ts src/components/ModelBrowser.test.tsx` — all still passing
- [x] `python3 -m pytest tests/ -k model -q --ignore=tests/e2e` — 437 passed