### PR TITLE
fix(store): agent-framework install enables deploy + prefetches base image + notifies (#1582)

### DIFF
--- a/desktop/src/apps/StoreApp/agent-framework-install.test.tsx
+++ b/desktop/src/apps/StoreApp/agent-framework-install.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for agent-framework install/open behaviour in the Store (#1582).
+ *
+ * Installing an agent-framework from the Store used to report "installed"
+ * without the backend doing anything, and clicking "Open" was a no-op. This
+ * verifies the frontend now (a) shows real base-image prefetch progress by
+ * polling /api/agent-image/status instead of an instant "done", and
+ * (b) routes an installed framework's action button into the Agents app
+ * instead of doing nothing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { StoreApp } from "./index";
+
+const FRAMEWORK_APP = {
+  id: "hermes",
+  name: "Hermes Agent Gateway",
+  type: "agent-framework",
+  version: "1.0.0",
+  description: "Nous Research agent gateway",
+  installed: false,
+  compat: "green",
+};
+
+function makeFetch(opts: {
+  catalogApp: Record<string, unknown>;
+  installResponse?: Record<string, unknown>;
+  imageStatusSequence?: Array<{ status: string }>;
+}) {
+  let imageStatusCalls = 0;
+  const imageStatusSequence = opts.imageStatusSequence ?? [{ status: "idle" }];
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === "/api/store/catalog") {
+      return new Response(JSON.stringify([opts.catalogApp]), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/store/installed-v2") {
+      return new Response(JSON.stringify({ installed: [] }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/store/install-v2" && init?.method === "POST") {
+      return new Response(
+        JSON.stringify(opts.installResponse ?? { ok: true, app_id: "hermes", status: "installed", prefetch: "skipped" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url === "/api/agent-image/status") {
+      const idx = Math.min(imageStatusCalls, imageStatusSequence.length - 1);
+      imageStatusCalls += 1;
+      return new Response(JSON.stringify(imageStatusSequence[idx]), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/store/install-progress/by-app/hermes") {
+      return new Response(JSON.stringify({ app_id: "hermes", active: null }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    // Everything else (frameworks feed, agents list, install targets, optional catalog): 404 is fine.
+    return new Response(null, { status: 404 });
+  });
+}
+
+beforeEach(() => {
+  if (!Element.prototype.scrollTo) {
+    Element.prototype.scrollTo = (() => {}) as typeof Element.prototype.scrollTo;
+  }
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((q: string) => ({
+        matches: false, media: q, onchange: null,
+        addListener: vi.fn(), removeListener: vi.fn(),
+        addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+async function goToAgentsTab() {
+  const agentsBtn = await screen.findByRole("button", { name: /^agents$/i });
+  fireEvent.click(agentsBtn);
+}
+
+describe("Store agent-framework install/open (#1582)", () => {
+  it("polls real base-image prefetch progress instead of instant-complete", async () => {
+    global.fetch = makeFetch({
+      catalogApp: FRAMEWORK_APP,
+      installResponse: { ok: true, app_id: "hermes", status: "installed", prefetch: "started" },
+      imageStatusSequence: [{ status: "downloading" }, { status: "importing" }, { status: "done" }],
+    }) as any;
+
+    render(<StoreApp windowId="test" />);
+    await goToAgentsTab();
+
+    const installBtn = await screen.findByRole("button", { name: /install hermes/i });
+    fireEvent.click(installBtn);
+
+    await waitFor(() => expect(screen.getByText(/downloading base image/i)).toBeInTheDocument());
+  });
+
+  it("does not show prefetch progress when the backend skips it", async () => {
+    global.fetch = makeFetch({
+      catalogApp: FRAMEWORK_APP,
+      installResponse: { ok: true, app_id: "hermes", status: "installed", prefetch: "skipped" },
+    }) as any;
+
+    render(<StoreApp windowId="test" />);
+    await goToAgentsTab();
+
+    const installBtn = await screen.findByRole("button", { name: /install hermes/i });
+    fireEvent.click(installBtn);
+
+    // A successful install swaps this card into its "installed" layout
+    // (Deploy in Agents + Uninstall) -- wait for that swap rather than the
+    // stale pre-install button, which React unmounts once installed flips.
+    await screen.findByRole("button", { name: /deploy hermes/i });
+    expect(screen.queryByText(/downloading base image/i)).not.toBeInTheDocument();
+  });
+
+  it("routes an installed framework's action button to the Agents app instead of a no-op", async () => {
+    global.fetch = makeFetch({ catalogApp: { ...FRAMEWORK_APP, installed: true } }) as any;
+
+    const onOpenApp = vi.fn();
+    window.addEventListener("taos:open-app", onOpenApp);
+
+    render(<StoreApp windowId="test" />);
+    await goToAgentsTab();
+
+    const deployBtn = await screen.findByRole("button", { name: /deploy hermes/i });
+    fireEvent.click(deployBtn);
+
+    expect(onOpenApp).toHaveBeenCalledTimes(1);
+    const detail = (onOpenApp.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail).toEqual({ app: "agents" });
+
+    window.removeEventListener("taos:open-app", onOpenApp);
+  });
+});

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -357,8 +357,40 @@ function AppCard({
   const [error, setError] = useState<string | null>(null);
   interface ProgressSnap { state: string; percent: number | null; bytes_downloaded: number; bytes_total: number; detail: string; error: string | null; }
   const [progress, setProgress] = useState<ProgressSnap | null>(null);
+  const isFramework = app.type === "agent-framework";
+  // Agent-framework installs kick off a background base-image prefetch (see
+  // POST /api/store/install-v2 -> _install_agent_framework). That work
+  // continues after the install call itself returns "installed", so this
+  // tracks the real download/import progress via the existing
+  // /api/agent-image/status endpoint instead of showing an instant "done".
+  const [prefetchActive, setPrefetchActive] = useState(false);
+  const [prefetchStatus, setPrefetchStatus] = useState<string | null>(null);
 
   useEffect(() => { if (defaultTargetRemote !== undefined) setSelectedTarget(defaultTargetRemote); }, [defaultTargetRemote]);
+
+  useEffect(() => {
+    if (!prefetchActive) return;
+    let cancelled = false;
+    const poll = async () => {
+      while (!cancelled) {
+        try {
+          const r = await fetch("/api/agent-image/status", { headers: { Accept: "application/json" } });
+          if (r.ok) {
+            const j = await r.json();
+            const status = String(j?.status ?? "idle");
+            if (!cancelled) setPrefetchStatus(status);
+            if (status === "done" || status === "failed") {
+              if (!cancelled) setPrefetchActive(false);
+              break;
+            }
+          }
+        } catch { /* network blip */ }
+        await new Promise((res) => setTimeout(res, 1500));
+      }
+    };
+    void poll();
+    return () => { cancelled = true; };
+  }, [prefetchActive]);
 
   useEffect(() => {
     if (!busy) return;
@@ -399,11 +431,21 @@ function AppCard({
         if (selectedVariant !== "auto") body.variant_id = selectedVariant;
         const res = await fetch("/api/store/install-v2", { method: "POST", headers: { "Content-Type": "application/json", Accept: "application/json" }, body: JSON.stringify(body) });
         if (!res.ok) { let msg = `Install failed (${res.status})`; try { const err = await res.json(); if (err?.error) msg = String(err.error); } catch { /* ignore */ } setError(msg); setBusy(false); return; }
+        if (isFramework) {
+          try {
+            const data = await res.json();
+            if (data?.prefetch === "started") { setPrefetchStatus("downloading"); setPrefetchActive(true); }
+          } catch { /* no body / not framework prefetch */ }
+        }
         onInstall(app.id);
       }
     } catch (e) { setError(e instanceof Error ? e.message : "Network error"); }
     setBusy(false);
     setTimeout(() => setProgress(null), 1500);
+  };
+
+  const handleOpen = () => {
+    window.dispatchEvent(new CustomEvent("taos:open-app", { detail: { app: "agents" } }));
   };
 
   const visuals = compatVisuals(resolveResponse);
@@ -460,6 +502,17 @@ function AppCard({
             {progress.detail && <span className="text-[10px] text-shell-text-tertiary truncate">{progress.detail}</span>}
           </div>
         )}
+        {isFramework && prefetchStatus && prefetchStatus !== "idle" && (
+          <div className="flex items-center gap-1.5 text-[10px] text-shell-text-tertiary" aria-live="polite">
+            {(prefetchStatus === "downloading" || prefetchStatus === "importing") && <Loader2 className="w-3 h-3 animate-spin shrink-0" />}
+            <span className="truncate">
+              {prefetchStatus === "downloading" ? "Downloading base image…"
+                : prefetchStatus === "importing" ? "Preparing base image…"
+                : prefetchStatus === "done" ? "Base image ready"
+                : "Base image prefetch failed — will fetch on first deploy"}
+            </span>
+          </div>
+        )}
         {showTargetPicker && (
           <div className="flex items-center gap-2">
             <label htmlFor={`target-${app.id}`} className="text-[11px] text-shell-text-tertiary whitespace-nowrap">Install on</label>
@@ -483,15 +536,37 @@ function AppCard({
             {runtimeHost === "127.0.0.1" ? "on controller" : `on ${runtimeHost}`}
           </p>
         )}
-        <button
-          type="button"
-          onClick={handleAction}
-          disabled={busy}
-          aria-label={app.installed ? `Uninstall ${app.name}` : `Install ${app.name}`}
-          className={`w-full flex items-center justify-center gap-1.5 py-1.5 rounded-full text-[12px] font-bold transition-colors ${app.installed ? "bg-red-500/15 text-red-400 hover:bg-red-500/25" : "bg-shell-surface-active text-shell-text hover:bg-white/10"}`}
-        >
-          {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : app.installed ? <><Trash2 className="w-3.5 h-3.5" /> Uninstall</> : <><Download className="w-3.5 h-3.5" /> Install</>}
-        </button>
+        {app.installed && isFramework ? (
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={handleOpen}
+              aria-label={`Deploy ${app.name} in Agents`}
+              className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-full text-[12px] font-bold transition-colors bg-shell-surface-active text-shell-text hover:bg-white/10"
+            >
+              <Bot className="w-3.5 h-3.5" /> Deploy in Agents
+            </button>
+            <button
+              type="button"
+              onClick={handleAction}
+              disabled={busy}
+              aria-label={`Uninstall ${app.name}`}
+              className="shrink-0 p-1.5 rounded-full text-red-400 bg-red-500/15 hover:bg-red-500/25 transition-colors"
+            >
+              {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={handleAction}
+            disabled={busy}
+            aria-label={app.installed ? `Uninstall ${app.name}` : `Install ${app.name}`}
+            className={`w-full flex items-center justify-center gap-1.5 py-1.5 rounded-full text-[12px] font-bold transition-colors ${app.installed ? "bg-red-500/15 text-red-400 hover:bg-red-500/25" : "bg-shell-surface-active text-shell-text hover:bg-white/10"}`}
+          >
+            {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : app.installed ? <><Trash2 className="w-3.5 h-3.5" /> Uninstall</> : <><Download className="w-3.5 h-3.5" /> Install</>}
+          </button>
+        )}
       </div>
     </div>
   );
@@ -525,7 +600,15 @@ function RichCard({
     setBusy(false);
   };
 
+  const isFramework = app.type === "agent-framework";
+
   const handleOpen = () => {
+    if (isFramework) {
+      // Agent frameworks have no standalone window -- deploying/using one
+      // happens from the Agents app's deploy flow.
+      window.dispatchEvent(new CustomEvent("taos:open-app", { detail: { app: "agents" } }));
+      return;
+    }
     // Future: launch the app window
   };
 
@@ -561,7 +644,7 @@ function RichCard({
             disabled={busy}
             className="px-4 py-1.5 rounded-full bg-shell-surface-active text-shell-text text-[12px] font-bold hover:bg-white/10 transition-colors"
           >
-            {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : app.installed ? "Open" : "Get"}
+            {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : app.installed ? (isFramework ? "Deploy in Agents" : "Open") : "Get"}
           </button>
         </div>
       </div>

--- a/desktop/src/lib/server-notifications.test.ts
+++ b/desktop/src/lib/server-notifications.test.ts
@@ -121,6 +121,10 @@ describe("server-notifications", () => {
       expect(sourceToTarget("decisions")).toEqual({ action: "decisions" });
     });
 
+    it("routes agent-framework install notifications to the Agents app", () => {
+      expect(sourceToTarget("agent_framework")).toEqual({ action: "agents" });
+    });
+
     it("returns no action for unknown sources", () => {
       expect(sourceToTarget("something.else")).toEqual({});
       expect(sourceToTarget("")).toEqual({});

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -56,6 +56,8 @@ export function sourceToTarget(
     case "app.installed":
     case "app.failed":
       return { action: "store" };
+    case "agent_framework":
+      return { action: "agents" };
     case "decisions":
     case "auth_requests":
       return { action: "decisions" };

--- a/tests/test_routes_store_install.py
+++ b/tests/test_routes_store_install.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tinyagentos.agent_image import base_image_alias
 from tinyagentos.catalog.resolver import DeviceCapability
 
 
@@ -51,6 +52,22 @@ def _make_service_manifest(
     m.id = manifest_id
     m.type = "service"
     m.install = {"method": method, "ports": [8080]}
+    m.requires = {}
+    m.hardware_tiers = {}
+    m.version = "1.0.0"
+    return m
+
+
+def _make_agent_framework_manifest(
+    manifest_id: str = "hermes",
+    name: str = "Hermes Agent Gateway",
+    script: str = "scripts/install.sh",
+) -> MagicMock:
+    m = MagicMock()
+    m.id = manifest_id
+    m.name = name
+    m.type = "agent-framework"
+    m.install = {"method": "script", "script": script}
     m.requires = {}
     m.hardware_tiers = {}
     m.version = "1.0.0"
@@ -412,6 +429,201 @@ class TestInstallV2:
         body = resp.json()
         assert "compat" in body
         assert "chain" in body
+
+
+# ---------------------------------------------------------------------------
+# POST /api/store/install-v2 -- agent-framework manifests (method: script) (#1582)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentFrameworkInstall:
+    """Installing an agent-framework manifest (hermes/openclaw's install.sh runs
+    inside a per-agent LXC container at deploy time, not here) enables it for
+    deploy, prefetches its base image in the background, and notifies -- it
+    must never silently do nothing while reporting "installed" (#1582)."""
+
+    @pytest.mark.asyncio
+    async def test_marks_installed_without_running_the_container_script(self, client):
+        manifest = _make_agent_framework_manifest("hermes")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        with patch(
+            "tinyagentos.routes.store_install.ensure_image_present",
+            new=AsyncMock(return_value=True),
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "hermes"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["status"] == "installed"
+        installed_apps.install.assert_called_once_with("hermes", "1.0.0", {})
+        reg.mark_installed.assert_called_once_with("hermes", "1.0.0")
+
+    @pytest.mark.asyncio
+    async def test_triggers_base_image_prefetch_for_dedicated_framework(self, client):
+        """hermes has a dedicated base image -- installing kicks off a
+        background ensure_image_present() for it."""
+        manifest = _make_agent_framework_manifest("hermes")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        client._transport.app.state.installed_apps = _make_installed_apps()
+
+        mock_ensure = AsyncMock(return_value=True)
+        with patch("tinyagentos.routes.store_install.ensure_image_present", new=mock_ensure):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "hermes"})
+
+        assert resp.status_code == 200
+        assert resp.json()["prefetch"] == "started"
+        mock_ensure.assert_called_once()
+        alias, url = mock_ensure.call_args[0]
+        assert alias == base_image_alias("hermes") == "taos-hermes-base"
+        assert alias in url
+
+    @pytest.mark.asyncio
+    async def test_skips_prefetch_for_framework_without_dedicated_base(self, client):
+        """agent-zero has no dedicated base image -- no prefetch is started;
+        it falls back to the generic base at deploy time."""
+        manifest = _make_agent_framework_manifest("agent-zero", name="Agent Zero")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        client._transport.app.state.installed_apps = _make_installed_apps()
+
+        mock_ensure = AsyncMock(return_value=True)
+        with patch("tinyagentos.routes.store_install.ensure_image_present", new=mock_ensure):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "agent-zero"})
+
+        assert resp.status_code == 200
+        assert resp.json()["prefetch"] == "skipped"
+        mock_ensure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prefetch_failure_is_non_fatal(self, client):
+        """A failed prefetch never blocks the install -- the framework stays
+        enabled and a first deploy just falls back to a cold image build."""
+        manifest = _make_agent_framework_manifest("hermes")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        with patch(
+            "tinyagentos.routes.store_install.ensure_image_present",
+            new=AsyncMock(side_effect=RuntimeError("network down")),
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "hermes"})
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        installed_apps.install.assert_called_once()
+        reg.mark_installed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_emits_actionable_notification(self, client):
+        manifest = _make_agent_framework_manifest("hermes", name="Hermes Agent Gateway")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        client._transport.app.state.installed_apps = _make_installed_apps()
+
+        mock_notifs = MagicMock()
+        mock_notifs.add = AsyncMock()
+        client._transport.app.state.notifications = mock_notifs
+
+        with patch(
+            "tinyagentos.routes.store_install.ensure_image_present",
+            new=AsyncMock(return_value=True),
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "hermes"})
+
+        assert resp.status_code == 200
+        mock_notifs.add.assert_called_once()
+        _, kwargs = mock_notifs.add.call_args
+        assert kwargs["source"] == "agent_framework"
+        assert kwargs["level"] == "success"
+        assert "Hermes Agent Gateway" in kwargs["title"]
+        assert "Agents app" in kwargs["message"]
+        assert kwargs["data"] == {"framework": "hermes"}
+
+    @pytest.mark.asyncio
+    async def test_pip_based_framework_unaffected(self, client):
+        """Pip/docker-based agent-frameworks (smolagents, langroid, ...) are
+        untouched -- they keep running the real installer, not the
+        script-only enable+prefetch+notify path."""
+        manifest = _make_agent_framework_manifest("smolagents")
+        manifest.install = {"method": "pip", "package": "smolagents"}
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(return_value={"success": True})
+        with patch(
+            "tinyagentos.installers.pip_installer.PipInstaller",
+            return_value=mock_installer,
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "smolagents"})
+
+        assert resp.status_code == 200
+        mock_installer.install.assert_called_once()
+        installed_apps.install.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/store/install-v2 -- non-framework method: script manifests (#1582)
+# ---------------------------------------------------------------------------
+
+
+class TestScriptBackendInstall:
+    """The generic install.method: script path (backend/plugin manifests
+    like ollama, tailscale) previously fell through to the default branch
+    and silently marked the app installed without ever running the script.
+    It must now actually run it, or fail loudly."""
+
+    @pytest.mark.asyncio
+    async def test_missing_script_returns_explicit_error_not_false_success(self, client):
+        manifest = _make_service_manifest("some-service", method="script")
+        manifest.install = {"method": "script", "script": "scripts/does-not-exist.sh"}
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        resp = await client.post("/api/store/install-v2", json={"manifest_id": "some-service"})
+
+        assert resp.status_code == 500
+        assert "error" in resp.json()
+        installed_apps.install.assert_not_called()
+        reg.mark_installed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_script_marks_installed(self, client):
+        manifest = _make_service_manifest("some-service", method="script")
+        manifest.install = {"method": "script", "script": "scripts/noop.sh"}
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(
+            return_value={"success": True, "app_id": "some-service", "method": "script"},
+        )
+        with patch(
+            "tinyagentos.routes.store_install.get_installer",
+            return_value=mock_installer,
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "some-service"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        mock_installer.install.assert_called_once_with("some-service", manifest.install)
+        installed_apps.install.assert_called_once()
+        reg.mark_installed.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -17,6 +17,12 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from tinyagentos.agent_image import (
+    FRAMEWORKS_WITH_DEDICATED_BASE,
+    base_image_alias,
+    base_image_url_for_alias,
+    ensure_image_present,
+)
 from tinyagentos.catalog.resolver import (
     DeviceCapability,
     ResolveErr,
@@ -27,6 +33,7 @@ from tinyagentos.catalog.resolver import (
 from tinyagentos.cluster.capabilities import hardware_to_targets
 from tinyagentos.installers.base import get_installer
 from tinyagentos.installers.lxc_installer import LXCInstaller
+from tinyagentos.task_utils import _create_supervised_task
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -197,6 +204,68 @@ def _registry_get(registry, app_id: str):
     return registry.get(app_id)
 
 
+async def _install_agent_framework(
+    request: Request, manifest, app_id: str, meta: dict, body: dict,
+) -> JSONResponse:
+    """Install an agent-framework manifest declaring ``install.method: script``.
+
+    That script (e.g. hermes/openclaw's ``scripts/install.sh``) is written to
+    run once *inside a fresh per-agent LXC container* at deploy time — it
+    installs Node/npm or pip packages, writes container-local config, and
+    enables systemd units for that container (see ``deployer.py``'s
+    method=="script" branch). Running it here, on the taOS controller host,
+    at Store-install time would be wrong: there is no target container yet,
+    and the script would pollute the host instead.
+
+    So "installing" a framework from the Store means: enable it for deploy
+    (mark it installed so the Store/Agents app reflect real state — the
+    adapter registry already knows how to deploy every listed framework),
+    kick off a best-effort background prefetch of its dedicated base image
+    (if it has one) so the first real deploy is fast, and notify the user it
+    is ready to deploy. Prefetch failure is non-fatal: the framework stays
+    enabled and a first deploy falls back to a cold image build.
+    """
+    registry = getattr(request.app.state, "registry", None)
+    store = getattr(request.app.state, "installed_apps", None)
+    version = body.get("version") or getattr(manifest, "version", "") or ""
+
+    if store is not None:
+        await store.install(app_id, version, meta)
+    if registry is not None and hasattr(registry, "mark_installed"):
+        registry.mark_installed(app_id, version)
+
+    prefetch_started = False
+    if app_id in FRAMEWORKS_WITH_DEDICATED_BASE:
+        alias = base_image_alias(app_id)
+        url = base_image_url_for_alias(alias)
+        bg_tasks = getattr(request.app.state, "_background_tasks", None)
+        if bg_tasks is None:
+            bg_tasks = set()
+            request.app.state._background_tasks = bg_tasks
+        _create_supervised_task(ensure_image_present(alias, url), bg_tasks)
+        prefetch_started = True
+
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is not None:
+        try:
+            await notifs.add(
+                title=f"{getattr(manifest, 'name', app_id)} installed",
+                message="You can now deploy it from the Agents app",
+                level="success",
+                source="agent_framework",
+                data={"framework": app_id},
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("_install_agent_framework: notification failed for %s", app_id, exc_info=True)
+
+    return JSONResponse({
+        "ok": True,
+        "app_id": app_id,
+        "status": "installed",
+        "prefetch": "started" if prefetch_started else "skipped",
+    })
+
+
 def _docker_published_port(install_config: dict) -> int:
     """Return the first host port a docker service publishes, or 0.
 
@@ -240,6 +309,16 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
             backend = install_block.get("method", "docker")
 
     meta = body.get("metadata") or {}
+
+    # Agent frameworks whose install.sh runs inside a per-agent LXC container
+    # at deploy time (method=="script") don't get a generic host-side
+    # install — see _install_agent_framework for why and what "install"
+    # means for them instead. Pip/docker-based frameworks (smolagents,
+    # langroid, ...) are unaffected and fall through to the normal dispatch
+    # below, unchanged.
+    if manifest is not None and getattr(manifest, "type", "") == "agent-framework" and backend == "script":
+        return await _install_agent_framework(request, manifest, app_id, meta, body)
+
     manifest_declared = manifest is not None
     if not manifest_declared:
         if isinstance(meta, dict) and meta.get("backend"):
@@ -357,6 +436,27 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
             registry.mark_installed(app_id, version)
         resp_target = _target_remote or "local"
         return JSONResponse({"ok": True, "app_id": app_id, "status": "installed", "target_remote": resp_target, **result})
+
+    # script — host-side backend/plugin manifests (e.g. ollama, tailscale)
+    # that declare install.method: script. Previously this fell straight
+    # through to the default branch below and silently marked the app
+    # installed without ever running the script (same class of bug as #410
+    # below for docker/pip, filed as #1582). Actually run it via
+    # ScriptInstaller and only mark installed on success; a missing or
+    # failing script now returns an explicit error instead of a false
+    # "installed".
+    if backend == "script":
+        installer = get_installer("script")
+        try:
+            inst_result = await installer.install(app_id, install_config)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("_legacy_install: script installer raised for %s", app_id)
+            return JSONResponse({"error": f"script install failed: {exc}"}, status_code=500)
+        if not inst_result.get("success"):
+            return JSONResponse(
+                {"error": inst_result.get("error", "script install failed")},
+                status_code=500,
+            )
 
     # docker / pip — actually run the installer.
     # Previously this branch fell straight through to the installed-apps


### PR DESCRIPTION
## Summary
- Root cause: `_legacy_install()` in `tinyagentos/routes/store_install.py` had no handler for `install.method: script`, so hermes/openclaw (`type: agent-framework`) fell through to the default branch, which marked them "installed" without running anything, and the Store's `Open` action was a stub.
- Their `scripts/install.sh` runs once inside a fresh per-agent LXC container at deploy time (`deployer.py`), not on the controller host at Store-install time -- so a generic host-side install would be the wrong fix. Installing a framework now: marks it installed for the registry/Store/Agents app, kicks off a background prefetch of its dedicated base image (`ensure_image_present`, trackable via the existing `GET /api/agent-image/status`) when one exists, and posts an actionable notification that opens the Agents app. Prefetch failure is non-fatal.
- Also fixed the same silent-success bug for non-framework `method: script` manifests (ollama, tailscale, ...): they now run through the existing `ScriptInstaller` and return an explicit error instead of a false "installed" when the script is missing or fails.
- Frontend (`StoreApp/index.tsx`): agent-framework cards poll real base-image prefetch progress instead of showing instant completion, and the installed-state action button now opens the Agents app ("Deploy in Agents") instead of doing nothing.
- `sourceToTarget` in `server-notifications.ts` gained a case routing the new `agent_framework` notification source to the Agents app.

## Test plan
- [x] `python -m pytest tests/ -k "store or install or framework" -q` -- 1466 passed, 1 skipped
- [x] `python -m pytest tests/test_routes_store_install.py -q` -- 31 passed (new `TestAgentFrameworkInstall` + `TestScriptBackendInstall` classes)
- [x] `cd desktop && npm run build` -- clean
- [x] `cd desktop && npx vitest run` -- 2369 passed (286 files), including new `agent-framework-install.test.tsx` and the `server-notifications.test.ts` addition
- [x] `python scripts/check_doc_gate.py diff-gate --base origin/dev` -- clean