### PR TITLE
fix(texteditor): guard remaining randomUUID call sites; keep focus while typing

### DIFF
--- a/desktop/src/apps/TextEditorApp.tsx
+++ b/desktop/src/apps/TextEditorApp.tsx
@@ -8,6 +8,7 @@ import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { syntaxHighlighting, defaultHighlightStyle } from "@codemirror/language";
 import { FilePlus, Trash2, ChevronLeft, Menu, FileText } from "lucide-react";
 import { useDropTarget } from "@/shell/dnd/use-drop-target";
+import { randomId } from "@/lib/uid";
 
 /* ── Note storage ────────────────────────────────────────── */
 
@@ -18,17 +19,6 @@ interface Note {
 }
 
 const STORAGE_KEY = "tinyagentos-notes";
-
-// crypto.randomUUID() only exists in secure contexts (https, or localhost).
-// taOS is normally reached over plain http (e.g. http://taos.local:6969), so
-// window.crypto.randomUUID is undefined there and calling it threw inside the
-// click handler, silently killing note creation. Fall back to a non-crypto id.
-function newNoteId(): string {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  return `note-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-}
 
 function loadNotes(): Note[] {
   try {
@@ -180,7 +170,14 @@ const MarkdownEditor = React.forwardRef<
       view.destroy();
       viewRef.current = null;
     };
-  }, [content]); // re-create when content identity changes (note switch)
+    // Mount once per note, not on every keystroke. The parent already remounts
+    // this component (via `key={activeNote.id}`) when the user switches notes,
+    // which re-runs this effect with the new note's `content` as the initial
+    // doc. Depending on `content` here instead destroyed and recreated the
+    // CodeMirror view on every `onChange` (i.e. every character typed), which
+    // dropped focus after exactly one keystroke (#1596).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return <div ref={containerRef} className="h-full w-full" />;
 });
@@ -210,7 +207,7 @@ export function TextEditorApp({ windowId: _windowId }: { windowId: string }) {
 
   const createNote = useCallback(() => {
     const note: Note = {
-      id: newNoteId(),
+      id: randomId("note-"),
       content: "# New Note\n\nStart writing...",
       updatedAt: Date.now(),
     };

--- a/desktop/src/apps/__tests__/TextEditorApp.test.tsx
+++ b/desktop/src/apps/__tests__/TextEditorApp.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 
 import { TextEditorApp } from "../TextEditorApp";
+import { startDrag, endDrag } from "@/shell/dnd/dnd-bus";
 
 describe("TextEditorApp", () => {
   beforeEach(() => {
@@ -12,6 +13,7 @@ describe("TextEditorApp", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    endDrag();
   });
 
   it("creates a note and shows it in the sidebar (crypto.randomUUID available)", () => {
@@ -50,6 +52,47 @@ describe("TextEditorApp", () => {
       expect(stored).toHaveLength(1);
       expect(typeof stored[0].id).toBe("string");
       expect(stored[0].id.length).toBeGreaterThan(0);
+    } finally {
+      Object.defineProperty(crypto, "randomUUID", { value: originalRandomUUID, configurable: true });
+    }
+  });
+
+  it("keeps the same CodeMirror instance and focus through continuous typing, even when crypto.randomUUID is unavailable (#1596)", () => {
+    // #1596: the editor accepted exactly one character then lost focus, 100%
+    // reproducible over plain http. Drive several sequential edits through the
+    // exact same dispatch -> updateListener -> onChange chain a real keystroke
+    // uses (via the editor's own insertAtCursor, triggered here through the
+    // drop-target plumbing) and confirm the underlying view survives them all.
+    const originalRandomUUID = crypto.randomUUID;
+    Object.defineProperty(crypto, "randomUUID", { value: undefined, configurable: true });
+
+    try {
+      const { container } = render(<TextEditorApp windowId="w1" />);
+      fireEvent.click(screen.getByRole("button", { name: /create your first note/i }));
+
+      const cmEditorBefore = container.querySelector(".cm-editor");
+      expect(cmEditorBefore).toBeTruthy();
+      const dropTarget = cmEditorBefore!.parentElement!.parentElement!;
+
+      const chars = ["h", "e", "l", "l", "o"];
+      chars.forEach((ch, i) => {
+        startDrag({ kind: "knowledge", id: `k${i}`, title: ch });
+        fireEvent.drop(dropTarget);
+      });
+
+      // Same DOM node throughout: the view was never destroyed and recreated,
+      // so the browser's focus was never yanked out from under the user.
+      const cmEditorAfter = container.querySelector(".cm-editor");
+      expect(cmEditorAfter).toBe(cmEditorBefore);
+      const cmContent = container.querySelector(".cm-content");
+      expect(document.activeElement).toBe(cmContent);
+
+      // A persistent view tracks the cursor across edits, so the characters
+      // land in typed order ("hello"). Recreating the view on every keystroke
+      // (the #1596 bug) resets the cursor to the document start each time,
+      // which prepends each new character and reverses the typed order.
+      const stored = JSON.parse(localStorage.getItem("tinyagentos-notes") ?? "[]");
+      expect(stored[0].content.startsWith("hello")).toBe(true);
     } finally {
       Object.defineProperty(crypto, "randomUUID", { value: originalRandomUUID, configurable: true });
     }


### PR DESCRIPTION
## Summary
- Fixes #1596: TextEditor accepted exactly one character then lost focus.
- Root cause: `MarkdownEditor`'s mount effect depended on `[content]`, so every `onChange` (i.e. every keystroke) re-ran the effect, destroying and recreating the whole CodeMirror view/DOM node. The parent already remounts the component via `key={activeNote.id}` when switching notes, so the internal effect only needs to run once per mount.
- Also consolidated `TextEditorApp`'s local, duplicated `newNoteId()` guard onto the shared `randomId()` helper from `src/lib/uid.ts`, matching the pattern already used by webstudio/officestudio/TaosAssistantPanel/browser-push-bootstrap after #1587. Confirmed via repo-wide grep that no unguarded `crypto.randomUUID()` call sites remain anywhere in `desktop/src`.

## Test plan
- [x] Extended `desktop/src/apps/__tests__/TextEditorApp.test.tsx` with a regression test that shadows `crypto.randomUUID` to `undefined` and drives 5 sequential character insertions through the editor's real dispatch path, asserting the CodeMirror DOM node/focus survive and characters land in typed order.
- [x] Verified the new test fails (content comes out reversed: "olleh" instead of "hello") when the `[content]` dependency bug is reintroduced, confirming it actually catches the regression.
- [x] `npx vitest run src/apps/__tests__/TextEditorApp.test.tsx` — 3 passed
- [x] `npm run build` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note editing reliability when switching between notes, helping keep the editor mounted correctly and preserving focus during typing.
  * Fixed note creation so new notes always get consistent unique IDs, including in environments without built-in UUID support.

* **Tests**
  * Added regression coverage for rapid editing and drag-and-drop interactions to prevent editor reset issues and content ordering problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->