### PR TITLE
fix(models/providers): actionable errors when a model's backend is down + real provider Test failures

### DIFF
--- a/tests/cluster/test_model_resolver.py
+++ b/tests/cluster/test_model_resolver.py
@@ -88,7 +88,7 @@ class TestCollectCloudModelIds:
 
 
 class TestResolveModelLocation:
-    def _make_request(self, *, local_model_names=None, backends=None, workers=None):
+    def _make_request(self, *, local_model_names=None, backends=None, workers=None, registry=None):
         """Build a minimal fake request with app.state wired up."""
         local_model_names = local_model_names or []
         backends = backends or []
@@ -107,6 +107,7 @@ class TestResolveModelLocation:
             cluster_manager=cluster,
             backend_catalog=catalog,
             config=config,
+            registry=registry,
         )
 
         app = SimpleNamespace(state=state)
@@ -144,4 +145,86 @@ class TestResolveModelLocation:
         # No backend_catalog attribute at all
         request = SimpleNamespace(app=SimpleNamespace(state=state))
         location = resolve_model_location(request, "some-model")
+        assert location.kind == "not_found"
+
+
+class TestDownloadedBackendDown:
+    """#1599/#1600: a downloaded rkllama model whose serving backend has
+    crashed/stopped must not report the generic "not found anywhere"
+    error — it should say exactly that the backend is down."""
+
+    def _manifest(self, model_id="qwen2.5-3b-rkllm", backend_id="rkllama"):
+        return SimpleNamespace(
+            id=model_id,
+            type="model",
+            variants=[
+                {"id": "w8a8", "requires": {"backends": [{"id": backend_id}]}},
+            ],
+        )
+
+    def _registry(self, manifest=None):
+        manifests = [manifest] if manifest else []
+        return SimpleNamespace(
+            get=lambda mid: next((m for m in manifests if m.id == mid), None),
+            list_available=lambda type_filter=None: manifests,
+        )
+
+    def _make_request(self, *, registry=None):
+        catalog = SimpleNamespace(all_models=lambda: [])
+        cluster = SimpleNamespace(get_workers=lambda: [])
+        config = SimpleNamespace(backends=[])
+        state = SimpleNamespace(
+            cluster_manager=cluster,
+            backend_catalog=catalog,
+            config=config,
+            registry=registry,
+        )
+        return SimpleNamespace(app=SimpleNamespace(state=state))
+
+    def test_downloaded_model_with_backend_confirmed_down_is_actionable(self, monkeypatch):
+        import tinyagentos.installers.rkllama_installer as rk
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+
+        manifest = self._manifest()
+        request = self._make_request(registry=self._registry(manifest))
+
+        location = resolve_model_location(request, "qwen2.5-3b-rkllm")
+        assert location.kind == "downloaded_backend_down"
+        assert location.backend_id == "rkllama"
+
+    def test_unknown_model_stays_not_found_even_with_backend_down(self, monkeypatch):
+        """A model with no manifest at all must NOT get the "downloaded"
+        message — the resolver can't claim it's downloaded when it never
+        heard of it."""
+        import tinyagentos.installers.rkllama_installer as rk
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+
+        request = self._make_request(registry=self._registry(manifest=None))
+
+        location = resolve_model_location(request, "totally-unknown-model")
+        assert location.kind == "not_found"
+
+    def test_backend_running_falls_back_to_generic_not_found(self, monkeypatch):
+        """If the backend IS confirmed running but the model still isn't in
+        any live catalog (e.g. a stale poll), that's a genuinely-unreachable
+        case, not the actionable "backend down" case."""
+        import tinyagentos.installers.rkllama_installer as rk
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: True)
+
+        manifest = self._manifest()
+        request = self._make_request(registry=self._registry(manifest))
+
+        location = resolve_model_location(request, "qwen2.5-3b-rkllm")
+        assert location.kind == "not_found"
+
+    def test_no_registry_falls_back_to_not_found(self):
+        request = self._make_request(registry=None)
+        location = resolve_model_location(request, "qwen2.5-3b-rkllm")
+        assert location.kind == "not_found"
+
+    def test_manifest_without_backend_requirement_falls_back_to_not_found(self):
+        manifest = SimpleNamespace(id="cloud-only-model", type="model", variants=[{"id": "v1"}])
+        request = self._make_request(registry=self._registry(manifest))
+
+        location = resolve_model_location(request, "cloud-only-model")
         assert location.kind == "not_found"

--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -90,8 +90,12 @@ def _patch_save(monkeypatch):
     monkeypatch.setattr(mod, "save_config_locked", _noop_save)
 
 
-def _make_location(kind):
-    return ModelLocation(kind=kind)
+def _make_location(kind_or_tuple):
+    """kind_or_tuple is either a bare kind string, or (kind, backend_id)."""
+    if isinstance(kind_or_tuple, tuple):
+        kind, backend_id = kind_or_tuple
+        return ModelLocation(kind=kind, backend_id=backend_id)
+    return ModelLocation(kind=kind_or_tuple)
 
 
 def _patch_resolver(monkeypatch, mapping: dict):
@@ -197,6 +201,26 @@ async def test_put_permitted_unreachable_model_returns_409(monkeypatch):
     import json
     data = json.loads(resp.body)
     assert data["model"] == "bad-model"
+
+
+@pytest.mark.asyncio
+async def test_put_permitted_downloaded_backend_down_returns_actionable_409(monkeypatch):
+    """A downloaded model whose backend is confirmed not running must get
+    the specific actionable message, not the generic "not reachable" one."""
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {"qwen2.5-3b-rkllm": ("downloaded_backend_down", "rkllama")})
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    agents = [{"name": "alpha", "model": "llama3"}]
+    req = _FakeRequest(agents)
+    body = PermittedModelsUpdate(models=["llama3", "qwen2.5-3b-rkllm"])
+    resp = await set_permitted_models(req, "alpha", body)
+    assert resp.status_code == 409
+    import json
+    data = json.loads(resp.body)
+    assert data["model"] == "qwen2.5-3b-rkllm"
+    assert data["backend"] == "rkllama"
+    assert "downloaded" in data["error"]
+    assert "not running" in data["error"]
 
 
 @pytest.mark.asyncio
@@ -319,6 +343,26 @@ async def test_update_agent_model_adds_new_model_to_permitted(monkeypatch):
     assert rescope_calls
     models_sent = rescope_calls[-1]["json"]["models"]
     assert "qwen3" in models_sent
+
+
+@pytest.mark.asyncio
+async def test_update_agent_model_downloaded_backend_down_returns_actionable_409(monkeypatch):
+    """A downloaded model whose backend is confirmed not running must get
+    the specific actionable message (#1600), not a generic not-reachable one."""
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {"qwen2.5-3b-rkllm": ("downloaded_backend_down", "rkllama")})
+    from tinyagentos.routes.agents import update_agent_model, AgentModelUpdate
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-a"}]
+    req = _FakeRequest(agents)
+    body = AgentModelUpdate(model="qwen2.5-3b-rkllm")
+    resp = await update_agent_model(req, "alpha", body)
+    assert resp.status_code == 409
+    import json
+    data = json.loads(resp.body)
+    assert data["model"] == "qwen2.5-3b-rkllm"
+    assert data["backend"] == "rkllama"
+    assert "downloaded" in data["error"]
+    assert "not running" in data["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backend_adapters.py
+++ b/tests/test_backend_adapters.py
@@ -94,6 +94,28 @@ class TestRkLlamaAdapter:
         assert result["status"] == "error"
         assert result["models"] == []
 
+    @pytest.mark.asyncio
+    async def test_unreachable_surfaces_real_connection_error(self):
+        """#1614: a connection failure must carry a specific, actionable
+        reason — not just a bare status the caller has to guess at."""
+        adapter = RkLlamaAdapter()
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+        result = await adapter.health(mock_client, "http://localhost:7833")
+        assert result["status"] == "error"
+        assert "error" in result
+        assert "http://localhost:7833" in result["error"]
+        assert "Connection refused" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_surfaces_timeout_error(self):
+        adapter = RkLlamaAdapter()
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.ConnectTimeout("timed out")
+        result = await adapter.health(mock_client, "http://localhost:7833")
+        assert result["status"] == "error"
+        assert "timed out" in result["error"]
+
 class TestOllamaAdapter:
     @pytest.mark.asyncio
     async def test_parse_tags_response(self):
@@ -155,6 +177,7 @@ class TestCloudAPIAdapter:
         mock_client.get.return_value = resp
         result = await adapter.health(mock_client, "https://api.openai.com/v1")
         assert result["status"] == "error"
+        assert "500" in result["error"]
 
     @pytest.mark.asyncio
     async def test_connection_error_is_error(self):
@@ -165,6 +188,7 @@ class TestCloudAPIAdapter:
         mock_client.get.assert_called_once_with("https://api.openai.com/v1/models", timeout=10)
         assert result["status"] == "error"
         assert result["models"] == []
+        assert "Connection refused" in result["error"]
 
     def test_get_adapter_openai_uses_cloud(self):
         assert isinstance(get_adapter("openai"), CloudAPIAdapter)

--- a/tests/test_routes_agent_deploy.py
+++ b/tests/test_routes_agent_deploy.py
@@ -200,6 +200,26 @@ class TestResolveDeployRouting:
         assert "nonexistent-model" in body["error"]
 
     @pytest.mark.asyncio
+    async def test_model_downloaded_backend_down_returns_actionable_404(self, client):
+        """A downloaded model whose backend is confirmed not running must
+        return a specific, actionable error — not the generic "not found
+        anywhere" message (#1600)."""
+        with patch(
+            "tinyagentos.cluster.model_resolver.resolve_model_location",
+            return_value=ModelLocation(kind="downloaded_backend_down", backend_id="rkllama"),
+        ):
+            r = await client.post(
+                "/api/agents/deploy",
+                json={"name": "test-agent", "model": "qwen2.5-3b-rkllm"},
+            )
+        assert r.status_code == 404
+        body = r.json()
+        assert "downloaded" in body["error"]
+        assert "rkllama" in body["error"]
+        assert "not running" in body["error"]
+        assert body["backend"] == "rkllama"
+
+    @pytest.mark.asyncio
     async def test_model_routed_to_worker_returns_202(self, client):
         """A model on a worker (no pin) must return 202 with routing info."""
         with patch(

--- a/tests/test_routes_providers.py
+++ b/tests/test_routes_providers.py
@@ -14,6 +14,51 @@ class TestProviderAPI:
         resp = await client.post("/api/providers/test", json={"type": "ollama"})
         assert resp.status_code == 422  # Pydantic validation requires url field
 
+    async def test_test_connection_surfaces_real_error(self, client):
+        """#1614: the Test button must show the actual failure reason, not
+        a hardcoded "unknown error" — the adapter's health() result carries
+        a specific message now that it no longer swallows the exception."""
+        class _FailingAdapter:
+            async def health(self, *_a, **_k):
+                return {
+                    "status": "error",
+                    "response_ms": 3,
+                    "models": [],
+                    "error": "Connection refused connecting to http://localhost:7833 — is the service running?",
+                }
+
+        with patch(
+            "tinyagentos.routes.providers.get_adapter",
+            return_value=_FailingAdapter(),
+        ):
+            resp = await client.post(
+                "/api/providers/test",
+                json={"type": "rkllama", "url": "http://localhost:7833"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reachable"] is False
+        assert "Connection refused" in body["error"]
+        assert body["error"] != "unknown error"
+
+    async def test_test_connection_success_has_no_error(self, client):
+        class _HealthyAdapter:
+            async def health(self, *_a, **_k):
+                return {"status": "ok", "response_ms": 12, "models": []}
+
+        with patch(
+            "tinyagentos.routes.providers.get_adapter",
+            return_value=_HealthyAdapter(),
+        ):
+            resp = await client.post(
+                "/api/providers/test",
+                json={"type": "ollama", "url": "http://localhost:11434"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reachable"] is True
+        assert body.get("error") is None
+
     async def test_add_provider(self, client):
         resp = await client.post("/api/providers", json={
             "name": "test-ollama", "type": "ollama",

--- a/tests/test_routes_taos_agent.py
+++ b/tests/test_routes_taos_agent.py
@@ -191,6 +191,32 @@ async def test_put_permitted_models_unreachable_returns_409(client, app, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_put_permitted_models_downloaded_backend_down_returns_actionable_409(client, app, monkeypatch):
+    """A downloaded model whose backend is confirmed down must return the
+    specific "downloaded but backend not running" message (#1599), not the
+    generic "not reachable anywhere" text."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+
+    monkeypatch.setattr(
+        _model_resolver_mod, "resolve_model_location",
+        lambda request, model_id: ModelLocation(
+            kind="downloaded_backend_down", backend_id="rkllama",
+        ),
+    )
+
+    resp = await client.put(
+        "/api/taos-agent/permitted-models",
+        json={"models": ["qwen2.5-3b-rkllm"]},
+    )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert "downloaded" in body["error"].lower()
+    assert "rkllama" in body["error"]
+    assert "not running" in body["error"]
+    assert body["backend"] == "rkllama"
+
+
+@pytest.mark.asyncio
 async def test_put_permitted_models_prepends_current_model(client, app, monkeypatch):
     """The current primary model is always included even if not in the list."""
     await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})

--- a/tinyagentos/backend_adapters.py
+++ b/tinyagentos/backend_adapters.py
@@ -6,6 +6,27 @@ from abc import ABC, abstractmethod
 import httpx
 
 
+def _describe_health_error(exc: Exception, url: str) -> str:
+    """Human-readable reason a health probe against *url* failed.
+
+    Every adapter below used to swallow the real exception and report a
+    bare ``{"status": "error"}`` — the Providers "Test" button then had
+    nothing to show but a hardcoded "unknown error" (#1614). This gives
+    each caught exception a specific, actionable description instead.
+    """
+    if isinstance(exc, httpx.ConnectError):
+        return f"Connection refused connecting to {url} — is the service running?"
+    if isinstance(exc, httpx.ConnectTimeout):
+        return f"Connection to {url} timed out"
+    if isinstance(exc, httpx.TimeoutException):
+        return f"{url} did not respond in time"
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"{url} returned HTTP {exc.response.status_code}"
+    if isinstance(exc, httpx.HTTPError):
+        return f"could not reach {url}: {exc}"
+    return str(exc) or repr(exc)
+
+
 class BackendAdapter(ABC):
     @abstractmethod
     async def health(self, client: httpx.AsyncClient, url: str) -> dict:
@@ -30,9 +51,14 @@ class OllamaCompatAdapter(BackendAdapter):
                 for m in data.get("models", [])
             ]
             return {"status": "ok", "response_ms": elapsed_ms, "models": models}
-        except Exception:
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, url),
+            }
 
 
 class StableDiffusionCppAdapter(BackendAdapter):
@@ -51,9 +77,14 @@ class StableDiffusionCppAdapter(BackendAdapter):
             resp = await client.get(f"{base}/sdapi/v1/options", timeout=10)
             elapsed_ms = int((time.monotonic() - start) * 1000)
             resp.raise_for_status()
-        except Exception:
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, base),
+            }
 
         # Server is alive — fetch model list best-effort; empty list is fine.
         models = []
@@ -88,9 +119,14 @@ class IOPaintAdapter(BackendAdapter):
             resp = await client.get(f"{base}/api/v1/server-config", timeout=10)
             elapsed_ms = int((time.monotonic() - start) * 1000)
             resp.raise_for_status()
-        except Exception:
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, base),
+            }
 
         models = []
         try:
@@ -130,9 +166,14 @@ class OpenAICompatAdapter(BackendAdapter):
             except Exception:
                 pass
             return {"status": "ok", "response_ms": elapsed_ms, "models": models}
-        except Exception:
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, base),
+            }
 
 
 class CloudAPIAdapter(BackendAdapter):
@@ -164,10 +205,20 @@ class CloudAPIAdapter(BackendAdapter):
                     except Exception:
                         pass
                 return {"status": "ok", "response_ms": elapsed_ms, "models": models}
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
-        except Exception:
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": f"{base}/models returned HTTP {resp.status_code}",
+            }
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, base),
+            }
 
 
 # Type aliases for backwards compatibility with tests

--- a/tinyagentos/cluster/model_resolver.py
+++ b/tinyagentos/cluster/model_resolver.py
@@ -30,17 +30,23 @@ class ModelLocation:
     """Result of :func:`find_model_hosts`.
 
     Attributes:
-        kind: One of ``controller`` | ``worker`` | ``cloud`` | ``not_found``.
+        kind: One of ``controller`` | ``worker`` | ``cloud`` | ``not_found``
+            | ``downloaded_backend_down``.
         hosts: Worker names that report the model (empty unless
             ``kind == "worker"``).
         canonical_host: The worker chosen when multiple have the model.
             Stubbed as alphabetical pick — Phase 1.5 will consider load
             and hardware.
+        backend_id: Set only when ``kind == "downloaded_backend_down"`` —
+            the manifest-declared backend (e.g. ``"rkllama"``) that this
+            model needs, confirmed not running right now (see
+            :func:`_check_downloaded_backend_down`).
     """
 
     kind: str
     hosts: list[str] = field(default_factory=list)
     canonical_host: str | None = None
+    backend_id: str | None = None
 
 
 def _normalise(model_id: str) -> str:
@@ -200,6 +206,131 @@ def find_model_hosts(
     return ModelLocation(kind="not_found")
 
 
+# Maps a manifest's ``requires.backends[].id`` to the probe that answers
+# "is this backend actually running on this host right now?" and to the
+# human-facing copy used in actionable error messages. Reuses the exact
+# probes the Setup checklist already relies on (#1535/#1597/#1598) so a
+# model resolver failure and the checklist agree on backend liveness.
+_BACKEND_LABELS: dict[str, str] = {
+    "rkllama": "rkllama NPU backend",
+    "rk-llama-cpp": "rk-llama.cpp NPU backend",
+    "llama-cpp": "llama.cpp backend",
+}
+
+_BACKEND_INSTALL_HINTS: dict[str, str] = {
+    "rkllama": "Install/start it from Setup > Install NPU backend",
+    "rk-llama-cpp": "Install/start it from Setup > Install NPU backend",
+    "llama-cpp": "Install/start it from Setup > Install llama.cpp server",
+}
+
+
+def _backend_is_running(backend_id: str) -> bool | None:
+    """True/False if we can positively probe *backend_id*, else None.
+
+    None means "we don't know how to check this backend" — callers must
+    NOT report it as down on an unknown answer, only on a confirmed-False
+    probe. Never raises: an import or probe error is treated as unknown.
+    """
+    try:
+        if backend_id == "rkllama":
+            from tinyagentos.installers.rkllama_installer import rkllama_is_running
+
+            return rkllama_is_running()
+        if backend_id == "rk-llama-cpp":
+            from tinyagentos.installers.rkllamacpp_installer import rkllamacpp_is_running
+
+            return rkllamacpp_is_running()
+        if backend_id == "llama-cpp":
+            from tinyagentos.installers.llamacpp_installer import llamacpp_is_running
+
+            return llamacpp_is_running()
+    except Exception:  # noqa: BLE001 — probe is best-effort, never break resolution
+        return None
+    return None
+
+
+def _find_model_manifest(registry, model_id: str):
+    """Best-effort manifest lookup for *model_id* against the app registry.
+
+    Tries an exact id match first (the common case — manifest ids like
+    ``qwen2.5-3b-rkllm`` are exactly what wizards/pickers pass through),
+    then falls back to the same loose :func:`_model_matches` used
+    elsewhere in this module. Returns ``None`` on any error or when the
+    registry doesn't know this model at all.
+    """
+    if registry is None:
+        return None
+    try:
+        manifest = registry.get(model_id)
+        if manifest is not None and manifest.type == "model":
+            return manifest
+        for m in registry.list_available(type_filter="model"):
+            if _model_matches(model_id, m.id):
+                return m
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _required_backend_ids(manifest) -> list[str]:
+    """Unique ``requires.backends[].id`` values declared across all variants."""
+    ids: list[str] = []
+    for v in getattr(manifest, "variants", None) or []:
+        for b in (v.get("requires") or {}).get("backends") or []:
+            bid = b.get("id") if isinstance(b, dict) else None
+            if bid and bid not in ids:
+                ids.append(bid)
+    return ids
+
+
+def _check_downloaded_backend_down(request, model_id: str) -> ModelLocation | None:
+    """When *model_id* resolved to ``not_found``, check whether it is a
+    known, downloaded model whose required backend we can positively
+    confirm is not running — the real cause behind #1599/#1600 (an
+    rkllama-backed model that shows as downloaded and selectable but the
+    rkllama server itself isn't up right now).
+
+    Returns a ``downloaded_backend_down`` :class:`ModelLocation` only when
+    every backend the manifest requires is confirmed down. Returns
+    ``None`` (defer to the generic "not found" message) when the manifest
+    is unknown, declares no backend requirement, or we can't positively
+    confirm any required backend is down (never claim a backend is down
+    on an inconclusive probe).
+    """
+    registry = getattr(request.app.state, "registry", None)
+    manifest = _find_model_manifest(registry, model_id)
+    if manifest is None:
+        return None
+    backend_ids = _required_backend_ids(manifest)
+    if not backend_ids:
+        return None
+    down: list[str] = []
+    for backend_id in backend_ids:
+        running = _backend_is_running(backend_id)
+        if running is None:
+            return None
+        if not running:
+            down.append(backend_id)
+    if not down:
+        return None
+    return ModelLocation(kind="downloaded_backend_down", backend_id=down[0])
+
+
+def describe_downloaded_backend_down(location: ModelLocation, model_id: str) -> str:
+    """Actionable error text for a ``downloaded_backend_down`` location.
+
+    Shared by every route that reports model reachability so the wording
+    — and any future fix to it — lives in one place.
+    """
+    backend_id = location.backend_id or ""
+    label = _BACKEND_LABELS.get(backend_id, f"{backend_id} backend" if backend_id else "backend")
+    hint = _BACKEND_INSTALL_HINTS.get(backend_id, f"Install/start the {label}")
+    return (
+        f"model '{model_id}' is downloaded but the {label} that serves it is not "
+        f"running. {hint} and try again."
+    )
+
+
 def collect_cloud_model_ids(config) -> list[str]:
     """Best-effort list of cloud-provider model ids advertised in config.backends.
 
@@ -234,9 +365,14 @@ def resolve_model_location(request, model_id: str) -> ModelLocation:
     local_models = catalog.all_models() if catalog is not None else []
     config = getattr(state, "config", None)
     cloud_models = collect_cloud_model_ids(config) if config is not None else []
-    return find_model_hosts(
+    location = find_model_hosts(
         model_id,
         cluster_state=cluster,
         local_models=local_models,
         cloud_models=cloud_models,
     )
+    if location.kind == "not_found":
+        downloaded_backend_down = _check_downloaded_backend_down(request, model_id)
+        if downloaded_backend_down is not None:
+            return downloaded_backend_down
+    return location

--- a/tinyagentos/cluster/model_resolver.py
+++ b/tinyagentos/cluster/model_resolver.py
@@ -273,9 +273,16 @@ def _find_model_manifest(registry, model_id: str):
 
 
 def _required_backend_ids(manifest) -> list[str]:
-    """Unique ``requires.backends[].id`` values declared across all variants."""
+    """Unique ``requires.backends[].id`` values declared across all variants.
+
+    Variants come straight from parsed manifest YAML (always dicts today),
+    but this runs on the hot HTTP resolution path, so a non-dict variant is
+    skipped rather than allowed to raise and turn a clean 4xx into a 500.
+    """
     ids: list[str] = []
     for v in getattr(manifest, "variants", None) or []:
+        if not isinstance(v, dict):
+            continue
         for b in (v.get("requires") or {}).get("backends") or []:
             bid = b.get("id") if isinstance(b, dict) else None
             if bid and bid not in ids:

--- a/tinyagentos/routes/agent_deploy.py
+++ b/tinyagentos/routes/agent_deploy.py
@@ -61,6 +61,7 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
     """Resolve cross-worker deploy routing for the requested model.
 
     Resolution order (task #176 stub):
+    - downloaded_backend_down: 404 (actionable — start the backend)
     - not_found: 404
     - worker + pin conflict: 409
     - worker (no conflict or no pin): 202 routed
@@ -70,9 +71,22 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
     controller-local deploy path.
     """
     if body.model:
-        from tinyagentos.cluster.model_resolver import resolve_model_location
+        from tinyagentos.cluster.model_resolver import (
+            describe_downloaded_backend_down,
+            resolve_model_location,
+        )
 
         location = resolve_model_location(request, body.model)
+
+        if location.kind == "downloaded_backend_down":
+            return JSONResponse(
+                {
+                    "error": describe_downloaded_backend_down(location, body.model),
+                    "model": body.model,
+                    "backend": location.backend_id,
+                },
+                status_code=404,
+            )
 
         if location.kind == "not_found":
             return JSONResponse(

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1075,9 +1075,22 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         return JSONResponse({"error": "model must not be empty"}, status_code=400)
 
     # Validate reachability against the live cluster state.
-    from tinyagentos.cluster.model_resolver import resolve_model_location
+    from tinyagentos.cluster.model_resolver import (
+        describe_downloaded_backend_down,
+        resolve_model_location,
+    )
 
     location = resolve_model_location(request, model_id)
+
+    if location.kind == "downloaded_backend_down":
+        return JSONResponse(
+            {
+                "error": describe_downloaded_backend_down(location, model_id),
+                "model": model_id,
+                "backend": location.backend_id,
+            },
+            status_code=409,
+        )
 
     if location.kind == "not_found":
         return JSONResponse(
@@ -1175,10 +1188,22 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
     if current and current not in permitted:
         permitted = [current, *permitted]
 
-    from tinyagentos.cluster.model_resolver import resolve_model_location
+    from tinyagentos.cluster.model_resolver import (
+        describe_downloaded_backend_down,
+        resolve_model_location,
+    )
 
     for model_id in permitted:
         location = resolve_model_location(request, model_id)
+        if location.kind == "downloaded_backend_down":
+            return JSONResponse(
+                {
+                    "error": describe_downloaded_backend_down(location, model_id),
+                    "model": model_id,
+                    "backend": location.backend_id,
+                },
+                status_code=409,
+            )
         if location.kind == "not_found":
             return JSONResponse(
                 {"error": f"model '{model_id}' is not reachable anywhere in the cluster right now.", "model": model_id},

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -528,10 +528,17 @@ async def test_provider(request: Request, body: ProviderTest):
         adapter = get_adapter(body.type)
         http_client = request.app.state.http_client
         result = await adapter.health(http_client, body.url)
+        reachable = result["status"] == "ok"
         return {
-            "reachable": result["status"] == "ok",
+            "reachable": reachable,
             "response_ms": result.get("response_ms", 0),
             "models": result.get("models", []),
+            # adapter.health() never raises (see backend_adapters.py) — a
+            # failed probe carries the real reason in result["error"].
+            # Surfacing it here is the actual fix for #1614: the Test
+            # button previously always fell back to "unknown error"
+            # because this response dropped the field entirely.
+            "error": None if reachable else result.get("error", "unknown error"),
         }
     except Exception as e:
         return {"reachable": False, "error": str(e)}

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -300,9 +300,21 @@ async def put_permitted_models(request: Request, body: PermittedModelsUpdate):
         permitted = [current_model, *permitted]
 
     # Validate every model is reachable.
-    from tinyagentos.cluster.model_resolver import resolve_model_location
+    from tinyagentos.cluster.model_resolver import (
+        describe_downloaded_backend_down,
+        resolve_model_location,
+    )
     for model_id in permitted:
         location = resolve_model_location(request, model_id)
+        if location.kind == "downloaded_backend_down":
+            return JSONResponse(
+                {
+                    "error": describe_downloaded_backend_down(location, model_id),
+                    "model": model_id,
+                    "backend": location.backend_id,
+                },
+                status_code=409,
+            )
         if location.kind == "not_found":
             return JSONResponse(
                 {


### PR DESCRIPTION
## Summary

Fixes #1599, #1600, #1614 — all three trace back to the same underlying gap plus one independent bug:

- **Root cause (environmental, confirmed by reading the resolver + BackendCatalog):** an rkllama-backed model only resolves as reachable once the rkllama service itself is running and advertising it — `BackendCatalog.all_models()` only counts live, `status == "ok"` backends. If rkllama isn't running on the reporter's board (most likely: the NPU backend needs to be (re-)started via Setup > Install NPU backend after the #1598 fix), a genuinely-downloaded model is indistinguishable from one that was never downloaded at all, so both `/api/agents/deploy` and the permitted-models endpoints collapsed every failure into the same generic "not found anywhere" text.
- **Independent bug (code, `#1614`):** every backend health-check adapter caught its connection exception and returned a bare `{"status": "error"}` with no reason at all. The Providers "Test" button always fell back to a hardcoded `"unknown error"` regardless of the actual cause (connection refused, timeout, bad HTTP status).

## Changes

- `tinyagentos/cluster/model_resolver.py`: `resolve_model_location` now distinguishes three cases instead of one generic `not_found`:
  - model manifest unknown entirely → unchanged generic message
  - model manifest known, and every backend it declares (`variant.requires.backends`) is confirmed down via the same probes the Setup checklist uses (`rkllama_is_running`, `rkllamacpp_is_running`, `llamacpp_is_running`) → new `downloaded_backend_down` location with an actionable message ("downloaded but the rkllama NPU backend that serves it is not running... Install/start it from Setup > Install NPU backend")
  - anything else (backend confirmed running but model still missing, or backend type unknown) → falls back to the existing generic message; never guesses
- Wired the new `downloaded_backend_down` case into all four routes that report model reachability: `POST /api/agents/deploy`, `PUT /api/taos-agent/permitted-models`, `POST /api/agents/{name}/model`, `PUT /api/agents/{name}/permitted-models`.
- `tinyagentos/backend_adapters.py`: every adapter's `health()` now captures the real exception (`_describe_health_error`) instead of swallowing it — connection refused, timeout, and HTTP-status failures each get a specific message.
- `tinyagentos/routes/providers.py`: `POST /api/providers/test` now forwards that real error to the response instead of dropping the field, so the Test button shows the actual reason instead of "unknown error".

## Test plan

- [x] `python3 -m pytest tests/ -k "provider or resolve or deploy or model" -q` — 765 passed
- [x] New tests: resolver returns `downloaded_backend_down` only when the manifest is known AND its backend is confirmed down (mocked probe), stays `not_found` when the model is unknown or the backend is confirmed running; adapters/`\`/api/providers/test\`` surface the real connection error instead of "unknown error"
- [x] `cd desktop && npm run build` — succeeds
- [x] `npx vitest run src/apps/ProvidersApp.test.tsx` — passes (frontend already reads `testResult.error`; no frontend changes needed)

Fixes #1599, #1600, #1614