### PR TITLE
fix(models): downloaded rkllama models register via /api/pull so the agent can select + deploy them (#1599, #1600)

### DIFF
--- a/desktop/src/apps/agents/TaosAgentDetailPanel.tsx
+++ b/desktop/src/apps/agents/TaosAgentDetailPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Bot, Settings, X } from "lucide-react";
 import { ModelPickerModal } from "@/components/ModelPickerModal";
 import type { AgentModel } from "@/components/ModelPickerFlow";
+import { loadAgentModels } from "@/lib/models";
 import {
   fetchTaosAgentConfig,
   setTaosAgentModel,
@@ -73,12 +74,12 @@ export function TaosAgentDetailPanel({
   async function ensureModelsLoaded() {
     if (modelsLoaded) return;
     try {
-      const res = await fetch("/api/providers/models?refresh=true", {
-        headers: { Accept: "application/json" },
-      });
-      const data = res.ok ? await res.json() : { data: [] };
-      setModels((data.data ?? []).map((m: { id: string }) => ({
-        id: m.id, name: m.id, hostKind: "cloud" as const,
+      // Use the same unified loader as the agent deploy picker so the taOS
+      // agent chooser lists exactly the same models (controller-catalog,
+      // cluster-worker, and cloud-provider models keyed back to a provider).
+      const aggregated = await loadAgentModels();
+      setModels(aggregated.map((m) => ({
+        id: m.id, name: m.name, host: m.host, hostKind: m.hostKind,
       })));
     } catch { /* leave empty */ }
     finally { setModelsLoaded(true); }

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -551,3 +551,52 @@ class TestDownloadWithFallback:
 
         assert task.status == "complete"
         assert task.error == ""
+
+
+# ---------------------------------------------------------------------------
+# start_installer_task
+# ---------------------------------------------------------------------------
+
+class TestStartInstallerTask:
+    """A backend-specific installer (e.g. RkllamaInstaller.install(), which
+    pulls a weight via the backend's own /api/pull instead of a raw HTTP
+    transfer) is tracked through the same DownloadTask polling API as a
+    regular download."""
+
+    @pytest.mark.asyncio
+    async def test_success_marks_task_complete(self):
+        dm = DownloadManager()
+
+        async def _install():
+            return {"success": True}
+
+        task = dm.start_installer_task("dl-installer", _install())
+        assert task.id == "dl-installer"
+        assert task.status == "pending"
+        await dm._running["dl-installer"]
+        assert task.status == "complete"
+        assert task.completed_at > 0
+
+    @pytest.mark.asyncio
+    async def test_failure_result_marks_task_error(self):
+        dm = DownloadManager()
+
+        async def _install():
+            return {"success": False, "error": "rkllama pull failed"}
+
+        task = dm.start_installer_task("dl-installer", _install())
+        await dm._running["dl-installer"]
+        assert task.status == "error"
+        assert task.error == "rkllama pull failed"
+
+    @pytest.mark.asyncio
+    async def test_raised_exception_marks_task_error(self):
+        dm = DownloadManager()
+
+        async def _install():
+            raise RuntimeError("connection refused")
+
+        task = dm.start_installer_task("dl-installer", _install())
+        await dm._running["dl-installer"]
+        assert task.status == "error"
+        assert task.error == "connection refused"

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -43,7 +43,8 @@ def catalog_with_models(tmp_path):
              "backend": ["ollama", "llama-cpp"]},
             {"id": "npu", "name": "NPU RKLLM", "format": "rkllm", "size_mb": 200,
              "min_ram_mb": 0, "download_url": "https://example.com/npu.rkllm",
-             "backend": ["rkllama"], "requires_npu": ["rk3588"]},
+             "backend": ["rkllama"], "requires_npu": ["rk3588"],
+             "requires": {"backends": [{"id": "rkllama"}]}},
         ],
         "hardware_tiers": {"arm-npu-16gb": {"recommended": "npu", "fallback": "small"}},
         "install": {"method": "download"},
@@ -267,6 +268,65 @@ class TestModelsDelete:
         assert delete_resp.status_code == 200
         assert "test-model-small.gguf" in delete_resp.json()["deleted_files"]
         assert not (models_dir / "test-model-small.gguf").exists()
+
+
+@pytest.mark.asyncio
+class TestModelDownload:
+    """POST /api/models/download must route variants that declare
+    requires.backends: [{id: rkllama}] through rkllama's own /api/pull
+    (RkllamaInstaller) instead of the generic byte-download path — a raw
+    file dump is invisible to the running rkllama server, so it can never
+    be selected as an agent model or deployed (#1599 / #1600).
+    """
+
+    async def test_generic_variant_still_uses_download_manager(self, models_app, models_client):
+        resp = await models_client.post(
+            "/api/models/download",
+            json={"app_id": "test-model", "variant_id": "small"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["download_id"] == "test-model-small"
+        task = models_app.state.download_manager.get_progress("test-model-small")
+        assert task is not None
+        assert task.url == "https://example.com/small.gguf"
+
+    async def test_rkllama_variant_routes_through_installer(self, models_app, models_client):
+        with patch(
+            "tinyagentos.installers.rkllama_installer.RkllamaInstaller.install",
+            new=AsyncMock(return_value={"success": True, "app_id": "test-model"}),
+        ) as mock_install:
+            resp = await models_client.post(
+                "/api/models/download",
+                json={"app_id": "test-model", "variant_id": "npu"},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        download_id = data["download_id"]
+        assert download_id == "test-model-npu"
+        mock_install.assert_awaited_once()
+        assert mock_install.await_args.args[0] == "test-model"
+
+        # Drain the background task so the tracked DownloadTask settles.
+        task = models_app.state.download_manager.get_progress(download_id)
+        await models_app.state.download_manager._running[download_id]
+        assert task.status == "complete"
+
+    async def test_rkllama_variant_install_failure_marks_task_error(self, models_app, models_client):
+        with patch(
+            "tinyagentos.installers.rkllama_installer.RkllamaInstaller.install",
+            new=AsyncMock(return_value={"success": False, "error": "pull failed"}),
+        ):
+            resp = await models_client.post(
+                "/api/models/download",
+                json={"app_id": "test-model", "variant_id": "npu"},
+            )
+        assert resp.status_code == 200
+        download_id = resp.json()["download_id"]
+        task = models_app.state.download_manager.get_progress(download_id)
+        await models_app.state.download_manager._running[download_id]
+        assert task.status == "error"
+        assert task.error == "pull failed"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/download_manager.py
+++ b/tinyagentos/download_manager.py
@@ -88,6 +88,37 @@ class DownloadManager:
         )
         return task
 
+    def start_installer_task(self, download_id: str, coro) -> DownloadTask:
+        """Track a model install driven by a backend-specific installer
+        coroutine (e.g. ``RkllamaInstaller.install()``, which pulls the
+        weight via the backend's own ``/api/pull`` instead of a raw HTTP/
+        torrent transfer) using the same DownloadTask the caller already
+        polls via :meth:`get_progress`. These installers don't report
+        incremental byte progress, so ``percent`` stays at 0 until the
+        task finishes.
+        """
+        task = DownloadTask(id=download_id, url="", dest=Path())
+        self._tasks[download_id] = task
+        self._running[download_id] = asyncio.create_task(self._run_installer(task, coro))
+        return task
+
+    async def _run_installer(self, task: DownloadTask, coro) -> None:
+        task.status = "downloading"
+        task.started_at = time.time()
+        try:
+            result = await coro
+        except Exception as exc:  # noqa: BLE001 — surface as a task error, never raise into the poll loop
+            task.status = "error"
+            task.error = str(exc)
+            logger.error("Installer task failed for %s: %s", task.id, exc)
+            return
+        if not result.get("success"):
+            task.status = "error"
+            task.error = result.get("error", "install failed")
+            return
+        task.status = "complete"
+        task.completed_at = time.time()
+
     def get_progress(self, download_id: str) -> DownloadTask | None:
         return self._tasks.get(download_id)
 

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -347,13 +347,39 @@ async def download_model(request: Request, body: DownloadRequest):
     if not url:
         return JSONResponse({"error": "No download URL for variant"}, status_code=400)
 
+    download_id = f"{body.app_id}-{body.variant_id}"
+    dm = request.app.state.download_manager
+
+    # Variants that declare requires.backends: [{id: rkllama, ...}] must be
+    # installed through rkllama's own /api/pull so the weight is registered
+    # with the running rkllama server (and shows up in its /api/tags). A raw
+    # HTTP download to disk here would leave the file invisible to rkllama —
+    # it never loads, so it can neither be selected as an agent model nor
+    # deployed (see #1599 / #1600).
+    backend_deps = (variant.get("requires") or {}).get("backends") or []
+    backend_ids = {b.get("id") for b in backend_deps if isinstance(b, dict)}
+    if "rkllama" in backend_ids:
+        from tinyagentos.installers.rkllama_installer import (
+            RkllamaInstaller,
+            resolve_rkllama_url,
+        )
+
+        installer = RkllamaInstaller(rkllama_url=resolve_rkllama_url(None))
+        dm.start_installer_task(
+            download_id,
+            installer.install(body.app_id, {}, variant=variant),
+        )
+        return {
+            "status": "started",
+            "download_id": download_id,
+            "app_id": body.app_id,
+            "variant_id": body.variant_id,
+        }
+
     models_dir = _models_dir(request)
     fmt = variant.get("format", "bin")
     filename = f"{body.app_id}-{body.variant_id}.{fmt}"
     dest = models_dir / filename
-
-    download_id = f"{body.app_id}-{body.variant_id}"
-    dm = request.app.state.download_manager
     # Hybrid download: DownloadManager tries the torrent swarm first if
     # the variant declares a magnet URI and the catalog publisher has
     # marked its licence as allowing redistribution. Failures fall back


### PR DESCRIPTION
## Summary

Fixes #1599 and #1600 (beta.21). Downloaded RKLLM models were unusable by agents due to two problems sharing one root cause: the on-disk weight was never registered with the running rkllama server.

### #1600 (root cause) — deploy fails with "model was not found on the controller…"
The `qwen2.5-3b-rkllm` manifest declares `variant.requires.backends: [{id: rkllama}]`, so it must be installed via rkllama's own `/api/pull` (which registers it in rkllama's `/api/tags`, making it visible to `BackendCatalog.all_models()` — the source `resolve_model_location()` consults at deploy time). Instead the Models-app Download button always hit the generic `POST /api/models/download`, which dumped raw bytes to disk via `DownloadManager`, bypassing rkllama entirely. The file showed up in the on-disk scan (so it was selectable in the deploy wizard) but rkllama never knew about it, so deploy correctly reported it "not found".

**Fix:** `download_model()` now inspects `variant.requires.backends`; when `rkllama` is declared it delegates to the existing `RkllamaInstaller` (the same installer the resolver-driven store path uses). Added `DownloadManager.start_installer_task()` so the installer-driven pull is tracked through the same `download_id`/polling contract the frontend already uses — no frontend change needed for this half.

### #1599 — downloaded models don't appear in the taOS-agent picker
`TaosAgentDetailPanel.tsx` (the default taOS system-agent settings panel) had its own narrow `ensureModelsLoaded()` that fetched only `/api/providers/models` (cloud) and hard-coded `hostKind: "cloud"`, never querying controller-downloaded or worker models. Its sibling `TaosAgentCard.tsx` already used the shared `loadAgentModels()` union helper.

**Fix:** switch `TaosAgentDetailPanel.tsx` to `loadAgentModels()` so Change model + Permitted models list controller/worker/cloud models identically to the deploy wizard.

## Changes
- `tinyagentos/routes/models.py` — route rkllama-backed variants through `RkllamaInstaller`
- `tinyagentos/download_manager.py` — add `start_installer_task()`
- `desktop/src/apps/agents/TaosAgentDetailPanel.tsx` — use shared `loadAgentModels()`
- `tests/test_routes_models.py` — 3 tests for the download-routing branch
- `tests/test_download_manager.py` — 3 tests for `start_installer_task`

## Verification
- Backend: 686 relevant tests pass (model/deploy/resolver/download subset)
- Frontend: full suite (290 files / 2378 tests) passes; `tsc --noEmit` clean

Closes #1599
Closes #1600

Docs-Reviewed: routes/models.py change is an internal install-path branch (no API contract or documented-endpoint change); no doc update required.