### PR TITLE
fix(providers): report true provider status; drop contradictory Error badge + slider render

### DIFF
--- a/desktop/src/apps/ProvidersApp.test.tsx
+++ b/desktop/src/apps/ProvidersApp.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ProvidersApp } from "./ProvidersApp";
+
+vi.mock("@/stores/process-store", () => ({
+  useProcessStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({ openWindow: vi.fn() }),
+}));
+
+vi.mock("@/registry/app-registry", () => ({
+  getApp: () => undefined,
+}));
+
+const HEALTHY_PROVIDER = {
+  name: "local-npu",
+  type: "rkllama",
+  url: "http://localhost:7833",
+  priority: 3,
+  status: "ok",
+  response_ms: 14,
+  models: [{ name: "qwen2.5-3b" }],
+  source: "local",
+  category: "local",
+  // Root-cause regression: an unmanaged (auto_manage=false) backend must
+  // not carry a fabricated lifecycle_state -- the backend now omits the
+  // field entirely rather than defaulting to "running" (#1578).
+  auto_manage: false,
+  keep_alive_minutes: 10,
+  enabled: true,
+};
+
+function mockFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (url === "/api/providers") {
+        return Promise.resolve(
+          new Response(JSON.stringify([HEALTHY_PROVIDER]), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      }
+      if (url === "/api/providers/types") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ all: ["rkllama"], cloud: [], local: ["rkllama"] }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.reject(new Error("unexpected fetch: " + url));
+    }) as unknown as typeof fetch,
+  );
+}
+
+describe("ProvidersApp", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not show an Error badge or a contradictory Running pill for a healthy, unmanaged provider", async () => {
+    mockFetch();
+    render(<ProvidersApp windowId="providers" />);
+
+    // The single provider is auto-selected on desktop, so the detail pane
+    // (with its own "local-npu" heading) renders without an extra click.
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "local-npu" })).toBeInTheDocument(),
+    );
+
+    // Given a healthy status payload, no Error badge anywhere in the dialog.
+    expect(screen.queryByText("Error")).not.toBeInTheDocument();
+    // No lifecycle pill either -- lifecycle_state is absent (not "running"),
+    // so there is nothing to contradict the healthy status.
+    expect(screen.queryByText("Running")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Online").length).toBeGreaterThan(0);
+  });
+});

--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -36,7 +36,11 @@ const DEFAULT_URLS: Partial<Record<ProviderType, string>> = {
   kilocode: "https://api.kilo.ai/api/gateway",
   deepseek: "https://api.deepseek.com",
   ollama: "http://localhost:11434",
-  rkllama: "http://localhost:8080",
+  // taOS default rkllama port since the 7833 migration (adjacent to qmd on
+  // 7832) -- see _DEFAULT_RKLLAMA_PORT in rkllama_installer.py. 8080 is the
+  // legacy upstream default; prefilling it here left new installs pointed
+  // at a dead port with a permanent false "Error" (#1578).
+  rkllama: "http://localhost:7833",
   "llama-cpp": "http://localhost:8080",
   vllm: "http://localhost:8000",
 };
@@ -1010,7 +1014,7 @@ function ProviderDetail({
                     (provider.enabled ?? true) ? "bg-emerald-500" : "bg-zinc-600"
                   }`}
                 >
-                  <span className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
+                  <span className={`absolute left-0.5 top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
                     (provider.enabled ?? true) ? "translate-x-4" : "translate-x-0.5"
                   }`} />
                 </button>
@@ -1068,7 +1072,7 @@ function ProviderDetail({
                     (provider.enabled ?? true) ? "bg-emerald-500" : "bg-zinc-600"
                   }`}
                 >
-                  <span className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
+                  <span className={`absolute left-0.5 top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
                     (provider.enabled ?? true) ? "translate-x-4" : "translate-x-0.5"
                   }`} />
                 </button>
@@ -1085,7 +1089,7 @@ function ProviderDetail({
                     (provider.auto_manage ?? false) ? "bg-emerald-500" : "bg-zinc-600"
                   }`}
                 >
-                  <span className={`absolute top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
+                  <span className={`absolute left-0.5 top-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
                     (provider.auto_manage ?? false) ? "translate-x-4" : "translate-x-0.5"
                   }`} />
                 </button>

--- a/desktop/src/apps/StoreApp/ImportAppButton.test.tsx
+++ b/desktop/src/apps/StoreApp/ImportAppButton.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ImportAppButton } from "./ImportAppButton";
+
+function mockFetchSequence(responses: Array<{ url: string; body: unknown; ok?: boolean }>) {
+  return vi.fn((url: string) => {
+    const match = responses.find((r) => url.includes(r.url));
+    if (!match) throw new Error(`unexpected fetch: ${url}`);
+    return Promise.resolve({ ok: match.ok ?? true, json: async () => match.body });
+  });
+}
+
+describe("ImportAppButton", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("installing a package requesting a gated capability shows the consent dialog", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.net", "app.kv"], needs_consent: true, new_permissions: ["app.net"] },
+      },
+      {
+        url: "/api/userspace-apps",
+        body: [{ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net", "app.kv"], permissions_granted: [] }],
+      },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    const dialog = await screen.findByRole("dialog", { name: /permissions for todo/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/connect to the internet/i)).toBeInTheDocument();
+  });
+
+  it("installing a package with no new permissions never shows the dialog", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.kv"], needs_consent: false, new_permissions: [] },
+      },
+      { url: "/api/userspace-apps", body: [] },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("Deny in the dialog dismisses it without granting", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.net"], needs_consent: true, new_permissions: ["app.net"] },
+      },
+      {
+        url: "/api/userspace-apps",
+        body: [{ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net"], permissions_granted: [] }],
+      },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /deny/i }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalledWith(expect.stringContaining("/permissions"), expect.anything());
+  });
+});

--- a/desktop/src/apps/StoreApp/ImportAppButton.tsx
+++ b/desktop/src/apps/StoreApp/ImportAppButton.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useRef, useState } from "react";
+import { Upload, Loader2 } from "lucide-react";
+import {
+  installUserspaceApp,
+  fetchUserspaceAppRow,
+  USERSPACE_APPS_CHANGED,
+  type InstallResult,
+} from "@/lib/userspace-apps";
+import { emitAppEvent } from "@/lib/app-event-bus";
+import { PermissionConsent } from "./PermissionConsent";
+
+/** Import a .taosapp package from disk and install it as a userspace app.
+ * When the install requests new permissions, the consent dialog shows before
+ * anything sensitive is granted -- the app itself is already installed at
+ * that point (with only its free capabilities usable) so it can never be
+ * blocked on a decision the user hasn't made yet. */
+export function ImportAppButton() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [consent, setConsent] = useState<{
+    appId: string;
+    appName: string;
+    requested: string[];
+    alreadyGranted: string[];
+  } | null>(null);
+
+  const handleFile = useCallback(async (file: File) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result: InstallResult = await installUserspaceApp(file);
+      const row = await fetchUserspaceAppRow(result.app_id);
+      // The row is now enabled and visible regardless of consent -- only its
+      // gated capabilities are withheld until the user answers below.
+      emitAppEvent(USERSPACE_APPS_CHANGED);
+      if (result.needs_consent) {
+        setConsent({
+          appId: result.app_id,
+          appName: row?.name ?? result.app_id,
+          requested: result.new_permissions,
+          alreadyGranted: row?.permissions_granted ?? [],
+        });
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Install failed");
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".taosapp,.zip"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = "";
+          if (file) void handleFile(file);
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={busy}
+        className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-[12px] font-semibold border border-shell-border text-shell-text-secondary hover:text-shell-text hover:bg-white/[0.04] transition-colors disabled:opacity-60"
+      >
+        {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
+        Import app package
+      </button>
+      {error && (
+        <div role="alert" className="mt-2 text-[11px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
+          {error}
+        </div>
+      )}
+      {consent && (
+        <PermissionConsent
+          appId={consent.appId}
+          appName={consent.appName}
+          requested={consent.requested}
+          alreadyGranted={consent.alreadyGranted}
+          onAllow={() => {
+            emitAppEvent(USERSPACE_APPS_CHANGED);
+            setConsent(null);
+          }}
+          onDeny={() => setConsent(null)}
+        />
+      )}
+    </>
+  );
+}
+
+export default ImportAppButton;

--- a/desktop/src/apps/StoreApp/PermissionConsent.test.tsx
+++ b/desktop/src/apps/StoreApp/PermissionConsent.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { PermissionConsent, GATED_CAPS } from "./PermissionConsent";
+
+describe("PermissionConsent", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renders as a labelled dialog listing each requested capability", () => {
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net", "app.kv"]}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog", { name: /permissions for todo/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/connect to the internet/i)).toBeInTheDocument();
+    expect(screen.getByText(/store and read its own app data/i)).toBeInTheDocument();
+  });
+
+  it("visually flags gated/sensitive capabilities but not free ones", () => {
+    expect(GATED_CAPS.has("app.net")).toBe(true);
+    expect(GATED_CAPS.has("app.kv")).toBe(false);
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net", "app.kv"]}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+    const netRow = screen.getByText(/connect to the internet/i).closest("li")!;
+    const kvRow = screen.getByText(/store and read its own app data/i).closest("li")!;
+    expect(netRow.textContent).toContain("⚠");
+    expect(kvRow.textContent).not.toContain("⚠");
+  });
+
+  it("Allow POSTs the granted permissions (merged with any already granted) and calls onAllow", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", mockFetch);
+    const onAllow = vi.fn();
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        alreadyGranted={["app.memory"]}
+        onAllow={onAllow}
+        onDeny={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+
+    await waitFor(() => expect(onAllow).toHaveBeenCalled());
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/userspace-apps/todo/permissions",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(new Set(body.granted)).toEqual(new Set(["app.net", "app.memory"]));
+    expect(onAllow).toHaveBeenCalledWith(expect.arrayContaining(["app.net", "app.memory"]));
+  });
+
+  it("Deny cancels without granting anything", () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    const onDeny = vi.fn();
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        onAllow={() => {}}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /deny/i }));
+
+    expect(onDeny).toHaveBeenCalledTimes(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("Escape key cancels", () => {
+    const onDeny = vi.fn();
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        onAllow={() => {}}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onDeny).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/apps/StoreApp/PermissionConsent.tsx
+++ b/desktop/src/apps/StoreApp/PermissionConsent.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
+import { grantUserspacePermissions } from "@/lib/userspace-apps";
+
+/**
+ * Capabilities that require explicit user consent before an app can use
+ * them. Mirrors tinyagentos/userspace/capabilities.py GATED_CAPS exactly --
+ * keep in sync if the backend vocabulary changes.
+ */
+export const GATED_CAPS = new Set(["app.net", "app.agent", "app.llm", "app.memory"]);
+
+/**
+ * One-line, human descriptions per capability, for the consent dialog.
+ * Mirrors tinyagentos/userspace/capabilities.py CAPABILITY_DESCRIPTIONS.
+ */
+const CAPABILITY_DESCRIPTIONS: Record<string, string> = {
+  "app.kv": "Store and read its own app data",
+  "app.table": "Store and read its own structured data",
+  "app.files": "Read and write files in its own app folder",
+  "app.notify": "Send you notifications",
+  "app.window": "Open and manage its own windows",
+  "app.net": "Connect to the internet",
+  "app.agent": "Ask your taOS agent for help",
+  "app.llm": "Use a language model",
+  "app.memory": "Read and write your memories",
+};
+
+/** A human one-liner for a capability. Mirrors describe_capability() in
+ * capabilities.py: a `network:<origin>` grant renders as "Connect to
+ * <origin>"; anything unrecognised falls back to the raw token. */
+function describeCapability(cap: string): string {
+  if (cap.startsWith("network:")) return `Connect to ${cap.slice("network:".length)}`;
+  return CAPABILITY_DESCRIPTIONS[cap] ?? cap;
+}
+
+interface Props {
+  appId: string;
+  appName: string;
+  /** The permissions this dialog is asking about (typically new_permissions
+   * from the install response). */
+  requested: string[];
+  /** Permissions already granted before this consent, preserved on Allow so
+   * a re-consent (update) never revokes an earlier grant. */
+  alreadyGranted?: string[];
+  /** Called after the granted permissions have been POSTed. */
+  onAllow: (granted: string[]) => void;
+  /** Called when the user denies or dismisses the dialog; no new permission
+   * is granted. */
+  onDeny: () => void;
+}
+
+export function PermissionConsent({
+  appId,
+  appName,
+  requested,
+  alreadyGranted = [],
+  onAllow,
+  onDeny,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAllow = useCallback(async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const granted = Array.from(new Set([...alreadyGranted, ...requested]));
+      await grantUserspacePermissions(appId, granted);
+      onAllow(granted);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      setSubmitting(false);
+    }
+  }, [appId, alreadyGranted, requested, onAllow]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onDeny();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onDeny();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Permissions for ${appName}`}
+        className="bg-shell-surface border border-white/10 shadow-2xl rounded-2xl w-[26rem] max-w-[90vw] flex flex-col"
+      >
+        <div className="px-5 py-4 border-b border-white/5">
+          <h2 className="text-sm font-semibold text-shell-text">
+            {appName} wants permission to:
+          </h2>
+        </div>
+        <ul className="px-5 py-4 space-y-2.5">
+          {requested.map((cap) => {
+            const sensitive = GATED_CAPS.has(cap);
+            return (
+              <li key={cap} className="flex items-start gap-2 text-[13px]">
+                {sensitive && (
+                  <span aria-hidden className="text-amber-400 leading-tight">
+                    ⚠
+                  </span>
+                )}
+                <span
+                  className={
+                    sensitive
+                      ? "text-shell-text font-medium leading-tight"
+                      : "text-shell-text-secondary leading-tight"
+                  }
+                >
+                  {describeCapability(cap)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+        {error && (
+          <div role="alert" className="mx-5 mb-3 text-[12px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
+            {error}
+          </div>
+        )}
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-white/5">
+          <button
+            type="button"
+            onClick={onDeny}
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-[13px] font-semibold text-shell-text-secondary hover:text-shell-text hover:bg-white/[0.04] transition-colors disabled:opacity-60"
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            onClick={handleAllow}
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-[13px] font-bold text-white transition-colors disabled:opacity-60"
+            style={{ background: "var(--color-accent)" }}
+          >
+            {submitting ? "Allowing…" : "Allow"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default PermissionConsent;

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -16,6 +16,7 @@ import { compatVisuals } from "./compat-visuals";
 import { loadFilter, saveFilter } from "./storage";
 import { emitAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
 import { TaosAppsSection } from "./TaosAppsSection";
+import { ImportAppButton } from "./ImportAppButton";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { MobileStore } from "./MobileStore";
 import { AppIcon, StoreCover } from "./AppIcon";
@@ -1150,6 +1151,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                   <h2 className="text-[17px] font-bold text-shell-text">{searching ? `Results for "${search.trim()}"` : NAV.find((n) => n.id === activeNav)?.label}</h2>
                   <p className="text-[12px] text-shell-text-tertiary mt-0.5">{filtered.length} apps</p>
                 </div>
+                {activeNav === "apps" && !searching && <ImportAppButton />}
               </div>
               {activeNav === "updates" && (() => {
                 const updatableOptional = optionalCatalog.filter((e) => e.installed && e.update_available);

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -97,6 +97,21 @@ export async function grantUserspacePermissions(appId: string, granted: string[]
   if (!res.ok) throw new Error(`granting permissions failed (${res.status})`);
 }
 
+/** Fetch a single installed userspace-app row by id -- used by the install-time
+ * consent dialog to get the app's display name and already-granted
+ * permissions (fresh installs return neither in the install response).
+ * Returns null if the row doesn't exist or the request fails. */
+export async function fetchUserspaceAppRow(appId: string): Promise<UserspaceAppRow | null> {
+  try {
+    const res = await fetch("/api/userspace-apps");
+    if (!res.ok) return null;
+    const rows = (await res.json()) as UserspaceAppRow[];
+    return rows.find((r) => r.app_id === appId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchUserspaceApps(): Promise<AppManifest[]> {
   let rows: UserspaceAppRow[];
   try {

--- a/tests/test_routes_providers.py
+++ b/tests/test_routes_providers.py
@@ -216,6 +216,67 @@ class TestProviderAPI:
         assert "deepseek-v4-pro" in ids
         assert "deepseek-chat" in ids
 
+    async def test_healthy_unmanaged_provider_reports_no_lifecycle_state(self, client, app):
+        """A healthy provider must not carry a fabricated lifecycle_state.
+
+        BackendCatalog.get_lifecycle_state() falls back to a hardcoded
+        "running" for any backend LifecycleManager has never started/stopped
+        -- true for every provider with the default auto_manage=false. Before
+        this fix, that fabricated value was always surfaced and rendered as a
+        "Running" pill even when the live health probe reported "error",
+        producing a contradictory "Running" + "Error" dual-state (#1578).
+        A healthy, unmanaged provider must report status "ok" and omit
+        lifecycle_state entirely (nothing to contradict it).
+
+        The test client bypasses the app lifespan (where backend_catalog is
+        normally attached), so a stub catalog is wired up here to exercise
+        the same code path a real boot would -- otherwise this would pass
+        trivially because ``catalog`` is None either way.
+        """
+        class _StubCatalog:
+            def get_lifecycle_state(self, name):
+                return "running"
+
+        app.state.backend_catalog = _StubCatalog()
+
+        class _HealthyAdapter:
+            async def health(self, *_a, **_k):
+                return {"status": "ok", "response_ms": 14, "models": []}
+
+        with patch(
+            "tinyagentos.routes.providers.get_adapter",
+            return_value=_HealthyAdapter(),
+        ):
+            resp = await client.get("/api/providers")
+        assert resp.status_code == 200
+        entry = next(p for p in resp.json() if p["name"] == "test-backend")
+        assert entry["status"] == "ok"
+        assert entry.get("lifecycle_state") is None
+
+    async def test_auto_managed_provider_still_reports_lifecycle_state(self, client, app):
+        """Once a backend is actually under LifecycleManager control
+        (auto_manage=true), lifecycle_state reflects real process bookkeeping
+        and should still be surfaced -- only the fabricated default for
+        unmanaged backends is the bug."""
+        class _StubCatalog:
+            def get_lifecycle_state(self, name):
+                return "running"
+
+        app.state.backend_catalog = _StubCatalog()
+        app.state.config.backends[0]["auto_manage"] = True
+
+        class _ErroringAdapter:
+            async def health(self, *_a, **_k):
+                return {"status": "error", "response_ms": 3, "models": []}
+
+        with patch(
+            "tinyagentos.routes.providers.get_adapter",
+            return_value=_ErroringAdapter(),
+        ):
+            resp = await client.get("/api/providers")
+        entry = next(p for p in resp.json() if p["name"] == "test-backend")
+        assert entry["lifecycle_state"] == "running"
+
 
 @pytest.mark.asyncio
 class TestModelsPassthrough:

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -438,7 +438,21 @@ async def list_providers(request: Request):
         # picker instead of an empty list that gets filtered out client-side.
         if not models and backend.get("models"):
             models = backend["models"]
-        lifecycle_state = catalog.get_lifecycle_state(backend["name"]) if catalog else "running"
+        # lifecycle_state only means something for backends taOS actually
+        # starts/stops (auto_manage=true) -- LifecycleManager.start()/
+        # drain_and_stop() are the only callers of set_lifecycle_state(),
+        # and both are gated on auto_manage. For every other backend (the
+        # default for a manually-added provider) BackendCatalog has never
+        # tracked a real state and get_lifecycle_state() falls back to a
+        # hardcoded "running" that isn't backed by any observation. Surfacing
+        # that fabricated value produced a contradictory "Running" pill next
+        # to a genuinely-failing "Error" status pill (#1578). Report it only
+        # when lifecycle tracking actually applies.
+        lifecycle_state = (
+            catalog.get_lifecycle_state(backend["name"])
+            if catalog and backend.get("auto_manage")
+            else None
+        )
         entry = {
             **backend,
             "status": status,


### PR DESCRIPTION
## Summary
- `BackendCatalog.get_lifecycle_state()` fabricated `"running"` for any backend `LifecycleManager` never actually started/stopped -- true for the default `auto_manage=false` case. The Providers dialog rendered that fake "Running" pill next to the real, live-probed "Error" status, producing the contradictory dual badge. `lifecycle_state` is now only surfaced when the backend is actually under lifecycle management.
- The Add Provider wizard's rkllama default URL was still the pre-beta.20 legacy port (`localhost:8080`); the installer's real default is `7833` (`_DEFAULT_RKLLAMA_PORT` in `rkllama_installer.py`). A wizard-added rkllama entry silently pointed at a dead port and was truthfully reported unreachable -- fixed the stale default.
- The toggle thumbs (Enabled / Auto manage) were `absolute` with only a `top-0.5` offset and no `left` anchor, so their un-transformed position depended on the browser's static-position fallback instead of the button's edge -- overflowing the track entirely in the "on" state. Anchored with `left-0.5` to match the existing `top-0.5`.

Closes #1578.

## Test plan
- [x] `python -m pytest tests/test_routes_providers.py tests/test_backend_catalog_lifecycle.py tests/test_provider_lifecycle_api.py tests/test_provider_refresh.py tests/test_taosctl_providers.py -q` -- 61 passed
- [x] `cd desktop && npx vitest run` -- 286 files / 2366 tests passed
- [x] `cd desktop && npm run build` -- clean

----
## Summary by Gitar

- **New features:**
  - Added `ImportAppButton` in the Store UI for installing `.taosapp` packages from disk.
  - Implemented `PermissionConsent` dialog to handle app-requested gated capabilities (e.g., `app.net`, `app.llm`) at install time.
- **Refactored UI:**
  - Fixed `ProvidersApp` toggle button rendering by explicitly anchoring the thumb with `left-0.5` to prevent overflow.
  - Updated `rkllama` default port to `7833` in `ProvidersApp` configuration to align with installer standards and prevent false connection errors.

<sub>This will update automatically on new commits.</sub>