### PR TITLE
release: promote dev to master (v1.0.0-beta.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.24] - 2026-07-04
+
+### Fixed
+- taOS Agent: the agent chat no longer wrongly reports "runtime unavailable" when opencode is installed system-wide. taOS now finds opencode on the PATH and at its default install location, and when the runtime genuinely can't start it shows the real error instead of a misleading generic message. The taOS Agent dialog also no longer opens as a blank window when launched from the Launchpad or Dock. Reported by @mandresve (#1615, #1616).
+- Settings: theme, wallpaper, dock position and dock icon size now persist across logout/login. They were applying in-session but a restore that ran before login completed left them reverting to defaults on the next session. Reported by @mandresve (#1601, #1603).
+- Models & Providers: when a downloaded model can't be used because the backend that serves it isn't running, taOS now says exactly that and how to fix it (install/start the backend) instead of a generic "not found anywhere", and provider connection tests report the real failure reason instead of "unknown error". Reported by @mandresve (#1599, #1600, #1614).
+
 ## [1.0.0-beta.23] - 2026-07-04
 
 ### Security

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.23",
+      "version": "1.0.0-beta.24",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -11,6 +11,7 @@ import { useSessionPersistence } from "@/hooks/use-session-persistence";
 import { useDeviceMode } from "@/hooks/use-device-mode";
 import { useIsPwa } from "@/hooks/use-is-pwa";
 import { useThemeStore, restoreActiveTheme, installWebkitRepaintGuards } from "@/stores/theme-store";
+import { useOnAuthReady } from "@/hooks/use-on-auth-ready";
 import { useProcessStore } from "@/stores/process-store";
 import { useDockStore } from "@/stores/dock-store";
 import { getApp } from "@/registry/app-registry";
@@ -204,14 +205,26 @@ export function App() {
   // primary push channel; useServerNotifications falls back to polling.
   useEventStream();
 
-  // Re-apply the persisted active theme on app boot so a reload keeps the
-  // user's chosen theme app-wide (not only when Settings is opened).
+  // WebKit blanks backdrop-filter surfaces when the tab is hidden then shown
+  // again (switching back into taOS); re-composite them on return. Not
+  // auth-gated: it only installs a visibility listener, no per-user fetch.
   useEffect(() => {
-    void restoreActiveTheme();
-    // WebKit blanks backdrop-filter surfaces when the tab is hidden then shown
-    // again (switching back into taOS); re-composite them on return.
     installWebkitRepaintGuards();
   }, []);
+
+  // Re-apply the persisted active theme once authenticated, so a reload keeps
+  // the user's chosen theme app-wide (not only when Settings is opened).
+  //
+  // SystemShortcuts mounts as a sibling of LoginGate, before LoginGate's own
+  // /auth/status check resolves, so firing this on bare mount races the auth
+  // check: right after a logout there is no session cookie yet, the fetch
+  // inside restoreActiveTheme 401s, and — since this used to run once on
+  // mount — it was never retried once the user logged back in (#1601).
+  // useOnAuthReady defers it until auth is confirmed and re-runs it on a
+  // later re-login.
+  useOnAuthReady(() => {
+    void restoreActiveTheme();
+  });
 
   // Apply reduce-effects / performance mode (#58) as a root attribute so the CSS
   // in tokens.css can strip blur, big shadows and continuous animations on

--- a/desktop/src/apps/TaosAssistantWindow.test.tsx
+++ b/desktop/src/apps/TaosAssistantWindow.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TaosAssistantWindow } from "./TaosAssistantWindow";
+import { useTaosAgentStore } from "@/stores/taos-agent-store";
+import { useProcessStore } from "@/stores/process-store";
+
+// Mock child that opens a modal — keeps the test surface narrow, mirrors
+// TaosAssistantPanel.test.tsx's approach.
+vi.mock("@/components/TaosAssistantSettings", () => ({
+  TaosAssistantSettings: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="settings-modal" /> : null,
+}));
+
+function resetStores() {
+  useTaosAgentStore.setState({
+    isOpen: false,
+    messages: [],
+    model: "qwen3",
+    streaming: false,
+    settingsOpen: false,
+  });
+  useProcessStore.setState({ windows: [] });
+}
+
+describe("TaosAssistantWindow", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("renders the chat shell when launched directly (no popOut prop) — regression for #1615", () => {
+    // Direct Launchpad/Dock launch calls openWindow("taos-agent", size) with
+    // no props, so windows never carries a matching entry with
+    // props.popOut. The window must still show its UI, not go blank.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ model: "qwen3" }) }),
+    );
+
+    render(<TaosAssistantWindow windowId="win-1" />);
+
+    expect(screen.getByText("taOS agent")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /message taOS agent/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /send message/i })).toBeInTheDocument();
+  });
+
+  it("renders the chat shell when opened via the pop-out button (props.popOut)", () => {
+    useProcessStore.setState({
+      windows: [
+        {
+          id: "win-2",
+          appId: "taos-agent",
+          position: { x: 0, y: 0 },
+          size: { w: 420, h: 640 },
+          zIndex: 1,
+          minimized: false,
+          maximized: false,
+          snapped: null,
+          focused: true,
+          props: { popOut: true },
+          launchNonce: 0,
+        },
+      ],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ model: "qwen3" }) }),
+    );
+
+    render(<TaosAssistantWindow windowId="win-2" />);
+
+    expect(screen.getByText("taOS agent")).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /message taOS agent/i })).toBeInTheDocument();
+  });
+
+  it("surfaces the runtime error inline instead of leaving the dialog blank", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (typeof url === "string" && url.includes("/api/taos-agent/settings")) {
+          return Promise.resolve({ ok: true, json: async () => ({ model: "qwen3" }) });
+        }
+        // /api/taos-agent/chat — simulate the runtime-unavailable 503.
+        return Promise.resolve({
+          ok: false,
+          body: null,
+          text: async () =>
+            JSON.stringify({ error: "opencode is not installed. Install it with: curl -fsSL https://opencode.ai/install | bash" }),
+        });
+      }),
+    );
+
+    render(<TaosAssistantWindow windowId="win-3" />);
+
+    const textarea = screen.getByRole("textbox", { name: /message taOS agent/i });
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    // The shell stays up (input still present) and the error is shown inline.
+    await waitFor(() => {
+      expect(screen.getByText(/opencode is not installed/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("textbox", { name: /message taOS agent/i })).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/TaosAssistantWindow.tsx
+++ b/desktop/src/apps/TaosAssistantWindow.tsx
@@ -6,15 +6,17 @@ export function TaosAssistantWindow({ windowId }: { windowId: string }) {
   const closeWindow = useProcessStore((s) => s.closeWindow);
   const removeWindow = useProcessStore((s) => s.removeWindow);
   const snap = useProcessStore((s) => s.snapWindow);
-  const isPopOut = useProcessStore((s) => s.windows.find((w) => w.id === windowId)?.props?.popOut);
 
   const handleClose = useCallback(() => {
     closeWindow(windowId);
     setTimeout(() => removeWindow(windowId), 250);
   }, [closeWindow, removeWindow, windowId]);
 
-  if (!isPopOut) return null;
-
+  // This window renders the chat unconditionally: it is reached both via the
+  // docked panel's "Pop out" button (which passes props.popOut) and directly
+  // from the Launchpad/dock ("taos-agent" is a regular app-registry entry).
+  // Gating render on props.popOut left the direct-launch path with nothing
+  // to show -- an empty window with no error, no content (#1615).
   return (
     <div className="h-full w-full flex flex-col bg-shell-bg-deep">
       <div className="flex items-center gap-2 px-4 py-3 border-b border-white/5 shrink-0 select-none">

--- a/desktop/src/components/LoginGate.tsx
+++ b/desktop/src/components/LoginGate.tsx
@@ -3,6 +3,7 @@ import { Lock } from "lucide-react";
 import { OnboardingScreen } from "./OnboardingScreen";
 import { OffNetworkScreen } from "./OffNetworkScreen";
 import { SESSION_EXPIRED_EVENT } from "@/lib/auth-guard";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
 
 interface Props {
   children: React.ReactNode;
@@ -60,6 +61,14 @@ export function LoginGate({ children }: Props) {
   useEffect(() => {
     refreshStatus();
   }, [refreshStatus]);
+
+  // Publish auth-readiness for session-scoped restore effects that live
+  // outside LoginGate's children (e.g. useSessionPersistence, active-theme
+  // restore) — they must not fetch per-user data until this flips true, and
+  // must re-fetch the next time it does (see auth-ready-store.ts).
+  useEffect(() => {
+    useAuthReadyStore.getState().setReady(status.phase === "ready");
+  }, [status.phase]);
 
   // Listen for session-expired events from the global auth guard. Any
   // /api/* call returning 401 fires this; we re-run /auth/status which

--- a/desktop/src/hooks/__tests__/use-on-auth-ready.test.ts
+++ b/desktop/src/hooks/__tests__/use-on-auth-ready.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useOnAuthReady } from "../use-on-auth-ready";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
+
+beforeEach(() => {
+  useAuthReadyStore.setState({ ready: false });
+});
+
+describe("useOnAuthReady (#1601, #1603)", () => {
+  it("does not run the callback while logged out", () => {
+    const callback = vi.fn();
+    renderHook(() => useOnAuthReady(callback));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it("runs the callback once auth becomes ready", () => {
+    const callback = vi.fn();
+    renderHook(() => useOnAuthReady(callback));
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-run while still authenticated (no duplicate restores per session)", () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(() => useOnAuthReady(callback));
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+    rerender();
+    rerender();
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the callback again after a logout/login cycle", () => {
+    // This is the exact bug: a theme/settings restore that only ever fires
+    // once on mount is never retried after the user logs back in following
+    // a logout. useOnAuthReady must re-arm on the falling edge so the next
+    // rising edge (the next login) restores the new session's data.
+    const callback = vi.fn();
+    renderHook(() => useOnAuthReady(callback));
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: false }); // logout
+    });
+    act(() => {
+      useAuthReadyStore.setState({ ready: true }); // login again
+    });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+});

--- a/desktop/src/hooks/__tests__/use-session-persistence.test.ts
+++ b/desktop/src/hooks/__tests__/use-session-persistence.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import { useSessionPersistence } from "../use-session-persistence";
 import { useDockStore } from "@/stores/dock-store";
 import { useThemeStore } from "@/stores/theme-store";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
 
 vi.mock("@/registry/app-registry", () => ({
   getApp: () => undefined,
@@ -33,6 +34,10 @@ beforeEach(() => {
     position: "bottom",
   });
   useThemeStore.setState({ wallpaperId: "graphite" } as never);
+  // Baseline: already authenticated, matching the pre-existing tests below
+  // which exercise restore-on-mount in isolation. The auth-gating tests
+  // further down explicitly manipulate this.
+  useAuthReadyStore.setState({ ready: true });
 });
 
 afterEach(() => {
@@ -94,5 +99,120 @@ describe("useSessionPersistence — dock settings restore (#1603)", () => {
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
     expect(useDockStore.getState().iconSize).toBe("medium");
     expect(useDockStore.getState().position).toBe("bottom");
+  });
+});
+
+describe("useSessionPersistence — persistence survives a logout/login cycle (#1601, #1603)", () => {
+  it("does not fetch per-user settings before the session is authenticated", async () => {
+    // SystemShortcuts (which owns this hook) mounts before LoginGate confirms
+    // auth. A mount-gated restore used to fire here regardless, 401 while
+    // logged out, and — having already "run" — never retry after login.
+    useAuthReadyStore.setState({ ready: false });
+    mockFetchWith({
+      "/api/desktop/settings": { wallpaper: "midnight" },
+      "/api/desktop/dock": { iconSize: "large", position: "left" },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    // Give any (wrongly) in-flight effect a tick, then assert nothing fired.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/desktop/settings"),
+    );
+    expect(globalThis.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/desktop/dock"),
+    );
+    expect(useThemeStore.getState().wallpaperId).toBe("graphite");
+    expect(useDockStore.getState().iconSize).toBe("medium");
+  });
+
+  it("restores the saved theme, wallpaper and dock settings once auth flips ready, and re-restores on a later re-login", async () => {
+    // Simulate a full app boot: SystemShortcuts mounts first (pre-auth), then
+    // LoginGate resolves /auth/status and the user logs in.
+    useAuthReadyStore.setState({ ready: false });
+    mockFetchWith({
+      "/api/desktop/settings": { wallpaper: "midnight" },
+      "/api/desktop/dock": { iconSize: "large", position: "left" },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    // Still logged out: the store must stay at its defaults, not midnight/large.
+    expect(useThemeStore.getState().wallpaperId).toBe("graphite");
+
+    // Login completes.
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("midnight");
+      expect(useDockStore.getState().iconSize).toBe("large");
+      expect(useDockStore.getState().position).toBe("left");
+    });
+
+    // Logout, then a second login as a user with different saved settings —
+    // the restore must run again, not stay stuck on the first session's values.
+    act(() => {
+      useAuthReadyStore.setState({ ready: false });
+    });
+    useDockStore.setState({ iconSize: "medium", position: "bottom" });
+    useThemeStore.setState({ wallpaperId: "graphite" } as never);
+    mockFetchWith({
+      "/api/desktop/settings": { wallpaper: "aurora" },
+      "/api/desktop/dock": { iconSize: "small", position: "bottom" },
+    });
+
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("aurora");
+      expect(useDockStore.getState().iconSize).toBe("small");
+    });
+  });
+
+  it("does not let a debounced auto-save clobber the backend with default values while restore is still in flight", async () => {
+    // Regression for the residual race: the old code gated every auto-save
+    // effect on the same flag the restore effect flipped the instant it
+    // *started* (not once its fetch resolved), so a slow restore GET could
+    // lose to a faster debounced auto-save PUT carrying the pre-restore
+    // default value. Here the wallpaper GET is deliberately slower than the
+    // 500ms auto-save debounce.
+    useAuthReadyStore.setState({ ready: false });
+    let resolveSettings: (body: unknown) => void = () => {};
+    const slowSettings = new Promise<unknown>((resolve) => {
+      resolveSettings = resolve;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/api/desktop/settings")) {
+        return slowSettings.then((body) => new Response(JSON.stringify(body)));
+      }
+      return Promise.resolve(new Response(JSON.stringify({})));
+    });
+
+    renderHook(() => useSessionPersistence());
+    act(() => {
+      useAuthReadyStore.setState({ ready: true });
+    });
+
+    // Let time pass well beyond the 500ms wallpaper auto-save debounce while
+    // the settings GET is still unresolved.
+    await new Promise((r) => setTimeout(r, 700));
+    const putCalls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([input, init]) =>
+        (typeof input === "string" ? input : input.toString()).includes("/api/desktop/settings") &&
+        (init as RequestInit | undefined)?.method === "PUT",
+    );
+    expect(putCalls).toHaveLength(0);
+
+    // Restore finally resolves with the real saved wallpaper.
+    resolveSettings({ wallpaper: "ocean" });
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("ocean");
+    });
   });
 });

--- a/desktop/src/hooks/use-on-auth-ready.ts
+++ b/desktop/src/hooks/use-on-auth-ready.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from "react";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
+
+// Runs `callback` once per authenticated session: the first time
+// auth-ready flips true, and again after it drops back to false and flips
+// true a second time (i.e. a subsequent login). Does NOT run while logged
+// out, and does not re-run on every render while still logged in.
+//
+// Extracted so session-scoped restore effects (active-theme, desktop
+// settings) that live outside LoginGate's children can share the same fix
+// for #1601/#1603: those effects used to run unconditionally on mount,
+// before LoginGate's /auth/status check resolves, so they either 401'd
+// against a logged-out session or read stale data — and, having already
+// "run" once, were never retried after the user actually logged in.
+export function useOnAuthReady(callback: () => void) {
+  const ranForThisSession = useRef(false);
+  const authReady = useAuthReadyStore((s) => s.ready);
+
+  useEffect(() => {
+    if (!authReady) {
+      ranForThisSession.current = false;
+      return;
+    }
+    if (ranForThisSession.current) return;
+    ranForThisSession.current = true;
+    callback();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authReady]);
+}

--- a/desktop/src/hooks/use-session-persistence.ts
+++ b/desktop/src/hooks/use-session-persistence.ts
@@ -7,6 +7,7 @@ import { getApp } from "@/registry/app-registry";
 import { useBrowserStore } from "@/stores/browser-store";
 import { loadWindows as loadBrowserWindows, saveWindows as saveBrowserWindows } from "@/lib/browser-windows-api";
 import type { BrowserWindowState } from "@/apps/BrowserApp/types";
+import { useAuthReadyStore } from "@/stores/auth-ready-store";
 
 interface SavedWindow {
   appId: string;
@@ -33,15 +34,39 @@ export function useSessionPersistence() {
 
   const browserWindows = useBrowserStore((s) => s.windows);
 
+  const authReady = useAuthReadyStore((s) => s.ready);
+
+  // `restored` guards the whole restore effect below (fires once per
+  // authenticated session). `dockRestored`/`wallpaperRestored` gate their own
+  // auto-save effects independently: the shared `restored` flag used to flip
+  // true the instant the effect *started*, not once its fetches actually
+  // landed, so a debounced auto-save (500ms wallpaper / 1s dock) could fire
+  // with the still-default in-memory value and overwrite the real saved
+  // setting before the slower restore GET came back (#1601, #1603).
   const restored = useRef(false);
+  const dockRestored = useRef(false);
+  const wallpaperRestored = useRef(false);
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dockTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wallpaperTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const widgetSaveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const browserSaveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Restore everything on mount (once)
+  // Restore everything once authenticated (once per session).
+  //
+  // SystemShortcuts (which owns this hook) mounts as a sibling of LoginGate,
+  // before LoginGate's /auth/status check resolves, so a mount-gated restore
+  // fires while logged out, 401s, and — since it only ran once — is never
+  // retried after a subsequent login. Gating on `authReady` (and resetting
+  // when it drops) means a fresh login always re-fetches this session's
+  // settings instead of leaving the defaults the pre-auth attempt left behind.
   useEffect(() => {
+    if (!authReady) {
+      restored.current = false;
+      dockRestored.current = false;
+      wallpaperRestored.current = false;
+      return;
+    }
     if (restored.current) return;
     restored.current = true;
 
@@ -80,7 +105,10 @@ export function useSessionPersistence() {
           useDockStore.getState().setPosition(data.position);
         }
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => {
+        dockRestored.current = true;
+      });
 
     // Restore wallpaper
     fetch("/api/desktop/settings")
@@ -90,7 +118,10 @@ export function useSessionPersistence() {
           useThemeStore.getState().setWallpaper(data.wallpaper);
         }
       })
-      .catch(() => {});
+      .catch(() => {})
+      .finally(() => {
+        wallpaperRestored.current = true;
+      });
 
     // Restore widgets
     fetch("/api/desktop/widgets")
@@ -125,7 +156,7 @@ export function useSessionPersistence() {
         useBrowserStore.setState({ windows });
       })
       .catch(() => {});
-  }, [openWindow, updatePosition, updateSize, maximizeWindow, snapWindow]);
+  }, [authReady, openWindow, updatePosition, updateSize, maximizeWindow, snapWindow]);
 
   // Auto-save windows (debounced 2s)
   useEffect(() => {
@@ -155,9 +186,13 @@ export function useSessionPersistence() {
     };
   }, [windows]);
 
-  // Auto-save dock (debounced 1s)
+  // Auto-save dock (debounced 1s). Gated on dockRestored, not the outer
+  // `restored` flag: that flips true the instant the restore effect starts,
+  // before its fetch resolves, so this would otherwise fire on mount with
+  // the still-default dock state and could beat a slow restore GET to the
+  // backend, overwriting the real saved dock settings (#1603).
   useEffect(() => {
-    if (!restored.current) return;
+    if (!dockRestored.current) return;
 
     if (dockTimeout.current) clearTimeout(dockTimeout.current);
     dockTimeout.current = setTimeout(() => {
@@ -173,9 +208,10 @@ export function useSessionPersistence() {
     };
   }, [pinned, dockIconSize, dockPosition]);
 
-  // Auto-save wallpaper (debounced 500ms)
+  // Auto-save wallpaper (debounced 500ms). Gated on wallpaperRestored (see
+  // the dock effect above for why the outer `restored` flag isn't enough).
   useEffect(() => {
-    if (!restored.current) return;
+    if (!wallpaperRestored.current) return;
 
     if (wallpaperTimeout.current) clearTimeout(wallpaperTimeout.current);
     wallpaperTimeout.current = setTimeout(() => {

--- a/desktop/src/stores/auth-ready-store.ts
+++ b/desktop/src/stores/auth-ready-store.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+// Tracks whether LoginGate has confirmed an authenticated session and is
+// rendering the real desktop (its "ready" phase), as opposed to the loading /
+// login / onboarding screens.
+//
+// SystemShortcuts (which drives useSessionPersistence and the active-theme
+// restore) mounts as a sibling of LoginGate, before LoginGate's own
+// /auth/status check resolves. Firing per-user restore fetches on bare
+// component mount therefore races the auth check: right after a logout, the
+// next mount has no session cookie yet, so the restore requests 401 and are
+// never retried once the user actually logs back in (#1601, #1603). Restore
+// effects gate on `ready` instead of mount, and reset when it drops back to
+// false so a subsequent login re-fetches that session's saved settings.
+interface AuthReadyStore {
+  ready: boolean;
+  setReady: (ready: boolean) => void;
+}
+
+export const useAuthReadyStore = create<AuthReadyStore>((set) => ({
+  ready: false,
+  setReady: (ready) => set({ ready }),
+}));

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.23"
+version = "1.0.0-beta.24"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tests/cluster/test_model_resolver.py
+++ b/tests/cluster/test_model_resolver.py
@@ -88,7 +88,7 @@ class TestCollectCloudModelIds:
 
 
 class TestResolveModelLocation:
-    def _make_request(self, *, local_model_names=None, backends=None, workers=None):
+    def _make_request(self, *, local_model_names=None, backends=None, workers=None, registry=None):
         """Build a minimal fake request with app.state wired up."""
         local_model_names = local_model_names or []
         backends = backends or []
@@ -107,6 +107,7 @@ class TestResolveModelLocation:
             cluster_manager=cluster,
             backend_catalog=catalog,
             config=config,
+            registry=registry,
         )
 
         app = SimpleNamespace(state=state)
@@ -144,4 +145,86 @@ class TestResolveModelLocation:
         # No backend_catalog attribute at all
         request = SimpleNamespace(app=SimpleNamespace(state=state))
         location = resolve_model_location(request, "some-model")
+        assert location.kind == "not_found"
+
+
+class TestDownloadedBackendDown:
+    """#1599/#1600: a downloaded rkllama model whose serving backend has
+    crashed/stopped must not report the generic "not found anywhere"
+    error — it should say exactly that the backend is down."""
+
+    def _manifest(self, model_id="qwen2.5-3b-rkllm", backend_id="rkllama"):
+        return SimpleNamespace(
+            id=model_id,
+            type="model",
+            variants=[
+                {"id": "w8a8", "requires": {"backends": [{"id": backend_id}]}},
+            ],
+        )
+
+    def _registry(self, manifest=None):
+        manifests = [manifest] if manifest else []
+        return SimpleNamespace(
+            get=lambda mid: next((m for m in manifests if m.id == mid), None),
+            list_available=lambda type_filter=None: manifests,
+        )
+
+    def _make_request(self, *, registry=None):
+        catalog = SimpleNamespace(all_models=lambda: [])
+        cluster = SimpleNamespace(get_workers=lambda: [])
+        config = SimpleNamespace(backends=[])
+        state = SimpleNamespace(
+            cluster_manager=cluster,
+            backend_catalog=catalog,
+            config=config,
+            registry=registry,
+        )
+        return SimpleNamespace(app=SimpleNamespace(state=state))
+
+    def test_downloaded_model_with_backend_confirmed_down_is_actionable(self, monkeypatch):
+        import tinyagentos.installers.rkllama_installer as rk
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+
+        manifest = self._manifest()
+        request = self._make_request(registry=self._registry(manifest))
+
+        location = resolve_model_location(request, "qwen2.5-3b-rkllm")
+        assert location.kind == "downloaded_backend_down"
+        assert location.backend_id == "rkllama"
+
+    def test_unknown_model_stays_not_found_even_with_backend_down(self, monkeypatch):
+        """A model with no manifest at all must NOT get the "downloaded"
+        message — the resolver can't claim it's downloaded when it never
+        heard of it."""
+        import tinyagentos.installers.rkllama_installer as rk
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: False)
+
+        request = self._make_request(registry=self._registry(manifest=None))
+
+        location = resolve_model_location(request, "totally-unknown-model")
+        assert location.kind == "not_found"
+
+    def test_backend_running_falls_back_to_generic_not_found(self, monkeypatch):
+        """If the backend IS confirmed running but the model still isn't in
+        any live catalog (e.g. a stale poll), that's a genuinely-unreachable
+        case, not the actionable "backend down" case."""
+        import tinyagentos.installers.rkllama_installer as rk
+        monkeypatch.setattr(rk, "rkllama_is_running", lambda: True)
+
+        manifest = self._manifest()
+        request = self._make_request(registry=self._registry(manifest))
+
+        location = resolve_model_location(request, "qwen2.5-3b-rkllm")
+        assert location.kind == "not_found"
+
+    def test_no_registry_falls_back_to_not_found(self):
+        request = self._make_request(registry=None)
+        location = resolve_model_location(request, "qwen2.5-3b-rkllm")
+        assert location.kind == "not_found"
+
+    def test_manifest_without_backend_requirement_falls_back_to_not_found(self):
+        manifest = SimpleNamespace(id="cloud-only-model", type="model", variants=[{"id": "v1"}])
+        request = self._make_request(registry=self._registry(manifest))
+
+        location = resolve_model_location(request, "cloud-only-model")
         assert location.kind == "not_found"

--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -90,8 +90,12 @@ def _patch_save(monkeypatch):
     monkeypatch.setattr(mod, "save_config_locked", _noop_save)
 
 
-def _make_location(kind):
-    return ModelLocation(kind=kind)
+def _make_location(kind_or_tuple):
+    """kind_or_tuple is either a bare kind string, or (kind, backend_id)."""
+    if isinstance(kind_or_tuple, tuple):
+        kind, backend_id = kind_or_tuple
+        return ModelLocation(kind=kind, backend_id=backend_id)
+    return ModelLocation(kind=kind_or_tuple)
 
 
 def _patch_resolver(monkeypatch, mapping: dict):
@@ -197,6 +201,26 @@ async def test_put_permitted_unreachable_model_returns_409(monkeypatch):
     import json
     data = json.loads(resp.body)
     assert data["model"] == "bad-model"
+
+
+@pytest.mark.asyncio
+async def test_put_permitted_downloaded_backend_down_returns_actionable_409(monkeypatch):
+    """A downloaded model whose backend is confirmed not running must get
+    the specific actionable message, not the generic "not reachable" one."""
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {"qwen2.5-3b-rkllm": ("downloaded_backend_down", "rkllama")})
+    from tinyagentos.routes.agents import set_permitted_models, PermittedModelsUpdate
+    agents = [{"name": "alpha", "model": "llama3"}]
+    req = _FakeRequest(agents)
+    body = PermittedModelsUpdate(models=["llama3", "qwen2.5-3b-rkllm"])
+    resp = await set_permitted_models(req, "alpha", body)
+    assert resp.status_code == 409
+    import json
+    data = json.loads(resp.body)
+    assert data["model"] == "qwen2.5-3b-rkllm"
+    assert data["backend"] == "rkllama"
+    assert "downloaded" in data["error"]
+    assert "not running" in data["error"]
 
 
 @pytest.mark.asyncio
@@ -319,6 +343,26 @@ async def test_update_agent_model_adds_new_model_to_permitted(monkeypatch):
     assert rescope_calls
     models_sent = rescope_calls[-1]["json"]["models"]
     assert "qwen3" in models_sent
+
+
+@pytest.mark.asyncio
+async def test_update_agent_model_downloaded_backend_down_returns_actionable_409(monkeypatch):
+    """A downloaded model whose backend is confirmed not running must get
+    the specific actionable message (#1600), not a generic not-reachable one."""
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {"qwen2.5-3b-rkllm": ("downloaded_backend_down", "rkllama")})
+    from tinyagentos.routes.agents import update_agent_model, AgentModelUpdate
+    agents = [{"name": "alpha", "model": "llama3", "llm_key": "sk-a"}]
+    req = _FakeRequest(agents)
+    body = AgentModelUpdate(model="qwen2.5-3b-rkllm")
+    resp = await update_agent_model(req, "alpha", body)
+    assert resp.status_code == 409
+    import json
+    data = json.loads(resp.body)
+    assert data["model"] == "qwen2.5-3b-rkllm"
+    assert data["backend"] == "rkllama"
+    assert "downloaded" in data["error"]
+    assert "not running" in data["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_backend_adapters.py
+++ b/tests/test_backend_adapters.py
@@ -94,6 +94,28 @@ class TestRkLlamaAdapter:
         assert result["status"] == "error"
         assert result["models"] == []
 
+    @pytest.mark.asyncio
+    async def test_unreachable_surfaces_real_connection_error(self):
+        """#1614: a connection failure must carry a specific, actionable
+        reason — not just a bare status the caller has to guess at."""
+        adapter = RkLlamaAdapter()
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+        result = await adapter.health(mock_client, "http://localhost:7833")
+        assert result["status"] == "error"
+        assert "error" in result
+        assert "http://localhost:7833" in result["error"]
+        assert "Connection refused" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_timeout_surfaces_timeout_error(self):
+        adapter = RkLlamaAdapter()
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.ConnectTimeout("timed out")
+        result = await adapter.health(mock_client, "http://localhost:7833")
+        assert result["status"] == "error"
+        assert "timed out" in result["error"]
+
 class TestOllamaAdapter:
     @pytest.mark.asyncio
     async def test_parse_tags_response(self):
@@ -155,6 +177,7 @@ class TestCloudAPIAdapter:
         mock_client.get.return_value = resp
         result = await adapter.health(mock_client, "https://api.openai.com/v1")
         assert result["status"] == "error"
+        assert "500" in result["error"]
 
     @pytest.mark.asyncio
     async def test_connection_error_is_error(self):
@@ -165,6 +188,7 @@ class TestCloudAPIAdapter:
         mock_client.get.assert_called_once_with("https://api.openai.com/v1/models", timeout=10)
         assert result["status"] == "error"
         assert result["models"] == []
+        assert "Connection refused" in result["error"]
 
     def test_get_adapter_openai_uses_cloud(self):
         assert isinstance(get_adapter("openai"), CloudAPIAdapter)

--- a/tests/test_desktop_settings.py
+++ b/tests/test_desktop_settings.py
@@ -76,3 +76,47 @@ async def test_widgets_roundtrip(store):
 async def test_widgets_default_empty(store):
     result = await store.get_widgets("user")
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_preference_roundtrip(store):
+    """save_preference/get_preference back the active-theme persistence path
+    (#1601): the theme id is stored via this namespaced blob, not the
+    settings/dock rows."""
+    await store.save_preference("user", "themes", {"active_theme_id": "indigo"})
+    pref = await store.get_preference("user", "themes")
+    assert pref == {"active_theme_id": "indigo"}
+
+
+@pytest.mark.asyncio
+async def test_preference_default_empty(store):
+    pref = await store.get_preference("user", "themes")
+    assert pref == {}
+
+
+@pytest.mark.asyncio
+async def test_settings_and_dock_survive_a_new_store_instance_on_the_same_db(tmp_path):
+    """Regression: settings/dock/preferences must be durable across a fresh
+    DesktopSettingsStore pointed at the same db_path (simulating a controller
+    restart or a new login session opening its own store instance), not just
+    within the connection that wrote them."""
+    db_path = tmp_path / "desktop.db"
+
+    first = DesktopSettingsStore(db_path)
+    await first.init()
+    await first.update_settings("user", {"wallpaper": "aurora"})
+    await first.update_dock("user", {"iconSize": "large", "position": "left"})
+    await first.save_preference("user", "themes", {"active_theme_id": "indigo"})
+    await first.close()
+
+    second = DesktopSettingsStore(db_path)
+    await second.init()
+    try:
+        settings = await second.get_settings("user")
+        assert settings["wallpaper"] == "aurora"
+        assert settings["dock"]["iconSize"] == "large"
+        assert settings["dock"]["position"] == "left"
+        pref = await second.get_preference("user", "themes")
+        assert pref == {"active_theme_id": "indigo"}
+    finally:
+        await second.close()

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -223,6 +223,68 @@ async def test_ensure_running_raises_on_timeout(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# resolve_opencode_binary / OpenCodeBinaryNotFoundError (#1616)
+#
+# opencode's official installer places the binary at ~/.opencode/bin/opencode
+# and only makes it reachable via a shell-rc PATH export, which a systemd
+# service never sources. resolve_opencode_binary() must fall back to that
+# fixed location, and ensure_running() must translate a genuine "not found"
+# into a distinct, actionable exception rather than a generic subprocess error.
+# ---------------------------------------------------------------------------
+
+class TestResolveOpencodeBinary:
+    def test_prefers_path_lookup(self, monkeypatch):
+        from tinyagentos import opencode_runtime as ocr
+
+        monkeypatch.setattr(ocr.shutil, "which", lambda name: "/usr/local/bin/opencode")
+        assert ocr.resolve_opencode_binary() == "/usr/local/bin/opencode"
+
+    def test_falls_back_to_installer_default_location(self, tmp_path, monkeypatch):
+        from tinyagentos import opencode_runtime as ocr
+
+        fake_home = tmp_path / "home"
+        opencode_dir = fake_home / ".opencode" / "bin"
+        opencode_dir.mkdir(parents=True)
+        binary = opencode_dir / "opencode"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        monkeypatch.setattr(ocr.shutil, "which", lambda name: None)
+        monkeypatch.setattr(ocr.Path, "home", classmethod(lambda cls: fake_home))
+
+        assert ocr.resolve_opencode_binary() == str(binary)
+
+    def test_returns_none_when_not_installed_anywhere(self, tmp_path, monkeypatch):
+        from tinyagentos import opencode_runtime as ocr
+
+        monkeypatch.setattr(ocr.shutil, "which", lambda name: None)
+        monkeypatch.setattr(ocr.Path, "home", classmethod(lambda cls: tmp_path / "no-home"))
+
+        assert ocr.resolve_opencode_binary() is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_running_raises_binary_not_found_error(tmp_path, monkeypatch):
+    """A bare exec failure (binary missing everywhere) surfaces as
+    OpenCodeBinaryNotFoundError, distinguishable from a start/health failure."""
+    from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
+
+    cfg = _make_server_cfg(tmp_path)
+    server = OpenCodeServer(cfg)
+
+    async def fake_create_subprocess(*args, **kwargs):
+        raise FileNotFoundError("[Errno 2] No such file or directory: 'opencode'")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess)
+    monkeypatch.setattr(
+        "tinyagentos.opencode_runtime.resolve_opencode_binary", lambda: None
+    )
+
+    with pytest.raises(OpenCodeBinaryNotFoundError):
+        await server.ensure_running(deadline_s=0.05, poll_s=0.01)
+
+
+# ---------------------------------------------------------------------------
 # drive_turn — sink wiring
 # ---------------------------------------------------------------------------
 

--- a/tests/test_routes_agent_deploy.py
+++ b/tests/test_routes_agent_deploy.py
@@ -200,6 +200,26 @@ class TestResolveDeployRouting:
         assert "nonexistent-model" in body["error"]
 
     @pytest.mark.asyncio
+    async def test_model_downloaded_backend_down_returns_actionable_404(self, client):
+        """A downloaded model whose backend is confirmed not running must
+        return a specific, actionable error — not the generic "not found
+        anywhere" message (#1600)."""
+        with patch(
+            "tinyagentos.cluster.model_resolver.resolve_model_location",
+            return_value=ModelLocation(kind="downloaded_backend_down", backend_id="rkllama"),
+        ):
+            r = await client.post(
+                "/api/agents/deploy",
+                json={"name": "test-agent", "model": "qwen2.5-3b-rkllm"},
+            )
+        assert r.status_code == 404
+        body = r.json()
+        assert "downloaded" in body["error"]
+        assert "rkllama" in body["error"]
+        assert "not running" in body["error"]
+        assert body["backend"] == "rkllama"
+
+    @pytest.mark.asyncio
     async def test_model_routed_to_worker_returns_202(self, client):
         """A model on a worker (no pin) must return 202 with routing info."""
         with patch(

--- a/tests/test_routes_providers.py
+++ b/tests/test_routes_providers.py
@@ -14,6 +14,51 @@ class TestProviderAPI:
         resp = await client.post("/api/providers/test", json={"type": "ollama"})
         assert resp.status_code == 422  # Pydantic validation requires url field
 
+    async def test_test_connection_surfaces_real_error(self, client):
+        """#1614: the Test button must show the actual failure reason, not
+        a hardcoded "unknown error" — the adapter's health() result carries
+        a specific message now that it no longer swallows the exception."""
+        class _FailingAdapter:
+            async def health(self, *_a, **_k):
+                return {
+                    "status": "error",
+                    "response_ms": 3,
+                    "models": [],
+                    "error": "Connection refused connecting to http://localhost:7833 — is the service running?",
+                }
+
+        with patch(
+            "tinyagentos.routes.providers.get_adapter",
+            return_value=_FailingAdapter(),
+        ):
+            resp = await client.post(
+                "/api/providers/test",
+                json={"type": "rkllama", "url": "http://localhost:7833"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reachable"] is False
+        assert "Connection refused" in body["error"]
+        assert body["error"] != "unknown error"
+
+    async def test_test_connection_success_has_no_error(self, client):
+        class _HealthyAdapter:
+            async def health(self, *_a, **_k):
+                return {"status": "ok", "response_ms": 12, "models": []}
+
+        with patch(
+            "tinyagentos.routes.providers.get_adapter",
+            return_value=_HealthyAdapter(),
+        ):
+            resp = await client.post(
+                "/api/providers/test",
+                json={"type": "ollama", "url": "http://localhost:11434"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["reachable"] is True
+        assert body.get("error") is None
+
     async def test_add_provider(self, client):
         resp = await client.post("/api/providers", json={
             "name": "test-ollama", "type": "ollama",

--- a/tests/test_routes_taos_agent.py
+++ b/tests/test_routes_taos_agent.py
@@ -191,6 +191,32 @@ async def test_put_permitted_models_unreachable_returns_409(client, app, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_put_permitted_models_downloaded_backend_down_returns_actionable_409(client, app, monkeypatch):
+    """A downloaded model whose backend is confirmed down must return the
+    specific "downloaded but backend not running" message (#1599), not the
+    generic "not reachable anywhere" text."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+
+    monkeypatch.setattr(
+        _model_resolver_mod, "resolve_model_location",
+        lambda request, model_id: ModelLocation(
+            kind="downloaded_backend_down", backend_id="rkllama",
+        ),
+    )
+
+    resp = await client.put(
+        "/api/taos-agent/permitted-models",
+        json={"models": ["qwen2.5-3b-rkllm"]},
+    )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert "downloaded" in body["error"].lower()
+    assert "rkllama" in body["error"]
+    assert "not running" in body["error"]
+    assert body["backend"] == "rkllama"
+
+
+@pytest.mark.asyncio
 async def test_put_permitted_models_prepends_current_model(client, app, monkeypatch):
     """The current primary model is always included even if not in the list."""
     await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -123,6 +123,66 @@ async def test_chat_proxy_not_running_returns_503(client, app):
 
 
 # ---------------------------------------------------------------------------
+# #1616 — opencode-not-found vs opencode-found-but-failed-to-start must
+# return distinct, accurate errors (the old code masked both behind a single
+# generic "check that opencode is installed" message).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_opencode_binary_not_found_returns_install_instructions(client, app, monkeypatch):
+    """When opencode genuinely isn't installed anywhere, the error tells the
+    user to install it -- not a vague "unavailable" message."""
+    from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
+
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+
+    async def fake_ensure_server(state, model):
+        raise OpenCodeBinaryNotFoundError("opencode binary not found (tried 'opencode')")
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hello"}]},
+    )
+    assert resp.status_code == 503
+    error = resp.json().get("error", "")
+    assert "install" in error.lower()
+    assert "opencode.ai/install" in error
+
+
+@pytest.mark.asyncio
+async def test_chat_opencode_start_failure_surfaces_real_error(client, app, monkeypatch):
+    """When opencode is found but fails to start, the real failure reason is
+    surfaced -- not masked behind the same generic message as a missing
+    binary. This must be text distinguishable from the not-found case."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+
+    async def fake_ensure_server(state, model):
+        raise TimeoutError("opencode server on port 4188 did not become healthy within 180.0s")
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hello"}]},
+    )
+    assert resp.status_code == 503
+    error = resp.json().get("error", "")
+    # The real failure reason must be present, not swallowed.
+    assert "did not become healthy" in error
+    assert "install" not in error.lower()
+
+
+# ---------------------------------------------------------------------------
 # Happy-path: two deltas then final → delta, delta, done
 # ---------------------------------------------------------------------------
 

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.23"
+__version__ = "1.0.0-beta.24"

--- a/tinyagentos/backend_adapters.py
+++ b/tinyagentos/backend_adapters.py
@@ -6,6 +6,27 @@ from abc import ABC, abstractmethod
 import httpx
 
 
+def _describe_health_error(exc: Exception, url: str) -> str:
+    """Human-readable reason a health probe against *url* failed.
+
+    Every adapter below used to swallow the real exception and report a
+    bare ``{"status": "error"}`` — the Providers "Test" button then had
+    nothing to show but a hardcoded "unknown error" (#1614). This gives
+    each caught exception a specific, actionable description instead.
+    """
+    if isinstance(exc, httpx.ConnectError):
+        return f"Connection refused connecting to {url} — is the service running?"
+    if isinstance(exc, httpx.ConnectTimeout):
+        return f"Connection to {url} timed out"
+    if isinstance(exc, httpx.TimeoutException):
+        return f"{url} did not respond in time"
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"{url} returned HTTP {exc.response.status_code}"
+    if isinstance(exc, httpx.HTTPError):
+        return f"could not reach {url}: {exc}"
+    return str(exc) or repr(exc)
+
+
 class BackendAdapter(ABC):
     @abstractmethod
     async def health(self, client: httpx.AsyncClient, url: str) -> dict:
@@ -30,9 +51,14 @@ class OllamaCompatAdapter(BackendAdapter):
                 for m in data.get("models", [])
             ]
             return {"status": "ok", "response_ms": elapsed_ms, "models": models}
-        except Exception:
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, url),
+            }
 
 
 class StableDiffusionCppAdapter(BackendAdapter):
@@ -51,9 +77,14 @@ class StableDiffusionCppAdapter(BackendAdapter):
             resp = await client.get(f"{base}/sdapi/v1/options", timeout=10)
             elapsed_ms = int((time.monotonic() - start) * 1000)
             resp.raise_for_status()
-        except Exception:
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, base),
+            }
 
         # Server is alive — fetch model list best-effort; empty list is fine.
         models = []
@@ -88,9 +119,14 @@ class IOPaintAdapter(BackendAdapter):
             resp = await client.get(f"{base}/api/v1/server-config", timeout=10)
             elapsed_ms = int((time.monotonic() - start) * 1000)
             resp.raise_for_status()
-        except Exception:
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, base),
+            }
 
         models = []
         try:
@@ -130,9 +166,14 @@ class OpenAICompatAdapter(BackendAdapter):
             except Exception:
                 pass
             return {"status": "ok", "response_ms": elapsed_ms, "models": models}
-        except Exception:
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, base),
+            }
 
 
 class CloudAPIAdapter(BackendAdapter):
@@ -164,10 +205,20 @@ class CloudAPIAdapter(BackendAdapter):
                     except Exception:
                         pass
                 return {"status": "ok", "response_ms": elapsed_ms, "models": models}
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
-        except Exception:
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": f"{base}/models returned HTTP {resp.status_code}",
+            }
+        except Exception as exc:
             elapsed_ms = int((time.monotonic() - start) * 1000)
-            return {"status": "error", "response_ms": elapsed_ms, "models": []}
+            return {
+                "status": "error",
+                "response_ms": elapsed_ms,
+                "models": [],
+                "error": _describe_health_error(exc, base),
+            }
 
 
 # Type aliases for backwards compatibility with tests

--- a/tinyagentos/cluster/model_resolver.py
+++ b/tinyagentos/cluster/model_resolver.py
@@ -30,17 +30,23 @@ class ModelLocation:
     """Result of :func:`find_model_hosts`.
 
     Attributes:
-        kind: One of ``controller`` | ``worker`` | ``cloud`` | ``not_found``.
+        kind: One of ``controller`` | ``worker`` | ``cloud`` | ``not_found``
+            | ``downloaded_backend_down``.
         hosts: Worker names that report the model (empty unless
             ``kind == "worker"``).
         canonical_host: The worker chosen when multiple have the model.
             Stubbed as alphabetical pick — Phase 1.5 will consider load
             and hardware.
+        backend_id: Set only when ``kind == "downloaded_backend_down"`` —
+            the manifest-declared backend (e.g. ``"rkllama"``) that this
+            model needs, confirmed not running right now (see
+            :func:`_check_downloaded_backend_down`).
     """
 
     kind: str
     hosts: list[str] = field(default_factory=list)
     canonical_host: str | None = None
+    backend_id: str | None = None
 
 
 def _normalise(model_id: str) -> str:
@@ -200,6 +206,138 @@ def find_model_hosts(
     return ModelLocation(kind="not_found")
 
 
+# Maps a manifest's ``requires.backends[].id`` to the probe that answers
+# "is this backend actually running on this host right now?" and to the
+# human-facing copy used in actionable error messages. Reuses the exact
+# probes the Setup checklist already relies on (#1535/#1597/#1598) so a
+# model resolver failure and the checklist agree on backend liveness.
+_BACKEND_LABELS: dict[str, str] = {
+    "rkllama": "rkllama NPU backend",
+    "rk-llama-cpp": "rk-llama.cpp NPU backend",
+    "llama-cpp": "llama.cpp backend",
+}
+
+_BACKEND_INSTALL_HINTS: dict[str, str] = {
+    "rkllama": "Install/start it from Setup > Install NPU backend",
+    "rk-llama-cpp": "Install/start it from Setup > Install NPU backend",
+    "llama-cpp": "Install/start it from Setup > Install llama.cpp server",
+}
+
+
+def _backend_is_running(backend_id: str) -> bool | None:
+    """True/False if we can positively probe *backend_id*, else None.
+
+    None means "we don't know how to check this backend" — callers must
+    NOT report it as down on an unknown answer, only on a confirmed-False
+    probe. Never raises: an import or probe error is treated as unknown.
+    """
+    try:
+        if backend_id == "rkllama":
+            from tinyagentos.installers.rkllama_installer import rkllama_is_running
+
+            return rkllama_is_running()
+        if backend_id == "rk-llama-cpp":
+            from tinyagentos.installers.rkllamacpp_installer import rkllamacpp_is_running
+
+            return rkllamacpp_is_running()
+        if backend_id == "llama-cpp":
+            from tinyagentos.installers.llamacpp_installer import llamacpp_is_running
+
+            return llamacpp_is_running()
+    except Exception:  # noqa: BLE001 — probe is best-effort, never break resolution
+        return None
+    return None
+
+
+def _find_model_manifest(registry, model_id: str):
+    """Best-effort manifest lookup for *model_id* against the app registry.
+
+    Tries an exact id match first (the common case — manifest ids like
+    ``qwen2.5-3b-rkllm`` are exactly what wizards/pickers pass through),
+    then falls back to the same loose :func:`_model_matches` used
+    elsewhere in this module. Returns ``None`` on any error or when the
+    registry doesn't know this model at all.
+    """
+    if registry is None:
+        return None
+    try:
+        manifest = registry.get(model_id)
+        if manifest is not None and manifest.type == "model":
+            return manifest
+        for m in registry.list_available(type_filter="model"):
+            if _model_matches(model_id, m.id):
+                return m
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _required_backend_ids(manifest) -> list[str]:
+    """Unique ``requires.backends[].id`` values declared across all variants.
+
+    Variants come straight from parsed manifest YAML (always dicts today),
+    but this runs on the hot HTTP resolution path, so a non-dict variant is
+    skipped rather than allowed to raise and turn a clean 4xx into a 500.
+    """
+    ids: list[str] = []
+    for v in getattr(manifest, "variants", None) or []:
+        if not isinstance(v, dict):
+            continue
+        for b in (v.get("requires") or {}).get("backends") or []:
+            bid = b.get("id") if isinstance(b, dict) else None
+            if bid and bid not in ids:
+                ids.append(bid)
+    return ids
+
+
+def _check_downloaded_backend_down(request, model_id: str) -> ModelLocation | None:
+    """When *model_id* resolved to ``not_found``, check whether it is a
+    known, downloaded model whose required backend we can positively
+    confirm is not running — the real cause behind #1599/#1600 (an
+    rkllama-backed model that shows as downloaded and selectable but the
+    rkllama server itself isn't up right now).
+
+    Returns a ``downloaded_backend_down`` :class:`ModelLocation` only when
+    every backend the manifest requires is confirmed down. Returns
+    ``None`` (defer to the generic "not found" message) when the manifest
+    is unknown, declares no backend requirement, or we can't positively
+    confirm any required backend is down (never claim a backend is down
+    on an inconclusive probe).
+    """
+    registry = getattr(request.app.state, "registry", None)
+    manifest = _find_model_manifest(registry, model_id)
+    if manifest is None:
+        return None
+    backend_ids = _required_backend_ids(manifest)
+    if not backend_ids:
+        return None
+    down: list[str] = []
+    for backend_id in backend_ids:
+        running = _backend_is_running(backend_id)
+        if running is None:
+            return None
+        if not running:
+            down.append(backend_id)
+    if not down:
+        return None
+    return ModelLocation(kind="downloaded_backend_down", backend_id=down[0])
+
+
+def describe_downloaded_backend_down(location: ModelLocation, model_id: str) -> str:
+    """Actionable error text for a ``downloaded_backend_down`` location.
+
+    Shared by every route that reports model reachability so the wording
+    — and any future fix to it — lives in one place.
+    """
+    backend_id = location.backend_id or ""
+    label = _BACKEND_LABELS.get(backend_id, f"{backend_id} backend" if backend_id else "backend")
+    hint = _BACKEND_INSTALL_HINTS.get(backend_id, f"Install/start the {label}")
+    return (
+        f"model '{model_id}' is downloaded but the {label} that serves it is not "
+        f"running. {hint} and try again."
+    )
+
+
 def collect_cloud_model_ids(config) -> list[str]:
     """Best-effort list of cloud-provider model ids advertised in config.backends.
 
@@ -234,9 +372,14 @@ def resolve_model_location(request, model_id: str) -> ModelLocation:
     local_models = catalog.all_models() if catalog is not None else []
     config = getattr(state, "config", None)
     cloud_models = collect_cloud_model_ids(config) if config is not None else []
-    return find_model_hosts(
+    location = find_model_hosts(
         model_id,
         cluster_state=cluster,
         local_models=local_models,
         cloud_models=cloud_models,
     )
+    if location.kind == "not_found":
+        downloaded_backend_down = _check_downloaded_backend_down(request, model_id)
+        if downloaded_backend_down is not None:
+            return downloaded_backend_down
+    return location

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
@@ -24,6 +25,40 @@ import httpx
 from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
 
 logger = logging.getLogger(__name__)
+
+
+class OpenCodeBinaryNotFoundError(RuntimeError):
+    """Raised when the ``opencode`` binary cannot be located anywhere.
+
+    opencode's official installer (``curl -fsSL https://opencode.ai/install |
+    bash``) drops the binary at ``~/.opencode/bin/opencode`` and makes it
+    reachable from a terminal by appending a PATH export to the user's shell
+    rc file (``.bashrc``/``.zshrc``). Those rc files are only sourced by
+    interactive shells -- the taOS backend normally runs as a systemd service,
+    which never sources them, so ``opencode`` can be "installed system-wide"
+    and still invisible to the service's PATH. See :func:`resolve_opencode_binary`.
+    """
+
+
+def resolve_opencode_binary() -> str | None:
+    """Locate the opencode binary, working around the PATH gap above.
+
+    Checks, in order:
+      1. ``shutil.which("opencode")`` -- covers PATH already containing it.
+      2. ``~/.opencode/bin/opencode`` -- the official installer's fixed
+         location, which a non-login process (e.g. a systemd service) never
+         picks up via PATH alone.
+
+    Returns the resolved path, or ``None`` if opencode isn't installed
+    anywhere we know to look.
+    """
+    found = shutil.which("opencode")
+    if found:
+        return found
+    candidate = Path.home() / ".opencode" / "bin" / "opencode"
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -161,15 +196,28 @@ class OpenCodeServer:
         except OSError:
             pass
 
-        self._proc = await asyncio.create_subprocess_exec(
-            self._cfg.binary,
-            "serve",
-            "--port", str(self._cfg.port),
-            "--hostname", "127.0.0.1",
-            stdout=self._log_fh,
-            stderr=asyncio.subprocess.STDOUT,
-            env=env,
-        )
+        # Resolve the bare "opencode" default past the PATH gap described in
+        # OpenCodeBinaryNotFoundError; an explicit binary override (tests, or
+        # a future config knob) is used as-is.
+        binary = self._cfg.binary
+        if binary == "opencode":
+            binary = resolve_opencode_binary() or binary
+
+        try:
+            self._proc = await asyncio.create_subprocess_exec(
+                binary,
+                "serve",
+                "--port", str(self._cfg.port),
+                "--hostname", "127.0.0.1",
+                stdout=self._log_fh,
+                stderr=asyncio.subprocess.STDOUT,
+                env=env,
+            )
+        except FileNotFoundError as exc:
+            raise OpenCodeBinaryNotFoundError(
+                f"opencode binary not found (tried {binary!r}). Install it with: "
+                "curl -fsSL https://opencode.ai/install | bash"
+            ) from exc
         logger.info(
             "opencode_runtime: spawned pid=%s port=%d",
             self._proc.pid, self._cfg.port,

--- a/tinyagentos/routes/agent_deploy.py
+++ b/tinyagentos/routes/agent_deploy.py
@@ -61,6 +61,7 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
     """Resolve cross-worker deploy routing for the requested model.
 
     Resolution order (task #176 stub):
+    - downloaded_backend_down: 404 (actionable — start the backend)
     - not_found: 404
     - worker + pin conflict: 409
     - worker (no conflict or no pin): 202 routed
@@ -70,9 +71,22 @@ def resolve_deploy_routing(request: Request, body: "DeployAgentRequest") -> "JSO
     controller-local deploy path.
     """
     if body.model:
-        from tinyagentos.cluster.model_resolver import resolve_model_location
+        from tinyagentos.cluster.model_resolver import (
+            describe_downloaded_backend_down,
+            resolve_model_location,
+        )
 
         location = resolve_model_location(request, body.model)
+
+        if location.kind == "downloaded_backend_down":
+            return JSONResponse(
+                {
+                    "error": describe_downloaded_backend_down(location, body.model),
+                    "model": body.model,
+                    "backend": location.backend_id,
+                },
+                status_code=404,
+            )
 
         if location.kind == "not_found":
             return JSONResponse(

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1075,9 +1075,22 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         return JSONResponse({"error": "model must not be empty"}, status_code=400)
 
     # Validate reachability against the live cluster state.
-    from tinyagentos.cluster.model_resolver import resolve_model_location
+    from tinyagentos.cluster.model_resolver import (
+        describe_downloaded_backend_down,
+        resolve_model_location,
+    )
 
     location = resolve_model_location(request, model_id)
+
+    if location.kind == "downloaded_backend_down":
+        return JSONResponse(
+            {
+                "error": describe_downloaded_backend_down(location, model_id),
+                "model": model_id,
+                "backend": location.backend_id,
+            },
+            status_code=409,
+        )
 
     if location.kind == "not_found":
         return JSONResponse(
@@ -1175,10 +1188,22 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
     if current and current not in permitted:
         permitted = [current, *permitted]
 
-    from tinyagentos.cluster.model_resolver import resolve_model_location
+    from tinyagentos.cluster.model_resolver import (
+        describe_downloaded_backend_down,
+        resolve_model_location,
+    )
 
     for model_id in permitted:
         location = resolve_model_location(request, model_id)
+        if location.kind == "downloaded_backend_down":
+            return JSONResponse(
+                {
+                    "error": describe_downloaded_backend_down(location, model_id),
+                    "model": model_id,
+                    "backend": location.backend_id,
+                },
+                status_code=409,
+            )
         if location.kind == "not_found":
             return JSONResponse(
                 {"error": f"model '{model_id}' is not reachable anywhere in the cluster right now.", "model": model_id},

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -528,10 +528,17 @@ async def test_provider(request: Request, body: ProviderTest):
         adapter = get_adapter(body.type)
         http_client = request.app.state.http_client
         result = await adapter.health(http_client, body.url)
+        reachable = result["status"] == "ok"
         return {
-            "reachable": result["status"] == "ok",
+            "reachable": reachable,
             "response_ms": result.get("response_ms", 0),
             "models": result.get("models", []),
+            # adapter.health() never raises (see backend_adapters.py) — a
+            # failed probe carries the real reason in result["error"].
+            # Surfacing it here is the actual fix for #1614: the Test
+            # button previously always fell back to "unknown error"
+            # because this response dropped the field entirely.
+            "error": None if reachable else result.get("error", "unknown error"),
         }
     except Exception as e:
         return {"reachable": False, "error": str(e)}

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -301,9 +301,21 @@ async def put_permitted_models(request: Request, body: PermittedModelsUpdate):
         permitted = [current_model, *permitted]
 
     # Validate every model is reachable.
-    from tinyagentos.cluster.model_resolver import resolve_model_location
+    from tinyagentos.cluster.model_resolver import (
+        describe_downloaded_backend_down,
+        resolve_model_location,
+    )
     for model_id in permitted:
         location = resolve_model_location(request, model_id)
+        if location.kind == "downloaded_backend_down":
+            return JSONResponse(
+                {
+                    "error": describe_downloaded_backend_down(location, model_id),
+                    "model": model_id,
+                    "backend": location.backend_id,
+                },
+                status_code=409,
+            )
         if location.kind == "not_found":
             return JSONResponse(
                 {

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -34,6 +34,7 @@ from fastapi.responses import FileResponse, JSONResponse, Response, StreamingRes
 from pydantic import BaseModel
 
 from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
+from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
 from tinyagentos.taos_agent_runtime import ensure_taos_opencode_server
 
 logger = logging.getLogger(__name__)
@@ -372,10 +373,28 @@ async def chat(request: Request, body: ChatRequest):
     # Ensure the host opencode server is running.
     try:
         server = await ensure_taos_opencode_server(request.app.state, model)
-    except Exception:
-        logger.exception("taos-agent: failed to start opencode server")
+    except OpenCodeBinaryNotFoundError as exc:
+        # The binary genuinely isn't reachable (not on PATH, not at the
+        # installer's default location) — a clear install instruction, not a
+        # generic "unavailable" message.
+        logger.error("taos-agent: opencode binary not found: %s", exc)
         return JSONResponse(
-            {"error": "taOS agent runtime unavailable. Check that opencode is installed."},
+            {
+                "error": (
+                    "opencode is not installed. Install it with: "
+                    "curl -fsSL https://opencode.ai/install | bash — then restart taOS."
+                )
+            },
+            status_code=503,
+        )
+    except Exception as exc:
+        # opencode was found but failed to start (or some other runtime
+        # error) — surface the real cause instead of masking it behind a
+        # generic message that sends users chasing an install that's already
+        # correct.
+        logger.exception("taos-agent: opencode server failed to start")
+        return JSONResponse(
+            {"error": f"taOS agent runtime failed to start: {exc}"},
             status_code=503,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b23"
+version = "1.0.0b24"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotes beta.24 to master for release. Contents: taOS Agent runtime + blank-dialog fixes (#1615/#1616), settings persistence (#1601/#1603), model/provider error clarity (#1599/#1600/#1614).