### PR TITLE
release: 1.0.0-beta.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.22] - 2026-07-04
+
+### Added
+- Game Studio is now a real AI-assisted game maker. Describe a game and the taOS agent generates a complete, playable game from a starter template; edit it with a file editor, a live sandboxed preview and an AI chat that proposes changes; save games to your cluster; and share a finished game as a sandboxed taOS app (it installs through the same security-analyzed app runtime as any other) or export it as a package (#1602).
+- One-tap local model backend install, per hardware. On a supported machine the setup checklist offers to install a local LLM backend for your device in a single tap, creating and starting the service and confirming it actually answers before marking it done. Rockchip installs rkllama; NVIDIA, AMD, Apple Silicon and CPU-only machines install a llama.cpp server that serves chat plus embeddings and reranking from one process, so the taOS agent and taOS memory share a single backend (#1597, #1608).
+- Settings account: the taOS account is framed as the key to taOSgo, app sharing and a reserved taOS username for a future website and social presence, with a prompt to reserve your username; onboarding gains an optional step to sign in to your taOS account (#1593, #1595).
+
 ### Fixed
-- Files: deleting a file or folder now moves it to the trash instead of permanently removing it, for your own workspace, agent workspaces, and project files alike. Restore or empty it from the Recycle Bin. Reported by @mandresve (#1604).
+- Store: installing an NPU/local backend now genuinely installs and starts it. A backend that showed as installed but never actually ran is repaired: the install creates and enables the service, self-heals a half-installed machine, and only reports success once the backend answers (#1598).
+- Models: models you download are now selectable in the taOS agent and accepted at deploy. RKLLM models register with rkllama on download instead of silently landing on disk where the agent could not find them, and the agent model picker lists locally downloaded models, not just cloud ones. Reported by @mandresve (#1599, #1600).
+- Settings: theme and wallpaper choices now persist across sessions, and Desktop & Dock settings (dock size and position) actually take effect. Reported by @mandresve (#1601, #1603).
+- Text Editor: typing works continuously again; the editor no longer loses focus after each keystroke. Reported by @mandresve (#1596).
+- Files: deleting a file or folder now moves it to the Recycle Bin instead of permanently removing it, across your own workspace, agent workspaces and project files; restore or empty it from the Recycle Bin. Reported by @mandresve (#1604).
 - Projects: the New Project dialog no longer opens behind the Projects window. Reported by @mandresve (#1605).
+- App Runtime: the install-time permission consent dialog can no longer be dismissed mid-request, and skips a redundant lookup when no consent is needed (#1592).
 
 ## [1.0.0-beta.21] - 2026-07-03
 

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.21"
+version = "1.0.0-beta.22"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.21"
+__version__ = "1.0.0-beta.22"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b21"
+version = "1.0.0b22"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump + CHANGELOG for 1.0.0-beta.22 (last release was beta.21; this ships the full accumulated dev slate).

**Features**
- Game Studio: real AI-assisted game maker (#1602)
- Per-platform one-tap local backend install: llama.cpp on CUDA/ROCm/Metal/CPU, rkllama on Rockchip (#1597, #1598, #1608)
- Account: Settings promo + reserve-username framing (#1593), onboarding cloud-account step (#1595)

**Fixes (mandresve beta.21 cluster)**
- NPU/local backend install now creates+starts+verifies the service, self-heals (#1598)
- Downloaded models selectable + deployable by the agent (#1599, #1600)
- Theme/wallpaper persist; Desktop & Dock settings apply (#1601, #1603)
- Text Editor focus loss fixed (#1596)
- Files → Recycle Bin instead of permanent delete (#1604)
- New Project dialog stacking (#1605)
- Consent dialog dismiss-guard (#1592)

Bumps pyproject.toml, desktop/package.json, tinyagentos/__init__.py, uv.lock, desktop/package-lock.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version **1.0.0-beta.22**.

* **Bug Fixes**
  * Deleting files and folders now shows them as moved to the Recycle Bin, with restore and empty actions available.
  * Fixed an issue where the New Project dialog could open behind the Projects window.

* **Chores**
  * Updated version numbers and changelog entries to match the new beta release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->