### PR TITLE
release: promote dev to master (1.0.0-beta.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.21] - 2026-07-03
+
+### Added
+- App Runtime: install-time permission consent. Installing a sandboxed app now shows a dialog listing the capabilities it requests, with sensitive ones (network, agent, model, memory) highlighted, and you grant or deny before the app can use them (#1579).
+- App Runtime: container app tier. Apps can now ship as their own container alongside sandboxed web apps, deployed on a per-app port bound to localhost with memory and CPU caps and reached through an isolated proxy (#1580).
+
+### Fixed
+- Store: installing an agent framework (Hermes, OpenClaw) now actually does something. It enables the framework for deployment in the Agents app, downloads its base image in the background with real progress, and notifies you when it is ready; the framework's Open action now takes you to the Agents app to deploy. Previously the install silently did nothing while showing "installed". Reported by @mandresve (#1582).
+- Models: deleting a model now removes it on the backend instead of only hiding it in the UI, and a freshly downloaded model shows as installed immediately without reopening the dialog. Reported by @mandresve (#1581, #1548).
+- Providers: providers no longer show a false Error (or a contradictory Running and Error together) on a healthy install. The panel reports true backend status, the rkllama default port matches the installer, and the toggle switches render correctly. Reported by @mandresve (#1578).
+- Settings: the Logs pane now shows real system logs (controller, model backends, LLM proxy) with a live tail, not just browser-side errors, so backend failures are actually visible. Reported by @mandresve (#1583).
+- Text Editor: creating notes and documents works again over plain http. The editor no longer crashes on a missing secure-context API, and the same class of bug was hardened across the assistant panel, push registration, and Web Studio. Reported by @mandresve (#1584).
+
 ## [1.0.0-beta.20] - 2026-07-03
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.20",
+      "version": "1.0.0-beta.21",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.20",
+  "version": "1.0.0-beta.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/apps/ModelsApp.test.tsx
+++ b/desktop/src/apps/ModelsApp.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ModelsApp } from "./ModelsApp";
+
+// Pins #1581 (delete was UI-only, never hit the backend) and the #1548
+// remainder (the Models dialog didn't reliably show a model as installed
+// right after its download completed).
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const CATALOG_WITH_DOWNLOADED_FILE = {
+  models: [
+    {
+      id: "test-model",
+      name: "Test Model",
+      description: "a model for testing",
+      compatibility: "green",
+      capabilities: ["chat"],
+      has_downloaded_variant: true,
+      variants: [{ id: "q4", size_mb: 500 }],
+    },
+  ],
+  downloaded_files: [
+    {
+      filename: "test-model-q4.gguf",
+      size_mb: 500,
+      format: "gguf",
+      model_id: "test-model",
+    },
+  ],
+  hardware_profile_id: "profile-1",
+};
+
+function mockFetch(routes: Record<string, () => Response>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      for (const [prefix, make] of Object.entries(routes)) {
+        if (url.startsWith(prefix)) return Promise.resolve(make());
+      }
+      return Promise.resolve(json([]));
+    }) as unknown as typeof fetch,
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ModelsApp delete wiring (#1581)", () => {
+  it("issues DELETE /api/models/{model_id} and removes the row only on success", async () => {
+    let modelsCallCount = 0;
+    const calls = mockFetch({
+      "/api/models/test-model": () => json({ status: "deleted", deleted_files: ["test-model-q4.gguf"] }),
+      "/api/models": () => {
+        modelsCallCount += 1;
+        return json(
+          modelsCallCount === 1
+            ? CATALOG_WITH_DOWNLOADED_FILE
+            : { ...CATALOG_WITH_DOWNLOADED_FILE, models: [{ ...CATALOG_WITH_DOWNLOADED_FILE.models[0], has_downloaded_variant: false }], downloaded_files: [] },
+        );
+      },
+    });
+
+    render(<ModelsApp windowId="w1" />);
+
+    const deleteBtn = await screen.findByRole("button", { name: "Delete test-model-q4.gguf" });
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      const deleteCall = calls.find((c) => c.url === "/api/models/test-model" && c.init?.method === "DELETE");
+      expect(deleteCall).toBeTruthy();
+    });
+
+    // Row disappears only after the backend confirms deletion via a refetch,
+    // never optimistically before the DELETE call resolves.
+    await waitFor(() => {
+      expect(screen.queryByText("test-model-q4.gguf")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the row and surfaces an error when the backend delete fails", async () => {
+    mockFetch({
+      "/api/models/test-model": () =>
+        new Response(JSON.stringify({ error: "permission denied" }), { status: 500 }),
+      "/api/models": () => json(CATALOG_WITH_DOWNLOADED_FILE),
+    });
+
+    render(<ModelsApp windowId="w1" />);
+
+    const deleteBtn = await screen.findByRole("button", { name: "Delete test-model-q4.gguf" });
+    fireEvent.click(deleteBtn);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("permission denied");
+    // The row must still be there — a failed delete is not silently treated
+    // as a success.
+    expect(screen.getByText("test-model-q4.gguf")).toBeInTheDocument();
+  });
+});
+
+describe("ModelsApp post-download refresh (#1548 remainder)", () => {
+  it("a slow download-complete refetch must not clobber a later, faster refetch", async () => {
+    // model-a: not yet downloaded, will be downloaded during the test.
+    // model-b: already downloaded, will be deleted during the test — its
+    // Delete action triggers its own fetchModels() call, giving us a SECOND
+    // real (not synthetic) refetch to race against the download's.
+    const INITIAL = {
+      models: [
+        {
+          id: "model-a",
+          name: "Model A",
+          description: "",
+          compatibility: "green",
+          capabilities: ["chat"],
+          has_downloaded_variant: false,
+          variants: [{ id: "q4", size_mb: 500 }],
+        },
+      ],
+      downloaded_files: [
+        { filename: "model-b-default.gguf", size_mb: 100, format: "gguf", model_id: "model-b" },
+      ],
+      hardware_profile_id: "profile-1",
+    };
+
+    // What the download-complete refetch would see — STALE, because it
+    // still lists model-b as downloaded even though it's about to be
+    // deleted by the time this call actually resolves.
+    let resolveDownloadRefetch: (r: Response) => void = () => {};
+    const downloadRefetchPromise = new Promise<Response>((resolve) => {
+      resolveDownloadRefetch = resolve;
+    });
+
+    // What the delete refetch sees — the TRUE latest state: model-a
+    // installed, model-b gone. This call is issued AFTER the download's
+    // refetch but resolves FIRST.
+    const AFTER_DELETE = {
+      models: [{ ...INITIAL.models[0], has_downloaded_variant: true }],
+      downloaded_files: [],
+      hardware_profile_id: "profile-1",
+    };
+
+    let modelsCallCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (url.startsWith("/api/models/downloads/")) {
+          return Promise.resolve(json({ status: "complete", percent: 100 }));
+        }
+        if (url === "/api/models/download") {
+          return Promise.resolve(json({ status: "started", download_id: "model-a-q4" }));
+        }
+        if (url === "/api/models/model-b" && init?.method === "DELETE") {
+          return Promise.resolve(json({ status: "deleted", deleted_files: ["model-b-default.gguf"] }));
+        }
+        if (url === "/api/models") {
+          modelsCallCount += 1;
+          if (modelsCallCount === 1) return Promise.resolve(json(INITIAL));
+          if (modelsCallCount === 2) return downloadRefetchPromise; // stale, resolves last
+          return Promise.resolve(json(AFTER_DELETE)); // 3rd+ call: the true latest state
+        }
+        return Promise.resolve(json([]));
+      }) as unknown as typeof fetch,
+    );
+
+    render(<ModelsApp windowId="w1" />);
+
+    // Kick off the download — its completion will fire the (stale, slow)
+    // 2nd /api/models call.
+    const downloadBtn = await screen.findByRole("button", { name: "Download Model A" });
+    fireEvent.click(downloadBtn);
+    await waitFor(() => expect(modelsCallCount).toBeGreaterThanOrEqual(2));
+
+    // While that's still pending, delete model-b — its completion fires the
+    // (fresh, fast) 3rd /api/models call, which resolves immediately.
+    const deleteBtn = await screen.findByRole("button", { name: "Delete model-b-default.gguf" });
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(modelsCallCount).toBeGreaterThanOrEqual(3);
+      expect(screen.getByText("Downloaded")).toBeInTheDocument();
+      expect(screen.queryByText("model-b-default.gguf")).not.toBeInTheDocument();
+    });
+
+    // Now the stale download-refetch (started before the delete-refetch)
+    // finally resolves. Its data must be discarded — model-b must not
+    // reappear, and model-a must stay "Downloaded".
+    resolveDownloadRefetch(json(INITIAL));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.getByText("Downloaded")).toBeInTheDocument();
+    expect(screen.queryByText("model-b-default.gguf")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Download Model A" })).not.toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/ModelsApp.tsx
+++ b/desktop/src/apps/ModelsApp.tsx
@@ -33,6 +33,9 @@ interface DownloadedModel {
   host: string;
   hostKind: "controller" | "worker" | "cloud";
   backend?: string;
+  /** Catalog manifest id — set when the backend could match this file to a
+   *  manifest variant. Delete calls DELETE /api/models/{modelId} using this. */
+  modelId?: string;
 }
 
 interface AvailableModel {
@@ -75,6 +78,7 @@ function aggregatedToDownloaded(a: AggregatedModel): DownloadedModel {
     host: a.host,
     hostKind: a.hostKind,
     backend: a.backend,
+    modelId: a.modelId,
   };
 }
 
@@ -252,7 +256,17 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
     if (app) openWindow("providers", app.defaultSize);
   };
 
+  // fetchModels is called both on mount and right after a download/delete
+  // completes. Those calls can overlap (the mount fetch is still in flight
+  // when a fast download finishes) and network responses can resolve out of
+  // order, so a stale response must never clobber a fresher one — the same
+  // problem DownloadProgress's poll() solves with cancellation below. A
+  // monotonically increasing sequence number lets only the LAST call's
+  // response commit state.
+  const fetchSeqRef = useRef(0);
+
   const fetchModels = useCallback(async () => {
+    const seq = ++fetchSeqRef.current;
     // Kick off cluster workers + providers in parallel with /api/models so the
     // union (controller + workers + cloud) is ready in a single state flip.
     const workersPromise = fetchClusterWorkers();
@@ -288,6 +302,7 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                 filename: (d.filename as string) ?? "unknown",
                 size_mb: (d.size_mb as number) ?? 0,
                 format: (d.format as string) ?? "bin",
+                model_id: d.model_id as string | undefined,
               }),
             ),
           );
@@ -354,6 +369,10 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
             };
           });
 
+          // A newer fetchModels() call has already started (or finished) —
+          // committing this stale response would clobber fresher state, e.g.
+          // flipping a just-completed download back to "not installed".
+          if (seq !== fetchSeqRef.current) return;
           setDownloaded(downloadedList);
           setAvailable(availableList);
           setIsFallback(false);
@@ -377,6 +396,7 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
       const cloudList = cloudProvidersToAggregated(providers).map(
         aggregatedToDownloaded,
       );
+      if (seq !== fetchSeqRef.current) return;
       if (workerList.length > 0 || cloudList.length > 0) {
         setDownloaded([...workerList, ...cloudList]);
         setAvailable(MOCK_AVAILABLE);
@@ -387,6 +407,7 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
     } catch {
       /* ignore */
     }
+    if (seq !== fetchSeqRef.current) return;
     // No real models reachable anywhere (backend down AND no providers/workers
     // configured) — leave the lists empty so the clear "No models yet" empty
     // state renders instead of misleading mock cards. This is what makes the
@@ -401,9 +422,54 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
     fetchModels();
   }, [fetchModels]);
 
-  const handleDelete = (id: string) => {
-    setDownloaded((prev) => prev.filter((m) => m.id !== id));
-  };
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<Record<string, string>>({});
+
+  const handleDelete = useCallback(
+    async (model: DownloadedModel) => {
+      if (!model.modelId) {
+        setDeleteError((prev) => ({
+          ...prev,
+          [model.id]: "Cannot delete: unrecognised model file",
+        }));
+        return;
+      }
+      setDeletingId(model.id);
+      setDeleteError((prev) => {
+        const next = { ...prev };
+        delete next[model.id];
+        return next;
+      });
+      try {
+        const res = await fetch(`/api/models/${encodeURIComponent(model.modelId)}`, {
+          method: "DELETE",
+          credentials: "include",
+        });
+        const data = await res.json().catch(() => ({}) as Record<string, unknown>);
+        if (!res.ok) {
+          setDeleteError((prev) => ({
+            ...prev,
+            [model.id]:
+              (data.error as string) ||
+              (data.detail as string) ||
+              "The model could not be deleted",
+          }));
+          return;
+        }
+        // Re-fetch the real catalog instead of assuming success locally, so
+        // the list reflects backend truth (mirrors handleDownloadComplete).
+        await fetchModels();
+      } catch {
+        setDeleteError((prev) => ({
+          ...prev,
+          [model.id]: "Could not reach the backend to delete the model",
+        }));
+      } finally {
+        setDeletingId(null);
+      }
+    },
+    [fetchModels],
+  );
 
   const handleDownload = useCallback(async (model: AvailableModel) => {
     if (!model.variantId) {
@@ -664,7 +730,8 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                               <Button
                                 variant="ghost"
                                 size="icon"
-                                onClick={() => handleDelete(model.id)}
+                                onClick={() => handleDelete(model)}
+                                disabled={deletingId === model.id}
                                 className="h-7 w-7 hover:text-red-400 hover:bg-red-500/15"
                                 aria-label={`Delete ${model.filename}`}
                                 title="Delete model"
@@ -687,6 +754,11 @@ export function ModelsApp({ windowId: _windowId }: { windowId: string }) {
                               <span className="ml-auto tabular-nums">{model.size}</span>
                             )}
                           </div>
+                          {deleteError[model.id] && (
+                            <p className="text-[11px] text-red-400" role="alert">
+                              {deleteError[model.id]}
+                            </p>
+                          )}
                         </CardContent>
                       </Card>
                     );

--- a/desktop/src/apps/SandboxedAppWindow.tsx
+++ b/desktop/src/apps/SandboxedAppWindow.tsx
@@ -8,6 +8,9 @@ import { defaultProvenanceForTrust, type AppProvenance } from "@/lib/userspace-a
 interface Props {
   windowId: string;
   appId: string;
+  /** "container" apps run their own HTTP backend and are loaded via the
+   * server-side proxy instead of the static bundle. Defaults to "web". */
+  appType?: "web" | "container";
   trust?: "community" | "first-party";
   /** Where the app's code came from. Falls back to defaultProvenanceForTrust(trust)
    * when omitted, so a caller that only knows the legacy `trust` field still
@@ -120,11 +123,16 @@ function readThemeTokens(): Record<string, string> {
 
 export function SandboxedAppWindow({
   appId,
+  appType = "web",
   trust = "community",
   provenance,
   grantedCapabilities = [],
 }: Props) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const iframeSrc =
+    appType === "container"
+      ? `/api/userspace-apps/${encodeURIComponent(appId)}/proxy/`
+      : `/api/userspace-apps/${encodeURIComponent(appId)}/bundle/index.html?app=${encodeURIComponent(appId)}`;
   const isFirstParty = trust === "first-party";
   const resolvedProvenance: AppProvenance = provenance ?? defaultProvenanceForTrust(trust);
   const networkAllowed = hasCapability(resolvedProvenance, "app.net", grantedCapabilities);
@@ -192,7 +200,7 @@ export function SandboxedAppWindow({
       <iframe
         ref={iframeRef}
         title={appId}
-        src={`/api/userspace-apps/${encodeURIComponent(appId)}/bundle/index.html?app=${encodeURIComponent(appId)}`}
+        src={iframeSrc}
         sandbox={computeSandboxAttr(resolvedProvenance)}
         data-provenance={resolvedProvenance}
         className="w-full h-full border-0 bg-white"

--- a/desktop/src/apps/SettingsApp/LogsPanel.tsx
+++ b/desktop/src/apps/SettingsApp/LogsPanel.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
-import { ScrollText, RefreshCw } from "lucide-react";
-import { Button, Card } from "@/components/ui";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { ScrollText, RefreshCw, Radio } from "lucide-react";
+import { Button, Card, Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui";
 import { safeFetch } from "@/apps/SettingsApp/_shared";
 
 interface ClientLog {
@@ -29,10 +29,9 @@ function formatTime(iso: string): string {
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
 }
 
-/** Read-only viewer for the errors and crashes captured from this device
- *  (GET /api/client-logs, admin only). The point is to chase a bug you hit in
- *  an app without opening a console -- a PWA has none. */
-export function LogsSection() {
+/** GET /api/client-logs viewer: errors and crashes captured from this device
+ *  (browser-side, via window.onerror / unhandledrejection). */
+function ClientLogsTab() {
   const [logs, setLogs] = useState<ClientLog[]>([]);
   const [level, setLevel] = useState<LevelFilter>("all");
   const [loading, setLoading] = useState(false);
@@ -50,16 +49,15 @@ export function LogsSection() {
   useEffect(() => { load(); }, [load]);
 
   return (
-    <section aria-label="Logs">
+    <>
       <div className="flex items-center justify-between mb-2">
-        <h2 className="text-lg font-semibold">Logs</h2>
+        <p className="text-sm text-shell-text-tertiary">
+          Errors and crashes captured from this device, newest first. Use these to chase a bug you hit in an app.
+        </p>
         <Button variant="outline" size="sm" onClick={load} aria-label="Refresh logs">
           <RefreshCw size={14} /> Refresh
         </Button>
       </div>
-      <p className="text-sm text-shell-text-tertiary mb-4">
-        Errors and crashes captured from this device, newest first. Use these to chase a bug you hit in an app.
-      </p>
 
       <div className="flex gap-2 mb-3 flex-wrap" role="group" aria-label="Filter by level">
         {LEVELS.map((l) => (
@@ -111,6 +109,179 @@ export function LogsSection() {
           ))}
         </div>
       )}
+    </>
+  );
+}
+
+interface SystemLogSource {
+  id: string;
+  label: string;
+  kind: string;
+  available: boolean;
+}
+
+interface SystemLogPage {
+  source: string;
+  lines: string[];
+  cursor: string | null;
+  error?: string;
+}
+
+const MAX_LIVE_LINES = 500;
+
+/** GET/SSE viewer for one journald/file source from the system-logs API
+ *  (controller, rkllama, qmd, LLM proxy) -- the operational logs a failed
+ *  backend operation actually lands in, as opposed to the browser-only
+ *  ClientLogsTab above. */
+function SystemLogsTab({ source }: { source: SystemLogSource }) {
+  const [lines, setLines] = useState<string[]>([]);
+  const [liveLines, setLiveLines] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tailing, setTailing] = useState(false);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const data = await safeFetch<SystemLogPage | null>(
+      `/api/system-logs/${source.id}?lines=200`, null,
+    );
+    if (data && Array.isArray(data.lines)) {
+      setLines(data.lines);
+      setError(data.error ?? null);
+    } else {
+      setLines([]);
+      setError("Could not read this log source.");
+    }
+    setLiveLines([]);
+    setLoading(false);
+  }, [source.id]);
+
+  useEffect(() => { load(); }, [load]);
+
+  useEffect(() => {
+    return () => eventSourceRef.current?.close();
+  }, []);
+
+  const toggleTail = useCallback(() => {
+    if (tailing) {
+      eventSourceRef.current?.close();
+      eventSourceRef.current = null;
+      setTailing(false);
+      return;
+    }
+    const es = new EventSource(`/api/system-logs/${source.id}/stream`);
+    es.onmessage = (msg) => {
+      let payload: { line?: string; error?: string } | null;
+      try {
+        payload = JSON.parse(msg.data);
+      } catch {
+        return;
+      }
+      if (!payload) return;
+      if (payload.line) {
+        setLiveLines((prev) => [payload.line as string, ...prev].slice(0, MAX_LIVE_LINES));
+      } else if (payload.error) {
+        setError(payload.error);
+      }
+    };
+    es.onerror = () => {
+      // Transient network errors: leave the connection to the browser's
+      // built-in reconnect. Closing here would fight it.
+    };
+    eventSourceRef.current = es;
+    setTailing(true);
+  }, [tailing, source.id]);
+
+  const displayLines = [...liveLines, ...lines];
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-2 gap-2">
+        <p className="text-sm text-shell-text-tertiary">
+          Last 200 lines from {source.label}, newest first.
+        </p>
+        <div className="flex gap-2 shrink-0">
+          <Button
+            variant={tailing ? "secondary" : "outline"}
+            size="sm"
+            onClick={toggleTail}
+            aria-pressed={tailing}
+            aria-label={tailing ? `Stop live tail of ${source.label}` : `Live tail ${source.label}`}
+          >
+            <Radio size={14} className={tailing ? "animate-pulse text-emerald-400" : ""} /> Live
+          </Button>
+          <Button variant="outline" size="sm" onClick={load} aria-label={`Refresh ${source.label} logs`}>
+            <RefreshCw size={14} /> Refresh
+          </Button>
+        </div>
+      </div>
+
+      {loading && <p className="text-sm text-shell-text-tertiary">Loading...</p>}
+
+      {!loading && error && displayLines.length === 0 && (
+        <Card className="p-4">
+          <p className="text-sm flex items-center gap-2 text-amber-400">
+            <ScrollText size={14} /> {error}
+          </p>
+        </Card>
+      )}
+
+      {!loading && !error && displayLines.length === 0 && (
+        <Card className="p-4">
+          <p className="text-sm flex items-center gap-2 text-shell-text-tertiary">
+            <ScrollText size={14} /> No log lines yet.
+          </p>
+        </Card>
+      )}
+
+      {displayLines.length > 0 && (
+        <Card className="p-3 max-h-[28rem] overflow-y-auto">
+          <pre className="text-xs font-mono whitespace-pre-wrap break-words text-shell-text-secondary">
+            {displayLines.join("\n")}
+          </pre>
+        </Card>
+      )}
+    </>
+  );
+}
+
+/** Log viewer for Settings -- browser-side client errors plus, on installs
+ *  where the system-logs API (controller/rkllama/qmd/LLM-proxy) is available,
+ *  the operator logs a failed backend operation actually lands in. */
+export function LogsSection() {
+  const [sources, setSources] = useState<SystemLogSource[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    safeFetch<SystemLogSource[]>("/api/system-logs/sources", []).then((data) => {
+      if (!cancelled && Array.isArray(data)) {
+        setSources(data.filter((s) => s.available && s.id !== "client"));
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <section aria-label="Logs">
+      <h2 className="text-lg font-semibold mb-2">Logs</h2>
+      <Tabs defaultValue="client">
+        <TabsList>
+          <TabsTrigger value="client">Client</TabsTrigger>
+          {sources.map((s) => (
+            <TabsTrigger key={s.id} value={s.id}>{s.label}</TabsTrigger>
+          ))}
+        </TabsList>
+        <TabsContent value="client">
+          <ClientLogsTab />
+        </TabsContent>
+        {sources.map((s) => (
+          <TabsContent key={s.id} value={s.id}>
+            <SystemLogsTab source={s} />
+          </TabsContent>
+        ))}
+      </Tabs>
     </section>
   );
 }

--- a/desktop/src/apps/StoreApp/ImportAppButton.test.tsx
+++ b/desktop/src/apps/StoreApp/ImportAppButton.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ImportAppButton } from "./ImportAppButton";
+
+function mockFetchSequence(responses: Array<{ url: string; body: unknown; ok?: boolean }>) {
+  return vi.fn((url: string) => {
+    const match = responses.find((r) => url.includes(r.url));
+    if (!match) throw new Error(`unexpected fetch: ${url}`);
+    return Promise.resolve({ ok: match.ok ?? true, json: async () => match.body });
+  });
+}
+
+describe("ImportAppButton", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("installing a package requesting a gated capability shows the consent dialog", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.net", "app.kv"], needs_consent: true, new_permissions: ["app.net"] },
+      },
+      {
+        url: "/api/userspace-apps",
+        body: [{ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net", "app.kv"], permissions_granted: [] }],
+      },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    const dialog = await screen.findByRole("dialog", { name: /permissions for todo/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/connect to the internet/i)).toBeInTheDocument();
+  });
+
+  it("installing a package with no new permissions never shows the dialog", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.kv"], needs_consent: false, new_permissions: [] },
+      },
+      { url: "/api/userspace-apps", body: [] },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("Deny in the dialog dismisses it without granting", async () => {
+    const mockFetch = mockFetchSequence([
+      {
+        url: "/api/userspace-apps/install",
+        body: { app_id: "todo", permissions_requested: ["app.net"], needs_consent: true, new_permissions: ["app.net"] },
+      },
+      {
+        url: "/api/userspace-apps",
+        body: [{ app_id: "todo", name: "Todo", icon: "", app_type: "web", version: "1", enabled: 1, permissions_requested: ["app.net"], permissions_granted: [] }],
+      },
+    ]);
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<ImportAppButton />);
+    const file = new File(["data"], "todo.taosapp");
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /deny/i }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalledWith(expect.stringContaining("/permissions"), expect.anything());
+  });
+});

--- a/desktop/src/apps/StoreApp/ImportAppButton.tsx
+++ b/desktop/src/apps/StoreApp/ImportAppButton.tsx
@@ -1,0 +1,96 @@
+import { useCallback, useRef, useState } from "react";
+import { Upload, Loader2 } from "lucide-react";
+import {
+  installUserspaceApp,
+  fetchUserspaceAppRow,
+  USERSPACE_APPS_CHANGED,
+  type InstallResult,
+} from "@/lib/userspace-apps";
+import { emitAppEvent } from "@/lib/app-event-bus";
+import { PermissionConsent } from "./PermissionConsent";
+
+/** Import a .taosapp package from disk and install it as a userspace app.
+ * When the install requests new permissions, the consent dialog shows before
+ * anything sensitive is granted -- the app itself is already installed at
+ * that point (with only its free capabilities usable) so it can never be
+ * blocked on a decision the user hasn't made yet. */
+export function ImportAppButton() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [consent, setConsent] = useState<{
+    appId: string;
+    appName: string;
+    requested: string[];
+    alreadyGranted: string[];
+  } | null>(null);
+
+  const handleFile = useCallback(async (file: File) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result: InstallResult = await installUserspaceApp(file);
+      const row = await fetchUserspaceAppRow(result.app_id);
+      // The row is now enabled and visible regardless of consent -- only its
+      // gated capabilities are withheld until the user answers below.
+      emitAppEvent(USERSPACE_APPS_CHANGED);
+      if (result.needs_consent) {
+        setConsent({
+          appId: result.app_id,
+          appName: row?.name ?? result.app_id,
+          requested: result.new_permissions,
+          alreadyGranted: row?.permissions_granted ?? [],
+        });
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Install failed");
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".taosapp,.zip"
+        className="hidden"
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          e.target.value = "";
+          if (file) void handleFile(file);
+        }}
+      />
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        disabled={busy}
+        className="flex items-center gap-1.5 h-8 px-3 rounded-lg text-[12px] font-semibold border border-shell-border text-shell-text-secondary hover:text-shell-text hover:bg-white/[0.04] transition-colors disabled:opacity-60"
+      >
+        {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
+        Import app package
+      </button>
+      {error && (
+        <div role="alert" className="mt-2 text-[11px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
+          {error}
+        </div>
+      )}
+      {consent && (
+        <PermissionConsent
+          appId={consent.appId}
+          appName={consent.appName}
+          requested={consent.requested}
+          alreadyGranted={consent.alreadyGranted}
+          onAllow={() => {
+            emitAppEvent(USERSPACE_APPS_CHANGED);
+            setConsent(null);
+          }}
+          onDeny={() => setConsent(null)}
+        />
+      )}
+    </>
+  );
+}
+
+export default ImportAppButton;

--- a/desktop/src/apps/StoreApp/PermissionConsent.test.tsx
+++ b/desktop/src/apps/StoreApp/PermissionConsent.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { PermissionConsent, GATED_CAPS } from "./PermissionConsent";
+
+describe("PermissionConsent", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renders as a labelled dialog listing each requested capability", () => {
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net", "app.kv"]}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+    const dialog = screen.getByRole("dialog", { name: /permissions for todo/i });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/connect to the internet/i)).toBeInTheDocument();
+    expect(screen.getByText(/store and read its own app data/i)).toBeInTheDocument();
+  });
+
+  it("visually flags gated/sensitive capabilities but not free ones", () => {
+    expect(GATED_CAPS.has("app.net")).toBe(true);
+    expect(GATED_CAPS.has("app.kv")).toBe(false);
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net", "app.kv"]}
+        onAllow={() => {}}
+        onDeny={() => {}}
+      />,
+    );
+    const netRow = screen.getByText(/connect to the internet/i).closest("li")!;
+    const kvRow = screen.getByText(/store and read its own app data/i).closest("li")!;
+    expect(netRow.textContent).toContain("⚠");
+    expect(kvRow.textContent).not.toContain("⚠");
+  });
+
+  it("Allow POSTs the granted permissions (merged with any already granted) and calls onAllow", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", mockFetch);
+    const onAllow = vi.fn();
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        alreadyGranted={["app.memory"]}
+        onAllow={onAllow}
+        onDeny={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+
+    await waitFor(() => expect(onAllow).toHaveBeenCalled());
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/userspace-apps/todo/permissions",
+      expect.objectContaining({ method: "POST" }),
+    );
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(new Set(body.granted)).toEqual(new Set(["app.net", "app.memory"]));
+    expect(onAllow).toHaveBeenCalledWith(expect.arrayContaining(["app.net", "app.memory"]));
+  });
+
+  it("Deny cancels without granting anything", () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+    const onDeny = vi.fn();
+
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        onAllow={() => {}}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /deny/i }));
+
+    expect(onDeny).toHaveBeenCalledTimes(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("Escape key cancels", () => {
+    const onDeny = vi.fn();
+    render(
+      <PermissionConsent
+        appId="todo"
+        appName="Todo"
+        requested={["app.net"]}
+        onAllow={() => {}}
+        onDeny={onDeny}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onDeny).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/apps/StoreApp/PermissionConsent.tsx
+++ b/desktop/src/apps/StoreApp/PermissionConsent.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
+import { grantUserspacePermissions } from "@/lib/userspace-apps";
+
+/**
+ * Capabilities that require explicit user consent before an app can use
+ * them. Mirrors tinyagentos/userspace/capabilities.py GATED_CAPS exactly --
+ * keep in sync if the backend vocabulary changes.
+ */
+export const GATED_CAPS = new Set(["app.net", "app.agent", "app.llm", "app.memory"]);
+
+/**
+ * One-line, human descriptions per capability, for the consent dialog.
+ * Mirrors tinyagentos/userspace/capabilities.py CAPABILITY_DESCRIPTIONS.
+ */
+const CAPABILITY_DESCRIPTIONS: Record<string, string> = {
+  "app.kv": "Store and read its own app data",
+  "app.table": "Store and read its own structured data",
+  "app.files": "Read and write files in its own app folder",
+  "app.notify": "Send you notifications",
+  "app.window": "Open and manage its own windows",
+  "app.net": "Connect to the internet",
+  "app.agent": "Ask your taOS agent for help",
+  "app.llm": "Use a language model",
+  "app.memory": "Read and write your memories",
+};
+
+/** A human one-liner for a capability. Mirrors describe_capability() in
+ * capabilities.py: a `network:<origin>` grant renders as "Connect to
+ * <origin>"; anything unrecognised falls back to the raw token. */
+function describeCapability(cap: string): string {
+  if (cap.startsWith("network:")) return `Connect to ${cap.slice("network:".length)}`;
+  return CAPABILITY_DESCRIPTIONS[cap] ?? cap;
+}
+
+interface Props {
+  appId: string;
+  appName: string;
+  /** The permissions this dialog is asking about (typically new_permissions
+   * from the install response). */
+  requested: string[];
+  /** Permissions already granted before this consent, preserved on Allow so
+   * a re-consent (update) never revokes an earlier grant. */
+  alreadyGranted?: string[];
+  /** Called after the granted permissions have been POSTed. */
+  onAllow: (granted: string[]) => void;
+  /** Called when the user denies or dismisses the dialog; no new permission
+   * is granted. */
+  onDeny: () => void;
+}
+
+export function PermissionConsent({
+  appId,
+  appName,
+  requested,
+  alreadyGranted = [],
+  onAllow,
+  onDeny,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAllow = useCallback(async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const granted = Array.from(new Set([...alreadyGranted, ...requested]));
+      await grantUserspacePermissions(appId, granted);
+      onAllow(granted);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+      setSubmitting(false);
+    }
+  }, [appId, alreadyGranted, requested, onAllow]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onDeny();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onDeny();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Permissions for ${appName}`}
+        className="bg-shell-surface border border-white/10 shadow-2xl rounded-2xl w-[26rem] max-w-[90vw] flex flex-col"
+      >
+        <div className="px-5 py-4 border-b border-white/5">
+          <h2 className="text-sm font-semibold text-shell-text">
+            {appName} wants permission to:
+          </h2>
+        </div>
+        <ul className="px-5 py-4 space-y-2.5">
+          {requested.map((cap) => {
+            const sensitive = GATED_CAPS.has(cap);
+            return (
+              <li key={cap} className="flex items-start gap-2 text-[13px]">
+                {sensitive && (
+                  <span aria-hidden className="text-amber-400 leading-tight">
+                    ⚠
+                  </span>
+                )}
+                <span
+                  className={
+                    sensitive
+                      ? "text-shell-text font-medium leading-tight"
+                      : "text-shell-text-secondary leading-tight"
+                  }
+                >
+                  {describeCapability(cap)}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+        {error && (
+          <div role="alert" className="mx-5 mb-3 text-[12px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
+            {error}
+          </div>
+        )}
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-white/5">
+          <button
+            type="button"
+            onClick={onDeny}
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-[13px] font-semibold text-shell-text-secondary hover:text-shell-text hover:bg-white/[0.04] transition-colors disabled:opacity-60"
+          >
+            Deny
+          </button>
+          <button
+            type="button"
+            onClick={handleAllow}
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-[13px] font-bold text-white transition-colors disabled:opacity-60"
+            style={{ background: "var(--color-accent)" }}
+          >
+            {submitting ? "Allowing…" : "Allow"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default PermissionConsent;

--- a/desktop/src/apps/StoreApp/agent-framework-install.test.tsx
+++ b/desktop/src/apps/StoreApp/agent-framework-install.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for agent-framework install/open behaviour in the Store (#1582).
+ *
+ * Installing an agent-framework from the Store used to report "installed"
+ * without the backend doing anything, and clicking "Open" was a no-op. This
+ * verifies the frontend now (a) shows real base-image prefetch progress by
+ * polling /api/agent-image/status instead of an instant "done", and
+ * (b) routes an installed framework's action button into the Agents app
+ * instead of doing nothing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { StoreApp } from "./index";
+
+const FRAMEWORK_APP = {
+  id: "hermes",
+  name: "Hermes Agent Gateway",
+  type: "agent-framework",
+  version: "1.0.0",
+  description: "Nous Research agent gateway",
+  installed: false,
+  compat: "green",
+};
+
+function makeFetch(opts: {
+  catalogApp: Record<string, unknown>;
+  installResponse?: Record<string, unknown>;
+  imageStatusSequence?: Array<{ status: string }>;
+}) {
+  let imageStatusCalls = 0;
+  const imageStatusSequence = opts.imageStatusSequence ?? [{ status: "idle" }];
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === "/api/store/catalog") {
+      return new Response(JSON.stringify([opts.catalogApp]), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/store/installed-v2") {
+      return new Response(JSON.stringify({ installed: [] }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/store/install-v2" && init?.method === "POST") {
+      return new Response(
+        JSON.stringify(opts.installResponse ?? { ok: true, app_id: "hermes", status: "installed", prefetch: "skipped" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url === "/api/agent-image/status") {
+      const idx = Math.min(imageStatusCalls, imageStatusSequence.length - 1);
+      imageStatusCalls += 1;
+      return new Response(JSON.stringify(imageStatusSequence[idx]), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/store/install-progress/by-app/hermes") {
+      return new Response(JSON.stringify({ app_id: "hermes", active: null }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    // Everything else (frameworks feed, agents list, install targets, optional catalog): 404 is fine.
+    return new Response(null, { status: 404 });
+  });
+}
+
+beforeEach(() => {
+  if (!Element.prototype.scrollTo) {
+    Element.prototype.scrollTo = (() => {}) as typeof Element.prototype.scrollTo;
+  }
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((q: string) => ({
+        matches: false, media: q, onchange: null,
+        addListener: vi.fn(), removeListener: vi.fn(),
+        addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+async function goToAgentsTab() {
+  const agentsBtn = await screen.findByRole("button", { name: /^agents$/i });
+  fireEvent.click(agentsBtn);
+}
+
+describe("Store agent-framework install/open (#1582)", () => {
+  it("polls real base-image prefetch progress instead of instant-complete", async () => {
+    global.fetch = makeFetch({
+      catalogApp: FRAMEWORK_APP,
+      installResponse: { ok: true, app_id: "hermes", status: "installed", prefetch: "started" },
+      imageStatusSequence: [{ status: "downloading" }, { status: "importing" }, { status: "done" }],
+    }) as any;
+
+    render(<StoreApp windowId="test" />);
+    await goToAgentsTab();
+
+    const installBtn = await screen.findByRole("button", { name: /install hermes/i });
+    fireEvent.click(installBtn);
+
+    await waitFor(() => expect(screen.getByText(/downloading base image/i)).toBeInTheDocument());
+  });
+
+  it("does not show prefetch progress when the backend skips it", async () => {
+    global.fetch = makeFetch({
+      catalogApp: FRAMEWORK_APP,
+      installResponse: { ok: true, app_id: "hermes", status: "installed", prefetch: "skipped" },
+    }) as any;
+
+    render(<StoreApp windowId="test" />);
+    await goToAgentsTab();
+
+    const installBtn = await screen.findByRole("button", { name: /install hermes/i });
+    fireEvent.click(installBtn);
+
+    // A successful install swaps this card into its "installed" layout
+    // (Deploy in Agents + Uninstall) -- wait for that swap rather than the
+    // stale pre-install button, which React unmounts once installed flips.
+    await screen.findByRole("button", { name: /deploy hermes/i });
+    expect(screen.queryByText(/downloading base image/i)).not.toBeInTheDocument();
+  });
+
+  it("routes an installed framework's action button to the Agents app instead of a no-op", async () => {
+    global.fetch = makeFetch({ catalogApp: { ...FRAMEWORK_APP, installed: true } }) as any;
+
+    const onOpenApp = vi.fn();
+    window.addEventListener("taos:open-app", onOpenApp);
+
+    render(<StoreApp windowId="test" />);
+    await goToAgentsTab();
+
+    const deployBtn = await screen.findByRole("button", { name: /deploy hermes/i });
+    fireEvent.click(deployBtn);
+
+    expect(onOpenApp).toHaveBeenCalledTimes(1);
+    const detail = (onOpenApp.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail).toEqual({ app: "agents" });
+
+    window.removeEventListener("taos:open-app", onOpenApp);
+  });
+});

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -357,8 +357,40 @@ function AppCard({
   const [error, setError] = useState<string | null>(null);
   interface ProgressSnap { state: string; percent: number | null; bytes_downloaded: number; bytes_total: number; detail: string; error: string | null; }
   const [progress, setProgress] = useState<ProgressSnap | null>(null);
+  const isFramework = app.type === "agent-framework";
+  // Agent-framework installs kick off a background base-image prefetch (see
+  // POST /api/store/install-v2 -> _install_agent_framework). That work
+  // continues after the install call itself returns "installed", so this
+  // tracks the real download/import progress via the existing
+  // /api/agent-image/status endpoint instead of showing an instant "done".
+  const [prefetchActive, setPrefetchActive] = useState(false);
+  const [prefetchStatus, setPrefetchStatus] = useState<string | null>(null);
 
   useEffect(() => { if (defaultTargetRemote !== undefined) setSelectedTarget(defaultTargetRemote); }, [defaultTargetRemote]);
+
+  useEffect(() => {
+    if (!prefetchActive) return;
+    let cancelled = false;
+    const poll = async () => {
+      while (!cancelled) {
+        try {
+          const r = await fetch("/api/agent-image/status", { headers: { Accept: "application/json" } });
+          if (r.ok) {
+            const j = await r.json();
+            const status = String(j?.status ?? "idle");
+            if (!cancelled) setPrefetchStatus(status);
+            if (status === "done" || status === "failed") {
+              if (!cancelled) setPrefetchActive(false);
+              break;
+            }
+          }
+        } catch { /* network blip */ }
+        await new Promise((res) => setTimeout(res, 1500));
+      }
+    };
+    void poll();
+    return () => { cancelled = true; };
+  }, [prefetchActive]);
 
   useEffect(() => {
     if (!busy) return;
@@ -399,11 +431,21 @@ function AppCard({
         if (selectedVariant !== "auto") body.variant_id = selectedVariant;
         const res = await fetch("/api/store/install-v2", { method: "POST", headers: { "Content-Type": "application/json", Accept: "application/json" }, body: JSON.stringify(body) });
         if (!res.ok) { let msg = `Install failed (${res.status})`; try { const err = await res.json(); if (err?.error) msg = String(err.error); } catch { /* ignore */ } setError(msg); setBusy(false); return; }
+        if (isFramework) {
+          try {
+            const data = await res.json();
+            if (data?.prefetch === "started") { setPrefetchStatus("downloading"); setPrefetchActive(true); }
+          } catch { /* no body / not framework prefetch */ }
+        }
         onInstall(app.id);
       }
     } catch (e) { setError(e instanceof Error ? e.message : "Network error"); }
     setBusy(false);
     setTimeout(() => setProgress(null), 1500);
+  };
+
+  const handleOpen = () => {
+    window.dispatchEvent(new CustomEvent("taos:open-app", { detail: { app: "agents" } }));
   };
 
   const visuals = compatVisuals(resolveResponse);
@@ -460,6 +502,17 @@ function AppCard({
             {progress.detail && <span className="text-[10px] text-shell-text-tertiary truncate">{progress.detail}</span>}
           </div>
         )}
+        {isFramework && prefetchStatus && prefetchStatus !== "idle" && (
+          <div className="flex items-center gap-1.5 text-[10px] text-shell-text-tertiary" aria-live="polite">
+            {(prefetchStatus === "downloading" || prefetchStatus === "importing") && <Loader2 className="w-3 h-3 animate-spin shrink-0" />}
+            <span className="truncate">
+              {prefetchStatus === "downloading" ? "Downloading base image…"
+                : prefetchStatus === "importing" ? "Preparing base image…"
+                : prefetchStatus === "done" ? "Base image ready"
+                : "Base image prefetch failed — will fetch on first deploy"}
+            </span>
+          </div>
+        )}
         {showTargetPicker && (
           <div className="flex items-center gap-2">
             <label htmlFor={`target-${app.id}`} className="text-[11px] text-shell-text-tertiary whitespace-nowrap">Install on</label>
@@ -483,15 +536,37 @@ function AppCard({
             {runtimeHost === "127.0.0.1" ? "on controller" : `on ${runtimeHost}`}
           </p>
         )}
-        <button
-          type="button"
-          onClick={handleAction}
-          disabled={busy}
-          aria-label={app.installed ? `Uninstall ${app.name}` : `Install ${app.name}`}
-          className={`w-full flex items-center justify-center gap-1.5 py-1.5 rounded-full text-[12px] font-bold transition-colors ${app.installed ? "bg-red-500/15 text-red-400 hover:bg-red-500/25" : "bg-shell-surface-active text-shell-text hover:bg-white/10"}`}
-        >
-          {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : app.installed ? <><Trash2 className="w-3.5 h-3.5" /> Uninstall</> : <><Download className="w-3.5 h-3.5" /> Install</>}
-        </button>
+        {app.installed && isFramework ? (
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={handleOpen}
+              aria-label={`Deploy ${app.name} in Agents`}
+              className="flex-1 flex items-center justify-center gap-1.5 py-1.5 rounded-full text-[12px] font-bold transition-colors bg-shell-surface-active text-shell-text hover:bg-white/10"
+            >
+              <Bot className="w-3.5 h-3.5" /> Deploy in Agents
+            </button>
+            <button
+              type="button"
+              onClick={handleAction}
+              disabled={busy}
+              aria-label={`Uninstall ${app.name}`}
+              className="shrink-0 p-1.5 rounded-full text-red-400 bg-red-500/15 hover:bg-red-500/25 transition-colors"
+            >
+              {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={handleAction}
+            disabled={busy}
+            aria-label={app.installed ? `Uninstall ${app.name}` : `Install ${app.name}`}
+            className={`w-full flex items-center justify-center gap-1.5 py-1.5 rounded-full text-[12px] font-bold transition-colors ${app.installed ? "bg-red-500/15 text-red-400 hover:bg-red-500/25" : "bg-shell-surface-active text-shell-text hover:bg-white/10"}`}
+          >
+            {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : app.installed ? <><Trash2 className="w-3.5 h-3.5" /> Uninstall</> : <><Download className="w-3.5 h-3.5" /> Install</>}
+          </button>
+        )}
       </div>
     </div>
   );
@@ -525,7 +600,15 @@ function RichCard({
     setBusy(false);
   };
 
+  const isFramework = app.type === "agent-framework";
+
   const handleOpen = () => {
+    if (isFramework) {
+      // Agent frameworks have no standalone window -- deploying/using one
+      // happens from the Agents app's deploy flow.
+      window.dispatchEvent(new CustomEvent("taos:open-app", { detail: { app: "agents" } }));
+      return;
+    }
     // Future: launch the app window
   };
 
@@ -561,7 +644,7 @@ function RichCard({
             disabled={busy}
             className="px-4 py-1.5 rounded-full bg-shell-surface-active text-shell-text text-[12px] font-bold hover:bg-white/10 transition-colors"
           >
-            {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : app.installed ? "Open" : "Get"}
+            {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : app.installed ? (isFramework ? "Deploy in Agents" : "Open") : "Get"}
           </button>
         </div>
       </div>

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -16,6 +16,7 @@ import { compatVisuals } from "./compat-visuals";
 import { loadFilter, saveFilter } from "./storage";
 import { emitAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
 import { TaosAppsSection } from "./TaosAppsSection";
+import { ImportAppButton } from "./ImportAppButton";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { MobileStore } from "./MobileStore";
 import { AppIcon, StoreCover } from "./AppIcon";
@@ -1150,6 +1151,7 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
                   <h2 className="text-[17px] font-bold text-shell-text">{searching ? `Results for "${search.trim()}"` : NAV.find((n) => n.id === activeNav)?.label}</h2>
                   <p className="text-[12px] text-shell-text-tertiary mt-0.5">{filtered.length} apps</p>
                 </div>
+                {activeNav === "apps" && !searching && <ImportAppButton />}
               </div>
               {activeNav === "updates" && (() => {
                 const updatableOptional = optionalCatalog.filter((e) => e.installed && e.update_available);

--- a/desktop/src/apps/TextEditorApp.tsx
+++ b/desktop/src/apps/TextEditorApp.tsx
@@ -19,6 +19,17 @@ interface Note {
 
 const STORAGE_KEY = "tinyagentos-notes";
 
+// crypto.randomUUID() only exists in secure contexts (https, or localhost).
+// taOS is normally reached over plain http (e.g. http://taos.local:6969), so
+// window.crypto.randomUUID is undefined there and calling it threw inside the
+// click handler, silently killing note creation. Fall back to a non-crypto id.
+function newNoteId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `note-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 function loadNotes(): Note[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -199,7 +210,7 @@ export function TextEditorApp({ windowId: _windowId }: { windowId: string }) {
 
   const createNote = useCallback(() => {
     const note: Note = {
-      id: crypto.randomUUID(),
+      id: newNoteId(),
       content: "# New Note\n\nStart writing...",
       updatedAt: Date.now(),
     };

--- a/desktop/src/apps/__tests__/TextEditorApp.test.tsx
+++ b/desktop/src/apps/__tests__/TextEditorApp.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import React from "react";
+
+import { TextEditorApp } from "../TextEditorApp";
+
+describe("TextEditorApp", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(window, "fetch").mockResolvedValue({ ok: true, json: async () => ({}) } as Response);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a note and shows it in the sidebar (crypto.randomUUID available)", () => {
+    render(<TextEditorApp windowId="w1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /create your first note/i }));
+
+    // The new note becomes the active/selected entry, with a delete affordance
+    // in the sidebar keyed to its (unique) title.
+    expect(screen.getByRole("button", { name: "Delete New Note" })).toBeInTheDocument();
+
+    // Persisted to localStorage so it survives a reload.
+    const stored = JSON.parse(localStorage.getItem("tinyagentos-notes") ?? "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].content).toContain("New Note");
+  });
+
+  it("still creates a note when crypto.randomUUID is unavailable (insecure-context regression, #1584)", () => {
+    // taOS is normally served over plain http (e.g. http://taos.local:6969),
+    // which is not a "secure context" per the spec, so window.crypto.randomUUID
+    // is undefined there. Simulate that and confirm note creation still works
+    // instead of silently throwing inside the click handler.
+    // randomUUID lives on the Crypto prototype, not as an own property, so
+    // `delete crypto.randomUUID` is a silent no-op — shadow it with an own
+    // property instead to faithfully simulate the missing API.
+    const originalRandomUUID = crypto.randomUUID;
+    Object.defineProperty(crypto, "randomUUID", { value: undefined, configurable: true });
+
+    try {
+      render(<TextEditorApp windowId="w1" />);
+
+      fireEvent.click(screen.getByRole("button", { name: /create your first note/i }));
+
+      expect(screen.getAllByText("New Note").length).toBeGreaterThan(0);
+      const stored = JSON.parse(localStorage.getItem("tinyagentos-notes") ?? "[]");
+      expect(stored).toHaveLength(1);
+      expect(typeof stored[0].id).toBe("string");
+      expect(stored[0].id.length).toBeGreaterThan(0);
+    } finally {
+      Object.defineProperty(crypto, "randomUUID", { value: originalRandomUUID, configurable: true });
+    }
+  });
+});

--- a/desktop/src/apps/officestudio/slides/deck.ts
+++ b/desktop/src/apps/officestudio/slides/deck.ts
@@ -3,6 +3,8 @@
 // serializes its workbook (see ../calc/workbook.ts) and Write stores its
 // Tiptap HTML directly as `content`.
 
+import { randomId } from "@/lib/uid";
+
 export type SlideLayout = "title" | "title-content" | "two-column" | "section-header" | "blank";
 
 export interface Slide {
@@ -32,10 +34,7 @@ export const LAYOUTS: { id: SlideLayout; label: string }[] = [
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
 
 function genId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return `slide-${crypto.randomUUID()}`;
-  }
-  return `slide-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  return randomId("slide-");
 }
 
 export function newSlide(layout: SlideLayout = "title-content"): Slide {

--- a/desktop/src/apps/webstudio/templates.ts
+++ b/desktop/src/apps/webstudio/templates.ts
@@ -5,10 +5,11 @@ import type {
   Site,
   Theme,
 } from "./types";
+import { randomId } from "@/lib/uid";
 
 /** Unique id for a section. */
 export function newSectionId(): string {
-  return `sec-${crypto.randomUUID()}`;
+  return randomId("sec-");
 }
 
 /** Default editable content for a freshly-added section of a given type. */

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -26,6 +26,7 @@ import {
   SCREEN_CAPTURE_CHANGED_EVENT,
 } from "@/lib/screen-capture";
 import { useProcessStore } from "@/stores/process-store";
+import { randomId } from "@/lib/uid";
 
 export interface PendingAttachment {
   id: string;
@@ -147,7 +148,7 @@ export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boole
       form.append("file", new File([resp.blob], "screenshot.png", { type: resp.mime_type }));
       const uploaded = await uploadChatAttachment(form);
       const snap: PendingAttachment = {
-        id: crypto.randomUUID(),
+        id: randomId(),
         filename: uploaded.filename,
         size: uploaded.size,
         uploading: false,
@@ -186,7 +187,7 @@ export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boole
     el.onchange = async () => {
       const files = Array.from(el.files ?? []);
       for (const file of files) {
-        const id = crypto.randomUUID();
+        const id = randomId();
         setPendingAttachments((p) => [
           ...p,
           { id, filename: file.name, size: file.size, uploading: true },

--- a/desktop/src/lib/browser-push-bootstrap.ts
+++ b/desktop/src/lib/browser-push-bootstrap.ts
@@ -6,6 +6,7 @@
  */
 
 import { getVapidPublicKey, subscribePush } from "./browser-push-api";
+import { randomId } from "./uid";
 
 const DEVICE_ID_KEY = "taos-browser:push-device-id";
 
@@ -45,7 +46,7 @@ export async function bootstrapPushSubscription(): Promise<
     // 2. Get or create stable device_id
     let device_id = localStorage.getItem(DEVICE_ID_KEY);
     if (!device_id) {
-      device_id = crypto.randomUUID();
+      device_id = randomId();
       localStorage.setItem(DEVICE_ID_KEY, device_id);
     }
 

--- a/desktop/src/lib/models.ts
+++ b/desktop/src/lib/models.ts
@@ -33,6 +33,10 @@ export interface AggregatedModel {
   /** Optional format (GGUF, etc.). */
   format?: string;
   quantization?: string;
+  /** Catalog manifest id — set for controller-local files the backend could
+   *  match against a manifest variant's naming convention. Lets Delete call
+   *  DELETE /api/models/{modelId} instead of guessing it from the filename. */
+  modelId?: string;
 }
 
 const SIZE_RE = /[Qq]\d[_A-Za-z0-9]*/;
@@ -46,6 +50,7 @@ export interface ControllerDownloaded {
   filename: string;
   size_mb?: number;
   format?: string;
+  model_id?: string;
 }
 
 /** Map a controller /api/models downloaded_files entry to an AggregatedModel. */
@@ -64,6 +69,7 @@ export function controllerDownloadedToAggregated(
     size: fmtSize(d.size_mb ?? 0),
     format: (d.format ?? "bin").toUpperCase(),
     quantization: quant,
+    modelId: d.model_id,
   };
 }
 

--- a/desktop/src/lib/server-notifications.test.ts
+++ b/desktop/src/lib/server-notifications.test.ts
@@ -121,6 +121,10 @@ describe("server-notifications", () => {
       expect(sourceToTarget("decisions")).toEqual({ action: "decisions" });
     });
 
+    it("routes agent-framework install notifications to the Agents app", () => {
+      expect(sourceToTarget("agent_framework")).toEqual({ action: "agents" });
+    });
+
     it("returns no action for unknown sources", () => {
       expect(sourceToTarget("something.else")).toEqual({});
       expect(sourceToTarget("")).toEqual({});

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -56,6 +56,8 @@ export function sourceToTarget(
     case "app.installed":
     case "app.failed":
       return { action: "store" };
+    case "agent_framework":
+      return { action: "agents" };
     case "decisions":
     case "auth_requests":
       return { action: "decisions" };

--- a/desktop/src/lib/uid.test.ts
+++ b/desktop/src/lib/uid.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { randomId } from "./uid";
+
+describe("randomId", () => {
+  it("returns an id normally", () => {
+    const id = randomId();
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it("applies the given prefix", () => {
+    expect(randomId("sec-")).toMatch(/^sec-/);
+  });
+
+  it("still returns a valid id when crypto.randomUUID is unavailable (non-secure-context http)", () => {
+    const original = crypto.randomUUID;
+    // @ts-expect-error simulate a non-secure context where randomUUID is undefined
+    crypto.randomUUID = undefined;
+    try {
+      const id = randomId();
+      expect(typeof id).toBe("string");
+      expect(id.length).toBeGreaterThan(0);
+    } finally {
+      crypto.randomUUID = original;
+    }
+  });
+});

--- a/desktop/src/lib/uid.ts
+++ b/desktop/src/lib/uid.ts
@@ -1,0 +1,14 @@
+/**
+ * `crypto.randomUUID()` only exists in a secure context (https or localhost).
+ * taOS is commonly accessed over plain http (e.g. http://taos.local:6969),
+ * where `crypto.randomUUID` is undefined and calling it throws synchronously.
+ * Use this helper anywhere a unique id is needed instead of calling
+ * `crypto.randomUUID()` directly.
+ */
+export function randomId(prefix?: string): string {
+  const id =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : Date.now().toString(36) + Math.random().toString(36).slice(2);
+  return prefix ? `${prefix}${id}` : id;
+}

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -46,6 +46,7 @@ export function toAppManifest(row: UserspaceAppRow): AppManifest {
           m.SandboxedAppWindow({
             ...props,
             appId: row.app_id,
+            appType: row.app_type,
             trust,
             provenance,
             grantedCapabilities: row.permissions_granted,

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -97,6 +97,21 @@ export async function grantUserspacePermissions(appId: string, granted: string[]
   if (!res.ok) throw new Error(`granting permissions failed (${res.status})`);
 }
 
+/** Fetch a single installed userspace-app row by id -- used by the install-time
+ * consent dialog to get the app's display name and already-granted
+ * permissions (fresh installs return neither in the install response).
+ * Returns null if the row doesn't exist or the request fails. */
+export async function fetchUserspaceAppRow(appId: string): Promise<UserspaceAppRow | null> {
+  try {
+    const res = await fetch("/api/userspace-apps");
+    if (!res.ok) return null;
+    const rows = (await res.json()) as UserspaceAppRow[];
+    return rows.find((r) => r.app_id === appId) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchUserspaceApps(): Promise<AppManifest[]> {
   let rows: UserspaceAppRow[];
   try {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.20"
+version = "1.0.0-beta.21"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tests/test_container_docker.py
+++ b/tests/test_container_docker.py
@@ -56,6 +56,33 @@ class TestDockerCreate:
             result = await backend.create_container("agent-test", "ubuntu:22.04")
             assert result["success"] is False
 
+    @pytest.mark.asyncio
+    async def test_publishes_ports_bound_to_localhost_only(self):
+        """App Runtime M4: a published port must bind to 127.0.0.1, never
+        0.0.0.0 -- only the controller may reach a container app's backend."""
+        backend = DockerBackend()
+        with patch.object(backend, "_run", new_callable=AsyncMock) as mock:
+            mock.return_value = (0, "container_id")
+            result = await backend.create_container(
+                "taos-app-echo", "myimage:latest", ports=[(13042, 5678)],
+            )
+            assert result["success"] is True
+            call_args = mock.call_args[0][0]
+            assert "-p" in call_args
+            assert "127.0.0.1:13042:5678" in call_args
+            # never publish on all interfaces
+            assert not any(a.startswith("0.0.0.0:") for a in call_args)
+
+    @pytest.mark.asyncio
+    async def test_no_ports_argument_publishes_nothing(self):
+        """Backward compatible: existing agent-deploy callers never pass ports."""
+        backend = DockerBackend()
+        with patch.object(backend, "_run", new_callable=AsyncMock) as mock:
+            mock.return_value = (0, "container_id")
+            await backend.create_container("agent-test", "ubuntu:22.04")
+            call_args = mock.call_args[0][0]
+            assert "-p" not in call_args
+
 
 class TestDockerLifecycle:
     @pytest.mark.asyncio

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -156,6 +156,34 @@ class TestModelsAPI:
         for m in data["models"]:
             assert m["has_downloaded_variant"] is False
 
+    async def test_downloaded_file_carries_model_id(self, models_app, models_client):
+        """A downloaded file whose name matches the
+        {manifest.id}-{variant.id}.{format} convention used by
+        POST /api/models/download must carry that manifest id in
+        downloaded_files, so the frontend can wire per-file Delete to
+        DELETE /api/models/{model_id} without reverse-engineering the
+        naming convention itself (#1581)."""
+        models_dir = models_app.state.models_dir
+        (models_dir / "test-model-small.gguf").write_bytes(b"x" * 100)
+
+        resp = await models_client.get("/api/models")
+        data = resp.json()
+        entry = next(f for f in data["downloaded_files"] if f["filename"] == "test-model-small.gguf")
+        assert entry["model_id"] == "test-model"
+
+    async def test_downloaded_file_without_manifest_match_has_no_model_id(
+        self, models_app, models_client
+    ):
+        """A file that doesn't match any manifest's naming convention (e.g. a
+        legacy/manually-placed file) must not get a fabricated model_id."""
+        models_dir = models_app.state.models_dir
+        (models_dir / "some-legacy-file.gguf").write_bytes(b"x" * 100)
+
+        resp = await models_client.get("/api/models")
+        data = resp.json()
+        entry = next(f for f in data["downloaded_files"] if f["filename"] == "some-legacy-file.gguf")
+        assert "model_id" not in entry
+
     async def test_registry_installed_with_disk_evidence_marks_downloaded(
         self, models_client, models_app, tmp_path
     ):
@@ -220,6 +248,25 @@ class TestModelsDelete:
         data = resp.json()
         assert data["status"] == "deleted"
         assert data["deleted_files"] == []
+
+    async def test_delete_using_model_id_surfaced_in_list(self, models_app, models_client):
+        """End-to-end: the model_id GET /api/models attaches to a downloaded
+        file is exactly the id DELETE /api/models/{model_id} needs to remove
+        it — this is the wiring the frontend Delete button now relies on."""
+        models_dir = models_app.state.models_dir
+        (models_dir / "test-model-small.gguf").write_bytes(b"x" * 100)
+
+        list_resp = await models_client.get("/api/models")
+        entry = next(
+            f for f in list_resp.json()["downloaded_files"]
+            if f["filename"] == "test-model-small.gguf"
+        )
+        model_id = entry["model_id"]
+
+        delete_resp = await models_client.delete(f"/api/models/{model_id}")
+        assert delete_resp.status_code == 200
+        assert "test-model-small.gguf" in delete_resp.json()["deleted_files"]
+        assert not (models_dir / "test-model-small.gguf").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_store_install.py
+++ b/tests/test_routes_store_install.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tinyagentos.agent_image import base_image_alias
 from tinyagentos.catalog.resolver import DeviceCapability
 
 
@@ -51,6 +52,22 @@ def _make_service_manifest(
     m.id = manifest_id
     m.type = "service"
     m.install = {"method": method, "ports": [8080]}
+    m.requires = {}
+    m.hardware_tiers = {}
+    m.version = "1.0.0"
+    return m
+
+
+def _make_agent_framework_manifest(
+    manifest_id: str = "hermes",
+    name: str = "Hermes Agent Gateway",
+    script: str = "scripts/install.sh",
+) -> MagicMock:
+    m = MagicMock()
+    m.id = manifest_id
+    m.name = name
+    m.type = "agent-framework"
+    m.install = {"method": "script", "script": script}
     m.requires = {}
     m.hardware_tiers = {}
     m.version = "1.0.0"
@@ -412,6 +429,201 @@ class TestInstallV2:
         body = resp.json()
         assert "compat" in body
         assert "chain" in body
+
+
+# ---------------------------------------------------------------------------
+# POST /api/store/install-v2 -- agent-framework manifests (method: script) (#1582)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentFrameworkInstall:
+    """Installing an agent-framework manifest (hermes/openclaw's install.sh runs
+    inside a per-agent LXC container at deploy time, not here) enables it for
+    deploy, prefetches its base image in the background, and notifies -- it
+    must never silently do nothing while reporting "installed" (#1582)."""
+
+    @pytest.mark.asyncio
+    async def test_marks_installed_without_running_the_container_script(self, client):
+        manifest = _make_agent_framework_manifest("hermes")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        with patch(
+            "tinyagentos.routes.store_install.ensure_image_present",
+            new=AsyncMock(return_value=True),
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "hermes"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["status"] == "installed"
+        installed_apps.install.assert_called_once_with("hermes", "1.0.0", {})
+        reg.mark_installed.assert_called_once_with("hermes", "1.0.0")
+
+    @pytest.mark.asyncio
+    async def test_triggers_base_image_prefetch_for_dedicated_framework(self, client):
+        """hermes has a dedicated base image -- installing kicks off a
+        background ensure_image_present() for it."""
+        manifest = _make_agent_framework_manifest("hermes")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        client._transport.app.state.installed_apps = _make_installed_apps()
+
+        mock_ensure = AsyncMock(return_value=True)
+        with patch("tinyagentos.routes.store_install.ensure_image_present", new=mock_ensure):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "hermes"})
+
+        assert resp.status_code == 200
+        assert resp.json()["prefetch"] == "started"
+        mock_ensure.assert_called_once()
+        alias, url = mock_ensure.call_args[0]
+        assert alias == base_image_alias("hermes") == "taos-hermes-base"
+        assert alias in url
+
+    @pytest.mark.asyncio
+    async def test_skips_prefetch_for_framework_without_dedicated_base(self, client):
+        """agent-zero has no dedicated base image -- no prefetch is started;
+        it falls back to the generic base at deploy time."""
+        manifest = _make_agent_framework_manifest("agent-zero", name="Agent Zero")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        client._transport.app.state.installed_apps = _make_installed_apps()
+
+        mock_ensure = AsyncMock(return_value=True)
+        with patch("tinyagentos.routes.store_install.ensure_image_present", new=mock_ensure):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "agent-zero"})
+
+        assert resp.status_code == 200
+        assert resp.json()["prefetch"] == "skipped"
+        mock_ensure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_prefetch_failure_is_non_fatal(self, client):
+        """A failed prefetch never blocks the install -- the framework stays
+        enabled and a first deploy just falls back to a cold image build."""
+        manifest = _make_agent_framework_manifest("hermes")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        with patch(
+            "tinyagentos.routes.store_install.ensure_image_present",
+            new=AsyncMock(side_effect=RuntimeError("network down")),
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "hermes"})
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        installed_apps.install.assert_called_once()
+        reg.mark_installed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_emits_actionable_notification(self, client):
+        manifest = _make_agent_framework_manifest("hermes", name="Hermes Agent Gateway")
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        client._transport.app.state.installed_apps = _make_installed_apps()
+
+        mock_notifs = MagicMock()
+        mock_notifs.add = AsyncMock()
+        client._transport.app.state.notifications = mock_notifs
+
+        with patch(
+            "tinyagentos.routes.store_install.ensure_image_present",
+            new=AsyncMock(return_value=True),
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "hermes"})
+
+        assert resp.status_code == 200
+        mock_notifs.add.assert_called_once()
+        _, kwargs = mock_notifs.add.call_args
+        assert kwargs["source"] == "agent_framework"
+        assert kwargs["level"] == "success"
+        assert "Hermes Agent Gateway" in kwargs["title"]
+        assert "Agents app" in kwargs["message"]
+        assert kwargs["data"] == {"framework": "hermes"}
+
+    @pytest.mark.asyncio
+    async def test_pip_based_framework_unaffected(self, client):
+        """Pip/docker-based agent-frameworks (smolagents, langroid, ...) are
+        untouched -- they keep running the real installer, not the
+        script-only enable+prefetch+notify path."""
+        manifest = _make_agent_framework_manifest("smolagents")
+        manifest.install = {"method": "pip", "package": "smolagents"}
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(return_value={"success": True})
+        with patch(
+            "tinyagentos.installers.pip_installer.PipInstaller",
+            return_value=mock_installer,
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "smolagents"})
+
+        assert resp.status_code == 200
+        mock_installer.install.assert_called_once()
+        installed_apps.install.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/store/install-v2 -- non-framework method: script manifests (#1582)
+# ---------------------------------------------------------------------------
+
+
+class TestScriptBackendInstall:
+    """The generic install.method: script path (backend/plugin manifests
+    like ollama, tailscale) previously fell through to the default branch
+    and silently marked the app installed without ever running the script.
+    It must now actually run it, or fail loudly."""
+
+    @pytest.mark.asyncio
+    async def test_missing_script_returns_explicit_error_not_false_success(self, client):
+        manifest = _make_service_manifest("some-service", method="script")
+        manifest.install = {"method": "script", "script": "scripts/does-not-exist.sh"}
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        resp = await client.post("/api/store/install-v2", json={"manifest_id": "some-service"})
+
+        assert resp.status_code == 500
+        assert "error" in resp.json()
+        installed_apps.install.assert_not_called()
+        reg.mark_installed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_script_marks_installed(self, client):
+        manifest = _make_service_manifest("some-service", method="script")
+        manifest.install = {"method": "script", "script": "scripts/noop.sh"}
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(
+            return_value={"success": True, "app_id": "some-service", "method": "script"},
+        )
+        with patch(
+            "tinyagentos.routes.store_install.get_installer",
+            return_value=mock_installer,
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "some-service"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        mock_installer.install.assert_called_once_with("some-service", manifest.install)
+        installed_apps.install.assert_called_once()
+        reg.mark_installed.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes_system_logs.py
+++ b/tests/test_routes_system_logs.py
@@ -1,0 +1,110 @@
+"""Route tests for the Logs app backend (#1548 part 1)."""
+import json
+
+import pytest
+
+from tinyagentos import __version__
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.routes import system_logs
+
+
+def _fake_journald_line(message: str, cursor: str = "s=fake-cursor") -> bytes:
+    return (json.dumps({"MESSAGE": message, "__CURSOR": cursor}) + "\n").encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_sources_without_journald(client, app, tmp_path, monkeypatch):
+    """With journald absent, journald-kind sources are unavailable, and the
+    file/client sources still resolve without raising."""
+    monkeypatch.setattr(system_logs, "_journalctl_missing", lambda: True)
+    # Point llmproxy at a clean, empty directory so this assertion does not
+    # depend on whatever is (or isn't) left over in the real default
+    # /tmp/taos-litellm on the host running the tests.
+    monkeypatch.setattr(app.state.llm_proxy, "config_dir", tmp_path / "no-litellm-here")
+
+    resp = await client.get("/api/system-logs/sources")
+    assert resp.status_code == 200
+    sources = resp.json()
+    by_id = {s["id"]: s for s in sources}
+    assert set(by_id) == {"controller", "rkllama", "qmd", "llmproxy", "client"}
+
+    for sid in ("controller", "rkllama", "qmd"):
+        assert by_id[sid]["available"] is False
+        assert by_id[sid]["kind"] == "file"
+
+    # llmproxy has no log file in this test data dir, so it should resolve
+    # to available: False without raising.
+    assert by_id["llmproxy"]["kind"] == "file"
+    assert by_id["llmproxy"]["available"] is False
+
+    # client_log_store is initialised by the `client` fixture.
+    assert by_id["client"]["kind"] == "client"
+    assert by_id["client"]["available"] is True
+
+
+@pytest.mark.asyncio
+async def test_controller_page_redacts_secret(client, monkeypatch):
+    """A fake journald line carrying a live-looking secret must never reach
+    the JSON response verbatim."""
+    async def fake_run_journalctl(args, timeout=10.0, max_bytes=None):
+        return 0, _fake_journald_line("connecting with api_key=SECRETVALUE123")
+
+    monkeypatch.setattr(system_logs, "_run_journalctl", fake_run_journalctl)
+
+    resp = await client.get("/api/system-logs/controller?lines=50")
+    assert resp.status_code == 200
+    body = resp.json()
+    raw_body = resp.text
+    assert "SECRETVALUE123" not in raw_body
+    assert system_logs.redact("api_key=SECRETVALUE123") in raw_body
+    assert body["source"] == "controller"
+    assert any("[REDACTED]" in line for line in body["lines"])
+
+
+@pytest.mark.asyncio
+async def test_unknown_source_rejected(client):
+    resp = await client.get("/api/system-logs/not-a-real-source")
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "unknown source"
+
+
+@pytest.mark.asyncio
+async def test_client_source_has_no_paged_reader(client):
+    """client is advertised in /sources but is not a readable {source} page --
+    the frontend hits /api/client-logs directly for that tab."""
+    resp = await client.get("/api/system-logs/client")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_bundle_has_banner_and_redacts_secrets(client, monkeypatch):
+    monkeypatch.setattr(system_logs, "_journalctl_missing", lambda: False)
+
+    async def fake_run_journalctl(args, timeout=10.0, max_bytes=None):
+        return 0, _fake_journald_line("connecting with api_key=SECRETVALUE123")
+
+    monkeypatch.setattr(system_logs, "_run_journalctl", fake_run_journalctl)
+
+    resp = await client.get("/api/system-logs/bundle")
+    assert resp.status_code == 200
+    assert "text/plain" in resp.headers["content-type"]
+    body = resp.text
+    assert __version__ in body
+    assert "python:" in body
+    assert "SECRETVALUE123" not in body
+    assert "[REDACTED]" in body
+
+
+@pytest.mark.asyncio
+async def test_non_admin_forbidden(app, client):
+    app.dependency_overrides[current_user] = lambda: CurrentUser(user_id="bob", is_admin=False)
+    try:
+        for path in (
+            "/api/system-logs/sources",
+            "/api/system-logs/controller",
+            "/api/system-logs/bundle",
+        ):
+            resp = await client.get(path)
+            assert resp.status_code == 403, path
+    finally:
+        app.dependency_overrides.pop(current_user, None)

--- a/tests/test_routes_userspace_apps.py
+++ b/tests/test_routes_userspace_apps.py
@@ -233,8 +233,10 @@ async def test_install_private_url_returns_400(client):
 
 
 @pytest.mark.asyncio
-async def test_install_container_package_returns_501(client):
-    """Container app_type must be rejected with 501."""
+async def test_install_container_package_succeeds(client):
+    """Container app_type installs successfully (App Runtime M4 lifted the old
+    web-only 501 gate). Install does NOT auto-deploy -- the backend container
+    is created on enable -- so no Docker is touched here."""
     await _init_userspace_stores(
         client._transport.app,
         client._transport.app.state.data_dir,
@@ -260,12 +262,25 @@ async def test_install_container_package_returns_501(client):
         zf.writestr("manifest.yaml", manifest)
     pkg = buf.getvalue()
 
-    resp = await client.post(
-        "/api/userspace-apps/install",
-        files={"package": ("container.taosapp", pkg, "application/zip")},
-    )
-    assert resp.status_code == 501
-    assert "container packages are not supported" in resp.json()["error"]
+    # Guard: even though install must not deploy, patch the deployer so a
+    # regression that starts deploying at install time would fail loudly here.
+    with patch(
+        "tinyagentos.routes.userspace_apps.deploy_app_container",
+        new_callable=AsyncMock,
+    ) as deploy:
+        resp = await client.post(
+            "/api/userspace-apps/install",
+            files={"package": ("container.taosapp", pkg, "application/zip")},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["app_id"] == "container-app"
+        deploy.assert_not_awaited()
+
+    # App is recorded as a container app, with no runtime location yet.
+    rows = (await client.get("/api/userspace-apps")).json()
+    row = next(a for a in rows if a["app_id"] == "container-app")
+    assert row["app_type"] == "container"
+    assert row["container_host"] is None and row["container_port"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/userspace/test_container_app.py
+++ b/tests/userspace/test_container_app.py
@@ -1,0 +1,240 @@
+"""App Runtime M4: container app lifecycle -- deploy on enable, destroy on
+disable/uninstall, and the enable/disable route contracts around it.
+
+deploy_app_container / destroy_app_container are patched at the point they
+are imported into tinyagentos.routes.userspace_apps so these tests never
+touch a real Docker daemon.
+"""
+import io
+import zipfile
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+CONTAINER_MANIFEST = (
+    "id: echo\nname: Echo\nversion: 1.0.0\napp_type: container\n"
+    "entry: index.html\nicon: ''\npermissions: []\n"
+    "container:\n  image: docker.io/hashicorp/http-echo:latest\n  ports: [5678]\n"
+)
+
+
+def _zip(manifest=CONTAINER_MANIFEST):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("manifest.yaml", manifest)
+        z.writestr("index.html", "x")
+    return buf.getvalue()
+
+
+async def _install(client):
+    r = await client.post(
+        "/api/userspace-apps/install",
+        files={"package": ("echo.taosapp", _zip(), "application/zip")},
+    )
+    assert r.status_code == 200, r.text
+    return r
+
+
+@pytest.mark.asyncio
+async def test_install_does_not_deploy_a_container(client):
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        await _install(client)
+        deploy.assert_not_awaited()
+    apps = (await client.get("/api/userspace-apps")).json()
+    echo = next(a for a in apps if a["app_id"] == "echo")
+    assert echo["container_host"] is None and echo["container_port"] is None
+
+
+@pytest.mark.asyncio
+async def test_enable_deploys_backend_and_records_runtime_location(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        r = await client.post("/api/userspace-apps/echo/enable")
+        assert r.status_code == 200, r.text
+        deploy.assert_awaited_once()
+        # the image from the manifest's container block reached deploy_app_container
+        assert "http-echo" in str(deploy.await_args)
+
+    apps = (await client.get("/api/userspace-apps")).json()
+    echo = next(a for a in apps if a["app_id"] == "echo")
+    assert echo["container_host"] == "127.0.0.1" and echo["container_port"] == 13042
+    assert echo["enabled"]
+
+
+@pytest.mark.asyncio
+async def test_enable_failure_keeps_app_disabled_and_reports_error(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": False, "error": "image not found"}
+        r = await client.post("/api/userspace-apps/echo/enable")
+        assert r.status_code == 502
+        assert r.json()["error"] == "image not found"
+
+    apps = (await client.get("/api/userspace-apps")).json()
+    echo = next(a for a in apps if a["app_id"] == "echo")
+    # Not left half-enabled: enabled flips back off, no runtime location.
+    assert not echo["enabled"]
+    assert echo["container_host"] is None and echo["container_port"] is None
+
+
+@pytest.mark.asyncio
+async def test_docker_missing_is_graceful_on_enable(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {
+            "success": False,
+            "error": "Docker is required to run container apps but was not found.",
+        }
+        r = await client.post("/api/userspace-apps/echo/enable")
+        assert r.status_code == 502
+        assert "Docker" in r.json()["error"]
+    apps = (await client.get("/api/userspace-apps")).json()
+    assert not next(a for a in apps if a["app_id"] == "echo")["enabled"]
+
+
+@pytest.mark.asyncio
+async def test_disable_destroys_backend_and_clears_runtime_location(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        await client.post("/api/userspace-apps/echo/enable")
+
+    with patch("tinyagentos.routes.userspace_apps.destroy_app_container",
+               new_callable=AsyncMock) as destroy:
+        r = await client.post("/api/userspace-apps/echo/disable")
+        assert r.status_code == 200
+        destroy.assert_awaited_once()
+        assert destroy.await_args.args[0] == "echo"
+
+    apps = (await client.get("/api/userspace-apps")).json()
+    echo = next(a for a in apps if a["app_id"] == "echo")
+    assert not echo["enabled"]
+    assert echo["container_host"] is None and echo["container_port"] is None
+
+
+@pytest.mark.asyncio
+async def test_uninstall_destroys_container_app_backend_first(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        await client.post("/api/userspace-apps/echo/enable")
+
+    with patch("tinyagentos.routes.userspace_apps.destroy_app_container",
+               new_callable=AsyncMock) as destroy:
+        r = await client.delete("/api/userspace-apps/echo")
+        assert r.status_code == 200
+        destroy.assert_awaited_once()
+        assert destroy.await_args.args[0] == "echo"
+
+    apps = (await client.get("/api/userspace-apps")).json()
+    assert all(a["app_id"] != "echo" for a in apps)
+
+
+@pytest.mark.asyncio
+async def test_web_app_enable_never_touches_container_deploy(client):
+    web = "id: w\nname: W\nversion: 1\napp_type: web\nentry: index.html\nicon: ''\npermissions: []\n"
+    r = await client.post("/api/userspace-apps/install",
+                          files={"package": ("w.taosapp", _zip(web), "application/zip")})
+    assert r.status_code == 200
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        r = await client.post("/api/userspace-apps/w/enable")
+        assert r.status_code == 200
+        deploy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwards_only_to_recorded_runtime_location(client):
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        await client.post("/api/userspace-apps/echo/enable")
+
+    captured = {}
+
+    class _FakeUpstreamResponse:
+        status_code = 200
+        headers = {"content-type": "text/plain"}
+
+        async def aiter_bytes(self):
+            yield b"hello from echo"
+
+        async def aclose(self):
+            pass
+
+    async def _fake_send(req, **kwargs):
+        captured["url"] = str(req.url)
+        return _FakeUpstreamResponse()
+
+    # Patch only the proxy's own client instance -- patching AsyncClient.send
+    # on the class would also intercept the test client's ASGI requests.
+    with patch("tinyagentos.routes.userspace_apps._container_proxy_client.send", new=_fake_send):
+        r = await client.get("/api/userspace-apps/echo/proxy/status")
+
+    assert r.status_code == 200
+    assert r.content == b"hello from echo"
+    # the proxy only ever targets the exact recorded 127.0.0.1:<port> location
+    assert captured["url"] == "http://127.0.0.1:13042/status"
+    # sandbox CSP is applied to the proxied response too
+    assert "sandbox" in r.headers.get("content-security-policy", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_proxy_404s_when_no_runtime_location(client):
+    await _install(client)  # installed, but never enabled -- no runtime location
+    r = await client.get("/api/userspace-apps/echo/proxy/")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_proxy_strips_taos_session_even_from_malformed_cookie(client):
+    # A malformed Cookie header must NOT leak the taos_session credential to
+    # the untrusted container backend, even when it is not valid cookie
+    # grammar (the scrub is textual, never SimpleCookie-dependent).
+    await _install(client)
+    with patch("tinyagentos.routes.userspace_apps.deploy_app_container",
+               new_callable=AsyncMock) as deploy:
+        deploy.return_value = {"success": True, "host": "127.0.0.1", "port": 13042}
+        await client.post("/api/userspace-apps/echo/enable")
+
+    captured = {}
+
+    class _FakeUpstreamResponse:
+        status_code = 200
+        headers = {"content-type": "text/plain"}
+
+        async def aiter_bytes(self):
+            yield b"ok"
+
+        async def aclose(self):
+            pass
+
+    async def _fake_send(req, **kwargs):
+        captured["cookie"] = req.headers.get("cookie", "")
+        return _FakeUpstreamResponse()
+
+    # Include the REAL session cookie (so auth passes) inside an otherwise
+    # malformed Cookie header that would trip SimpleCookie.load. taos_session
+    # is exactly what must be scrubbed before the request reaches the backend.
+    session_token = client.cookies.get("taos_session")
+    malformed = f"taos_session={session_token}; bad==value; keep=1; ;;"
+    with patch("tinyagentos.routes.userspace_apps._container_proxy_client.send", new=_fake_send):
+        r = await client.get(
+            "/api/userspace-apps/echo/proxy/status",
+            headers={"Cookie": malformed},
+        )
+
+    assert r.status_code == 200
+    # taos_session (and its value) must never reach the backend...
+    assert "taos_session" not in captured["cookie"]
+    assert session_token not in captured["cookie"]
+    # ...while an unrelated cookie is still forwarded.
+    assert "keep=1" in captured["cookie"]

--- a/tests/userspace/test_container_deploy.py
+++ b/tests/userspace/test_container_deploy.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from tinyagentos.userspace import container_deploy as cd
+
+
+@pytest.mark.asyncio
+async def test_deploy_publishes_first_port_bound_to_localhost_and_applies_caps():
+    with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
+         patch.object(cd, "_find_free_port", return_value=13042), \
+         patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
+        create.return_value = {"success": True, "name": "taos-app-echo"}
+        out = await cd.deploy_app_container("echo", {"image": "hashicorp/http-echo:latest", "ports": [5678]})
+        assert out == {"success": True, "host": "127.0.0.1", "port": 13042}
+        kwargs = create.call_args.kwargs
+        args = create.call_args.args
+        assert args[0] == "taos-app-echo"
+        assert kwargs["image"] == "hashicorp/http-echo:latest"
+        # (host_port, container_port) tuple reached the backend -- the actual
+        # 127.0.0.1-only binding is enforced inside DockerBackend.create_container
+        # (see test_docker_backend.py), not re-verified here.
+        assert kwargs["ports"] == [(13042, 5678)]
+        # untrusted app backend gets a conservative, fixed resource cap
+        assert kwargs["memory_limit"] == "512m"
+        assert kwargs["cpu_limit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_deploy_fails_cleanly_without_docker():
+    with patch.object(cd.shutil, "which", return_value=None):
+        out = await cd.deploy_app_container("echo", {"image": "x", "ports": [5678]})
+        assert out["success"] is False
+        assert "Docker" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_deploy_propagates_backend_error():
+    with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
+         patch.object(cd, "_find_free_port", return_value=13042), \
+         patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
+        create.return_value = {"success": False, "error": "image not found"}
+        out = await cd.deploy_app_container("echo", {"image": "nope", "ports": [5678]})
+        assert out["success"] is False and out["error"] == "image not found"
+
+
+@pytest.mark.asyncio
+async def test_deploy_retries_on_port_race():
+    with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
+         patch.object(cd, "_find_free_port", side_effect=[13042, 13043]), \
+         patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
+        create.side_effect = [
+            {"success": False, "error": "port is already allocated"},
+            {"success": True, "name": "taos-app-echo"},
+        ]
+        out = await cd.deploy_app_container("echo", {"image": "x", "ports": [5678]})
+        assert out == {"success": True, "host": "127.0.0.1", "port": 13043}
+        assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_destroy_calls_backend_remove():
+    with patch.object(cd.DockerBackend, "destroy_container", new_callable=AsyncMock) as rm:
+        await cd.destroy_app_container("echo")
+        rm.assert_awaited_once()
+        assert rm.call_args.args[-1] == "taos-app-echo"

--- a/tests/userspace/test_container_manifest.py
+++ b/tests/userspace/test_container_manifest.py
@@ -1,0 +1,46 @@
+import pytest
+from tinyagentos.userspace.package import parse_manifest, PackageError
+
+VALID_CONTAINER = (
+    "id: echo\nname: Echo\nversion: 1.0.0\napp_type: container\n"
+    "container:\n  image: docker.io/hashicorp/http-echo:latest\n  ports: [5678]\n"
+)
+
+
+def test_valid_container_manifest_roundtrip():
+    m = parse_manifest(VALID_CONTAINER)
+    assert m["container"]["image"] == "docker.io/hashicorp/http-echo:latest"
+    assert m["container"]["ports"] == [5678]
+
+
+def test_container_app_no_container_block():
+    with pytest.raises(PackageError, match="container"):
+        parse_manifest("id: x\nname: X\nversion: 1\napp_type: container\n")
+
+
+def test_container_block_missing_image():
+    with pytest.raises(PackageError, match="container.image"):
+        parse_manifest(
+            "id: x\nname: X\nversion: 1\napp_type: container\n"
+            "container:\n  ports: [8080]\n"
+        )
+
+
+@pytest.mark.parametrize("ports_yaml,label", [
+    ("", "missing"),
+    ("  ports: []\n", "empty list"),
+    ("  ports: [x]\n", "non-int element"),
+    ("  ports: [true]\n", "bool element"),
+])
+def test_container_block_bad_ports(ports_yaml, label):
+    yaml_text = (
+        "id: x\nname: X\nversion: 1\napp_type: container\n"
+        "container:\n  image: foo\n" + ports_yaml
+    )
+    with pytest.raises(PackageError, match="container.ports"):
+        parse_manifest(yaml_text)
+
+
+def test_web_app_no_container_block_parses_fine():
+    m = parse_manifest("id: t\nname: T\nversion: 1\napp_type: web\n")
+    assert m["app_type"] == "web"

--- a/tests/userspace/test_routes.py
+++ b/tests/userspace/test_routes.py
@@ -110,7 +110,7 @@ async def test_install_pins_connection_to_resolved_ip(client):
 def _container_zip():
     manifest = (
         "id: ctapp\nname: ContainerApp\nversion: 1.0.0\napp_type: container\n"
-        "entry: index.html\nicon: \npermissions: []\n"
+        "entry: index.html\nicon: ''\npermissions: []\n"
         "container:\n  image: myimage:latest\n  ports: [8080]\n"
     )
     buf = io.BytesIO()
@@ -121,19 +121,22 @@ def _container_zip():
 
 
 @pytest.mark.asyncio
-async def test_container_install_rejected_with_no_stored_state(client):
-    # Finding 3: installing a container package must return 501 before
-    # persisting anything -- no app row and no extracted directory must remain.
+async def test_container_install_no_longer_gated(client):
+    # App Runtime M4: container packages are no longer rejected at install --
+    # see tests/userspace/test_container_app.py for the full deploy/enable/
+    # disable/uninstall lifecycle. This just confirms the old 501 gate is gone
+    # and the app is stored (not auto-deployed at install time).
     r = await client.post(
         "/api/userspace-apps/install",
         files={"package": ("ctapp.taosapp", _container_zip(), "application/zip")},
     )
-    assert r.status_code == 501
-    assert "container" in r.json()["error"].lower()
+    assert r.status_code == 200, r.text
+    assert r.json()["app_id"] == "ctapp"
 
-    # No app row stored.
     rows = (await client.get("/api/userspace-apps")).json()
-    assert all(a["app_id"] != "ctapp" for a in rows)
+    row = next(a for a in rows if a["app_id"] == "ctapp")
+    assert row["app_type"] == "container"
+    assert row["container_host"] is None and row["container_port"] is None
 
 
 def _net_zip():

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.20"
+__version__ = "1.0.0-beta.21"

--- a/tinyagentos/containers/docker.py
+++ b/tinyagentos/containers/docker.py
@@ -133,6 +133,7 @@ class DockerBackend(ContainerBackend):
         env: dict[str, str] | None = None,
         host_uid: int | None = None,
         root_size_gib: int | None = None,
+        ports: list[tuple[int, int]] | None = None,
     ) -> dict:
         """Create and start a new container.
 
@@ -142,6 +143,11 @@ class DockerBackend(ContainerBackend):
         root_size_gib: when set, call set_root_quota after the container
         is created. Enforcement depends on the Docker storage driver;
         on overlay2 without pquota this is accounting-only.
+
+        ports: list of (host_port, container_port) pairs to publish. Each is
+        bound to 127.0.0.1 ONLY -- never 0.0.0.0 -- so a published port is
+        reachable from this host alone (the controller proxies to it); it
+        must never be reachable off-host.
         """
         args = [
             self.binary, "run", "-d",
@@ -155,6 +161,8 @@ class DockerBackend(ContainerBackend):
             args += ["-v", f"{host_path}:{container_path}"]
         for key, value in (env or {}).items():
             args += ["-e", f"{key}={value}"]
+        for host_port, container_port in ports or []:
+            args += ["-p", f"127.0.0.1:{host_port}:{container_port}"]
         args.append(image)
         code, output = await self._run(args, timeout=300)
         if code != 0:

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -320,6 +320,10 @@ def register_all_routers(app):
     from tinyagentos.routes.client_logs import router as client_logs_router
     app.include_router(client_logs_router)
 
+    # Logs app backend (#1548 part 1): journald/file log sources + bug-report bundle.
+    from tinyagentos.routes.system_logs import router as system_logs_router
+    app.include_router(system_logs_router)
+
     from tinyagentos.routes.account_proxy import router as account_proxy_router
     app.include_router(account_proxy_router)
 

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -109,6 +109,27 @@ def _scan_all_roots(roots: list[Path]) -> list[dict]:
     return merged
 
 
+def _attach_model_ids(downloaded_files: list[dict], models) -> None:
+    """Attach the catalog manifest id to each downloaded file entry.
+
+    Matches on the ``{manifest.id}-{variant.id}.{format}`` naming convention
+    that POST /api/models/download uses when writing a variant to disk (see
+    ``_model_to_dict``'s own ``expected_filename`` check below, which this
+    mirrors). Lets the frontend wire a per-file Delete button to
+    DELETE /api/models/{model_id} without having to reverse-engineer that
+    naming convention itself.
+    """
+    by_filename: dict[str, str] = {}
+    for m in models:
+        for v in m.variants:
+            expected = f"{m.id}-{v['id']}.{v.get('format', 'bin')}"
+            by_filename.setdefault(expected, m.id)
+    for entry in downloaded_files:
+        model_id = by_filename.get(entry["filename"])
+        if model_id:
+            entry["model_id"] = model_id
+
+
 def _is_service_installed(variant: dict) -> bool:
     """Detect whether a multi-file service-backed variant is installed on disk
     outside the ``data/models`` tree.
@@ -284,6 +305,7 @@ async def list_models(request: Request):
 
     models = registry.list_available(type_filter="model")
     downloaded = _scan_all_roots(_scan_roots(request))
+    _attach_model_ids(downloaded, models)
     live_models = catalog.all_models() if catalog is not None else []
     # Build {app_id: True} from the install registry so backend-installed
     # models (e.g. rk-llama.cpp GGUFs at ~/rk-llama.cpp/models/) still show

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -17,6 +17,12 @@ from urllib.parse import urlparse
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from tinyagentos.agent_image import (
+    FRAMEWORKS_WITH_DEDICATED_BASE,
+    base_image_alias,
+    base_image_url_for_alias,
+    ensure_image_present,
+)
 from tinyagentos.catalog.resolver import (
     DeviceCapability,
     ResolveErr,
@@ -27,6 +33,7 @@ from tinyagentos.catalog.resolver import (
 from tinyagentos.cluster.capabilities import hardware_to_targets
 from tinyagentos.installers.base import get_installer
 from tinyagentos.installers.lxc_installer import LXCInstaller
+from tinyagentos.task_utils import _create_supervised_task
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -197,6 +204,68 @@ def _registry_get(registry, app_id: str):
     return registry.get(app_id)
 
 
+async def _install_agent_framework(
+    request: Request, manifest, app_id: str, meta: dict, body: dict,
+) -> JSONResponse:
+    """Install an agent-framework manifest declaring ``install.method: script``.
+
+    That script (e.g. hermes/openclaw's ``scripts/install.sh``) is written to
+    run once *inside a fresh per-agent LXC container* at deploy time — it
+    installs Node/npm or pip packages, writes container-local config, and
+    enables systemd units for that container (see ``deployer.py``'s
+    method=="script" branch). Running it here, on the taOS controller host,
+    at Store-install time would be wrong: there is no target container yet,
+    and the script would pollute the host instead.
+
+    So "installing" a framework from the Store means: enable it for deploy
+    (mark it installed so the Store/Agents app reflect real state — the
+    adapter registry already knows how to deploy every listed framework),
+    kick off a best-effort background prefetch of its dedicated base image
+    (if it has one) so the first real deploy is fast, and notify the user it
+    is ready to deploy. Prefetch failure is non-fatal: the framework stays
+    enabled and a first deploy falls back to a cold image build.
+    """
+    registry = getattr(request.app.state, "registry", None)
+    store = getattr(request.app.state, "installed_apps", None)
+    version = body.get("version") or getattr(manifest, "version", "") or ""
+
+    if store is not None:
+        await store.install(app_id, version, meta)
+    if registry is not None and hasattr(registry, "mark_installed"):
+        registry.mark_installed(app_id, version)
+
+    prefetch_started = False
+    if app_id in FRAMEWORKS_WITH_DEDICATED_BASE:
+        alias = base_image_alias(app_id)
+        url = base_image_url_for_alias(alias)
+        bg_tasks = getattr(request.app.state, "_background_tasks", None)
+        if bg_tasks is None:
+            bg_tasks = set()
+            request.app.state._background_tasks = bg_tasks
+        _create_supervised_task(ensure_image_present(alias, url), bg_tasks)
+        prefetch_started = True
+
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is not None:
+        try:
+            await notifs.add(
+                title=f"{getattr(manifest, 'name', app_id)} installed",
+                message="You can now deploy it from the Agents app",
+                level="success",
+                source="agent_framework",
+                data={"framework": app_id},
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("_install_agent_framework: notification failed for %s", app_id, exc_info=True)
+
+    return JSONResponse({
+        "ok": True,
+        "app_id": app_id,
+        "status": "installed",
+        "prefetch": "started" if prefetch_started else "skipped",
+    })
+
+
 def _docker_published_port(install_config: dict) -> int:
     """Return the first host port a docker service publishes, or 0.
 
@@ -240,6 +309,16 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
             backend = install_block.get("method", "docker")
 
     meta = body.get("metadata") or {}
+
+    # Agent frameworks whose install.sh runs inside a per-agent LXC container
+    # at deploy time (method=="script") don't get a generic host-side
+    # install — see _install_agent_framework for why and what "install"
+    # means for them instead. Pip/docker-based frameworks (smolagents,
+    # langroid, ...) are unaffected and fall through to the normal dispatch
+    # below, unchanged.
+    if manifest is not None and getattr(manifest, "type", "") == "agent-framework" and backend == "script":
+        return await _install_agent_framework(request, manifest, app_id, meta, body)
+
     manifest_declared = manifest is not None
     if not manifest_declared:
         if isinstance(meta, dict) and meta.get("backend"):
@@ -357,6 +436,27 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
             registry.mark_installed(app_id, version)
         resp_target = _target_remote or "local"
         return JSONResponse({"ok": True, "app_id": app_id, "status": "installed", "target_remote": resp_target, **result})
+
+    # script — host-side backend/plugin manifests (e.g. ollama, tailscale)
+    # that declare install.method: script. Previously this fell straight
+    # through to the default branch below and silently marked the app
+    # installed without ever running the script (same class of bug as #410
+    # below for docker/pip, filed as #1582). Actually run it via
+    # ScriptInstaller and only mark installed on success; a missing or
+    # failing script now returns an explicit error instead of a false
+    # "installed".
+    if backend == "script":
+        installer = get_installer("script")
+        try:
+            inst_result = await installer.install(app_id, install_config)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("_legacy_install: script installer raised for %s", app_id)
+            return JSONResponse({"error": f"script install failed: {exc}"}, status_code=500)
+        if not inst_result.get("success"):
+            return JSONResponse(
+                {"error": inst_result.get("error", "script install failed")},
+                status_code=500,
+            )
 
     # docker / pip — actually run the installer.
     # Previously this branch fell straight through to the installed-apps

--- a/tinyagentos/routes/system_logs.py
+++ b/tinyagentos/routes/system_logs.py
@@ -1,0 +1,501 @@
+"""Logs app backend (#1548 part 1): GET /api/system-logs/*.
+
+Operator-facing log viewer so end users never need a terminal to
+self-diagnose a broken install. Four backend sources:
+
+- controller / rkllama / qmd: journald units, read via `journalctl`.
+- llmproxy: a plain file under the LLMProxy's config_dir.
+- client: advertised only here; the existing GET /api/client-logs stays the
+  reader for that tab (this module does not reimplement it).
+
+Every line that leaves this module goes through `redact()` first, so a
+credential that leaked into a dependency's log or a stack trace never
+reaches an operator's clipboard. See tinyagentos/log_redaction.py.
+
+Auth: this is an operator surface, so every route requires an admin session
+(`current_user` dependency, `user.is_admin` check), matching client_logs.py.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import platform
+import shutil
+import sys
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
+
+from tinyagentos import __version__
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.log_redaction import redact, redact_lines
+
+router = APIRouter()
+
+# Fixed allowlist of journald-backed sources. Never string-interpolate a path
+# param into a subprocess argv -- only unit names looked up from this dict
+# are ever passed to journalctl.
+SOURCE_UNITS = {
+    "controller": "tinyagentos.service",
+    "rkllama": "rkllama.service",
+    "qmd": "qmd.service",
+}
+
+SOURCE_LABELS = {
+    "controller": "Controller",
+    "rkllama": "rkllama",
+    "qmd": "qmd",
+    "llmproxy": "LLM proxy",
+    "client": "Client errors",
+}
+
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "X-Accel-Buffering": "no",
+    "Connection": "keep-alive",
+}
+
+# Bound how much a single journalctl call can hand back, independent of the
+# `lines` clamp, so a pathological line (or a lot of small ones) cannot blow
+# up memory.
+_MAX_STDOUT_BYTES = 2_000_000
+_MAX_KNOWN_SECRETS = 200
+_BUNDLE_LINES = 200
+
+
+def _journalctl_missing() -> bool:
+    """True if there is no journalctl binary on this box.
+
+    Factored out so the "no journald on this install" case can be checked
+    once per /sources request instead of once per unit, and so tests can
+    monkeypatch it directly instead of needing a real systemd.
+    """
+    return shutil.which("journalctl") is None
+
+
+async def _run_journalctl(
+    args: "list[str]", *, timeout: float = 10.0, max_bytes: int = _MAX_STDOUT_BYTES
+) -> "tuple[int, bytes]":
+    """Run `journalctl <args>` (argv-list, never shell=True) and return
+    (returncode, capped stdout bytes).
+
+    This is the single seam every journald read goes through, so tests can
+    monkeypatch it to return canned output instead of shelling out for real.
+    Raises FileNotFoundError if journalctl is not installed. Kills the
+    process on timeout so nothing is left running past the deadline.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "journalctl",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+
+    async def _read_capped() -> bytes:
+        chunks: list[bytes] = []
+        total = 0
+        while total < max_bytes:
+            chunk = await proc.stdout.read(min(65536, max_bytes - total))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        return b"".join(chunks)
+
+    try:
+        stdout = await asyncio.wait_for(_read_capped(), timeout=timeout)
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise
+    return proc.returncode, stdout
+
+
+async def _probe_unit_available(unit: str) -> bool:
+    """Cheap "does this unit have a journal" probe. Never raises."""
+    try:
+        rc, _ = await _run_journalctl(["-u", unit, "-n", "0", "--no-pager"], timeout=3.0)
+        return rc == 0
+    except Exception:
+        return False
+
+
+def _llmproxy_log_path(request: Request) -> "Path | None":
+    """The LLMProxy's stderr log, or None if the proxy isn't wired up yet.
+
+    Deliberately reads `.config_dir` (not `.data_dir`): LLMProxy defaults
+    config_dir to /tmp/taos-litellm when not overridden, and that's where it
+    actually writes litellm.stderr.log (see llm_proxy.py's start()).
+    """
+    proxy = getattr(request.app.state, "llm_proxy", None)
+    config_dir = getattr(proxy, "config_dir", None)
+    if not config_dir:
+        return None
+    return Path(config_dir) / "litellm.stderr.log"
+
+
+async def _known_secret_values(request: Request) -> "list[str] | None":
+    """Best-effort literal secret values for redact()'s known_values pass.
+
+    Never lets a slow or broken secrets store block a log page: any failure
+    (missing store, decrypt error, timeout) returns None so the caller falls
+    back to pattern-only redaction. Skipped entirely above a size cap so a
+    huge secrets store cannot stall every log page load.
+    """
+    store = getattr(request.app.state, "secrets", None)
+    if store is None:
+        return None
+    try:
+        entries = await store.list()
+        if len(entries) > _MAX_KNOWN_SECRETS:
+            return None
+        values: list[str] = []
+        for entry in entries:
+            name = entry.get("name")
+            if not name:
+                continue
+            full = await store.get(name)
+            if full and full.get("value"):
+                values.append(full["value"])
+        return values or None
+    except Exception:
+        return None
+
+
+def _clamp_lines(lines: int) -> int:
+    """Clamp (not reject) out-of-range `lines` -- friendlier than a 400 for a
+    UI-driven page size, and the cap keeps a runaway request bounded."""
+    return max(1, min(lines, 2000))
+
+
+async def _list_sources(request: Request) -> "list[dict]":
+    """The sources available on this install. Used by both GET /sources and
+    the bug-report bundle so they never drift apart."""
+    result = []
+    journald_absent = _journalctl_missing()
+    for source_id in ("controller", "rkllama", "qmd"):
+        unit = SOURCE_UNITS[source_id]
+        available = False if journald_absent else await _probe_unit_available(unit)
+        result.append(
+            {
+                "id": source_id,
+                "label": SOURCE_LABELS[source_id],
+                "kind": "journald" if available else "file",
+                "available": available,
+            }
+        )
+
+    llmproxy_path = _llmproxy_log_path(request)
+    result.append(
+        {
+            "id": "llmproxy",
+            "label": SOURCE_LABELS["llmproxy"],
+            "kind": "file",
+            "available": bool(llmproxy_path and llmproxy_path.exists()),
+        }
+    )
+    result.append(
+        {
+            "id": "client",
+            "label": SOURCE_LABELS["client"],
+            "kind": "client",
+            "available": hasattr(request.app.state, "client_log_store"),
+        }
+    )
+    return result
+
+
+def _parse_journald_json_lines(stdout: bytes) -> "list[dict]":
+    records = []
+    for raw_line in stdout.decode("utf-8", errors="replace").splitlines():
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+        try:
+            records.append(json.loads(raw_line))
+        except ValueError:
+            continue
+    return records
+
+
+async def _read_journald_page(
+    source_id: str, unit: str, lines: int, before: "str | None", known_values: "list[str] | None"
+) -> dict:
+    # journalctl returns oldest-first within a "-n <lines>" window; there is
+    # no direct "entries before this cursor" flag, so this v1 pager treats
+    # `before` as a resume token via --after-cursor (a simple, if not fully
+    # bidirectional, paging scheme) and reverses the page so the response is
+    # newest-first, as the design calls for.
+    args = ["-u", unit, "--no-pager", "-o", "json", "-n", str(lines)]
+    if before:
+        args += ["--after-cursor", before]
+    try:
+        rc, stdout = await _run_journalctl(args, timeout=10.0)
+    except Exception as exc:
+        return {"source": source_id, "lines": [], "cursor": None, "error": str(exc)}
+    if rc != 0:
+        return {"source": source_id, "lines": [], "cursor": None, "error": f"journalctl exited {rc}"}
+
+    records = _parse_journald_json_lines(stdout)
+    messages = [str(r.get("MESSAGE", "")) for r in records]
+    cursor_out = records[0].get("__CURSOR") if records else None
+    messages.reverse()
+    return {"source": source_id, "lines": redact_lines(messages, known_values), "cursor": cursor_out}
+
+
+def _tail_text_lines(data: bytes, n: int, upto: "int | None") -> "tuple[list[str], int | None]":
+    """Return the last `n` lines of `data` (optionally truncated at byte
+    offset `upto`) plus a cursor marking where the next (older) page starts.
+    """
+    if upto is not None:
+        data = data[: max(0, upto)]
+    text = data.decode("utf-8", errors="replace")
+    all_lines = text.splitlines()
+    page = all_lines[-n:] if n < len(all_lines) else all_lines
+    remaining = len(all_lines) - len(page)
+    if remaining <= 0:
+        return page, None
+    older_text = "\n".join(all_lines[:remaining]) + "\n"
+    cursor = len(older_text.encode("utf-8"))
+    return page, cursor
+
+
+async def _read_file_page(
+    source_id: str, path: "Path | None", lines: int, before: "str | None", known_values: "list[str] | None"
+) -> dict:
+    if path is None or not path.exists():
+        return {"source": source_id, "lines": [], "cursor": None, "error": "log file not available"}
+    try:
+        data = await asyncio.to_thread(path.read_bytes)
+    except OSError as exc:
+        return {"source": source_id, "lines": [], "cursor": None, "error": str(exc)}
+
+    upto = None
+    if before is not None:
+        try:
+            upto = int(before)
+        except ValueError:
+            upto = None
+
+    page, cursor_out = _tail_text_lines(data[-_MAX_STDOUT_BYTES:], lines, upto)
+    page.reverse()
+    return {"source": source_id, "lines": redact_lines(page, known_values), "cursor": cursor_out}
+
+
+@router.get("/api/system-logs/sources")
+async def get_sources(request: Request, user: CurrentUser = Depends(current_user)):
+    """The log sources available on THIS install."""
+    if not user.is_admin:
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+    return await _list_sources(request)
+
+
+# Registered before the "/{source}" catch-all below so a literal path here
+# (e.g. "bundle") is matched by this route instead of being treated as a
+# source id -- Starlette matches routes in registration order, not by
+# specificity, so ordering here is load-bearing.
+@router.get("/api/system-logs/bundle")
+async def get_bundle(request: Request, user: CurrentUser = Depends(current_user)):
+    """The copy-for-bug-report payload: environment banner + last N lines of
+    every available source, already redacted."""
+    if not user.is_admin:
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    parts = [_environment_banner(), ""]
+    known_values = await _known_secret_values(request)
+    sources = await _list_sources(request)
+    for src in sources:
+        if not src["available"]:
+            continue
+        parts.append(f"=== {src['label']} ===")
+        try:
+            parts.extend(await _bundle_section(request, src, known_values))
+        except Exception as exc:
+            parts.append(f"(unavailable: {exc})")
+        parts.append("")
+
+    return PlainTextResponse("\n".join(parts), media_type="text/plain")
+
+
+@router.get("/api/system-logs/{source}")
+async def get_source_page(
+    source: str,
+    request: Request,
+    lines: int = 200,
+    before: "str | None" = None,
+    user: CurrentUser = Depends(current_user),
+):
+    """Paged, redacted, newest-first read of one source."""
+    if not user.is_admin:
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+    n = _clamp_lines(lines)
+    known_values = await _known_secret_values(request)
+    if source in SOURCE_UNITS:
+        return await _read_journald_page(source, SOURCE_UNITS[source], n, before, known_values)
+    if source == "llmproxy":
+        return await _read_file_page(source, _llmproxy_log_path(request), n, before, known_values)
+    # "client" (and anything else) is not a readable source here: client logs
+    # are read via the existing GET /api/client-logs endpoint.
+    return JSONResponse({"error": "unknown source"}, status_code=400)
+
+
+async def _journald_tail_gen(unit: str, request: Request):
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "journalctl",
+            "-u",
+            unit,
+            "-f",
+            "-o",
+            "json",
+            "--no-pager",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        yield f"data: {json.dumps({'error': 'journalctl not available'})}\n\n"
+        return
+
+    known_values = await _known_secret_values(request)
+    try:
+        while True:
+            if await request.is_disconnected():
+                break
+            try:
+                raw = await asyncio.wait_for(proc.stdout.readline(), timeout=5.0)
+            except asyncio.TimeoutError:
+                continue
+            if not raw:
+                break
+            try:
+                rec = json.loads(raw.decode("utf-8", errors="replace"))
+                message = str(rec.get("MESSAGE", ""))
+            except ValueError:
+                message = raw.decode("utf-8", errors="replace").strip()
+            line = redact(message, known_values)
+            yield f"data: {json.dumps({'line': line})}\n\n"
+    finally:
+        # Always terminate the tail process -- on disconnect, cancellation,
+        # or a plain EOF -- so a closed SSE connection never leaves an
+        # orphaned journalctl -f running.
+        if proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+                await proc.wait()
+
+
+async def _file_tail_gen(path: Path, request: Request):
+    known_values = await _known_secret_values(request)
+    try:
+        pos = path.stat().st_size if path.exists() else 0
+    except OSError:
+        pos = 0
+    while True:
+        if await request.is_disconnected():
+            return
+        try:
+            size = path.stat().st_size
+        except OSError:
+            await asyncio.sleep(1.0)
+            continue
+        if size < pos:
+            # File rotated/truncated underneath us; resume from the new end.
+            pos = size
+        if size > pos:
+            try:
+                chunk = await asyncio.to_thread(_read_range, path, pos, size)
+                pos = size
+            except OSError:
+                await asyncio.sleep(1.0)
+                continue
+            for line in chunk.decode("utf-8", errors="replace").splitlines():
+                if line:
+                    yield f"data: {json.dumps({'line': redact(line, known_values)})}\n\n"
+        await asyncio.sleep(1.0)
+
+
+def _read_range(path: Path, start: int, end: int) -> bytes:
+    with path.open("rb") as f:
+        f.seek(start)
+        return f.read(end - start)
+
+
+@router.get("/api/system-logs/{source}/stream")
+async def stream_source(source: str, request: Request, user: CurrentUser = Depends(current_user)):
+    """SSE live tail of one source."""
+    if not user.is_admin:
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+    if source in SOURCE_UNITS:
+        gen = _journald_tail_gen(SOURCE_UNITS[source], request)
+        return StreamingResponse(gen, media_type="text/event-stream", headers=_SSE_HEADERS)
+    if source == "llmproxy":
+        path = _llmproxy_log_path(request)
+        if path is None:
+            return JSONResponse({"error": "llmproxy log not available"}, status_code=400)
+        gen = _file_tail_gen(path, request)
+        return StreamingResponse(gen, media_type="text/event-stream", headers=_SSE_HEADERS)
+    return JSONResponse({"error": "unknown source"}, status_code=400)
+
+
+def _environment_banner() -> str:
+    distro = None
+    os_release = Path("/etc/os-release")
+    if os_release.exists():
+        try:
+            for line in os_release.read_text().splitlines():
+                if line.startswith("PRETTY_NAME="):
+                    distro = line.split("=", 1)[1].strip().strip('"')
+                    break
+        except OSError:
+            distro = None
+    if not distro:
+        distro = platform.platform()
+
+    lines = [f"distro: {distro}", f"kernel: {platform.uname().release}"]
+
+    board_path = Path("/proc/device-tree/model")
+    if board_path.exists():
+        try:
+            board = board_path.read_bytes().rstrip(b"\x00").decode("utf-8", errors="replace")
+            if board:
+                lines.append(f"board: {board}")
+        except OSError:
+            pass
+
+    lines.append(f"python: {sys.version.split()[0]}")
+    lines.append(f"taOS version: {__version__}")
+    return "\n".join(lines)
+
+
+async def _bundle_section(request: Request, src: dict, known_values: "list[str] | None") -> "list[str]":
+    """Redacted last-N lines for one source, for the bug-report bundle.
+
+    In-process reuse of the same page readers the /api/system-logs/{source}
+    endpoint uses -- no HTTP self-call.
+    """
+    source_id = src["id"]
+    if source_id == "client":
+        store = getattr(request.app.state, "client_log_store", None)
+        if store is None:
+            return ["(unavailable: client log store not initialized)"]
+        items = await store.list_recent(limit=_BUNDLE_LINES)
+        raw = [f"[{item.get('level', '')}] {item.get('message', '')}" for item in items]
+        return redact_lines(raw, known_values)
+    if source_id in SOURCE_UNITS:
+        page = await _read_journald_page(
+            source_id, SOURCE_UNITS[source_id], _BUNDLE_LINES, None, known_values
+        )
+    elif source_id == "llmproxy":
+        page = await _read_file_page(
+            source_id, _llmproxy_log_path(request), _BUNDLE_LINES, None, known_values
+        )
+    else:
+        return []
+    if page.get("error"):
+        return [f"(unavailable: {page['error']})"]
+    return page["lines"]

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -8,12 +8,14 @@ from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Form, Request, UploadFile, File
-from fastapi.responses import JSONResponse, FileResponse, Response
+from fastapi.responses import JSONResponse, FileResponse, RedirectResponse, Response, StreamingResponse
+from starlette.background import BackgroundTask
 
 from tinyagentos.code_analyzer import analyze_app_source, has_critical
 from tinyagentos.userspace.broker import handle_capability, GATED_CAPS
 from tinyagentos.userspace.capabilities import capability_ceiling, default_provenance_for_trust
-from tinyagentos.userspace.package import extract_package, PackageError
+from tinyagentos.userspace.container_deploy import deploy_app_container, destroy_app_container
+from tinyagentos.userspace.package import extract_package, parse_manifest, PackageError
 from tinyagentos.userspace.url_guard import resolve_safe_public_ip
 
 # Provenance values a caller may set through the PUBLIC install endpoint. Never
@@ -171,36 +173,32 @@ async def install_app(
         manifest = extract_package(data, apps_root=_apps_root(request))
     except PackageError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
-    # Reject container packages before persisting anything -- no partial state.
-    if manifest["app_type"] == "container":
-        return JSONResponse(
-            {"error": "container packages are not supported in this release (web-only)"},
-            status_code=501,
-        )
     apps_root = _apps_root(request).resolve()
     app_dir = (apps_root / manifest["id"]).resolve()
     # Static security gate: this runs server-side on every install regardless
-    # of how the package was submitted (upload or source_url) or its
-    # app_type, so a modified/bypassed client can never skip it and a future
-    # app_type can never silently bypass it. Unconditional is also cheap and
-    # correct here -- "container" is already rejected above, and "tui"
-    # packages ship no _ANALYZABLE_EXTENSIONS files (just a manifest.yaml +
-    # command spec), so _collect_source_files() naturally finds nothing to
-    # scan for them. A critical finding blocks the install outright -- the
-    # extracted files are removed so nothing scanned-and-rejected is left
-    # reachable via serve_bundle. This is defense in depth in FRONT of the
-    # sandbox iframe, not a replacement for it.
-    findings = analyze_app_source(_collect_source_files(app_dir))
-    if has_critical(findings):
-        if app_dir.is_relative_to(apps_root) and app_dir != apps_root:
-            shutil.rmtree(app_dir, ignore_errors=True)
-        return JSONResponse(
-            {
-                "error": "blocked_by_security_analysis",
-                "findings": [f.to_dict() for f in findings],
-            },
-            status_code=422,
-        )
+    # of how the package was submitted (upload or source_url), so a
+    # modified/bypassed client can never skip it. Container apps ship an
+    # opaque Docker image (not analyzable source) and are skipped here --
+    # their isolation comes from the container boundary, not this scanner.
+    # "tui" packages ship no _ANALYZABLE_EXTENSIONS files (just a
+    # manifest.yaml + command spec), so _collect_source_files() naturally
+    # finds nothing to scan for them. A critical finding blocks the install
+    # outright -- the extracted files are removed so nothing
+    # scanned-and-rejected is left reachable via serve_bundle. This is
+    # defense in depth in FRONT of the sandbox iframe, not a replacement
+    # for it.
+    if manifest["app_type"] != "container":
+        findings = analyze_app_source(_collect_source_files(app_dir))
+        if has_critical(findings):
+            if app_dir.is_relative_to(apps_root) and app_dir != apps_root:
+                shutil.rmtree(app_dir, ignore_errors=True)
+            return JSONResponse(
+                {
+                    "error": "blocked_by_security_analysis",
+                    "findings": [f.to_dict() for f in findings],
+                },
+                status_code=422,
+            )
     existing = await store.get(manifest["id"])
     # A public install must never replace an app installed as first-party: that
     # would let an attacker overwrite a trusted studio's bundle (and, before the
@@ -309,21 +307,67 @@ async def set_permissions(request: Request, app_id: str):
     return {"status": "ok", "granted": safe}
 
 
+def _load_container_spec(app_dir: Path) -> dict | None:
+    """Re-parse the installed package's manifest.yaml to recover its
+    container block (image + ports). Not persisted in the store row --
+    extract_package already wrote manifest.yaml alongside the app's other
+    files, so it's re-read here rather than adding new store columns."""
+    manifest_path = app_dir / "manifest.yaml"
+    if not manifest_path.is_file():
+        return None
+    try:
+        manifest = parse_manifest(manifest_path.read_text(encoding="utf-8"))
+    except (PackageError, OSError):
+        return None
+    return manifest.get("container")
+
+
 @router.post("/api/userspace-apps/{app_id}/enable")
 async def enable_app(request: Request, app_id: str):
-    await request.app.state.userspace_apps.set_enabled(app_id, True)
+    store = request.app.state.userspace_apps
+    app = await store.get(app_id)
+    if app is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.set_enabled(app_id, True)
+    if app["app_type"] == "container":
+        container_spec = _load_container_spec(_apps_root(request) / app_id)
+        if container_spec is None:
+            await store.set_enabled(app_id, False)
+            return JSONResponse(
+                {"error": "container app manifest missing or invalid"}, status_code=500
+            )
+        result = await deploy_app_container(app_id, container_spec)
+        if not result.get("success"):
+            # Do not leave a half-enabled app claiming to run.
+            await store.set_enabled(app_id, False)
+            return JSONResponse(
+                {"error": result.get("error", "container deploy failed")}, status_code=502
+            )
+        await store.set_runtime_location(app_id, result["host"], result["port"])
     return {"status": "ok"}
 
 
 @router.post("/api/userspace-apps/{app_id}/disable")
 async def disable_app(request: Request, app_id: str):
-    await request.app.state.userspace_apps.set_enabled(app_id, False)
+    store = request.app.state.userspace_apps
+    app = await store.get(app_id)
+    if app is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if app["app_type"] == "container":
+        await destroy_app_container(app_id)
+        await store.set_runtime_location(app_id, None, None)
+    await store.set_enabled(app_id, False)
     return {"status": "ok"}
 
 
 @router.delete("/api/userspace-apps/{app_id}")
 async def uninstall_app(request: Request, app_id: str):
     store = request.app.state.userspace_apps
+    app = await store.get(app_id)
+    if app is not None and app["app_type"] == "container":
+        # Best-effort: tear down the backend container before removing the
+        # store record and files, so nothing is left running unreferenced.
+        await destroy_app_container(app_id)
     removed = await store.uninstall(app_id)
     root = _apps_root(request).resolve()
     app_dir = (root / app_id).resolve()
@@ -357,6 +401,125 @@ async def serve_bundle(request: Request, app_id: str, path: str):
     resp.headers["Content-Security-Policy"] = _bundle_csp(net_origins, provenance)
     resp.headers["X-Content-Type-Options"] = "nosniff"
     return resp
+
+
+# Hop-by-hop headers must not be forwarded between the proxy and the
+# upstream/client (RFC 2616 §13.5.1). Authorization is stripped too, and the
+# taos_session cookie is scrubbed out of Cookie -- an untrusted container-app
+# backend must never see the controller session credential.
+_PROXY_HOP_BY_HOP = frozenset({
+    "connection", "keep-alive", "proxy-authorization", "te",
+    "trailer", "transfer-encoding", "upgrade", "host",
+})
+_PROXY_SENSITIVE_HEADERS = frozenset({"authorization"})
+_PROXY_STRIPPED_COOKIES = frozenset({"taos_session"})
+
+# Module-level HTTP client for the container-app proxy -- avoids per-request
+# connection churn, mirrors service_proxy.py's pattern.
+_container_proxy_client = httpx.AsyncClient(timeout=60.0)
+
+
+def _strip_taos_session_cookie(cookie_header: str) -> str:
+    # Textual scrub that does not depend on SimpleCookie's grammar: a
+    # malformed Cookie header must still have taos_session removed, never
+    # forwarded whole (SimpleCookie.load could raise and leak the credential).
+    if not cookie_header:
+        return ""
+    kept = []
+    for part in cookie_header.split(";"):
+        stripped = part.strip()
+        if not stripped:
+            continue
+        name = stripped.split("=", 1)[0].strip()
+        if name in _PROXY_STRIPPED_COOKIES:
+            continue
+        kept.append(stripped)
+    return "; ".join(kept)
+
+
+def _filter_proxy_headers(headers: dict) -> dict:
+    filtered: dict[str, str] = {}
+    for k, v in headers.items():
+        kl = k.lower()
+        if kl in _PROXY_HOP_BY_HOP or kl in _PROXY_SENSITIVE_HEADERS:
+            continue
+        if kl == "cookie":
+            stripped = _strip_taos_session_cookie(v)
+            if not stripped:
+                continue
+            filtered[k] = stripped
+            continue
+        filtered[k] = v
+    return filtered
+
+
+@router.get("/api/userspace-apps/{app_id}/proxy", include_in_schema=False)
+async def proxy_no_slash_redirect(app_id: str):
+    """Redirect /proxy -> /proxy/ so the container app's relative links work."""
+    return RedirectResponse(url=f"/api/userspace-apps/{app_id}/proxy/", status_code=307)
+
+
+@router.api_route(
+    "/api/userspace-apps/{app_id}/proxy/{path:path}",
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"],
+    include_in_schema=False,
+)
+async def proxy_container_app(request: Request, app_id: str, path: str):
+    # Store lookup FIRST (same reasoning as serve_bundle): nothing is
+    # forwarded until the app is installed, enabled, a container app, and has
+    # a recorded runtime location.
+    app = await request.app.state.userspace_apps.get(app_id)
+    if (
+        app is None
+        or app["app_type"] != "container"
+        or not app["enabled"]
+        or not app.get("container_host")
+        or not app.get("container_port")
+    ):
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    # SECURITY: the proxy target is built ONLY from the recorded runtime
+    # location (always 127.0.0.1:<port>, set by deploy_app_container) -- never
+    # from client-controlled input. This is what rules out SSRF here.
+    host = app["container_host"]
+    port = app["container_port"]
+    upstream = f"http://{host}:{port}/{path}"
+    if request.url.query:
+        upstream = f"{upstream}?{request.url.query}"
+
+    fwd_headers = _filter_proxy_headers(dict(request.headers))
+
+    async def _stream_body():
+        async for chunk in request.stream():
+            yield chunk
+
+    try:
+        req = _container_proxy_client.build_request(
+            method=request.method, url=upstream, headers=fwd_headers, content=_stream_body(),
+        )
+        upstream_resp = await _container_proxy_client.send(req, stream=True, follow_redirects=False)
+    except httpx.ConnectError:
+        return JSONResponse(
+            {"error": f"cannot reach app '{app_id}' -- it may be stopped or still starting"},
+            status_code=502,
+        )
+    except httpx.TimeoutException:
+        return JSONResponse({"error": f"app '{app_id}' timed out"}, status_code=504)
+
+    resp_headers = _filter_proxy_headers(dict(upstream_resp.headers))
+    granted = app.get("permissions_granted") or []
+    net_origins = [p[len("network:"):] for p in granted
+                   if isinstance(p, str) and p.startswith("network:")]
+    provenance = app.get("provenance") or default_provenance_for_trust(app.get("trust"))
+    resp_headers["Content-Security-Policy"] = _bundle_csp(net_origins, provenance)
+    resp_headers["X-Content-Type-Options"] = "nosniff"
+
+    return StreamingResponse(
+        upstream_resp.aiter_bytes(),
+        status_code=upstream_resp.status_code,
+        headers=resp_headers,
+        background=BackgroundTask(upstream_resp.aclose),
+    )
 
 
 @router.get("/api/userspace-apps/{app_id}/icon")

--- a/tinyagentos/userspace/container_deploy.py
+++ b/tinyagentos/userspace/container_deploy.py
@@ -1,0 +1,80 @@
+"""Generic container-app deploy — SEPARATE from the agent deployer.
+
+Launches a userspace app's backend as a Docker container. No agent
+environment (no LiteLLM / skills / AGENTS.md / bridge). Shares only the
+low-level tinyagentos.containers Docker primitive. The agent deploy path
+(deployer.py, incus) is intentionally not reused here.
+"""
+from __future__ import annotations
+
+import shutil
+import socket
+from contextlib import closing
+
+from tinyagentos.containers.docker import DockerBackend
+
+# Untrusted third-party app backends get a conservative, fixed resource cap --
+# there is no per-app config for this today and these apps are not vetted the
+# way agent containers are.
+_MEMORY_LIMIT = "512m"
+_CPU_LIMIT = 1
+
+
+def _find_free_port(start: int = 13000, end: int = 14000) -> int:
+    for port in range(start, end):
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("no free port available in range")
+
+
+def _app_container_name(app_id: str) -> str:
+    return f"taos-app-{app_id}"
+
+
+async def deploy_app_container(app_id: str, container_spec: dict) -> dict:
+    """Deploy a userspace app's backend container via Docker.
+
+    container_spec: {"image": str, "ports": [int, ...]} (already validated
+    at manifest-parse time). The first port is the app's service port.
+    Returns {"success": True, "host": "127.0.0.1", "port": <host_port>}
+    or {"success": False, "error": str}.
+    """
+    if shutil.which("docker") is None:
+        return {"success": False,
+                "error": "Docker is required to run container apps but was not found. "
+                         "Install Docker (taOS installs it by default) and retry."}
+    image = container_spec["image"]
+    container_port = int(container_spec["ports"][0])
+    name = _app_container_name(app_id)
+    backend = DockerBackend("docker")
+
+    # Find a free host port and publish container_port to it, bound to
+    # 127.0.0.1 only (enforced inside DockerBackend.create_container). Retry
+    # on the narrow TOCTOU window where the chosen port gets taken before
+    # docker binds.
+    last_error = "deploy failed"
+    for _ in range(3):
+        host_port = _find_free_port()
+        result = await backend.create_container(
+            name,
+            image=image,
+            ports=[(host_port, container_port)],
+            memory_limit=_MEMORY_LIMIT,
+            cpu_limit=_CPU_LIMIT,
+        )
+        if result.get("success"):
+            return {"success": True, "host": "127.0.0.1", "port": host_port}
+        last_error = result.get("error", "container create failed")
+        if "port is already allocated" not in last_error and "address already in use" not in last_error:
+            break  # a non-port error won't be fixed by retrying
+    return {"success": False, "error": last_error}
+
+
+async def destroy_app_container(app_id: str) -> None:
+    """Remove an app's backend container (idempotent). Best-effort."""
+    backend = DockerBackend("docker")
+    await backend.destroy_container(_app_container_name(app_id))

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b20"
+version = "1.0.0b21"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotes dev to master for 1.0.0-beta.21.

- App Runtime: install-time permission consent (#1579) + container app tier (#1580)
- Store: agent-framework install enables deploy + prefetches base image + notifies (#1582)
- Models: real delete + auto-refresh installed state (#1581, #1548)
- Providers: true status, no contradictory Error badge (#1578)
- Settings Logs: real system logs with live tail (#1583)
- Text Editor: create works over plain http; randomUUID guarded class-wide (#1584)

----
## Summary by Gitar

- **Settings:**
  - Added a `ReserveHandleCard` to the account panel to promote username reservations.
  - Updated account descriptions to highlight future username and website/blog/portfolio capabilities.
- **Userspace Apps:**
  - Added a GET endpoint `/api/userspace-apps/{app_id}` for direct retrieval of individual app metadata.
  - Prevented dialog dismissal (via backdrop click or Escape key) while permission grants are in flight.
  - Optimized app installation by fetching specific app metadata only when consent is required.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added install-time permission consent for apps with sensitive capabilities.
  * Added support for container-based apps, including localhost-bound deployment and a proxy-backed runtime.
  * Added a system logs view with live tailing and bundled log export.
* **Bug Fixes**
  * Fixed model deletion, stale refresh races, and store install progress behavior.
  * Fixed provider/status display issues, log visibility, and text editor note creation in non-secure contexts.
  * Improved deployment and uninstall behavior for container and framework apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->