### PR TITLE
fix(taos-agent): unmask real runtime errors + fix blank agent dialog

### DIFF
--- a/desktop/src/apps/TaosAssistantWindow.test.tsx
+++ b/desktop/src/apps/TaosAssistantWindow.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TaosAssistantWindow } from "./TaosAssistantWindow";
+import { useTaosAgentStore } from "@/stores/taos-agent-store";
+import { useProcessStore } from "@/stores/process-store";
+
+// Mock child that opens a modal — keeps the test surface narrow, mirrors
+// TaosAssistantPanel.test.tsx's approach.
+vi.mock("@/components/TaosAssistantSettings", () => ({
+  TaosAssistantSettings: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="settings-modal" /> : null,
+}));
+
+function resetStores() {
+  useTaosAgentStore.setState({
+    isOpen: false,
+    messages: [],
+    model: "qwen3",
+    streaming: false,
+    settingsOpen: false,
+  });
+  useProcessStore.setState({ windows: [] });
+}
+
+describe("TaosAssistantWindow", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("renders the chat shell when launched directly (no popOut prop) — regression for #1615", () => {
+    // Direct Launchpad/Dock launch calls openWindow("taos-agent", size) with
+    // no props, so windows never carries a matching entry with
+    // props.popOut. The window must still show its UI, not go blank.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ model: "qwen3" }) }),
+    );
+
+    render(<TaosAssistantWindow windowId="win-1" />);
+
+    expect(screen.getByText("taOS agent")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /message taOS agent/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /send message/i })).toBeInTheDocument();
+  });
+
+  it("renders the chat shell when opened via the pop-out button (props.popOut)", () => {
+    useProcessStore.setState({
+      windows: [
+        {
+          id: "win-2",
+          appId: "taos-agent",
+          position: { x: 0, y: 0 },
+          size: { w: 420, h: 640 },
+          zIndex: 1,
+          minimized: false,
+          maximized: false,
+          snapped: null,
+          focused: true,
+          props: { popOut: true },
+          launchNonce: 0,
+        },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ model: "qwen3" }) }),
+    );
+
+    render(<TaosAssistantWindow windowId="win-2" />);
+
+    expect(screen.getByText("taOS agent")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /message taOS agent/i })).toBeInTheDocument();
+  });
+
+  it("surfaces the runtime error inline instead of leaving the dialog blank", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (typeof url === "string" && url.includes("/api/taos-agent/settings")) {
+          return Promise.resolve({ ok: true, json: async () => ({ model: "qwen3" }) });
+        }
+        // /api/taos-agent/chat — simulate the runtime-unavailable 503.
+        return Promise.resolve({
+          ok: false,
+          body: null,
+          text: async () =>
+            JSON.stringify({ error: "opencode is not installed. Install it with: curl -fsSL https://opencode.ai/install | bash" }),
+        });
+      }),
+    );
+
+    render(<TaosAssistantWindow windowId="win-3" />);
+
+    const textarea = screen.getByRole("textbox", { name: /message taOS agent/i });
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    // The shell stays up (input still present) and the error is shown inline.
+    await waitFor(() => {
+      expect(screen.getByText(/opencode is not installed/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("textbox", { name: /message taOS agent/i })).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/TaosAssistantWindow.tsx
+++ b/desktop/src/apps/TaosAssistantWindow.tsx
@@ -6,15 +6,17 @@ export function TaosAssistantWindow({ windowId }: { windowId: string }) {
   const closeWindow = useProcessStore((s) => s.closeWindow);
   const removeWindow = useProcessStore((s) => s.removeWindow);
   const snap = useProcessStore((s) => s.snapWindow);
-  const isPopOut = useProcessStore((s) => s.windows.find((w) => w.id === windowId)?.props?.popOut);
 
   const handleClose = useCallback(() => {
     closeWindow(windowId);
     setTimeout(() => removeWindow(windowId), 250);
   }, [closeWindow, removeWindow, windowId]);
 
-  if (!isPopOut) return null;
-
+  // This window renders the chat unconditionally: it is reached both via the
+  // docked panel's "Pop out" button (which passes props.popOut) and directly
+  // from the Launchpad/dock ("taos-agent" is a regular app-registry entry).
+  // Gating render on props.popOut left the direct-launch path with nothing
+  // to show -- an empty window with no error, no content (#1615).
   return (
     <div className="h-full w-full flex flex-col bg-shell-bg-deep">
       <div className="flex items-center gap-2 px-4 py-3 border-b border-white/5 shrink-0 select-none">

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -223,6 +223,68 @@ async def test_ensure_running_raises_on_timeout(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# resolve_opencode_binary / OpenCodeBinaryNotFoundError (#1616)
+#
+# opencode's official installer places the binary at ~/.opencode/bin/opencode
+# and only makes it reachable via a shell-rc PATH export, which a systemd
+# service never sources. resolve_opencode_binary() must fall back to that
+# fixed location, and ensure_running() must translate a genuine "not found"
+# into a distinct, actionable exception rather than a generic subprocess error.
+# ---------------------------------------------------------------------------
+
+class TestResolveOpencodeBinary:
+    def test_prefers_path_lookup(self, monkeypatch):
+        from tinyagentos import opencode_runtime as ocr
+
+        monkeypatch.setattr(ocr.shutil, "which", lambda name: "/usr/local/bin/opencode")
+        assert ocr.resolve_opencode_binary() == "/usr/local/bin/opencode"
+
+    def test_falls_back_to_installer_default_location(self, tmp_path, monkeypatch):
+        from tinyagentos import opencode_runtime as ocr
+
+        fake_home = tmp_path / "home"
+        opencode_dir = fake_home / ".opencode" / "bin"
+        opencode_dir.mkdir(parents=True)
+        binary = opencode_dir / "opencode"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        monkeypatch.setattr(ocr.shutil, "which", lambda name: None)
+        monkeypatch.setattr(ocr.Path, "home", classmethod(lambda cls: fake_home))
+
+        assert ocr.resolve_opencode_binary() == str(binary)
+
+    def test_returns_none_when_not_installed_anywhere(self, tmp_path, monkeypatch):
+        from tinyagentos import opencode_runtime as ocr
+
+        monkeypatch.setattr(ocr.shutil, "which", lambda name: None)
+        monkeypatch.setattr(ocr.Path, "home", classmethod(lambda cls: tmp_path / "no-home"))
+
+        assert ocr.resolve_opencode_binary() is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_running_raises_binary_not_found_error(tmp_path, monkeypatch):
+    """A bare exec failure (binary missing everywhere) surfaces as
+    OpenCodeBinaryNotFoundError, distinguishable from a start/health failure."""
+    from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
+
+    cfg = _make_server_cfg(tmp_path)
+    server = OpenCodeServer(cfg)
+
+    async def fake_create_subprocess(*args, **kwargs):
+        raise FileNotFoundError("[Errno 2] No such file or directory: 'opencode'")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess)
+    monkeypatch.setattr(
+        "tinyagentos.opencode_runtime.resolve_opencode_binary", lambda: None
+    )
+
+    with pytest.raises(OpenCodeBinaryNotFoundError):
+        await server.ensure_running(deadline_s=0.05, poll_s=0.01)
+
+
+# ---------------------------------------------------------------------------
 # drive_turn — sink wiring
 # ---------------------------------------------------------------------------
 

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -123,6 +123,66 @@ async def test_chat_proxy_not_running_returns_503(client, app):
 
 
 # ---------------------------------------------------------------------------
+# #1616 — opencode-not-found vs opencode-found-but-failed-to-start must
+# return distinct, accurate errors (the old code masked both behind a single
+# generic "check that opencode is installed" message).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_opencode_binary_not_found_returns_install_instructions(client, app, monkeypatch):
+    """When opencode genuinely isn't installed anywhere, the error tells the
+    user to install it -- not a vague "unavailable" message."""
+    from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
+
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+
+    async def fake_ensure_server(state, model):
+        raise OpenCodeBinaryNotFoundError("opencode binary not found (tried 'opencode')")
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hello"}]},
+    )
+    assert resp.status_code == 503
+    error = resp.json().get("error", "")
+    assert "install" in error.lower()
+    assert "opencode.ai/install" in error
+
+
+@pytest.mark.asyncio
+async def test_chat_opencode_start_failure_surfaces_real_error(client, app, monkeypatch):
+    """When opencode is found but fails to start, the real failure reason is
+    surfaced -- not masked behind the same generic message as a missing
+    binary. This must be text distinguishable from the not-found case."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+
+    async def fake_ensure_server(state, model):
+        raise TimeoutError("opencode server on port 4188 did not become healthy within 180.0s")
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hello"}]},
+    )
+    assert resp.status_code == 503
+    error = resp.json().get("error", "")
+    # The real failure reason must be present, not swallowed.
+    assert "did not become healthy" in error
+    assert "install" not in error.lower()
+
+
+# ---------------------------------------------------------------------------
 # Happy-path: two deltas then final → delta, delta, done
 # ---------------------------------------------------------------------------
 

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
@@ -24,6 +25,40 @@ import httpx
 from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
 
 logger = logging.getLogger(__name__)
+
+
+class OpenCodeBinaryNotFoundError(RuntimeError):
+    """Raised when the ``opencode`` binary cannot be located anywhere.
+
+    opencode's official installer (``curl -fsSL https://opencode.ai/install |
+    bash``) drops the binary at ``~/.opencode/bin/opencode`` and makes it
+    reachable from a terminal by appending a PATH export to the user's shell
+    rc file (``.bashrc``/``.zshrc``). Those rc files are only sourced by
+    interactive shells -- the taOS backend normally runs as a systemd service,
+    which never sources them, so ``opencode`` can be "installed system-wide"
+    and still invisible to the service's PATH. See :func:`resolve_opencode_binary`.
+    """
+
+
+def resolve_opencode_binary() -> str | None:
+    """Locate the opencode binary, working around the PATH gap above.
+
+    Checks, in order:
+      1. ``shutil.which("opencode")`` -- covers PATH already containing it.
+      2. ``~/.opencode/bin/opencode`` -- the official installer's fixed
+         location, which a non-login process (e.g. a systemd service) never
+         picks up via PATH alone.
+
+    Returns the resolved path, or ``None`` if opencode isn't installed
+    anywhere we know to look.
+    """
+    found = shutil.which("opencode")
+    if found:
+        return found
+    candidate = Path.home() / ".opencode" / "bin" / "opencode"
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -161,15 +196,28 @@ class OpenCodeServer:
         except OSError:
             pass
 
-        self._proc = await asyncio.create_subprocess_exec(
-            self._cfg.binary,
-            "serve",
-            "--port", str(self._cfg.port),
-            "--hostname", "127.0.0.1",
-            stdout=self._log_fh,
-            stderr=asyncio.subprocess.STDOUT,
-            env=env,
-        )
+        # Resolve the bare "opencode" default past the PATH gap described in
+        # OpenCodeBinaryNotFoundError; an explicit binary override (tests, or
+        # a future config knob) is used as-is.
+        binary = self._cfg.binary
+        if binary == "opencode":
+            binary = resolve_opencode_binary() or binary
+
+        try:
+            self._proc = await asyncio.create_subprocess_exec(
+                binary,
+                "serve",
+                "--port", str(self._cfg.port),
+                "--hostname", "127.0.0.1",
+                stdout=self._log_fh,
+                stderr=asyncio.subprocess.STDOUT,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise OpenCodeBinaryNotFoundError(
+                f"opencode binary not found (tried {binary!r}). Install it with: "
+                "curl -fsSL https://opencode.ai/install | bash"
+            ) from exc
         logger.info(
             "opencode_runtime: spawned pid=%s port=%d",
             self._proc.pid, self._cfg.port,

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -34,6 +34,7 @@ from fastapi.responses import FileResponse, JSONResponse, Response, StreamingRes
 from pydantic import BaseModel
 
 from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
+from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
 from tinyagentos.taos_agent_runtime import ensure_taos_opencode_server
 
 logger = logging.getLogger(__name__)
@@ -372,10 +373,28 @@ async def chat(request: Request, body: ChatRequest):
     # Ensure the host opencode server is running.
     try:
         server = await ensure_taos_opencode_server(request.app.state, model)
-    except Exception:
-        logger.exception("taos-agent: failed to start opencode server")
+    except OpenCodeBinaryNotFoundError as exc:
+        # The binary genuinely isn't reachable (not on PATH, not at the
+        # installer's default location) — a clear install instruction, not a
+        # generic "unavailable" message.
+        logger.error("taos-agent: opencode binary not found: %s", exc)
         return JSONResponse(
-            {"error": "taOS agent runtime unavailable. Check that opencode is installed."},
+            {
+                "error": (
+                    "opencode is not installed. Install it with: "
+                    "curl -fsSL https://opencode.ai/install | bash — then restart taOS."
+                )
+            },
+            status_code=503,
+        )
+    except Exception as exc:
+        # opencode was found but failed to start (or some other runtime
+        # error) — surface the real cause instead of masking it behind a
+        # generic message that sends users chasing an install that's already
+        # correct.
+        logger.exception("taos-agent: opencode server failed to start")
+        return JSONResponse(
+            {"error": f"taOS agent runtime failed to start: {exc}"},
             status_code=503,
         )
 


### PR DESCRIPTION
## Summary
- Fixes #1616: the taOS Agent chat endpoint reported "check that opencode is installed" even with opencode installed system-wide. Root cause: opencode's installer places the binary at `~/.opencode/bin/opencode` and only makes it reachable via a shell-rc PATH export (`.bashrc`/`.zshrc`). The taOS backend runs as a systemd service, which never sources those rc files, so the service's PATH never saw the binary even though a terminal did. `ensure_taos_opencode_server` also masked every failure (missing binary, failed start, timeout, etc.) behind one generic 503 message.
  - `opencode_runtime.resolve_opencode_binary()` falls back to the installer's fixed location when a bare PATH lookup misses.
  - A genuine exec failure now raises `OpenCodeBinaryNotFoundError` instead of a raw `FileNotFoundError`.
  - `routes/taos_agent.py`'s chat handler distinguishes "binary not found" (install instructions) from "found but failed to start" (the real error is surfaced).
- Fixes #1615: the taOS Agent dialog opened as a completely blank window with no errors or logs. Root cause: `TaosAssistantWindow` (the component behind the "taOS Agent" Launchpad/Dock entry) gated its entire render on `props.popOut`, a prop only set when the docked panel's "Pop out" button opens the window. Launching directly from the Launchpad/Dock never sets that prop, so the window rendered nothing. The chat shell (input, attachments, settings) now always renders; runtime failures surface inline in the conversation via the existing send-path error handling.

## Test plan
- [x] `python3 -m pytest tests/ -k "agent or opencode or taos_agent" -q` — 1258 passed, 2 skipped
- [x] `cd desktop && npm run build` — succeeds
- [x] `npx vitest run` (desktop) — 298 files / 2430 tests passed, including new `TaosAssistantWindow.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The assistant window now opens correctly whether launched directly or from the pop-out flow.
  * Chat startup errors now show clearer, more specific messages when the backend cannot start.

* **Bug Fixes**
  * Improved handling when the required runtime tool is missing, including clearer install guidance.
  * If the runtime fails for another reason, the error shown in chat now includes the underlying issue instead of a generic message.
  * Added stronger test coverage for window rendering and chat error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->