### PR TITLE
release: 1.0.0-beta.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.21] - 2026-07-03
+
+### Added
+- App Runtime: install-time permission consent. Installing a sandboxed app now shows a dialog listing the capabilities it requests, with sensitive ones (network, agent, model, memory) highlighted, and you grant or deny before the app can use them (#1579).
+- App Runtime: container app tier. Apps can now ship as their own container alongside sandboxed web apps, deployed on a per-app port bound to localhost with memory and CPU caps and reached through an isolated proxy (#1580).
+
+### Fixed
+- Store: installing an agent framework (Hermes, OpenClaw) now actually does something. It enables the framework for deployment in the Agents app, downloads its base image in the background with real progress, and notifies you when it is ready; the framework's Open action now takes you to the Agents app to deploy. Previously the install silently did nothing while showing "installed". Reported by @mandresve (#1582).
+- Models: deleting a model now removes it on the backend instead of only hiding it in the UI, and a freshly downloaded model shows as installed immediately without reopening the dialog. Reported by @mandresve (#1581, #1548).
+- Providers: providers no longer show a false Error (or a contradictory Running and Error together) on a healthy install. The panel reports true backend status, the rkllama default port matches the installer, and the toggle switches render correctly. Reported by @mandresve (#1578).
+- Settings: the Logs pane now shows real system logs (controller, model backends, LLM proxy) with a live tail, not just browser-side errors, so backend failures are actually visible. Reported by @mandresve (#1583).
+- Text Editor: creating notes and documents works again over plain http. The editor no longer crashes on a missing secure-context API, and the same class of bug was hardened across the assistant panel, push registration, and Web Studio. Reported by @mandresve (#1584).
+
 ## [1.0.0-beta.20] - 2026-07-03
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.20",
+      "version": "1.0.0-beta.21",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.20"
+version = "1.0.0-beta.21"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.20"
+__version__ = "1.0.0-beta.21"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b20"
+version = "1.0.0b21"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump + CHANGELOG for 1.0.0-beta.21. Ships App Runtime M3+M4 plus the beta.20 desktop-wiring fix cluster reported by @mandresve.

**App Runtime**
- Install-time permission consent dialog (#1579)
- Container app tier: per-app localhost-bound container + proxy + caps (#1580)

**beta.20 wiring fixes (@mandresve)**
- Store agent-framework install actually enables deploy + prefetches base image + notifies (#1582)
- Model delete hits the backend; installed-state auto-refresh (#1581, #1548)
- Providers report true status; rkllama port; toggle render (#1578)
- Settings Logs shows real system logs with live tail (#1583)
- Text Editor create works over http; randomUUID guarded class-wide (#1584)

Bumps pyproject.toml, desktop/package.json, tinyagentos/__init__.py, uv.lock, desktop/package-lock.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app runtime enhancements for install-time permission consent and a new container app tier with isolated proxy deployment.

* **Bug Fixes**
  * Resolved issues affecting agent-framework installs, backend model deletion, instant-install state, provider status display, live system logs in Settings, and text editor stability for plain HTTP and related hardened components.

* **Chores**
  * Updated the app version to `1.0.0-beta.21`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->