### PR TITLE
feat(projects): relational task context (goal ancestry + blocker graph) (#158)

### DIFF
--- a/desktop/src/apps/ProjectsApp/board/__tests__/Relationships.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/Relationships.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { Relationships } from "../modal/Relationships";
+import { projectsApi } from "../../../../lib/projects";
+import type { ProjectRelationship, TaskContext } from "../../../../lib/projects";
+
+const emptyContext: TaskContext = {
+  project: { id: "p1", name: null, description: null },
+  ancestry: [],
+  blockers: [],
+  is_blocked: false,
+};
+
+beforeEach(() => {
+  vi.spyOn(projectsApi.tasks, "listRelationships").mockResolvedValue([]);
+  vi.spyOn(projectsApi.tasks, "getContext").mockResolvedValue(emptyContext);
+});
+
+describe("Relationships", () => {
+  it("renders nothing when there is no context, no ancestry, and no relationships", async () => {
+    const { container } = render(<Relationships projectId="p1" taskId="t1" />);
+    await waitFor(() => expect(projectsApi.tasks.getContext).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the ancestry breadcrumb when ancestors exist", async () => {
+    vi.spyOn(projectsApi.tasks, "getContext").mockResolvedValue({
+      project: { id: "p1", name: "Launch", description: "" },
+      ancestry: [
+        { id: "a1", title: "Epic", status: "open" },
+        { id: "a2", title: "Story", status: "open" },
+      ],
+      blockers: [],
+      is_blocked: false,
+    });
+    render(<Relationships projectId="p1" taskId="t1" />);
+    await waitFor(() => expect(screen.getByText("Launch › Epic › Story")).toBeInTheDocument());
+  });
+
+  it("renders blockers and flags is_blocked", async () => {
+    vi.spyOn(projectsApi.tasks, "getContext").mockResolvedValue({
+      project: { id: "p1", name: "Launch", description: "" },
+      ancestry: [],
+      blockers: [{ id: "b1", title: "Blocking task", status: "open" }],
+      is_blocked: true,
+    });
+    render(<Relationships projectId="p1" taskId="t1" />);
+    await waitFor(() => expect(screen.getByText(/Blocking task/)).toBeInTheDocument());
+    expect(screen.getByRole("heading", { name: /Blockers/ })).toBeInTheDocument();
+    expect(screen.getByLabelText("Blocking task — blocking")).toBeInTheDocument();
+  });
+
+  it("renders the plain relationships list as before", async () => {
+    const rel: ProjectRelationship = {
+      id: "rel1", project_id: "p1", from_task_id: "t1", to_task_id: "t2",
+      kind: "relates_to", created_by: "u", created_at: 0,
+    };
+    vi.spyOn(projectsApi.tasks, "listRelationships").mockImplementation(async (_pid, _tid, direction) =>
+      direction === "from" ? [rel] : [],
+    );
+    render(<Relationships projectId="p1" taskId="t1" />);
+    await waitFor(() => expect(screen.getByText("relates_to")).toBeInTheDocument());
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
@@ -16,6 +16,12 @@ beforeEach(() => {
   vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([]);
   vi.spyOn(projectsApi.tasks, "listRelationships").mockResolvedValue([]);
   vi.spyOn(projectsApi.tasks, "listComments").mockResolvedValue([]);
+  vi.spyOn(projectsApi.tasks, "getContext").mockResolvedValue({
+    project: { id: "p1", name: null, description: null },
+    ancestry: [],
+    blockers: [],
+    is_blocked: false,
+  });
 });
 
 describe("TaskModal", () => {

--- a/desktop/src/apps/ProjectsApp/board/modal/Relationships.tsx
+++ b/desktop/src/apps/ProjectsApp/board/modal/Relationships.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from "react";
 import { projectsApi } from "../../../../lib/projects";
-import type { ProjectRelationship } from "../../../../lib/projects";
+import type { ProjectRelationship, TaskContext } from "../../../../lib/projects";
 
 export function Relationships({ projectId, taskId }: { projectId: string; taskId: string }) {
   const [rels, setRels] = useState<ProjectRelationship[]>([]);
+  const [context, setContext] = useState<TaskContext | null>(null);
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -15,19 +17,67 @@ export function Relationships({ projectId, taskId }: { projectId: string; taskId
     })();
     return () => { cancelled = true; };
   }, [projectId, taskId]);
-  if (rels.length === 0) return null;
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const ctx = await projectsApi.tasks.getContext(taskId);
+        if (!cancelled) setContext(ctx);
+      } catch {
+        // Context is best-effort UI enrichment — a fetch failure just means
+        // the breadcrumb/blockers panel stays hidden.
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [taskId]);
+
+  const ancestry = context?.ancestry ?? [];
+  const blockers = context?.blockers ?? [];
+  const isBlocked = context?.is_blocked ?? false;
+
+  if (rels.length === 0 && ancestry.length === 0 && blockers.length === 0) return null;
+
   return (
-    <section className="board-section">
-      <h3>Relationships</h3>
-      <ul>
-        {rels.map(r => (
-          <li key={r.id}>
-            <b>{r.kind}</b>{" "}
-            {r.from_task_id === taskId ? "→" : "←"}{" "}
-            {r.from_task_id === taskId ? r.to_task_id : r.from_task_id}
-          </li>
-        ))}
-      </ul>
-    </section>
+    <>
+      {ancestry.length > 0 && (
+        <section className="board-section" aria-label="Task ancestry">
+          <h3>Context</h3>
+          <nav aria-label="Goal breadcrumb">
+            {[context?.project.name || "Project", ...ancestry.map(a => a.title)].join(" › ")}
+          </nav>
+        </section>
+      )}
+      {blockers.length > 0 && (
+        <section className="board-section" aria-label="Blockers">
+          <h3>Blockers{isBlocked ? " ⛔" : ""}</h3>
+          <ul>
+            {blockers.map(b => {
+              const open = b.status !== "closed" && b.status !== "cancelled";
+              return (
+                <li key={b.id} aria-label={open ? `${b.title} — blocking` : `${b.title} — resolved`}>
+                  {open ? "⛔ " : "✅ "}
+                  {b.title} <span>({b.status})</span>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+      {rels.length > 0 && (
+        <section className="board-section">
+          <h3>Relationships</h3>
+          <ul>
+            {rels.map(r => (
+              <li key={r.id}>
+                <b>{r.kind}</b>{" "}
+                {r.from_task_id === taskId ? "→" : "←"}{" "}
+                {r.from_task_id === taskId ? r.to_task_id : r.from_task_id}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </>
   );
 }

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -75,6 +75,16 @@ export type ProjectEvent = {
   ts: number;
 };
 
+export type TaskContextAncestor = { id: string; title: string; status: string };
+export type TaskContextBlocker = { id: string; title: string; status: string };
+
+export type TaskContext = {
+  project: { id: string; name: string | null; description: string | null };
+  ancestry: TaskContextAncestor[];
+  blockers: TaskContextBlocker[];
+  is_blocked: boolean;
+};
+
 async function http<T>(path: string, init?: RequestInit): Promise<T> {
   const r = await fetch(path, {
     credentials: "include",
@@ -179,6 +189,8 @@ export const projectsApi = {
         method: "POST",
         body: JSON.stringify(input),
       }),
+    getContext: (tid: string) =>
+      http<TaskContext>(`/api/projects/tasks/${tid}/context`),
   },
 
   activity: (pid: string) =>

--- a/tests/projects/test_beads_bridge.py
+++ b/tests/projects/test_beads_bridge.py
@@ -29,6 +29,14 @@ def _make_bridge(tmp_path: Path, **overrides) -> BeadsBridge:
     task_store.create_task = AsyncMock(
         return_value={"id": "tsk_new1", "project_id": "prj_1", "title": "New task"}
     )
+    task_store.get_task_context = AsyncMock(
+        return_value={
+            "project": {"id": "prj_1", "name": None, "description": None},
+            "ancestry": [],
+            "blockers": [],
+            "is_blocked": False,
+        }
+    )
 
     channel_store = MagicMock()
     channel_store.list_channels = AsyncMock(return_value=[])
@@ -1100,3 +1108,119 @@ async def test_resolve_assignee_config_none_falls_back_to_member_id(tmp_path):
     await bridge.on_chat_message("prj_1", "ch_1", _msg('/new "T" @john'))
     kwargs = bridge._task_store.create_task.await_args.kwargs
     assert kwargs["assignee_id"] == "john"
+
+
+# ---------------------------------------------------------------------------
+# "Why" line injection (relational task context)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_on_event_claimed_appends_why_line_when_ancestry_exists(tmp_path):
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._task_store.get_task = AsyncMock(
+        return_value={"id": "tsk_a", "title": "Hello", "status": "claimed"}
+    )
+    bridge._task_store.get_task_context = AsyncMock(
+        return_value={
+            "project": {"id": "prj_1", "name": "Launch", "description": "Ship the v2 release"},
+            "ancestry": [{"id": "tsk_root", "title": "Epic: onboarding", "status": "open"}],
+            "blockers": [],
+            "is_blocked": False,
+        }
+    )
+    await bridge.on_event(
+        "prj_1",
+        {"kind": "task.claimed", "payload": {"id": "tsk_a", "claimed_by": "alice"}},
+    )
+    content = bridge._msg_store.send_message.await_args.kwargs["content"]
+    assert "alice claimed tsk_a" in content
+    assert "Why: Launch → Epic: onboarding (goal: Ship the v2 release)" in content
+
+
+@pytest.mark.asyncio
+async def test_on_event_claimed_no_why_line_when_no_ancestry_or_description(tmp_path):
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._task_store.get_task = AsyncMock(
+        return_value={"id": "tsk_a", "title": "Hello", "status": "claimed"}
+    )
+    # Default get_task_context mock from _make_bridge: empty ancestry, no description.
+    await bridge.on_event(
+        "prj_1",
+        {"kind": "task.claimed", "payload": {"id": "tsk_a", "claimed_by": "alice"}},
+    )
+    content = bridge._msg_store.send_message.await_args.kwargs["content"]
+    assert content == "🤚 alice claimed tsk_a — \"Hello\""
+    assert "Why:" not in content
+
+
+@pytest.mark.asyncio
+async def test_on_event_claimed_why_line_survives_context_fetch_failure(tmp_path):
+    """A context-fetch failure must not break the base claimed announce."""
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(return_value=[_a2a_ch()])
+    bridge._task_store.get_task = AsyncMock(
+        return_value={"id": "tsk_a", "title": "Hello", "status": "claimed"}
+    )
+    bridge._task_store.get_task_context = AsyncMock(side_effect=RuntimeError("boom"))
+    await bridge.on_event(
+        "prj_1",
+        {"kind": "task.claimed", "payload": {"id": "tsk_a", "claimed_by": "alice"}},
+    )
+    content = bridge._msg_store.send_message.await_args.kwargs["content"]
+    assert "alice claimed tsk_a" in content
+    assert "Why:" not in content
+
+
+@pytest.mark.asyncio
+async def test_announce_newly_ready_appends_why_line(tmp_path):
+    bridge = _make_bridge(tmp_path)
+    bridge._channel_store.list_channels = AsyncMock(
+        return_value=[_a2a_ch()]
+    )
+
+    async def _get_task(task_id):
+        if task_id == "tsk_a":
+            return {"id": "tsk_a", "title": "A", "status": "closed", "closed_by": "alice"}
+        if task_id == "tsk_b":
+            return {"id": "tsk_b", "title": "B", "status": "open", "labels": []}
+        return None
+
+    bridge._task_store.get_task = AsyncMock(side_effect=_get_task)
+
+    async def _list_rels(task_id, direction="from"):
+        if task_id == "tsk_a" and direction == "from":
+            return [{"from_task_id": "tsk_a", "to_task_id": "tsk_b", "kind": "blocks"}]
+        if task_id == "tsk_b" and direction == "to":
+            return [{"from_task_id": "tsk_a", "to_task_id": "tsk_b", "kind": "blocks"}]
+        return []
+
+    bridge._task_store.list_relationships = AsyncMock(side_effect=_list_rels)
+
+    async def _get_context(task_id):
+        if task_id == "tsk_b":
+            return {
+                "project": {"id": "prj_1", "name": "Launch", "description": ""},
+                "ancestry": [{"id": "tsk_root", "title": "Epic", "status": "open"}],
+                "blockers": [],
+                "is_blocked": False,
+            }
+        return {
+            "project": {"id": "prj_1", "name": None, "description": None},
+            "ancestry": [],
+            "blockers": [],
+            "is_blocked": False,
+        }
+
+    bridge._task_store.get_task_context = AsyncMock(side_effect=_get_context)
+
+    await bridge.on_event(
+        "prj_1",
+        {"kind": "task.closed", "payload": {"id": "tsk_a", "closed_by": "alice"}},
+    )
+
+    bodies = [
+        c.kwargs["content"] for c in bridge._msg_store.send_message.await_args_list
+    ]
+    assert any("tsk_b ready" in b and "Why: Launch → Epic" in b for b in bodies)

--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -229,3 +229,115 @@ async def test_closing_blocker_unblocks_ready_view(store):
     await store.close_task(c["id"], closed_by="u")
     ready = await store.list_ready_tasks(project_id="p")
     assert {t["id"] for t in ready} == {a["id"]}
+
+
+# ---------------------------------------------------------------------------
+# get_task_context — goal ancestry + blocker graph
+# ---------------------------------------------------------------------------
+
+class _FakeProjectStore:
+    def __init__(self, projects: dict):
+        self._projects = projects
+
+    async def get_project(self, project_id: str):
+        return self._projects.get(project_id)
+
+
+@pytest.mark.asyncio
+async def test_get_task_context_not_found(store):
+    with pytest.raises(ValueError):
+        await store.get_task_context("tsk-nope")
+
+
+@pytest.mark.asyncio
+async def test_get_task_context_ancestry_order(store):
+    root = await store.create_task(project_id="p", title="Root", created_by="u")
+    mid = await store.create_task(
+        project_id="p", title="Mid", created_by="u", parent_task_id=root["id"]
+    )
+    leaf = await store.create_task(
+        project_id="p", title="Leaf", created_by="u", parent_task_id=mid["id"]
+    )
+
+    ctx = await store.get_task_context(leaf["id"])
+    assert [a["id"] for a in ctx["ancestry"]] == [root["id"], mid["id"]]
+    assert ctx["ancestry"][0]["title"] == "Root"
+    assert ctx["ancestry"][1]["title"] == "Mid"
+    # The task itself is excluded from its own ancestry.
+    assert leaf["id"] not in [a["id"] for a in ctx["ancestry"]]
+
+
+@pytest.mark.asyncio
+async def test_get_task_context_no_ancestry_for_root_task(store):
+    root = await store.create_task(project_id="p", title="Root", created_by="u")
+    ctx = await store.get_task_context(root["id"])
+    assert ctx["ancestry"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_task_context_cycle_guard(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(
+        project_id="p", title="B", created_by="u", parent_task_id=a["id"]
+    )
+    # Force a cycle: a's parent becomes b, so a -> b -> a.
+    await store.update_task(a["id"], parent_task_id=b["id"])
+
+    ctx = await store.get_task_context(a["id"])
+    # Must terminate (no infinite loop / crash) and not include a itself.
+    assert a["id"] not in [x["id"] for x in ctx["ancestry"]]
+    assert len(ctx["ancestry"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_get_task_context_blockers_and_is_blocked(store):
+    dependent = await store.create_task(project_id="p", title="Dependent", created_by="u")
+    blocker = await store.create_task(project_id="p", title="Blocker", created_by="u")
+    await store.add_relationship(
+        project_id="p", from_task_id=dependent["id"], to_task_id=blocker["id"],
+        kind="blocks", created_by="u",
+    )
+
+    ctx = await store.get_task_context(dependent["id"])
+    assert [b["id"] for b in ctx["blockers"]] == [blocker["id"]]
+    assert ctx["is_blocked"] is True
+
+    await store.close_task(blocker["id"], closed_by="u")
+    ctx = await store.get_task_context(dependent["id"])
+    assert ctx["is_blocked"] is False
+    assert ctx["blockers"][0]["status"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_get_task_context_ignores_non_blocks_relationships(store):
+    a = await store.create_task(project_id="p", title="A", created_by="u")
+    b = await store.create_task(project_id="p", title="B", created_by="u")
+    await store.add_relationship(
+        project_id="p", from_task_id=a["id"], to_task_id=b["id"],
+        kind="relates_to", created_by="u",
+    )
+    ctx = await store.get_task_context(a["id"])
+    assert ctx["blockers"] == []
+    assert ctx["is_blocked"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_task_context_project_enrichment(tmp_path):
+    fake_project_store = _FakeProjectStore(
+        {"prj-1": {"id": "prj-1", "name": "Alpha", "description": "Ship the thing"}}
+    )
+    s = ProjectTaskStore(tmp_path / "tasks2.db", project_store=fake_project_store)
+    await s.init()
+    try:
+        t = await s.create_task(project_id="prj-1", title="T", created_by="u")
+        ctx = await s.get_task_context(t["id"])
+        assert ctx["project"] == {"id": "prj-1", "name": "Alpha", "description": "Ship the thing"}
+    finally:
+        await s.close()
+
+
+@pytest.mark.asyncio
+async def test_get_task_context_project_falls_back_without_project_store(store):
+    t = await store.create_task(project_id="p", title="T", created_by="u")
+    ctx = await store.get_task_context(t["id"])
+    assert ctx["project"]["id"] == "p"

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -430,3 +430,36 @@ async def test_create_project_duplicate_slug_via_store_concurrent(client):
     await store.create_project(name="A", slug="race", created_by="u")
     with pytest.raises(ValueError, match="slug already used"):
         await store.create_project(name="B", slug="race", created_by="u")
+
+
+@pytest.mark.asyncio
+async def test_task_context_route_shape(client):
+    pid = (await client.post(
+        "/api/projects", json={"name": "Alpha", "slug": "alpha", "description": "Ship v2"},
+    )).json()["id"]
+    root = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "Epic"})).json()
+    leaf = (await client.post(
+        f"/api/projects/{pid}/tasks",
+        json={"title": "Subtask", "parent_task_id": root["id"]},
+    )).json()
+    blocker = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "Blocker"})).json()
+    await client.post(
+        f"/api/projects/{pid}/tasks/{leaf['id']}/relationships",
+        json={"to_task_id": blocker["id"], "kind": "blocks"},
+    )
+
+    resp = await client.get(f"/api/projects/tasks/{leaf['id']}/context")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["project"]["id"] == pid
+    assert body["project"]["name"] == "Alpha"
+    assert body["project"]["description"] == "Ship v2"
+    assert [a["id"] for a in body["ancestry"]] == [root["id"]]
+    assert [b["id"] for b in body["blockers"]] == [blocker["id"]]
+    assert body["is_blocked"] is True
+
+
+@pytest.mark.asyncio
+async def test_task_context_route_unknown_task_returns_404(client):
+    resp = await client.get("/api/projects/tasks/tsk-nope/context")
+    assert resp.status_code == 404

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -371,7 +371,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.receipt_store import ReceiptStore
     receipt_store = ReceiptStore(data_dir / "receipts.db")
     project_task_store = ProjectTaskStore(
-        data_dir / "projects.db", broker=project_event_broker, audit=board_audit_store
+        data_dir / "projects.db",
+        broker=project_event_broker,
+        audit=board_audit_store,
+        project_store=project_store,
     )
     project_canvas_store = ProjectCanvasStoreImpl(data_dir / "projects.db", broker=project_event_broker)
     from tinyagentos.decisions.decision_store import DecisionStore

--- a/tinyagentos/projects/beads_bridge.py
+++ b/tinyagentos/projects/beads_bridge.py
@@ -260,6 +260,21 @@ class BeadsBridge:
         except Exception:
             logger.exception("beads bridge: send_message failed for %s", channel_id)
 
+    async def _why_suffix(self, task_id: str) -> str:
+        """Best-effort 'Why: ...' breadcrumb line to append to an announce
+        message (goal ancestry / project description). Never raises — a
+        context-fetch failure just means no suffix is added."""
+        from tinyagentos.projects.beads_format import format_why
+        try:
+            context = await self._task_store.get_task_context(task_id)
+        except Exception:
+            logger.warning(
+                "beads bridge: get_task_context failed for %s", task_id, exc_info=True
+            )
+            return ""
+        why = format_why(context["project"], context["ancestry"])
+        return f"\n{why}" if why else ""
+
     async def on_event(self, project_id: str, event: dict) -> None:
         try:
             kind = event.get("kind")
@@ -283,9 +298,8 @@ class BeadsBridge:
             )
             if kind == "task.claimed":
                 actor = payload.get("claimed_by") or task.get("claimed_by") or "agent"
-                await self._post_system(
-                    channel["id"], format_claimed(actor, tsk_id, title)
-                )
+                msg = format_claimed(actor, tsk_id, title) + await self._why_suffix(tsk_id)
+                await self._post_system(channel["id"], msg)
             elif kind == "task.released":
                 # release_task clears claimed_by before publishing the event,
                 # so prefer payload.releaser_id (the user/agent who released)
@@ -346,10 +360,10 @@ class BeadsBridge:
                     break
             if still_blocked:
                 continue
-            await self._post_system(
-                channel_id,
-                format_ready(dependent_id, dep.get("title", ""), list(dep.get("labels") or [])),
-            )
+            msg = format_ready(
+                dependent_id, dep.get("title", ""), list(dep.get("labels") or [])
+            ) + await self._why_suffix(dependent_id)
+            await self._post_system(channel_id, msg)
 
     async def on_chat_message(
         self, project_id: str, channel_id: str, message: dict

--- a/tinyagentos/projects/beads_format.py
+++ b/tinyagentos/projects/beads_format.py
@@ -95,6 +95,30 @@ def format_created(author: str, tsk_id: str, title: str) -> str:
     return f'✨ {author} created {tsk_id} — "{title}"'
 
 
+_WHY_GOAL_MAX = 120
+
+
+def format_why(project: dict, ancestry: list[dict]) -> str | None:
+    """One-line 'why this task exists' breadcrumb: project name -> ancestor
+    chain (root first) -> ... (goal: <project description, truncated>).
+
+    Returns None when there's nothing worth surfacing (no ancestry and no
+    project description) so callers can leave the announce message unchanged.
+    """
+    description = (project.get("description") or "").strip()
+    if not ancestry and not description:
+        return None
+    parts = [project.get("name") or project.get("id") or "project"]
+    parts.extend(a["title"] for a in ancestry)
+    chain = " → ".join(parts)
+    if description:
+        goal = description[:_WHY_GOAL_MAX]
+        if len(description) > _WHY_GOAL_MAX:
+            goal += "…"
+        return f"Why: {chain} (goal: {goal})"
+    return f"Why: {chain}"
+
+
 Verb = Literal["claim", "release", "close"]
 
 

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -12,8 +12,13 @@ from tinyagentos.projects.ids import new_id
 if TYPE_CHECKING:
     from tinyagentos.board_audit import BoardAuditLog
     from tinyagentos.projects.events import ProjectEventBroker
+    from tinyagentos.projects.project_store import ProjectStore
 
 logger = logging.getLogger(__name__)
+
+# Ancestor-walk depth cap for get_task_context — mirrors the cycle guard in
+# routes/projects.py's parent-chain check.
+_MAX_ANCESTRY_DEPTH = 50
 
 TASK_SCHEMA = """
 CREATE TABLE IF NOT EXISTS project_tasks (
@@ -96,10 +101,12 @@ class ProjectTaskStore(BaseStore):
         *,
         broker: "ProjectEventBroker | None" = None,
         audit: "BoardAuditLog | None" = None,
+        project_store: "ProjectStore | None" = None,
     ) -> None:
         super().__init__(db_path)
         self._broker = broker
         self._audit = audit
+        self._project_store = project_store
 
     async def _publish(self, project_id: str, kind: str, payload: dict) -> None:
         if self._broker is not None:
@@ -409,6 +416,70 @@ class ProjectTaskStore(BaseStore):
             rows = await cur.fetchall()
             desc = cur.description
         return [_row_to_task(r, desc) for r in rows]
+
+    async def get_task_context(self, task_id: str) -> dict:
+        """Relational context for a task: its goal (project + parent-task
+        ancestry) and what's blocking it.
+
+        Ancestry is ordered root -> leaf (the task's immediate parent last),
+        excluding the task itself. The walk is capped at
+        _MAX_ANCESTRY_DEPTH and guards against cycles via a visited set.
+
+        Blockers are read via `direction="from"` on this task: a `blocks`
+        relationship is stored as (from=dependent, to=blocker) — see
+        ready_tasks / test_closing_blocker_unblocks_ready_view, where a task
+        with an outbound `blocks` edge to an open task is excluded from the
+        ready set until that target closes.
+        """
+        task = await self.get_task(task_id)
+        if task is None:
+            raise ValueError(f"task not found: {task_id}")
+
+        ancestry: list[dict] = []
+        seen = {task_id}
+        parent_id = task.get("parent_task_id")
+        depth = 0
+        while parent_id and depth < _MAX_ANCESTRY_DEPTH:
+            if parent_id in seen:
+                break
+            seen.add(parent_id)
+            parent = await self.get_task(parent_id)
+            if parent is None:
+                break
+            ancestry.append({
+                "id": parent["id"], "title": parent["title"], "status": parent["status"],
+            })
+            parent_id = parent.get("parent_task_id")
+            depth += 1
+        ancestry.reverse()
+
+        project_id = task["project_id"]
+        project: dict = {"id": project_id, "name": None, "description": None}
+        if self._project_store is not None:
+            proj = await self._project_store.get_project(project_id)
+            if proj is not None:
+                project = {
+                    "id": proj["id"],
+                    "name": proj.get("name"),
+                    "description": proj.get("description", ""),
+                }
+
+        outbound = await self.list_relationships(task_id, direction="from")
+        blockers: list[dict] = []
+        for rel in outbound:
+            if rel.get("kind") != "blocks":
+                continue
+            blocker = await self.get_task(rel["to_task_id"])
+            if blocker is not None:
+                blockers.append({"id": blocker["id"], "title": blocker["title"], "status": blocker["status"]})
+        is_blocked = any(b["status"] not in ("closed", "cancelled") for b in blockers)
+
+        return {
+            "project": project,
+            "ancestry": ancestry,
+            "blockers": blockers,
+            "is_blocked": is_blocked,
+        }
 
     async def add_comment(
         self,

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -709,6 +709,26 @@ async def task_audit_history(
     return {"task_id": task_id, "events": events}
 
 
+@router.get("/api/projects/tasks/{task_id}/context")
+async def task_context(
+    task_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Relational context for a task: its goal (project + ancestry) and
+    blockers. Project-agnostic path — task_id alone resolves the project
+    for the ownership check, since task ids are globally unique."""
+    store = request.app.state.project_task_store
+    task = await store.get_task(task_id)
+    if task is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, task["project_id"], user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    return await store.get_task_context(task_id)
+
+
 @router.post("/api/projects/{project_id}/tasks/{task_id}/relationships")
 async def add_relationship(
     project_id: str,


### PR DESCRIPTION
## Summary

- Adds `ProjectTaskStore.get_task_context(task_id)`: parent-task ancestry (root → leaf, cycle-guarded, capped at 50 hops), the task's project (id/name/description as the v1 "goal" source), and the blocker graph (open incoming `blocks` edges + `is_blocked`). No schema changes — reuses `parent_task_id` and `task_relationships(kind='blocks')`.
- New endpoint: `GET /api/projects/tasks/{task_id}/context` (task-id-scoped path since task ids are globally unique; ownership is checked via the task's own `project_id`).
- Beads bridge (`beads_bridge.py`): appends a one-line `Why: <project> → <ancestor> → ... (goal: <description>)` breadcrumb to the A2A system message when a task is claimed (`on_event`) or newly ready (`_announce_newly_ready`). Best-effort — a context-fetch failure never breaks the base announce message.
- Projects UI: the task modal's `Relationships` panel now also renders an ancestry breadcrumb and a blockers list (flagged when `is_blocked`), fetched from the new endpoint.

## Notes / deviations

- The `blocks` relationship direction has two conflicting conventions already coexisting in this codebase: the `ready_tasks` SQL view / `list_ready_tasks` treats `from_task_id` as the *dependent* task and `to_task_id` as the *blocker* (confirmed by the existing `test_closing_blocker_unblocks_ready_view` integration test), while `beads_bridge.py`'s own JSONL/ready-announce logic reads it the other way round. I implemented `get_task_context`'s blocker list to match the convention proven correct by the real `add_relationship` → `list_ready_tasks` integration test (`direction="from"`, blocker = `to_task_id`), since that's the only one with end-to-end proof; the original task spec text described the opposite direction. This is a pre-existing inconsistency in the repo, not introduced here — flagging it for awareness, not fixing it in this PR.
- No new files under `apps/` — all changes are to existing modules (`tinyagentos/projects/*`, `tinyagentos/routes/projects.py`, `desktop/src/apps/ProjectsApp/board/modal/Relationships.tsx`, `desktop/src/lib/projects.ts`) plus tests.

## Test plan

- [x] `python -m pytest tests/projects/test_task_store.py tests/projects/test_beads_bridge.py tests/test_routes_projects.py -q` — all pass
- [x] `cd desktop && npx vitest run src/apps/ProjectsApp` — all pass
- [x] `cd desktop && npm run build` — succeeds, no TS errors