### PR TITLE
feat(office): add Database view to complete the Office Studio suite

### DIFF
--- a/desktop/src/apps/OfficeStudioApp.test.tsx
+++ b/desktop/src/apps/OfficeStudioApp.test.tsx
@@ -14,6 +14,7 @@ describe("OfficeStudioApp", () => {
     // query within nav to avoid ambiguity with toolbar buttons
     expect(nav.querySelector('[aria-label="Write"]')).toBeTruthy();
     expect(nav.querySelector('[aria-label="Calc"]')).toBeTruthy();
+    expect(nav.querySelector('[aria-label="Database"]')).toBeTruthy();
     expect(nav.querySelector('[aria-label="Slides"]')).toBeTruthy();
     expect(nav.querySelector('[aria-label="Assist"]')).toBeTruthy();
   });
@@ -65,6 +66,19 @@ describe("OfficeStudioApp", () => {
     expect(screen.getByLabelText("Add sheet")).toBeDefined();
     // workbook title + save/new actions
     expect(screen.getByLabelText("Workbook title")).toBeDefined();
+    expect(screen.getByRole("button", { name: /Save/ })).toBeDefined();
+  });
+
+  it("switches to Database view and shows a real, editable table", () => {
+    renderApp();
+    fireEvent.click(screen.getByRole("button", { name: "Database" }));
+    expect(screen.getByRole("button", { name: "Database" }).getAttribute("aria-current")).toBe(
+      "page",
+    );
+    // default table: one Name column, one row, table title + save/new actions
+    expect(screen.getByLabelText("Table title")).toBeDefined();
+    expect(screen.getAllByLabelText("Column name")[0]).toHaveValue("Name");
+    expect(screen.getByLabelText("Name, row 1")).toBeDefined();
     expect(screen.getByRole("button", { name: /Save/ })).toBeDefined();
   });
 

--- a/desktop/src/apps/OfficeStudioApp.tsx
+++ b/desktop/src/apps/OfficeStudioApp.tsx
@@ -1,14 +1,16 @@
 import { useState } from "react";
-import { Sparkles, Type, Grid, Monitor } from "lucide-react";
+import { Sparkles, Type, Grid, Table2, Monitor } from "lucide-react";
 import { WriteView } from "./officestudio/WriteView";
 import { CalcView } from "./officestudio/CalcView";
+import { DatabaseView } from "./officestudio/DatabaseView";
 import { SlidesView } from "./officestudio/SlidesView";
 
-type OfficeView = "write" | "calc" | "slides";
+type OfficeView = "write" | "calc" | "db" | "slides";
 
 const RAIL: { id: OfficeView; label: string; icon: typeof Sparkles }[] = [
   { id: "write", label: "Write", icon: Type },
   { id: "calc", label: "Calc", icon: Grid },
+  { id: "db", label: "Database", icon: Table2 },
   { id: "slides", label: "Slides", icon: Monitor },
 ];
 
@@ -59,6 +61,7 @@ export function OfficeStudioApp({ windowId: _windowId }: { windowId: string }) {
         <div className="flex min-w-0 flex-1 flex-col">
           {view === "write" && <WriteView />}
           {view === "calc" && <CalcView />}
+          {view === "db" && <DatabaseView />}
           {view === "slides" && <SlidesView />}
         </div>
       </div>

--- a/desktop/src/apps/officestudio/DatabaseView.tsx
+++ b/desktop/src/apps/officestudio/DatabaseView.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Plus, Save, Sparkles, X } from "lucide-react";
 import {
   addColumn,
   addRow,
   blankTable,
+  type CellValue,
+  changeType,
   COLUMN_TYPES,
   type ColumnType,
   type DbTable,
@@ -13,7 +15,6 @@ import {
   renameColumn,
   serializeTable,
   setCell,
-  setColumnType,
 } from "./db/table";
 
 type OfficeDocListItem = {
@@ -43,6 +44,18 @@ export function DatabaseView() {
   const [error, setError] = useState<string | null>(null);
   const [table, setTable] = useState<DbTable>(() => blankTable());
 
+  // Monotonic token for the in-flight openDoc request. Bumping it invalidates
+  // any pending open (on unmount, on a newer open, or on newDoc), so a slow
+  // response can't land setState on an unmounted/closing view or clobber a
+  // newer selection.
+  const openReqRef = useRef(0);
+  useEffect(
+    () => () => {
+      openReqRef.current += 1;
+    },
+    [],
+  );
+
   const loadList = useCallback(async () => {
     const res = await fetch("/api/office/docs", { credentials: "include" });
     if (!res.ok) throw new Error("Could not load tables");
@@ -68,6 +81,7 @@ export function DatabaseView() {
   }, [loadList]);
 
   const openDoc = async (docId: string) => {
+    const reqId = ++openReqRef.current;
     setError(null);
     try {
       const res = await fetch(`/api/office/docs/${encodeURIComponent(docId)}`, {
@@ -75,16 +89,22 @@ export function DatabaseView() {
       });
       if (!res.ok) throw new Error("Could not open table");
       const doc = (await res.json()) as OfficeDoc;
+      // A newer open (or newDoc/unmount) superseded this request; drop it.
+      if (openReqRef.current !== reqId) return;
       setActiveId(doc.id);
       setTitle(doc.title);
       setUpdatedAt(doc.updated_at);
       setTable(parseTableContent(doc.content));
     } catch (e) {
+      if (openReqRef.current !== reqId) return;
       setError(e instanceof Error ? e.message : "Open failed");
     }
   };
 
   const newDoc = () => {
+    // Invalidate any in-flight open so its response can't overwrite this fresh
+    // table once it resolves.
+    openReqRef.current += 1;
     setActiveId(null);
     setTitle("Untitled table");
     setUpdatedAt(undefined);
@@ -95,6 +115,7 @@ export function DatabaseView() {
   const saveDoc = async () => {
     setSaving(true);
     setError(null);
+    let saved: OfficeDoc;
     try {
       const content = serializeTable(table);
       const payload = { kind: "db", title: title.trim() || "Untitled table", content };
@@ -111,26 +132,42 @@ export function DatabaseView() {
         const body = await res.json().catch(() => ({}));
         throw new Error((body as { error?: string }).error || "Save failed");
       }
-      const saved = (await res.json()) as OfficeDoc;
-      setActiveId(saved.id);
-      setTitle(saved.title);
-      setUpdatedAt(saved.updated_at);
-      await loadList();
+      saved = (await res.json()) as OfficeDoc;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Save failed");
-    } finally {
       setSaving(false);
+      return;
+    }
+    // The save itself succeeded: clear the saving state and reflect the saved
+    // doc before refreshing the list.
+    setActiveId(saved.id);
+    setTitle(saved.title);
+    setUpdatedAt(saved.updated_at);
+    setSaving(false);
+    // Refresh the sidebar list separately; a refresh failure must not report
+    // the (already successful) save as failed.
+    try {
+      await loadList();
+    } catch {
+      /* non-fatal: the save succeeded; the list refreshes on the next action */
     }
   };
 
-  const renderCellInput = (columnId: string, type: ColumnType, rowId: string, columnName: string, rowIndex: number, value: unknown) => {
+  const renderCellInput = (
+    columnId: string,
+    type: ColumnType,
+    rowId: string,
+    columnName: string,
+    rowIndex: number,
+    value: CellValue | undefined,
+  ) => {
     const label = `${columnName}, row ${rowIndex + 1}`;
     if (type === "checkbox") {
       return (
         <input
           type="checkbox"
           aria-label={label}
-          checked={Boolean(value)}
+          checked={value === true}
           onChange={(e) => setTable((t) => setCell(t, rowId, columnId, e.target.checked))}
           className="h-4 w-4 accent-accent"
         />
@@ -141,7 +178,7 @@ export function DatabaseView() {
         <input
           type="number"
           aria-label={label}
-          value={value == null ? "" : String(value)}
+          value={typeof value === "number" ? String(value) : ""}
           onChange={(e) =>
             setTable((t) =>
               setCell(t, rowId, columnId, e.target.value === "" ? null : Number(e.target.value)),
@@ -302,7 +339,7 @@ export function DatabaseView() {
                       <select
                         value={col.type}
                         onChange={(e) =>
-                          setTable((t) => setColumnType(t, col.id, e.target.value as ColumnType))
+                          setTable((t) => changeType(t, col.id, e.target.value as ColumnType))
                         }
                         aria-label={`Column type for ${col.name}`}
                         className="mt-1 w-full rounded border-0 bg-transparent text-[10.5px] font-medium text-shell-text-tertiary outline-none"

--- a/desktop/src/apps/officestudio/DatabaseView.tsx
+++ b/desktop/src/apps/officestudio/DatabaseView.tsx
@@ -1,0 +1,379 @@
+import { useCallback, useEffect, useState } from "react";
+import { Plus, Save, Sparkles, X } from "lucide-react";
+import {
+  addColumn,
+  addRow,
+  blankTable,
+  COLUMN_TYPES,
+  type ColumnType,
+  type DbTable,
+  parseTableContent,
+  removeColumn,
+  removeRow,
+  renameColumn,
+  serializeTable,
+  setCell,
+  setColumnType,
+} from "./db/table";
+
+type OfficeDocListItem = {
+  id: string;
+  kind: string;
+  title: string;
+  updated_at?: number;
+};
+
+type OfficeDoc = OfficeDocListItem & {
+  content: string;
+};
+
+function formatUpdated(ts?: number): string {
+  if (!ts) return "Draft";
+  const d = new Date(ts * 1000);
+  return `Updated ${d.toLocaleString()}`;
+}
+
+export function DatabaseView() {
+  const [docs, setDocs] = useState<OfficeDocListItem[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [title, setTitle] = useState("Untitled table");
+  const [updatedAt, setUpdatedAt] = useState<number | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [table, setTable] = useState<DbTable>(() => blankTable());
+
+  const loadList = useCallback(async () => {
+    const res = await fetch("/api/office/docs", { credentials: "include" });
+    if (!res.ok) throw new Error("Could not load tables");
+    const items = (await res.json()) as OfficeDocListItem[];
+    setDocs(items.filter((d) => d.kind === "db"));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        await loadList();
+        if (!cancelled) setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Load failed");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadList]);
+
+  const openDoc = async (docId: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/office/docs/${encodeURIComponent(docId)}`, {
+        credentials: "include",
+      });
+      if (!res.ok) throw new Error("Could not open table");
+      const doc = (await res.json()) as OfficeDoc;
+      setActiveId(doc.id);
+      setTitle(doc.title);
+      setUpdatedAt(doc.updated_at);
+      setTable(parseTableContent(doc.content));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Open failed");
+    }
+  };
+
+  const newDoc = () => {
+    setActiveId(null);
+    setTitle("Untitled table");
+    setUpdatedAt(undefined);
+    setError(null);
+    setTable(blankTable());
+  };
+
+  const saveDoc = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const content = serializeTable(table);
+      const payload = { kind: "db", title: title.trim() || "Untitled table", content };
+      const url = activeId
+        ? `/api/office/docs/${encodeURIComponent(activeId)}`
+        : "/api/office/docs";
+      const res = await fetch(url, {
+        method: activeId ? "PUT" : "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error || "Save failed");
+      }
+      const saved = (await res.json()) as OfficeDoc;
+      setActiveId(saved.id);
+      setTitle(saved.title);
+      setUpdatedAt(saved.updated_at);
+      await loadList();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const renderCellInput = (columnId: string, type: ColumnType, rowId: string, columnName: string, rowIndex: number, value: unknown) => {
+    const label = `${columnName}, row ${rowIndex + 1}`;
+    if (type === "checkbox") {
+      return (
+        <input
+          type="checkbox"
+          aria-label={label}
+          checked={Boolean(value)}
+          onChange={(e) => setTable((t) => setCell(t, rowId, columnId, e.target.checked))}
+          className="h-4 w-4 accent-accent"
+        />
+      );
+    }
+    if (type === "number") {
+      return (
+        <input
+          type="number"
+          aria-label={label}
+          value={value == null ? "" : String(value)}
+          onChange={(e) =>
+            setTable((t) =>
+              setCell(t, rowId, columnId, e.target.value === "" ? null : Number(e.target.value)),
+            )
+          }
+          className="w-full border-0 bg-transparent text-[12.5px] text-shell-text outline-none"
+        />
+      );
+    }
+    if (type === "date") {
+      return (
+        <input
+          type="date"
+          aria-label={label}
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => setTable((t) => setCell(t, rowId, columnId, e.target.value))}
+          className="w-full border-0 bg-transparent text-[12.5px] text-shell-text outline-none"
+        />
+      );
+    }
+    return (
+      <input
+        type="text"
+        aria-label={label}
+        value={typeof value === "string" ? value : ""}
+        onChange={(e) => setTable((t) => setCell(t, rowId, columnId, e.target.value))}
+        className="w-full border-0 bg-transparent text-[12.5px] text-shell-text outline-none placeholder:text-shell-text-tertiary"
+      />
+    );
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* view header */}
+      <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
+        <h2 className="text-[17px] font-bold tracking-[-0.02em]">Database</h2>
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          aria-label="Table title"
+          className="w-52 truncate border-0 bg-transparent text-[13px] font-semibold text-shell-text outline-none placeholder:text-shell-text-tertiary"
+        />
+        <span className="truncate text-[12px] text-shell-text-tertiary">
+          {docs.length} table{docs.length === 1 ? "" : "s"} &middot;{" "}
+          {activeId ? formatUpdated(updatedAt) : "New table"}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={newDoc}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] border border-shell-border px-3 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Plus size={14} />
+            New
+          </button>
+          <button
+            type="button"
+            onClick={saveDoc}
+            disabled={saving}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] bg-gradient-to-br from-accent to-accent/70 px-3.5 text-[12px] font-bold text-white disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Save size={14} />
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+
+      {/* toolbar: add column / add row */}
+      <div className="flex h-[42px] flex-none items-center gap-1.5 overflow-x-auto border-b border-shell-border bg-shell-bg-deep px-3">
+        <button
+          type="button"
+          onClick={() => setTable((t) => addColumn(t))}
+          className="flex h-8 flex-none items-center gap-1.5 rounded-lg px-2.5 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <Plus size={14} />
+          Column
+        </button>
+        <button
+          type="button"
+          onClick={() => setTable((t) => addRow(t))}
+          className="flex h-8 flex-none items-center gap-1.5 rounded-lg px-2.5 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        >
+          <Plus size={14} />
+          Row
+        </button>
+      </div>
+
+      {error && (
+        <p className="border-b border-shell-border px-3.5 py-1.5 text-[12px] text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex min-h-0 flex-1">
+        {/* documents sidebar */}
+        <aside className="flex w-[200px] flex-none flex-col border-r border-shell-border bg-shell-bg-deep">
+          <div className="border-b border-shell-border px-3 py-2 text-[11px] font-bold uppercase tracking-wide text-shell-text-tertiary">
+            Tables
+          </div>
+          <div className="min-h-0 flex-1 overflow-auto p-2">
+            {loading && (
+              <p className="px-2 py-1 text-[12px] text-shell-text-tertiary">Loading...</p>
+            )}
+            {!loading && docs.length === 0 && (
+              <p className="px-2 py-1 text-[12px] text-shell-text-tertiary">No saved tables yet</p>
+            )}
+            {docs.map((doc) => (
+              <button
+                key={doc.id}
+                type="button"
+                onClick={() => openDoc(doc.id)}
+                className={`mb-1 w-full rounded-lg px-2 py-2 text-left text-[12px] transition-colors hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  activeId === doc.id
+                    ? "bg-shell-surface text-shell-text"
+                    : "text-shell-text-secondary"
+                }`}
+              >
+                <div className="truncate font-semibold">{doc.title}</div>
+                <div className="truncate text-[10px] text-shell-text-tertiary">
+                  {formatUpdated(doc.updated_at)}
+                </div>
+              </button>
+            ))}
+          </div>
+        </aside>
+
+        <div className="min-h-0 min-w-0 flex-1 overflow-auto p-[18px]">
+          <div className="overflow-auto rounded-[13px] border border-shell-border">
+            <table className="w-full border-collapse text-[12.5px]">
+              <thead>
+                <tr className="border-b border-shell-border bg-shell-bg-deep">
+                  {table.columns.map((col) => (
+                    <th
+                      key={col.id}
+                      scope="col"
+                      className="min-w-[140px] border-r border-shell-border px-2 py-1.5 text-left align-top"
+                    >
+                      <div className="flex items-center gap-1">
+                        <input
+                          value={col.name}
+                          onChange={(e) =>
+                            setTable((t) => renameColumn(t, col.id, e.target.value))
+                          }
+                          aria-label="Column name"
+                          className="min-w-0 flex-1 border-0 bg-transparent text-[12.5px] font-semibold text-shell-text outline-none"
+                        />
+                        {table.columns.length > 1 && (
+                          <button
+                            type="button"
+                            aria-label={`Delete column ${col.name}`}
+                            onClick={() => setTable((t) => removeColumn(t, col.id))}
+                            className="flex h-5 w-5 flex-none items-center justify-center rounded text-shell-text-tertiary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                          >
+                            <X size={12} />
+                          </button>
+                        )}
+                      </div>
+                      <select
+                        value={col.type}
+                        onChange={(e) =>
+                          setTable((t) => setColumnType(t, col.id, e.target.value as ColumnType))
+                        }
+                        aria-label={`Column type for ${col.name}`}
+                        className="mt-1 w-full rounded border-0 bg-transparent text-[10.5px] font-medium text-shell-text-tertiary outline-none"
+                      >
+                        {COLUMN_TYPES.map((ct) => (
+                          <option key={ct.id} value={ct.id}>
+                            {ct.label}
+                          </option>
+                        ))}
+                      </select>
+                    </th>
+                  ))}
+                  <th scope="col" className="w-9 flex-none" aria-hidden="true" />
+                </tr>
+              </thead>
+              <tbody>
+                {table.rows.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={table.columns.length + 1}
+                      className="px-2 py-3 text-center text-[12px] text-shell-text-tertiary"
+                    >
+                      No rows yet
+                    </td>
+                  </tr>
+                )}
+                {table.rows.map((row, i) => (
+                  <tr key={row.id} className="border-b border-shell-border last:border-b-0">
+                    {table.columns.map((col) => (
+                      <td key={col.id} className="border-r border-shell-border px-2 py-1.5">
+                        {renderCellInput(col.id, col.type, row.id, col.name, i, row.cells[col.id])}
+                      </td>
+                    ))}
+                    <td className="px-1 py-1.5 text-center">
+                      <button
+                        type="button"
+                        aria-label={`Delete row ${i + 1}`}
+                        onClick={() => setTable((t) => removeRow(t, row.id))}
+                        className="flex h-6 w-6 items-center justify-center rounded text-shell-text-tertiary hover:bg-shell-surface-active hover:text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                      >
+                        <X size={12} />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* right sidebar */}
+        <aside className="flex w-[262px] flex-none flex-col gap-3.5 border-l border-shell-border bg-shell-bg p-[18px]">
+          <div
+            className="rounded-[13px] border p-3"
+            style={{
+              borderColor: "rgba(139,146,163,0.35)",
+              background:
+                "radial-gradient(120% 130% at 12% 10%, rgba(139,146,163,0.35), transparent 60%), var(--color-shell-surface, rgba(255,255,255,0.045))",
+            }}
+          >
+            <div className="flex items-center gap-1.5 text-[12.5px] font-bold text-shell-text">
+              <Sparkles size={15} className="text-accent" />
+              Ask your table
+            </div>
+            <p className="mt-1.5 text-[11.5px] leading-[1.45] text-shell-text-secondary">
+              &ldquo;Which rows are missing a due date?&rdquo; taOS reads the table and answers, on
+              your hardware.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/officestudio/__tests__/DatabaseView.test.tsx
+++ b/desktop/src/apps/officestudio/__tests__/DatabaseView.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { DatabaseView } from "../DatabaseView";
+
+/* A tiny in-memory fake of the /api/office/docs backend, keyed by URL and
+ * method, mirroring the convention used for GameStudioApp's fetch mock. */
+type StoredDoc = {
+  id: string;
+  kind: string;
+  title: string;
+  content: string;
+  created_at: number;
+  updated_at: number;
+};
+
+function makeFetchMock(seed: StoredDoc[] = []) {
+  const docs = new Map<string, StoredDoc>(seed.map((d) => [d.id, d]));
+  let nextId = 1;
+
+  return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url === "/api/office/docs" && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve(
+            [...docs.values()].map(({ id, kind, title, updated_at }) => ({
+              id,
+              kind,
+              title,
+              updated_at,
+            })),
+          ),
+      } as Response);
+    }
+
+    if (url === "/api/office/docs" && method === "POST") {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      const id = `doc-${nextId++}`;
+      const now = Date.now() / 1000;
+      const record: StoredDoc = {
+        id,
+        kind: body.kind,
+        title: body.title,
+        content: body.content,
+        created_at: now,
+        updated_at: now,
+      };
+      docs.set(id, record);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(record) } as Response);
+    }
+
+    const docMatch = url.match(/^\/api\/office\/docs\/([^/]+)$/);
+    if (docMatch) {
+      const id = docMatch[1]!;
+      if (method === "GET") {
+        const record = docs.get(id);
+        if (!record) {
+          return Promise.resolve({
+            ok: false,
+            status: 404,
+            json: () => Promise.resolve({ error: "not found" }),
+          } as Response);
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(record) } as Response);
+      }
+      if (method === "PUT") {
+        const existing = docs.get(id);
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        const record: StoredDoc = {
+          id,
+          kind: body.kind ?? existing?.kind ?? "db",
+          title: body.title ?? existing?.title ?? "",
+          content: body.content ?? existing?.content ?? "",
+          created_at: existing?.created_at ?? Date.now() / 1000,
+          updated_at: Date.now() / 1000,
+        };
+        docs.set(id, record);
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(record) } as Response);
+      }
+    }
+
+    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) } as Response);
+  });
+}
+
+function lastCallTo(mock: ReturnType<typeof vi.fn>, url: string, method: string) {
+  const calls = mock.mock.calls as [RequestInfo | URL, RequestInit | undefined][];
+  const match = [...calls]
+    .reverse()
+    .find(([u, init]) => String(u) === url && (init?.method ?? "GET").toUpperCase() === method);
+  if (!match) throw new Error(`no ${method} call to ${url} recorded`);
+  return match[1];
+}
+
+describe("DatabaseView", () => {
+  let fetchMock: ReturnType<typeof makeFetchMock>;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the default table with a title, Name column and one row", async () => {
+    fetchMock = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    render(<DatabaseView />);
+
+    expect(await screen.findByLabelText("Table title")).toHaveValue("Untitled table");
+    expect(screen.getAllByLabelText("Column name")[0]).toHaveValue("Name");
+    expect(screen.getByLabelText("Name, row 1")).toBeDefined();
+    expect(await screen.findByText("No saved tables yet")).toBeDefined();
+  });
+
+  it("creates a new doc on Save with kind db and the default column/row shape", async () => {
+    fetchMock = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    render(<DatabaseView />);
+    await screen.findByText("No saved tables yet");
+
+    fireEvent.change(screen.getByLabelText("Table title"), { target: { value: "Contacts" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => lastCallTo(fetchMock, "/api/office/docs", "POST"));
+    const init = lastCallTo(fetchMock, "/api/office/docs", "POST")!;
+    const body = JSON.parse(String(init.body));
+    expect(body.kind).toBe("db");
+    expect(body.title).toBe("Contacts");
+    const content = JSON.parse(body.content);
+    expect(content.columns).toHaveLength(1);
+    expect(content.columns[0].name).toBe("Name");
+    expect(content.columns[0].type).toBe("text");
+    expect(content.rows).toHaveLength(1);
+  });
+
+  it("adds a column and a row, edits a cell, and saves the full content shape", async () => {
+    fetchMock = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    render(<DatabaseView />);
+    await screen.findByText("No saved tables yet");
+
+    fireEvent.click(screen.getByRole("button", { name: "Column" }));
+    fireEvent.click(screen.getByRole("button", { name: "Row" }));
+
+    const names = screen.getAllByLabelText("Column name");
+    expect(names).toHaveLength(2);
+    fireEvent.change(names[1], { target: { value: "Email" } });
+
+    fireEvent.change(screen.getByLabelText("Name, row 1"), { target: { value: "Ada" } });
+    fireEvent.change(screen.getByLabelText("Email, row 1"), { target: { value: "ada@example.com" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => lastCallTo(fetchMock, "/api/office/docs", "POST"));
+    const init = lastCallTo(fetchMock, "/api/office/docs", "POST")!;
+    const body = JSON.parse(String(init.body));
+    const content = JSON.parse(body.content);
+    expect(content.columns.map((c: { name: string }) => c.name)).toEqual(["Name", "Email"]);
+    expect(content.rows).toHaveLength(2);
+    const [nameCol, emailCol] = content.columns;
+    expect(content.rows[0].cells[nameCol.id]).toBe("Ada");
+    expect(content.rows[0].cells[emailCol.id]).toBe("ada@example.com");
+  });
+
+  it("loads an existing doc and renders its saved columns and rows", async () => {
+    const seedContent = JSON.stringify({
+      version: 1,
+      columns: [
+        { id: "c1", name: "Task", type: "text" },
+        { id: "c2", name: "Done", type: "checkbox" },
+      ],
+      rows: [
+        { id: "r1", cells: { c1: "Ship database view", c2: true } },
+        { id: "r2", cells: { c1: "Write tests", c2: false } },
+      ],
+    });
+    fetchMock = makeFetchMock([
+      {
+        id: "doc-seed",
+        kind: "db",
+        title: "Roadmap",
+        content: seedContent,
+        created_at: 1,
+        updated_at: 2,
+      },
+    ]);
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    render(<DatabaseView />);
+
+    fireEvent.click(await screen.findByText("Roadmap"));
+
+    expect(await screen.findByLabelText("Table title")).toHaveValue("Roadmap");
+    const columnNames = screen.getAllByLabelText("Column name").map((el) => (el as HTMLInputElement).value);
+    expect(columnNames).toEqual(["Task", "Done"]);
+    expect(screen.getByLabelText("Task, row 1")).toHaveValue("Ship database view");
+    expect(screen.getByLabelText("Task, row 2")).toHaveValue("Write tests");
+    expect(screen.getByLabelText("Done, row 1")).toHaveProperty("checked", true);
+    expect(screen.getByLabelText("Done, row 2")).toHaveProperty("checked", false);
+  });
+});

--- a/desktop/src/apps/officestudio/db/__tests__/table.test.ts
+++ b/desktop/src/apps/officestudio/db/__tests__/table.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  addColumn,
+  addRow,
+  blankTable,
+  parseTableContent,
+  removeColumn,
+  removeRow,
+  renameColumn,
+  serializeTable,
+  setCell,
+  setColumnType,
+  type DbTable,
+} from "../table";
+
+describe("blankTable", () => {
+  it("starts with one text column and one row", () => {
+    const table = blankTable();
+    expect(table.columns).toHaveLength(1);
+    expect(table.columns[0].name).toBe("Name");
+    expect(table.columns[0].type).toBe("text");
+    expect(table.rows).toHaveLength(1);
+  });
+});
+
+describe("addColumn / removeColumn", () => {
+  it("adds a column and seeds the default value onto every existing row", () => {
+    let table = blankTable();
+    table = addRow(table);
+    table = addColumn(table, "number");
+    expect(table.columns).toHaveLength(2);
+    const newCol = table.columns[1];
+    expect(newCol.type).toBe("number");
+    for (const row of table.rows) {
+      expect(row.cells[newCol.id]).toBeNull();
+    }
+  });
+
+  it("refuses to remove the last remaining column", () => {
+    const table = blankTable();
+    const next = removeColumn(table, table.columns[0].id);
+    expect(next).toBe(table);
+  });
+
+  it("removes a column and its cells from every row", () => {
+    let table = blankTable();
+    table = addColumn(table, "text");
+    const toRemove = table.columns[1].id;
+    table = removeColumn(table, toRemove);
+    expect(table.columns).toHaveLength(1);
+    for (const row of table.rows) {
+      expect(toRemove in row.cells).toBe(false);
+    }
+  });
+});
+
+describe("renameColumn / setColumnType", () => {
+  it("renames a column", () => {
+    const table = blankTable();
+    const renamed = renameColumn(table, table.columns[0].id, "Title");
+    expect(renamed.columns[0].name).toBe("Title");
+  });
+
+  it("resets cell values to the new type's default", () => {
+    let table = blankTable();
+    table = setCell(table, table.rows[0].id, table.columns[0].id, "hello");
+    table = setColumnType(table, table.columns[0].id, "checkbox");
+    expect(table.columns[0].type).toBe("checkbox");
+    expect(table.rows[0].cells[table.columns[0].id]).toBe(false);
+  });
+});
+
+describe("addRow / removeRow / setCell", () => {
+  it("adds a row seeded with default values for every column", () => {
+    let table = blankTable();
+    table = addColumn(table, "checkbox");
+    table = addRow(table);
+    const row = table.rows[table.rows.length - 1];
+    expect(row.cells[table.columns[0].id]).toBe("");
+    expect(row.cells[table.columns[1].id]).toBe(false);
+  });
+
+  it("removes a row by id", () => {
+    let table = blankTable();
+    table = addRow(table);
+    const [first, second] = table.rows;
+    table = removeRow(table, first.id);
+    expect(table.rows).toEqual([second]);
+  });
+
+  it("edits a single cell without touching others", () => {
+    let table = blankTable();
+    const rowId = table.rows[0].id;
+    const colId = table.columns[0].id;
+    table = setCell(table, rowId, colId, "Widget");
+    expect(table.rows[0].cells[colId]).toBe("Widget");
+  });
+});
+
+describe("serializeTable / parseTableContent round trip", () => {
+  it("round-trips columns and rows through JSON", () => {
+    let table = blankTable();
+    table = addColumn(table, "number");
+    table = setCell(table, table.rows[0].id, table.columns[0].id, "Widget");
+    table = setCell(table, table.rows[0].id, table.columns[1].id, 42);
+
+    const content = serializeTable(table);
+    const restored = parseTableContent(content);
+
+    expect(restored).toEqual(table);
+  });
+
+  // blankTable() mints fresh random column/row ids each call, so a fallback
+  // table can't be compared with toEqual(blankTable()) directly; check its
+  // shape instead (single "Name" text column with one blank row).
+  function expectBlankTableShape(table: DbTable) {
+    expect(table.columns).toHaveLength(1);
+    expect(table.columns[0]).toMatchObject({ name: "Name", type: "text" });
+    expect(table.rows).toHaveLength(1);
+    expect(table.rows[0].cells[table.columns[0].id]).toBe("");
+  }
+
+  it("falls back to a blank table for empty or invalid content", () => {
+    expectBlankTableShape(parseTableContent(""));
+    expectBlankTableShape(parseTableContent("not json"));
+    expectBlankTableShape(parseTableContent(JSON.stringify({ version: 1, columns: [], rows: [] })));
+  });
+
+  it("falls back to a blank table when a column or row is corrupted", () => {
+    expectBlankTableShape(
+      parseTableContent(JSON.stringify({ version: 1, columns: [{ notAColumn: true }], rows: [] })),
+    );
+    expectBlankTableShape(
+      parseTableContent(
+        JSON.stringify({
+          version: 1,
+          columns: [{ id: "c1", name: "Name", type: "bogus" }],
+          rows: [],
+        }),
+      ),
+    );
+    expectBlankTableShape(
+      parseTableContent(
+        JSON.stringify({
+          version: 1,
+          columns: [{ id: "c1", name: "Name", type: "text" }],
+          rows: [{ notARow: true }],
+        }),
+      ),
+    );
+    const badShape: Partial<DbTable> = { version: 1, columns: "not-an-array" as never };
+    expectBlankTableShape(parseTableContent(JSON.stringify(badShape)));
+  });
+});

--- a/desktop/src/apps/officestudio/db/__tests__/table.test.ts
+++ b/desktop/src/apps/officestudio/db/__tests__/table.test.ts
@@ -3,13 +3,14 @@ import {
   addColumn,
   addRow,
   blankTable,
+  changeType,
+  coerceValue,
   parseTableContent,
   removeColumn,
   removeRow,
   renameColumn,
   serializeTable,
   setCell,
-  setColumnType,
   type DbTable,
 } from "../table";
 
@@ -54,19 +55,92 @@ describe("addColumn / removeColumn", () => {
   });
 });
 
-describe("renameColumn / setColumnType", () => {
+describe("renameColumn", () => {
   it("renames a column", () => {
     const table = blankTable();
     const renamed = renameColumn(table, table.columns[0].id, "Title");
     expect(renamed.columns[0].name).toBe("Title");
   });
+});
 
-  it("resets cell values to the new type's default", () => {
+describe("coerceValue", () => {
+  it("coerces into number: parses strings, maps booleans, non-numeric -> null", () => {
+    expect(coerceValue("42", "number")).toBe(42);
+    expect(coerceValue("3.5", "number")).toBe(3.5);
+    expect(coerceValue("abc", "number")).toBeNull();
+    expect(coerceValue("", "number")).toBeNull();
+    expect(coerceValue(null, "number")).toBeNull();
+    expect(coerceValue(true, "number")).toBe(1);
+    expect(coerceValue(false, "number")).toBe(0);
+  });
+
+  it("coerces into date: normalizes valid dates to YYYY-MM-DD, invalid -> null", () => {
+    expect(coerceValue("2024-01-15", "date")).toBe("2024-01-15");
+    expect(coerceValue("not a date", "date")).toBeNull();
+    expect(coerceValue("", "date")).toBeNull();
+    expect(coerceValue(null, "date")).toBeNull();
+    expect(coerceValue(true, "date")).toBeNull();
+    expect(coerceValue(42, "date")).toBeNull();
+  });
+
+  it("coerces into checkbox via truthiness", () => {
+    expect(coerceValue("hello", "checkbox")).toBe(true);
+    expect(coerceValue("", "checkbox")).toBe(false);
+    expect(coerceValue(1, "checkbox")).toBe(true);
+    expect(coerceValue(0, "checkbox")).toBe(false);
+    expect(coerceValue(null, "checkbox")).toBe(false);
+    expect(coerceValue(true, "checkbox")).toBe(true);
+  });
+
+  it("coerces into text via String(), null/undefined -> empty string", () => {
+    expect(coerceValue(42, "text")).toBe("42");
+    expect(coerceValue(true, "text")).toBe("true");
+    expect(coerceValue(false, "text")).toBe("false");
+    expect(coerceValue(null, "text")).toBe("");
+    expect(coerceValue(undefined, "text")).toBe("");
+    expect(coerceValue("keep", "text")).toBe("keep");
+  });
+});
+
+describe("changeType", () => {
+  it("changes the column type", () => {
     let table = blankTable();
-    table = setCell(table, table.rows[0].id, table.columns[0].id, "hello");
-    table = setColumnType(table, table.columns[0].id, "checkbox");
-    expect(table.columns[0].type).toBe("checkbox");
-    expect(table.rows[0].cells[table.columns[0].id]).toBe(false);
+    table = changeType(table, table.columns[0].id, "number");
+    expect(table.columns[0].type).toBe("number");
+  });
+
+  it("coerces convertible values instead of wiping them (text -> number)", () => {
+    let table = blankTable();
+    const colId = table.columns[0].id;
+    table = addRow(table);
+    table = setCell(table, table.rows[0].id, colId, "42");
+    table = setCell(table, table.rows[1].id, colId, "oops");
+    table = changeType(table, colId, "number");
+    expect(table.rows[0].cells[colId]).toBe(42);
+    expect(table.rows[1].cells[colId]).toBeNull();
+  });
+
+  it("coerces across every transition (number/date/checkbox/text)", () => {
+    let table = blankTable();
+    const colId = table.columns[0].id;
+
+    // text -> checkbox (truthiness)
+    table = setCell(table, table.rows[0].id, colId, "yes");
+    table = changeType(table, colId, "checkbox");
+    expect(table.rows[0].cells[colId]).toBe(true);
+
+    // checkbox -> number (true -> 1)
+    table = changeType(table, colId, "number");
+    expect(table.rows[0].cells[colId]).toBe(1);
+
+    // number -> text (String())
+    table = changeType(table, colId, "text");
+    expect(table.rows[0].cells[colId]).toBe("1");
+
+    // text -> date (valid date normalizes; other text -> null)
+    table = setCell(table, table.rows[0].id, colId, "2024-03-09");
+    table = changeType(table, colId, "date");
+    expect(table.rows[0].cells[colId]).toBe("2024-03-09");
   });
 });
 
@@ -108,6 +182,17 @@ describe("serializeTable / parseTableContent round trip", () => {
     const restored = parseTableContent(content);
 
     expect(restored).toEqual(table);
+  });
+
+  it("drops orphan cell keys that don't reference a current column", () => {
+    const restored = parseTableContent(
+      JSON.stringify({
+        version: 1,
+        columns: [{ id: "c1", name: "Name", type: "text" }],
+        rows: [{ id: "r1", cells: { c1: "keep", cGONE: "drop me" } }],
+      }),
+    );
+    expect(restored.rows[0].cells).toEqual({ c1: "keep" });
   });
 
   // blankTable() mints fresh random column/row ids each call, so a fallback

--- a/desktop/src/apps/officestudio/db/table.ts
+++ b/desktop/src/apps/officestudio/db/table.ts
@@ -86,14 +86,45 @@ export function renameColumn(table: DbTable, columnId: string, name: string): Db
   };
 }
 
-// Changing a column's type resets that column's cells to the new type's
-// default rather than trying to coerce old values (e.g. free text into a
-// checkbox), which would otherwise silently produce nonsense values.
-export function setColumnType(table: DbTable, columnId: string, type: ColumnType): DbTable {
+// Coerces a single cell value into the target column type, preserving data
+// wherever a sensible conversion exists rather than wiping it. Only genuinely
+// unconvertible values collapse to null (or "" for text):
+//   - number:   parsed via Number (booleans -> 1/0); non-numeric -> null
+//   - date:     parsed via Date.parse, normalized to YYYY-MM-DD; invalid -> null
+//   - checkbox: truthiness of the existing value
+//   - text:     String(value); null/undefined -> ""
+export function coerceValue(value: CellValue | undefined, type: ColumnType): CellValue {
+  switch (type) {
+    case "checkbox":
+      return Boolean(value);
+    case "number": {
+      if (value === null || value === undefined || value === "") return null;
+      const n = typeof value === "boolean" ? (value ? 1 : 0) : Number(value);
+      return Number.isFinite(n) ? n : null;
+    }
+    case "date": {
+      // Only text is a meaningful date source; booleans and numbers (a bare
+      // number string like "42" would otherwise parse to a year via Date.parse)
+      // are not dates and collapse to null.
+      if (typeof value !== "string" || value === "") return null;
+      const ts = Date.parse(value);
+      if (Number.isNaN(ts)) return null;
+      return new Date(ts).toISOString().slice(0, 10);
+    }
+    case "text":
+    default:
+      return value === null || value === undefined ? "" : String(value);
+  }
+}
+
+// Changes a column's type and coerces every existing cell in that column into
+// the new type (see coerceValue), so a type change preserves convertible data
+// instead of silently wiping the column.
+export function changeType(table: DbTable, columnId: string, type: ColumnType): DbTable {
   const columns = table.columns.map((c) => (c.id === columnId ? { ...c, type } : c));
   const rows = table.rows.map((r) => ({
     ...r,
-    cells: { ...r.cells, [columnId]: defaultValueForType(type) },
+    cells: { ...r.cells, [columnId]: coerceValue(r.cells[columnId], type) },
   }));
   return { ...table, columns, rows };
 }
@@ -153,7 +184,19 @@ export function parseTableContent(content: string): DbTable {
     if (!parsed.rows.every(isValidRow)) {
       return blankTable();
     }
-    return { version: 1, columns: parsed.columns as Column[], rows: parsed.rows as Row[] };
+    const columns = parsed.columns as Column[];
+    // Drop any orphan cell keys that don't reference a current column id
+    // (e.g. from a removed column left behind by a manual JSON edit or a
+    // future schema migration), so dead data isn't silently re-serialized.
+    const validIds = new Set(columns.map((c) => c.id));
+    const rows = (parsed.rows as Row[]).map((r) => {
+      const cells: Record<string, CellValue> = {};
+      for (const [colId, value] of Object.entries(r.cells)) {
+        if (validIds.has(colId)) cells[colId] = value;
+      }
+      return { id: r.id, cells };
+    });
+    return { version: 1, columns, rows };
   } catch {
     return blankTable();
   }

--- a/desktop/src/apps/officestudio/db/table.ts
+++ b/desktop/src/apps/officestudio/db/table.ts
@@ -1,0 +1,160 @@
+// Table model for the Database view. Persisted as the office doc's `content`
+// (kind "db"): the whole table is serialized to JSON, mirroring how Calc
+// serializes its workbook (see ../calc/workbook.ts) and Slides its deck
+// (see ../slides/deck.ts).
+
+import { randomId } from "@/lib/uid";
+
+export type ColumnType = "text" | "number" | "checkbox" | "date";
+
+export type Column = {
+  id: string;
+  name: string;
+  type: ColumnType;
+};
+
+export type CellValue = string | number | boolean | null;
+
+export type Row = {
+  id: string;
+  cells: Record<string, CellValue>;
+};
+
+export type DbTable = {
+  version: 1;
+  columns: Column[];
+  rows: Row[];
+};
+
+export const COLUMN_TYPES: { id: ColumnType; label: string }[] = [
+  { id: "text", label: "Text" },
+  { id: "number", label: "Number" },
+  { id: "checkbox", label: "Checkbox" },
+  { id: "date", label: "Date" },
+];
+
+export function defaultValueForType(type: ColumnType): CellValue {
+  switch (type) {
+    case "checkbox":
+      return false;
+    case "number":
+      return null;
+    default:
+      return "";
+  }
+}
+
+export function newColumn(name: string, type: ColumnType = "text"): Column {
+  return { id: randomId("col-"), name, type };
+}
+
+export function newRow(columns: Column[]): Row {
+  const cells: Record<string, CellValue> = {};
+  for (const col of columns) cells[col.id] = defaultValueForType(col.type);
+  return { id: randomId("row-"), cells };
+}
+
+export function blankTable(): DbTable {
+  const nameCol = newColumn("Name", "text");
+  return { version: 1, columns: [nameCol], rows: [newRow([nameCol])] };
+}
+
+export function addColumn(table: DbTable, type: ColumnType = "text"): DbTable {
+  const col = newColumn(`Column ${table.columns.length + 1}`, type);
+  const rows = table.rows.map((r) => ({
+    ...r,
+    cells: { ...r.cells, [col.id]: defaultValueForType(type) },
+  }));
+  return { ...table, columns: [...table.columns, col], rows };
+}
+
+export function removeColumn(table: DbTable, columnId: string): DbTable {
+  if (table.columns.length <= 1) return table;
+  const columns = table.columns.filter((c) => c.id !== columnId);
+  const rows = table.rows.map((r) => {
+    const cells = { ...r.cells };
+    delete cells[columnId];
+    return { ...r, cells };
+  });
+  return { ...table, columns, rows };
+}
+
+export function renameColumn(table: DbTable, columnId: string, name: string): DbTable {
+  return {
+    ...table,
+    columns: table.columns.map((c) => (c.id === columnId ? { ...c, name } : c)),
+  };
+}
+
+// Changing a column's type resets that column's cells to the new type's
+// default rather than trying to coerce old values (e.g. free text into a
+// checkbox), which would otherwise silently produce nonsense values.
+export function setColumnType(table: DbTable, columnId: string, type: ColumnType): DbTable {
+  const columns = table.columns.map((c) => (c.id === columnId ? { ...c, type } : c));
+  const rows = table.rows.map((r) => ({
+    ...r,
+    cells: { ...r.cells, [columnId]: defaultValueForType(type) },
+  }));
+  return { ...table, columns, rows };
+}
+
+export function addRow(table: DbTable): DbTable {
+  return { ...table, rows: [...table.rows, newRow(table.columns)] };
+}
+
+export function removeRow(table: DbTable, rowId: string): DbTable {
+  return { ...table, rows: table.rows.filter((r) => r.id !== rowId) };
+}
+
+export function setCell(table: DbTable, rowId: string, columnId: string, value: CellValue): DbTable {
+  return {
+    ...table,
+    rows: table.rows.map((r) =>
+      r.id === rowId ? { ...r, cells: { ...r.cells, [columnId]: value } } : r,
+    ),
+  };
+}
+
+export function serializeTable(table: DbTable): string {
+  return JSON.stringify(table);
+}
+
+const VALID_TYPES: ColumnType[] = ["text", "number", "checkbox", "date"];
+
+function isValidColumn(value: unknown): value is Column {
+  if (!value || typeof value !== "object") return false;
+  const c = value as Partial<Column>;
+  if (typeof c.id !== "string") return false;
+  if (typeof c.name !== "string") return false;
+  if (!VALID_TYPES.includes(c.type as ColumnType)) return false;
+  return true;
+}
+
+function isValidRow(value: unknown): value is Row {
+  if (!value || typeof value !== "object") return false;
+  const r = value as Partial<Row>;
+  if (typeof r.id !== "string") return false;
+  if (!r.cells || typeof r.cells !== "object") return false;
+  return true;
+}
+
+// Parses saved content into a DbTable, falling back to a fresh blank table on
+// any malformed or corrupted content instead of crashing the view.
+export function parseTableContent(content: string): DbTable {
+  if (!content || !content.trim()) return blankTable();
+  try {
+    const parsed = JSON.parse(content) as Partial<DbTable>;
+    if (!parsed || !Array.isArray(parsed.columns) || !Array.isArray(parsed.rows)) {
+      return blankTable();
+    }
+    if (parsed.columns.length === 0 || !parsed.columns.every(isValidColumn)) {
+      return blankTable();
+    }
+    if (!parsed.rows.every(isValidRow)) {
+      return blankTable();
+    }
+    return { version: 1, columns: parsed.columns as Column[], rows: parsed.rows as Row[] };
+  } catch {
+    return blankTable();
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a **Database** tab to Office Studio, alongside Write / Calc / Slides — a lightweight "Base"-style table editor (Airtable-lite / MS Access table), not a SQL console.
- Reuses the existing `/api/office/docs` backend as-is: `kind: "db"` was already in `VALID_KINDS` (`tinyagentos/office_docs.py`), so no backend changes were needed. List/create/save wiring mirrors `CalcView.tsx` exactly (`GET /api/office/docs`, `GET/POST/PUT /api/office/docs/{id}`, `credentials: "include"`).

## Content schema

The doc's `content` is JSON-serialized as:

```ts
type ColumnType = "text" | "number" | "checkbox" | "date";
type Column = { id: string; name: string; type: ColumnType };
type CellValue = string | number | boolean | null;
type Row = { id: string; cells: Record<string /* column id */, CellValue> };
type DbTable = { version: 1; columns: Column[]; rows: Row[] };
```

Parsing falls back to a blank table (one "Name" text column, one row) on empty/malformed content, matching the pattern in `calc/workbook.ts` and `slides/deck.ts`.

## Table editor

- `desktop/src/apps/officestudio/db/table.ts` — pure model helpers (add/remove/rename column, change column type, add/remove row, set cell, serialize/parse).
- `desktop/src/apps/officestudio/DatabaseView.tsx` — the view: doc list sidebar (create/open/rename-via-title-save), an editable `<table>` with inline column-name inputs + a type `<select>` per column, typed cell inputs (text/number/checkbox/date), add-column/add-row toolbar, per-row/per-column delete buttons, and a Save button with a "Saving..." state — same styling, theme tokens (`shell-*`, `accent`), and a11y conventions (`aria-label`s, focus rings) as `CalcView.tsx`.
- `OfficeStudioApp.tsx` — registers the tab (`Table2` icon) in the natural suite order: Write, Calc, Database, Presentations.

## Test plan

- [x] `npx vitest run src/apps/officestudio src/apps/OfficeStudioApp.test.tsx` — 76 passed (10 files): new `db/__tests__/table.test.ts` (model round-trip + fallback), new `officestudio/__tests__/DatabaseView.test.tsx` (create → POST kind `db`, add column+row+edit cell → PUT with correct content shape, load existing doc renders its columns/rows), extended `OfficeStudioApp.test.tsx` for the new rail tab.
- [x] `npm run build` — tsc clean, 0 errors.
- [x] `pytest tests/test_office_docs.py` — 25 passed, confirms `VALID_KINDS == {"write", "calc", "db", "slides"}` (backend untouched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Database section in Office Studio with a table-based editor.
  * Users can create, open, edit, and save database-style tables with text, number, checkbox, and date fields.
  * Table editing now supports adding/removing rows and columns, renaming columns, and changing column types.

* **Bug Fixes**
  * Improved handling of invalid or empty saved table data by falling back to a usable default table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->