### PR TITLE
feat(projects): routines & schedules — cron/webhook/api triggers auto-create tasks + wake agent (#159)

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectRoutines.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectRoutines.tsx
@@ -1,0 +1,315 @@
+import { useEffect, useState } from "react";
+import { projectsApi, type Project, type ProjectMember, type Routine } from "@/lib/projects";
+
+// Project-scoped Routines & Schedules panel: a routine fires on a cron
+// schedule, an inbound webhook, or a manual/API trigger, auto-creating a task
+// on this project's board and best-effort waking the assignee agent. Kept
+// inside ProjectsApp (not the global TasksApp) because routines are always
+// scoped to one project's board.
+
+const CRON_PRESETS: { label: string; expr: string }[] = [
+  { label: "Every hour", expr: "0 * * * *" },
+  { label: "Daily at 3am", expr: "0 3 * * *" },
+  { label: "Every 15 min", expr: "*/15 * * * *" },
+];
+
+function relativeTime(ts: number | null): string {
+  if (!ts) return "never";
+  const diff = Math.max(0, Date.now() - ts * 1000);
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function untilTime(ts: number | null): string {
+  if (!ts) return "—";
+  const diff = ts * 1000 - Date.now();
+  if (diff <= 0) return "due now";
+  const mins = Math.round(diff / 60_000);
+  if (mins < 60) return `in ${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `in ${hrs}h`;
+  return `in ${Math.round(hrs / 24)}d`;
+}
+
+export function ProjectRoutines({ project }: { project: Project }) {
+  const [items, setItems] = useState<Routine[]>([]);
+  const [members, setMembers] = useState<ProjectMember[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [assigneeId, setAssigneeId] = useState("");
+  const [triggerKind, setTriggerKind] = useState<"cron" | "webhook" | "api">("cron");
+  const [cronExpr, setCronExpr] = useState("0 3 * * *");
+  const [submitting, setSubmitting] = useState(false);
+
+  const refresh = () =>
+    projectsApi.routines
+      .list(project.id)
+      .then(setItems)
+      .catch(() => setError("Could not load routines for this project."));
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    projectsApi.routines
+      .list(project.id)
+      .then((rows) => {
+        if (!cancelled) setItems(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Could not load routines for this project.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    projectsApi.members
+      .list(project.id)
+      .then((rows) => {
+        if (!cancelled) setMembers(rows);
+      })
+      .catch(() => {
+        if (!cancelled) setMembers([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [project.id]);
+
+  const create = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = title.trim();
+    if (!trimmed || submitting) return;
+    setSubmitting(true);
+    try {
+      await projectsApi.routines.create(project.id, {
+        title: trimmed,
+        body_template: body.trim(),
+        assignee_id: assigneeId || null,
+        trigger_kind: triggerKind,
+        cron_expr: triggerKind === "cron" ? cronExpr : null,
+      });
+      setTitle("");
+      setBody("");
+      setAssigneeId("");
+      setError(null);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const toggleEnabled = async (r: Routine) => {
+    try {
+      await projectsApi.routines.update(project.id, r.id, { enabled: !r.enabled });
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const runNow = async (r: Routine) => {
+    try {
+      await projectsApi.routines.trigger(project.id, r.id);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  const remove = async (r: Routine) => {
+    try {
+      await projectsApi.routines.remove(project.id, r.id);
+      await refresh();
+    } catch (err) {
+      setError(String(err));
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-4">
+      <form
+        onSubmit={create}
+        className="flex flex-col gap-2 rounded-xl border border-shell-border bg-shell-surface p-3.5"
+        aria-label="Create routine"
+      >
+        <label className="text-sm text-shell-text-secondary">
+          Title
+          <input
+            aria-label="Routine title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="e.g. Weekly report"
+            required
+            className="mt-1 w-full rounded bg-shell-bg-deep px-2 py-1 text-sm text-shell-text outline-none focus:ring-2 focus:ring-accent-line"
+          />
+        </label>
+        <label className="text-sm text-shell-text-secondary">
+          Task body
+          <textarea
+            aria-label="Routine task body"
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={2}
+            className="mt-1 w-full rounded bg-shell-bg-deep px-2 py-1 text-sm text-shell-text outline-none focus:ring-2 focus:ring-accent-line"
+          />
+        </label>
+        <div className="flex flex-wrap gap-3">
+          <label className="flex-1 text-sm text-shell-text-secondary">
+            Assignee
+            <select
+              aria-label="Assignee"
+              value={assigneeId}
+              onChange={(e) => setAssigneeId(e.target.value)}
+              className="mt-1 w-full rounded bg-shell-bg-deep px-2 py-1 text-sm text-shell-text"
+            >
+              <option value="">Unassigned</option>
+              {members.map((m) => (
+                <option key={m.member_id} value={m.member_id}>
+                  {m.member_id}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex-1 text-sm text-shell-text-secondary">
+            Trigger
+            <select
+              aria-label="Trigger kind"
+              value={triggerKind}
+              onChange={(e) => setTriggerKind(e.target.value as "cron" | "webhook" | "api")}
+              className="mt-1 w-full rounded bg-shell-bg-deep px-2 py-1 text-sm text-shell-text"
+            >
+              <option value="cron">Schedule (cron)</option>
+              <option value="webhook">Webhook</option>
+              <option value="api">API / manual only</option>
+            </select>
+          </label>
+        </div>
+        {triggerKind === "cron" && (
+          <div className="flex flex-col gap-2">
+            <label className="text-sm text-shell-text-secondary">
+              Cron schedule
+              <input
+                aria-label="Cron expression"
+                value={cronExpr}
+                onChange={(e) => setCronExpr(e.target.value)}
+                placeholder="0 3 * * *"
+                required
+                className="mt-1 w-full rounded bg-shell-bg-deep px-2 py-1 font-mono text-sm text-shell-text outline-none focus:ring-2 focus:ring-accent-line"
+              />
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {CRON_PRESETS.map((p) => (
+                <button
+                  key={p.expr}
+                  type="button"
+                  onClick={() => setCronExpr(p.expr)}
+                  className="rounded-full bg-accent/10 px-2 py-0.5 text-xs font-medium text-accent hover:bg-accent/20"
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        {triggerKind === "webhook" && (
+          <p className="text-xs text-shell-text-tertiary">
+            A unique webhook URL is generated once the routine is created.
+          </p>
+        )}
+        {error && (
+          <div role="alert" className="text-xs text-red-400">
+            {error}
+          </div>
+        )}
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded bg-accent/10 px-3 py-1 text-sm font-medium text-accent hover:bg-accent/20 disabled:opacity-50"
+          >
+            {submitting ? "Creating…" : "Create routine"}
+          </button>
+        </div>
+      </form>
+
+      {loading ? (
+        <p className="text-sm text-shell-text-tertiary">Loading routines…</p>
+      ) : items.length === 0 ? (
+        <p className="text-sm text-shell-text-secondary">No routines for this project yet.</p>
+      ) : (
+        <ul className="flex flex-col gap-2" aria-label="Project routines">
+          {items.map((r) => {
+            const webhookUrl =
+              r.trigger_kind === "webhook" && r.webhook_token
+                ? `${window.location.origin}/api/webhooks/routines/${r.webhook_token}`
+                : null;
+            return (
+              <li
+                key={r.id}
+                className="flex flex-col gap-1.5 rounded-xl border border-shell-border bg-shell-surface p-3.5"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="inline-flex items-center rounded-full bg-accent/10 px-2 py-0.5 text-xs font-medium capitalize text-accent">
+                    {r.trigger_kind}
+                  </span>
+                  <p className="text-sm font-medium text-shell-text">{r.title}</p>
+                  <label className="ml-auto flex items-center gap-1.5 text-xs text-shell-text-secondary">
+                    <input
+                      type="checkbox"
+                      checked={!!r.enabled}
+                      onChange={() => toggleEnabled(r)}
+                      aria-label={`Toggle enabled for ${r.title}`}
+                    />
+                    Enabled
+                  </label>
+                </div>
+                {r.trigger_kind === "cron" && (
+                  <p className="text-xs text-shell-text-tertiary">
+                    <code>{r.cron_expr}</code> · last fired {relativeTime(r.last_fired)} · next fire{" "}
+                    {untilTime(r.next_fire)}
+                  </p>
+                )}
+                {webhookUrl && (
+                  <p className="truncate text-xs text-shell-text-tertiary" title={webhookUrl}>
+                    {webhookUrl}
+                  </p>
+                )}
+                {r.assignee_id && (
+                  <p className="text-xs text-shell-text-tertiary">Assignee: {r.assignee_id}</p>
+                )}
+                <div className="flex justify-end gap-3 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => runNow(r)}
+                    className="text-accent hover:underline"
+                  >
+                    Run now
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => remove(r)}
+                    className="text-red-400 hover:underline"
+                    aria-label={`Delete ${r.title}`}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default ProjectRoutines;

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -4,6 +4,7 @@ import { ProjectTaskList } from "./ProjectTaskList";
 import { ProjectMembers } from "./ProjectMembers";
 import { ProjectActivity } from "./ProjectActivity";
 import { ProjectDecisions } from "./ProjectDecisions";
+import { ProjectRoutines } from "./ProjectRoutines";
 import { ProjectBoard } from "./board/ProjectBoard";
 import { TaskModal } from "./board/TaskModal";
 import { FilesApp } from "@/apps/FilesApp";
@@ -17,8 +18,8 @@ import { ProjectFab } from "./mobile/ProjectFab";
 import { TaskCreateSheet } from "./mobile/TaskCreateSheet";
 import styles from "./ProjectsApp.module.css";
 
-type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity" | "decisions";
-const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity", "decisions"];
+type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity" | "decisions" | "routines";
+const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity", "decisions", "routines"];
 
 interface AgentSummary {
   id: string;
@@ -59,7 +60,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
   // Mobile pill order: surface Messages right after Workspace so it is reachable
   // without scrolling (on mobile Messages is its own full page, not a squeezed
   // pane inside Workspace).
-  const mobileTabOrder: Tab[] = ["workspace", "messages", "board", "tasks", "canvas", "files", "members", "activity", "decisions"];
+  const mobileTabOrder: Tab[] = ["workspace", "messages", "board", "tasks", "canvas", "files", "members", "activity", "decisions", "routines"];
   const tabPills = mobileTabOrder.map((t) => ({
     id: t,
     label: t.charAt(0).toUpperCase() + t.slice(1),
@@ -220,6 +221,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         {tab === "members" && <ProjectMembers project={project} onChanged={onChanged} />}
         {tab === "activity" && <ProjectActivity projectId={project.id} />}
         {tab === "decisions" && <ProjectDecisions projectId={project.id} />}
+        {tab === "routines" && <ProjectRoutines project={project} />}
       </div>
 
       {isMobile && (tab === "tasks" || tab === "board") && (

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectRoutines.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectRoutines.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { Project } from "@/lib/projects";
+import { ProjectRoutines } from "../ProjectRoutines";
+
+const fakeProject: Project = {
+  id: "p1",
+  slug: "p1",
+  name: "P1",
+  description: "",
+  status: "active",
+  created_by: "u1",
+  created_at: 0,
+  updated_at: 0,
+};
+
+function ok(data: unknown) {
+  return { ok: true, status: 200, json: async () => data };
+}
+
+describe("ProjectRoutines", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn((url: string) => {
+      if (url.includes("/routines") && !url.includes("/trigger")) {
+        return Promise.resolve(ok({ items: [] }));
+      }
+      if (url.includes("/members")) {
+        return Promise.resolve(ok({ items: [] }));
+      }
+      return Promise.resolve(ok({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("shows an empty state when the project has no routines", async () => {
+    await act(async () => {
+      render(<ProjectRoutines project={fakeProject} />);
+    });
+    expect(await screen.findByText(/no routines for this project yet/i)).toBeInTheDocument();
+  });
+
+  it("renders an existing cron routine with its schedule", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/routines") && !url.includes("/trigger")) {
+        return Promise.resolve(
+          ok({
+            items: [
+              {
+                id: "rtn-1",
+                project_id: "p1",
+                title: "Nightly sweep",
+                body_template: "",
+                assignee_id: null,
+                trigger_kind: "cron",
+                cron_expr: "0 3 * * *",
+                webhook_token: null,
+                enabled: 1,
+                last_fired: null,
+                next_fire: Date.now() / 1000 + 3600,
+                created_by: "u1",
+                created_at: 0,
+                updated_at: 0,
+              },
+            ],
+          }),
+        );
+      }
+      return Promise.resolve(ok({ items: [] }));
+    });
+
+    await act(async () => {
+      render(<ProjectRoutines project={fakeProject} />);
+    });
+    expect(await screen.findByText("Nightly sweep")).toBeInTheDocument();
+    expect(screen.getByText("0 3 * * *")).toBeInTheDocument();
+  });
+
+  it("submits the create form and refreshes the list", async () => {
+    let created = false;
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes("/routines") && init?.method === "POST") {
+        created = true;
+        return Promise.resolve(ok({ id: "rtn-new", trigger_kind: "cron" }));
+      }
+      if (url.includes("/routines")) {
+        return Promise.resolve(
+          ok({ items: created ? [{ id: "rtn-new", title: "New routine", trigger_kind: "cron", cron_expr: "0 3 * * *", enabled: 1 }] : [] }),
+        );
+      }
+      return Promise.resolve(ok({ items: [] }));
+    });
+
+    await act(async () => {
+      render(<ProjectRoutines project={fakeProject} />);
+    });
+
+    fireEvent.change(screen.getByLabelText(/routine title/i), { target: { value: "New routine" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /create routine/i }));
+    });
+
+    await waitFor(() => expect(created).toBe(true));
+    expect(await screen.findByText("New routine")).toBeInTheDocument();
+  });
+
+  it("applies a cron preset when clicked", async () => {
+    await act(async () => {
+      render(<ProjectRoutines project={fakeProject} />);
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /daily at 3am/i }));
+    expect(screen.getByLabelText(/cron expression/i)).toHaveValue("0 3 * * *");
+  });
+
+  it("calls the trigger endpoint when Run now is clicked", async () => {
+    let triggered = false;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/trigger")) {
+        triggered = true;
+        return Promise.resolve(ok({ ok: true, task: { id: "tsk-1" } }));
+      }
+      if (url.includes("/routines")) {
+        return Promise.resolve(
+          ok({
+            items: [
+              {
+                id: "rtn-1",
+                title: "Nightly sweep",
+                trigger_kind: "api",
+                cron_expr: null,
+                webhook_token: null,
+                enabled: 1,
+                last_fired: null,
+                next_fire: null,
+                assignee_id: null,
+              },
+            ],
+          }),
+        );
+      }
+      return Promise.resolve(ok({ items: [] }));
+    });
+
+    await act(async () => {
+      render(<ProjectRoutines project={fakeProject} />);
+    });
+    await screen.findByText("Nightly sweep");
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /run now/i }));
+    });
+    await waitFor(() => expect(triggered).toBe(true));
+  });
+});

--- a/desktop/src/lib/__tests__/projects-routines.test.ts
+++ b/desktop/src/lib/__tests__/projects-routines.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { projectsApi } from "../projects";
+
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+function ok(data: unknown) {
+  return { ok: true, status: 200, json: async () => data };
+}
+
+describe("projectsApi.routines", () => {
+  it("list fetches routines for a project", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ items: [{ id: "rtn-1" }] }));
+    const r = await projectsApi.routines.list("p1");
+    expect(fetchMock.mock.calls[0][0]).toMatch("/api/projects/p1/routines");
+    expect(r).toEqual([{ id: "rtn-1" }]);
+  });
+
+  it("create POSTs the routine payload", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ id: "rtn-1", trigger_kind: "cron" }));
+    await projectsApi.routines.create("p1", {
+      title: "Nightly",
+      trigger_kind: "cron",
+      cron_expr: "0 3 * * *",
+    });
+    expect(fetchMock.mock.calls[0][0]).toMatch("/api/projects/p1/routines");
+    expect(fetchMock.mock.calls[0][1].method).toBe("POST");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({ title: "Nightly", trigger_kind: "cron", cron_expr: "0 3 * * *" });
+  });
+
+  it("update PATCHes the routine", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ id: "rtn-1", enabled: 0 }));
+    await projectsApi.routines.update("p1", "rtn-1", { enabled: false });
+    expect(fetchMock.mock.calls[0][0]).toMatch("/api/projects/p1/routines/rtn-1");
+    expect(fetchMock.mock.calls[0][1].method).toBe("PATCH");
+  });
+
+  it("remove DELETEs the routine", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ ok: true }));
+    await projectsApi.routines.remove("p1", "rtn-1");
+    expect(fetchMock.mock.calls[0][1].method).toBe("DELETE");
+  });
+
+  it("trigger POSTs to the /trigger endpoint", async () => {
+    fetchMock.mockResolvedValueOnce(ok({ ok: true, task: { id: "tsk-1" } }));
+    const r = await projectsApi.routines.trigger("p1", "rtn-1");
+    expect(fetchMock.mock.calls[0][0]).toMatch("/api/projects/p1/routines/rtn-1/trigger");
+    expect(fetchMock.mock.calls[0][1].method).toBe("POST");
+    expect(r.task.id).toBe("tsk-1");
+  });
+});

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -75,6 +75,23 @@ export type ProjectEvent = {
   ts: number;
 };
 
+export type Routine = {
+  id: string;
+  project_id: string;
+  title: string;
+  body_template: string;
+  assignee_id: string | null;
+  trigger_kind: "cron" | "webhook" | "api";
+  cron_expr: string | null;
+  webhook_token: string | null;
+  enabled: number;
+  last_fired: number | null;
+  next_fire: number | null;
+  created_by: string;
+  created_at: number;
+  updated_at: number;
+};
+
 export type TaskContextAncestor = { id: string; title: string; status: string };
 export type TaskContextBlocker = { id: string; title: string; status: string };
 
@@ -191,6 +208,47 @@ export const projectsApi = {
       }),
     getContext: (tid: string) =>
       http<TaskContext>(`/api/projects/tasks/${tid}/context`),
+  },
+
+  routines: {
+    list: (pid: string) =>
+      http<{ items: Routine[] }>(`/api/projects/${pid}/routines`).then((r) => r.items),
+    create: (
+      pid: string,
+      input: {
+        title: string;
+        body_template?: string;
+        assignee_id?: string | null;
+        trigger_kind: "cron" | "webhook" | "api";
+        cron_expr?: string | null;
+        enabled?: boolean;
+      },
+    ) =>
+      http<Routine>(`/api/projects/${pid}/routines`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    update: (
+      pid: string,
+      rid: string,
+      patch: {
+        title?: string;
+        body_template?: string;
+        assignee_id?: string | null;
+        cron_expr?: string | null;
+        enabled?: boolean;
+      },
+    ) =>
+      http<Routine>(`/api/projects/${pid}/routines/${rid}`, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      }),
+    remove: (pid: string, rid: string) =>
+      http<{ ok: boolean }>(`/api/projects/${pid}/routines/${rid}`, { method: "DELETE" }),
+    trigger: (pid: string, rid: string) =>
+      http<{ ok: boolean; task: ProjectTask }>(`/api/projects/${pid}/routines/${rid}/trigger`, {
+        method: "POST",
+      }),
   },
 
   activity: (pid: string) =>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dependencies = [
     # Diff/patch for the notes revision log: computes and applies text diffs
     # for the Time Machine history layer (tinyagentos/notes/shared_docs_store.py).
     "diff-match-patch>=20230430",
+    # Cron expression parsing for project routines (schedule -> next_fire).
+    "croniter>=3.0.3",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,10 @@ async def client(app, tmp_data_dir):
     if project_task_store._db is not None:
         await project_task_store.close()
     await project_task_store.init()
+    routine_store = app.state.routine_store
+    if routine_store._db is not None:
+        await routine_store.close()
+    await routine_store.init()
     decision_store = app.state.decision_store
     if decision_store._db is not None:
         await decision_store.close()
@@ -388,6 +392,7 @@ async def client(app, tmp_data_dir):
         yield c
     await canvas_store.close()
     await project_task_store.close()
+    await routine_store.close()
     await board_audit.close()
     await project_store.close()
     await chat_channels.close()
@@ -545,6 +550,10 @@ async def client_with_qmd(app_with_qmd):
     if project_task_store._db is not None:
         await project_task_store.close()
     await project_task_store.init()
+    routine_store = app_with_qmd.state.routine_store
+    if routine_store._db is not None:
+        await routine_store.close()
+    await routine_store.init()
     app_with_qmd.state.projects_root.mkdir(parents=True, exist_ok=True)
     canvas_store = app_with_qmd.state.canvas_store
     if canvas_store._db is not None:
@@ -564,6 +573,7 @@ async def client_with_qmd(app_with_qmd):
         yield c
     await canvas_store.close()
     await project_task_store.close()
+    await routine_store.close()
     await board_audit.close()
     await project_store.close()
     await chat_channels.close()

--- a/tests/projects/test_routine_runner.py
+++ b/tests/projects/test_routine_runner.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos.projects.routine_runner import (
+    _resolve_assignee_agent,
+    fire_routine,
+    routine_tick_loop,
+)
+
+
+def _make_state(**overrides) -> SimpleNamespace:
+    routine_store = MagicMock()
+    routine_store.record_fire = AsyncMock(return_value=None)
+    routine_store.list_due = AsyncMock(return_value=[])
+
+    task_store = MagicMock()
+    task_store.create_task = AsyncMock(
+        return_value={"id": "tsk-new1", "project_id": "prj-1", "title": "Fired task"}
+    )
+
+    project_store = MagicMock()
+    project_store.list_members = AsyncMock(return_value=[])
+    project_store.get_project = AsyncMock(return_value={"id": "prj-1", "slug": "demo", "created_by": "u"})
+    project_store.list_projects = AsyncMock(return_value=[])
+
+    chat_channels = MagicMock()
+    chat_channels.list_channels = AsyncMock(return_value=[])
+    chat_channels.create_channel = AsyncMock(return_value={"id": "chan-a2a", "members": []})
+
+    chat_messages = MagicMock()
+    chat_messages.send_message = AsyncMock(return_value={"id": "msg-1"})
+
+    bridge_sessions = MagicMock()
+    bridge_sessions.enqueue_user_message = AsyncMock()
+
+    state = SimpleNamespace(
+        routine_store=overrides.get("routine_store", routine_store),
+        project_task_store=overrides.get("project_task_store", task_store),
+        project_store=overrides.get("project_store", project_store),
+        chat_channels=overrides.get("chat_channels", chat_channels),
+        chat_messages=overrides.get("chat_messages", chat_messages),
+        bridge_sessions=overrides.get("bridge_sessions", bridge_sessions),
+        config=overrides.get("config", None),
+    )
+    return state
+
+
+def _routine(**overrides) -> dict:
+    base = {
+        "id": "rtn-abc123",
+        "project_id": "prj-1",
+        "title": "Nightly sweep",
+        "body_template": "do the thing",
+        "assignee_id": None,
+        "trigger_kind": "cron",
+        "cron_expr": "0 3 * * *",
+        "enabled": 1,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_fire_routine_always_creates_task():
+    state = _make_state()
+    routine = _routine()
+    task = await fire_routine(state, routine)
+    assert task["id"] == "tsk-new1"
+    state.project_task_store.create_task.assert_awaited_once()
+    kwargs = state.project_task_store.create_task.call_args.kwargs
+    assert kwargs["project_id"] == "prj-1"
+    assert kwargs["title"] == "Nightly sweep"
+    assert kwargs["body"] == "do the thing"
+    assert kwargs["created_by"] == "routine:rtn-abc123"
+
+
+@pytest.mark.asyncio
+async def test_fire_routine_records_fire():
+    state = _make_state()
+    routine = _routine()
+    await fire_routine(state, routine)
+    state.routine_store.record_fire.assert_awaited_once()
+    call_args = state.routine_store.record_fire.call_args.args
+    assert call_args[0] == "rtn-abc123"
+
+
+@pytest.mark.asyncio
+async def test_fire_routine_posts_a2a_system_message():
+    state = _make_state()
+    routine = _routine()
+    await fire_routine(state, routine)
+    state.chat_messages.send_message.assert_awaited_once()
+    kwargs = state.chat_messages.send_message.call_args.kwargs
+    assert kwargs["channel_id"] == "chan-a2a"
+    assert kwargs["content_type"] == "system"
+    assert "Nightly sweep" in kwargs["content"]
+
+
+@pytest.mark.asyncio
+async def test_fire_routine_creates_task_even_when_announce_fails():
+    """Task creation must never be rolled back or skipped by a wake/announce
+    failure — the wake edge is best-effort only."""
+    state = _make_state()
+    state.chat_messages.send_message = AsyncMock(side_effect=RuntimeError("boom"))
+    routine = _routine()
+    task = await fire_routine(state, routine)
+    assert task["id"] == "tsk-new1"
+    state.project_task_store.create_task.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fire_routine_wakes_running_assignee_agent():
+    config = SimpleNamespace(agents=[{"id": "agent-hex-1", "name": "worker-agent", "status": "running"}])
+    state = _make_state(config=config)
+    routine = _routine(assignee_id="agent-hex-1")
+    task = await fire_routine(state, routine)
+    state.bridge_sessions.enqueue_user_message.assert_awaited_once()
+    args = state.bridge_sessions.enqueue_user_message.call_args.args
+    assert args[0] == "worker-agent"
+    assert args[1]["id"] == task["id"]
+
+
+@pytest.mark.asyncio
+async def test_fire_routine_does_not_wake_stopped_agent():
+    config = SimpleNamespace(agents=[{"id": "agent-hex-1", "name": "worker-agent", "status": "stopped"}])
+    state = _make_state(config=config)
+    routine = _routine(assignee_id="agent-hex-1")
+    await fire_routine(state, routine)
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fire_routine_does_not_wake_when_assignee_unresolved():
+    config = SimpleNamespace(agents=[])
+    state = _make_state(config=config)
+    routine = _routine(assignee_id="unknown-agent")
+    task = await fire_routine(state, routine)
+    assert task["id"] == "tsk-new1"
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+
+
+def test_resolve_assignee_agent_matches_by_id_or_name():
+    config = SimpleNamespace(agents=[{"id": "hex1", "name": "worker", "status": "running"}])
+    assert _resolve_assignee_agent(config, "hex1")["name"] == "worker"
+    assert _resolve_assignee_agent(config, "worker")["name"] == "worker"
+    assert _resolve_assignee_agent(config, "nope") is None
+    assert _resolve_assignee_agent(config, None) is None
+    assert _resolve_assignee_agent(None, "hex1") is None
+
+
+@pytest.mark.asyncio
+async def test_routine_tick_loop_fires_due_routines_then_sleeps(monkeypatch):
+    routine = _routine()
+    state = _make_state()
+    state.routine_store.list_due = AsyncMock(side_effect=[[routine], AssertionError("should not tick twice")])
+
+    sleeps = []
+    import asyncio as _asyncio
+
+    async def _fake_sleep(seconds):
+        sleeps.append(seconds)
+        raise _asyncio.CancelledError()
+
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
+
+    with pytest.raises(_asyncio.CancelledError):
+        await routine_tick_loop(state)
+
+    state.project_task_store.create_task.assert_awaited_once()
+    assert sleeps == [60]
+
+
+@pytest.mark.asyncio
+async def test_routine_tick_loop_survives_a_bad_routine(monkeypatch):
+    """One routine raising during fire must not stop the sweep from
+    continuing to the next routine, nor crash the loop."""
+    good = _routine(id="rtn-good")
+    bad = _routine(id="rtn-bad")
+    state = _make_state()
+    state.routine_store.list_due = AsyncMock(return_value=[bad, good])
+
+    calls = []
+
+    async def _create_task(*args, **kwargs):
+        calls.append(kwargs.get("created_by"))
+        if kwargs.get("created_by") == "routine:rtn-bad":
+            raise RuntimeError("boom")
+        return {"id": "tsk-good", "project_id": "prj-1", "title": "ok"}
+
+    state.project_task_store.create_task = AsyncMock(side_effect=_create_task)
+
+    import asyncio as _asyncio
+
+    async def _fake_sleep(seconds):
+        raise _asyncio.CancelledError()
+
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
+
+    with pytest.raises(_asyncio.CancelledError):
+        await routine_tick_loop(state)
+
+    assert calls == ["routine:rtn-bad", "routine:rtn-good"]

--- a/tests/projects/test_routine_runner.py
+++ b/tests/projects/test_routine_runner.py
@@ -6,16 +6,19 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from tinyagentos.projects.routine_runner import (
+    _create_task_and_wake,
     _resolve_assignee_agent,
     fire_routine,
     routine_tick_loop,
 )
+from tinyagentos.projects.routines_store import RoutineStore
 
 
 def _make_state(**overrides) -> SimpleNamespace:
     routine_store = MagicMock()
     routine_store.record_fire = AsyncMock(return_value=None)
     routine_store.list_due = AsyncMock(return_value=[])
+    routine_store.claim_due = AsyncMock(return_value=True)
 
     task_store = MagicMock()
     task_store.create_task = AsyncMock(
@@ -59,6 +62,7 @@ def _routine(**overrides) -> dict:
         "trigger_kind": "cron",
         "cron_expr": "0 3 * * *",
         "enabled": 1,
+        "next_fire": 1000.0,
     }
     base.update(overrides)
     return base
@@ -150,6 +154,65 @@ def test_resolve_assignee_agent_matches_by_id_or_name():
     assert _resolve_assignee_agent(config, "nope") is None
     assert _resolve_assignee_agent(config, None) is None
     assert _resolve_assignee_agent(None, "hex1") is None
+
+
+@pytest.mark.asyncio
+async def test_fire_routine_resolves_native_member_hex_id_to_agent_slug():
+    """A native project member stores the agent's config id (a 12-char hex, e.g.
+    '91a640130122') as its member_id, and that is exactly what the UI assignee
+    picker sends. Confirm a routine whose assignee_id is that hex id resolves to
+    the agent's name (slug) and wakes it — proving the wake edge actually fires
+    for real assignees, not just when id==name."""
+    hex_id = "91a640130122"
+    config = SimpleNamespace(
+        agents=[{"id": hex_id, "name": "researcher", "status": "running"}]
+    )
+    state = _make_state(config=config)
+    routine = _routine(assignee_id=hex_id)
+    await fire_routine(state, routine)
+    state.bridge_sessions.enqueue_user_message.assert_awaited_once()
+    slug = state.bridge_sessions.enqueue_user_message.call_args.args[0]
+    assert slug == "researcher"
+
+
+@pytest.mark.asyncio
+async def test_due_routine_fires_exactly_once_across_two_concurrent_ticks(tmp_path):
+    """Two ticks that both selected the same due routine from list_due (same
+    next_fire snapshot) must not both fire it: claim_due lets exactly one win,
+    so the task is created exactly once."""
+    store = RoutineStore(tmp_path / "routines.db")
+    await store.init()
+    try:
+        r = await store.create_routine(
+            project_id="prj-1", title="Once", created_by="u", cron_expr="* * * * *",
+        )
+        now = 2_000_000.0
+        # Force it due at `now`.
+        await store._db.execute(
+            "UPDATE routines SET next_fire = ? WHERE id = ?", (now - 10, r["id"])
+        )
+        await store._db.commit()
+        snapshot = await store.get_routine(r["id"])
+
+        created = 0
+
+        async def _create_task(**kwargs):
+            nonlocal created
+            created += 1
+            return {"id": f"tsk-{created}", "project_id": "prj-1", "title": "Once"}
+
+        state = _make_state(routine_store=store)
+        state.project_task_store.create_task = AsyncMock(side_effect=_create_task)
+
+        # Two back-to-back ticks, each holding the same pre-claim snapshot.
+        for _ in range(2):
+            claimed = await store.claim_due(snapshot["id"], snapshot["next_fire"], now)
+            if claimed:
+                await _create_task_and_wake(state, snapshot)
+
+        assert created == 1
+    finally:
+        await store.close()
 
 
 @pytest.mark.asyncio

--- a/tests/projects/test_routines_store.py
+++ b/tests/projects/test_routines_store.py
@@ -1,0 +1,245 @@
+import time
+
+import pytest
+import pytest_asyncio
+from croniter import croniter
+
+from tinyagentos.projects.routines_store import RoutineStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = RoutineStore(tmp_path / "routines.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_create_cron_routine_computes_next_fire(store):
+    before = time.time()
+    r = await store.create_routine(
+        project_id="prj-1",
+        title="Daily standup task",
+        created_by="user-1",
+        cron_expr="0 3 * * *",
+    )
+    assert r["id"].startswith("rtn-")
+    assert r["project_id"] == "prj-1"
+    assert r["trigger_kind"] == "cron"
+    assert r["cron_expr"] == "0 3 * * *"
+    assert r["enabled"] == 1
+    assert r["webhook_token"] is None
+    assert r["last_fired"] is None
+    # next_fire must be exactly what croniter computes from a timestamp in
+    # [before, after] — assert it lands in the expected window rather than a
+    # frozen value, since real time elapsed during the call.
+    after = time.time()
+    expected_lo = croniter("0 3 * * *", before).get_next(float)
+    expected_hi = croniter("0 3 * * *", after).get_next(float)
+    assert expected_lo <= r["next_fire"] <= expected_hi + 1
+
+
+@pytest.mark.asyncio
+async def test_create_cron_routine_requires_cron_expr(store):
+    with pytest.raises(ValueError):
+        await store.create_routine(
+            project_id="prj-1", title="Bad", created_by="u", trigger_kind="cron",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_routine_rejects_bad_trigger_kind(store):
+    with pytest.raises(ValueError):
+        await store.create_routine(
+            project_id="prj-1", title="Bad", created_by="u", trigger_kind="carrier-pigeon",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_webhook_routine_generates_token(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Inbound hook", created_by="u", trigger_kind="webhook",
+    )
+    assert r["trigger_kind"] == "webhook"
+    assert r["webhook_token"]
+    assert r["next_fire"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_api_routine_has_no_schedule_or_token(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="API only", created_by="u", trigger_kind="api",
+    )
+    assert r["trigger_kind"] == "api"
+    assert r["webhook_token"] is None
+    assert r["next_fire"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_webhook_token_matches(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Hook", created_by="u", trigger_kind="webhook",
+    )
+    found = await store.get_by_webhook_token(r["webhook_token"])
+    assert found is not None
+    assert found["id"] == r["id"]
+
+
+@pytest.mark.asyncio
+async def test_get_by_webhook_token_rejects_unknown(store):
+    await store.create_routine(
+        project_id="prj-1", title="Hook", created_by="u", trigger_kind="webhook",
+    )
+    assert await store.get_by_webhook_token("not-a-real-token") is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_webhook_token_rejects_disabled_routine(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Hook", created_by="u", trigger_kind="webhook",
+    )
+    await store.update_routine(r["id"], enabled=False)
+    assert await store.get_by_webhook_token(r["webhook_token"]) is None
+
+
+@pytest.mark.asyncio
+async def test_list_routines_scoped_to_project(store):
+    await store.create_routine(project_id="prj-1", title="A", created_by="u", trigger_kind="api")
+    await store.create_routine(project_id="prj-2", title="B", created_by="u", trigger_kind="api")
+    items = await store.list_routines("prj-1")
+    assert len(items) == 1
+    assert items[0]["title"] == "A"
+
+
+@pytest.mark.asyncio
+async def test_list_due_returns_only_past_due_enabled_cron_routines(store):
+    now = time.time()
+    due = await store.create_routine(
+        project_id="prj-1", title="Due", created_by="u", cron_expr="0 3 * * *",
+    )
+    # Force it into the past so it is due right now.
+    await store._db.execute(
+        "UPDATE routines SET next_fire = ? WHERE id = ?", (now - 10, due["id"])
+    )
+    await store._db.commit()
+
+    not_due = await store.create_routine(
+        project_id="prj-1", title="Not due", created_by="u", cron_expr="0 3 * * *",
+    )
+    await store._db.execute(
+        "UPDATE routines SET next_fire = ? WHERE id = ?", (now + 100000, not_due["id"])
+    )
+    await store._db.commit()
+
+    webhook = await store.create_routine(
+        project_id="prj-1", title="Webhook", created_by="u", trigger_kind="webhook",
+    )
+    api_only = await store.create_routine(
+        project_id="prj-1", title="Api", created_by="u", trigger_kind="api",
+    )
+
+    result = await store.list_due(now)
+    ids = {r["id"] for r in result}
+    assert ids == {due["id"]}
+    assert webhook["id"] not in ids
+    assert api_only["id"] not in ids
+
+
+@pytest.mark.asyncio
+async def test_list_due_excludes_disabled_routine(store):
+    now = time.time()
+    r = await store.create_routine(
+        project_id="prj-1", title="Due but disabled", created_by="u", cron_expr="0 3 * * *",
+    )
+    await store._db.execute(
+        "UPDATE routines SET next_fire = ? WHERE id = ?", (now - 10, r["id"])
+    )
+    await store._db.commit()
+    await store.update_routine(r["id"], enabled=False)
+
+    result = await store.list_due(now)
+    assert r["id"] not in {x["id"] for x in result}
+
+
+@pytest.mark.asyncio
+async def test_update_routine_changes_fields(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Original", created_by="u", cron_expr="0 3 * * *",
+    )
+    updated = await store.update_routine(r["id"], title="Renamed", body_template="new body")
+    assert updated["title"] == "Renamed"
+    assert updated["body_template"] == "new body"
+
+
+@pytest.mark.asyncio
+async def test_update_routine_cron_expr_recomputes_next_fire(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Original", created_by="u", cron_expr="0 3 * * *",
+    )
+    old_next = r["next_fire"]
+    updated = await store.update_routine(r["id"], cron_expr="*/5 * * * *")
+    assert updated["cron_expr"] == "*/5 * * * *"
+    assert updated["next_fire"] != old_next
+
+
+@pytest.mark.asyncio
+async def test_update_routine_disable_clears_next_fire(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Original", created_by="u", cron_expr="0 3 * * *",
+    )
+    updated = await store.update_routine(r["id"], enabled=False)
+    assert updated["enabled"] == 0
+    assert updated["next_fire"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_routine_reenable_recomputes_next_fire(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Original", created_by="u", cron_expr="0 3 * * *",
+    )
+    await store.update_routine(r["id"], enabled=False)
+    updated = await store.update_routine(r["id"], enabled=True)
+    assert updated["enabled"] == 1
+    assert updated["next_fire"] is not None
+
+
+@pytest.mark.asyncio
+async def test_update_routine_returns_none_for_missing(store):
+    assert await store.update_routine("rtn-missing", title="x") is None
+
+
+@pytest.mark.asyncio
+async def test_record_fire_advances_schedule(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Original", created_by="u", cron_expr="* * * * *",
+    )
+    first_next = r["next_fire"]
+    fired_at = first_next + 1
+    updated = await store.record_fire(r["id"], fired_at)
+    assert updated["last_fired"] == fired_at
+    assert updated["next_fire"] > first_next
+
+
+@pytest.mark.asyncio
+async def test_record_fire_on_webhook_routine_leaves_next_fire_none(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Hook", created_by="u", trigger_kind="webhook",
+    )
+    updated = await store.record_fire(r["id"], time.time())
+    assert updated["next_fire"] is None
+    assert updated["last_fired"] is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_routine(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Gone", created_by="u", trigger_kind="api",
+    )
+    assert await store.delete_routine(r["id"]) is True
+    assert await store.get_routine(r["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent_routine(store):
+    assert await store.delete_routine("rtn-missing") is False

--- a/tests/projects/test_routines_store.py
+++ b/tests/projects/test_routines_store.py
@@ -57,6 +57,23 @@ async def test_create_routine_rejects_bad_trigger_kind(store):
 
 
 @pytest.mark.asyncio
+async def test_create_cron_routine_rejects_invalid_cron_expr(store):
+    with pytest.raises(ValueError):
+        await store.create_routine(
+            project_id="prj-1", title="Bad", created_by="u", cron_expr="not a cron",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_routine_rejects_invalid_cron_expr(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Original", created_by="u", cron_expr="0 3 * * *",
+    )
+    with pytest.raises(ValueError):
+        await store.update_routine(r["id"], cron_expr="0 99 * * *")
+
+
+@pytest.mark.asyncio
 async def test_create_webhook_routine_generates_token(store):
     r = await store.create_routine(
         project_id="prj-1", title="Inbound hook", created_by="u", trigger_kind="webhook",
@@ -92,6 +109,27 @@ async def test_get_by_webhook_token_rejects_unknown(store):
         project_id="prj-1", title="Hook", created_by="u", trigger_kind="webhook",
     )
     assert await store.get_by_webhook_token("not-a-real-token") is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_webhook_token_rejects_empty(store):
+    # An empty token must never match the NULL webhook_token of cron/api rows.
+    await store.create_routine(
+        project_id="prj-1", title="Cron", created_by="u", cron_expr="0 3 * * *",
+    )
+    assert await store.get_by_webhook_token("") is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_webhook_token_distinguishes_multiple_routines(store):
+    a = await store.create_routine(
+        project_id="prj-1", title="Hook A", created_by="u", trigger_kind="webhook",
+    )
+    b = await store.create_routine(
+        project_id="prj-1", title="Hook B", created_by="u", trigger_kind="webhook",
+    )
+    assert (await store.get_by_webhook_token(a["webhook_token"]))["id"] == a["id"]
+    assert (await store.get_by_webhook_token(b["webhook_token"]))["id"] == b["id"]
 
 
 @pytest.mark.asyncio
@@ -229,6 +267,51 @@ async def test_record_fire_on_webhook_routine_leaves_next_fire_none(store):
     updated = await store.record_fire(r["id"], time.time())
     assert updated["next_fire"] is None
     assert updated["last_fired"] is not None
+
+
+@pytest.mark.asyncio
+async def test_claim_due_advances_schedule_and_returns_true(store):
+    r = await store.create_routine(
+        project_id="prj-1", title="Due", created_by="u", cron_expr="* * * * *",
+    )
+    first_next = r["next_fire"]
+    fired_at = first_next + 1
+    claimed = await store.claim_due(r["id"], first_next, fired_at)
+    assert claimed is True
+    after = await store.get_routine(r["id"])
+    assert after["last_fired"] == fired_at
+    assert after["next_fire"] > first_next
+
+
+@pytest.mark.asyncio
+async def test_claim_due_second_claim_of_same_instant_returns_false(store):
+    """The double-fire guard: once a routine's next_fire has been advanced, a
+    second claim for the SAME original next_fire must fail so the routine fires
+    exactly once per due instant."""
+    r = await store.create_routine(
+        project_id="prj-1", title="Due once", created_by="u", cron_expr="* * * * *",
+    )
+    original_next = r["next_fire"]
+    fired_at = original_next + 1
+    first = await store.claim_due(r["id"], original_next, fired_at)
+    second = await store.claim_due(r["id"], original_next, fired_at)
+    assert first is True
+    assert second is False
+
+
+@pytest.mark.asyncio
+async def test_claim_due_ignores_non_cron_and_disabled(store):
+    webhook = await store.create_routine(
+        project_id="prj-1", title="Hook", created_by="u", trigger_kind="webhook",
+    )
+    assert await store.claim_due(webhook["id"], 0.0, time.time()) is False
+
+    cron = await store.create_routine(
+        project_id="prj-1", title="Disabled", created_by="u", cron_expr="* * * * *",
+    )
+    original_next = cron["next_fire"]
+    await store.update_routine(cron["id"], enabled=False)
+    assert await store.claim_due(cron["id"], original_next, time.time()) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_routines.py
+++ b/tests/test_routes_routines.py
@@ -1,0 +1,247 @@
+"""Tests for the project routines routes: CRUD, ownership, manual trigger,
+and the inbound webhook trigger."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_create_cron_routine(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    resp = await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Nightly", "cron_expr": "0 3 * * *", "trigger_kind": "cron"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"].startswith("rtn-")
+    assert body["project_id"] == pid
+    assert body["trigger_kind"] == "cron"
+    assert body["next_fire"] is not None
+    assert body["webhook_token"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_cron_routine_missing_cron_expr_400(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    resp = await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Bad", "trigger_kind": "cron"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_webhook_routine_returns_token(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    resp = await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Hook", "trigger_kind": "webhook"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["webhook_token"]
+
+
+@pytest.mark.asyncio
+async def test_create_routine_unknown_project_404(client):
+    resp = await client.post(
+        "/api/projects/prj-doesnotexist/routines",
+        json={"title": "X", "trigger_kind": "api"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_routines(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    await client.post(f"/api/projects/{pid}/routines", json={"title": "One", "trigger_kind": "api"})
+    await client.post(f"/api/projects/{pid}/routines", json={"title": "Two", "trigger_kind": "api"})
+    resp = await client.get(f"/api/projects/{pid}/routines")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 2
+    assert {i["title"] for i in items} == {"One", "Two"}
+
+
+@pytest.mark.asyncio
+async def test_update_routine(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    rid = (await client.post(
+        f"/api/projects/{pid}/routines", json={"title": "Original", "trigger_kind": "api"}
+    )).json()["id"]
+    resp = await client.patch(
+        f"/api/projects/{pid}/routines/{rid}",
+        json={"title": "Renamed", "enabled": False},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "Renamed"
+    assert body["enabled"] == 0
+
+
+@pytest.mark.asyncio
+async def test_update_routine_unknown_404(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    resp = await client.patch(f"/api/projects/{pid}/routines/rtn-nope", json={"title": "X"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_routine_wrong_project_404(client):
+    pid_a = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    pid_b = (await client.post("/api/projects", json={"name": "B", "slug": "b"})).json()["id"]
+    rid = (await client.post(
+        f"/api/projects/{pid_a}/routines", json={"title": "Original", "trigger_kind": "api"}
+    )).json()["id"]
+    resp = await client.patch(f"/api/projects/{pid_b}/routines/{rid}", json={"title": "X"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_routine(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    rid = (await client.post(
+        f"/api/projects/{pid}/routines", json={"title": "Gone", "trigger_kind": "api"}
+    )).json()["id"]
+    resp = await client.delete(f"/api/projects/{pid}/routines/{rid}")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    resp = await client.get(f"/api/projects/{pid}/routines")
+    assert resp.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_manual_trigger_creates_task(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    rid = (await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Manual fire", "body_template": "do it", "trigger_kind": "api"},
+    )).json()["id"]
+
+    resp = await client.post(f"/api/projects/{pid}/routines/{rid}/trigger")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["task"]["title"] == "Manual fire"
+    assert body["task"]["body"] == "do it"
+
+    tasks = (await client.get(f"/api/projects/{pid}/tasks")).json()["items"]
+    assert any(t["id"] == body["task"]["id"] for t in tasks)
+
+
+@pytest.mark.asyncio
+async def test_manual_trigger_unknown_routine_404(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    resp = await client.post(f"/api/projects/{pid}/routines/rtn-nope/trigger")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_webhook_trigger_creates_task(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    routine = (await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Inbound", "body_template": "hook body", "trigger_kind": "webhook"},
+    )).json()
+    token = routine["webhook_token"]
+
+    resp = await client.post(f"/api/webhooks/routines/{token}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["task"]["title"] == "Inbound"
+
+    tasks = (await client.get(f"/api/projects/{pid}/tasks")).json()["items"]
+    assert any(t["id"] == body["task"]["id"] for t in tasks)
+
+
+@pytest.mark.asyncio
+async def test_webhook_trigger_unknown_token_404(client):
+    resp = await client.post("/api/webhooks/routines/not-a-real-token")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_webhook_trigger_disabled_routine_404(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    routine = (await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Inbound", "trigger_kind": "webhook"},
+    )).json()
+    rid = routine["id"]
+    token = routine["webhook_token"]
+    await client.patch(f"/api/projects/{pid}/routines/{rid}", json={"enabled": False})
+
+    resp = await client.post(f"/api/webhooks/routines/{token}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Ownership: a non-owner member must not see or manage another user's routines
+# ---------------------------------------------------------------------------
+
+def _add_member_user(app, username: str, password: str) -> str:
+    auth = app.state.auth
+    invite_code = auth.add_user_invite(username, invited_by_username="admin")
+    auth.complete_invite(
+        username=username,
+        invite_code=invite_code,
+        full_name="Member User",
+        email=f"{username}@test.local",
+        password=password,
+    )
+    return auth.find_user(username)["id"]
+
+
+@pytest_asyncio.fixture
+async def two_owner_clients(app, tmp_data_dir):
+    """Two separate non-admin users (alice, bob) sharing one app instance."""
+    for attr in ("project_store", "project_task_store", "routine_store", "board_audit"):
+        store = getattr(app.state, attr, None)
+        if store is not None and store._db is None:
+            await store.init()
+    app.state.projects_root.mkdir(parents=True, exist_ok=True)
+    if not app.state.auth.is_configured():
+        app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+
+    alice_uid = _add_member_user(app, "alice", "alicepass1")
+    bob_uid = _add_member_user(app, "bob", "bobspass1")
+    alice_token = app.state.auth.create_session(user_id=alice_uid, long_lived=True)
+    bob_token = app.state.auth.create_session(user_id=bob_uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": alice_token},
+    ) as alice_c:
+        async with AsyncClient(
+            transport=transport, base_url="http://test", cookies={"taos_session": bob_token},
+        ) as bob_c:
+            yield alice_c, bob_c
+
+    await app.state.project_store.close()
+    await app.state.project_task_store.close()
+    await app.state.routine_store.close()
+    await app.state.board_audit.close()
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_list_or_create_routines(two_owner_clients):
+    alice_c, bob_c = two_owner_clients
+    pid = (await alice_c.post("/api/projects", json={"name": "Alice Proj", "slug": "alice-proj"})).json()["id"]
+
+    resp = await bob_c.get(f"/api/projects/{pid}/routines")
+    assert resp.status_code == 404
+
+    resp = await bob_c.post(
+        f"/api/projects/{pid}/routines", json={"title": "Sneaky", "trigger_kind": "api"}
+    )
+    assert resp.status_code == 404
+
+    rid = (await alice_c.post(
+        f"/api/projects/{pid}/routines", json={"title": "Alice routine", "trigger_kind": "api"}
+    )).json()["id"]
+    resp = await bob_c.post(f"/api/projects/{pid}/routines/{rid}/trigger")
+    assert resp.status_code == 404

--- a/tests/test_routes_routines.py
+++ b/tests/test_routes_routines.py
@@ -34,6 +34,31 @@ async def test_create_cron_routine_missing_cron_expr_400(client):
 
 
 @pytest.mark.asyncio
+async def test_create_cron_routine_invalid_cron_expr_400(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    resp = await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Bad", "trigger_kind": "cron", "cron_expr": "not a cron"},
+    )
+    assert resp.status_code == 400
+    assert "cron" in resp.json()["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_update_routine_invalid_cron_expr_400(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    rid = (await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Good", "trigger_kind": "cron", "cron_expr": "0 3 * * *"},
+    )).json()["id"]
+    resp = await client.patch(
+        f"/api/projects/{pid}/routines/{rid}",
+        json={"cron_expr": "0 99 * * *"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_create_webhook_routine_returns_token(client):
     pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
     resp = await client.post(
@@ -176,6 +201,26 @@ async def test_webhook_trigger_disabled_routine_404(client):
 
     resp = await client.post(f"/api/webhooks/routines/{token}")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_webhook_trigger_rate_limited_after_burst(client):
+    """The unauthenticated webhook must not be spammable to mass-create tasks:
+    a burst on one token eventually 429s."""
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    token = (await client.post(
+        f"/api/projects/{pid}/routines",
+        json={"title": "Inbound", "trigger_kind": "webhook"},
+    )).json()["webhook_token"]
+
+    statuses = []
+    for _ in range(8):
+        statuses.append((await client.post(f"/api/webhooks/routines/{token}")).status_code)
+
+    # Bucket capacity is small (5) with slow refill, so a tight burst of 8 must
+    # include at least one 429 while the earliest requests succeed.
+    assert 200 in statuses
+    assert 429 in statuses
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -376,6 +376,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         audit=board_audit_store,
         project_store=project_store,
     )
+    from tinyagentos.projects.routines_store import RoutineStore
+    routine_store = RoutineStore(data_dir / "routines.db")
     project_canvas_store = ProjectCanvasStoreImpl(data_dir / "projects.db", broker=project_event_broker)
     from tinyagentos.decisions.decision_store import DecisionStore
     decision_store = DecisionStore(data_dir / "decisions.db")
@@ -491,6 +493,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await receipt_store.init()
         app.state.receipt_store = receipt_store
         await project_task_store.init()
+        await routine_store.init()
+        app.state.routine_store = routine_store
         await project_canvas_store.init()
         await decision_store.init()
         app.state.decision_store = decision_store
@@ -1160,6 +1164,14 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             logger.exception("beads bridge failed to start — continuing without")
             app.state.beads_bridge = None
 
+        # Routines executor: sweeps due cron routines every 60s, creating a
+        # project task and best-effort waking the assignee for each. A plain
+        # supervised loop (not a class with its own start/stop) so it rides
+        # the existing bounded cancel_and_wait shutdown path below like every
+        # other background loop.
+        from tinyagentos.projects.routine_runner import routine_tick_loop
+        _create_supervised_task(routine_tick_loop(app.state), app.state._background_tasks)
+
         try:
             canvas_snapshotter = CanvasSnapshotter(
                 project_store=project_store,
@@ -1316,6 +1328,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 logger.exception("canvas snapshotter stop failed")
         await project_canvas_store.close()
         await project_task_store.close()
+        await routine_store.close()
         await project_store.close()
         await chat_channels.close()
         await chat_messages.close()
@@ -1461,6 +1474,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.board_audit = board_audit_store
     app.state.receipt_store = receipt_store
     app.state.project_task_store = project_task_store
+    app.state.routine_store = routine_store
     app.state.project_event_broker = project_event_broker
     app.state.desktop_command_broker = desktop_command_broker
     app.state.project_canvas_store = project_canvas_store

--- a/tinyagentos/projects/ids.py
+++ b/tinyagentos/projects/ids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import secrets
 
-ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "rev", "cs")
+ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "rev", "cs", "rtn")
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
 
 

--- a/tinyagentos/projects/routine_runner.py
+++ b/tinyagentos/projects/routine_runner.py
@@ -1,0 +1,143 @@
+"""Routine executor: cron tick loop + the shared fire helper.
+
+A routine auto-creates a task on its project board when it fires (on a cron
+schedule, via webhook, or via manual/API trigger) and best-effort wakes the
+assignee agent. Task creation always happens; the wake (bridge_sessions
+enqueue + a2a system message) is best-effort — the assignee may be offline
+and will pick the task up later.
+
+The tick loop mirrors the other lifespan-owned background loops in app.py
+(e.g. `_ephemeral_sweep_loop`): a plain `while True` + try/except-per-iteration
++ sleep, registered in `app.state._background_tasks` so the existing bounded
+`cancel_and_wait` shutdown path cancels it alongside every other loop — no
+separate start/stop lifecycle needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+TICK_INTERVAL = 60  # seconds between due-routine sweeps
+
+
+def _resolve_assignee_agent(config, assignee_id: str | None) -> dict | None:
+    """Resolve a routine's assignee_id (a project member_id — an agent's
+    config id or name) to its config agent record.
+
+    Mirrors the id/name lookup used by tinyagentos/projects/a2a.py's
+    _resolve_member_names and the reverse direction in
+    beads_bridge.BeadsBridge._resolve_assignee. Returns None when config is
+    unavailable or assignee_id doesn't match any configured agent — callers
+    must treat the wake as best-effort in that case.
+    """
+    if not assignee_id or config is None:
+        return None
+    for agent in getattr(config, "agents", None) or []:
+        if agent.get("id") == assignee_id or agent.get("name") == assignee_id:
+            return agent
+    return None
+
+
+async def _wake_and_announce(app_state, routine: dict, task: dict) -> None:
+    """Best-effort: enqueue a user_message to a running assignee agent and
+    post a system message into the project's a2a channel. Never raises —
+    callers already wrap this in a try/except, but each sub-step also
+    degrades independently so a bridge failure doesn't skip the chat post."""
+    project_id = routine["project_id"]
+    config = getattr(app_state, "config", None)
+    bridge_sessions = getattr(app_state, "bridge_sessions", None)
+
+    agent = _resolve_assignee_agent(config, routine.get("assignee_id"))
+    if agent is not None and agent.get("status") == "running" and bridge_sessions is not None:
+        try:
+            await bridge_sessions.enqueue_user_message(
+                agent["name"],
+                {
+                    "id": task["id"],
+                    "trace_id": task["id"],
+                    "channel_id": None,
+                    "from": "routine",
+                    "text": f"Routine \"{routine['title']}\" fired — created task {task['id']}: {task['title']}",
+                    "author_type": "system",
+                    "hops_since_user": 0,
+                },
+            )
+        except Exception:
+            logger.warning(
+                "routine %s: wake enqueue failed for agent %s",
+                routine["id"], agent.get("name"), exc_info=True,
+            )
+
+    chat_channels = getattr(app_state, "chat_channels", None)
+    chat_messages = getattr(app_state, "chat_messages", None)
+    project_store = getattr(app_state, "project_store", None)
+    if chat_channels is not None and chat_messages is not None and project_store is not None:
+        try:
+            from tinyagentos.projects.a2a import ensure_a2a_channel
+            channel = await ensure_a2a_channel(
+                chat_channels, project_store, project_id, config=config
+            )
+            await chat_messages.send_message(
+                channel_id=channel["id"],
+                author_id="routine",
+                author_type="system",
+                content=f"Routine \"{routine['title']}\" fired — created task {task['id']}: {task['title']}",
+                content_type="system",
+                state="complete",
+            )
+        except Exception:
+            logger.warning(
+                "routine %s: a2a announce failed", routine["id"], exc_info=True,
+            )
+
+
+async def fire_routine(app_state, routine: dict) -> dict:
+    """Create a task from *routine*, advance its schedule, then best-effort
+    wake the assignee. Task creation always happens regardless of what
+    happens afterwards. Returns the created task dict."""
+    task_store = app_state.project_task_store
+    routine_store = app_state.routine_store
+
+    task = await task_store.create_task(
+        project_id=routine["project_id"],
+        title=routine["title"],
+        created_by=f"routine:{routine['id']}",
+        body=routine.get("body_template") or "",
+        assignee_id=routine.get("assignee_id"),
+    )
+
+    await routine_store.record_fire(routine["id"], time.time())
+
+    try:
+        await _wake_and_announce(app_state, routine, task)
+    except Exception:
+        logger.warning("routine %s: wake/announce crashed", routine["id"], exc_info=True)
+
+    return task
+
+
+async def routine_tick_loop(app_state) -> None:
+    """Sweep due cron routines every TICK_INTERVAL seconds and fire each one.
+
+    Failure-isolated per iteration and per routine: one bad routine (e.g. a
+    stale project) is logged and skipped, never aborting the loop.
+    """
+    routine_store = app_state.routine_store
+    while True:
+        try:
+            due = await routine_store.list_due(time.time())
+            for routine in due:
+                try:
+                    await fire_routine(app_state, routine)
+                except Exception:
+                    logger.exception(
+                        "routine tick: fire failed for routine %s", routine.get("id")
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("routine tick: sweep iteration crashed")
+        await asyncio.sleep(TICK_INTERVAL)

--- a/tinyagentos/projects/routine_runner.py
+++ b/tinyagentos/projects/routine_runner.py
@@ -94,44 +94,64 @@ async def _wake_and_announce(app_state, routine: dict, task: dict) -> None:
             )
 
 
-async def fire_routine(app_state, routine: dict) -> dict:
-    """Create a task from *routine*, advance its schedule, then best-effort
-    wake the assignee. Task creation always happens regardless of what
-    happens afterwards. Returns the created task dict."""
-    task_store = app_state.project_task_store
-    routine_store = app_state.routine_store
+async def _create_task_and_wake(app_state, routine: dict) -> dict:
+    """Create the board task for *routine* and best-effort wake the assignee.
 
-    task = await task_store.create_task(
+    Does NOT advance the routine's schedule — the caller is responsible for
+    that (record_fire for manual/webhook, claim_due for the scheduler tick).
+    Task creation always happens; wake is best-effort. Returns the task dict.
+    """
+    task = await app_state.project_task_store.create_task(
         project_id=routine["project_id"],
         title=routine["title"],
         created_by=f"routine:{routine['id']}",
         body=routine.get("body_template") or "",
         assignee_id=routine.get("assignee_id"),
     )
-
-    await routine_store.record_fire(routine["id"], time.time())
-
     try:
         await _wake_and_announce(app_state, routine, task)
     except Exception:
         logger.warning("routine %s: wake/announce crashed", routine["id"], exc_info=True)
+    return task
 
+
+async def fire_routine(app_state, routine: dict) -> dict:
+    """Manual/API and webhook entry point: create a task, advance the schedule,
+    then best-effort wake the assignee. Task creation always happens regardless
+    of what happens afterwards. Returns the created task dict.
+
+    The scheduler's tick loop does NOT call this — it claims the schedule
+    atomically first (see routine_tick_loop) to avoid double-firing.
+    """
+    task = await _create_task_and_wake(app_state, routine)
+    await app_state.routine_store.record_fire(routine["id"], time.time())
     return task
 
 
 async def routine_tick_loop(app_state) -> None:
     """Sweep due cron routines every TICK_INTERVAL seconds and fire each one.
 
-    Failure-isolated per iteration and per routine: one bad routine (e.g. a
-    stale project) is logged and skipped, never aborting the loop.
+    Each due routine is claimed atomically (claim_due advances its schedule
+    under a next_fire guard) BEFORE the task is created, so a concurrent or
+    restarted tick that selected the same routine loses the claim and skips it —
+    the routine fires exactly once per due instant. Failure-isolated per
+    iteration and per routine: one bad routine (e.g. a stale project) is logged
+    and skipped, never aborting the loop.
     """
     routine_store = app_state.routine_store
     while True:
         try:
-            due = await routine_store.list_due(time.time())
+            now = time.time()
+            due = await routine_store.list_due(now)
             for routine in due:
                 try:
-                    await fire_routine(app_state, routine)
+                    claimed = await routine_store.claim_due(
+                        routine["id"], routine["next_fire"], now
+                    )
+                    if not claimed:
+                        # Another tick already fired this due instant.
+                        continue
+                    await _create_task_and_wake(app_state, routine)
                 except Exception:
                     logger.exception(
                         "routine tick: fire failed for routine %s", routine.get("id")

--- a/tinyagentos/projects/routines_store.py
+++ b/tinyagentos/projects/routines_store.py
@@ -27,12 +27,28 @@ CREATE TABLE IF NOT EXISTS routines (
 );
 CREATE INDEX IF NOT EXISTS idx_routines_project ON routines(project_id);
 CREATE INDEX IF NOT EXISTS idx_routines_due ON routines(enabled, next_fire);
+-- Webhook tokens are high-entropy opaque strings; a unique index makes the
+-- token->routine lookup an indexed O(log n) probe. SQLite treats NULLs as
+-- distinct, so the many non-webhook rows (token IS NULL) don't collide.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_routines_webhook_token ON routines(webhook_token);
 """
 
 
 def _row_to_routine(row, description) -> dict:
     keys = [d[0] for d in description]
     return dict(zip(keys, row))
+
+
+def _validate_cron(cron_expr: str) -> None:
+    """Raise ValueError if cron_expr is not a valid cron expression.
+
+    Without this, an invalid schedule reaches croniter only when next_fire is
+    computed and raises an uncaught error (croniter's own CroniterBadCronError /
+    ValueError) — surfacing as a 500. Validating up front lets the route map it
+    to a clean 400.
+    """
+    if not croniter.is_valid(cron_expr):
+        raise ValueError(f"invalid cron expression: {cron_expr!r}")
 
 
 def _compute_next_fire(cron_expr: str, base_ts: float) -> float:
@@ -55,8 +71,10 @@ class RoutineStore(BaseStore):
     ) -> dict:
         if trigger_kind not in ("cron", "webhook", "api"):
             raise ValueError(f"invalid trigger_kind: {trigger_kind}")
-        if trigger_kind == "cron" and not cron_expr:
-            raise ValueError("cron_expr is required for trigger_kind='cron'")
+        if trigger_kind == "cron":
+            if not cron_expr:
+                raise ValueError("cron_expr is required for trigger_kind='cron'")
+            _validate_cron(cron_expr)
 
         rid = new_id("rtn")
         now = time.time()
@@ -87,22 +105,25 @@ class RoutineStore(BaseStore):
             return _row_to_routine(row, cur.description)
 
     async def get_by_webhook_token(self, token: str) -> dict | None:
-        """Look up an enabled webhook routine by its token.
+        """Look up an enabled webhook routine by its token via the unique index.
 
-        Returns None for any non-match (unknown token, disabled routine, or
-        wrong trigger_kind) so callers can 404 uniformly without leaking which
-        case applied.
+        The token is a high-entropy opaque secret, so an exact indexed lookup is
+        the correct (and fastest) match — no per-row comparison needed. Returns
+        None for any non-match (unknown token, disabled routine, or wrong
+        trigger_kind, including an empty token) so callers can 404 uniformly
+        without leaking which case applied.
         """
+        if not token:
+            return None
         async with self._db.execute(
-            "SELECT * FROM routines WHERE trigger_kind = 'webhook' AND enabled = 1"
+            """SELECT * FROM routines
+               WHERE webhook_token = ? AND trigger_kind = 'webhook' AND enabled = 1""",
+            (token,),
         ) as cur:
-            rows = await cur.fetchall()
-            desc = cur.description
-        for row in rows:
-            routine = _row_to_routine(row, desc)
-            if secrets.compare_digest(routine.get("webhook_token") or "", token):
-                return routine
-        return None
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_routine(row, cur.description)
 
     async def list_routines(self, project_id: str) -> list[dict]:
         async with self._db.execute(
@@ -137,6 +158,9 @@ class RoutineStore(BaseStore):
         existing = await self.get_routine(routine_id)
         if existing is None:
             return None
+
+        if cron_expr is not None:
+            _validate_cron(cron_expr)
 
         candidates = [
             ("title", title),
@@ -176,7 +200,14 @@ class RoutineStore(BaseStore):
         return await self.get_routine(routine_id)
 
     async def record_fire(self, routine_id: str, now_ts: float) -> dict | None:
-        """Stamp last_fired and advance next_fire (cron routines only)."""
+        """Stamp last_fired and advance next_fire (cron routines only).
+
+        Used by the manual/API and webhook trigger paths, where there is no
+        double-fire race (a human/caller drives them). The scheduler's tick
+        loop must instead use claim_due(), which advances the schedule
+        atomically under a guard so a concurrent/restarted tick can't re-fire
+        the same due routine.
+        """
         existing = await self.get_routine(routine_id)
         if existing is None:
             return None
@@ -189,6 +220,35 @@ class RoutineStore(BaseStore):
         )
         await self._db.commit()
         return await self.get_routine(routine_id)
+
+    async def claim_due(
+        self, routine_id: str, expected_next_fire: float, now_ts: float
+    ) -> bool:
+        """Atomically claim a due cron routine for firing.
+
+        Advances next_fire (and stamps last_fired) in a single UPDATE guarded on
+        the routine still having the next_fire the caller selected it with. If a
+        concurrent or restarted tick already claimed it, next_fire no longer
+        matches and rowcount is 0 — so the routine fires exactly once per due
+        instant. Returns True only for the tick that won the claim.
+        """
+        existing = await self.get_routine(routine_id)
+        if (
+            existing is None
+            or existing["trigger_kind"] != "cron"
+            or not existing["enabled"]
+            or not existing["cron_expr"]
+        ):
+            return False
+        next_fire = _compute_next_fire(existing["cron_expr"], now_ts)
+        cursor = await self._db.execute(
+            """UPDATE routines
+               SET last_fired = ?, next_fire = ?, updated_at = ?
+               WHERE id = ? AND enabled = 1 AND next_fire = ?""",
+            (now_ts, next_fire, now_ts, routine_id, expected_next_fire),
+        )
+        await self._db.commit()
+        return cursor.rowcount == 1
 
     async def delete_routine(self, routine_id: str) -> bool:
         cursor = await self._db.execute("DELETE FROM routines WHERE id = ?", (routine_id,))

--- a/tinyagentos/projects/routines_store.py
+++ b/tinyagentos/projects/routines_store.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import secrets
+import time
+
+from croniter import croniter
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+ROUTINES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS routines (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body_template TEXT NOT NULL DEFAULT '',
+    assignee_id TEXT,
+    trigger_kind TEXT NOT NULL DEFAULT 'cron',
+    cron_expr TEXT,
+    webhook_token TEXT,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    last_fired REAL,
+    next_fire REAL,
+    created_by TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_routines_project ON routines(project_id);
+CREATE INDEX IF NOT EXISTS idx_routines_due ON routines(enabled, next_fire);
+"""
+
+
+def _row_to_routine(row, description) -> dict:
+    keys = [d[0] for d in description]
+    return dict(zip(keys, row))
+
+
+def _compute_next_fire(cron_expr: str, base_ts: float) -> float:
+    return croniter(cron_expr, base_ts).get_next(float)
+
+
+class RoutineStore(BaseStore):
+    SCHEMA = ROUTINES_SCHEMA
+
+    async def create_routine(
+        self,
+        project_id: str,
+        title: str,
+        created_by: str,
+        body_template: str = "",
+        assignee_id: str | None = None,
+        trigger_kind: str = "cron",
+        cron_expr: str | None = None,
+        enabled: bool = True,
+    ) -> dict:
+        if trigger_kind not in ("cron", "webhook", "api"):
+            raise ValueError(f"invalid trigger_kind: {trigger_kind}")
+        if trigger_kind == "cron" and not cron_expr:
+            raise ValueError("cron_expr is required for trigger_kind='cron'")
+
+        rid = new_id("rtn")
+        now = time.time()
+        webhook_token = secrets.token_urlsafe(32) if trigger_kind == "webhook" else None
+        next_fire = _compute_next_fire(cron_expr, now) if trigger_kind == "cron" and enabled else None
+
+        await self._db.execute(
+            """INSERT INTO routines
+               (id, project_id, title, body_template, assignee_id, trigger_kind,
+                cron_expr, webhook_token, enabled, last_fired, next_fire,
+                created_by, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)""",
+            (
+                rid, project_id, title, body_template, assignee_id, trigger_kind,
+                cron_expr, webhook_token, int(enabled), next_fire, created_by, now, now,
+            ),
+        )
+        await self._db.commit()
+        return await self.get_routine(rid)
+
+    async def get_routine(self, routine_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM routines WHERE id = ?", (routine_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_routine(row, cur.description)
+
+    async def get_by_webhook_token(self, token: str) -> dict | None:
+        """Look up an enabled webhook routine by its token.
+
+        Returns None for any non-match (unknown token, disabled routine, or
+        wrong trigger_kind) so callers can 404 uniformly without leaking which
+        case applied.
+        """
+        async with self._db.execute(
+            "SELECT * FROM routines WHERE trigger_kind = 'webhook' AND enabled = 1"
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        for row in rows:
+            routine = _row_to_routine(row, desc)
+            if secrets.compare_digest(routine.get("webhook_token") or "", token):
+                return routine
+        return None
+
+    async def list_routines(self, project_id: str) -> list[dict]:
+        async with self._db.execute(
+            "SELECT * FROM routines WHERE project_id = ? ORDER BY created_at ASC",
+            (project_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_routine(r, desc) for r in rows]
+
+    async def list_due(self, now_ts: float) -> list[dict]:
+        async with self._db.execute(
+            """SELECT * FROM routines
+               WHERE trigger_kind = 'cron' AND enabled = 1
+                 AND next_fire IS NOT NULL AND next_fire <= ?
+               ORDER BY next_fire ASC""",
+            (now_ts,),
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_routine(r, desc) for r in rows]
+
+    async def update_routine(
+        self,
+        routine_id: str,
+        title: str | None = None,
+        body_template: str | None = None,
+        assignee_id: str | None = None,
+        cron_expr: str | None = None,
+        enabled: bool | None = None,
+    ) -> dict | None:
+        existing = await self.get_routine(routine_id)
+        if existing is None:
+            return None
+
+        candidates = [
+            ("title", title),
+            ("body_template", body_template),
+            ("assignee_id", assignee_id),
+            ("cron_expr", cron_expr),
+        ]
+        sets: list[str] = []
+        params: list = []
+        for col, val in candidates:
+            if val is not None:
+                sets.append(f"{col} = ?")
+                params.append(val)
+        if enabled is not None:
+            sets.append("enabled = ?")
+            params.append(int(enabled))
+
+        new_cron_expr = cron_expr if cron_expr is not None else existing["cron_expr"]
+        new_enabled = enabled if enabled is not None else bool(existing["enabled"])
+        # Recompute next_fire whenever the schedule or enabled flag could have
+        # changed what "due" means for this routine.
+        if existing["trigger_kind"] == "cron" and (cron_expr is not None or enabled is not None):
+            next_fire = _compute_next_fire(new_cron_expr, time.time()) if new_enabled and new_cron_expr else None
+            sets.append("next_fire = ?")
+            params.append(next_fire)
+
+        if not sets:
+            return existing
+
+        sets.append("updated_at = ?")
+        params.append(time.time())
+        params.append(routine_id)
+        await self._db.execute(
+            f"UPDATE routines SET {', '.join(sets)} WHERE id = ?", params
+        )
+        await self._db.commit()
+        return await self.get_routine(routine_id)
+
+    async def record_fire(self, routine_id: str, now_ts: float) -> dict | None:
+        """Stamp last_fired and advance next_fire (cron routines only)."""
+        existing = await self.get_routine(routine_id)
+        if existing is None:
+            return None
+        next_fire = None
+        if existing["trigger_kind"] == "cron" and existing["cron_expr"] and existing["enabled"]:
+            next_fire = _compute_next_fire(existing["cron_expr"], now_ts)
+        await self._db.execute(
+            "UPDATE routines SET last_fired = ?, next_fire = ?, updated_at = ? WHERE id = ?",
+            (now_ts, next_fire, now_ts, routine_id),
+        )
+        await self._db.commit()
+        return await self.get_routine(routine_id)
+
+    async def delete_routine(self, routine_id: str) -> bool:
+        cursor = await self._db.execute("DELETE FROM routines WHERE id = ?", (routine_id,))
+        await self._db.commit()
+        return cursor.rowcount > 0

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -48,6 +48,9 @@ def register_all_routers(app):
     from tinyagentos.routes import projects as projects_routes
     app.include_router(projects_routes.router)
 
+    from tinyagentos.routes import routines as routines_routes
+    app.include_router(routines_routes.router)
+
     from tinyagentos.routes.github_sync import router as github_sync_router
     app.include_router(github_sync_router)
 

--- a/tinyagentos/routes/routines.py
+++ b/tinyagentos/routes/routines.py
@@ -8,9 +8,18 @@ from pydantic import BaseModel
 
 from tinyagentos.auth_context import CurrentUser, current_user
 from tinyagentos.projects.routine_runner import fire_routine
+from tinyagentos.rate_limit import RateLimiter
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+# Abuse guard for the unauthenticated webhook trigger. Keyed per token, this
+# caps how fast a single routine's webhook can mass-create tasks: a small burst
+# then a steady trickle. Unknown/disabled tokens 404 before this is consulted,
+# so they cost nothing here. In-process (resets on restart) — the right
+# trade-off for a self-hosted single-process controller; front with Caddy/nginx
+# for cross-process limits.
+_webhook_limiter = RateLimiter(capacity=5, refill_per_second=0.1)
 
 
 async def _get_owned_project(
@@ -109,7 +118,10 @@ async def update_routine(
     guard = await _require_routine_in_project(store, project_id, rid)
     if isinstance(guard, JSONResponse):
         return guard
-    return await store.update_routine(rid, **payload.model_dump(exclude_none=True))
+    try:
+        return await store.update_routine(rid, **payload.model_dump(exclude_none=True))
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
 
 
 @router.delete("/api/projects/{project_id}/routines/{rid}")
@@ -155,10 +167,12 @@ async def trigger_routine(
 @router.post("/api/webhooks/routines/{token}")
 async def webhook_trigger_routine(token: str, request: Request):
     """Inbound webhook trigger — no session auth. Authenticated solely by the
-    per-routine opaque token embedded in the URL (constant-time compared in
-    RoutineStore.get_by_webhook_token, mirroring gh_webhook.py's HMAC check).
-    Unknown or disabled tokens 404 rather than distinguishing the reason, so
-    the endpoint never leaks which routines exist."""
+    per-routine opaque token embedded in the URL, matched via an indexed unique
+    lookup in RoutineStore.get_by_webhook_token. Unknown or disabled tokens 404
+    rather than distinguishing the reason, so the endpoint never leaks which
+    routines exist. A per-token rate limit caps task-creation spam."""
+    if not _webhook_limiter.check(token):
+        return JSONResponse({"error": "rate limited"}, status_code=429)
     store = request.app.state.routine_store
     routine = await store.get_by_webhook_token(token)
     if routine is None:

--- a/tinyagentos/routes/routines.py
+++ b/tinyagentos/routes/routines.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.projects.routine_runner import fire_routine
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+async def _get_owned_project(
+    pstore, project_id: str, user: CurrentUser
+) -> "dict | JSONResponse":
+    """Fetch a project and apply existence-hiding 404 for non-owners.
+
+    Mirrors tinyagentos/routes/projects.py's helper of the same name.
+    """
+    p = await pstore.get_project(project_id)
+    if p is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if not user.is_admin and user.user_id != p["user_id"]:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return p
+
+
+async def _require_routine_in_project(store, project_id: str, routine_id: str) -> "dict | JSONResponse":
+    routine = await store.get_routine(routine_id)
+    if routine is None or routine["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return routine
+
+
+class CreateRoutineIn(BaseModel):
+    title: str
+    body_template: str = ""
+    assignee_id: str | None = None
+    trigger_kind: str = "cron"
+    cron_expr: str | None = None
+    enabled: bool = True
+
+
+class UpdateRoutineIn(BaseModel):
+    title: str | None = None
+    body_template: str | None = None
+    assignee_id: str | None = None
+    cron_expr: str | None = None
+    enabled: bool | None = None
+
+
+@router.post("/api/projects/{project_id}/routines")
+async def create_routine(
+    project_id: str,
+    payload: CreateRoutineIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    store = request.app.state.routine_store
+    try:
+        return await store.create_routine(
+            project_id=project_id,
+            title=payload.title,
+            created_by=user.user_id,
+            body_template=payload.body_template,
+            assignee_id=payload.assignee_id,
+            trigger_kind=payload.trigger_kind,
+            cron_expr=payload.cron_expr,
+            enabled=payload.enabled,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+
+
+@router.get("/api/projects/{project_id}/routines")
+async def list_routines(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    store = request.app.state.routine_store
+    return {"items": await store.list_routines(project_id)}
+
+
+@router.patch("/api/projects/{project_id}/routines/{rid}")
+async def update_routine(
+    project_id: str,
+    rid: str,
+    payload: UpdateRoutineIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    store = request.app.state.routine_store
+    guard = await _require_routine_in_project(store, project_id, rid)
+    if isinstance(guard, JSONResponse):
+        return guard
+    return await store.update_routine(rid, **payload.model_dump(exclude_none=True))
+
+
+@router.delete("/api/projects/{project_id}/routines/{rid}")
+async def delete_routine(
+    project_id: str,
+    rid: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    store = request.app.state.routine_store
+    guard = await _require_routine_in_project(store, project_id, rid)
+    if isinstance(guard, JSONResponse):
+        return guard
+    await store.delete_routine(rid)
+    return {"ok": True}
+
+
+@router.post("/api/projects/{project_id}/routines/{rid}/trigger")
+async def trigger_routine(
+    project_id: str,
+    rid: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Manual/API trigger: fires the routine immediately regardless of its
+    schedule. Session-authenticated, project-owner-gated."""
+    pstore = request.app.state.project_store
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
+    store = request.app.state.routine_store
+    guard = await _require_routine_in_project(store, project_id, rid)
+    if isinstance(guard, JSONResponse):
+        return guard
+    task = await fire_routine(request.app.state, guard)
+    return {"ok": True, "task": task}
+
+
+@router.post("/api/webhooks/routines/{token}")
+async def webhook_trigger_routine(token: str, request: Request):
+    """Inbound webhook trigger — no session auth. Authenticated solely by the
+    per-routine opaque token embedded in the URL (constant-time compared in
+    RoutineStore.get_by_webhook_token, mirroring gh_webhook.py's HMAC check).
+    Unknown or disabled tokens 404 rather than distinguishing the reason, so
+    the endpoint never leaks which routines exist."""
+    store = request.app.state.routine_store
+    routine = await store.get_by_webhook_token(token)
+    if routine is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    task = await fire_routine(request.app.state, routine)
+    return {"ok": True, "task": task}

--- a/uv.lock
+++ b/uv.lock
@@ -3009,6 +3009,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "argon2-cffi" },
+    { name = "croniter" },
     { name = "diff-match-patch" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -3058,6 +3059,7 @@ worker = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
+    { name = "croniter", specifier = ">=3.0.3" },
     { name = "diff-match-patch", specifier = ">=20230430" },
     { name = "fastapi", specifier = ">=0.115.0,<0.137" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary
Adds **project-scoped Routines & Schedules**. A routine fires on a schedule or trigger and auto-creates a task on the project board, then wakes the assigned agent. This builds the missing executor on top of the persistence-only scheduler: a real tick loop plus a full cron parser (croniter).

## Store — `tinyagentos/projects/routines_store.py`
`RoutineStore(BaseStore)` backed by `data/routines.db`. Columns: `id, project_id, title, body_template, assignee_id, trigger_kind ('cron'|'webhook'|'api'), cron_expr, webhook_token, enabled, last_fired, next_fire, created_by, created_at, updated_at`. IDs via `new_id("rtn")`. CRUD mirrors `task_store.py` plus:
- `list_due(now_ts)` — enabled cron routines whose `next_fire <= now`.
- `record_fire()` — stamps `last_fired`, advances `next_fire`.
- `get_by_webhook_token()` — constant-time (`secrets.compare_digest`) match over enabled webhook routines; returns `None` for unknown/disabled/wrong-kind so the endpoint never leaks.
`next_fire` is (re)computed with croniter on create/update/fire.

## Executor loop — `tinyagentos/projects/routine_runner.py`
`routine_tick_loop(app_state)`: every 60s calls `list_due(now)` and fires each due routine. Failure-isolated per iteration **and** per routine (mirrors `beads_bridge._writer_loop`). Registered in the app lifespan via `_create_supervised_task(routine_tick_loop(app.state), app.state._background_tasks)`, so shutdown's existing bounded `cancel_and_wait(_bg, timeout=5.0)` cancels it cleanly alongside every other loop — no bespoke start/stop lifecycle.

## Shared fire helper — `fire_routine(app_state, routine)`
1. **Always** creates the task via `project_task_store.create_task(project_id, title, created_by=f"routine:{id}", body=body_template, assignee_id=…)` — this triggers the existing broker/audit path.
2. Advances the schedule (`record_fire`).
3. **Best-effort wake**: if `assignee_id` resolves to a running config agent, `bridge_sessions.enqueue_user_message(slug, {…})`; and posts a system message into the project's a2a channel (via `ensure_a2a_channel` + `chat_messages.send_message`). Wake failures never roll back task creation.

## Endpoints — `tinyagentos/routes/routines.py`
- `GET/POST /api/projects/{project_id}/routines`, `PATCH/DELETE /api/projects/{project_id}/routines/{rid}` — `Depends(current_user)` + `_get_owned_project` ownership (existence-hiding 404), mirroring `projects.py`.
- `POST /api/projects/{project_id}/routines/{rid}/trigger` — manual/API trigger (session auth).
- `POST /api/webhooks/routines/{token}` — no session; token-authenticated (constant-time), 404 on unknown/disabled.

## Wake edge
Task creation is the durable contract; the wake is opportunistic. An offline assignee simply picks the task off the board later. Resolution copies the id/name lookup used by `beads_bridge._resolve_assignee` and gates on `agent.status == "running"` (same guard the chat router uses before enqueuing).

## croniter dependency
Cron is already the stored format (`"0 3 * * *"`), so full cron support is correct. Added `croniter>=3.0.3` to `pyproject.toml` and locked to **6.2.2** in `uv.lock`.

## UI
New **Routines** tab inside `ProjectsApp` (project-scoped — not the global TasksApp). Lists the project's routines; create/edit form with title, body, assignee (project members), trigger kind (cron with schedule input + presets / webhook shows the token URL / api), enabled toggle, and **Run now**. Matches ProjectsApp theme tokens (no hardcoded colors), a11y labels. `projectsApi.routines.*` added to `desktop/src/lib/projects.ts`.

## Tests
- `tests/projects/test_routines_store.py` (20) — CRUD, `list_due`, next_fire via croniter, webhook token accept/reject.
- `tests/projects/test_routine_runner.py` (10) — fire always creates a task (wake mocked/spied), best-effort announce, tick loop fires due routines then sleeps, survives a bad routine.
- `tests/test_routes_routines.py` (15) — CRUD auth/ownership, manual trigger creates a task, webhook token accept/reject.
- Frontend vitest: `projects-routines.test.ts` (lib) + `ProjectRoutines.test.tsx` (panel).

## Verification
- `pytest tests/projects/test_routines_store.py tests/test_routes_routines.py -q` → **35 passed**.
- Regression `pytest tests/ -k "scheduler or routines or projects or task" -q` → **631 passed**.
- `npx vitest run` (new files) → **10 passed**; full desktop suite **2451 passed**.
- `npm run build` → tsc -b clean, vite built (0 TS errors).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added project routines with support for scheduled, webhook-based, and manual triggers.
  - New routines tab in Projects lets you create, view, enable/disable, run, and delete routines.
  - Routines now show schedule timing details, assignee info, and webhook trigger links.

- **Bug Fixes**
  - Improved routine execution reliability so one failed routine won’t stop others from running.
  - Better handling for routine firing and background processing on app startup/shutdown.

- **Tests**
  - Added coverage for routines UI, API behavior, scheduling, triggering, and storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->