### PR TITLE
feat(setup): per-platform one-tap local backend install (llama.cpp server on CUDA/ROCm/Metal/CPU)

### DIFF
--- a/app-catalog/services/llama-cpp/manifest.yaml
+++ b/app-catalog/services/llama-cpp/manifest.yaml
@@ -3,22 +3,64 @@ name: llama.cpp
 type: service
 category: llm-runtime
 version: latest
-description: "C++ inference engine for GGUF models — runs on CPU, Vulkan, and Metal without CUDA."
-homepage: https://github.com/ggerganov/llama.cpp
+description: "taOS default local LLM backend (router mode) — chat, embeddings, and rerank from one process on NVIDIA CUDA, AMD ROCm, Apple Silicon, or CPU."
+homepage: https://github.com/ggml-org/llama.cpp
 license: MIT
 
+# taOS default port is 7835 (see scripts/install-llama-cpp.sh,
+# TAOS_LLAMACPP_PORT, and tinyagentos/installers/port_allocator.py
+# RESERVED_PORTS). Distinct from 7834 (LiteLLM proxy) and 7833 (rkllama).
 requires:
   ram_mb: 512
-  disk_mb: 300
-  ports: [8080]
+  disk_mb: 500
+  ports: [7835]
 
 install:
   method: script
   script: scripts/install-llama-cpp.sh
 
+lifecycle:
+  # Auto-register as a backend so the LiteLLM proxy gets a route to the
+  # local llama-server. llama-server's router mode speaks OpenAI-compatible
+  # /v1/chat/completions (plus /v1/embeddings, /v1/rerank); without this
+  # block the service runs but no agent / assistant call ever finds it.
+  backend_type: openai-compatible
+  default_url: http://localhost:7835
+  auto_manage: false
+  keep_alive_minutes: 0  # always-on — router mode itself manages per-model load/unload
+  startup_timeout_seconds: 60
+
+# Ladder-matched by tinyagentos.cluster.capabilities.tier_compatible (used
+# by config.py's auto-register gate): one minimum VRAM/RAM entry per
+# arch+accel covers every bigger machine of the same kind. apple-silicon
+# is a flat tier (unified memory, no ladder). Rockchip NPU keeps its own
+# rkllama / rk-llama.cpp manifests untouched; Intel Arc / Mali have no
+# entry here (unsupported — no one-tap backend yet).
+#
+# The x86-vulkan-* / arm-vulkan-* / arm-cpu-8gb / cpu-only entries below
+# predate this change and drive the separate (exact-match only)
+# HardwareProfile.profile_id-based Store display badge — kept as-is.
 hardware_tiers:
   x86-vulkan-4gb: full
   x86-vulkan-8gb: full
   arm-vulkan-8gb: full
   arm-cpu-8gb: full
   cpu-only: full
+
+  x86-cuda-4gb: full
+  x86-cuda-8gb: full
+  x86-cuda-12gb: full
+  x86-cuda-16gb: full
+  x86-cuda-24gb: full
+  x86-rocm-4gb: full
+  x86-rocm-8gb: full
+  x86-rocm-16gb: full
+  x86-cpu-2gb: full
+  apple-silicon: full
+  arm-cpu-16gb: full
+  arm-cpu-24gb: full
+  arm-cpu-32gb: full
+  arm-cpu-48gb: full
+  arm-cpu-64gb: full
+  arm-cpu-96gb: full
+  arm-cpu-128gb: full

--- a/desktop/src/components/SetupChecklist.test.tsx
+++ b/desktop/src/components/SetupChecklist.test.tsx
@@ -63,30 +63,39 @@ function mockFetchStatus(status: Record<string, unknown>) {
   );
 }
 
-// Same poll interval the component uses (NPU_POLL_MS in SetupChecklist.tsx)
+// Same poll interval the component uses (BACKEND_POLL_MS in SetupChecklist.tsx)
 // while an install is in flight.
-const NPU_POLL_MS = 3000;
+const BACKEND_POLL_MS = 3000;
 
 /**
- * Stateful fetch mock for the NPU one-tap install flow: /api/setup/status
- * reflects `state.npuRunning`, and /api/setup/install-npu-backend responds
- * according to `installOk`. Returns the mutable state so a test can flip
- * npuRunning to simulate the backend coming up mid-poll.
+ * Stateful fetch mock for the one-tap backend install flow: /api/setup/status
+ * reflects `state.backendRunning` for the given `accel`, and
+ * /api/setup/install-backend responds according to `installOk`. Returns the
+ * mutable state so a test can flip backendRunning to simulate the backend
+ * coming up mid-poll.
  */
-function mockFetchNpuInstallFlow({ installOk = true }: { installOk?: boolean } = {}) {
-  const state = { npuRunning: false };
+function mockFetchBackendInstallFlow(
+  { accel = "rknpu", installOk = true }: { accel?: string; installOk?: boolean } = {},
+) {
+  const state = { backendRunning: false };
   vi.stubGlobal(
     "fetch",
     vi.fn((url: string) => {
       if (url === "/api/setup/status") {
         return Promise.resolve(
           new Response(
-            JSON.stringify({ ...baseStatus, npu_present: true, npu_backend_running: state.npuRunning }),
+            JSON.stringify({
+              ...baseStatus,
+              npu_present: accel === "rknpu",
+              npu_backend_running: accel === "rknpu" && state.backendRunning,
+              accel,
+              default_backend_running: state.backendRunning,
+            }),
             { status: 200, headers: { "Content-Type": "application/json" } },
           ),
         );
       }
-      if (url === "/api/setup/install-npu-backend") {
+      if (url === "/api/setup/install-backend") {
         return Promise.resolve(new Response("{}", { status: installOk ? 200 : 500 }));
       }
       if (url === "/api/setup/dismiss") {
@@ -244,7 +253,13 @@ describe("SetupChecklist", () => {
   });
 
   it("shows the NPU step as an additional item when an NPU is present", async () => {
-    mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: false });
+    mockFetchStatus({
+      ...baseStatus,
+      npu_present: true,
+      npu_backend_running: false,
+      accel: "rknpu",
+      default_backend_running: false,
+    });
     render(<SetupChecklist />);
     expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
     expect(
@@ -261,6 +276,8 @@ describe("SetupChecklist", () => {
       complete: true,
       npu_present: true,
       npu_backend_running: false,
+      accel: "rknpu",
+      default_backend_running: false,
     });
     render(<SetupChecklist />);
     expect(await screen.findByText("Install the NPU backend")).toBeInTheDocument();
@@ -272,6 +289,8 @@ describe("SetupChecklist", () => {
       complete: true,
       npu_present: true,
       npu_backend_running: true,
+      accel: "rknpu",
+      default_backend_running: true,
     });
     const { container } = render(<SetupChecklist />);
     await waitFor(() => expect(vi.mocked(fetch)).toHaveBeenCalledWith("/api/setup/status"));
@@ -280,7 +299,13 @@ describe("SetupChecklist", () => {
   });
 
   it("marks the NPU step complete when the backend is running", async () => {
-    mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: true });
+    mockFetchStatus({
+      ...baseStatus,
+      npu_present: true,
+      npu_backend_running: true,
+      accel: "rknpu",
+      default_backend_running: true,
+    });
     render(<SetupChecklist />);
     const doneStep = await screen.findByRole("button", {
       name: "Install the NPU backend — complete",
@@ -365,14 +390,20 @@ describe("SetupChecklist", () => {
   });
 
   it("also offers a secondary Open in Store link on the outstanding NPU step", async () => {
-    mockFetchStatus({ ...baseStatus, npu_present: true, npu_backend_running: false });
+    mockFetchStatus({
+      ...baseStatus,
+      npu_present: true,
+      npu_backend_running: false,
+      accel: "rknpu",
+      default_backend_running: false,
+    });
     render(<SetupChecklist />);
     expect(await screen.findByRole("button", { name: "Install NPU backend" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Open in Store" })).toBeInTheDocument();
   });
 
-  it("tapping Install NPU backend POSTs to install-npu-backend and shows an in-progress state", async () => {
-    mockFetchNpuInstallFlow();
+  it("tapping Install NPU backend POSTs to install-backend and shows an in-progress state", async () => {
+    mockFetchBackendInstallFlow({ accel: "rknpu" });
     render(<SetupChecklist />);
     const installBtn = await screen.findByRole("button", { name: "Install NPU backend" });
 
@@ -380,17 +411,17 @@ describe("SetupChecklist", () => {
 
     await waitFor(() => {
       expect(vi.mocked(fetch)).toHaveBeenCalledWith(
-        "/api/setup/install-npu-backend",
+        "/api/setup/install-backend",
         expect.objectContaining({ method: "POST" }),
       );
     });
     expect(await screen.findByText("Installing NPU backend...")).toBeInTheDocument();
   });
 
-  it("ticks the NPU step automatically once a status poll reports npu_backend_running", async () => {
+  it("ticks the NPU step automatically once a status poll reports the backend running", async () => {
     vi.useFakeTimers();
     try {
-      const state = mockFetchNpuInstallFlow();
+      const state = mockFetchBackendInstallFlow({ accel: "rknpu" });
       render(<SetupChecklist />);
 
       // Let the initial /api/setup/status fetch (mount effect) resolve.
@@ -408,9 +439,9 @@ describe("SetupChecklist", () => {
       expect(screen.getByText("Installing NPU backend...")).toBeInTheDocument();
 
       // Simulate the backend coming up, then let the in-flight poll interval fire.
-      state.npuRunning = true;
+      state.backendRunning = true;
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(NPU_POLL_MS);
+        await vi.advanceTimersByTimeAsync(BACKEND_POLL_MS);
       });
 
       expect(
@@ -422,7 +453,7 @@ describe("SetupChecklist", () => {
   });
 
   it("shows a clear error with retry when the install POST fails", async () => {
-    mockFetchNpuInstallFlow({ installOk: false });
+    mockFetchBackendInstallFlow({ accel: "rknpu", installOk: false });
     render(<SetupChecklist />);
     const installBtn = await screen.findByRole("button", { name: "Install NPU backend" });
 
@@ -431,5 +462,106 @@ describe("SetupChecklist", () => {
     expect(await screen.findByText("Couldn't install the NPU backend. Try again.")).toBeInTheDocument();
     // The button reverts to its idle label so tapping it again retries.
     expect(screen.getByRole("button", { name: "Install NPU backend" })).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Platform-generalized backend step (beyond Rockchip): NVIDIA CUDA / AMD
+  // ROCm / Apple Silicon (Metal) / x86 CPU-only all get the llama.cpp-server
+  // copy and one-tap flow via the same /api/setup/install-backend endpoint.
+  // -------------------------------------------------------------------------
+
+  it("hides the backend step entirely when accel is none (e.g. Intel Arc)", async () => {
+    mockFetchStatus({ ...baseStatus, accel: "none", default_backend_running: false });
+    render(<SetupChecklist />);
+    await screen.findByText("Get started");
+    expect(screen.queryByText("Install a local model backend")).toBeNull();
+    expect(screen.getByText("0/6")).toBeInTheDocument();
+  });
+
+  it("shows the llama.cpp-server copy for a CUDA device", async () => {
+    mockFetchStatus({ ...baseStatus, accel: "cuda", default_backend_running: false });
+    render(<SetupChecklist />);
+    expect(await screen.findByText("Install a local model backend")).toBeInTheDocument();
+    expect(
+      screen.getByText("Runs chat and memory models locally on this device's GPU."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Install llama.cpp server" })).toBeInTheDocument();
+  });
+
+  it("shows the llama.cpp-server copy for a ROCm device", async () => {
+    mockFetchStatus({ ...baseStatus, accel: "rocm", default_backend_running: false });
+    render(<SetupChecklist />);
+    expect(await screen.findByText("Install a local model backend")).toBeInTheDocument();
+    expect(
+      screen.getByText("Runs chat and memory models locally on this device's GPU."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the llama.cpp-server copy for an Apple Silicon (Metal) device", async () => {
+    mockFetchStatus({ ...baseStatus, accel: "metal", default_backend_running: false });
+    render(<SetupChecklist />);
+    expect(await screen.findByText("Install a local model backend")).toBeInTheDocument();
+    expect(
+      screen.getByText("Runs chat and memory models locally on this device's GPU."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the CPU-flavored copy for a CPU-only device", async () => {
+    mockFetchStatus({ ...baseStatus, accel: "cpu", default_backend_running: false });
+    render(<SetupChecklist />);
+    expect(await screen.findByText("Install a local model backend")).toBeInTheDocument();
+    expect(
+      screen.getByText("Runs chat and memory models locally on this device's CPU."),
+    ).toBeInTheDocument();
+  });
+
+  it("tapping Install llama.cpp server on a CUDA device POSTs to install-backend and ticks on completion", async () => {
+    vi.useFakeTimers();
+    try {
+      const state = mockFetchBackendInstallFlow({ accel: "cuda" });
+      render(<SetupChecklist />);
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const installBtn = screen.getByRole("button", { name: "Install llama.cpp server" });
+
+      await act(async () => {
+        fireEvent.click(installBtn);
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(vi.mocked(fetch)).toHaveBeenCalledWith(
+        "/api/setup/install-backend",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(screen.getByText("Installing llama.cpp server...")).toBeInTheDocument();
+
+      state.backendRunning = true;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(BACKEND_POLL_MS);
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Install a local model backend — complete" }),
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("shows a clear error with retry for the llama.cpp-server install on a CUDA device", async () => {
+    mockFetchBackendInstallFlow({ accel: "cuda", installOk: false });
+    render(<SetupChecklist />);
+    const installBtn = await screen.findByRole("button", { name: "Install llama.cpp server" });
+
+    fireEvent.click(installBtn);
+
+    expect(
+      await screen.findByText("Couldn't install the local model backend. Try again."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Install llama.cpp server" })).toBeInTheDocument();
   });
 });

--- a/desktop/src/components/SetupChecklist.tsx
+++ b/desktop/src/components/SetupChecklist.tsx
@@ -4,6 +4,11 @@ import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
 import { fetchAccount, type AccountState } from "@/lib/account-client";
 
+// accel identifies the accelerator this device's default local-LLM-backend
+// step targets. "none" (or absent) means no one-tap backend step is shown
+// (e.g. Intel Arc / Mali have no one-tap backend yet).
+type Accel = "rknpu" | "cuda" | "rocm" | "metal" | "cpu" | "none";
+
 interface SetupStatus {
   account: boolean;
   has_provider: boolean;
@@ -12,6 +17,8 @@ interface SetupStatus {
   memory_enabled: boolean;
   npu_present?: boolean;
   npu_backend_running?: boolean;
+  accel?: Accel;
+  default_backend_running?: boolean;
   dismissed: boolean;
   complete: boolean;
 }
@@ -66,20 +73,54 @@ const STEPS: Step[] = [
   },
 ];
 
-// Shown only when the board has a Rockchip NPU (#1535): without this step
-// nothing in the setup flow ever surfaces the on-device NPU backend. Tapping
-// it is a one-tap install (POST /api/setup/install-npu-backend); "Open in
-// Store" stays as a secondary, manual escape hatch.
-const NPU_STEP: Step = {
-  key: "npu_backend_running",
-  label: "Install the NPU backend",
-  detail: "Installs the Rockchip NPU runtime so models run on this device's NPU.",
+// Platform-aware "install a local model backend" step. Originally
+// Rockchip-only (#1535: rkllama / rk-llama.cpp), generalized to every other
+// accelerator via the llama.cpp router-mode server (locked product
+// decision: MIT, one binary, NVIDIA CUDA / AMD ROCm / Apple Silicon /
+// x86 CPU-only). Shown whenever this device has a supported accel and the
+// backend isn't already running; hidden entirely when accel is "none"
+// (e.g. Intel Arc / Mali have no one-tap backend yet). Tapping it is a
+// one-tap install (POST /api/setup/install-backend); "Open in Store"
+// stays as a secondary, manual escape hatch.
+interface BackendStepCopy {
+  label: string;
+  detail: string;
+  buttonLabel: string;
+  buttonBusyLabel: string;
+  errorText: string;
+}
+
+function backendStepCopyFor(accel: Accel): BackendStepCopy {
+  if (accel === "rknpu") {
+    // Rockchip keeps its pre-#1597 copy verbatim.
+    return {
+      label: "Install the NPU backend",
+      detail: "Installs the Rockchip NPU runtime so models run on this device's NPU.",
+      buttonLabel: "Install NPU backend",
+      buttonBusyLabel: "Installing NPU backend...",
+      errorText: "Couldn't install the NPU backend. Try again.",
+    };
+  }
+  const device = accel === "cpu" ? "CPU" : "GPU";
+  return {
+    label: "Install a local model backend",
+    detail: `Runs chat and memory models locally on this device's ${device}.`,
+    buttonLabel: "Install llama.cpp server",
+    buttonBusyLabel: "Installing llama.cpp server...",
+    errorText: "Couldn't install the local model backend. Try again.",
+  };
+}
+
+const BACKEND_STEP_BASE: Step = {
+  key: "default_backend_running",
+  label: "",
+  detail: "",
   appId: "store",
 };
 
-// How often to re-poll /api/setup/status while an NPU install is in flight,
-// so the step ticks on its own once the backend comes up.
-const NPU_POLL_MS = 3000;
+// How often to re-poll /api/setup/status while a backend install is in
+// flight, so the step ticks on its own once the backend comes up.
+const BACKEND_POLL_MS = 3000;
 
 export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   const [status, setStatus] = useState<SetupStatus | null>(null);
@@ -88,8 +129,8 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   // status endpoint; it degrades to "unavailable" rather than throwing when
   // the account service can't be reached, so onboarding still works offline.
   const [cloudAccount, setCloudAccount] = useState<AccountState>({ kind: "loading" });
-  const [npuInstalling, setNpuInstalling] = useState(false);
-  const [npuError, setNpuError] = useState<string | null>(null);
+  const [backendInstalling, setBackendInstalling] = useState(false);
+  const [backendError, setBackendError] = useState<string | null>(null);
   const openWindow = useProcessStore((s) => s.openWindow);
 
   useEffect(() => {
@@ -111,11 +152,11 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
     return () => { cancelled = true; };
   }, []);
 
-  // While an NPU install is in flight, re-poll status so the step ticks over
-  // to done on its own the moment npu_backend_running flips true — no manual
-  // refresh needed.
+  // While a backend install is in flight, re-poll status so the step ticks
+  // over to done on its own the moment default_backend_running flips true —
+  // no manual refresh needed.
   useEffect(() => {
-    if (!npuInstalling) return;
+    if (!backendInstalling) return;
     let cancelled = false;
     const id = setInterval(() => {
       fetch("/api/setup/status")
@@ -123,12 +164,12 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
         .then((data: SetupStatus | null) => {
           if (cancelled || !data) return;
           setStatus(data);
-          if (data.npu_backend_running) setNpuInstalling(false);
+          if (data.default_backend_running) setBackendInstalling(false);
         })
         .catch(() => {});
-    }, NPU_POLL_MS);
+    }, BACKEND_POLL_MS);
     return () => { cancelled = true; clearInterval(id); };
-  }, [npuInstalling]);
+  }, [backendInstalling]);
 
   const handleDismiss = async () => {
     setDismissing(true);
@@ -145,33 +186,47 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
   };
 
   const cloudSignedIn = cloudAccount.kind === "signed-in";
-  const isDone = (step: Step) =>
-    step.key === "cloud_account" ? cloudSignedIn : Boolean(status?.[step.key]);
+  // default_backend_running falls back to the legacy npu_backend_running
+  // field so a payload that only sends the pre-generalization shape (or an
+  // older-shaped test mock) still reflects the real running state.
+  const isDone = (step: Step) => {
+    if (step.key === "cloud_account") return cloudSignedIn;
+    if (step.key === "default_backend_running") {
+      return Boolean(status?.default_backend_running ?? status?.npu_backend_running ?? false);
+    }
+    return Boolean(status?.[step.key]);
+  };
 
-  // Primary one-tap action for the NPU step: trigger the server-side install
-  // of both NPU backends rather than sending the user to the Store to hunt
-  // for it. Stays "installing" until the poll above confirms the backend is
+  // Primary one-tap action for the backend step: trigger the server-side
+  // install (rkllama + rk-llama.cpp on Rockchip, llama.cpp server
+  // everywhere else) rather than sending the user to the Store to hunt for
+  // it. Stays "installing" until the poll above confirms the backend is
   // actually answering — the tap only starts the install, it doesn't finish it.
-  const handleInstallNpu = async () => {
-    setNpuError(null);
-    setNpuInstalling(true);
+  const handleInstallBackend = async () => {
+    setBackendError(null);
+    setBackendInstalling(true);
     try {
-      const res = await fetch("/api/setup/install-npu-backend", { method: "POST" });
-      if (!res.ok) throw new Error(`install-npu-backend: ${res.status}`);
+      const res = await fetch("/api/setup/install-backend", { method: "POST" });
+      if (!res.ok) throw new Error(`install-backend: ${res.status}`);
     } catch {
-      setNpuInstalling(false);
-      setNpuError("Couldn't install the NPU backend. Try again.");
+      setBackendInstalling(false);
+      setBackendError(backendStepCopyFor(status?.accel ?? "none").errorText);
     }
   };
 
   if (!status || status.dismissed) return null;
-  // complete covers the two core steps only; on an NPU board the backend
-  // install still deserves a surface until it is running (or the user
-  // dismisses the checklist), otherwise it would never be seen (#1535).
-  const npuOutstanding = status.npu_present === true && !status.npu_backend_running;
-  if (status.complete && !npuOutstanding) return null;
+  const accel = status.accel ?? (status.npu_present ? "rknpu" : "none");
+  const showBackendStep = accel !== "none";
+  // complete covers the two core steps only; a device with a supported
+  // accel still deserves the backend-install surface until it is running
+  // (or the user dismisses the checklist), otherwise it would never be
+  // seen (#1535).
+  const backendOutstanding = showBackendStep && !isDone(BACKEND_STEP_BASE);
+  if (status.complete && !backendOutstanding) return null;
 
-  const steps = status.npu_present ? [...STEPS, NPU_STEP] : STEPS;
+  const backendCopy = backendStepCopyFor(accel);
+  const backendStep: Step = { ...BACKEND_STEP_BASE, label: backendCopy.label, detail: backendCopy.detail };
+  const steps = showBackendStep ? [...STEPS, backendStep] : STEPS;
   const doneCount = steps.filter((s) => isDone(s)).length;
   // Signed in but hasn't claimed a username yet -- surfaced as a nudge, not
   // a blocker; omitted when signed out or once a handle exists.
@@ -203,30 +258,31 @@ export function SetupChecklist({ onDismissed }: { onDismissed?: () => void }) {
       <ul role="list" className="pb-2">
         {steps.map((step) => {
           const done = isDone(step);
-          const isNpuStep = step.key === "npu_backend_running";
+          const isBackendStep = step.key === "default_backend_running";
 
-          // The NPU step gets a one-tap install action + a secondary "Open in
-          // Store" link instead of a single row-as-button; every other step
-          // (and the NPU step once done) keeps the plain tap-to-open row.
-          if (isNpuStep && !done) {
+          // The backend step gets a one-tap install action + a secondary
+          // "Open in Store" link instead of a single row-as-button; every
+          // other step (and this one once done) keeps the plain
+          // tap-to-open row.
+          if (isBackendStep && !done) {
             return (
               <li key={step.key}>
                 <div className="flex items-center gap-2.5 px-4 py-2">
                   <Circle size={14} className="text-shell-text-tertiary shrink-0" />
                   <div className="flex-1 min-w-0">
                     <p className="text-xs text-shell-text">{step.label}</p>
-                    <p className={`text-[10px] truncate ${npuError ? "text-red-400" : "text-shell-text-tertiary"}`}>
-                      {npuError ?? step.detail}
+                    <p className={`text-[10px] truncate ${backendError ? "text-red-400" : "text-shell-text-tertiary"}`}>
+                      {backendError ?? step.detail}
                     </p>
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     <button
-                      onClick={handleInstallNpu}
-                      disabled={npuInstalling}
+                      onClick={handleInstallBackend}
+                      disabled={backendInstalling}
                       className="flex items-center gap-1 text-[10px] font-medium px-2 py-1 rounded-full bg-accent/15 text-accent hover:bg-accent/25 disabled:opacity-60 disabled:cursor-default"
                     >
-                      {npuInstalling && <Loader2 size={10} className="animate-spin" />}
-                      {npuInstalling ? "Installing NPU backend..." : "Install NPU backend"}
+                      {backendInstalling && <Loader2 size={10} className="animate-spin" />}
+                      {backendInstalling ? backendCopy.buttonBusyLabel : backendCopy.buttonLabel}
                     </button>
                     <button
                       onClick={() => handleStep(step)}

--- a/scripts/install-llama-cpp.sh
+++ b/scripts/install-llama-cpp.sh
@@ -1,71 +1,353 @@
-#!/bin/bash
-# tinyagentos installer for llama.cpp
-# ---------------------------------------------------------------------------
-# Clones ggerganov/llama.cpp and builds llama-server with auto-detected
-# acceleration (CUDA, Metal, Vulkan, or CPU). For Pi-NPU users, prefer
-# install-rk-llama-cpp.sh which uses pre-compiled aarch64 binaries with
-# the RKNPU2 ggml backend.
+#!/usr/bin/env bash
+# taOS llama.cpp server installer — the default local LLM backend on
+# NVIDIA CUDA, AMD ROCm, Apple Silicon (Metal), and x86 CPU-only.
+#
+# llama.cpp (MIT) ships a built-in "router mode" (llama-server
+# --models-dir <dir>) that serves chat, /v1/embeddings and /v1/rerank
+# from one process, auto-discovering whatever GGUF files are dropped into
+# the models directory — no per-model config needed here. Router mode is
+# young (announced ~May 2026; this build's own log literally says
+# "router mode is experimental"), so this script health-gates hard on
+# /health before ever reporting success.
+#
+# Previous version of this script built llama.cpp from source on every
+# install (5-15 min, needs cmake + a C++ toolchain, and never created a
+# service or health-gated anything). That's now a documented fallback
+# only (see TAOS_LLAMACPP_BUILD_FROM_SOURCE below) — the default path
+# downloads the pinned official release binary for the detected
+# platform, matching the rest of the fleet's install scripts
+# (install-rknpu.sh, install-rk-llama-cpp.sh).
+#
+# This is the Store's install.method=script entrypoint for the
+# `llama-cpp` service manifest (app-catalog/services/llama-cpp/manifest.yaml)
+# — the ScriptInstaller runs it non-interactively as
+# `bash install-llama-cpp.sh <project_dir>`, mirroring
+# install-rk-llama-cpp.sh's contract for the Rockchip backend. Rockchip
+# NPU boards never reach this script: they keep rkllama / rk-llama.cpp
+# (install-rknpu.sh / install-rk-llama-cpp.sh) untouched.
+#
+# Usage:
+#     bash scripts/install-llama-cpp.sh [project_dir]
 #
 # Environment overrides:
-#   TAOS_LLAMACPP_DIR     install dir (default: ~/llama.cpp)
-#   TAOS_LLAMACPP_BACKEND force a specific backend (cuda|metal|vulkan|cpu)
-# ---------------------------------------------------------------------------
+#     TAOS_LLAMACPP_DIR          install dir for the binary (default: ~<user>/llama-cpp)
+#     TAOS_LLAMACPP_MODELS_DIR   models dir router mode scans (default: <project_dir>/data/llama-cpp/models)
+#     TAOS_LLAMACPP_PORT         HTTP port (default: 7835 — see port_allocator.py)
+#     TAOS_LLAMACPP_HOST         bind address (default: 127.0.0.1 — loopback only)
+#     TAOS_LLAMACPP_VARIANT      override auto-detected variant: cuda|rocm|apple-silicon|cpu
+#
+# Safety:
+#   - No models are downloaded here — models go through the per-model
+#     Store flow with their own license acceptance. This script installs
+#     exactly one MIT-licensed binary.
+#   - Idempotent: re-running skips the download if the binary is already
+#     present, but always rewrites the unit/plist and (re)starts it — a
+#     binary-present-but-service-missing-or-dead box self-heals.
+#   - HEALTH GATE: exits non-zero (and does not report success) unless
+#     the service actually answers GET /health within the timeout below.
+#     Verified against a real b9867 macOS build: router mode answers
+#     /health with {"status":"ok"} even with ZERO models in the
+#     directory (llama-server logs "Available models (0)" and keeps
+#     serving) — so the gate below is a plain health check, no
+#     "will start once a model exists" fallback needed.
 set -euo pipefail
 
-log() { echo -e "\033[1;34m[llama-cpp]\033[0m $*"; }
-die() { echo -e "\033[1;31m[llama-cpp]\033[0m $*" >&2; exit 1; }
+log()  { printf '\033[1;34m[llama-cpp]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[llama-cpp]\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31m[llama-cpp]\033[0m %s\n' "$*" >&2; exit 1; }
 
-# Pinned llama.cpp commit — update when testing a new upstream release.
-# To get the latest: git ls-remote https://github.com/ggerganov/llama.cpp.git HEAD
-# Pinned: 2026-06-07 (corresponds to b5340 / llama.cpp v0.0.5340)
-LLAMACPP_COMMIT="${TAOS_LLAMACPP_COMMIT:-e7a7a7f94c58e2e0aed5c27e5e2c3b5f67d8a1c3}"
+PROJECT_DIR="${1:-$(pwd)}"
 
-INSTALL_DIR="${TAOS_LLAMACPP_DIR:-$HOME/llama.cpp}"
+# -------- pinned release ---------------------------------------------------
+# llama.cpp (ggml-org/llama.cpp) tags a new bNNNN build several times a
+# day — there is no separate "stable" channel. b9867 was the newest tag
+# at the time this pin was written (2026-07-03); router mode is
+# experimental upstream, so every asset below was hand-verified (download
+# + sha256 + a real run of llama-server --models-dir against an empty
+# directory) before being pinned here. Bump LLAMACPP_VERSION (and the
+# per-variant sha256 below) deliberately, not automatically.
+LLAMACPP_VERSION="b9867"
+BASE_URL="https://github.com/ggml-org/llama.cpp/releases/download/${LLAMACPP_VERSION}"
 
-# Detect accel
-detect_backend() {
-    if [[ -n "${TAOS_LLAMACPP_BACKEND:-}" ]]; then
-        echo "$TAOS_LLAMACPP_BACKEND"; return
+PORT="${TAOS_LLAMACPP_PORT:-7835}"
+HOST="${TAOS_LLAMACPP_HOST:-127.0.0.1}"
+
+# -------- sha256 helper (Linux sha256sum vs macOS shasum) -------------------
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        die "neither sha256sum nor shasum available — cannot verify download integrity"
     fi
-    if [[ "$(uname -s)" == "Darwin" ]]; then echo "metal"; return; fi
-    if command -v nvidia-smi >/dev/null 2>&1; then echo "cuda"; return; fi
-    if command -v vulkaninfo >/dev/null 2>&1; then echo "vulkan"; return; fi
-    echo "cpu"
 }
 
-BACKEND=$(detect_backend)
-log "target backend: $BACKEND, install dir: $INSTALL_DIR"
+verify_sha256() {
+    local file="$1" expected="$2" label="$3" actual
+    actual="$(sha256_of "$file")"
+    if [[ "$actual" != "$expected" ]]; then
+        die "sha256 mismatch for $label: expected $expected, got $actual — corrupted download or tampered release, refusing to install"
+    fi
+    log "sha256 ok for $label (${actual:0:12}…)"
+}
 
-if [[ -x "$INSTALL_DIR/build/bin/llama-server" ]]; then
-    log "llama-server already built at $INSTALL_DIR/build/bin/llama-server — skipping"
-    exit 0
+# -------- (1) platform + variant detection ----------------------------------
+#
+# nvidia -> CUDA build, amd -> ROCm/HIP build, apple-silicon -> Metal,
+# else -> CPU. TAOS_LLAMACPP_VARIANT overrides detection entirely.
+detect_variant() {
+    if [[ -n "${TAOS_LLAMACPP_VARIANT:-}" ]]; then
+        VARIANT="$TAOS_LLAMACPP_VARIANT"
+        log "variant forced via TAOS_LLAMACPP_VARIANT=$VARIANT"
+        return
+    fi
+
+    local os arch
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    if [[ "$os" == "Darwin" ]]; then
+        [[ "$arch" == "arm64" ]] || die "install-llama-cpp.sh on macOS only supports Apple Silicon (arm64) — got $arch"
+        VARIANT="apple-silicon"
+        log "detected platform: macOS Apple Silicon -> Metal build"
+        return
+    fi
+
+    [[ "$os" == "Linux" ]] || die "unsupported OS: $os (install-llama-cpp.sh supports Linux and macOS only)"
+    [[ "$arch" == "x86_64" ]] || die "install-llama-cpp.sh only supports x86_64 Linux — got $arch. Rockchip ARM boards use install-rknpu.sh / install-rk-llama-cpp.sh instead."
+
+    if [[ -d /opt/rocm ]]; then
+        VARIANT="rocm"
+        log "detected platform: Linux x86_64, /opt/rocm present -> ROCm build"
+    elif command -v nvidia-smi >/dev/null 2>&1 || [[ -d /proc/driver/nvidia/gpus ]]; then
+        VARIANT="cuda"
+        log "detected platform: Linux x86_64, NVIDIA driver present -> CUDA-target build"
+    else
+        VARIANT="cpu"
+        log "detected platform: Linux x86_64, no GPU driver found -> CPU-only build"
+    fi
+}
+
+# -------- (2) resolve asset + sha256 for the detected variant ---------------
+resolve_asset() {
+    case "$VARIANT" in
+        apple-silicon)
+            ASSET="llama-${LLAMACPP_VERSION}-bin-macos-arm64.tar.gz"
+            ASSET_SHA256="8614dce043dcf54150185c6568c0fa092f8cfd2944617aac305e70a8ce1027e3"
+            ;;
+        rocm)
+            # AMD-validated official ROCm/HIP Linux build.
+            ASSET="llama-${LLAMACPP_VERSION}-bin-ubuntu-rocm-7.2-x64.tar.gz"
+            ASSET_SHA256="53b1c78c0afd096febea64f323f6cb33fe707fb3f5ece384dd48646901108c69"
+            ;;
+        cuda)
+            # ggml-org/llama.cpp does not currently publish a prebuilt
+            # Linux+CUDA binary (only Windows CUDA zips exist in release
+            # b9867's asset list — verified directly against the GitHub
+            # API). Use the official Linux Vulkan build instead: it runs
+            # on NVIDIA GPUs via the system's Vulkan driver, needs no CUDA
+            # toolkit, and is still an official prebuilt (not a source
+            # build). If you specifically need a true CUDA build, set
+            # TAOS_LLAMACPP_BUILD_FROM_SOURCE=1 (documented fallback,
+            # below) rather than waiting on an upstream Linux+CUDA asset.
+            ASSET="llama-${LLAMACPP_VERSION}-bin-ubuntu-vulkan-x64.tar.gz"
+            ASSET_SHA256="f436e38d10eb53815ee5d6af14f286a7f90339960d060c1391bbf41a84d4a018"
+            warn "ggml-org/llama.cpp publishes no Linux+CUDA release binary; using the official Vulkan build (runs on NVIDIA GPUs, no CUDA toolkit required)"
+            ;;
+        cpu)
+            ASSET="llama-${LLAMACPP_VERSION}-bin-ubuntu-x64.tar.gz"
+            ASSET_SHA256="a2dc4404fb43f2bb7818fd3a0602b0e59dfe67ab972ce79b3479ad764249fbd4"
+            ;;
+        *)
+            die "unknown variant: $VARIANT (expected cuda|rocm|apple-silicon|cpu)"
+            ;;
+    esac
+}
+
+# Documented fallback, not default (per taOS policy): a true source build
+# with CUDA support, only when explicitly requested.
+#
+#   TAOS_LLAMACPP_BUILD_FROM_SOURCE=1 bash scripts/install-llama-cpp.sh
+#
+# would need, roughly (not implemented here — advanced users only):
+#   git clone https://github.com/ggml-org/llama.cpp && cd llama.cpp
+#   git checkout "$LLAMACPP_VERSION"
+#   cmake -B build -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
+#   cmake --build build --config Release -j"$(nproc)" --target llama-server
+if [[ "${TAOS_LLAMACPP_BUILD_FROM_SOURCE:-0}" == "1" ]]; then
+    die "TAOS_LLAMACPP_BUILD_FROM_SOURCE=1 is a documented manual fallback, not an automated path — see the comment above main() in this script for the exact cmake invocation, then point TAOS_LLAMACPP_DIR/llama-server at the result."
 fi
 
-command -v cmake >/dev/null 2>&1 || die "cmake not installed (apt install cmake / brew install cmake)"
-command -v git >/dev/null 2>&1 || die "git not installed"
-
-if [[ ! -d "$INSTALL_DIR/.git" ]]; then
-    log "cloning ggerganov/llama.cpp into $INSTALL_DIR"
-    git clone --quiet https://github.com/ggerganov/llama.cpp "$INSTALL_DIR"
-    git -C "$INSTALL_DIR" checkout --quiet "$LLAMACPP_COMMIT"
-    log "llama.cpp pinned to $(git -C "$INSTALL_DIR" rev-parse --short HEAD)"
-elif [[ "$(git -C "$INSTALL_DIR" rev-parse HEAD)" != "$(git -C "$INSTALL_DIR" rev-parse "$LLAMACPP_COMMIT" 2>/dev/null || true)" ]]; then
-    log "llama.cpp checkout exists but not at pinned commit — fetching and resetting"
-    git -C "$INSTALL_DIR" fetch --quiet origin
-    git -C "$INSTALL_DIR" checkout --quiet "$LLAMACPP_COMMIT"
-    log "llama.cpp pinned to $(git -C "$INSTALL_DIR" rev-parse --short HEAD)"
+# -------- (3) resolve install dir + models dir ------------------------------
+if [[ -n "${SUDO_USER:-}" && "${SUDO_USER}" != "root" ]]; then
+    TARGET_USER="$SUDO_USER"
+else
+    TARGET_USER="$(id -un)"
 fi
+TARGET_HOME="$(eval echo "~$TARGET_USER")"
+[[ -d "$TARGET_HOME" ]] || die "cannot resolve home directory for user $TARGET_USER"
+TARGET_GROUP="$(id -gn "$TARGET_USER" 2>/dev/null || echo "$TARGET_USER")"
 
-log "configuring cmake (backend=$BACKEND)"
-case "$BACKEND" in
-    cuda)    CMAKE_FLAGS=(-DGGML_CUDA=ON) ;;
-    metal)   CMAKE_FLAGS=(-DGGML_METAL=ON) ;;
-    vulkan)  CMAKE_FLAGS=(-DGGML_VULKAN=ON) ;;
-    cpu|*)   CMAKE_FLAGS=() ;;
-esac
+INSTALL_DIR="${TAOS_LLAMACPP_DIR:-$TARGET_HOME/llama-cpp}"
+MODELS_DIR="${TAOS_LLAMACPP_MODELS_DIR:-$PROJECT_DIR/data/llama-cpp/models}"
 
-cmake -B "$INSTALL_DIR/build" -S "$INSTALL_DIR" "${CMAKE_FLAGS[@]}"
-log "building llama-server (this may take 5-15 min)"
-cmake --build "$INSTALL_DIR/build" --target llama-server -j"$(nproc 2>/dev/null || echo 4)"
+run_as_user() {
+    if [[ "$(id -un)" == "$TARGET_USER" ]]; then
+        "$@"
+    else
+        sudo -u "$TARGET_USER" -H "$@"
+    fi
+}
 
-log "done: $INSTALL_DIR/build/bin/llama-server"
+# -------- (4) download + extract --------------------------------------------
+download_and_extract() {
+    local url="${BASE_URL}/${ASSET}"
+    local tmp
+    tmp="$(mktemp -t llamacpp.XXXXXX.tar.gz)"
+    trap 'rm -f "$tmp"' RETURN
+
+    log "downloading $url"
+    curl -fSL --retry 3 --retry-delay 2 -o "$tmp" "$url" \
+        || die "failed to download $url"
+    verify_sha256 "$tmp" "$ASSET_SHA256" "$ASSET"
+
+    run_as_user mkdir -p "$INSTALL_DIR"
+    log "extracting into $INSTALL_DIR"
+    # Release tarballs wrap everything in a top-level llama-b<ver>/ dir —
+    # strip it so the binary + shared libs land directly under INSTALL_DIR.
+    run_as_user tar -xzf "$tmp" -C "$INSTALL_DIR" --strip-components=1
+    chmod +x "$INSTALL_DIR/llama-server" 2>/dev/null || true
+}
+
+# -------- (5) service unit (systemd on Linux, launchd on macOS) ------------
+install_linux_service() {
+    local unit="/etc/systemd/system/llama-cpp.service"
+    log "writing $unit (port $PORT)"
+    sudo tee "$unit" >/dev/null <<EOF
+[Unit]
+Description=llama.cpp server (router mode) — taOS default local LLM backend
+After=network.target
+
+[Service]
+Type=simple
+User=$TARGET_USER
+Group=$TARGET_GROUP
+WorkingDirectory=$INSTALL_DIR
+Environment=LD_LIBRARY_PATH=$INSTALL_DIR
+ExecStartPre=-/usr/bin/pkill -9 -f $INSTALL_DIR/llama-server
+ExecStart=$INSTALL_DIR/llama-server --models-dir $MODELS_DIR --host $HOST --port $PORT
+Restart=always
+RestartSec=5
+KillMode=mixed
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now llama-cpp.service
+    log "llama-cpp.service enabled + started"
+}
+
+install_macos_service() {
+    local label="com.taos.llama-cpp"
+    local agents_dir="$TARGET_HOME/Library/LaunchAgents"
+    local plist="$agents_dir/${label}.plist"
+    run_as_user mkdir -p "$agents_dir"
+
+    log "writing $plist (port $PORT)"
+    run_as_user tee "$plist" >/dev/null <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>${label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${INSTALL_DIR}/llama-server</string>
+        <string>--models-dir</string><string>${MODELS_DIR}</string>
+        <string>--host</string><string>${HOST}</string>
+        <string>--port</string><string>${PORT}</string>
+    </array>
+    <key>WorkingDirectory</key><string>${INSTALL_DIR}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>DYLD_LIBRARY_PATH</key><string>${INSTALL_DIR}</string>
+    </dict>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+    <key>StandardOutPath</key><string>${INSTALL_DIR}/llama-cpp.log</string>
+    <key>StandardErrorPath</key><string>${INSTALL_DIR}/llama-cpp.err.log</string>
+</dict>
+</plist>
+EOF
+
+    local uid
+    uid="$(id -u "$TARGET_USER")"
+    pkill -9 -f "$INSTALL_DIR/llama-server" 2>/dev/null || true
+    run_as_user launchctl bootout "gui/$uid/${label}" 2>/dev/null || true
+    run_as_user launchctl bootstrap "gui/$uid" "$plist"
+    run_as_user launchctl enable "gui/$uid/${label}"
+    run_as_user launchctl kickstart -k "gui/$uid/${label}"
+    log "${label} loaded + started via launchd"
+}
+
+install_service() {
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        install_macos_service
+    else
+        install_linux_service
+    fi
+}
+
+# -------- (6) health gate ----------------------------------------------------
+wait_for_health() {
+    local i
+    for (( i = 0; i < 60; i++ )); do
+        if curl -fs "http://${HOST}:${PORT}/health" >/dev/null 2>&1; then
+            log "llama-server /health is up on http://${HOST}:${PORT}"
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+# -------- main ----------------------------------------------------------------
+main() {
+    detect_variant
+    resolve_asset
+
+    run_as_user mkdir -p "$MODELS_DIR"
+
+    if [[ -x "$INSTALL_DIR/llama-server" ]]; then
+        log "llama-server binary already present at $INSTALL_DIR — skipping download"
+    else
+        download_and_extract
+    fi
+
+    # Always (re)write + (re)enable the service — this is the self-heal
+    # path: a binary present but a missing/dead unit gets recreated and
+    # started, exactly like re-clicking Install in the Store.
+    install_service
+
+    if ! wait_for_health; then
+        die "llama-server did not answer http://${HOST}:${PORT}/health within 60s — check the service logs (journalctl -u llama-cpp on Linux, $INSTALL_DIR/llama-cpp.err.log on macOS)"
+    fi
+
+    cat <<EOF
+
+  =================================================================
+  llama.cpp server installed successfully (router mode)
+  =================================================================
+    variant:       $VARIANT
+    binary dir:    $INSTALL_DIR
+    models dir:    $MODELS_DIR (drop GGUF files here — no models installed by this script)
+    HTTP endpoint: http://${HOST}:${PORT}
+    pinned build:  $LLAMACPP_VERSION
+
+EOF
+}
+
+main "$@"

--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -23,6 +23,9 @@ class TestReservedPorts:
     def test_litellm_new_host_port_reserved(self):
         assert 7834 in RESERVED_PORTS
 
+    def test_llamacpp_port_reserved(self):
+        assert 7835 in RESERVED_PORTS
+
 
 class TestAllocateHostPort:
     def test_deterministic_for_same_app_id(self):

--- a/tests/test_install_llama_cpp_health_gate.sh
+++ b/tests/test_install_llama_cpp_health_gate.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Syntax + health-gate + variant-detection behaviour tests for the
+# generalized llama.cpp install script (per-platform one-tap backend).
+set -euo pipefail
+SCRIPT=scripts/install-llama-cpp.sh
+
+echo "test: bash -n syntax (install-llama-cpp.sh)"
+bash -n "$SCRIPT"
+
+echo "test: wait_for_health fails loudly when nothing answers on the port"
+# Extract just the wait_for_health() function and shrink its retry loop
+# (60 -> 2 iterations) so this runs in ~2s instead of a full minute — the
+# failure path under test (curl never succeeds -> return non-zero) is
+# unchanged.
+FN="$(sed -n '/^wait_for_health() {/,/^}/p' "$SCRIPT" | sed 's/i < 60/i < 2/')"
+if [ -z "$FN" ]; then
+  echo "FAIL: could not extract wait_for_health() from $SCRIPT"
+  exit 1
+fi
+
+out="$(
+  (
+    log()  { :; }
+    eval "$FN"
+    # Port 1 (tcpmux) is privileged and never bound by llama-server in any
+    # test environment, so the curl probe reliably fails without touching
+    # the network.
+    HOST=127.0.0.1
+    PORT=1
+    if wait_for_health; then
+      echo "UNEXPECTED_SUCCESS"
+    else
+      echo "EXPECTED_FAILURE"
+    fi
+  ) 2>&1
+)"
+
+if ! grep -q "EXPECTED_FAILURE" <<<"$out"; then
+  echo "FAIL: wait_for_health reported success despite nothing listening"
+  echo "$out"
+  exit 1
+fi
+echo "PASS: wait_for_health returns non-zero when the service never answers"
+
+echo "test: variant detection maps forced TAOS_LLAMACPP_VARIANT through to the resolved asset"
+for pair in "cuda:ubuntu-vulkan-x64" "rocm:ubuntu-rocm-7.2-x64" "apple-silicon:macos-arm64" "cpu:ubuntu-x64"; do
+  variant="${pair%%:*}"
+  expect_substr="${pair##*:}"
+  FN2="$(sed -n '/^resolve_asset() {/,/^}/p' "$SCRIPT")"
+  out2="$(
+    (
+      warn() { :; }
+      die()  { printf 'DIE:%s\n' "$*"; exit 1; }
+      LLAMACPP_VERSION="bTEST"
+      VARIANT="$variant"
+      eval "$FN2"
+      resolve_asset
+      echo "$ASSET"
+    ) 2>&1
+  )"
+  if ! grep -q "$expect_substr" <<<"$out2"; then
+    echo "FAIL: variant=$variant expected asset to contain '$expect_substr', got: $out2"
+    exit 1
+  fi
+done
+echo "PASS: resolve_asset() maps every supported variant to the expected release asset"
+
+echo "test: install-llama-cpp.sh installs + enables + starts the systemd unit (Linux)"
+if ! grep -q "systemctl enable --now llama-cpp.service" "$SCRIPT"; then
+  echo "FAIL: install-llama-cpp.sh no longer enables+starts llama-cpp.service"
+  exit 1
+fi
+
+echo "test: install-llama-cpp.sh installs a launchd agent (macOS)"
+if ! grep -q "launchctl bootstrap" "$SCRIPT"; then
+  echo "FAIL: install-llama-cpp.sh no longer bootstraps a launchd agent for macOS"
+  exit 1
+fi
+
+echo "test: no models are downloaded by this script (backend-only install)"
+if grep -iE '^\s*curl' "$SCRIPT" | grep -qiE '\.gguf|MODELS_DIR'; then
+  echo "FAIL: install-llama-cpp.sh appears to curl-download a model file — it must only install the server binary"
+  exit 1
+fi
+echo "PASS: script installs the server binary only, no models"
+
+echo "all tests passed"

--- a/tests/test_routes_setup.py
+++ b/tests/test_routes_setup.py
@@ -300,6 +300,132 @@ class TestSetupStatus:
 
 
 # ---------------------------------------------------------------------------
+# accel detection + default_backend_running — generalizes the NPU-only step
+# (#1535/#1597/#1598) to NVIDIA CUDA / AMD ROCm / Apple Silicon / x86 CPU.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestAccelDetection:
+    async def test_accel_none_without_hardware_profile(self, client, app):
+        app.state.hardware_profile = None
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["accel"] == "none"
+        assert data["default_backend_running"] is False
+
+    async def test_accel_rknpu_on_rockchip_board(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+        import tinyagentos.installers.rkllama_installer as rk
+        import tinyagentos.installers.rkllamacpp_installer as rkcpp
+        import tinyagentos.routes.setup as setup_routes
+
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+        monkeypatch.setattr(rkcpp, "rkllamacpp_is_running", lambda: False)
+        monkeypatch.setattr(setup_routes, "_npu_probe_cache", (0.0, False))
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["accel"] == "rknpu"
+        assert data["default_backend_running"] is False
+
+    async def test_accel_cuda_on_nvidia_gpu(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="nvidia", cuda=True, rocm=False),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+        import tinyagentos.installers.llamacpp_installer as llamacpp
+        import tinyagentos.routes.setup as setup_routes
+
+        monkeypatch.setattr(llamacpp, "llamacpp_is_running", lambda: False)
+        monkeypatch.setattr(setup_routes, "_llamacpp_probe_cache", (0.0, False))
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["accel"] == "cuda"
+        assert data["default_backend_running"] is False
+
+    async def test_accel_rocm_on_amd_gpu(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="amd", cuda=False, rocm=True),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+        import tinyagentos.installers.llamacpp_installer as llamacpp
+        import tinyagentos.routes.setup as setup_routes
+
+        monkeypatch.setattr(llamacpp, "llamacpp_is_running", lambda: True)
+        monkeypatch.setattr(setup_routes, "_llamacpp_probe_cache", (0.0, False))
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["accel"] == "rocm"
+        assert data["default_backend_running"] is True
+
+    async def test_accel_metal_on_apple_silicon(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="apple", cuda=False, rocm=False),
+            cpu=SimpleNamespace(arch="arm64"),
+        )
+        import tinyagentos.installers.llamacpp_installer as llamacpp
+        import tinyagentos.routes.setup as setup_routes
+
+        monkeypatch.setattr(llamacpp, "llamacpp_is_running", lambda: False)
+        monkeypatch.setattr(setup_routes, "_llamacpp_probe_cache", (0.0, False))
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["accel"] == "metal"
+
+    async def test_accel_cpu_on_x86_with_no_gpu(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="none", cuda=False, rocm=False),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+        import tinyagentos.installers.llamacpp_installer as llamacpp
+        import tinyagentos.routes.setup as setup_routes
+
+        monkeypatch.setattr(llamacpp, "llamacpp_is_running", lambda: False)
+        monkeypatch.setattr(setup_routes, "_llamacpp_probe_cache", (0.0, False))
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["accel"] == "cpu"
+
+    async def test_accel_none_on_intel_arc(self, client, app):
+        """Intel Arc: skip — no one-tap backend step is shown."""
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="intel", cuda=False, rocm=False),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+        resp = await client.get("/api/setup/status")
+        data = resp.json()
+        assert data["accel"] == "none"
+        assert data["default_backend_running"] is False
+
+    async def test_accel_none_on_mali(self, client, app):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="mali", cuda=False, rocm=False),
+            cpu=SimpleNamespace(arch="aarch64"),
+        )
+        resp = await client.get("/api/setup/status")
+        assert resp.json()["accel"] == "none"
+
+
+# ---------------------------------------------------------------------------
 # Dismiss tests
 # ---------------------------------------------------------------------------
 
@@ -414,3 +540,181 @@ class TestInstallNpuBackend:
         second = await client.post("/api/setup/install-npu-backend")
         assert first.status_code == 200
         assert second.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# POST /api/setup/install-backend — generalized one-tap backend install
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestInstallBackend:
+    """Dispatches per accel: rknpu delegates to install-npu-backend's exact
+    behavior; cuda/rocm/metal/cpu install the llama-cpp Store manifest
+    through the same script/progress machinery; none 400s."""
+
+    async def test_400_when_accel_none(self, client, app):
+        app.state.hardware_profile = None
+        resp = await client.post("/api/setup/install-backend")
+        assert resp.status_code == 400
+        assert "error" in resp.json()
+
+    async def test_400_on_intel_arc(self, client, app):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="intel", cuda=False, rocm=False),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+        resp = await client.post("/api/setup/install-backend")
+        assert resp.status_code == 400
+
+    async def test_rknpu_delegates_to_install_npu_backend(self, client, app, monkeypatch):
+        """On a Rockchip board, install-backend does exactly what
+        install-npu-backend does (both rkllama + rk-llama-cpp)."""
+        from types import SimpleNamespace
+
+        from fastapi.responses import JSONResponse
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="rknpu", tops=6)
+        )
+
+        import tinyagentos.routes.store_install as store_install
+
+        calls: list[str] = []
+
+        async def fake_legacy_install(request, body, app_id, target_remote):
+            calls.append(app_id)
+            return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
+
+        monkeypatch.setattr(store_install, "_legacy_install", fake_legacy_install)
+
+        resp = await client.post("/api/setup/install-backend")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["npu_present"] is True
+        assert set(data["backends"].keys()) == {"rkllama", "rk-llama-cpp"}
+
+        for _ in range(50):
+            if len(calls) == 2:
+                break
+            await asyncio.sleep(0.01)
+        assert set(calls) == {"rkllama", "rk-llama-cpp"}
+
+    async def test_cuda_dispatches_llama_cpp_install(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        from fastapi.responses import JSONResponse
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="nvidia", cuda=True, rocm=False),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+
+        import tinyagentos.routes.store_install as store_install
+
+        calls: list[str] = []
+
+        async def fake_legacy_install(request, body, app_id, target_remote):
+            calls.append(app_id)
+            return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
+
+        monkeypatch.setattr(store_install, "_legacy_install", fake_legacy_install)
+
+        resp = await client.post("/api/setup/install-backend")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["accel"] == "cuda"
+        assert data["backend"]["llama-cpp"]["started"] is True
+        assert "install_id" in data["backend"]["llama-cpp"]
+
+        for _ in range(50):
+            if calls:
+                break
+            await asyncio.sleep(0.01)
+        assert calls == ["llama-cpp"]
+
+    async def test_rocm_dispatches_llama_cpp_install(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        from fastapi.responses import JSONResponse
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="amd", cuda=False, rocm=True),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+
+        import tinyagentos.routes.store_install as store_install
+
+        async def fake_legacy_install(request, body, app_id, target_remote):
+            return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
+
+        monkeypatch.setattr(store_install, "_legacy_install", fake_legacy_install)
+
+        resp = await client.post("/api/setup/install-backend")
+        assert resp.status_code == 200
+        assert resp.json()["accel"] == "rocm"
+
+    async def test_metal_dispatches_llama_cpp_install(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        from fastapi.responses import JSONResponse
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="apple", cuda=False, rocm=False),
+            cpu=SimpleNamespace(arch="arm64"),
+        )
+
+        import tinyagentos.routes.store_install as store_install
+
+        async def fake_legacy_install(request, body, app_id, target_remote):
+            return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
+
+        monkeypatch.setattr(store_install, "_legacy_install", fake_legacy_install)
+
+        resp = await client.post("/api/setup/install-backend")
+        assert resp.status_code == 200
+        assert resp.json()["accel"] == "metal"
+
+    async def test_cpu_dispatches_llama_cpp_install(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        from fastapi.responses import JSONResponse
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="none", cuda=False, rocm=False),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+
+        import tinyagentos.routes.store_install as store_install
+
+        async def fake_legacy_install(request, body, app_id, target_remote):
+            return JSONResponse({"ok": True, "app_id": app_id, "status": "installed"})
+
+        monkeypatch.setattr(store_install, "_legacy_install", fake_legacy_install)
+
+        resp = await client.post("/api/setup/install-backend")
+        assert resp.status_code == 200
+        assert resp.json()["accel"] == "cpu"
+
+    async def test_500_when_llama_cpp_not_in_catalog(self, client, app, monkeypatch):
+        from types import SimpleNamespace
+
+        app.state.hardware_profile = SimpleNamespace(
+            npu=SimpleNamespace(type="none"),
+            gpu=SimpleNamespace(type="nvidia", cuda=True, rocm=False),
+            cpu=SimpleNamespace(arch="x86_64"),
+        )
+
+        class _EmptyRegistry:
+            def get(self, app_id):
+                return None
+
+        app.state.registry = _EmptyRegistry()
+        resp = await client.post("/api/setup/install-backend")
+        assert resp.status_code == 500

--- a/tinyagentos/installers/llamacpp_installer.py
+++ b/tinyagentos/installers/llamacpp_installer.py
@@ -1,0 +1,62 @@
+"""llama.cpp server (router mode) — the taOS default local LLM backend.
+
+Generalizes the Rockchip-only NPU one-tap install (#1535/#1597/#1598) to
+every other platform: llama.cpp (MIT) built-in "router mode" gives chat,
+``/v1/embeddings`` and ``/v1/rerank`` from one process, so it's the single
+default local backend on NVIDIA CUDA, AMD ROCm, Apple Silicon (Metal) and
+x86 CPU-only. Rockchip NPU boards are unaffected — they keep rkllama /
+rk-llama.cpp exactly as-is (see rkllama_installer.py / rkllamacpp_installer.py).
+
+The actual install (binary download + systemd unit / launchd plist +
+health-gate) lives in ``scripts/install-llama-cpp.sh``, run via the same
+Store ScriptInstaller path every other script-backed service manifest
+uses. This module only holds the runtime constant (default port) and the
+cheap local-only health probe used by ``routes/setup.py`` and by
+``config.py``'s auto-register gate — mirrors ``rkllamacpp_is_running()``.
+"""
+from __future__ import annotations
+
+import os
+import socket
+import urllib.request
+
+# taOS default port for the generic (non-Rockchip) llama.cpp router-mode
+# server — see tinyagentos/installers/port_allocator.py RESERVED_PORTS and
+# app-catalog/services/llama-cpp/manifest.yaml requires.ports. Distinct from
+# 7834 (LiteLLM proxy) and 7833 (rkllama).
+DEFAULT_PORT = 7835
+
+
+def _default_port() -> int:
+    """Resolve port from TAOS_LLAMACPP_PORT or fallback to DEFAULT_PORT."""
+    raw = os.environ.get("TAOS_LLAMACPP_PORT", str(DEFAULT_PORT))
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_PORT
+
+
+def llamacpp_is_running(timeout: float = 1.0) -> bool:
+    """True if a live llama.cpp router-mode server answers /health locally.
+
+    Verified against a real llama-server (b9867) build: router mode
+    (``--models-dir``) answers ``GET /health`` with ``{"status":"ok"}``
+    even when the models directory is empty — no model needs to be
+    installed for this probe (or the setup checklist's completion state)
+    to go green once the server itself is up.
+
+    Callers should run this off the event loop (``asyncio.to_thread``)
+    since it blocks on socket I/O.
+    """
+    port = _default_port()
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=timeout):
+            pass
+    except OSError:
+        return False
+    try:
+        req = urllib.request.Request(f"http://127.0.0.1:{port}/health")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status == 200
+    except Exception:
+        return False

--- a/tinyagentos/installers/port_allocator.py
+++ b/tinyagentos/installers/port_allocator.py
@@ -42,6 +42,7 @@ RESERVED_PORTS: frozenset[int] = frozenset({
     7832,  # taOS qmd memory service
     7833,  # taOS rkllama NPU backend
     7834,  # taOS LiteLLM proxy (new default host port)
+    7835,  # taOS llama-cpp server (default local LLM backend: CUDA/ROCm/Metal/CPU)
     7900,  # taosmd A2A bus
     8000,  # Django / generic dev
     8080,  # Tomcat / common web app default

--- a/tinyagentos/routes/setup.py
+++ b/tinyagentos/routes/setup.py
@@ -24,6 +24,79 @@ _NPU_PROBE_TTL_S = 5.0
 _NPU_PROBE_TIMEOUT_S = 5.0
 _npu_probe_cache: tuple[float, bool] = (0.0, False)
 
+# Same reasoning as the NPU probe cache above, for the llama-cpp /health probe.
+_LLAMACPP_PROBE_TTL_S = 5.0
+_LLAMACPP_PROBE_TIMEOUT_S = 5.0
+_llamacpp_probe_cache: tuple[float, bool] = (0.0, False)
+
+
+def _accel_for_profile(profile) -> str:
+    """Map a HardwareProfile to the accelerator its default local-LLM-backend
+    setup step targets: ``"rknpu"|"cuda"|"rocm"|"metal"|"cpu"|"none"``.
+
+    Locked product decision: llama.cpp server (MIT, router mode) is the
+    default local backend on NVIDIA CUDA, AMD ROCm, Apple Silicon (Metal),
+    and x86 CPU-only. Rockchip NPU boards keep their existing rkllama /
+    rk-llama.cpp one-tap untouched (mapped to "rknpu" here, handled by the
+    existing NPU probes/endpoint). Intel Arc and Mali have no one-tap
+    backend yet, so they map to "none" (no step shown) — including the
+    "intel" gpu.type documented in hardware.py's GpuInfo even though
+    current detection never actually sets it.
+    """
+    if profile is None:
+        return "none"
+    npu = getattr(profile, "npu", None)
+    if npu is not None and getattr(npu, "type", "none") == "rknpu":
+        return "rknpu"
+    gpu = getattr(profile, "gpu", None)
+    gpu_type = getattr(gpu, "type", "none") if gpu is not None else "none"
+    if gpu_type == "nvidia" and getattr(gpu, "cuda", False):
+        return "cuda"
+    if gpu_type == "amd" and getattr(gpu, "rocm", False):
+        return "rocm"
+    if gpu_type == "apple":
+        return "metal"
+    if gpu_type in ("intel", "mali"):
+        return "none"
+    # x86 CPU-only fallback (also covers an nvidia/amd card present without
+    # its driver/toolkit actually usable — cuda/rocm flags false above).
+    cpu = getattr(profile, "cpu", None)
+    arch = getattr(cpu, "arch", "") if cpu is not None else ""
+    if arch in ("x86_64", "amd64", "AMD64", "i686", "x86"):
+        return "cpu"
+    return "none"
+
+
+async def _llamacpp_backend_running() -> bool:
+    """True if the generic (non-Rockchip) llama.cpp router-mode server
+    answers /health on its default port. TTL-cached for the same reason
+    as ``_npu_backend_running`` — this is polled by the setup checklist."""
+    global _llamacpp_probe_cache
+    now = time.monotonic()
+    cached_at, cached = _llamacpp_probe_cache
+    if cached_at and now - cached_at < _LLAMACPP_PROBE_TTL_S:
+        return cached
+
+    from tinyagentos.installers.llamacpp_installer import llamacpp_is_running
+
+    try:
+        running = await asyncio.wait_for(
+            asyncio.to_thread(llamacpp_is_running), _LLAMACPP_PROBE_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        running = False
+    _llamacpp_probe_cache = (now, running)
+    return running
+
+
+async def _default_backend_running(accel: str) -> bool:
+    """Probe this device's default local LLM backend, dispatched by accel."""
+    if accel == "rknpu":
+        return await _npu_backend_running()
+    if accel in ("cuda", "rocm", "metal", "cpu"):
+        return await _llamacpp_backend_running()
+    return False
+
 
 async def _npu_backend_running() -> bool:
     """True if either NPU LLM backend (rkllama or rk-llama.cpp) is live.
@@ -68,6 +141,13 @@ async def setup_status(request: Request):
       memory_enabled  — user completed the taOSmd memory setup wizard
       npu_present     — a Rockchip NPU was detected on this board (#1535)
       npu_backend_running — a live rkllama OR rk-llama.cpp answers locally
+      accel           — this device's default-local-backend accelerator:
+                         "rknpu"|"cuda"|"rocm"|"metal"|"cpu"|"none". "none"
+                         means no one-tap backend step is shown (e.g. Intel
+                         Arc / Mali have none yet).
+      default_backend_running — the accel-appropriate backend answers
+                         locally (rkllama/rk-llama.cpp probes for "rknpu",
+                         llama.cpp server /health for the other four)
       dismissed       — user dismissed the checklist
       complete        — has_provider AND taos_model_set (the core two steps)
     """
@@ -102,6 +182,15 @@ async def setup_status(request: Request):
     if npu_present:
         npu_backend_running = await _npu_backend_running()
 
+    # Generalized platform-conditional step (beyond Rockchip): every other
+    # supported accelerator gets the same one-tap treatment via the
+    # llama.cpp router-mode server. accel=="none" hides the step entirely
+    # (e.g. Intel Arc / Mali, or no hardware profile at all).
+    accel = _accel_for_profile(profile)
+    default_backend_running = False
+    if accel != "none":
+        default_backend_running = await _default_backend_running(accel)
+
     # complete: the two core steps done
     complete = has_provider and taos_model_set
 
@@ -113,6 +202,8 @@ async def setup_status(request: Request):
         "memory_enabled": memory_enabled,
         "npu_present": npu_present,
         "npu_backend_running": npu_backend_running,
+        "accel": accel,
+        "default_backend_running": default_backend_running,
         "dismissed": dismissed,
         "complete": complete,
     })
@@ -206,3 +297,79 @@ async def install_npu_backend(request: Request):
         backends[backend_app_id] = {"started": True, "install_id": install_id}
 
     return JSONResponse({"ok": True, "npu_present": True, "backends": backends})
+
+
+@router.post("/api/setup/install-backend")
+async def install_backend(request: Request):
+    """One-tap install of this device's default local LLM backend.
+
+    Generalizes install-npu-backend (#1535/#1597/#1598) beyond Rockchip:
+    on a Rockchip board this IS the NPU path (delegates to
+    install_npu_backend above, kept as a thin compat alias at its own
+    route too). On NVIDIA CUDA / AMD ROCm / Apple Silicon (Metal) / x86
+    CPU-only, dispatches the ``llama-cpp`` Store manifest's install
+    (scripts/install-llama-cpp.sh) through the exact same
+    ScriptInstaller / supervised-background-task / install-progress-store
+    machinery the NPU path already uses — same one-tap discipline
+    (create+enable+start+health-gate, mark-installed only when verified).
+
+    llama.cpp is MIT-licensed, so this one tap is the user's full consent
+    for installing that single server binary — no models are pulled here
+    (those go through the per-model Store flow with their own license
+    acceptance) and no other stack is touched. 400 when this device has
+    no supported accelerator (accel == "none", e.g. Intel Arc / Mali).
+    """
+    profile = getattr(request.app.state, "hardware_profile", None)
+    accel = _accel_for_profile(profile)
+    if accel == "none":
+        return JSONResponse(
+            {"error": "no supported local model backend for this device"}, status_code=400,
+        )
+    if accel == "rknpu":
+        return await install_npu_backend(request)
+
+    registry = getattr(request.app.state, "registry", None)
+    if registry is None:
+        return JSONResponse({"error": "app registry unavailable"}, status_code=500)
+
+    app_id = "llama-cpp"
+    manifest = registry.get(app_id) if hasattr(registry, "get") else None
+    if manifest is None:
+        return JSONResponse({"error": f"{app_id!r} not in catalog"}, status_code=500)
+
+    from tinyagentos.install_progress import get_global_store
+    from tinyagentos.routes.store_install import _legacy_install
+    from tinyagentos.task_utils import _create_supervised_task
+
+    progress = getattr(request.app.state, "install_progress_store", None) or get_global_store()
+    bg_tasks = getattr(request.app.state, "_background_tasks", None)
+    if bg_tasks is None:
+        bg_tasks = set()
+        request.app.state._background_tasks = bg_tasks
+
+    entry = progress.start(app_id=app_id, target_remote=None)
+    install_id = entry.install_id
+
+    async def _run(install_id: str = install_id) -> None:
+        progress.update(install_id, state="unpacking", detail=f"installing {app_id}")
+        try:
+            resp = await _legacy_install(request, {}, app_id, None)
+        except Exception as exc:  # noqa: BLE001
+            progress.finish(install_id, success=False, error=str(exc))
+            return
+        success = getattr(resp, "status_code", 200) < 400
+        error = None
+        if not success:
+            try:
+                error = json.loads(resp.body).get("error")
+            except Exception:  # noqa: BLE001
+                error = "install failed"
+        progress.finish(install_id, success=success, error=error)
+
+    _create_supervised_task(_run(), bg_tasks)
+
+    return JSONResponse({
+        "ok": True,
+        "accel": accel,
+        "backend": {app_id: {"started": True, "install_id": install_id}},
+    })


### PR DESCRIPTION
Generalizes taOS's hardware-conditional "install a backend" setup step from Rockchip-only (#1535/#1597/#1598) to every supported platform, per the locked product decision: the default local LLM backend is **llama.cpp server (MIT) in router mode** on NVIDIA CUDA, AMD ROCm, Apple Silicon (Metal), and x86 CPU-only. Rockchip keeps its existing rkllama + rk-llama.cpp one-tap exactly as-is.

## What changed

**Backend (`tinyagentos/routes/setup.py`)**
- `GET /api/setup/status` gains two fields: `accel` (`rknpu|cuda|rocm|metal|cpu|none`) and `default_backend_running` (probes the accel-appropriate backend — rkllama/rk-llama.cpp for rknpu, llama.cpp `/health` on 7835 for the other four). `intel`/`mali` → `none` so no step shows.
- `POST /api/setup/install-backend`: on `rknpu` delegates to the existing `install-npu-backend` (kept as a thin compat alias), on `cuda/rocm/metal/cpu` dispatches the `llama-cpp` Store manifest through the same `_legacy_install` / supervised-background-task / install-progress machinery. `400` when `accel=="none"`.

**Probe (`tinyagentos/installers/llamacpp_installer.py`)** — new `llamacpp_is_running()` mirroring `rkllamacpp_is_running()`; default port `7835` reserved in `port_allocator.py` (7834 is already LiteLLM).

**Install script (`scripts/install-llama-cpp.sh`)** — replaces the old build-from-source path with a pinned prebuilt release download + health-gated systemd unit (Linux) / launchd agent (macOS), running `llama-server --models-dir data/llama-cpp/models/` in router mode. Idempotent + self-healing. No models installed (those go through the per-model Store flow). Build-from-source remains a documented opt-in fallback only.

**Manifest (`app-catalog/services/llama-cpp/manifest.yaml`)** — port corrected to 7835 (the #1598 port-reconciliation lesson), lifecycle block for LiteLLM auto-registration, hardware_tiers covering the four platforms.

**Frontend (`SetupChecklist.tsx`)** — the NPU step becomes a platform-aware "Install a local model backend" step. Rockchip copy is unchanged; others get "Install llama.cpp server" / "Runs chat and memory models locally on this device's GPU|CPU." Same one-tap → progress → auto-tick pattern, now posting to `/api/setup/install-backend`.

## Verification
- `pytest -k "setup or llama or backend"` → 400 passed
- `bash -n` + `shellcheck` on the install script → clean; `tests/test_install_llama_cpp_health_gate.sh` → passes
- `vitest SetupChecklist.test.tsx` → 34 passed; `npm run build` → clean

Docs-Reviewed: routes/setup.py behavior changes reviewed against docs/agent-coordination.md; no route module added/removed and no new endpoint pattern needs documenting there (same rationale as #1598 for the sibling endpoint).