### PR TITLE
fix(settings): persist theme/wallpaper across sessions + apply Desktop & Dock settings

### DIFF
--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui";
 import { useShortcuts } from "@/hooks/use-shortcut-registry";
 import { useThemeStore } from "@/stores/theme-store";
+import { useDockStore } from "@/stores/dock-store";
 import { ThemesPanel } from "@/apps/SettingsApp/ThemesPanel";
 import { safeFetch, ProgressBar, RestartProgressModal } from "@/apps/SettingsApp/_shared";
 import { UpdatesSection } from "@/apps/SettingsApp/UpdatesPanel";
@@ -680,23 +681,11 @@ function AccessibilitySection() {
 /*  Desktop & Dock                                                     */
 /* ------------------------------------------------------------------ */
 
-function DesktopDockSection() {
-  const [dockSize, setDockSize] = useState(
-    () => localStorage.getItem("taos-dock-size") ?? "medium"
-  );
-  const [dockPosition, setDockPosition] = useState(
-    () => localStorage.getItem("taos-dock-position") ?? "bottom"
-  );
-
-  const applyDockSize = (size: string) => {
-    setDockSize(size);
-    localStorage.setItem("taos-dock-size", size);
-  };
-
-  const applyDockPosition = (position: string) => {
-    setDockPosition(position);
-    localStorage.setItem("taos-dock-position", position);
-  };
+export function DesktopDockSection() {
+  const dockSize = useDockStore((s) => s.iconSize);
+  const dockPosition = useDockStore((s) => s.position);
+  const applyDockSize = useDockStore((s) => s.setIconSize);
+  const applyDockPosition = useDockStore((s) => s.setPosition);
 
   return (
     <section aria-label="Desktop and dock settings">
@@ -723,10 +712,12 @@ function DesktopDockSection() {
         <Card className="p-4">
           <p className="text-sm font-medium mb-3">Dock position</p>
           <div className="flex gap-2" role="group" aria-label="Dock position">
-            {[
-              { value: "bottom", label: "Bottom" },
-              { value: "left", label: "Left" },
-            ].map((opt) => (
+            {(
+              [
+                { value: "bottom", label: "Bottom" },
+                { value: "left", label: "Left" },
+              ] as const
+            ).map((opt) => (
               <Button
                 key={opt.value}
                 variant={dockPosition === opt.value ? "secondary" : "outline"}

--- a/desktop/src/apps/SettingsApp/__tests__/DesktopDockSection.test.tsx
+++ b/desktop/src/apps/SettingsApp/__tests__/DesktopDockSection.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DesktopDockSection } from "@/apps/SettingsApp";
+import { useDockStore } from "@/stores/dock-store";
+
+beforeEach(() => {
+  useDockStore.setState({
+    pinned: ["messages", "agents", "files", "store", "settings"],
+    iconSize: "medium",
+    position: "bottom",
+  });
+});
+
+describe("DesktopDockSection — writes to the dock-store (#1603)", () => {
+  it("updates the dock-store icon size instead of an orphaned localStorage key", () => {
+    render(<DesktopDockSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Large" }));
+
+    expect(useDockStore.getState().iconSize).toBe("large");
+    expect(localStorage.getItem("taos-dock-size")).toBeNull();
+  });
+
+  it("updates the dock-store position instead of an orphaned localStorage key", () => {
+    render(<DesktopDockSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Left" }));
+
+    expect(useDockStore.getState().position).toBe("left");
+    expect(localStorage.getItem("taos-dock-position")).toBeNull();
+  });
+
+  it("reflects the current dock-store values as pressed", () => {
+    useDockStore.setState({ iconSize: "small", position: "left" });
+    render(<DesktopDockSection />);
+
+    expect(screen.getByRole("button", { name: "Small" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/desktop/src/components/Dock.tsx
+++ b/desktop/src/components/Dock.tsx
@@ -10,6 +10,8 @@ interface Props {
 
 export function Dock({ onLaunchpadOpen }: Props) {
   const pinned = useDockStore((s) => s.pinned);
+  const iconSize = useDockStore((s) => s.iconSize);
+  const position = useDockStore((s) => s.position);
   const windows = useProcessStore((s) => s.windows);
   const { openWindow, focusWindow, restoreWindow } = useProcessStore();
   const variant = useThemeStore((s) => (s.structure?.dock?.variant as DockVariantId) ?? "macos-dock");
@@ -38,6 +40,8 @@ export function Dock({ onLaunchpadOpen }: Props) {
       windows={windows}
       onAppClick={handleClick}
       onLaunchpadOpen={onLaunchpadOpen}
+      iconSize={iconSize}
+      position={position}
     />
   );
 }

--- a/desktop/src/components/DockIcon.tsx
+++ b/desktop/src/components/DockIcon.tsx
@@ -5,13 +5,28 @@ import { useProcessStore } from "@/stores/process-store";
 import { useDockStore } from "@/stores/dock-store";
 import { ContextMenu, type MenuItem } from "./ContextMenu";
 
+type DockIconSize = "small" | "medium" | "large";
+
 interface Props {
   appId: string;
   isRunning: boolean;
   onClick: () => void;
+  size?: DockIconSize;
 }
 
-export function DockIcon({ appId, isRunning, onClick }: Props) {
+const SIZE_CLASSES: Record<DockIconSize, string> = {
+  small: "w-8 h-8",
+  medium: "w-10 h-10",
+  large: "w-14 h-14",
+};
+
+const ICON_PX: Record<DockIconSize, number> = {
+  small: 16,
+  medium: 20,
+  large: 28,
+};
+
+export function DockIcon({ appId, isRunning, onClick, size = "medium" }: Props) {
   const app = getApp(appId);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
 
@@ -94,11 +109,11 @@ export function DockIcon({ appId, isRunning, onClick }: Props) {
         onClick={onClick}
         onContextMenu={onContextMenu}
         onMouseEnter={() => prefetchApp(appId)}
-        className="group relative flex items-center justify-center w-10 h-10 rounded-lg bg-shell-surface hover:bg-shell-surface-active transition-all hover:scale-110"
+        className={`group relative flex items-center justify-center ${SIZE_CLASSES[size]} rounded-lg bg-shell-surface hover:bg-shell-surface-active transition-all hover:scale-110`}
         aria-label={`Open ${app.name}`}
         title={app.name}
       >
-        <IconComponent size={20} className="text-shell-text" />
+        <IconComponent size={ICON_PX[size]} className="text-shell-text" />
         {isRunning && (
           <div className="absolute -bottom-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-accent" />
         )}

--- a/desktop/src/components/dock/MacosDock.tsx
+++ b/desktop/src/components/dock/MacosDock.tsx
@@ -1,4 +1,5 @@
 import type { WindowState } from "@/stores/process-store";
+import type { DockIconSize, DockPosition } from "@/stores/dock-store";
 import { DockIcon } from "../DockIcon";
 
 export interface DockVariantProps {
@@ -6,18 +7,33 @@ export interface DockVariantProps {
   windows: WindowState[];
   onAppClick: (appId: string) => void;
   onLaunchpadOpen: () => void;
+  iconSize?: DockIconSize;
+  position?: DockPosition;
 }
 
-export function MacosDock({ pinned, windows, onAppClick, onLaunchpadOpen }: DockVariantProps) {
+export function MacosDock({
+  pinned,
+  windows,
+  onAppClick,
+  onLaunchpadOpen,
+  iconSize = "medium",
+  position = "bottom",
+}: DockVariantProps) {
   const runningAppIds = windows.map((w) => w.appId);
   const runningNotPinned = runningAppIds.filter((id) => !pinned.includes(id));
+  const isLeft = position === "left";
+  const dividerClassName = isLeft ? "h-px w-8 bg-shell-border my-1" : "w-px h-8 bg-shell-border mx-1";
 
   return (
     <div
       data-testid="dock-variant-macos-dock"
-      className="fixed bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 px-3 rounded-2xl z-[9999] select-none"
+      className={
+        isLeft
+          ? "fixed left-3 top-1/2 -translate-y-1/2 flex flex-col items-center gap-1.5 py-3 rounded-2xl z-[9999] select-none"
+          : "fixed bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 px-3 rounded-2xl z-[9999] select-none"
+      }
       style={{
-        height: "var(--spacing-dock-h)",
+        [isLeft ? "width" : "height"]: "var(--spacing-dock-h)",
         padding: "var(--spacing-dock-padding)",
         backgroundColor: "var(--color-dock-bg)",
         border: "1px solid var(--color-dock-border)",
@@ -38,16 +54,22 @@ export function MacosDock({ pinned, windows, onAppClick, onLaunchpadOpen }: Dock
         </svg>
       </button>
 
-      <div className="w-px h-8 bg-shell-border mx-1" />
+      <div className={dividerClassName} />
 
       {pinned.map((appId) => (
-        <DockIcon key={appId} appId={appId} isRunning={runningAppIds.includes(appId)} onClick={() => onAppClick(appId)} />
+        <DockIcon
+          key={appId}
+          appId={appId}
+          isRunning={runningAppIds.includes(appId)}
+          onClick={() => onAppClick(appId)}
+          size={iconSize}
+        />
       ))}
 
-      {runningNotPinned.length > 0 && <div className="w-px h-8 bg-shell-border mx-1" />}
+      {runningNotPinned.length > 0 && <div className={dividerClassName} />}
 
       {runningNotPinned.map((appId) => (
-        <DockIcon key={appId} appId={appId} isRunning={true} onClick={() => onAppClick(appId)} />
+        <DockIcon key={appId} appId={appId} isRunning={true} onClick={() => onAppClick(appId)} size={iconSize} />
       ))}
     </div>
   );

--- a/desktop/src/components/dock/WindowsTaskbar.tsx
+++ b/desktop/src/components/dock/WindowsTaskbar.tsx
@@ -1,19 +1,31 @@
 import { DockIcon } from "../DockIcon";
 import type { DockVariantProps } from "./MacosDock";
 
-export function WindowsTaskbar({ pinned, windows, onAppClick, onLaunchpadOpen }: DockVariantProps) {
+export function WindowsTaskbar({
+  pinned,
+  windows,
+  onAppClick,
+  onLaunchpadOpen,
+  iconSize = "medium",
+  position = "bottom",
+}: DockVariantProps) {
   const runningAppIds = windows.map((w) => w.appId);
   const runningNotPinned = runningAppIds.filter((id) => !pinned.includes(id));
   const items = [...pinned, ...runningNotPinned];
+  const isLeft = position === "left";
 
   return (
     <div
       data-testid="dock-variant-windows-taskbar"
-      className="fixed bottom-0 left-0 right-0 flex items-center gap-1 px-2 z-[9999] select-none"
+      className={
+        isLeft
+          ? "fixed top-0 bottom-0 left-0 flex flex-col items-center gap-1 py-2 z-[9999] select-none"
+          : "fixed bottom-0 left-0 right-0 flex items-center gap-1 px-2 z-[9999] select-none"
+      }
       style={{
-        height: "var(--spacing-dock-h)",
+        [isLeft ? "width" : "height"]: "var(--spacing-dock-h)",
         backgroundColor: "var(--color-dock-bg)",
-        borderTop: "1px solid var(--color-dock-border)",
+        [isLeft ? "borderRight" : "borderTop"]: "1px solid var(--color-dock-border)",
         boxShadow: "var(--shadow-dock)",
       }}
     >
@@ -31,15 +43,16 @@ export function WindowsTaskbar({ pinned, windows, onAppClick, onLaunchpadOpen }:
         </svg>
       </button>
 
-      <div className="w-px h-7 bg-shell-border mx-1" />
+      <div className={isLeft ? "h-px w-7 bg-shell-border my-1" : "w-px h-7 bg-shell-border mx-1"} />
 
-      <div className="flex items-center gap-1">
+      <div className={isLeft ? "flex flex-col items-center gap-1" : "flex items-center gap-1"}>
         {items.map((appId) => (
           <DockIcon
             key={appId}
             appId={appId}
             isRunning={runningAppIds.includes(appId)}
             onClick={() => onAppClick(appId)}
+            size={iconSize}
           />
         ))}
       </div>

--- a/desktop/src/components/dock/__tests__/DockVariants.test.tsx
+++ b/desktop/src/components/dock/__tests__/DockVariants.test.tsx
@@ -17,3 +17,23 @@ describe("Dock variant selection", () => {
     expect(screen.getByTestId("dock-variant-windows-taskbar")).toBeInTheDocument();
   });
 });
+
+describe("Dock — Desktop & Dock settings flow to the rendered dock (#1603)", () => {
+  it("applies the dock-store icon size to pinned app buttons", () => {
+    useDockStore.setState({ pinned: ["files"], iconSize: "large", position: "bottom" } as never);
+    useThemeStore.setState({ structure: {} } as never);
+    render(<Dock onLaunchpadOpen={() => {}} />);
+    const icon = screen.getByRole("button", { name: /open files/i });
+    expect(icon.className).toContain("w-14");
+    expect(icon.className).toContain("h-14");
+  });
+
+  it("moves the dock to the left edge when the dock-store position is 'left'", () => {
+    useDockStore.setState({ pinned: ["files"], iconSize: "medium", position: "left" } as never);
+    useThemeStore.setState({ structure: {} } as never);
+    render(<Dock onLaunchpadOpen={() => {}} />);
+    const dock = screen.getByTestId("dock-variant-macos-dock");
+    expect(dock.className).toContain("left-3");
+    expect(dock.className).not.toContain("bottom-3");
+  });
+});

--- a/desktop/src/hooks/__tests__/use-session-persistence.test.ts
+++ b/desktop/src/hooks/__tests__/use-session-persistence.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useSessionPersistence } from "../use-session-persistence";
+import { useDockStore } from "@/stores/dock-store";
+import { useThemeStore } from "@/stores/theme-store";
+
+vi.mock("@/registry/app-registry", () => ({
+  getApp: () => undefined,
+  prefetchApp: () => {},
+}));
+
+vi.mock("@/lib/browser-windows-api", () => ({
+  loadWindows: async () => [],
+  saveWindows: async () => {},
+}));
+
+function mockFetchWith(responses: Record<string, unknown>) {
+  vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    for (const [path, body] of Object.entries(responses)) {
+      if (url.includes(path)) {
+        return Promise.resolve(new Response(JSON.stringify(body)));
+      }
+    }
+    return Promise.resolve(new Response(JSON.stringify({})));
+  });
+}
+
+beforeEach(() => {
+  useDockStore.setState({
+    pinned: ["messages", "agents", "files", "store", "settings"],
+    iconSize: "medium",
+    position: "bottom",
+  });
+  useThemeStore.setState({ wallpaperId: "graphite" } as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useSessionPersistence — wallpaper restore (#1601)", () => {
+  it("restores a saved wallpaper on mount, including one whose id is literally 'default'", async () => {
+    // Regression test: the "Classic" wallpaper's catalog id is the string
+    // "default", which collided with the old "nothing saved" sentinel check
+    // (`data.wallpaper !== "default"`) and was silently skipped on restore.
+    mockFetchWith({ "/api/desktop/settings": { wallpaper: "default" } });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("default");
+    });
+  });
+
+  it("restores an ordinary saved wallpaper choice on mount", async () => {
+    mockFetchWith({ "/api/desktop/settings": { wallpaper: "midnight" } });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("midnight");
+    });
+  });
+});
+
+describe("useSessionPersistence — dock settings restore (#1603)", () => {
+  it("restores saved dock icon size and position on mount", async () => {
+    mockFetchWith({
+      "/api/desktop/dock": {
+        pinned: ["messages", "files"],
+        iconSize: "large",
+        position: "left",
+      },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      expect(useDockStore.getState().iconSize).toBe("large");
+      expect(useDockStore.getState().position).toBe("left");
+    });
+    expect(useDockStore.getState().pinned).toEqual(["messages", "files"]);
+  });
+
+  it("ignores an invalid persisted icon size or position", async () => {
+    mockFetchWith({
+      "/api/desktop/dock": { iconSize: "huge", position: "top" },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    // Give the restore effect's promise chain a tick to resolve.
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(useDockStore.getState().iconSize).toBe("medium");
+    expect(useDockStore.getState().position).toBe("bottom");
+  });
+});

--- a/desktop/src/hooks/use-session-persistence.ts
+++ b/desktop/src/hooks/use-session-persistence.ts
@@ -26,6 +26,8 @@ export function useSessionPersistence() {
   const maximizeWindow = useProcessStore((s) => s.maximizeWindow);
   const snapWindow = useProcessStore((s) => s.snapWindow);
   const pinned = useDockStore((s) => s.pinned);
+  const dockIconSize = useDockStore((s) => s.iconSize);
+  const dockPosition = useDockStore((s) => s.position);
   const wallpaperId = useThemeStore((s) => s.wallpaperId);
   const widgets = useWidgetStore((s) => s.widgets);
 
@@ -67,9 +69,15 @@ export function useSessionPersistence() {
     // Restore dock
     fetch("/api/desktop/dock")
       .then((r) => r.json())
-      .then((data: { pinned?: string[] }) => {
+      .then((data: { pinned?: string[]; iconSize?: string; position?: string }) => {
         if (data.pinned && Array.isArray(data.pinned)) {
           useDockStore.getState().reorder(data.pinned);
+        }
+        if (data.iconSize === "small" || data.iconSize === "medium" || data.iconSize === "large") {
+          useDockStore.getState().setIconSize(data.iconSize);
+        }
+        if (data.position === "bottom" || data.position === "left") {
+          useDockStore.getState().setPosition(data.position);
         }
       })
       .catch(() => {});
@@ -78,7 +86,7 @@ export function useSessionPersistence() {
     fetch("/api/desktop/settings")
       .then((r) => r.json())
       .then((data: { wallpaper?: string }) => {
-        if (data.wallpaper && data.wallpaper !== "default") {
+        if (data.wallpaper) {
           useThemeStore.getState().setWallpaper(data.wallpaper);
         }
       })
@@ -156,14 +164,14 @@ export function useSessionPersistence() {
       fetch("/api/desktop/dock", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pinned }),
+        body: JSON.stringify({ pinned, iconSize: dockIconSize, position: dockPosition }),
       }).catch(() => {});
     }, 1000);
 
     return () => {
       if (dockTimeout.current) clearTimeout(dockTimeout.current);
     };
-  }, [pinned]);
+  }, [pinned, dockIconSize, dockPosition]);
 
   // Auto-save wallpaper (debounced 500ms)
   useEffect(() => {

--- a/desktop/src/stores/dock-store.test.ts
+++ b/desktop/src/stores/dock-store.test.ts
@@ -4,12 +4,29 @@ import { useDockStore } from "./dock-store";
 const DEFAULT_PINNED = ["messages", "agents", "files", "store", "settings"];
 
 beforeEach(() => {
-  useDockStore.setState({ pinned: [...DEFAULT_PINNED] });
+  useDockStore.setState({ pinned: [...DEFAULT_PINNED], iconSize: "medium", position: "bottom" });
 });
 
 describe("dock-store — defaults", () => {
   it("starts with the default pinned list", () => {
     expect(useDockStore.getState().pinned).toEqual(DEFAULT_PINNED);
+  });
+
+  it("starts with medium icon size and bottom position", () => {
+    expect(useDockStore.getState().iconSize).toBe("medium");
+    expect(useDockStore.getState().position).toBe("bottom");
+  });
+});
+
+describe("dock-store — setIconSize / setPosition", () => {
+  it("updates the icon size", () => {
+    useDockStore.getState().setIconSize("large");
+    expect(useDockStore.getState().iconSize).toBe("large");
+  });
+
+  it("updates the position", () => {
+    useDockStore.getState().setPosition("left");
+    expect(useDockStore.getState().position).toBe("left");
   });
 });
 

--- a/desktop/src/stores/dock-store.ts
+++ b/desktop/src/stores/dock-store.ts
@@ -2,15 +2,24 @@ import { create } from "zustand";
 
 const DEFAULT_PINNED = ["messages", "agents", "files", "store", "settings"];
 
+export type DockIconSize = "small" | "medium" | "large";
+export type DockPosition = "bottom" | "left";
+
 interface DockStore {
   pinned: string[];
+  iconSize: DockIconSize;
+  position: DockPosition;
   pin: (appId: string) => void;
   unpin: (appId: string) => void;
   reorder: (appIds: string[]) => void;
+  setIconSize: (size: DockIconSize) => void;
+  setPosition: (position: DockPosition) => void;
 }
 
 export const useDockStore = create<DockStore>((set, get) => ({
   pinned: DEFAULT_PINNED,
+  iconSize: "medium",
+  position: "bottom",
 
   pin(appId) {
     if (get().pinned.includes(appId)) return;
@@ -23,5 +32,13 @@ export const useDockStore = create<DockStore>((set, get) => ({
 
   reorder(appIds) {
     set({ pinned: appIds });
+  },
+
+  setIconSize(size) {
+    set({ iconSize: size });
+  },
+
+  setPosition(position) {
+    set({ position });
   },
 }));

--- a/tests/test_desktop_settings.py
+++ b/tests/test_desktop_settings.py
@@ -16,7 +16,7 @@ async def store(tmp_path):
 async def test_get_default_settings(store):
     settings = await store.get_settings("user")
     assert settings["mode"] == "dark"
-    assert settings["wallpaper"] == "default"
+    assert settings["wallpaper"] == "graphite"
     assert "pinned" in settings["dock"]
 
 
@@ -32,6 +32,8 @@ async def test_get_dock_layout(store):
     dock = await store.get_dock("user")
     assert isinstance(dock["pinned"], list)
     assert "messages" in dock["pinned"]
+    assert dock["iconSize"] == "medium"
+    assert dock["position"] == "bottom"
 
 
 @pytest.mark.asyncio
@@ -39,6 +41,16 @@ async def test_update_dock_layout(store):
     await store.update_dock("user", {"pinned": ["agents", "files"]})
     dock = await store.get_dock("user")
     assert dock["pinned"] == ["agents", "files"]
+
+
+@pytest.mark.asyncio
+async def test_update_dock_icon_size_and_position(store):
+    await store.update_dock("user", {"iconSize": "large", "position": "left"})
+    dock = await store.get_dock("user")
+    assert dock["iconSize"] == "large"
+    assert dock["position"] == "left"
+    # Unrelated fields (e.g. pinned) survive the partial update.
+    assert "messages" in dock["pinned"]
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/desktop_settings.py
+++ b/tinyagentos/desktop_settings.py
@@ -6,13 +6,19 @@ from tinyagentos.base_store import BaseStore
 DEFAULT_SETTINGS = {
     "mode": "dark",
     "accentColor": "#667eea",
-    "wallpaper": "default",
+    # Must match the frontend's own boot-time default (theme-store's
+    # DEFAULT_WP, "graphite"). "default" is a real, selectable wallpaper
+    # ("Classic") elsewhere in the catalog, so it cannot double as the
+    # "nothing saved yet" sentinel without colliding with that choice.
+    "wallpaper": "graphite",
     "dockMagnification": False,
     "topBarOpacity": 0.95,
 }
 
 DEFAULT_DOCK = {
     "pinned": ["messages", "agents", "files", "store", "settings"],
+    "iconSize": "medium",
+    "position": "bottom",
 }
 
 


### PR DESCRIPTION
## Summary

Fixes two reported settings bugs (reporter: mandresve), both root-caused to code that sits next to — but doesn't correctly reuse — the app's existing preference-persistence pattern (`get_preference`/`save_preference` + `useSessionPersistence`).

**#1601 — Theme/wallpaper not persisted across sessions**

The "Classic" wallpaper's catalog id is literally the string `"default"`. `use-session-persistence.ts` treated `wallpaper === "default"` as "nothing saved yet" and skipped restoring it — because the backend's own `DEFAULT_SETTINGS["wallpaper"]` was *also* the string `"default"`, colliding with a real, selectable wallpaper. Picking Classic wallpaper saved correctly but was silently dropped on the next login, reverting to graphite.

Fix: align the backend's default wallpaper value with the frontend's actual boot-time default (`"graphite"`, matching `theme-store.ts`'s `DEFAULT_WP`), so `"default"` never doubles as a sentinel. The restore path now just trusts whatever the backend returns.

**#1603 — Desktop & Dock settings have no effect**

`DesktopDockSection` (Settings → Desktop & Dock) wrote dock icon size/position to bare `localStorage` keys (`taos-dock-size`, `taos-dock-position`) that nothing else in the app ever read. The actual `Dock` component only consumed `dock-store`'s pinned-apps list and a theme-driven variant — the icon size/position controls were fully orphaned.

Fix: move `iconSize`/`position` into `dock-store` (alongside `pinned`), persist them through the existing `/api/desktop/dock` round trip via `useSessionPersistence` (the same pattern already used for pinned apps), and wire `Dock`/`MacosDock`/`WindowsTaskbar`/`DockIcon` to actually render the chosen size and edge position.

## Test plan

- [x] `cd desktop && npm run build` — passes (tsc + vite build)
- [x] `npx vitest run` (desktop) — 297 files / 2417 tests pass, including new coverage:
  - `use-session-persistence.test.ts` — saved wallpaper (including the `"default"`/Classic id) is re-read on load; saved dock icon size/position restored; invalid values ignored
  - `DesktopDockSection.test.tsx` — settings controls write to `dock-store`, not `localStorage`
  - `DockVariants.test.tsx` — dock-store icon size/position flow through to the rendered `Dock`
  - `dock-store.test.ts` — new `setIconSize`/`setPosition` actions
- [x] `python3 -m pytest tests/test_desktop_settings.py tests/test_routes_desktop.py -q` — 17 passed