### PR TITLE
release: promote dev to master (1.0.0-beta.23 security patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.23] - 2026-07-04
+
+### Security
+- Fixed a high-severity missing-authorization vulnerability (GHSA-h24f-gp4c-8qjm, CWE-862): the skill-execution endpoint `POST /api/skill-exec/{skill_id}/call` ran built-in skills, including one that executes arbitrary Python on the host, without any authorization check, so an authenticated non-admin user could achieve remote code execution as the backend process user. Skill execution now requires an admin session or the host local token (the credential deployed agents authenticate with); a non-admin session is rejected with 403 before any skill code runs, with a defense-in-depth check at the code-execution sink. Reported by EQSTLab.
+
 ## [1.0.0-beta.22] - 2026-07-04
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.22"
+version = "1.0.0-beta.23"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tests/test_skill_exec_authz.py
+++ b/tests/test_skill_exec_authz.py
@@ -1,0 +1,219 @@
+"""Authorization gate for skill EXECUTION (GHSA-h24f-gp4c-8qjm).
+
+``POST /api/skill-exec/{skill_id}/call`` previously had no authorization check
+beyond "any valid session": a plain non-admin user could invoke the built-in
+``code_exec`` skill and get arbitrary Python execution on the host
+(``subprocess.run(["python3", "-c", code])``). The only legitimate callers are
+an admin session or a deployed agent presenting the host's local token (see
+``tinyagentos/routes/skill_exec.py::_is_admin_or_local_token`` and
+``tinyagentos/auth_middleware.py``).
+
+This suite locks in the fix end-to-end through the real ``AuthMiddleware``:
+  (a) a non-admin user session is rejected 403 and ``subprocess.run`` is
+      never invoked;
+  (b) an admin session is allowed;
+  (c) a request presenting the valid local token is allowed;
+  (d) an invalid/absent token from a non-admin caller is rejected and never
+      elevates privilege, and ``subprocess.run`` is never invoked.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+async def _ensure_skills_seeded(app) -> None:
+    """The ``client`` fixture in conftest.py does not initialise app.state.skills
+    (it is untouched by most route tests); execute_skill needs the DB open and
+    the builtin skills (incl. code_exec) seeded before any /call request."""
+    store = app.state.skills
+    if store._db is None:
+        await store.init()
+
+
+async def _member_client(app) -> AsyncClient:
+    """Cookie'd client for a non-admin member session on *app*.
+
+    Requires the admin created by the ``client`` fixture (add_user_invite
+    checks the inviter is an admin), so callers must depend on ``client`` (or
+    otherwise set up the admin) before calling this.
+    """
+    auth_mgr = app.state.auth
+    invite_code = auth_mgr.add_user_invite("member", "admin")
+    auth_mgr.complete_invite(
+        "member", invite_code, "Test Member", "", "memberpass123"
+    )
+    member = auth_mgr.find_user("member")
+    token = auth_mgr.create_session(user_id=member["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+def _fake_subprocess_result() -> MagicMock:
+    result = MagicMock()
+    result.stdout = "hello\n"
+    result.stderr = ""
+    result.returncode = 0
+    return result
+
+
+@pytest.mark.asyncio
+class TestSkillExecAuthz:
+    async def test_non_admin_user_rejected_403_and_no_subprocess(self, client, app):
+        """(a) Plain non-admin user session must be rejected 403 and the
+        subprocess must never run."""
+        await _ensure_skills_seeded(app)
+        member_client = await _member_client(app)
+        try:
+            with patch("subprocess.run") as mock_run:
+                resp = await member_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('should not run')"}},
+                )
+        finally:
+            await member_client.aclose()
+
+        assert resp.status_code == 403
+        assert resp.json() != {"stdout": "hello\n", "stderr": "", "returncode": 0}
+        mock_run.assert_not_called()
+
+    async def test_admin_session_allowed(self, client, app):
+        """(b) An admin session may execute code_exec."""
+        await _ensure_skills_seeded(app)
+        with patch("subprocess.run", return_value=_fake_subprocess_result()) as mock_run:
+            resp = await client.post(
+                "/api/skill-exec/code_exec/call",
+                json={"args": {"code": "print('hello')"}},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["returncode"] == 0
+        mock_run.assert_called_once()
+
+    async def test_valid_local_token_allowed(self, client, app):
+        """(c) A request presenting the valid local token is allowed, with no
+        session cookie at all."""
+        await _ensure_skills_seeded(app)
+        local_token = app.state.auth.get_local_token()
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            with patch("subprocess.run", return_value=_fake_subprocess_result()) as mock_run:
+                resp = await bare_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('hello')"}},
+                    headers={"Authorization": f"Bearer {local_token}"},
+                )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["returncode"] == 0
+        mock_run.assert_called_once()
+
+    async def test_invalid_token_no_session_rejected_and_no_subprocess(self, client, app):
+        """(d) An invalid token with no session at all is rejected (the
+        AuthMiddleware session gate itself denies it) and the subprocess never
+        runs."""
+        await _ensure_skills_seeded(app)
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            with patch("subprocess.run") as mock_run:
+                resp = await bare_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('should not run')"}},
+                    headers={"Authorization": "Bearer not-a-real-token"},
+                )
+        finally:
+            await bare_client.aclose()
+
+        assert resp.status_code in (401, 403)
+        mock_run.assert_not_called()
+
+    async def test_non_admin_session_with_invalid_token_still_rejected(self, client, app):
+        """(d) A non-admin session cannot escalate to local-token auth by also
+        presenting a bogus Bearer token -- the bad token must not be accepted,
+        and the session's own is_admin=False still governs the route gate."""
+        await _ensure_skills_seeded(app)
+        member_client = await _member_client(app)
+        try:
+            with patch("subprocess.run") as mock_run:
+                resp = await member_client.post(
+                    "/api/skill-exec/code_exec/call",
+                    json={"args": {"code": "print('should not run')"}},
+                    headers={"Authorization": "Bearer not-a-real-token"},
+                )
+        finally:
+            await member_client.aclose()
+
+        assert resp.status_code == 403
+        mock_run.assert_not_called()
+
+    async def test_non_admin_user_rejected_for_other_skills_too(self, client, app):
+        """The gate applies to skill execution generally, not just code_exec --
+        a non-admin session must not be able to invoke file_write either."""
+        await _ensure_skills_seeded(app)
+        member_client = await _member_client(app)
+        try:
+            resp = await member_client.post(
+                "/api/skill-exec/file_write/call",
+                json={"args": {"path": "x.txt", "content": "y"}},
+            )
+        finally:
+            await member_client.aclose()
+
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestIsAdminOrLocalToken:
+    """Unit coverage for the gate predicate itself, independent of the route,
+    including the code_exec inline defense-in-depth check."""
+
+    def _request_with_state(self, **state):
+        req = MagicMock()
+        for key, value in state.items():
+            setattr(req.state, key, value)
+        return req
+
+    async def test_predicate_true_for_admin(self):
+        from tinyagentos.routes.skill_exec import _is_admin_or_local_token
+
+        req = self._request_with_state(is_admin=True, via="session")
+        assert _is_admin_or_local_token(req) is True
+
+    async def test_predicate_true_for_local_token_pre_onboarding(self):
+        """is_admin is False before a primary user exists, but via ==
+        'local_token' must still authorize (matches AuthMiddleware)."""
+        from tinyagentos.routes.skill_exec import _is_admin_or_local_token
+
+        req = self._request_with_state(is_admin=False, via="local_token")
+        assert _is_admin_or_local_token(req) is True
+
+    async def test_predicate_false_for_plain_session(self):
+        from tinyagentos.routes.skill_exec import _is_admin_or_local_token
+
+        req = self._request_with_state(is_admin=False, via="session")
+        assert _is_admin_or_local_token(req) is False
+
+    async def test_code_exec_inline_gate_blocks_direct_call_without_route(self):
+        """Defense-in-depth: even calling _skill_code_exec directly (bypassing
+        execute_skill's route-level gate) must not run the subprocess for an
+        unauthorized caller."""
+        from tinyagentos.routes.skill_exec import _skill_code_exec
+
+        req = self._request_with_state(is_admin=False, via="session")
+        with patch("subprocess.run") as mock_run:
+            result = await _skill_code_exec({"code": "print('no')"}, req)
+
+        assert "error" in result
+        mock_run.assert_not_called()

--- a/tests/test_skill_runtime.py
+++ b/tests/test_skill_runtime.py
@@ -26,6 +26,17 @@ from tinyagentos.skills import SkillStore
 @pytest_asyncio.fixture
 async def app_with_store(tmp_path):
     app = FastAPI()
+
+    # This bare app has no AuthMiddleware, so simulate an already-authenticated
+    # admin request (request.state.is_admin) -- these tests exercise the skill
+    # implementations themselves, not the admin-or-local-token authz gate that
+    # execute_skill now enforces (see test_skill_exec_authz.py for that).
+    @app.middleware("http")
+    async def _fake_admin_auth(request, call_next):
+        request.state.is_admin = True
+        request.state.via = "session"
+        return await call_next(request)
+
     app.include_router(router)
     store = SkillStore(tmp_path / "skills.db")
     await store.init()

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.22"
+__version__ = "1.0.0-beta.23"

--- a/tinyagentos/routes/skill_exec.py
+++ b/tinyagentos/routes/skill_exec.py
@@ -25,6 +25,30 @@ router = APIRouter()
 _bg_receipt_tasks: set = set()
 
 
+def _is_admin_or_local_token(request: Request) -> bool:
+    """True if the caller is an admin session or presented the host's local token.
+
+    Skill EXECUTION (unlike the read-only discovery GET) must never be reachable
+    by a plain non-admin user session -- built-in skills include ``code_exec``,
+    which runs ``subprocess.run(["python3", "-c", code])`` against attacker-
+    supplied code, i.e. host RCE (GHSA-h24f-gp4c-8qjm). The legitimate callers
+    are: (a) an admin session, or (b) a deployed agent presenting the
+    ``TAOS_LOCAL_TOKEN`` local token (see ``deployer.py`` + ``AuthManager.
+    validate_local_token``).
+
+    ``AuthMiddleware`` (tinyagentos/auth_middleware.py) sets both signals on
+    ``request.state``: ``is_admin`` is True for an admin session AND for a
+    local token that maps to the primary user, while ``via == "local_token"``
+    is set for a valid local token even in the pre-onboarding edge case where
+    there is no primary user yet (so ``is_admin`` is False there). Checking
+    both keeps agent tool-calls working in every state the middleware allows,
+    without ever accepting a bare non-admin user session.
+    """
+    if getattr(request.state, "is_admin", False):
+        return True
+    return getattr(request.state, "via", None) == "local_token"
+
+
 # ---------------------------------------------------------------------------
 # Built-in skill implementations
 # ---------------------------------------------------------------------------
@@ -145,8 +169,24 @@ async def _skill_web_search(args: dict, request: Request) -> dict:
 
 
 async def _skill_code_exec(args: dict, request: Request) -> dict:
-    """Execute Python code in a basic sandbox."""
+    """Execute Python code in a basic sandbox.
+
+    SECURITY: this is host RCE by design -- ``subprocess.run`` against caller-
+    supplied code with no sandboxing (GHSA-h24f-gp4c-8qjm). ``execute_skill``
+    already gates every skill EXECUTION to admin-or-local-token before this
+    function is ever reached; the check below is deliberate defense-in-depth
+    so a regression in that route-level gate (or any future call site that
+    invokes this function directly) cannot resurrect the non-admin RCE. Do
+    not remove it because it looks redundant.
+
+    TODO(#131): move this to a sandboxed runner (container/seccomp/gVisor)
+    instead of a bare subprocess against the host's python3 -- this comment
+    marks the follow-up; it is out of scope for the authz fix.
+    """
     import subprocess
+
+    if not _is_admin_or_local_token(request):
+        return {"error": "forbidden: code_exec requires admin or local-token auth"}
 
     code = args.get("code", "")
     try:
@@ -496,7 +536,17 @@ def _capture_tool_receipt(request: Request, skill_id: str, args: dict, result) -
 
 @router.post("/api/skill-exec/{skill_id}/call")
 async def execute_skill(skill_id: str, request: Request):
-    """Execute a skill with the given arguments."""
+    """Execute a skill with the given arguments.
+
+    Gated to admin or the host local token (see ``_is_admin_or_local_token``
+    above) -- this EXECUTES skills, including ``code_exec`` (host RCE), so a
+    plain non-admin user session must never reach ``impl(...)`` below
+    (GHSA-h24f-gp4c-8qjm). Checked first, before touching the skill store or
+    parsing args, so no attacker-controlled work happens pre-authorization.
+    """
+    if not _is_admin_or_local_token(request):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
     body = await request.json()
     args = body.get("args", {})
     # Propagate agent_name from the request body into args so file-read

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b22"
+version = "1.0.0b23"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Security patch promotion: fixes GHSA-h24f-gp4c-8qjm (skill-execution missing-authorization RCE, reported by EQSTLab). Skill execution now requires admin or local-token auth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened access control on skill execution so non-admin sessions are blocked with 403 before any execution occurs.
  * Added an extra safeguard to prevent unauthorized code execution even if a request reaches the execution layer.

* **Tests**
  * Added coverage for admin, local token, and non-admin access scenarios.
  * Verified unauthorized requests do not trigger code execution.

* **Chores**
  * Bumped the app version to `1.0.0-beta.23`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

----
## Summary by Gitar

- **Backend diagnostics:**
  - Improved error messages for backend connectivity issues by surfacing the actual cause (connection refused, timeout, etc.) instead of generic "unknown error" labels.
- **Model resolution:**
  - Added a new `downloaded_backend_down` state to `resolve_model_location` to provide actionable instructions when a downloaded model's required backend (e.g., `rkllama`) is not running.
- **OpenCode runtime:**
  - Updated `OpenCodeServer` to resolve the binary location beyond the `PATH`, fixing issues where systemd-run services could not find installed binaries; added `OpenCodeBinaryNotFoundError` to distinguish missing binaries from start-up failures.
- **Session persistence:**
  - Fixed race conditions in `useSessionPersistence` where default theme/wallpaper settings could overwrite user settings before restoration completed; migrated persistence logic to gate on `auth-ready` state.
- **UI/UX improvements:**
  - Fixed a bug in `TaosAssistantWindow` where direct launches (not via "Pop out") rendered as a blank window by removing the conditional `isPopOut` render guard.


<sub>This will update automatically on new commits.</sub>