### PR TITLE
feat(setup): one-tap NPU backend install from the checklist + notification

### DIFF
--- a/desktop/src/components/SetupChecklist.test.tsx
+++ b/desktop/src/components/SetupChecklist.test.tsx
@@ -63,6 +63,41 @@ function mockFetchStatus(status: Record<string, unknown>) {
   );
 }
 
+// Same poll interval the component uses (NPU_POLL_MS in SetupChecklist.tsx)
+// while an install is in flight.
+const NPU_POLL_MS = 3000;
+
+/**
+ * Stateful fetch mock for the NPU one-tap install flow: /api/setup/status
+ * reflects `state.npuRunning`, and /api/setup/install-npu-backend responds
+ * according to `installOk`. Returns the mutable state so a test can flip
+ * npuRunning to simulate the backend coming up mid-poll.
+ */
+function mockFetchNpuInstallFlow({ installOk = true }: { installOk?: boolean } = {}) {
+  const state = { npuRunning: false };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => {
+      if (url === "/api/setup/status") {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ ...baseStatus, npu_present: true, npu_backend_running: state.npuRunning }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      if (url === "/api/setup/install-npu-backend") {
+        return Promise.resolve(new Response("{}", { status: installOk ? 200 : 500 }));
+      }
+      if (url === "/api/setup/dismiss") {
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }
+      return Promise.reject(new Error("unexpected fetch: " + url));
+    }) as unknown as typeof fetch,
+  );
+  return state;
+}
+
 describe("SetupChecklist", () => {
   beforeEach(() => {
     // Default the cloud account to unavailable so tests that don't care
@@ -213,7 +248,7 @@ describe("SetupChecklist", () => {
     render(<SetupChecklist />);
     expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
     expect(
-      screen.getByText("Install rkllama from the Store to run models on this device's NPU"),
+      screen.getByText("Installs the Rockchip NPU runtime so models run on this device's NPU."),
     ).toBeInTheDocument();
     expect(screen.getByText("0/7")).toBeInTheDocument();
   });
@@ -327,5 +362,74 @@ describe("SetupChecklist", () => {
     render(<SetupChecklist />);
     await screen.findByText(CLOUD_LABEL);
     expect(screen.queryByText(HANDLE_HINT)).toBeNull();
+  });
+
+  it("also offers a secondary Open in Store link on the outstanding NPU step", async () => {
+    mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: false });
+    render(<SetupChecklist />);
+    expect(await screen.findByRole("button", { name: "Install NPU backend" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open in Store" })).toBeInTheDocument();
+  });
+
+  it("tapping Install NPU backend POSTs to install-npu-backend and shows an in-progress state", async () => {
+    mockFetchNpuInstallFlow();
+    render(<SetupChecklist />);
+    const installBtn = await screen.findByRole("button", { name: "Install NPU backend" });
+
+    fireEvent.click(installBtn);
+
+    await waitFor(() => {
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        "/api/setup/install-npu-backend",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    expect(await screen.findByText("Installing NPU backend...")).toBeInTheDocument();
+  });
+
+  it("ticks the NPU step automatically once a status poll reports npu_backend_running", async () => {
+    vi.useFakeTimers();
+    try {
+      const state = mockFetchNpuInstallFlow();
+      render(<SetupChecklist />);
+
+      // Let the initial /api/setup/status fetch (mount effect) resolve.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const installBtn = screen.getByRole("button", { name: "Install NPU backend" });
+
+      await act(async () => {
+        fireEvent.click(installBtn);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(screen.getByText("Installing NPU backend...")).toBeInTheDocument();
+
+      // Simulate the backend coming up, then let the in-flight poll interval fire.
+      state.npuRunning = true;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(NPU_POLL_MS);
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Install the NPU backend — complete" }),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows a clear error with retry when the install POST fails", async () => {
+    mockFetchNpuInstallFlow({ installOk: false });
+    render(<SetupChecklist />);
+    const installBtn = await screen.findByRole("button", { name: "Install NPU backend" });
+
+    fireEvent.click(installBtn);
+
+    expect(await screen.findByText("Couldn't install the NPU backend. Try again.")).toBeInTheDocument();
+    // The button reverts to its idle label so tapping it again retries.
+    expect(screen.getByRole("button", { name: "Install NPU backend" })).toBeInTheDocument();
   });
 });

--- a/desktop/src/components/SetupChecklist.tsx
+++ b/desktop/src/components/SetupChecklist.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { CheckCircle2, Circle, ChevronRight, X } from "lucide-react";
+import { CheckCircle2, Circle, ChevronRight, Loader2, X } from "lucide-react";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
 import { fetchAccount, type AccountState } from "@/lib/account-client";
@@ -66,15 +66,20 @@ const STEPS: Step[] = [
   },
 ];
 
-// Shown only when the board has a Rockchip NPU (#1535): the backend that
-// serves on-device models is a Store install, and without this step nothing
-// in the setup flow ever surfaces it.
+// Shown only when the board has a Rockchip NPU (#1535): without this step
+// nothing in the setup flow ever surfaces the on-device NPU backend. Tapping
+// it is a one-tap install (POST /api/setup/install-npu-backend); "Open in
+// Store" stays as a secondary, manual escape hatch.
 const NPU_STEP: Step = {
   key: "npu_backend_running",
   label: "Install the NPU backend",
-  detail: "Install rkllama from the Store to run models on this device's NPU",
+  detail: "Installs the Rockchip NPU runtime so models run on this device's NPU.",
   appId: "store",
 };
+
+// How often to re-poll /api/setup/status while an NPU install is in flight,
+// so the step ticks on its own once the backend comes up.
+const NPU_POLL_MS = 3000;
 
 export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   const [status, setStatus] = useState<SetupStatus | null>(null);
@@ -83,6 +88,8 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   // status endpoint; it degrades to "unavailable" rather than throwing when
   // the account service can't be reached, so onboarding still works offline.
   const [cloudAccount, setCloudAccount] = useState<AccountState>({ kind: "loading" });
+  const [npuInstalling, setNpuInstalling] = useState(false);
+  const [npuError, setNpuError] = useState<string | null>(null);
   const openWindow = useProcessStore((s) => s.openWindow);
 
   useEffect(() => {
@@ -104,6 +111,25 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
     return () => { cancelled = true; };
   }, []);
 
+  // While an NPU install is in flight, re-poll status so the step ticks over
+  // to done on its own the moment npu_backend_running flips true — no manual
+  // refresh needed.
+  useEffect(() => {
+    if (!npuInstalling) return;
+    let cancelled = false;
+    const id = setInterval(() => {
+      fetch("/api/setup/status")
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data: SetupStatus | null) => {
+          if (cancelled || !data) return;
+          setStatus(data);
+          if (data.npu_backend_running) setNpuInstalling(false);
+        })
+        .catch(() => {});
+    }, NPU_POLL_MS);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [npuInstalling]);
+
   const handleDismiss = async () => {
     setDismissing(true);
     try {
@@ -121,6 +147,22 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   const cloudSignedIn = cloudAccount.kind === "signed-in";
   const isDone = (step: Step) =>
     step.key === "cloud_account" ? cloudSignedIn : Boolean(status?.[step.key]);
+
+  // Primary one-tap action for the NPU step: trigger the server-side install
+  // of both NPU backends rather than sending the user to the Store to hunt
+  // for it. Stays "installing" until the poll above confirms the backend is
+  // actually answering — the tap only starts the install, it doesn't finish it.
+  const handleInstallNpu = async () => {
+    setNpuError(null);
+    setNpuInstalling(true);
+    try {
+      const res = await fetch("/api/setup/install-npu-backend", { method: "POST" });
+      if (!res.ok) throw new Error(`install-npu-backend: ${res.status}`);
+    } catch {
+      setNpuInstalling(false);
+      setNpuError("Couldn't install the NPU backend. Try again.");
+    }
+  };
 
   if (!status || status.dismissed) return null;
   // complete covers the two core steps only; on an NPU board the backend
@@ -161,6 +203,43 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
       <ul role="list" className="pb-2">
         {steps.map((step) => {
           const done = isDone(step);
+          const isNpuStep = step.key === "npu_backend_running";
+
+          // The NPU step gets a one-tap install action + a secondary "Open in
+          // Store" link instead of a single row-as-button; every other step
+          // (and the NPU step once done) keeps the plain tap-to-open row.
+          if (isNpuStep && !done) {
+            return (
+              <li key={step.key}>
+                <div className="flex items-center gap-2.5 px-4 py-2">
+                  <Circle size={14} className="text-shell-text-tertiary shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs text-shell-text">{step.label}</p>
+                    <p className={`text-[10px] truncate ${npuError ? "text-red-400" : "text-shell-text-tertiary"}`}>
+                      {npuError ?? step.detail}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <button
+                      onClick={handleInstallNpu}
+                      disabled={npuInstalling}
+                      className="flex items-center gap-1 text-[10px] font-medium px-2 py-1 rounded-full bg-accent/15 text-accent hover:bg-accent/25 disabled:opacity-60 disabled:cursor-default"
+                    >
+                      {npuInstalling && <Loader2 size={10} className="animate-spin" />}
+                      {npuInstalling ? "Installing NPU backend..." : "Install NPU backend"}
+                    </button>
+                    <button
+                      onClick={() => handleStep(step)}
+                      className="text-[10px] text-shell-text-tertiary hover:text-shell-text underline underline-offset-2"
+                    >
+                      Open in Store
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          }
+
           return (
             <li key={step.key}>
               <button


### PR DESCRIPTION
## Summary
- `SetupChecklist.tsx`'s NPU step now installs the NPU backend itself instead of only opening the Store: tapping "Install NPU backend" POSTs to `POST /api/setup/install-npu-backend`, shows an inline "Installing NPU backend..." state, and ticks automatically once a status poll reports `npu_backend_running: true`.
- A secondary "Open in Store" link is kept for manual/advanced use.
- Failures show a clear inline error and the primary button reverts to its idle label so tapping it again retries.
- The same NPU prompt is embedded directly in `NotificationCentre` (it renders `SetupChecklist`), so the notification surface picks up the one-tap install for free — no separate file to touch.
- Depends on the sibling backend PR `fix/npu-backend-install-runs-service` for `POST /api/setup/install-npu-backend`; frontend is built against that contract and mocks it in tests.

## Test plan
- [x] `npx vitest run src/components/SetupChecklist.test.tsx` — 21 passed, including new coverage for the POST, in-progress state, auto-tick on a later status poll, and the failure/retry path
- [x] `npx vitest run src/components/NotificationCentre.test.tsx` — 7 passed (unaffected; `SetupChecklist` is mocked there)
- [x] `cd desktop && npm run build` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated NPU backend install flow during setup, including an install button, loading state, and automatic completion once the backend is ready.
  * Added a secondary “Open in Store” link for the NPU setup step.

* **Bug Fixes**
  * Improved error handling for NPU backend installation, with a clearer retry message when installation fails.
  * Updated the NPU setup description to reflect the current runtime guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->