### PR TITLE
fix(userspace): consent dialog dismiss-guard + skip needless row fetch

### DIFF
--- a/desktop/src/apps/StoreApp/ImportAppButton.test.tsx
+++ b/desktop/src/apps/StoreApp/ImportAppButton.test.tsx
@@ -4,7 +4,11 @@ import { ImportAppButton } from "./ImportAppButton";
 
 function mockFetchSequence(responses: Array<{ url: string; body: unknown; ok?: boolean }>) {
   return vi.fn((url: string) => {
-    const match = responses.find((r) => url.includes(r.url));
+    // Exact match first so a specific per-id URL (e.g. "/api/userspace-apps/todo")
+    // isn't shadowed by a broader substring match (e.g. the "/api/userspace-apps"
+    // list endpoint, which is itself a substring of the per-id one).
+    const match =
+      responses.find((r) => url === r.url) ?? responses.find((r) => url.includes(r.url));
     if (!match) throw new Error(`unexpected fetch: ${url}`);
     return Promise.resolve({ ok: match.ok ?? true, json: async () => match.body });
   });
@@ -20,8 +24,8 @@ describe("ImportAppButton", () => {
         body: { app_id: "todo", permissions_requested: ["app.net", "app.kv"], needs_consent: true, new_permissions: ["app.net"] },
       },
       {
-        url: "/api/userspace-apps",
-        body: [{ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net", "app.kv"], permissions_granted: [] }],
+        url: "/api/userspace-apps/todo",
+        body: { app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net", "app.kv"], permissions_granted: [] },
       },
     ]);
     vi.stubGlobal("fetch", mockFetch);
@@ -36,13 +40,13 @@ describe("ImportAppButton", () => {
     expect(screen.getByText(/connect to the internet/i)).toBeInTheDocument();
   });
 
-  it("installing a package with no new permissions never shows the dialog", async () => {
+  it("installing a package with no new permissions never shows the dialog and skips the row fetch", async () => {
     const mockFetch = mockFetchSequence([
       {
         url: "/api/userspace-apps/install",
         body: { app_id: "todo", permissions_requested: ["app.kv"], needs_consent: false, new_permissions: [] },
       },
-      { url: "/api/userspace-apps", body: [] },
+      { url: "/api/userspace-apps/todo", body: { app_id: "todo" } },
     ]);
     vi.stubGlobal("fetch", mockFetch);
 
@@ -53,6 +57,13 @@ describe("ImportAppButton", () => {
 
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
     expect(screen.queryByRole("dialog")).toBeNull();
+    // Only the install call should happen -- no reason to fetch the row when
+    // the install didn't need consent.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/userspace-apps/install",
+      expect.anything(),
+    );
   });
 
   it("Deny in the dialog dismisses it without granting", async () => {
@@ -62,8 +73,8 @@ describe("ImportAppButton", () => {
         body: { app_id: "todo", permissions_requested: ["app.net"], needs_consent: true, new_permissions: ["app.net"] },
       },
       {
-        url: "/api/userspace-apps",
-        body: [{ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net"], permissions_granted: [] }],
+        url: "/api/userspace-apps/todo",
+        body: { app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net"], permissions_granted: [] },
       },
     ]);
     vi.stubGlobal("fetch", mockFetch);

--- a/desktop/src/apps/StoreApp/ImportAppButton.tsx
+++ b/desktop/src/apps/StoreApp/ImportAppButton.tsx
@@ -30,11 +30,11 @@ export function ImportAppButton() {
     setError(null);
     try {
       const result: InstallResult = await installUserspaceApp(file);
-      const row = await fetchUserspaceAppRow(result.app_id);
       // The row is now enabled and visible regardless of consent -- only its
       // gated capabilities are withheld until the user answers below.
       emitAppEvent(USERSPACE_APPS_CHANGED);
       if (result.needs_consent) {
+        const row = await fetchUserspaceAppRow(result.app_id);
         setConsent({
           appId: result.app_id,
           appName: row?.name ?? result.app_id,

--- a/desktop/src/apps/StoreApp/PermissionConsent.test.tsx
+++ b/desktop/src/apps/StoreApp/PermissionConsent.test.tsx
@@ -101,4 +101,37 @@ describe("PermissionConsent", () => {
     fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
     expect(onDeny).toHaveBeenCalledTimes(1);
   });
+
+  it("ignores backdrop-click and Escape while a grant POST is in flight", async () => {
+    let resolveFetch!: (value: { ok: boolean }) => void;
+    const pending = new Promise<{ ok: boolean }>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const mockFetch = vi.fn().mockReturnValue(pending);
+    vi.stubGlobal("fetch", mockFetch);
+    const onAllow = vi.fn();
+    const onDeny = vi.fn();
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        onAllow={onAllow}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allowing/i })).toBeInTheDocument(),
+    );
+
+    const backdrop = screen.getByRole("dialog").parentElement!;
+    fireEvent.click(backdrop, { target: backdrop });
+    fireEvent.keyDown(backdrop, { key: "Escape" });
+    expect(onDeny).not.toHaveBeenCalled();
+
+    resolveFetch({ ok: true });
+    await waitFor(() => expect(onAllow).toHaveBeenCalled());
+  });
 });

--- a/desktop/src/apps/StoreApp/PermissionConsent.tsx
+++ b/desktop/src/apps/StoreApp/PermissionConsent.tsx
@@ -80,9 +80,11 @@ export function PermissionConsent({
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={(e) => {
+        if (submitting) return;
         if (e.target === e.currentTarget) onDeny();
       }}
       onKeyDown={(e) => {
+        if (submitting) return;
         if (e.key === "Escape") onDeny();
       }}
     >

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -104,10 +104,9 @@ export async function grantUserspacePermissions(appId: string, granted: string[]
  * Returns null if the row doesn't exist or the request fails. */
 export async function fetchUserspaceAppRow(appId: string): Promise<UserspaceAppRow | null> {
   try {
-    const res = await fetch("/api/userspace-apps");
+    const res = await fetch(`/api/userspace-apps/${encodeURIComponent(appId)}`);
     if (!res.ok) return null;
-    const rows = (await res.json()) as UserspaceAppRow[];
-    return rows.find((r) => r.app_id === appId) ?? null;
+    return (await res.json()) as UserspaceAppRow;
   } catch {
     return null;
   }

--- a/tests/userspace/test_routes.py
+++ b/tests/userspace/test_routes.py
@@ -39,6 +39,20 @@ async def test_install_list_bundle_uninstall(client):
 
 
 @pytest.mark.asyncio
+async def test_get_single_app_by_id(client):
+    await client.post("/api/userspace-apps/install",
+                      files={"package": ("todo.taosapp", _zip(), "application/zip")})
+
+    r = await client.get("/api/userspace-apps/todo")
+    assert r.status_code == 200
+    assert r.json()["app_id"] == "todo"
+    assert r.json()["name"] == "Todo"
+
+    r = await client.get("/api/userspace-apps/does-not-exist")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_bundle_path_traversal_404(client):
     await client.post("/api/userspace-apps/install",
                       files={"package": ("todo.taosapp", _zip(), "application/zip")})

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -111,6 +111,14 @@ async def list_apps(request: Request):
     return await request.app.state.userspace_apps.list_installed()
 
 
+@router.get("/api/userspace-apps/{app_id}")
+async def get_app(request: Request, app_id: str):
+    app = await request.app.state.userspace_apps.get(app_id)
+    if app is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return app
+
+
 # Cap the package upload / fetch size to bound memory and pre-filter zip bombs.
 _MAX_PACKAGE_BYTES = 64 * 1024 * 1024
 


### PR DESCRIPTION
## Summary
Three small Kilo review findings on the App Runtime consent UI:

- `PermissionConsent.tsx`: backdrop-click and Escape now no-op while a grant POST is in flight (`submitting`), so the dialog can no longer be dismissed mid-request and orphan the grant.
- `ImportAppButton.tsx`: `fetchUserspaceAppRow` is now only called when `result.needs_consent` is true -- no reason to fetch it otherwise.
- `userspace-apps.ts`: added `GET /api/userspace-apps/{app_id}` (mirrors the existing `store.get()` pattern already used by every other single-app route) and switched `fetchUserspaceAppRow` to use it instead of fetching the whole list and scanning it client-side.

## Test plan
- [x] `cd desktop && npm run build` -- clean
- [x] `npx vitest run src/apps/StoreApp` -- 68 passed
- [x] `python3 -m pytest tests/userspace/ -q` -- 133 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new way to view a specific installed app by its ID, with a clear not-found response when it doesn’t exist.
  * App installation now refreshes the app list immediately so newly installed apps appear sooner.

* **Bug Fixes**
  * Fixed app details loading so the correct app entry is used instead of a broader list result.
  * Permission dialogs can no longer be dismissed while a grant action is still processing.
  * Improved install flow behavior when no extra permissions are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->