### PR TITLE
fix(settings): actually persist theme/wallpaper/dock across sessions

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -11,6 +11,7 @@ import { useSessionPersistence } from "@/hooks/use-session-persistence";
 import { useDeviceMode } from "@/hooks/use-device-mode";
 import { useIsPwa } from "@/hooks/use-is-pwa";
 import { useThemeStore, restoreActiveTheme, installWebkitRepaintGuards } from "@/stores/theme-store";
+import { useOnAuthReady } from "@/hooks/use-on-auth-ready";
 import { useProcessStore } from "@/stores/process-store";
 import { useDockStore } from "@/stores/dock-store";
 import { getApp } from "@/registry/app-registry";
@@ -204,14 +205,26 @@ export function App() {
   // primary push channel; useServerNotifications falls back to polling.
   useEventStream();
 
-  // Re-apply the persisted active theme on app boot so a reload keeps the
-  // user's chosen theme app-wide (not only when Settings is opened).
+  // WebKit blanks backdrop-filter surfaces when the tab is hidden then shown
+  // again (switching back into taOS); re-composite them on return. Not
+  // auth-gated: it only installs a visibility listener, no per-user fetch.
   useEffect(() => {
-    void restoreActiveTheme();
-    // WebKit blanks backdrop-filter surfaces when the tab is hidden then shown
-    // again (switching back into taOS); re-composite them on return.
     installWebkitRepaintGuards();
   }, []);
+
+  // Re-apply the persisted active theme once authenticated, so a reload keeps
+  // the user's chosen theme app-wide (not only when Settings is opened).
+  //
+  // SystemShortcuts mounts as a sibling of LoginGate, before LoginGate's own
+  // /auth/status check resolves, so firing this on bare mount races the auth
+  // check: right after a logout there is no session cookie yet, the fetch
+  // inside restoreActiveTheme 401s, and — since this used to run once on
+  // mount — it was never retried once the user logged back in (#1601).
+  // useOnAuthReady defers it until auth is confirmed and re-runs it on a
+  // later re-login.
+  useOnAuthReady(() => {
+    void restoreActiveTheme();
+  });
 
   // Apply reduce-effects / performance mode (#58) as a root attribute so the CSS
   // in tokens.css can strip blur, big shadows and continuous animations on

--- a/desktop/src/components/LoginGate.tsx
+++ b/desktop/src/components/LoginGate.tsx
@@ -3,6 +3,7 @@ import { Lock } from "lucide-react";
 import { OnboardingScreen } from "./OnboardingScreen";
 import { OffNetworkScreen } from "./OffNetworkScreen";
 import { SESSION_EXPIRED_EVENT } from "@/lib/auth-guard";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
 
 interface Props {
   children: React.ReactNode;
@@ -60,6 +61,14 @@ export function LoginGate({ children }: Props) {
   useEffect(() => {
     refreshStatus();
   }, [refreshStatus]);
+
+  // Publish auth-readiness for session-scoped restore effects that live
+  // outside LoginGate's children (e.g. useSessionPersistence, active-theme
+  // restore) — they must not fetch per-user data until this flips true, and
+  // must re-fetch the next time it does (see auth-ready-store.ts).
+  useEffect(() => {
+    useAuthReadyStore.getState().setReady(status.phase === "ready");
+  }, [status.phase]);
 
   // Listen for session-expired events from the global auth guard. Any
   // /api/* call returning 401 fires this; we re-run /auth/status which

--- a/desktop/src/hooks/__tests__/use-on-auth-ready.test.ts
+++ b/desktop/src/hooks/__tests__/use-on-auth-ready.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useOnAuthReady } from "../use-on-auth-ready";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
+
+beforeEach(() => {
+  useAuthReadyStore.setState({ ready: false });
+});
+
+describe("useOnAuthReady (#1601, #1603)", () => {
+  it("does not run the callback while logged out", () => {
+    const callback = vi.fn();
+    renderHook(() => useOnAuthReady(callback));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("runs the callback once auth becomes ready", () => {
+    const callback = vi.fn();
+    renderHook(() => useOnAuthReady(callback));
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-run while still authenticated (no duplicate restores per session)", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(() => useOnAuthReady(callback));
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+    rerender();
+    rerender();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the callback again after a logout/login cycle", () => {
+    // This is the exact bug: a theme/settings restore that only ever fires
+    // once on mount is never retried after the user logs back in following
+    // a logout. useOnAuthReady must re-arm on the falling edge so the next
+    // rising edge (the next login) restores the new session's data.
+    const callback = vi.fn();
+    renderHook(() => useOnAuthReady(callback));
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: false }); // logout
+    });
+    act(() => {
+      useAuthReadyStore.setState({ ready: true }); // login again
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});

--- a/desktop/src/hooks/__tests__/use-session-persistence.test.ts
+++ b/desktop/src/hooks/__tests__/use-session-persistence.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import { useSessionPersistence } from "../use-session-persistence";
 import { useDockStore } from "@/stores/dock-store";
 import { useThemeStore } from "@/stores/theme-store";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
 
 vi.mock("@/registry/app-registry", () => ({
   getApp: () => undefined,
@@ -33,6 +34,10 @@ beforeEach(() => {
     position: "bottom",
   });
   useThemeStore.setState({ wallpaperId: "graphite" } as never);
+  // Baseline: already authenticated, matching the pre-existing tests below
+  // which exercise restore-on-mount in isolation. The auth-gating tests
+  // further down explicitly manipulate this.
+  useAuthReadyStore.setState({ ready: true });
 });
 
 afterEach(() => {
@@ -94,5 +99,120 @@ describe("useSessionPersistence — dock settings restore (#1603)", () => {
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
     expect(useDockStore.getState().iconSize).toBe("medium");
     expect(useDockStore.getState().position).toBe("bottom");
+  });
+});
+
+describe("useSessionPersistence — persistence survives a logout/login cycle (#1601, #1603)", () => {
+  it("does not fetch per-user settings before the session is authenticated", async () => {
+    // SystemShortcuts (which owns this hook) mounts before LoginGate confirms
+    // auth. A mount-gated restore used to fire here regardless, 401 while
+    // logged out, and — having already "run" — never retry after login.
+    useAuthReadyStore.setState({ ready: false });
+    mockFetchWith({
+      "/api/desktop/settings": { wallpaper: "midnight" },
+      "/api/desktop/dock": { iconSize: "large", position: "left" },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    // Give any (wrongly) in-flight effect a tick, then assert nothing fired.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/desktop/settings"),
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/desktop/dock"),
+    );
+    expect(useThemeStore.getState().wallpaperId).toBe("graphite");
+    expect(useDockStore.getState().iconSize).toBe("medium");
+  });
+
+  it("restores the saved theme, wallpaper and dock settings once auth flips ready, and re-restores on a later re-login", async () => {
+    // Simulate a full app boot: SystemShortcuts mounts first (pre-auth), then
+    // LoginGate resolves /auth/status and the user logs in.
+    useAuthReadyStore.setState({ ready: false });
+    mockFetchWith({
+      "/api/desktop/settings": { wallpaper: "midnight" },
+      "/api/desktop/dock": { iconSize: "large", position: "left" },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    // Still logged out: the store must stay at its defaults, not midnight/large.
+    expect(useThemeStore.getState().wallpaperId).toBe("graphite");
+
+    // Login completes.
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("midnight");
+      expect(useDockStore.getState().iconSize).toBe("large");
+      expect(useDockStore.getState().position).toBe("left");
+    });
+
+    // Logout, then a second login as a user with different saved settings —
+    // the restore must run again, not stay stuck on the first session's values.
+    act(() => {
+      useAuthReadyStore.setState({ ready: false });
+    });
+    useDockStore.setState({ iconSize: "medium", position: "bottom" });
+    useThemeStore.setState({ wallpaperId: "graphite" } as never);
+    mockFetchWith({
+      "/api/desktop/settings": { wallpaper: "aurora" },
+      "/api/desktop/dock": { iconSize: "small", position: "bottom" },
+    });
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("aurora");
+      expect(useDockStore.getState().iconSize).toBe("small");
+    });
+  });
+
+  it("does not let a debounced auto-save clobber the backend with default values while restore is still in flight", async () => {
+    // Regression for the residual race: the old code gated every auto-save
+    // effect on the same flag the restore effect flipped the instant it
+    // *started* (not once its fetch resolved), so a slow restore GET could
+    // lose to a faster debounced auto-save PUT carrying the pre-restore
+    // default value. Here the wallpaper GET is deliberately slower than the
+    // 500ms auto-save debounce.
+    useAuthReadyStore.setState({ ready: false });
+    let resolveSettings: (body: unknown) => void = () => {};
+    const slowSettings = new Promise<unknown>((resolve) => {
+      resolveSettings = resolve;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/desktop/settings")) {
+        return slowSettings.then((body) => new Response(JSON.stringify(body)));
+      }
+      return Promise.resolve(new Response(JSON.stringify({})));
+    });
+
+    renderHook(() => useSessionPersistence());
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+
+    // Let time pass well beyond the 500ms wallpaper auto-save debounce while
+    // the settings GET is still unresolved.
+    await new Promise((r) => setTimeout(r, 700));
+    const putCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([input, init]) =>
+        (typeof input === "string" ? input : input.toString()).includes("/api/desktop/settings") &&
+        (init as RequestInit | undefined)?.method === "PUT",
+    );
+    expect(putCalls).toHaveLength(0);
+
+    // Restore finally resolves with the real saved wallpaper.
+    resolveSettings({ wallpaper: "ocean" });
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("ocean");
+    });
   });
 });

--- a/desktop/src/hooks/use-on-auth-ready.ts
+++ b/desktop/src/hooks/use-on-auth-ready.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from "react";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
+
+// Runs `callback` once per authenticated session: the first time
+// auth-ready flips true, and again after it drops back to false and flips
+// true a second time (i.e. a subsequent login). Does NOT run while logged
+// out, and does not re-run on every render while still logged in.
+//
+// Extracted so session-scoped restore effects (active-theme, desktop
+// settings) that live outside LoginGate's children can share the same fix
+// for #1601/#1603: those effects used to run unconditionally on mount,
+// before LoginGate's /auth/status check resolves, so they either 401'd
+// against a logged-out session or read stale data — and, having already
+// "run" once, were never retried after the user actually logged in.
+export function useOnAuthReady(callback: () => void) {
+  const ranForThisSession = useRef(false);
+  const authReady = useAuthReadyStore((s) => s.ready);
+
+  useEffect(() => {
+    if (!authReady) {
+      ranForThisSession.current = false;
+      return;
+    }
+    if (ranForThisSession.current) return;
+    ranForThisSession.current = true;
+    callback();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authReady]);
+}

--- a/desktop/src/hooks/use-session-persistence.ts
+++ b/desktop/src/hooks/use-session-persistence.ts
@@ -7,6 +7,7 @@ import { getApp } from "@/registry/app-registry";
 import { useBrowserStore } from "@/stores/browser-store";
 import { loadWindows as loadBrowserWindows, saveWindows as saveBrowserWindows } from "@/lib/browser-windows-api";
 import type { BrowserWindowState } from "@/apps/BrowserApp/types";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
 
 interface SavedWindow {
   appId: string;
@@ -33,15 +34,39 @@ export function useSessionPersistence() {
 
   const browserWindows = useBrowserStore((s) => s.windows);
 
+  const authReady = useAuthReadyStore((s) => s.ready);
+
+  // `restored` guards the whole restore effect below (fires once per
+  // authenticated session). `dockRestored`/`wallpaperRestored` gate their own
+  // auto-save effects independently: the shared `restored` flag used to flip
+  // true the instant the effect *started*, not once its fetches actually
+  // landed, so a debounced auto-save (500ms wallpaper / 1s dock) could fire
+  // with the still-default in-memory value and overwrite the real saved
+  // setting before the slower restore GET came back (#1601, #1603).
   const restored = useRef(false);
+  const dockRestored = useRef(false);
+  const wallpaperRestored = useRef(false);
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dockTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wallpaperTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const widgetSaveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const browserSaveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Restore everything on mount (once)
+  // Restore everything once authenticated (once per session).
+  //
+  // SystemShortcuts (which owns this hook) mounts as a sibling of LoginGate,
+  // before LoginGate's /auth/status check resolves, so a mount-gated restore
+  // fires while logged out, 401s, and — since it only ran once — is never
+  // retried after a subsequent login. Gating on `authReady` (and resetting
+  // when it drops) means a fresh login always re-fetches this session's
+  // settings instead of leaving the defaults the pre-auth attempt left behind.
   useEffect(() => {
+    if (!authReady) {
+      restored.current = false;
+      dockRestored.current = false;
+      wallpaperRestored.current = false;
+      return;
+    }
     if (restored.current) return;
     restored.current = true;
 
@@ -80,7 +105,10 @@ export function useSessionPersistence() {
           useDockStore.getState().setPosition(data.position);
         }
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => {
+        dockRestored.current = true;
+      });
 
     // Restore wallpaper
     fetch("/api/desktop/settings")
@@ -90,7 +118,10 @@ export function useSessionPersistence() {
           useThemeStore.getState().setWallpaper(data.wallpaper);
         }
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => {
+        wallpaperRestored.current = true;
+      });
 
     // Restore widgets
     fetch("/api/desktop/widgets")
@@ -125,7 +156,7 @@ export function useSessionPersistence() {
         useBrowserStore.setState({ windows });
       })
       .catch(() => {});
-  }, [openWindow, updatePosition, updateSize, maximizeWindow, snapWindow]);
+  }, [authReady, openWindow, updatePosition, updateSize, maximizeWindow, snapWindow]);
 
   // Auto-save windows (debounced 2s)
   useEffect(() => {
@@ -155,9 +186,13 @@ export function useSessionPersistence() {
     };
   }, [windows]);
 
-  // Auto-save dock (debounced 1s)
+  // Auto-save dock (debounced 1s). Gated on dockRestored, not the outer
+  // `restored` flag: that flips true the instant the restore effect starts,
+  // before its fetch resolves, so this would otherwise fire on mount with
+  // the still-default dock state and could beat a slow restore GET to the
+  // backend, overwriting the real saved dock settings (#1603).
   useEffect(() => {
-    if (!restored.current) return;
+    if (!dockRestored.current) return;
 
     if (dockTimeout.current) clearTimeout(dockTimeout.current);
     dockTimeout.current = setTimeout(() => {
@@ -173,9 +208,10 @@ export function useSessionPersistence() {
     };
   }, [pinned, dockIconSize, dockPosition]);
 
-  // Auto-save wallpaper (debounced 500ms)
+  // Auto-save wallpaper (debounced 500ms). Gated on wallpaperRestored (see
+  // the dock effect above for why the outer `restored` flag isn't enough).
   useEffect(() => {
-    if (!restored.current) return;
+    if (!wallpaperRestored.current) return;
 
     if (wallpaperTimeout.current) clearTimeout(wallpaperTimeout.current);
     wallpaperTimeout.current = setTimeout(() => {

--- a/desktop/src/stores/auth-ready-store.ts
+++ b/desktop/src/stores/auth-ready-store.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+// Tracks whether LoginGate has confirmed an authenticated session and is
+// rendering the real desktop (its "ready" phase), as opposed to the loading /
+// login / onboarding screens.
+//
+// SystemShortcuts (which drives useSessionPersistence and the active-theme
+// restore) mounts as a sibling of LoginGate, before LoginGate's own
+// /auth/status check resolves. Firing per-user restore fetches on bare
+// component mount therefore races the auth check: right after a logout, the
+// next mount has no session cookie yet, so the restore requests 401 and are
+// never retried once the user actually logs back in (#1601, #1603). Restore
+// effects gate on `ready` instead of mount, and reset when it drops back to
+// false so a subsequent login re-fetches that session's saved settings.
+interface AuthReadyStore {
+  ready: boolean;
+  setReady: (ready: boolean) => void;
+}
+
+export const useAuthReadyStore = create<AuthReadyStore>((set) => ({
+  ready: false,
+  setReady: (ready) => set({ ready }),
+}));

--- a/tests/test_desktop_settings.py
+++ b/tests/test_desktop_settings.py
@@ -76,3 +76,47 @@ async def test_widgets_roundtrip(store):
 async def test_widgets_default_empty(store):
     result = await store.get_widgets("user")
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_preference_roundtrip(store):
+    """save_preference/get_preference back the active-theme persistence path
+    (#1601): the theme id is stored via this namespaced blob, not the
+    settings/dock rows."""
+    await store.save_preference("user", "themes", {"active_theme_id": "indigo"})
+    pref = await store.get_preference("user", "themes")
+    assert pref == {"active_theme_id": "indigo"}
+
+
+@pytest.mark.asyncio
+async def test_preference_default_empty(store):
+    pref = await store.get_preference("user", "themes")
+    assert pref == {}
+
+
+@pytest.mark.asyncio
+async def test_settings_and_dock_survive_a_new_store_instance_on_the_same_db(tmp_path):
+    """Regression: settings/dock/preferences must be durable across a fresh
+    DesktopSettingsStore pointed at the same db_path (simulating a controller
+    restart or a new login session opening its own store instance), not just
+    within the connection that wrote them."""
+    db_path = tmp_path / "desktop.db"
+
+    first = DesktopSettingsStore(db_path)
+    await first.init()
+    await first.update_settings("user", {"wallpaper": "aurora"})
+    await first.update_dock("user", {"iconSize": "large", "position": "left"})
+    await first.save_preference("user", "themes", {"active_theme_id": "indigo"})
+    await first.close()
+
+    second = DesktopSettingsStore(db_path)
+    await second.init()
+    try:
+        settings = await second.get_settings("user")
+        assert settings["wallpaper"] == "aurora"
+        assert settings["dock"]["iconSize"] == "large"
+        assert settings["dock"]["position"] == "left"
+        pref = await second.get_preference("user", "themes")
+        assert pref == {"active_theme_id": "indigo"}
+    finally:
+        await second.close()


### PR DESCRIPTION
## Summary

Fixes #1601 and #1603. Both were reported after #1611 landed (which wired up the apply path + debounced auto-save/restore machinery) — theme, wallpaper, dock position and dock icon size all still apply correctly in-session but revert to defaults after logout + login.

**Root cause:** the restore effects for desktop settings and the active theme live in `SystemShortcuts` (`App.tsx`), which mounts as a sibling of `LoginGate` — before `LoginGate`'s own `/auth/status` check resolves. On a fresh login right after a logout, that mount-time restore fires while the session is still unauthenticated, gets a 401, and — since it's a one-shot effect gated by a ref — is never retried once the user actually logs in. The in-memory stores stay at their defaults for the rest of that session, which is exactly the reported symptom. (The backend side, `tinyagentos/desktop_settings.py`, was already correctly disk-backed via SQLite, keyed by user — that part was fine.)

There was also a secondary race: the dock/wallpaper auto-save effects were gated on the same flag the restore effect flipped the instant it *started* running, not once its fetch actually resolved. A slow restore GET could lose to the debounced auto-save PUT (500ms wallpaper / 1s dock) and get overwritten with the pre-restore default value.

## Changes

- `desktop/src/stores/auth-ready-store.ts` (new) — tiny store `LoginGate` publishes to once it reaches its "ready" phase.
- `desktop/src/components/LoginGate.tsx` — publish auth-readiness on phase change.
- `desktop/src/hooks/use-on-auth-ready.ts` (new) — small hook that runs a callback once per authenticated session and re-arms after a logout/login cycle; used for the active-theme restore.
- `desktop/src/App.tsx` — gate the active-theme restore on auth-ready instead of firing on bare mount.
- `desktop/src/hooks/use-session-persistence.ts` — gate the whole restore effect on auth-ready (resetting on logout so a later login re-fetches), and split the dock/wallpaper auto-save guards onto their own "restore settled" flags instead of the shared one.
- Tests: `use-session-persistence.test.ts` and new `use-on-auth-ready.test.ts` cover the full set-then-reload cycle (pre-auth: no fetch; login: restore fires; logout+login again: re-restores a *different* saved value, not stuck on the first session's); `tests/test_desktop_settings.py` adds a `save_preference`/`get_preference` round-trip test and a fresh-store-instance-same-db test proving the backend is durable across restarts, not just in-memory.

## Test plan

- [x] `cd desktop && npm run build`
- [x] `npx vitest run` (298 files, 2434 tests passed)
- [x] `python3 -m pytest tests/test_desktop_settings.py tests/test_routes_desktop.py -q` (20 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop themes now restore only after sign-in is confirmed, reducing flashes of the wrong theme during login.
  * Session restores for themes, wallpaper, and dock settings now run reliably after logout/login cycles.
  * Prevented settings autosave from overwriting restored values while data is still loading.
* **Tests**
  * Expanded coverage for login readiness, session persistence, and preference storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->