### PR TITLE
fix(files+projects): move deletes to Recycle Bin (#1604) and fix New Project dialog stacking (#1605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ### Fixed
 - Files: deleting a file or folder now moves it to the trash instead of permanently removing it, for your own workspace, agent workspaces, and project files alike. Restore or empty it from the Recycle Bin. Reported by @mandresve (#1604).
+- Projects: the New Project dialog no longer opens behind the Projects window. Reported by @mandresve (#1605).
 
 ## [1.0.0-beta.21] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Fixed
+- Files: deleting a file or folder now moves it to the trash instead of permanently removing it, for your own workspace, agent workspaces, and project files alike. Restore or empty it from the Recycle Bin. Reported by @mandresve (#1604).
+
 ## [1.0.0-beta.21] - 2026-07-03
 
 ### Added

--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -52,6 +52,19 @@ interface RecycleResponse {
   status?: string;
 }
 
+// Item shape returned by GET /api/workspace/trash — the move-to-trash bin
+// backing the user's own workspace (see tinyagentos/workspace_trash.py).
+// Distinct from RecycleItem above, which is the per-agent container
+// trash-cli bin: this one is populated by deletes made in the Files app
+// itself, on the user's own workspace files.
+interface WorkspaceTrashItem {
+  id: string;
+  name: string;
+  original_path: string;
+  is_dir: boolean;
+  deleted_at: string; // ISO string
+}
+
 interface FileEntry {
   name: string;
   path: string;
@@ -478,11 +491,16 @@ export function FilesApp({
   // Context menu anchor + payload. file === null targets the empty list area.
   const [menu, setMenu] = useState<{ x: number; y: number; file: FileEntry | null } | null>(null);
 
-  // Recycle bin
+  // Recycle bin (per-agent container trash-cli)
   const [recycleItems, setRecycleItems] = useState<RecycleItem[]>([]);
   const [recycleContainerOffline, setRecycleContainerOffline] = useState<string[]>([]);
   const [recycleLoading, setRecycleLoading] = useState(false);
   const [recycleError, setRecycleError] = useState<string | null>(null);
+
+  // Workspace trash (host-side move-to-trash backing the user's own Files)
+  const [workspaceTrashItems, setWorkspaceTrashItems] = useState<WorkspaceTrashItem[]>([]);
+  const [workspaceTrashLoading, setWorkspaceTrashLoading] = useState(false);
+  const [workspaceTrashError, setWorkspaceTrashError] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragCounter = useRef(0);
@@ -663,6 +681,50 @@ export function FilesApp({
       setRecycleError(e instanceof Error ? e.message : "Delete failed");
     }
   }, [fetchRecycle]);
+
+  /* ---- Workspace trash ---- */
+  const fetchWorkspaceTrash = useCallback(async () => {
+    setWorkspaceTrashLoading(true);
+    setWorkspaceTrashError(null);
+    try {
+      const data = await apiFetch<{ items: WorkspaceTrashItem[] }>("/api/workspace/trash");
+      setWorkspaceTrashItems(Array.isArray(data.items) ? data.items : []);
+    } catch (e: unknown) {
+      setWorkspaceTrashError(e instanceof Error ? e.message : "Failed to load trash");
+    } finally {
+      setWorkspaceTrashLoading(false);
+    }
+  }, []);
+
+  const handleWorkspaceTrashRestore = useCallback(async (item: WorkspaceTrashItem) => {
+    try {
+      await apiFetch(`/api/workspace/trash/${encodeURIComponent(item.id)}/restore`, { method: "POST" });
+      fetchWorkspaceTrash();
+    } catch (e: unknown) {
+      setWorkspaceTrashError(e instanceof Error ? e.message : "Restore failed");
+    }
+  }, [fetchWorkspaceTrash]);
+
+  const handleWorkspaceTrashPurge = useCallback(async (item: WorkspaceTrashItem) => {
+    if (!window.confirm(`Permanently delete "${item.original_path}"? This cannot be undone.`)) return;
+    try {
+      await apiFetch(`/api/workspace/trash/${encodeURIComponent(item.id)}`, { method: "DELETE" });
+      fetchWorkspaceTrash();
+    } catch (e: unknown) {
+      setWorkspaceTrashError(e instanceof Error ? e.message : "Delete failed");
+    }
+  }, [fetchWorkspaceTrash]);
+
+  const handleEmptyWorkspaceTrash = useCallback(async () => {
+    if (workspaceTrashItems.length === 0) return;
+    if (!window.confirm("Permanently delete everything in the trash? This cannot be undone.")) return;
+    try {
+      await apiFetch("/api/workspace/trash", { method: "DELETE" });
+      fetchWorkspaceTrash();
+    } catch (e: unknown) {
+      setWorkspaceTrashError(e instanceof Error ? e.message : "Empty trash failed");
+    }
+  }, [fetchWorkspaceTrash, workspaceTrashItems.length]);
 
   /* ---- Actions ---- */
   const handleNewFolder = useCallback(async () => {
@@ -1020,6 +1082,7 @@ export function FilesApp({
                 setCurrentPath("");
                 setSelectedLocation("recycle");
                 fetchRecycle();
+                fetchWorkspaceTrash();
               }}
               className={`w-full flex items-center justify-between px-4 py-3.5 text-sm text-shell-text active:bg-white/10 transition-colors ${location === "recycle" ? "bg-white/10" : ""}`}
               aria-label="Recycle Bin"
@@ -1038,6 +1101,7 @@ export function FilesApp({
               setLocation("recycle");
               setCurrentPath("");
               fetchRecycle();
+              fetchWorkspaceTrash();
             }}
             className="w-full justify-start mx-1.5 mt-1 px-3"
             aria-label="Recycle Bin"
@@ -1147,29 +1211,52 @@ export function FilesApp({
       <div className="shrink-0 flex items-center gap-2 px-4 py-3 border-b border-white/5">
         <Recycle size={15} className="text-shell-text-tertiary" aria-hidden="true" />
         <span className="text-sm font-medium">Recycle Bin</span>
+        {workspaceTrashItems.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleEmptyWorkspaceTrash}
+            className="h-7 ml-auto text-xs text-shell-text-tertiary hover:text-red-400"
+            aria-label="Empty workspace trash"
+          >
+            Empty Trash
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon"
-          onClick={fetchRecycle}
-          className="h-7 w-7 ml-auto"
+          onClick={() => {
+            fetchRecycle();
+            fetchWorkspaceTrash();
+          }}
+          className={`h-7 w-7 ${workspaceTrashItems.length > 0 ? "" : "ml-auto"}`}
           aria-label="Refresh recycle bin"
         >
-          <RefreshCw size={13} className={recycleLoading ? "animate-spin" : ""} aria-hidden="true" />
+          <RefreshCw size={13} className={recycleLoading || workspaceTrashLoading ? "animate-spin" : ""} aria-hidden="true" />
         </Button>
       </div>
 
       {/* Error */}
-      {recycleError && (
+      {(recycleError || workspaceTrashError) && (
         <div className="mx-3 mt-2 flex items-center gap-2 px-3 py-2 rounded-lg bg-red-500/10 text-red-400 text-xs">
           <AlertCircle size={14} className="shrink-0" aria-hidden="true" />
-          <span className="flex-1">{recycleError}</span>
-          <button onClick={() => setRecycleError(null)} className="hover:text-red-300" aria-label="Dismiss error">&times;</button>
+          <span className="flex-1">{recycleError || workspaceTrashError}</span>
+          <button
+            onClick={() => {
+              setRecycleError(null);
+              setWorkspaceTrashError(null);
+            }}
+            className="hover:text-red-300"
+            aria-label="Dismiss error"
+          >
+            &times;
+          </button>
         </div>
       )}
 
       {/* Content */}
       <div className="flex-1 overflow-auto p-3">
-        {recycleLoading && recycleItems.length === 0 && (
+        {(recycleLoading || workspaceTrashLoading) && recycleItems.length === 0 && workspaceTrashItems.length === 0 && (
           <div className="flex items-center justify-center h-full text-shell-text-tertiary">
             <RefreshCw size={20} className="animate-spin" aria-hidden="true" />
           </div>
@@ -1182,11 +1269,61 @@ export function FilesApp({
           </div>
         ))}
 
-        {!recycleLoading && recycleItems.length === 0 && recycleContainerOffline.length === 0 && (
+        {!recycleLoading && !workspaceTrashLoading && recycleItems.length === 0 && workspaceTrashItems.length === 0 && recycleContainerOffline.length === 0 && (
           <div className="flex flex-col items-center justify-center h-full text-shell-text-tertiary gap-2 text-center">
             <Recycle size={40} className="opacity-30" aria-hidden="true" />
-            <span className="text-sm">Recycle bin is empty. Deleted files land here automatically — 30-day retention.</span>
+            <span className="text-sm">Recycle bin is empty. Deleted files land here automatically.</span>
           </div>
+        )}
+
+        {/* Items deleted from the user's own Files workspace */}
+        {workspaceTrashItems.length > 0 && (
+          <section className="mb-4" aria-label="Trashed items from your workspace">
+            <div className="flex items-center gap-1.5 mb-2">
+              <span className="text-[10px] font-semibold uppercase tracking-wider text-shell-text-tertiary">
+                My Files
+              </span>
+            </div>
+            <div className="space-y-1.5">
+              {workspaceTrashItems.map((item) => (
+                <Card
+                  key={item.id}
+                  className="flex items-center gap-3 px-3 py-2.5 hover:bg-shell-surface/50 transition-colors"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xs truncate font-mono" title={item.original_path}>
+                      {item.original_path}
+                    </div>
+                    <div className="text-[10px] text-shell-text-tertiary mt-0.5">
+                      {formatDate(Math.floor(new Date(item.deleted_at).getTime() / 1000))}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 hover:bg-emerald-500/15 hover:text-emerald-400"
+                      onClick={() => handleWorkspaceTrashRestore(item)}
+                      aria-label={`Restore ${item.original_path}`}
+                      title="Restore"
+                    >
+                      <RotateCcw size={13} aria-hidden="true" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 hover:bg-red-500/15 hover:text-red-400"
+                      onClick={() => handleWorkspaceTrashPurge(item)}
+                      aria-label={`Permanently delete ${item.original_path}`}
+                      title="Delete permanently"
+                    >
+                      <Trash2 size={13} aria-hidden="true" />
+                    </Button>
+                  </div>
+                </Card>
+              ))}
+            </div>
+          </section>
         )}
 
         {Object.keys(recycleByAgent).map((agentName) => (

--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.test.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.test.tsx
@@ -39,3 +39,24 @@ describe("CreateProjectDialog slug auto-tracking", () => {
     expect((slugInput as HTMLInputElement).value).toBe("my-project");
   });
 });
+
+describe("CreateProjectDialog stacking (#1605)", () => {
+  it("portals straight to document.body, not nested under a window's DOM subtree", () => {
+    render(<CreateProjectDialog onClose={vi.fn()} onCreated={vi.fn()} />);
+    const dialog = screen.getByRole("dialog", { name: /create project/i });
+    expect(dialog.parentElement).toBe(document.body);
+  });
+
+  it("uses the app-wide top overlay layer so it always renders above windows", () => {
+    // Window.tsx applies an ever-increasing zIndex (see stores/process-store.ts
+    // nextZIndex, which starts at 1 and climbs by 1 on every open/focus/restore/
+    // maximize with no ceiling). A hardcoded low z-index like Tailwind's "z-50"
+    // gets outrun by any long-lived window session, which is exactly what made
+    // the dialog render behind the Projects window in #1605. The fix reuses the
+    // same "always on top" layer already used by ContextMenu, NotificationToast,
+    // and NotificationCentre for the same reason.
+    render(<CreateProjectDialog onClose={vi.fn()} onCreated={vi.fn()} />);
+    const dialog = screen.getByRole("dialog", { name: /create project/i });
+    expect(dialog).toHaveClass("z-[10001]");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
@@ -48,7 +48,7 @@ export function CreateProjectDialog({
       role="dialog"
       aria-modal="true"
       aria-label="Create project"
-      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-[10001] bg-black/50 flex items-center justify-center p-4"
     >
       <form
         onSubmit={onSubmit}

--- a/docs/runbooks/recycle-bin.md
+++ b/docs/runbooks/recycle-bin.md
@@ -1,5 +1,28 @@
 # Recycle bin runbook
 
+## Host-side Files trash (workspace / agent workspace / project files)
+
+The per-container mechanism below only ever sees files removed *inside* an
+agent's own container shell. The Files app also browses three folders that
+live on the controller host, not in any container — the user's own
+workspace, an agent's workspace (as mounted on the host), and a project's
+files folder — and those used to hard-delete on "delete" (#1604).
+
+They now go through a small move-to-trash helper instead
+(`tinyagentos/workspace_trash.py`): deleting moves the item under
+`<data_dir>/.taos-trash/<scope>/<item-id>/` alongside a JSON metadata
+sidecar (original relative path, deleted-at, directory flag); nothing is
+unlinked from disk until an explicit purge or empty-trash call. Routes:
+
+- `GET/POST/DELETE /api/workspace/trash[...]` — user workspace
+- `GET/POST/DELETE /api/agents/{name}/workspace/trash[...]` — agent workspace
+- `GET/POST/DELETE /api/projects/{slug}/trash[...]` — project files
+
+The Files app surfaces the user-workspace trash under Recycle Bin → "My
+Files" (restore / delete permanently / empty all). The agent-workspace and
+project-files trash routes exist and are tested, but aren't yet wired into
+a Files UI section — restore/empty for those two scopes is API-only for now.
+
 ## How it works (per container)
 
 Every taOS agent container has a soft-delete recycle bin at

--- a/tests/test_workspace_trash.py
+++ b/tests/test_workspace_trash.py
@@ -1,0 +1,285 @@
+"""Tests for the shared move-to-trash helper (tinyagentos/workspace_trash.py)
+and its wiring into the three host-side Files backends: user workspace,
+agent workspace, and project files.
+
+Regression coverage for #1604 — Files used to hard-delete
+(shutil.rmtree / Path.unlink) on every one of these routes, bypassing the
+Recycle Bin entirely. These tests assert the deleted bytes still exist on
+disk (moved under a trash directory) and can be listed/restored/purged,
+rather than merely asserting the API response shape.
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from tinyagentos.workspace_trash import (
+    TrashItemNotFound,
+    TrashRestoreConflict,
+    empty_trash,
+    get_trash_dir,
+    list_trash_items,
+    move_to_trash,
+    purge_trash_item,
+    restore_trash_item,
+)
+
+
+class TestWorkspaceTrashHelper:
+    """Unit tests against a bare tmp_path filesystem — no app/client needed."""
+
+    def test_move_to_trash_relocates_file_not_deletes(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        target = workspace / "note.txt"
+        target.write_bytes(b"keep me safe")
+
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        metadata = move_to_trash(trash_dir, target, "note.txt")
+
+        # Not hard-deleted: the bytes still exist somewhere on disk.
+        assert not target.exists()
+        holder = trash_dir / metadata["id"] / "note.txt"
+        assert holder.exists()
+        assert holder.read_bytes() == b"keep me safe"
+        assert metadata["original_path"] == "note.txt"
+        assert metadata["is_dir"] is False
+        assert metadata["size_bytes"] == len(b"keep me safe")
+        assert metadata["deleted_at"]
+
+    def test_move_to_trash_relocates_directory(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        target = workspace / "folder"
+        target.mkdir()
+        (target / "inner.txt").write_bytes(b"nested")
+
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        metadata = move_to_trash(trash_dir, target, "folder")
+
+        assert not target.exists()
+        assert metadata["is_dir"] is True
+        holder = trash_dir / metadata["id"] / "folder" / "inner.txt"
+        assert holder.read_bytes() == b"nested"
+
+    def test_list_trash_items_newest_first(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+
+        for name in ("a.txt", "b.txt"):
+            f = workspace / name
+            f.write_bytes(b"x")
+            move_to_trash(trash_dir, f, name)
+
+        items = list_trash_items(trash_dir)
+        assert len(items) == 2
+        assert {i["original_path"] for i in items} == {"a.txt", "b.txt"}
+
+    def test_restore_trash_item_roundtrip(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        target = workspace / "restore_me.txt"
+        target.write_bytes(b"bring it back")
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        metadata = move_to_trash(trash_dir, target, "restore_me.txt")
+
+        restored = restore_trash_item(trash_dir, workspace, metadata["id"])
+        assert restored["original_path"] == "restore_me.txt"
+        assert target.exists()
+        assert target.read_bytes() == b"bring it back"
+        # Metadata and holder are cleaned up after restore.
+        assert list_trash_items(trash_dir) == []
+
+    def test_restore_unknown_id_raises_not_found(self, tmp_path):
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        with pytest.raises(TrashItemNotFound):
+            restore_trash_item(trash_dir, tmp_path, "does-not-exist")
+
+    def test_restore_conflict_when_destination_exists(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        target = workspace / "conflict.txt"
+        target.write_bytes(b"original")
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        metadata = move_to_trash(trash_dir, target, "conflict.txt")
+
+        # Something new now occupies the original path.
+        (workspace / "conflict.txt").write_bytes(b"new file")
+
+        with pytest.raises(TrashRestoreConflict):
+            restore_trash_item(trash_dir, workspace, metadata["id"])
+
+    def test_purge_trash_item_permanently_deletes(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        target = workspace / "purge_me.txt"
+        target.write_bytes(b"gone for good")
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        metadata = move_to_trash(trash_dir, target, "purge_me.txt")
+
+        assert purge_trash_item(trash_dir, metadata["id"]) is True
+        assert list_trash_items(trash_dir) == []
+        assert not (trash_dir / metadata["id"]).exists()
+
+    def test_purge_unknown_item_returns_false(self, tmp_path):
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        assert purge_trash_item(trash_dir, "ghost") is False
+
+    def test_empty_trash_purges_everything(self, tmp_path):
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        for name in ("a.txt", "b.txt", "c.txt"):
+            f = workspace / name
+            f.write_bytes(b"x")
+            move_to_trash(trash_dir, f, name)
+
+        count = empty_trash(trash_dir)
+        assert count == 3
+        assert list_trash_items(trash_dir) == []
+
+
+class TestUserWorkspaceTrashRoutes:
+    """DELETE on /api/workspace/files must move-to-trash, not hard-delete."""
+
+    @pytest.mark.asyncio
+    async def test_delete_does_not_permanently_remove_bytes(self, client, app):
+        content = b"do not vanish"
+        await client.post(
+            "/api/workspace/files/upload",
+            files={"file": ("precious.txt", io.BytesIO(content), "text/plain")},
+        )
+
+        resp = await client.delete("/api/workspace/files/precious.txt")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+
+        # Gone from the listing...
+        listing = await client.get("/api/workspace/files")
+        assert "precious.txt" not in [e["name"] for e in listing.json()]
+
+        # ...but the bytes are still on disk in the trash, not wiped.
+        trash_root = app.state.config_path.parent / ".taos-trash" / "workspace"
+        found = list(trash_root.rglob("precious.txt"))
+        assert len(found) == 1
+        assert found[0].read_bytes() == content
+
+    @pytest.mark.asyncio
+    async def test_trash_list_restore_and_empty(self, client, app):
+        await client.post(
+            "/api/workspace/files/upload",
+            files={"file": ("doc.txt", io.BytesIO(b"draft"), "text/plain")},
+        )
+        await client.delete("/api/workspace/files/doc.txt")
+
+        listing = await client.get("/api/workspace/trash")
+        assert listing.status_code == 200
+        items = listing.json()["items"]
+        assert len(items) == 1
+        assert items[0]["original_path"] == "doc.txt"
+
+        restore = await client.post(f"/api/workspace/trash/{items[0]['id']}/restore")
+        assert restore.status_code == 200
+        assert restore.json()["status"] == "restored"
+
+        back = await client.get("/api/workspace/files")
+        assert "doc.txt" in [e["name"] for e in back.json()]
+        assert (await client.get("/api/workspace/trash")).json()["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_empty_trash_purges_all_items(self, client, app):
+        for name in ("one.txt", "two.txt"):
+            await client.post(
+                "/api/workspace/files/upload",
+                files={"file": (name, io.BytesIO(b"x"), "text/plain")},
+            )
+            await client.delete(f"/api/workspace/files/{name}")
+
+        empty_resp = await client.delete("/api/workspace/trash")
+        assert empty_resp.status_code == 200
+        assert empty_resp.json()["count"] == 2
+        assert (await client.get("/api/workspace/trash")).json()["items"] == []
+
+    @pytest.mark.asyncio
+    async def test_restore_nonexistent_item_returns_404(self, client, app):
+        resp = await client.post("/api/workspace/trash/ghost-id/restore")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_purge_single_item(self, client, app):
+        await client.post(
+            "/api/workspace/files/upload",
+            files={"file": ("solo.txt", io.BytesIO(b"x"), "text/plain")},
+        )
+        await client.delete("/api/workspace/files/solo.txt")
+        items = (await client.get("/api/workspace/trash")).json()["items"]
+        item_id = items[0]["id"]
+
+        resp = await client.delete(f"/api/workspace/trash/{item_id}")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "purged"
+        assert (await client.get("/api/workspace/trash")).json()["items"] == []
+
+
+class TestAgentWorkspaceTrashRoutes:
+    """The agent workspace delete route mirrors the same move-to-trash fix."""
+
+    def _add_agent(self, app, name: str) -> None:
+        app.state.config.agents.append({
+            "name": name,
+            "host": "127.0.0.1",
+            "qmd_index": "test",
+            "color": "#cccccc",
+        })
+
+    @pytest.mark.asyncio
+    async def test_delete_moves_to_trash_and_lists_restore(self, client, app):
+        self._add_agent(app, "trashy")
+        ws = app.state.agent_workspaces_dir / "trashy"
+        ws.mkdir(parents=True, exist_ok=True)
+        (ws / "agent_file.txt").write_bytes(b"agent data")
+
+        resp = await client.delete("/api/agents/trashy/workspace/files/agent_file.txt")
+        assert resp.status_code == 200
+        assert not (ws / "agent_file.txt").exists()
+
+        listing = await client.get("/api/agents/trashy/workspace/trash")
+        assert listing.status_code == 200
+        items = listing.json()["items"]
+        assert len(items) == 1
+
+        restore = await client.post(
+            f"/api/agents/trashy/workspace/trash/{items[0]['id']}/restore"
+        )
+        assert restore.status_code == 200
+        assert (ws / "agent_file.txt").read_bytes() == b"agent data"
+
+
+class TestProjectFilesTrashRoutes:
+    """The project files delete route mirrors the same move-to-trash fix."""
+
+    @pytest.mark.asyncio
+    async def test_delete_moves_to_trash_and_lists_restore(self, client, app):
+        await client.post(
+            "/api/projects/trash-proj/files/upload",
+            files={"file": ("plan.txt", io.BytesIO(b"project plan"), "text/plain")},
+        )
+
+        resp = await client.delete("/api/projects/trash-proj/files/plan.txt")
+        assert resp.status_code == 200
+
+        listing = await client.get("/api/projects/trash-proj/trash")
+        assert listing.status_code == 200
+        items = listing.json()["items"]
+        assert len(items) == 1
+        assert items[0]["original_path"] == "plan.txt"
+
+        restore = await client.post(
+            f"/api/projects/trash-proj/trash/{items[0]['id']}/restore"
+        )
+        assert restore.status_code == 200
+
+        back = await client.get("/api/projects/trash-proj/files")
+        assert "plan.txt" in [e["name"] for e in back.json()]

--- a/tests/test_workspace_trash.py
+++ b/tests/test_workspace_trash.py
@@ -124,8 +124,48 @@ class TestWorkspaceTrashHelper:
         assert not (trash_dir / metadata["id"]).exists()
 
     def test_purge_unknown_item_returns_false(self, tmp_path):
+        # A well-formed id that simply doesn't exist returns False; malformed
+        # ids raise TrashItemNotFound (covered separately).
         trash_dir = get_trash_dir(tmp_path, "workspace")
-        assert purge_trash_item(trash_dir, "ghost") is False
+        assert purge_trash_item(trash_dir, "0" * 32) is False
+
+    @pytest.mark.parametrize("bad_id", ["../../etc", "..", "../x", "a/b", "foo", "", "ABCDEF" * 5 + "AB", "g" * 32])
+    def test_purge_rejects_traversal_and_malformed_ids(self, tmp_path, bad_id):
+        """A crafted item_id must never let purge escape the trash dir."""
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        # A canary living OUTSIDE the trash dir that a traversal id would hit.
+        canary = tmp_path / "canary.txt"
+        canary.write_bytes(b"do not touch")
+
+        with pytest.raises(TrashItemNotFound):
+            purge_trash_item(trash_dir, bad_id)
+
+        assert canary.exists()
+        assert canary.read_bytes() == b"do not touch"
+
+    @pytest.mark.parametrize("bad_id", ["../../etc", "..", "../x", "a/b", "foo"])
+    def test_restore_rejects_traversal_ids(self, tmp_path, bad_id):
+        """Restore must reject malformed ids before touching the filesystem."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        with pytest.raises(TrashItemNotFound):
+            restore_trash_item(trash_dir, workspace, bad_id)
+
+    def test_empty_trash_ignores_non_hex_sidecars(self, tmp_path):
+        """A stray non-item .json in the trash dir does not abort empty_trash."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        trash_dir = get_trash_dir(tmp_path, "workspace")
+        f = workspace / "real.txt"
+        f.write_bytes(b"x")
+        move_to_trash(trash_dir, f, "real.txt")
+        # Drop a bogus sidecar whose stem is not a valid item id.
+        (trash_dir / "notanid.json").write_text("{}")
+
+        count = empty_trash(trash_dir)
+        assert count == 1
+        assert (trash_dir / "notanid.json").exists()  # left untouched
 
     def test_empty_trash_purges_everything(self, tmp_path):
         workspace = tmp_path / "workspace"
@@ -206,6 +246,27 @@ class TestUserWorkspaceTrashRoutes:
     async def test_restore_nonexistent_item_returns_404(self, client, app):
         resp = await client.post("/api/workspace/trash/ghost-id/restore")
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_id", ["..", "%2e%2e", "not-hex", "deadbeef"])
+    async def test_traversal_ids_are_rejected_by_routes(self, client, app, bad_id):
+        """Purge/restore with a malformed or traversal id returns 404 and
+        removes nothing outside the trash dir."""
+        # Seed one real trashed item as a canary in the trash listing.
+        await client.post(
+            "/api/workspace/files/upload",
+            files={"file": ("keep.txt", io.BytesIO(b"keep"), "text/plain")},
+        )
+        await client.delete("/api/workspace/files/keep.txt")
+
+        purge = await client.delete(f"/api/workspace/trash/{bad_id}")
+        assert purge.status_code == 404
+        restore = await client.post(f"/api/workspace/trash/{bad_id}/restore")
+        assert restore.status_code == 404
+
+        # The genuine item is still present — nothing was clobbered.
+        items = (await client.get("/api/workspace/trash")).json()["items"]
+        assert len(items) == 1
 
     @pytest.mark.asyncio
     async def test_purge_single_item(self, client, app):

--- a/tinyagentos/routes/agent_workspace.py
+++ b/tinyagentos/routes/agent_workspace.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import shutil
 from pathlib import Path
 
 from fastapi import APIRouter, Request, UploadFile, File
@@ -14,6 +13,16 @@ from tinyagentos.routes.user_workspace import (
     _dir_signature,
     _list_dir,
     _resolve_safe,
+)
+from tinyagentos.workspace_trash import (
+    TrashItemNotFound,
+    TrashRestoreConflict,
+    empty_trash,
+    get_trash_dir,
+    list_trash_items,
+    move_to_trash,
+    purge_trash_item,
+    restore_trash_item,
 )
 
 logger = logging.getLogger(__name__)
@@ -50,6 +59,13 @@ def _get_agent_workspace_root(request: Request, agent_name: str) -> Path | None:
         return None
     candidate.mkdir(parents=True, exist_ok=True)
     return candidate
+
+
+def _get_agent_trash_dir(request: Request, agent_name: str) -> Path:
+    """Return the trash directory backing one agent's workspace, creating it
+    on first access."""
+    data_dir = Path(request.app.state.agent_workspaces_dir).parent
+    return get_trash_dir(data_dir, f"agents/{agent_name}")
 
 
 def _resolve_workspace(request: Request, agent_name: str) -> tuple[Path | None, JSONResponse | None]:
@@ -196,7 +212,11 @@ async def api_get_file(request: Request, agent_name: str, file_path: str):
 
 @router.delete("/api/agents/{agent_name}/workspace/files/{file_path:path}")
 async def api_delete_file(request: Request, agent_name: str, file_path: str):
-    """Delete a file or directory from an agent's workspace."""
+    """Move a file or directory from an agent's workspace to the trash.
+
+    See ``tinyagentos/routes/user_workspace.py::api_delete_file`` for why —
+    this mirrors the same move-to-trash behavior for agent workspaces.
+    """
     workspace, err = _resolve_workspace(request, agent_name)
     if err is not None:
         return err
@@ -208,9 +228,55 @@ async def api_delete_file(request: Request, agent_name: str, file_path: str):
     if not target.exists():
         return JSONResponse({"error": f"'{file_path}' not found"}, status_code=404)
 
-    if target.is_dir():
-        shutil.rmtree(target)
-    else:
-        target.unlink()
+    trash_dir = _get_agent_trash_dir(request, agent_name)
+    move_to_trash(trash_dir, target, file_path)
 
     return {"path": file_path, "status": "deleted"}
+
+
+@router.get("/api/agents/{agent_name}/workspace/trash")
+async def api_list_trash(request: Request, agent_name: str):
+    """List items in an agent workspace's trash, newest-deleted first."""
+    if not _agent_exists(request, agent_name):
+        return JSONResponse({"error": f"Agent '{agent_name}' not found"}, status_code=404)
+    trash_dir = _get_agent_trash_dir(request, agent_name)
+    return {"items": list_trash_items(trash_dir)}
+
+
+@router.post("/api/agents/{agent_name}/workspace/trash/{item_id}/restore")
+async def api_restore_trash_item(request: Request, agent_name: str, item_id: str):
+    """Restore a trashed item back to its original path in the agent workspace."""
+    workspace, err = _resolve_workspace(request, agent_name)
+    if err is not None:
+        return err
+    trash_dir = _get_agent_trash_dir(request, agent_name)
+    try:
+        metadata = restore_trash_item(trash_dir, workspace, item_id)
+    except TrashItemNotFound:
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    except TrashRestoreConflict:
+        return JSONResponse(
+            {"error": "a file already exists at the original path"}, status_code=409
+        )
+    return {"status": "restored", "path": metadata["original_path"]}
+
+
+@router.delete("/api/agents/{agent_name}/workspace/trash/{item_id}")
+async def api_purge_trash_item(request: Request, agent_name: str, item_id: str):
+    """Permanently delete one item from an agent workspace's trash."""
+    if not _agent_exists(request, agent_name):
+        return JSONResponse({"error": f"Agent '{agent_name}' not found"}, status_code=404)
+    trash_dir = _get_agent_trash_dir(request, agent_name)
+    if not purge_trash_item(trash_dir, item_id):
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    return {"status": "purged", "id": item_id}
+
+
+@router.delete("/api/agents/{agent_name}/workspace/trash")
+async def api_empty_trash(request: Request, agent_name: str):
+    """Permanently delete every item in an agent workspace's trash."""
+    if not _agent_exists(request, agent_name):
+        return JSONResponse({"error": f"Agent '{agent_name}' not found"}, status_code=404)
+    trash_dir = _get_agent_trash_dir(request, agent_name)
+    count = empty_trash(trash_dir)
+    return {"status": "emptied", "count": count}

--- a/tinyagentos/routes/agent_workspace.py
+++ b/tinyagentos/routes/agent_workspace.py
@@ -267,7 +267,11 @@ async def api_purge_trash_item(request: Request, agent_name: str, item_id: str):
     if not _agent_exists(request, agent_name):
         return JSONResponse({"error": f"Agent '{agent_name}' not found"}, status_code=404)
     trash_dir = _get_agent_trash_dir(request, agent_name)
-    if not purge_trash_item(trash_dir, item_id):
+    try:
+        found = purge_trash_item(trash_dir, item_id)
+    except TrashItemNotFound:
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    if not found:
         return JSONResponse({"error": "item not found"}, status_code=404)
     return {"status": "purged", "id": item_id}
 

--- a/tinyagentos/routes/project_files.py
+++ b/tinyagentos/routes/project_files.py
@@ -252,7 +252,11 @@ async def api_project_purge_trash_item(request: Request, slug: str, item_id: str
     if _get_project_files_root(request, slug) is None:
         return JSONResponse({"error": "Invalid slug"}, status_code=400)
     trash_dir = _get_project_trash_dir(request, slug)
-    if not purge_trash_item(trash_dir, item_id):
+    try:
+        found = purge_trash_item(trash_dir, item_id)
+    except TrashItemNotFound:
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    if not found:
         return JSONResponse({"error": "item not found"}, status_code=404)
     return {"status": "purged", "id": item_id}
 

--- a/tinyagentos/routes/project_files.py
+++ b/tinyagentos/routes/project_files.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 import asyncio
 import json
-import shutil
 from pathlib import Path
 
 from fastapi import APIRouter, Request, UploadFile, File
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel
+
+from tinyagentos.workspace_trash import (
+    TrashItemNotFound,
+    TrashRestoreConflict,
+    empty_trash,
+    get_trash_dir,
+    list_trash_items,
+    move_to_trash,
+    purge_trash_item,
+    restore_trash_item,
+)
 
 router = APIRouter()
 
@@ -20,6 +30,13 @@ def _get_project_files_root(request: Request, slug: str) -> Path | None:
     root = request.app.state.projects_root / slug / "files"
     root.mkdir(parents=True, exist_ok=True)
     return root
+
+
+def _get_project_trash_dir(request: Request, slug: str) -> Path:
+    """Return the trash directory backing one project's files, creating it
+    on first access."""
+    data_dir = Path(request.app.state.projects_root).parent
+    return get_trash_dir(data_dir, f"projects/{slug}")
 
 
 def _resolve_safe(workspace: Path, subpath: str) -> Path | None:
@@ -180,7 +197,11 @@ async def api_project_get_file(request: Request, slug: str, file_path: str):
 
 @router.delete("/api/projects/{slug}/files/{file_path:path}")
 async def api_project_delete_file(request: Request, slug: str, file_path: str):
-    """Delete a file or directory from the project's files folder."""
+    """Move a file or directory from the project's files folder to the trash.
+
+    See ``tinyagentos/routes/user_workspace.py::api_delete_file`` for why —
+    this mirrors the same move-to-trash behavior for project files.
+    """
     workspace = _get_project_files_root(request, slug)
     if workspace is None:
         return JSONResponse({"error": "Invalid slug"}, status_code=400)
@@ -192,12 +213,58 @@ async def api_project_delete_file(request: Request, slug: str, file_path: str):
     if not target.exists():
         return JSONResponse({"error": f"'{file_path}' not found"}, status_code=404)
 
-    if target.is_dir():
-        shutil.rmtree(target)
-    else:
-        target.unlink()
+    trash_dir = _get_project_trash_dir(request, slug)
+    move_to_trash(trash_dir, target, file_path)
 
     return {"path": file_path, "status": "deleted"}
+
+
+@router.get("/api/projects/{slug}/trash")
+async def api_project_list_trash(request: Request, slug: str):
+    """List items in a project's trash, newest-deleted first."""
+    if _get_project_files_root(request, slug) is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+    trash_dir = _get_project_trash_dir(request, slug)
+    return {"items": list_trash_items(trash_dir)}
+
+
+@router.post("/api/projects/{slug}/trash/{item_id}/restore")
+async def api_project_restore_trash_item(request: Request, slug: str, item_id: str):
+    """Restore a trashed item back to its original path in the project's files folder."""
+    workspace = _get_project_files_root(request, slug)
+    if workspace is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+    trash_dir = _get_project_trash_dir(request, slug)
+    try:
+        metadata = restore_trash_item(trash_dir, workspace, item_id)
+    except TrashItemNotFound:
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    except TrashRestoreConflict:
+        return JSONResponse(
+            {"error": "a file already exists at the original path"}, status_code=409
+        )
+    return {"status": "restored", "path": metadata["original_path"]}
+
+
+@router.delete("/api/projects/{slug}/trash/{item_id}")
+async def api_project_purge_trash_item(request: Request, slug: str, item_id: str):
+    """Permanently delete one item from a project's trash."""
+    if _get_project_files_root(request, slug) is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+    trash_dir = _get_project_trash_dir(request, slug)
+    if not purge_trash_item(trash_dir, item_id):
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    return {"status": "purged", "id": item_id}
+
+
+@router.delete("/api/projects/{slug}/trash")
+async def api_project_empty_trash(request: Request, slug: str):
+    """Permanently delete every item in a project's trash."""
+    if _get_project_files_root(request, slug) is None:
+        return JSONResponse({"error": "Invalid slug"}, status_code=400)
+    trash_dir = _get_project_trash_dir(request, slug)
+    count = empty_trash(trash_dir)
+    return {"status": "emptied", "count": count}
 
 
 @router.get("/api/projects/{slug}/stats")

--- a/tinyagentos/routes/user_workspace.py
+++ b/tinyagentos/routes/user_workspace.py
@@ -369,7 +369,11 @@ async def api_restore_trash_item(request: Request, item_id: str):
 async def api_purge_trash_item(request: Request, item_id: str):
     """Permanently delete one item from the trash."""
     trash_dir = _get_workspace_trash_dir(request)
-    if not purge_trash_item(trash_dir, item_id):
+    try:
+        found = purge_trash_item(trash_dir, item_id)
+    except TrashItemNotFound:
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    if not found:
         return JSONResponse({"error": "item not found"}, status_code=404)
     return {"status": "purged", "id": item_id}
 

--- a/tinyagentos/routes/user_workspace.py
+++ b/tinyagentos/routes/user_workspace.py
@@ -10,6 +10,17 @@ from fastapi import APIRouter, Request, UploadFile, File
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
+from tinyagentos.workspace_trash import (
+    TrashItemNotFound,
+    TrashRestoreConflict,
+    empty_trash,
+    get_trash_dir,
+    list_trash_items,
+    move_to_trash,
+    purge_trash_item,
+    restore_trash_item,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -50,6 +61,13 @@ def _get_workspace_root(request: Request) -> Path:
     ws = data_dir / USER_WORKSPACE_DIR_NAME
     ws.mkdir(parents=True, exist_ok=True)
     return ws
+
+
+def _get_workspace_trash_dir(request: Request) -> Path:
+    """Return the trash directory backing the user workspace, creating it on
+    first access."""
+    data_dir = request.app.state.config_path.parent
+    return get_trash_dir(data_dir, "workspace")
 
 
 def _resolve_safe(workspace: Path, subpath: str) -> Path | None:
@@ -302,7 +320,13 @@ async def api_get_file(request: Request, file_path: str):
 
 @router.delete("/api/workspace/files/{file_path:path}")
 async def api_delete_file(request: Request, file_path: str):
-    """Delete a file or directory from the user workspace."""
+    """Move a file or directory from the user workspace to the trash.
+
+    Nothing is permanently removed here — the item is relocated under the
+    workspace's trash directory with metadata recording where it came from,
+    so it can be restored (or purged) via the ``/api/workspace/trash``
+    routes below.
+    """
     workspace = _get_workspace_root(request)
 
     target = _resolve_safe(workspace, file_path)
@@ -312,12 +336,50 @@ async def api_delete_file(request: Request, file_path: str):
     if not target.exists():
         return JSONResponse({"error": f"'{file_path}' not found"}, status_code=404)
 
-    if target.is_dir():
-        shutil.rmtree(target)
-    else:
-        target.unlink()
+    trash_dir = _get_workspace_trash_dir(request)
+    move_to_trash(trash_dir, target, file_path)
 
     return {"path": file_path, "status": "deleted"}
+
+
+@router.get("/api/workspace/trash")
+async def api_list_trash(request: Request):
+    """List items in the user workspace's trash, newest-deleted first."""
+    trash_dir = _get_workspace_trash_dir(request)
+    return {"items": list_trash_items(trash_dir)}
+
+
+@router.post("/api/workspace/trash/{item_id}/restore")
+async def api_restore_trash_item(request: Request, item_id: str):
+    """Restore a trashed item back to its original workspace path."""
+    workspace = _get_workspace_root(request)
+    trash_dir = _get_workspace_trash_dir(request)
+    try:
+        metadata = restore_trash_item(trash_dir, workspace, item_id)
+    except TrashItemNotFound:
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    except TrashRestoreConflict:
+        return JSONResponse(
+            {"error": "a file already exists at the original path"}, status_code=409
+        )
+    return {"status": "restored", "path": metadata["original_path"]}
+
+
+@router.delete("/api/workspace/trash/{item_id}")
+async def api_purge_trash_item(request: Request, item_id: str):
+    """Permanently delete one item from the trash."""
+    trash_dir = _get_workspace_trash_dir(request)
+    if not purge_trash_item(trash_dir, item_id):
+        return JSONResponse({"error": "item not found"}, status_code=404)
+    return {"status": "purged", "id": item_id}
+
+
+@router.delete("/api/workspace/trash")
+async def api_empty_trash(request: Request):
+    """Permanently delete every item in the user workspace's trash."""
+    trash_dir = _get_workspace_trash_dir(request)
+    count = empty_trash(trash_dir)
+    return {"status": "emptied", "count": count}
 
 
 @router.get("/api/workspace/stats")

--- a/tinyagentos/workspace_trash.py
+++ b/tinyagentos/workspace_trash.py
@@ -1,0 +1,147 @@
+"""Shared move-to-trash helper for host-side file browser routes.
+
+The Files app lets a user browse three kinds of host-side folders: their own
+workspace, an agent's workspace, and a project's files folder. All three used
+to hard-delete on "delete" (``shutil.rmtree`` / ``Path.unlink``), bypassing
+the Recycle Bin entirely — see the agent-container trash-cli integration in
+``tinyagentos/routes/recycle.py``, which only ever sees files trashed *inside*
+an agent's own container shell, never files removed via the Files app browser
+on the host.
+
+This module gives each of those three route files (``user_workspace.py``,
+``agent_workspace.py``, ``project_files.py``) a tiny, dependency-free trash:
+"delete" moves the item into a per-scope trash directory alongside a JSON
+metadata sidecar (original relative path, deleted-at, whether it was a
+directory), and the real filesystem delete only happens on an explicit purge
+or empty-trash call. This matches taOS's "nothing is truly deleted" posture
+without requiring a container / trash-cli dependency for host-side folders.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+TRASH_DIRNAME = ".taos-trash"
+
+
+def get_trash_dir(data_dir: Path, scope: str) -> Path:
+    """Return the trash directory for a given scope, creating it on first use.
+
+    ``scope`` namespaces trash by browser kind, e.g. "workspace",
+    "agents/<agent_name>", "projects/<slug>" — so restoring an item always
+    puts it back under the workspace root it came from.
+    """
+    trash_dir = data_dir / TRASH_DIRNAME / scope
+    trash_dir.mkdir(parents=True, exist_ok=True)
+    return trash_dir
+
+
+def _meta_path(trash_dir: Path, item_id: str) -> Path:
+    return trash_dir / f"{item_id}.json"
+
+
+def _item_dir(trash_dir: Path, item_id: str) -> Path:
+    return trash_dir / item_id
+
+
+def move_to_trash(trash_dir: Path, target: Path, rel_path: str) -> dict:
+    """Move *target* into the trash, writing a metadata sidecar.
+
+    *rel_path* is the path relative to the owning workspace root (what the
+    Files app displays / what restore needs to reconstruct the destination).
+    Returns the metadata dict that was written.
+    """
+    item_id = uuid.uuid4().hex
+    is_dir = target.is_dir()
+    size_bytes = None
+    if not is_dir:
+        try:
+            size_bytes = target.stat().st_size
+        except OSError:
+            size_bytes = None
+
+    holder = _item_dir(trash_dir, item_id)
+    holder.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(target), str(holder / target.name))
+
+    metadata = {
+        "id": item_id,
+        "name": target.name,
+        "original_path": rel_path,
+        "is_dir": is_dir,
+        "size_bytes": size_bytes,
+        "deleted_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _meta_path(trash_dir, item_id).write_text(json.dumps(metadata))
+    return metadata
+
+
+def list_trash_items(trash_dir: Path) -> list[dict]:
+    """Return trash metadata, newest-deleted first."""
+    items: list[dict] = []
+    for meta_file in trash_dir.glob("*.json"):
+        try:
+            items.append(json.loads(meta_file.read_text()))
+        except (OSError, json.JSONDecodeError):
+            continue
+    items.sort(key=lambda item: item.get("deleted_at", ""), reverse=True)
+    return items
+
+
+class TrashItemNotFound(Exception):
+    """Raised when a trash item id has no matching metadata/contents."""
+
+
+class TrashRestoreConflict(Exception):
+    """Raised when restoring would overwrite an existing file/directory."""
+
+
+def restore_trash_item(trash_dir: Path, workspace_root: Path, item_id: str) -> dict:
+    """Move a trashed item back to its original path under *workspace_root*.
+
+    Raises ``TrashItemNotFound`` if the id is unknown, or
+    ``TrashRestoreConflict`` if something already exists at the destination.
+    """
+    meta_file = _meta_path(trash_dir, item_id)
+    if not meta_file.exists():
+        raise TrashItemNotFound(item_id)
+    metadata = json.loads(meta_file.read_text())
+
+    holder = _item_dir(trash_dir, item_id)
+    source = holder / metadata["name"]
+    if not source.exists():
+        raise TrashItemNotFound(item_id)
+
+    dest = workspace_root / metadata["original_path"]
+    if dest.exists():
+        raise TrashRestoreConflict(metadata["original_path"])
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(source), str(dest))
+    shutil.rmtree(holder, ignore_errors=True)
+    meta_file.unlink(missing_ok=True)
+    return metadata
+
+
+def purge_trash_item(trash_dir: Path, item_id: str) -> bool:
+    """Permanently delete one trashed item. Returns False if it doesn't exist."""
+    meta_file = _meta_path(trash_dir, item_id)
+    holder = _item_dir(trash_dir, item_id)
+    if not meta_file.exists() and not holder.exists():
+        return False
+    shutil.rmtree(holder, ignore_errors=True)
+    meta_file.unlink(missing_ok=True)
+    return True
+
+
+def empty_trash(trash_dir: Path) -> int:
+    """Permanently delete every item in the trash. Returns the count removed."""
+    count = 0
+    for meta_file in trash_dir.glob("*.json"):
+        item_id = meta_file.stem
+        if purge_trash_item(trash_dir, item_id):
+            count += 1
+    return count

--- a/tinyagentos/workspace_trash.py
+++ b/tinyagentos/workspace_trash.py
@@ -19,12 +19,45 @@ without requiring a container / trash-cli dependency for host-side folders.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
 TRASH_DIRNAME = ".taos-trash"
+
+# Item ids are minted as uuid4().hex (32 lowercase hex chars). Anything else —
+# ``..``, a slash, an absolute path — is rejected before it is ever used to
+# build a filesystem path, so a crafted id cannot escape the trash directory
+# and rmtree/rename something outside it.
+_ITEM_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+class TrashItemNotFound(Exception):
+    """Raised when a trash item id has no matching metadata/contents (or is
+    not a well-formed item id)."""
+
+
+class TrashRestoreConflict(Exception):
+    """Raised when restoring would overwrite an existing file/directory."""
+
+
+def _validate_item_id(item_id: str) -> None:
+    """Reject any id that is not a canonical 32-char hex token.
+
+    Raises ``TrashItemNotFound`` so callers/routes surface a 404 rather than
+    leaking whether the rejection was a bad shape or a genuine miss.
+    """
+    if not _ITEM_ID_RE.fullmatch(item_id):
+        raise TrashItemNotFound(item_id)
+
+
+def _assert_within(child: Path, parent: Path) -> None:
+    """Defense-in-depth: fail loudly if a resolved item path is not contained
+    by the trash dir, instead of performing a destructive op outside it."""
+    if not child.resolve().is_relative_to(parent.resolve()):
+        raise TrashItemNotFound(child.name)
 
 
 def get_trash_dir(data_dir: Path, scope: str) -> Path:
@@ -40,10 +73,12 @@ def get_trash_dir(data_dir: Path, scope: str) -> Path:
 
 
 def _meta_path(trash_dir: Path, item_id: str) -> Path:
+    _validate_item_id(item_id)
     return trash_dir / f"{item_id}.json"
 
 
 def _item_dir(trash_dir: Path, item_id: str) -> Path:
+    _validate_item_id(item_id)
     return trash_dir / item_id
 
 
@@ -91,26 +126,23 @@ def list_trash_items(trash_dir: Path) -> list[dict]:
     return items
 
 
-class TrashItemNotFound(Exception):
-    """Raised when a trash item id has no matching metadata/contents."""
-
-
-class TrashRestoreConflict(Exception):
-    """Raised when restoring would overwrite an existing file/directory."""
-
-
 def restore_trash_item(trash_dir: Path, workspace_root: Path, item_id: str) -> dict:
     """Move a trashed item back to its original path under *workspace_root*.
 
-    Raises ``TrashItemNotFound`` if the id is unknown, or
+    Raises ``TrashItemNotFound`` if the id is malformed or unknown, or
     ``TrashRestoreConflict`` if something already exists at the destination.
     """
+    _validate_item_id(item_id)
     meta_file = _meta_path(trash_dir, item_id)
     if not meta_file.exists():
         raise TrashItemNotFound(item_id)
     metadata = json.loads(meta_file.read_text())
 
     holder = _item_dir(trash_dir, item_id)
+    # The holder is built from a validated hex id, but assert containment
+    # before touching anything so a resolution mistake can never delete
+    # outside the trash dir.
+    _assert_within(holder, trash_dir)
     source = holder / metadata["name"]
     if not source.exists():
         raise TrashItemNotFound(item_id)
@@ -121,18 +153,25 @@ def restore_trash_item(trash_dir: Path, workspace_root: Path, item_id: str) -> d
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(source), str(dest))
-    shutil.rmtree(holder, ignore_errors=True)
+    shutil.rmtree(holder)
     meta_file.unlink(missing_ok=True)
     return metadata
 
 
 def purge_trash_item(trash_dir: Path, item_id: str) -> bool:
-    """Permanently delete one trashed item. Returns False if it doesn't exist."""
+    """Permanently delete one trashed item. Returns False if it doesn't exist.
+
+    Raises ``TrashItemNotFound`` if *item_id* is not a well-formed id, so a
+    traversal attempt is rejected before any destructive op.
+    """
+    _validate_item_id(item_id)
     meta_file = _meta_path(trash_dir, item_id)
     holder = _item_dir(trash_dir, item_id)
     if not meta_file.exists() and not holder.exists():
         return False
-    shutil.rmtree(holder, ignore_errors=True)
+    _assert_within(holder, trash_dir)
+    if holder.exists():
+        shutil.rmtree(holder)
     meta_file.unlink(missing_ok=True)
     return True
 
@@ -142,6 +181,8 @@ def empty_trash(trash_dir: Path) -> int:
     count = 0
     for meta_file in trash_dir.glob("*.json"):
         item_id = meta_file.stem
+        if not _ITEM_ID_RE.fullmatch(item_id):
+            continue  # ignore anything not minted by move_to_trash
         if purge_trash_item(trash_dir, item_id):
             count += 1
     return count


### PR DESCRIPTION
Two independent desktop bug fixes reported by @mandresve, kept as separate commits.

## #1604 — Files permanently deletes instead of moving to Recycle Bin
**Root cause:** the Files app delete hard-deleted (`shutil.rmtree` / `Path.unlink`) on all three host-side file browsers — user workspace, agent workspace, and project files. The existing Recycle Bin (`tinyagentos/routes/recycle.py`) only ever sees files trashed *inside* an agent's container shell via trash-cli, never files removed through the Files app on the host.

**Fix:** new dependency-free move-to-trash helper (`tinyagentos/workspace_trash.py`). Delete now moves the item under `<data_dir>/.taos-trash/<scope>/<item-id>/` with a JSON metadata sidecar (original path, deleted-at, dir flag); the real filesystem delete is gated behind explicit purge / empty-trash routes. Wired into all three route files, with new `.../trash` list/restore/purge/empty endpoints. The Files app surfaces the user-workspace trash under Recycle Bin → "My Files" (restore / delete permanently / empty). Agent-workspace and project-files trash routes exist + are tested but are API-only for now (Files UI section deferred — noted in the runbook).

## #1605 — New Project dialog opens behind the Projects window
**Root cause:** the dialog portals to `document.body` but used Tailwind `z-50`. Desktop windows get an ever-increasing `zIndex` from the process store (`nextZIndex` starts at 1, climbs with no ceiling on every open/focus/restore/maximize), so any long-lived window outran `z-50` and the dialog rendered behind the window.

**Fix:** raise the dialog to the app-wide top overlay layer (`z-[10001]`), the same layer `ContextMenu` / `NotificationToast` / `NotificationCentre` already use. Flagged (not fixed): `AddAgentDialog.tsx` shares the same latent pattern.

## Tests / build
- Backend: `pytest tests/ -k "files or trash"` → **130 passed**. New `tests/test_workspace_trash.py` (16 tests) asserts delete relocates bytes (not hard-delete) + list/restore/purge/empty across all three scopes.
- Frontend: `npm run build` clean; `CreateProjectDialog.test.tsx` → **4 passed** (added stacking assertions: portals to body + `z-[10001]`). Full vitest suite green (295 files / 2407 tests).