### PR TITLE
feat(onboarding): optional taOS cloud-account step with reserve-username hint (#141)

### DIFF
--- a/desktop/src/components/SetupChecklist.test.tsx
+++ b/desktop/src/components/SetupChecklist.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { SetupChecklist } from "./SetupChecklist";
+import { fetchAccount } from "@/lib/account-client";
 
 vi.mock("@/stores/process-store", () => ({
   useProcessStore: (sel: (s: Record<string, unknown>) => unknown) =>
@@ -22,6 +23,15 @@ vi.mock("@/registry/app-registry", () => ({
     launchpadOrder: 1,
   }),
 }));
+
+vi.mock("@/lib/account-client", () => ({
+  fetchAccount: vi.fn(),
+}));
+
+const CLOUD_LABEL = "Sign in to your taOS account (optional)";
+const CLOUD_DETAIL =
+  "One account for taOSgo remote access, app sharing, and reserving your taOS username for a future website and socials.";
+const HANDLE_HINT = "Tip: reserve your taOS username in Settings before someone else takes it.";
 
 const baseStatus = {
   account: false,
@@ -54,6 +64,12 @@ function mockFetchStatus(status: Record<string, unknown>) {
 }
 
 describe("SetupChecklist", () => {
+  beforeEach(() => {
+    // Default the cloud account to unavailable so tests that don't care
+    // about it settle deterministically instead of hanging on "loading".
+    vi.mocked(fetchAccount).mockResolvedValue({ kind: "unavailable" });
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });
@@ -95,13 +111,14 @@ describe("SetupChecklist", () => {
     mockFetchStatus(baseStatus);
     render(<SetupChecklist />);
     expect(await screen.findByText("Get started")).toBeInTheDocument();
-    expect(screen.getByText("0/5")).toBeInTheDocument();
+    expect(screen.getByText("0/6")).toBeInTheDocument();
   });
 
-  it("renders all five step labels", async () => {
+  it("renders all six step labels", async () => {
     mockFetchStatus(baseStatus);
     render(<SetupChecklist />);
     expect(await screen.findByText("Create your account")).toBeInTheDocument();
+    expect(screen.getByText(CLOUD_LABEL)).toBeInTheDocument();
     expect(screen.getByText("Add a provider")).toBeInTheDocument();
     expect(screen.getByText("Choose a model for the taOS agent")).toBeInTheDocument();
     expect(screen.getByText("Deploy your first agent")).toBeInTheDocument();
@@ -124,7 +141,7 @@ describe("SetupChecklist", () => {
       has_provider: true,
     });
     render(<SetupChecklist />);
-    expect(await screen.findByText("2/5")).toBeInTheDocument();
+    expect(await screen.findByText("2/6")).toBeInTheDocument();
   });
 
   it("does not show detail text for completed steps", async () => {
@@ -188,17 +205,17 @@ describe("SetupChecklist", () => {
     render(<SetupChecklist />);
     await screen.findByText("Get started");
     expect(screen.queryByText("Install the NPU backend")).toBeNull();
-    expect(screen.getByText("0/5")).toBeInTheDocument();
+    expect(screen.getByText("0/6")).toBeInTheDocument();
   });
 
-  it("shows the NPU step as a sixth item when an NPU is present", async () => {
+  it("shows the NPU step as an additional item when an NPU is present", async () => {
     mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: false });
     render(<SetupChecklist />);
     expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
     expect(
       screen.getByText("Install rkllama from the Store to run models on this device's NPU"),
     ).toBeInTheDocument();
-    expect(screen.getByText("0/6")).toBeInTheDocument();
+    expect(screen.getByText("0/7")).toBeInTheDocument();
   });
 
   it("stays visible when core steps are complete but the NPU step is outstanding", async () => {
@@ -234,6 +251,81 @@ describe("SetupChecklist", () => {
       name: "Install the NPU backend — complete",
     });
     expect(doneStep).toBeInTheDocument();
+    expect(screen.getByText("1/7")).toBeInTheDocument();
+  });
+
+  it("renders the cloud-account step with the exact label and detail copy", async () => {
+    mockFetchStatus(baseStatus);
+    render(<SetupChecklist />);
+    expect(await screen.findByText(CLOUD_LABEL)).toBeInTheDocument();
+    expect(screen.getByText(CLOUD_DETAIL)).toBeInTheDocument();
+  });
+
+  it("ticks the cloud-account step when the cloud account is signed in", async () => {
+    vi.mocked(fetchAccount).mockResolvedValue({
+      kind: "signed-in",
+      account: {
+        user_id: "u1",
+        email: "user@example.com",
+        taosgo: { status: "none" },
+        handle: "someuser",
+      },
+    });
+    mockFetchStatus(baseStatus);
+    render(<SetupChecklist />);
+    const doneStep = await screen.findByRole("button", {
+      name: `${CLOUD_LABEL} — complete`,
+    });
+    expect(doneStep).toBeInTheDocument();
     expect(screen.getByText("1/6")).toBeInTheDocument();
+  });
+
+  it("shows the cloud-account step unticked without error when the account service is unavailable", async () => {
+    vi.mocked(fetchAccount).mockResolvedValue({ kind: "unavailable" });
+    mockFetchStatus(baseStatus);
+    render(<SetupChecklist />);
+    const pendingStep = await screen.findByRole("button", { name: CLOUD_LABEL });
+    expect(pendingStep).toBeInTheDocument();
+    expect(screen.getByText("0/6")).toBeInTheDocument();
+    expect(screen.queryByText(HANDLE_HINT)).toBeNull();
+  });
+
+  it("shows the reserve-username hint when signed in without a handle", async () => {
+    vi.mocked(fetchAccount).mockResolvedValue({
+      kind: "signed-in",
+      account: {
+        user_id: "u1",
+        email: "user@example.com",
+        taosgo: { status: "none" },
+        handle: null,
+      },
+    });
+    mockFetchStatus(baseStatus);
+    render(<SetupChecklist />);
+    expect(await screen.findByText(HANDLE_HINT)).toBeInTheDocument();
+  });
+
+  it("omits the reserve-username hint when the account has a handle", async () => {
+    vi.mocked(fetchAccount).mockResolvedValue({
+      kind: "signed-in",
+      account: {
+        user_id: "u1",
+        email: "user@example.com",
+        taosgo: { status: "none" },
+        handle: "someuser",
+      },
+    });
+    mockFetchStatus(baseStatus);
+    render(<SetupChecklist />);
+    await screen.findByRole("button", { name: `${CLOUD_LABEL} — complete` });
+    expect(screen.queryByText(HANDLE_HINT)).toBeNull();
+  });
+
+  it("omits the reserve-username hint when signed out", async () => {
+    vi.mocked(fetchAccount).mockResolvedValue({ kind: "signed-out" });
+    mockFetchStatus(baseStatus);
+    render(<SetupChecklist />);
+    await screen.findByText(CLOUD_LABEL);
+    expect(screen.queryByText(HANDLE_HINT)).toBeNull();
   });
 });

--- a/desktop/src/components/SetupChecklist.tsx
+++ b/desktop/src/components/SetupChecklist.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { CheckCircle2, Circle, ChevronRight, X } from "lucide-react";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
+import { fetchAccount, type AccountState } from "@/lib/account-client";
 
 interface SetupStatus {
   account: boolean;
@@ -15,11 +16,14 @@ interface SetupStatus {
   complete: boolean;
 }
 
+// "cloud_account" isn't part of the backend status payload -- it self-ticks
+// from the taos.my account state (see CLOUD_ACCOUNT_STEP below).
 interface Step {
-  key: keyof SetupStatus;
+  key: keyof SetupStatus | "cloud_account";
   label: string;
   detail: string;
   appId?: string;
+  appProps?: Record<string, unknown>;
 }
 
 const STEPS: Step[] = [
@@ -27,6 +31,14 @@ const STEPS: Step[] = [
     key: "account",
     label: "Create your account",
     detail: "Done at sign-up",
+  },
+  {
+    key: "cloud_account",
+    label: "Sign in to your taOS account (optional)",
+    detail:
+      "One account for taOSgo remote access, app sharing, and reserving your taOS username for a future website and socials.",
+    appId: "settings",
+    appProps: { section: "account" },
   },
   {
     key: "has_provider",
@@ -67,6 +79,10 @@ const NPU_STEP: Step = {
 export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   const [status, setStatus] = useState<SetupStatus | null>(null);
   const [dismissing, setDismissing] = useState(false);
+  // The taos.my cloud account is optional and separate from the local setup
+  // status endpoint; it degrades to "unavailable" rather than throwing when
+  // the account service can't be reached, so onboarding still works offline.
+  const [cloudAccount, setCloudAccount] = useState<AccountState>({ kind: "loading" });
   const openWindow = useProcessStore((s) => s.openWindow);
 
   useEffect(() => {
@@ -77,6 +93,14 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
         if (!cancelled && data) setStatus(data);
       })
       .catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAccount().then((state) => {
+      if (!cancelled) setCloudAccount(state);
+    });
     return () => { cancelled = true; };
   }, []);
 
@@ -91,8 +115,12 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   const handleStep = (step: Step) => {
     if (!step.appId) return;
     const app = getApp(step.appId);
-    if (app) openWindow(step.appId, app.defaultSize);
+    if (app) openWindow(step.appId, app.defaultSize, step.appProps);
   };
+
+  const cloudSignedIn = cloudAccount.kind === "signed-in";
+  const isDone = (step: Step) =>
+    step.key === "cloud_account" ? cloudSignedIn : Boolean(status?.[step.key]);
 
   if (!status || status.dismissed) return null;
   // complete covers the two core steps only; on an NPU board the backend
@@ -102,7 +130,11 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   if (status.complete && !npuOutstanding) return null;
 
   const steps = status.npu_present ? [...STEPS, NPU_STEP] : STEPS;
-  const doneCount = steps.filter((s) => Boolean(status[s.key])).length;
+  const doneCount = steps.filter((s) => isDone(s)).length;
+  // Signed in but hasn't claimed a username yet -- surfaced as a nudge, not
+  // a blocker; omitted when signed out or once a handle exists.
+  const showHandleHint =
+    cloudAccount.kind === "signed-in" && !cloudAccount.account.handle;
 
   return (
     <div className="border-b border-white/10">
@@ -128,7 +160,7 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
       {/* Steps */}
       <ul role="list" className="pb-2">
         {steps.map((step) => {
-          const done = Boolean(status[step.key]);
+          const done = isDone(step);
           return (
             <li key={step.key}>
               <button
@@ -150,6 +182,11 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
                   </p>
                   {!done && (
                     <p className="text-[10px] text-shell-text-tertiary truncate">{step.detail}</p>
+                  )}
+                  {step.key === "cloud_account" && showHandleHint && (
+                    <p className="text-[10px] text-shell-text-tertiary/70 truncate">
+                      Tip: reserve your taOS username in Settings before someone else takes it.
+                    </p>
                   )}
                 </div>
                 {!done && step.appId && (


### PR DESCRIPTION
## Summary

Adds an OPTIONAL "taOS cloud account" step to the setup checklist (#141), right after the local "Create your account" step.

- **New step** `cloud_account`: "Sign in to your taOS account (optional)" with the one-account pitch (taOSgo remote access, app sharing, username reservation).
- **Opens Settings > Account**: clicking the step uses the same `getApp` + `openWindow` mechanism as the other steps, passing `{ section: "account" }` as window props so `SettingsApp` opens straight on the Account panel.
- **Self-ticks**: the step reads `fetchAccount()` from `account-client` and shows complete when the cloud account state is `signed-in`. It is not part of the backend `/api/setup/status` payload and never affects the checklist's `complete` gate, so it can never block onboarding.
- **Offline-safe**: when the account service is unreachable (`unavailable`), the step simply renders unticked — no error, onboarding works fully offline.
- **Reserve-username hint**: when signed in without a `handle` (added upstream in #1593), a muted hint nudges the user to reserve their taOS username in Settings; omitted once a handle exists or when signed out.

## Tests

- Extended `SetupChecklist.test.tsx` (23 pass): exact label + detail copy, ticks on signed-in, unticked without error on unavailable, hint only when signed-in without handle (omitted with handle / signed out), and updated step-count assertions (6 base steps, 7 with NPU).
- `npm run build` (tsc + vite) clean; `NotificationCentre` tests (checklist host) still green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional cloud account step to the setup checklist.
  * The checklist now shows cloud sign-in status, completion state, and a helpful username hint when needed.

* **Bug Fixes**
  * Updated checklist counts so completed steps and totals display correctly, including with the new cloud and NPU-related steps.
  * Made setup tests more reliable by handling unavailable cloud account data consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->