### PR TITLE
feat(settings): frame taOS account for future features + reserve-your-username promo

### DIFF
--- a/desktop/src/apps/SettingsApp/AccountPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.test.tsx
@@ -83,6 +83,50 @@ describe("AccountSection", () => {
     );
   });
 
+  it("shows the 'Reserve your username' promo when signed in with no handle", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      if (String(input).includes("/auth/status")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            user_id: "u1",
+            email: "jay@example.com",
+            taosgo: { status: "none" },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    });
+    render(<AccountSection />);
+    expect(await screen.findByText("Reserve your taOS username")).toBeInTheDocument();
+    expect(screen.getByText("Reserve your username")).toBeInTheDocument();
+  });
+
+  it("shows the reserved handle instead of the CTA when the account has one", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      if (String(input).includes("/auth/status")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            user_id: "u1",
+            email: "jay@example.com",
+            taosgo: { status: "none" },
+            handle: "jay",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    });
+    render(<AccountSection />);
+    expect(await screen.findByText("@jay")).toBeInTheDocument();
+    expect(screen.getByText("jay.taos.my")).toBeInTheDocument();
+    expect(screen.queryByText("Reserve your username")).not.toBeInTheDocument();
+  });
+
   it("shows the local 'this device' identity from /auth/status", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
       if (String(input).includes("/auth/status")) {

--- a/desktop/src/apps/SettingsApp/AccountPanel.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, type FormEvent } from "react";
-import { LogOut, AlertCircle, ShieldCheck, Plane, UserCircle } from "lucide-react";
+import { LogOut, AlertCircle, ShieldCheck, Plane, UserCircle, AtSign } from "lucide-react";
 import { Button, Card, Input, Label } from "@/components/ui";
 import {
   fetchAccount,
@@ -126,6 +126,46 @@ function TaosgoCard({ account }: { account: Account }) {
 }
 
 /* ------------------------------------------------------------------ */
+/*  Reserve-your-username promo card                                  */
+/* ------------------------------------------------------------------ */
+
+function ReserveHandleCard({ account }: { account: Account }) {
+  const { handle } = account;
+
+  if (handle) {
+    return (
+      <Card className="p-4">
+        <div className="flex items-center gap-2 mb-2">
+          <AtSign size={16} className="text-sky-400" />
+          <h3 className="text-sm font-medium">Your taOS username</h3>
+        </div>
+        <p className="text-sm font-medium">@{handle}</p>
+        <p className="text-xs text-shell-text-tertiary mt-0.5">{handle}.taos.my</p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <AtSign size={16} className="text-sky-400" />
+        <h3 className="text-sm font-medium">Reserve your taOS username</h3>
+      </div>
+      <p className="text-xs text-shell-text-tertiary mb-3">
+        Claim your handle for your website, blog, portfolio, and socials — held for you across
+        taOS. Included with taOSgo.
+      </p>
+      <Button
+        size="sm"
+        onClick={() => { window.location.href = "https://taos.my/account/username"; }}
+      >
+        Reserve your username
+      </Button>
+    </Card>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  Signed-in view                                                    */
 /* ------------------------------------------------------------------ */
 
@@ -142,6 +182,7 @@ function SignedIn({ account, onSignOut }: { account: Account; onSignOut: () => v
         </Button>
       </Card>
       <TaosgoCard account={account} />
+      <ReserveHandleCard account={account} />
     </div>
   );
 }
@@ -232,7 +273,8 @@ function SignedOut({ onSignedIn }: { onSignedIn: (account: Account) => void }) {
       </form>
 
       <p className="text-xs text-shell-text-tertiary mt-3 flex items-center gap-1.5">
-        <ShieldCheck size={12} /> Your taOS account unlocks taOSgo and syncs across your devices.
+        <ShieldCheck size={12} /> Your taOS account unlocks taOSgo, app sharing, and your reserved
+        taOS username.
       </p>
     </Card>
   );
@@ -266,7 +308,9 @@ export function AccountSection() {
       <LocalAccountCard />
 
       <p className="text-sm text-shell-text-tertiary mb-5">
-        Sign in to your taOS cloud account to manage taOSgo and sync settings across your devices.
+        One taOS account for everything: secure remote access with taOSgo, sharing the apps you
+        build, and soon your own taOS username for a website, blog, portfolio, and social
+        presence.
       </p>
 
       {state.kind === "loading" && (

--- a/desktop/src/lib/account-client.ts
+++ b/desktop/src/lib/account-client.ts
@@ -21,6 +21,9 @@ export interface Account {
   user_id: string;
   email: string;
   taosgo: TaosgoEntitlement;
+  /** Reserved taOS username (e.g. for a future website/blog/portfolio). Not
+   *  yet returned by /me; treated as absent until the backend adds it. */
+  handle?: string | null;
 }
 
 export type AccountState =


### PR DESCRIPTION
## Summary
- Reframes the Settings → Account section intro and signed-out footer copy to present the taOS account as the key to a growing set of features (taOSgo, app sharing, and an upcoming taOS username), not just taOSgo + sync.
- Adds a `ReserveHandleCard` below the taOSgo card in the signed-in view: promotes reserving a taOS username (CTA links out to taos.my) when `account.handle` is unset, or shows the reserved `@handle` / `handle.taos.my` identity when it is set.
- Adds an optional `handle?: string | null` field to the `Account` type in `account-client.ts` (not yet returned by `/me`; handled gracefully as absent).

## Test plan
- [x] `npx vitest run src/apps/SettingsApp` — 19 passed (4 test files), including 2 new cases: signed-in + no handle shows the CTA, signed-in + handle shows `@jay` with no CTA.
- [x] `npm run build` (tsc -b && vite build) — clean, exit 0.

Docs-Reviewed: Settings Account copy + reserve-username promo card, no route/app surface change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new account section showing reserved username status for signed-in users.
  * If a username is already reserved, the account page now displays the handle and related web address.
  * If no username is reserved yet, users now see a prompt to reserve one.

* **Bug Fixes**
  * Improved account-page behavior so the reserved-username prompt only appears when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->