### PR TITLE
fix(texteditor): stop focus loss per keystroke (#1596)

### DIFF
--- a/desktop/src/apps/TextEditorApp.tsx
+++ b/desktop/src/apps/TextEditorApp.tsx
@@ -180,7 +180,16 @@ const MarkdownEditor = React.forwardRef<
       view.destroy();
       viewRef.current = null;
     };
-  }, [content]); // re-create when content identity changes (note switch)
+    // Mount once per component instance. The parent already remounts this
+    // component (fresh `key={activeNote.id}`) when the active note changes,
+    // so a new view with the right initial doc is created on note switch.
+    // Depending on `content` here as well made the effect re-fire on every
+    // keystroke (onChange -> setNotes -> content prop changes), destroying
+    // and recreating the CodeMirror view mid-edit. The new view isn't
+    // focused, so the editor dropped keyboard focus after each character
+    // typed (#1596).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return <div ref={containerRef} className="h-full w-full" />;
 });

--- a/desktop/src/apps/__tests__/TextEditorApp.test.tsx
+++ b/desktop/src/apps/__tests__/TextEditorApp.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
+import { EditorView } from "@codemirror/view";
 
 import { TextEditorApp } from "../TextEditorApp";
 
@@ -50,6 +51,58 @@ describe("TextEditorApp", () => {
       expect(stored).toHaveLength(1);
       expect(typeof stored[0].id).toBe("string");
       expect(stored[0].id.length).toBeGreaterThan(0);
+    } finally {
+      Object.defineProperty(crypto, "randomUUID", { value: originalRandomUUID, configurable: true });
+    }
+  });
+
+  it("keeps the CodeMirror view mounted and focused across consecutive keystrokes (#1596)", () => {
+    // Simulate the non-secure-context (plain http) environment taOS normally
+    // runs in, same as the regression test above, so this also proves the
+    // remaining fix isn't hiding behind an available crypto.randomUUID.
+    const originalRandomUUID = crypto.randomUUID;
+    Object.defineProperty(crypto, "randomUUID", { value: undefined, configurable: true });
+
+    try {
+      const { container } = render(<TextEditorApp windowId="w1" />);
+      fireEvent.click(screen.getByRole("button", { name: /create your first note/i }));
+
+      const cmDom = container.querySelector(".cm-editor") as HTMLElement;
+      expect(cmDom).toBeTruthy();
+      const initialView = EditorView.findFromDOM(cmDom);
+      expect(initialView).toBeTruthy();
+      act(() => initialView!.focus());
+
+      // Type several characters one at a time, the way a real keystroke
+      // reaches CodeMirror: each one dispatches a doc change, which fires the
+      // app's onChange -> setNotes -> re-render with the updated content.
+      let view = initialView!;
+      for (const ch of ["h", "e", "l", "l", "o"]) {
+        expect(() => {
+          act(() => {
+            const head = view.state.selection.main.head;
+            view.dispatch({
+              changes: { from: head, insert: ch },
+              selection: { anchor: head + ch.length },
+            });
+          });
+        }).not.toThrow();
+
+        // The view must survive the resulting re-render untouched: same DOM
+        // node, same EditorView instance, still focused. Before the fix, the
+        // editor's mount effect depended on `content` and tore the whole view
+        // down and rebuilt it (unfocused) on every keystroke, matching the
+        // reported "type one char, lose focus, click, type one more" bug.
+        const domAfter = container.querySelector(".cm-editor") as HTMLElement;
+        expect(domAfter).toBe(cmDom);
+        const viewAfter = EditorView.findFromDOM(domAfter);
+        expect(viewAfter).toBe(view);
+        expect(viewAfter!.hasFocus).toBe(true);
+        view = viewAfter!;
+      }
+
+      const stored = JSON.parse(localStorage.getItem("tinyagentos-notes") ?? "[]");
+      expect(stored[0].content).toContain("hello");
     } finally {
       Object.defineProperty(crypto, "randomUUID", { value: originalRandomUUID, configurable: true });
     }


### PR DESCRIPTION
## Summary
- Fixes #1596: TextEditor lost keyboard focus after every keystroke, forcing a re-click to type each character.
- Root cause: `MarkdownEditor`'s CodeMirror mount `useEffect` in `desktop/src/apps/TextEditorApp.tsx` depended on the `content` prop. Every keystroke flows through `onChange -> setNotes -> activeNote.content` back into that prop, so the effect re-fired on every character, destroying and rebuilding the entire `EditorView`. The freshly created view is never focused, so the editor dropped focus after each character typed.
- Note switching is already handled by the stable `key={activeNote.id}` on `<MarkdownEditor>` at the call site (it fully remounts the component), so the internal effect only needs to run once per mount — it no longer needs (or should) depend on `content`.
- I could not reproduce the `crypto.randomUUID is not a function` error from the issue logs against current `dev`: the only `crypto.randomUUID()` call in this file is already guarded (`newNoteId`, used only by `createNote`), and a repo-wide grep found no other unguarded call site reachable from typing. Prior PRs #1584/#1585 (create path) and #1587 (assistant/push/webstudio) already closed those. The logged error was most likely from a stale cached bundle predating those fixes.

## Test plan
- [x] Added a regression test that shadows `crypto.randomUUID` to `undefined` (matching taOS's plain-http deployment), creates a note, then dispatches five keystrokes one at a time against the live CodeMirror view — asserting no throw and that the exact same `EditorView` instance/DOM node stays mounted and focused after every character.
- [x] Verified the new test fails against the pre-fix code (reverted the dependency array locally) and passes after the fix, confirming it captures the real regression.
- [x] `cd desktop && npm run build` — clean, exit 0.
- [x] `npx vitest run src/apps/__tests__/TextEditorApp.test.tsx` — 3/3 passed.
- [x] `npx vitest run src/lib/uid.test.ts` — 3/3 passed (unaffected, sanity check).

https://github.com/jaylfc/taOS/issues/1596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the text editor experience so the editor stays mounted and keeps focus while typing, preventing interruptions between keystrokes.
  * Preserved note content more reliably during editing, with changes continuing to save correctly as you type.

* **Tests**
  * Added coverage for continuous typing behavior to ensure the editor remains stable and focused across updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->