### PR TITLE
fix(npu): store install actually creates+starts+verifies rkllama + one-tap install

### DIFF
--- a/app-catalog/services/rkllama/manifest.yaml
+++ b/app-catalog/services/rkllama/manifest.yaml
@@ -7,10 +7,14 @@ description: "Ollama-compatible LLM server on Rockchip NPU — run RKNN models n
 homepage: https://github.com/NotByAI/rkllama
 license: Apache-2.0
 
+# taOS default port is 7833 (see scripts/install-rknpu.sh, RKLLAMA_PORT).
+# 8080 is the upstream rkllama default and is only kept as a legacy
+# fallback probe (rkllama_is_running() checks both) for pre-existing
+# installs that predate the 7833 switch — new installs land on 7833.
 requires:
   ram_mb: 512
   disk_mb: 500
-  ports: [8080]
+  ports: [7833]
 
 install:
   method: script
@@ -25,7 +29,7 @@ hardware_tiers:
 
 lifecycle:
   backend_type: rkllama
-  default_url: http://localhost:8080
+  default_url: http://localhost:7833
   auto_manage: true
   keep_alive_minutes: 0
   start_cmd: "systemctl start rkllama"

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -586,14 +586,14 @@ EOF
 
 wait_for_rkllama() {
     local i
-    for (( i = 0; i < 30; i++ )); do
+    for (( i = 0; i < 60; i++ )); do
         if curl -fs "http://localhost:$RKLLAMA_PORT/api/tags" >/dev/null 2>&1; then
             log "rkllama HTTP API is up on :$RKLLAMA_PORT"
             return 0
         fi
         sleep 1
     done
-    die "rkllama HTTP API did not come up within 30s — check: sudo journalctl -u rkllama -n 100"
+    die "rkllama HTTP API did not come up within 60s — check: sudo journalctl -u rkllama -n 100"
 }
 
 # -------- (7) end-to-end verify ------------------------------------------

--- a/tests/test_install_rknpu_health_gate.sh
+++ b/tests/test_install_rknpu_health_gate.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Syntax + health-gate behaviour tests for the RKNPU/rkllama install scripts.
+set -euo pipefail
+NPU_SCRIPT=scripts/install-rknpu.sh
+RKLLAMA_SCRIPT=scripts/install-rkllama.sh
+
+echo "test: bash -n syntax (install-rknpu.sh)"
+bash -n "$NPU_SCRIPT"
+
+echo "test: bash -n syntax (install-rkllama.sh)"
+bash -n "$RKLLAMA_SCRIPT"
+
+echo "test: wait_for_rkllama fails loudly when nothing answers on the port"
+# Extract just the wait_for_rkllama() function and shrink its retry loop
+# (60 -> 2 iterations) so this runs in ~2s instead of a full minute — the
+# failure path under test (curl never succeeds -> die with a clear message)
+# is unchanged.
+FN="$(sed -n '/^wait_for_rkllama() {/,/^}/p' "$NPU_SCRIPT" | sed 's/i < 60/i < 2/')"
+if [ -z "$FN" ]; then
+  echo "FAIL: could not extract wait_for_rkllama() from $NPU_SCRIPT"
+  exit 1
+fi
+
+out="$(
+  (
+    log()  { :; }
+    warn() { :; }
+    die()  { printf '%s\n' "$*"; exit 1; }
+    eval "$FN"
+    # Port 1 (tcpmux) is privileged and never bound by rkllama in any test
+    # environment, so the curl probe reliably fails without touching the
+    # network.
+    RKLLAMA_PORT=1
+    wait_for_rkllama
+  ) 2>&1
+)" && rc=0 || rc=$?
+
+if [ "$rc" -eq 0 ]; then
+  echo "FAIL: wait_for_rkllama reported success despite nothing listening"
+  exit 1
+fi
+if ! grep -q "did not come up" <<<"$out"; then
+  echo "FAIL: expected a 'did not come up within 60s' message, got:"
+  echo "$out"
+  exit 1
+fi
+echo "PASS: wait_for_rkllama exits non-zero with a clear message when the service never answers"
+
+echo "test: install-rkllama.sh delegates to install-rknpu.sh with TAOS_RKNPU_SETUP=1"
+if ! grep -q "TAOS_RKNPU_SETUP=1" "$RKLLAMA_SCRIPT"; then
+  echo "FAIL: install-rkllama.sh no longer forces TAOS_RKNPU_SETUP=1 on delegation"
+  exit 1
+fi
+
+echo "test: install-rknpu.sh installs + enables + starts the systemd unit"
+if ! grep -q "systemctl enable --now rkllama.service" "$NPU_SCRIPT"; then
+  echo "FAIL: install-rknpu.sh no longer enables+starts rkllama.service"
+  exit 1
+fi
+
+echo "all tests passed"

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -4,6 +4,8 @@ Also covers the account-email path in /auth/setup.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -242,9 +244,11 @@ class TestSetupStatus:
             npu=SimpleNamespace(type="rknpu", tops=6)
         )
         import tinyagentos.installers.rkllama_installer as rk
+        import tinyagentos.installers.rkllamacpp_installer as rkcpp
         import tinyagentos.routes.setup as setup_routes
 
         monkeypatch.setattr(rk, "rkllama_is_running", lambda: True)
+        monkeypatch.setattr(rkcpp, "rkllamacpp_is_running", lambda: False)
         # The probe result is TTL-cached; reset so this test sees a fresh probe.
         monkeypatch.setattr(setup_routes, "_npu_probe_cache", (0.0, False))
         resp = await client.get("/api/setup/status")
@@ -259,14 +263,36 @@ class TestSetupStatus:
             npu=SimpleNamespace(type="rknpu", tops=6)
         )
         import tinyagentos.installers.rkllama_installer as rk
+        import tinyagentos.installers.rkllamacpp_installer as rkcpp
         import tinyagentos.routes.setup as setup_routes
 
         monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+        monkeypatch.setattr(rkcpp, "rkllamacpp_is_running", lambda: False)
         monkeypatch.setattr(setup_routes, "_npu_probe_cache", (0.0, False))
         resp = await client.get("/api/setup/status")
         data = resp.json()
         assert data["npu_present"] is True
         assert data["npu_backend_running"] is False
+
+    async def test_npu_backend_running_true_via_rkllamacpp_alone(self, client, app, monkeypatch):
+        """Either NPU backend running satisfies the step — they're
+        alternatives, not a matched pair."""
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+        import tinyagentos.installers.rkllama_installer as rk
+        import tinyagentos.installers.rkllamacpp_installer as rkcpp
+        import tinyagentos.routes.setup as setup_routes
+
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+        monkeypatch.setattr(rkcpp, "rkllamacpp_is_running", lambda: True)
+        monkeypatch.setattr(setup_routes, "_npu_probe_cache", (0.0, False))
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["npu_present"] is True
+        assert data["npu_backend_running"] is True
 
     async def test_dismissed_false_initially(self, client):
         resp = await client.get("/api/setup/status")
@@ -300,3 +326,91 @@ class TestSetupDismiss:
         resp = await client.post("/api/setup/dismiss")
         assert resp.status_code == 200
         assert resp.json()["dismissed"] is True
+
+
+# ---------------------------------------------------------------------------
+# POST /api/setup/install-npu-backend — one-tap NPU backend install
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestInstallNpuBackend:
+    """Gated on npu_present; triggers the rkllama + rk-llama.cpp backend
+    SERVER installs (not model pulls) via the same script path the Store
+    uses."""
+
+    async def test_404_or_400_when_no_hardware_profile(self, client, app):
+        app.state.hardware_profile = None
+        resp = await client.post("/api/setup/install-npu-backend")
+        assert resp.status_code in (400, 404)
+        assert "error" in resp.json()
+
+    async def test_400_when_npu_not_rockchip(self, client, app):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(npu=SimpleNamespace(type="none"))
+        resp = await client.post("/api/setup/install-npu-backend")
+        assert resp.status_code == 400
+
+    async def test_triggers_both_backend_installs_when_npu_present(
+        self, client, app, monkeypatch,
+    ):
+        """Both rkllama and rk-llama-cpp get dispatched through
+        _legacy_install — the exact same script path Store installs use —
+        and never touch the model-pull or image-gen paths."""
+        from types import SimpleNamespace
+
+        from fastapi.responses import JSONResponse
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+
+        import tinyagentos.routes.store_install as store_install
+
+        calls: list[str] = []
+
+        async def fake_legacy_install(request, body, app_id, target_remote):
+            calls.append(app_id)
+            return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
+
+        monkeypatch.setattr(store_install, "_legacy_install", fake_legacy_install)
+
+        resp = await client.post("/api/setup/install-npu-backend")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["npu_present"] is True
+        assert set(data["backends"].keys()) == {"rkllama", "rk-llama-cpp"}
+        assert data["backends"]["rkllama"]["started"] is True
+        assert data["backends"]["rk-llama-cpp"]["started"] is True
+        assert "install_id" in data["backends"]["rkllama"]
+
+        # The two installs run as background tasks; let the loop drain them.
+        for _ in range(50):
+            if len(calls) == 2:
+                break
+            await asyncio.sleep(0.01)
+        assert set(calls) == {"rkllama", "rk-llama-cpp"}
+
+    async def test_reruns_safely_when_already_running(self, client, app, monkeypatch):
+        """Re-running (e.g. a half-installed box) is a no-op-safe retry —
+        the endpoint doesn't refuse a second call."""
+        from types import SimpleNamespace
+
+        from fastapi.responses import JSONResponse
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+
+        import tinyagentos.routes.store_install as store_install
+
+        async def fake_legacy_install(request, body, app_id, target_remote):
+            return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
+
+        monkeypatch.setattr(store_install, "_legacy_install", fake_legacy_install)
+
+        first = await client.post("/api/setup/install-npu-backend")
+        second = await client.post("/api/setup/install-npu-backend")
+        assert first.status_code == 200
+        assert second.status_code == 200

--- a/tests/test_routes_store_install.py
+++ b/tests/test_routes_store_install.py
@@ -625,6 +625,65 @@ class TestScriptBackendInstall:
         installed_apps.install.assert_called_once()
         reg.mark_installed.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_failing_script_does_not_mark_installed_or_record_location(self, client):
+        """rc!=0 from the script -> surfaced error, no install/mark_installed/
+        runtime-location call at all (the exact rkllama-service bug: never
+        claim success unless the script's own health gate passed)."""
+        manifest = _make_service_manifest("rkllama", method="script")
+        manifest.install = {"method": "script", "script": "scripts/install-rkllama.sh"}
+        manifest.requires = {"ports": [7833]}
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(
+            return_value={"success": False, "error": "rkllama HTTP API did not come up within 60s"},
+        )
+        with patch(
+            "tinyagentos.routes.store_install.get_installer",
+            return_value=mock_installer,
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "rkllama"})
+
+        assert resp.status_code == 500
+        assert "did not come up" in resp.json()["error"]
+        installed_apps.install.assert_not_called()
+        installed_apps.update_runtime_location.assert_not_called()
+        reg.mark_installed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_script_records_runtime_location_from_manifest_port(self, client):
+        """On a verified-running exit 0, the service's declared port
+        (manifest.requires.ports, e.g. rkllama's 7833) is recorded as its
+        runtime location so it gets a Launchpad shortcut / proxy target."""
+        manifest = _make_service_manifest("rkllama", method="script")
+        manifest.install = {"method": "script", "script": "scripts/install-rkllama.sh"}
+        manifest.requires = {"ports": [7833]}
+        reg = _make_registry(manifest)
+        client._transport.app.state.registry = reg
+        installed_apps = _make_installed_apps()
+        client._transport.app.state.installed_apps = installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(
+            return_value={"success": True, "app_id": "rkllama", "method": "script"},
+        )
+        with patch(
+            "tinyagentos.routes.store_install.get_installer",
+            return_value=mock_installer,
+        ):
+            resp = await client.post("/api/store/install-v2", json={"manifest_id": "rkllama"})
+
+        assert resp.status_code == 200
+        installed_apps.install.assert_called_once()
+        reg.mark_installed.assert_called_once()
+        installed_apps.update_runtime_location.assert_called_once_with(
+            "rkllama", host="127.0.0.1", port=7833, backend="rkllama", ui_path="/",
+        )
+
 
 # ---------------------------------------------------------------------------
 # POST /api/store/uninstall-v2

--- a/tinyagentos/installers/rkllamacpp_installer.py
+++ b/tinyagentos/installers/rkllamacpp_installer.py
@@ -35,6 +35,8 @@ import asyncio
 import hashlib
 import logging
 import os
+import socket
+import urllib.request
 from pathlib import Path
 from typing import Any
 
@@ -68,6 +70,30 @@ def _default_port() -> int:
 
 
 SERVICE_NAME = "rkllamacpp"
+
+
+def rkllamacpp_is_running(timeout: float = 1.0) -> bool:
+    """True if a live rk-llama.cpp llama-server answers /health locally.
+
+    Mirrors ``rkllama_is_running()`` in rkllama_installer.py — a cheap
+    synchronous socket + HTTP probe (no variant/model context needed),
+    used so the setup checklist's NPU step can be satisfied by either
+    NPU backend, and so a running-but-unregistered service is still
+    detected. Callers should run this off the event loop
+    (``asyncio.to_thread``) since it blocks on socket I/O.
+    """
+    port = _default_port()
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
+            pass
+    except OSError:
+        return False
+    try:
+        req = urllib.request.Request(f"http://127.0.0.1:{port}/health")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status == 200
+    except Exception:
+        return False
 
 
 class RkLlamaCppInstaller(AppInstaller):

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -6,6 +6,7 @@ POST /api/setup/dismiss → persist user's dismissal of the checklist
 from __future__ import annotations
 
 import asyncio
+import json
 import time
 from pathlib import Path
 
@@ -25,6 +26,11 @@ _npu_probe_cache: tuple[float, bool] = (0.0, False)
 
 
 async def _npu_backend_running() -> bool:
+    """True if either NPU LLM backend (rkllama or rk-llama.cpp) is live.
+
+    Installing either one from the Store satisfies the checklist step —
+    they're alternative backends for the same NPU, not a matched pair.
+    """
     global _npu_probe_cache
     now = time.monotonic()
     cached_at, cached = _npu_probe_cache
@@ -32,15 +38,20 @@ async def _npu_backend_running() -> bool:
         return cached
 
     from tinyagentos.installers.rkllama_installer import rkllama_is_running
+    from tinyagentos.installers.rkllamacpp_installer import rkllamacpp_is_running
 
-    try:
-        # rkllama_is_running never raises, but its socket probes block;
-        # keep them off the event loop and cap how long one can hang.
-        running = await asyncio.wait_for(
-            asyncio.to_thread(rkllama_is_running), _NPU_PROBE_TIMEOUT_S
-        )
-    except asyncio.TimeoutError:
-        running = False
+    async def _probe(fn) -> bool:
+        try:
+            # Neither probe raises, but both block on socket I/O; keep them
+            # off the event loop and cap how long one can hang.
+            return await asyncio.wait_for(asyncio.to_thread(fn), _NPU_PROBE_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            return False
+
+    rkllama_up, rkllamacpp_up = await asyncio.gather(
+        _probe(rkllama_is_running), _probe(rkllamacpp_is_running),
+    )
+    running = rkllama_up or rkllamacpp_up
     _npu_probe_cache = (now, running)
     return running
 
@@ -56,7 +67,7 @@ async def setup_status(request: Request):
       has_agent       — at least one deployed agent exists
       memory_enabled  — user completed the taOSmd memory setup wizard
       npu_present     — a Rockchip NPU was detected on this board (#1535)
-      npu_backend_running — a live rkllama answers on the taOS or legacy port
+      npu_backend_running — a live rkllama OR rk-llama.cpp answers locally
       dismissed       — user dismissed the checklist
       complete        — has_provider AND taos_model_set (the core two steps)
     """
@@ -115,3 +126,83 @@ async def setup_dismiss(request: Request):
     prefs["dismissed"] = True
     await store.save_preference("user", _PREF_NAMESPACE, prefs)
     return JSONResponse({"ok": True, "dismissed": True})
+
+
+@router.post("/api/setup/install-npu-backend")
+async def install_npu_backend(request: Request):
+    """One-tap install of the NPU LLM backend SERVERS (rkllama + rk-llama.cpp).
+
+    Runs each backend's Store install script via the same privileged
+    ScriptInstaller path the Store itself uses (creates/enables/starts the
+    systemd unit and health-gates on the service actually answering before
+    the script exits 0 — see scripts/install-rknpu.sh and
+    scripts/install-rk-llama-cpp.sh). Idempotent: re-running is safe and
+    self-heals a half-installed box, exactly like re-clicking Install in
+    the Store.
+
+    Deliberately scoped to just these two permissively-licensed
+    (Apache-2.0 / MIT) LLM-runtime servers — this is the user's one
+    explicit tap of consent for exactly those two installs, nothing more.
+    No models are pulled here (those go through the existing per-model
+    Store flow with their own license acceptance) and the AGPL RK NPU
+    image-gen stack is never touched by this endpoint. Only meaningful on
+    a Rockchip NPU board — 400 otherwise.
+    """
+    profile = getattr(request.app.state, "hardware_profile", None)
+    npu = getattr(profile, "npu", None)
+    npu_present = bool(npu is not None and getattr(npu, "type", "none") == "rknpu")
+    if not npu_present:
+        return JSONResponse(
+            {"error": "no Rockchip NPU detected on this device"}, status_code=400,
+        )
+
+    registry = getattr(request.app.state, "registry", None)
+    if registry is None:
+        return JSONResponse({"error": "app registry unavailable"}, status_code=500)
+
+    from tinyagentos.install_progress import get_global_store
+    from tinyagentos.routes.store_install import _legacy_install
+    from tinyagentos.task_utils import _create_supervised_task
+
+    progress = getattr(request.app.state, "install_progress_store", None) or get_global_store()
+    bg_tasks = getattr(request.app.state, "_background_tasks", None)
+    if bg_tasks is None:
+        bg_tasks = set()
+        request.app.state._background_tasks = bg_tasks
+
+    backends: dict[str, dict] = {}
+    for backend_app_id in ("rkllama", "rk-llama-cpp"):
+        manifest = registry.get(backend_app_id) if hasattr(registry, "get") else None
+        if manifest is None:
+            backends[backend_app_id] = {
+                "started": False,
+                "error": f"{backend_app_id!r} not in catalog",
+            }
+            continue
+
+        entry = progress.start(app_id=backend_app_id, target_remote=None)
+        install_id = entry.install_id
+
+        async def _run(app_id: str = backend_app_id, install_id: str = install_id) -> None:
+            progress.update(install_id, state="unpacking", detail=f"installing {app_id}")
+            try:
+                # Same dispatcher the Store's install-v2 endpoint uses for
+                # type=service manifests — running the real script, gated
+                # on it exiting 0 (verified-running), not just "ran".
+                resp = await _legacy_install(request, {}, app_id, None)
+            except Exception as exc:  # noqa: BLE001
+                progress.finish(install_id, success=False, error=str(exc))
+                return
+            success = getattr(resp, "status_code", 200) < 400
+            error = None
+            if not success:
+                try:
+                    error = json.loads(resp.body).get("error")
+                except Exception:  # noqa: BLE001
+                    error = "install failed"
+            progress.finish(install_id, success=success, error=error)
+
+        _create_supervised_task(_run(), bg_tasks)
+        backends[backend_app_id] = {"started": True, "install_id": install_id}
+
+    return JSONResponse({"ok": True, "npu_present": True, "backends": backends})

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -285,6 +285,23 @@ def _docker_published_port(install_config: dict) -> int:
     return 0
 
 
+def _manifest_first_port(manifest) -> int:
+    """Return the first port declared in a manifest's top-level ``requires.ports``.
+
+    Script-backed service manifests (rkllama, rk-llama-cpp, ollama, ...)
+    declare their port under the manifest's top-level ``requires`` block,
+    not under ``install`` (that's a docker-only convention — see
+    ``_docker_published_port``).
+    """
+    ports = (getattr(manifest, "requires", None) or {}).get("ports") or []
+    for p in ports:
+        try:
+            return int(p)
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
 async def _legacy_install(request: Request, body: dict, app_id: str | None, target_remote: str | None) -> JSONResponse:
     """Legacy method-driven install path for non-model manifests.
 
@@ -437,14 +454,17 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
         resp_target = _target_remote or "local"
         return JSONResponse({"ok": True, "app_id": app_id, "status": "installed", "target_remote": resp_target, **result})
 
-    # script — host-side backend/plugin manifests (e.g. ollama, tailscale)
-    # that declare install.method: script. Previously this fell straight
-    # through to the default branch below and silently marked the app
-    # installed without ever running the script (same class of bug as #410
-    # below for docker/pip, filed as #1582). Actually run it via
-    # ScriptInstaller and only mark installed on success; a missing or
-    # failing script now returns an explicit error instead of a false
-    # "installed".
+    # script — host-side backend/plugin manifests (e.g. ollama, rkllama,
+    # tailscale) that declare install.method: script. Previously this fell
+    # straight through to the default branch below and silently marked the
+    # app installed without ever running the script (same class of bug as
+    # #410 below for docker/pip, filed as #1582). Actually run it via
+    # ScriptInstaller and only mark installed / record the runtime location
+    # when the script EXITS 0. These scripts are written to be their own
+    # health gate (e.g. install-rkllama.sh delegates to install-rknpu.sh,
+    # which polls the service's HTTP port before returning) so rc==0 here
+    # means the service is actually up, not just that files landed on disk.
+    # On failure, surface the real script error and do not mark installed.
     if backend == "script":
         installer = get_installer("script")
         try:
@@ -457,6 +477,24 @@ async def _legacy_install(request: Request, body: dict, app_id: str | None, targ
                 {"error": inst_result.get("error", "script install failed")},
                 status_code=500,
             )
+        store = getattr(request.app.state, "installed_apps", None)
+        if store is not None:
+            await store.install(app_id, body.get("version", ""), meta)
+            # Record where the now-verified-running service actually
+            # listens, same as the docker branch below, so it gets a
+            # Launchpad shortcut / proxy target. Script-backed services are
+            # host-level systemd units (installed via sudo on this
+            # controller), not remote-incus deploys, so always 127.0.0.1.
+            script_port = _manifest_first_port(manifest) if manifest is not None else 0
+            if script_port:
+                await store.update_runtime_location(
+                    app_id, host="127.0.0.1", port=script_port, backend=app_id,
+                    ui_path=(install_config.get("ui_path", "/") if isinstance(install_config, dict) else "/"),
+                )
+        if registry is not None:
+            version = body.get("version") or (getattr(manifest, "version", "") if manifest else "")
+            registry.mark_installed(app_id, version)
+        return JSONResponse({"ok": True, "app_id": app_id, "status": "installed", **inst_result})
 
     # docker / pip — actually run the installer.
     # Previously this branch fell straight through to the installed-apps


### PR DESCRIPTION
## Summary

Fixes the production bug where installing the rkllama NPU backend from the Store marked it "installed" without ever standing up a running service.

- **Port mismatch (root cause of "looks installed but never seen as running")**: `app-catalog/services/rkllama/manifest.yaml` declared `requires.ports: [8080]` / `lifecycle.default_url: http://localhost:8080`, but `scripts/install-rknpu.sh` sets the service up on **7833** (taOS default), and `rkllama_is_running()` / setup.py probe 7833 first with 8080 only as a legacy fallback. Reconciled the manifest to 7833; 8080 stays documented as the legacy fallback.
- **Self-heal + health gate confirmed / hardened**: `scripts/install-rkllama.sh` (the Store's actual entrypoint) delegates to `scripts/install-rknpu.sh`, which already (re)creates + `systemctl enable --now`s `rkllama.service` and polls the HTTP port before exiting 0 — this already self-heals a half-installed box (package present, unit missing/dead). Widened the post-install health-gate timeout 30s → 60s for real-hardware headroom.
- **`tinyagentos/routes/store_install.py`**: the generic `method: script` install path now records the verified service's runtime location (from the manifest's declared port) together with `mark_installed`, both gated on the script exiting 0. A failing script surfaces its real error and touches neither. Confirmed the rkllama SERVICE manifest (`type: service, method: script`) routes through this script/ScriptInstaller path, not the model-pull `RkllamaInstaller` path (unchanged, only used for `method: rkllama` MODEL entries).
- **`tinyagentos/routes/setup.py` `_npu_backend_running`**: now probes both rkllama and rk-llama.cpp — either backend running satisfies the setup checklist step (they're alternatives, not a matched pair). Added `rkllamacpp_is_running()` to `rkllamacpp_installer.py` for the second probe.
- **New `POST /api/setup/install-npu-backend`**: one-tap install of the two NPU LLM backend **servers only** (rkllama, rk-llama.cpp — Apache-2.0 / MIT), dispatched through the same script path the Store uses, gated on `npu_present` (400 otherwise), idempotent/self-healing on re-run. Does **not** pull any models and does not touch the AGPL RK NPU image-gen stack — those stay on their existing, separately-consented flows.

## Test plan
- [x] `python3 -m pytest tests/ -k "setup or rkllama or npu or store_install" -q` — 196 passed, 1 skipped
- [x] `bash -n scripts/install-rkllama.sh scripts/install-rknpu.sh`
- [x] `shellcheck scripts/install-rkllama.sh scripts/install-rknpu.sh` — only pre-existing, unrelated findings (SC1091/SC2034), no new issues
- [x] New `tests/test_install_rknpu_health_gate.sh` — asserts the health gate fails cleanly with a clear message when the service never answers on its port
- [x] `python3 scripts/audit-manifests.py` — catalog still clean after the manifest port fix