### PR TITLE
fix(settings): require admin or local token on system settings router (GHSA-47g9-fwwp-hrfp)

### DIFF
--- a/tests/test_settings_authz.py
+++ b/tests/test_settings_authz.py
@@ -1,0 +1,241 @@
+"""Authorization gate for the system-settings router (GHSA-47g9-fwwp-hrfp).
+
+``tinyagentos/routes/settings.py`` previously had no authorization check beyond
+"any valid session": a plain non-admin user could read or overwrite system
+config (``/api/config``, ``/api/settings/platform``) and trigger updates or
+restarts (``/api/settings/update``, ``/api/settings/update-channel``). The only
+legitimate callers are an admin session or a caller presenting the host's
+local token (see ``tinyagentos/routes/settings.py::_require_admin_or_local_token``
+and ``tinyagentos/auth_middleware.py``) -- mirrors the fix already shipped for
+skill EXECUTION in ``tests/test_skill_exec_authz.py``.
+
+This suite locks in the fix end-to-end through the real ``AuthMiddleware``:
+  (a) a non-admin user session is rejected 403 on every gated endpoint;
+  (b) an admin session is allowed;
+  (c) a request presenting the valid local token is allowed, with no session
+      cookie at all.
+"""
+from __future__ import annotations
+
+import yaml
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+async def _member_client(app) -> AsyncClient:
+    """Cookie'd client for a non-admin member session on *app*.
+
+    Requires the admin created by the ``client`` fixture (add_user_invite
+    checks the inviter is an admin), so callers must depend on ``client`` (or
+    otherwise set up the admin) before calling this.
+    """
+    auth_mgr = app.state.auth
+    invite_code = auth_mgr.add_user_invite("member", "admin")
+    auth_mgr.complete_invite(
+        "member", invite_code, "Test Member", "", "membersettingspass123"
+    )
+    member = auth_mgr.find_user("member")
+    token = auth_mgr.create_session(user_id=member["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+@pytest.mark.asyncio
+class TestSettingsAuthzNonAdminRejected:
+    """(a) A plain non-admin user session must be rejected 403 on every
+    sensitive settings endpoint."""
+
+    async def test_get_config_rejected(self, client, app):
+        member_client = await _member_client(app)
+        try:
+            resp = await member_client.get("/api/config")
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403
+
+    async def test_put_config_rejected(self, client, app):
+        member_client = await _member_client(app)
+        try:
+            new_yaml = yaml.dump({
+                "server": {"host": "0.0.0.0", "port": 9999},
+                "backends": [],
+                "qmd": {"url": "http://localhost:7832"},
+                "agents": [],
+                "metrics": {"poll_interval": 60, "retention_days": 7},
+            })
+            resp = await member_client.put("/api/config", json={"yaml": new_yaml})
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403
+
+    async def test_put_platform_settings_rejected(self, client, app):
+        member_client = await _member_client(app)
+        try:
+            resp = await member_client.put(
+                "/api/settings/platform",
+                json={"poll_interval": 60, "retention_days": 14},
+            )
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403
+
+    async def test_post_update_rejected(self, client, app):
+        member_client = await _member_client(app)
+        try:
+            with patch("tinyagentos.routes.settings.asyncio.create_subprocess_exec") as mock_exec:
+                resp = await member_client.post("/api/settings/update")
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403
+        mock_exec.assert_not_called()
+
+    async def test_post_update_channel_rejected(self, client, app):
+        member_client = await _member_client(app)
+        try:
+            with patch(
+                "tinyagentos.routes.settings._remote_branches",
+                new=AsyncMock(return_value=["master", "dev"]),
+            ) as mock_branches:
+                resp = await member_client.post(
+                    "/api/settings/update-channel", json={"branch": "dev"}
+                )
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403
+        mock_branches.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestSettingsAuthzAdminAllowed:
+    """(b) An admin session must not be blocked by the new guard."""
+
+    async def test_get_config_allowed(self, client):
+        resp = await client.get("/api/config")
+        assert resp.status_code == 200
+
+    async def test_put_config_allowed(self, client):
+        new_yaml = yaml.dump({
+            "server": {"host": "0.0.0.0", "port": 9999},
+            "backends": [],
+            "qmd": {"url": "http://localhost:7832"},
+            "agents": [],
+            "metrics": {"poll_interval": 60, "retention_days": 7},
+        })
+        resp = await client.put("/api/config", json={"yaml": new_yaml})
+        assert resp.status_code == 200
+
+    async def test_put_platform_settings_allowed(self, client):
+        resp = await client.put(
+            "/api/settings/platform",
+            json={"poll_interval": 60, "retention_days": 14},
+        )
+        assert resp.status_code == 200
+
+    async def test_post_update_allowed(self, client):
+        """Mirrors TestUpdateAlwaysRestarts in test_routes_settings.py -- the
+        heavy git/pip/restart machinery is mocked out; only the authz gate is
+        under test here."""
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.communicate = AsyncMock(return_value=(b"Already up to date.\n", b""))
+
+        async def _fake_restart(_app_state):
+            return None
+
+        with (
+            patch(
+                "tinyagentos.routes.settings.asyncio.create_subprocess_exec",
+                return_value=fake_proc,
+            ),
+            patch(
+                "tinyagentos.routes.settings._run_capture",
+                new=AsyncMock(return_value=(0, "ok")),
+            ),
+            patch(
+                "tinyagentos.desktop_rebuild.rebuild_desktop_bundle_if_stale",
+                new=AsyncMock(
+                    return_value=MagicMock(rebuilt=False, success=True, message="current")
+                ),
+            ),
+            patch(
+                "tinyagentos.routes.system._do_restart",
+                new=_fake_restart,
+            ),
+            patch("tinyagentos.restart_orchestrator.write_pending_restart"),
+        ):
+            resp = await client.post("/api/settings/update")
+
+        assert resp.status_code != 403
+        assert resp.status_code == 200
+
+    async def test_post_update_channel_allowed(self, client, monkeypatch):
+        """Mirrors test_noop_on_same_branch in test_update_channel_routes.py --
+        the branch is already current so the route short-circuits before any
+        real switch machinery runs; only the authz gate is under test here."""
+        import tinyagentos.routes.settings as s
+
+        async def fake_lsremote(project_dir):
+            return ["master", "dev"]
+
+        async def fake_resolve(store, project_dir):
+            return "master"
+
+        monkeypatch.setattr(s, "_remote_branches", fake_lsremote, raising=False)
+        monkeypatch.setattr(s, "resolve_tracked_branch", fake_resolve, raising=False)
+
+        resp = await client.post("/api/settings/update-channel", json={"branch": "master"})
+        assert resp.status_code != 403
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "unchanged"
+
+
+@pytest.mark.asyncio
+class TestSettingsAuthzLocalTokenAllowed:
+    """(c) A request presenting the valid local token is allowed, with no
+    session cookie at all."""
+
+    async def test_local_token_get_config_allowed(self, client, app):
+        local_token = app.state.auth.get_local_token()
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            resp = await bare_client.get(
+                "/api/config",
+                headers={"Authorization": f"Bearer {local_token}"},
+            )
+        finally:
+            await bare_client.aclose()
+        assert resp.status_code == 200
+
+    async def test_local_token_put_platform_settings_allowed(self, client, app):
+        local_token = app.state.auth.get_local_token()
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            resp = await bare_client.put(
+                "/api/settings/platform",
+                json={"poll_interval": 60, "retention_days": 14},
+                headers={"Authorization": f"Bearer {local_token}"},
+            )
+        finally:
+            await bare_client.aclose()
+        assert resp.status_code == 200
+
+    async def test_no_auth_at_all_rejected(self, client, app):
+        """Sanity check: no session, no token at all is rejected by the
+        AuthMiddleware session gate before it ever reaches the router guard."""
+        bare_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        )
+        try:
+            resp = await bare_client.get("/api/config")
+        finally:
+            await bare_client.aclose()
+        assert resp.status_code in (401, 403)

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -10,7 +10,7 @@ import time
 from pathlib import Path
 
 import yaml
-from fastapi import APIRouter, Request, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 from tinyagentos.config import AppConfig, save_config_locked, validate_config
@@ -21,7 +21,28 @@ from tinyagentos.restart_orchestrator import write_pending_restart
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+
+async def _require_admin_or_local_token(request: Request) -> None:
+    """Gate the entire system-settings router to admin or the host local token.
+
+    This router reads/overwrites system config and triggers updates/restarts
+    (GHSA-47g9-fwwp-hrfp): a plain non-admin user session must never reach any
+    handler below. Mirrors ``tinyagentos.routes.skill_exec._is_admin_or_local_token``
+    -- see that function's docstring for why both signals (``is_admin`` and
+    ``via == "local_token"``) are checked; ``AuthMiddleware``
+    (tinyagentos/auth_middleware.py) sets both on ``request.state``.
+
+    Attached as a router-level dependency so every route in this module is
+    covered without each handler repeating the check.
+    """
+    if getattr(request.state, "is_admin", False):
+        return
+    if getattr(request.state, "via", None) == "local_token":
+        return
+    raise HTTPException(status_code=403, detail="forbidden")
+
+
+router = APIRouter(dependencies=[Depends(_require_admin_or_local_token)])
 
 
 async def _run_capture(


### PR DESCRIPTION
## Summary
- Fixes a High-severity missing-authorization vulnerability (GHSA-47g9-fwwp-hrfp, CWE-862): `tinyagentos/routes/settings.py` had no authorization guard beyond a valid session, so any authenticated non-admin user could reach every endpoint on the system-settings router.
- Now-gated sensitive endpoints (entire router, non-exhaustive highlights):
  - `GET`/`PUT /api/config` — read/overwrite the full system config
  - `PUT /api/settings/platform` — metrics interval/retention
  - `POST /api/settings/update`, `POST /api/settings/update-channel` — pull code from GitHub / switch branches, install deps, and restart the service
  - `POST /api/backup`, `POST /api/restore` — download/restore full config+app-data backups
  - `PUT /api/settings/container-runtime`, webhook CRUD, backup schedule, notification prefs, `/api/settings/rebuild-frontend`
- Mirrors the fix already shipped for skill execution (GHSA-h24f-gp4c-8qjm, `tinyagentos/routes/skill_exec.py::_is_admin_or_local_token`): added a router-level FastAPI dependency, `_require_admin_or_local_token`, so every handler in the module is covered without repeating the check per-endpoint.

```python
async def _require_admin_or_local_token(request: Request) -> None:
    if getattr(request.state, "is_admin", False):
        return
    if getattr(request.state, "via", None) == "local_token":
        return
    raise HTTPException(status_code=403, detail="forbidden")


router = APIRouter(dependencies=[Depends(_require_admin_or_local_token)])
```

`is_admin` / `via` are set on `request.state` by `AuthMiddleware` (`tinyagentos/auth_middleware.py`) — an admin session sets `is_admin=True`, and a valid host local token sets `via == "local_token"` (admin-equivalent, including the pre-onboarding edge case where there's no primary user yet).

No endpoint's business logic, request/response shape, or path changed — this is purely an authorization guard.

I checked the desktop frontend (`desktop/src`) for any non-admin UI path depending on these endpoints; all calls to `/api/settings/*` and `/api/config` live in `SettingsApp` (system Settings), which is system-administration surface — no onboarding/login flow depends on this router (that lives on the auth router and is separately exempted in `AuthMiddleware`).

## Test coverage
Added `tests/test_settings_authz.py` (13 tests, mirrors `tests/test_skill_exec_authz.py`'s conventions):
- Non-admin session → 403 on `GET`/`PUT /api/config`, `PUT /api/settings/platform`, `POST /api/settings/update`, `POST /api/settings/update-channel`.
- Admin session → not blocked (200 / normal response), including for `/api/settings/update` and `/api/settings/update-channel` with the heavy git/pip/restart side effects mocked out (same pattern as the existing `test_routes_settings.py` / `test_update_channel_routes.py` tests).
- Local-token request (no session cookie) → allowed.
- Sanity check: no auth at all is still rejected by the session gate.

## Test plan
- [x] `pytest tests/test_settings_authz.py -q` → 13 passed
- [x] `pytest tests/ -k "settings or config or auth" --ignore=tests/e2e -q` → same pass/fail counts as the `origin/dev` baseline (6 pre-existing failures + 1 pre-existing error, all subprocess-timing related in `_run_capture`/`resolve_tracked_branch` tests, unrelated to this change and reproduced identically with this branch's fix reverted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened access control for system settings pages and APIs.
  * Non-admin users are now blocked from sensitive settings actions, while admins and valid local-token requests can continue normally.
  * Unauthorized requests are rejected before any settings changes or restart-related actions can occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->