### PR TITLE
feat(web-studio): real AI generation + sandboxed preview + share-as-app (static-first v1)

### DIFF
--- a/desktop/src/apps/WebStudioApp.test.tsx
+++ b/desktop/src/apps/WebStudioApp.test.tsx
@@ -39,30 +39,50 @@ function sectionTypes(container: HTMLElement): string[] {
   );
 }
 
+/** A /api/taos-agent/chat NDJSON stream whose deltas concatenate to `text`. */
+function chatStreamResponse(text: string): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(JSON.stringify({ delta: text }) + "\n"));
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
 describe("WebStudioApp shell", () => {
   beforeEach(() => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => ({ ok: true, json: async () => [] })),
+      vi.fn(async (url: string) => {
+        if (url === "/api/taos-agent/chat") {
+          // No real agent in tests: an unparsable reply exercises the same
+          // honest matchTemplate() fallback a real agent failure would.
+          return chatStreamResponse("Sorry, I can't help with that request.");
+        }
+        return { ok: true, json: async () => [] };
+      }),
     );
   });
 
-  it("renders the five studio views in the rail", () => {
+  it("renders the six studio views in the rail", () => {
     render(<WebStudioApp windowId="w1" />);
     const nav = screen.getByRole("navigation", { name: "Web Studio views" });
     const labels = within(nav)
       .getAllByRole("button")
       .map((b) => b.getAttribute("aria-label"));
-    expect(labels).toEqual(["Generate", "Templates", "Edit", "Preview", "Export"]);
+    expect(labels).toEqual(["Generate", "Templates", "Edit", "Preview", "Export", "Share"]);
   });
 
-  it("generate seeds a multi-section site into the Edit view", () => {
+  it("generate seeds a multi-section site into the Edit view, falling back to a template", async () => {
     const { container } = render(<WebStudioApp windowId="w1" />);
-    // Pick a prompt idea, then generate.
+    // Pick a prompt idea, then generate. No real agent in tests, so this
+    // exercises the honest matchTemplate() fallback path.
     fireEvent.click(screen.getByRole("button", { name: "A cafe with a menu and bookings" }));
     fireEvent.click(screen.getByRole("button", { name: /Generate site/i }));
     // Now on the Edit view with real sections rendered.
-    expect(screen.getByLabelText("Site title")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText("Site title")).toBeInTheDocument());
     expect(sectionTypes(container).length).toBeGreaterThan(1);
     expect(sectionTypes(container)).toContain("hero");
   });

--- a/desktop/src/apps/WebStudioApp.tsx
+++ b/desktop/src/apps/WebStudioApp.tsx
@@ -1,26 +1,30 @@
 import { useCallback, useEffect, useState } from "react";
-import { Wand2, LayoutGrid, Pencil, Eye, Download } from "lucide-react";
+import { Wand2, LayoutGrid, Pencil, Eye, Download, Share2 } from "lucide-react";
 import { GenerateView } from "./webstudio/GenerateView";
 import { TemplatesView } from "./webstudio/TemplatesView";
 import { EditView, type SavedSite } from "./webstudio/EditView";
 import { PreviewView } from "./webstudio/PreviewView";
 import { ExportView } from "./webstudio/ExportView";
+import { ShareView } from "./webstudio/ShareView";
+import { exportSiteHtml } from "./webstudio/export";
 import { emptySite } from "./webstudio/templates";
 import { isValidSite, MAX_CONTENT_BYTES, type Site, type StudioView } from "./webstudio/types";
 
 /* ------------------------------------------------------------------ */
-/*  Web Studio - shell (phase 1)                                       */
+/*  Web Studio - shell                                                  */
 /*                                                                     */
 /*  A Wix-style, section-based website builder. Left icon rail         */
-/*  (Generate / Templates / Edit / Preview / Export) + the active      */
-/*  surface, the same shape as the other taOS studios.                 */
+/*  (Generate / Templates / Edit / Preview / Export / Share) + the      */
+/*  active surface, the same shape as the other taOS studios.           */
 /*                                                                     */
-/*  Phase 1 ships a genuinely usable editor: template-matched          */
-/*  scaffolding, a visual sections editor with inline text + image     */
-/*  swap, live device preview, a self-contained static-HTML export     */
-/*  and backend persistence (/api/web/sites). Full offline-LLM         */
-/*  generation and publish-to-host are later phases, surfaced as       */
-/*  honest "coming" affordances, never faked.                          */
+/*  Generate streams the taos-agent for a real, bespoke Site (with an   */
+/*  honest template-match fallback if that fails); Edit is a visual     */
+/*  sections editor; Preview is a sandboxed iframe (either the saved,    */
+/*  backend-rendered page or a srcDoc of the live in-memory edits);      */
+/*  Export downloads the self-contained static HTML; Share installs the  */
+/*  site as a real taOS app (or exports the same .taosapp package).      */
+/*  Saving also persists the rendered index.html alongside the editable  */
+/*  Site JSON, so Preview/Share have something servable.                 */
 /* ------------------------------------------------------------------ */
 
 const RAIL: { id: StudioView; label: string; icon: typeof Wand2 }[] = [
@@ -29,6 +33,7 @@ const RAIL: { id: StudioView; label: string; icon: typeof Wand2 }[] = [
   { id: "edit", label: "Edit", icon: Pencil },
   { id: "preview", label: "Preview", icon: Eye },
   { id: "export", label: "Export", icon: Download },
+  { id: "share", label: "Share", icon: Share2 },
 ];
 
 export function WebStudioApp(_props: { windowId: string }) {
@@ -126,7 +131,10 @@ export function WebStudioApp(_props: { windowId: string }) {
           "This site is too large to save (over 5 MB). Remove or shrink some images and try again.",
         );
       }
-      const payload = { title: site.title.trim() || "Untitled site", content };
+      // Persist the rendered static HTML alongside the editable Site JSON --
+      // the derived artifact the preview/package routes serve, so Preview
+      // and Share never have to re-render the site server-side.
+      const payload = { title: site.title.trim() || "Untitled site", content, index_html: exportSiteHtml(site) };
       const url = activeId ? `/api/web/sites/${encodeURIComponent(activeId)}` : "/api/web/sites";
       const res = await fetch(url, {
         method: activeId ? "PUT" : "POST",
@@ -212,8 +220,9 @@ export function WebStudioApp(_props: { windowId: string }) {
               onDelete={deleteSite}
             />
           )}
-          {view === "preview" && <PreviewView site={site} />}
+          {view === "preview" && <PreviewView site={site} siteId={activeId} dirty={dirty} />}
           {view === "export" && <ExportView site={site} />}
+          {view === "share" && <ShareView siteId={activeId} />}
         </div>
       </div>
     </div>

--- a/desktop/src/apps/WebStudioApp.tsx
+++ b/desktop/src/apps/WebStudioApp.tsx
@@ -45,6 +45,17 @@ export function WebStudioApp(_props: { windowId: string }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
+  // True when the active saved site has a stored rendered index.html the
+  // /preview route can serve. Legacy rows (saved before this feature) have an
+  // empty index_html, so Preview must fall back to a client-side srcDoc render
+  // rather than point the iframe at a 404. Any save with the current code
+  // populates it, so it's true after a successful save.
+  const [activeHasRender, setActiveHasRender] = useState(false);
+  // Honest provenance for the current editing session: only a site the agent
+  // actually generated is "ai-generated"; templates, manual edits, a matched
+  // fallback, or a reopened saved site are "user-uploaded" (the safe default;
+  // both tiers carry the same capability ceiling, so this is a labeling fix).
+  const [provenance, setProvenance] = useState<"ai-generated" | "user-uploaded">("user-uploaded");
 
   const loadList = useCallback(async () => {
     const res = await fetch("/api/web/sites", { credentials: "include" });
@@ -73,12 +84,14 @@ export function WebStudioApp(_props: { windowId: string }) {
   const confirmDiscard = () =>
     !dirty || window.confirm("Discard unsaved changes to the current site?");
 
-  const seedInEditor = (next: Site) => {
+  const seedInEditor = (next: Site, wasAiGenerated = false) => {
     if (!confirmDiscard()) return;
     setSite(next);
     setActiveId(null);
     setView("edit");
     setDirty(false);
+    setActiveHasRender(false);
+    setProvenance(wasAiGenerated ? "ai-generated" : "user-uploaded");
   };
 
   const newSite = () => {
@@ -87,6 +100,8 @@ export function WebStudioApp(_props: { windowId: string }) {
     setActiveId(null);
     setError(null);
     setDirty(false);
+    setActiveHasRender(false);
+    setProvenance("user-uploaded");
   };
 
   const updateSite = (next: Site) => {
@@ -100,7 +115,7 @@ export function WebStudioApp(_props: { windowId: string }) {
     try {
       const res = await fetch(`/api/web/sites/${encodeURIComponent(id)}`, { credentials: "include" });
       if (!res.ok) throw new Error("Could not open site");
-      const row = (await res.json()) as { id: string; title: string; content: string };
+      const row = (await res.json()) as { id: string; title: string; content: string; index_html?: string };
       let model: Site;
       try {
         const parsed: unknown = JSON.parse(row.content);
@@ -113,6 +128,11 @@ export function WebStudioApp(_props: { windowId: string }) {
       setSite(model);
       setActiveId(row.id);
       setDirty(false);
+      // Legacy rows have no stored render; Preview will use a srcDoc fallback.
+      setActiveHasRender(Boolean(row.index_html));
+      // A reopened saved site's origin isn't tracked across sessions; fall
+      // back to the safe, non-agent tier rather than assume ai-generated.
+      setProvenance("user-uploaded");
     } catch (e) {
       setError(e instanceof Error ? e.message : "Open failed");
     }
@@ -123,18 +143,23 @@ export function WebStudioApp(_props: { windowId: string }) {
     setError(null);
     try {
       const content = JSON.stringify(site);
+      // The rendered static HTML persisted alongside the editable Site JSON --
+      // the derived artifact the preview/package routes serve, so Preview and
+      // Share never have to re-render the site server-side.
+      const indexHtml = exportSiteHtml(site);
       // Catch an over-cap site (usually too many/too-large inlined images)
-      // here with a clear message rather than letting it fail only at PUT
-      // time with a raw 413. The cap mirrors the backend's MAX_CONTENT_BYTES.
-      if (new Blob([content]).size > MAX_CONTENT_BYTES) {
+      // here with a clear message rather than letting it fail only at PUT time
+      // with a raw 413. Both the JSON content and the rendered HTML are capped
+      // at the backend's MAX_CONTENT_BYTES, so check both before the request.
+      if (
+        new Blob([content]).size > MAX_CONTENT_BYTES ||
+        new Blob([indexHtml]).size > MAX_CONTENT_BYTES
+      ) {
         throw new Error(
           "This site is too large to save (over 5 MB). Remove or shrink some images and try again.",
         );
       }
-      // Persist the rendered static HTML alongside the editable Site JSON --
-      // the derived artifact the preview/package routes serve, so Preview
-      // and Share never have to re-render the site server-side.
-      const payload = { title: site.title.trim() || "Untitled site", content, index_html: exportSiteHtml(site) };
+      const payload = { title: site.title.trim() || "Untitled site", content, index_html: indexHtml };
       const url = activeId ? `/api/web/sites/${encodeURIComponent(activeId)}` : "/api/web/sites";
       const res = await fetch(url, {
         method: activeId ? "PUT" : "POST",
@@ -149,6 +174,8 @@ export function WebStudioApp(_props: { windowId: string }) {
       const savedRow = (await res.json()) as { id: string };
       setActiveId(savedRow.id);
       setDirty(false);
+      // We just persisted index_html, so the /preview route can serve it.
+      setActiveHasRender(true);
       await loadList();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Save failed");
@@ -220,9 +247,11 @@ export function WebStudioApp(_props: { windowId: string }) {
               onDelete={deleteSite}
             />
           )}
-          {view === "preview" && <PreviewView site={site} siteId={activeId} dirty={dirty} />}
+          {view === "preview" && (
+            <PreviewView site={site} siteId={activeId} dirty={dirty} hasRender={activeHasRender} />
+          )}
           {view === "export" && <ExportView site={site} />}
-          {view === "share" && <ShareView siteId={activeId} />}
+          {view === "share" && <ShareView siteId={activeId} provenance={provenance} />}
         </div>
       </div>
     </div>

--- a/desktop/src/apps/webstudio/ExportView.tsx
+++ b/desktop/src/apps/webstudio/ExportView.tsx
@@ -47,8 +47,8 @@ export function ExportView({ site }: { site: Site }) {
           <div className="mt-3 flex items-start gap-2 rounded-xl border border-shell-border bg-shell-surface px-3.5 py-3 text-[12px] text-shell-text-tertiary">
             <Globe size={15} className="mt-0.5 shrink-0" />
             <span>
-              One-click publish to a taOS-hosted address on your LAN is coming in a later phase. Nothing is published
-              yet; only the download above is live.
+              To install this site as a real taOS app (or export it as a shareable .taosapp package), save it first,
+              then open the Share view.
             </span>
           </div>
         </div>

--- a/desktop/src/apps/webstudio/GenerateView.test.tsx
+++ b/desktop/src/apps/webstudio/GenerateView.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { GenerateView } from "./GenerateView";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function chatStreamResponse(text: string): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(JSON.stringify({ delta: text }) + "\n"));
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+const VALID_SITE_JSON = JSON.stringify({
+  title: "Fresh Cafe",
+  theme: { palette: "sand", font: "serif" },
+  sections: [
+    {
+      id: "hero-1",
+      type: "hero",
+      content: {
+        eyebrow: "Now open",
+        heading: "Coffee worth the walk",
+        subheading: "A neighborhood cafe.",
+        ctaLabel: "See the menu",
+        image: "",
+      },
+    },
+    {
+      id: "footer-1",
+      type: "footer",
+      content: { businessName: "Fresh Cafe", tagline: "" },
+    },
+  ],
+});
+
+describe("GenerateView", () => {
+  it("loads a valid AI-generated Site into the editor with no fallback notice", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => chatStreamResponse(`\`\`\`json\n${VALID_SITE_JSON}\n\`\`\``)),
+    );
+    const onGenerate = vi.fn();
+    render(<GenerateView onGenerate={onGenerate} />);
+
+    fireEvent.change(screen.getByLabelText("What are you building?"), {
+      target: { value: "a cafe landing page" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Generate site/i }));
+
+    await waitFor(() => expect(onGenerate).toHaveBeenCalledTimes(1));
+    const site = onGenerate.mock.calls[0][0];
+    expect(site.title).toBe("Fresh Cafe");
+    expect(screen.queryByText(/could not be parsed/)).not.toBeInTheDocument();
+  });
+
+  it("falls back to matchTemplate and shows a notice when the response has no parseable JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => chatStreamResponse("Sorry, I can't help with that request.")),
+    );
+    const onGenerate = vi.fn();
+    render(<GenerateView onGenerate={onGenerate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Generate site/i }));
+
+    await waitFor(() => expect(onGenerate).toHaveBeenCalledTimes(1));
+    const site = onGenerate.mock.calls[0][0];
+    expect(site.sections.length).toBeGreaterThan(0);
+    expect(screen.getByText(/could not be parsed/)).toBeInTheDocument();
+  });
+
+  it("surfaces a stream error instead of silently falling back", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 500, text: async () => "agent unreachable" })),
+    );
+    const onGenerate = vi.fn();
+    render(<GenerateView onGenerate={onGenerate} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Generate site/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(onGenerate).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/webstudio/GenerateView.test.tsx
+++ b/desktop/src/apps/webstudio/GenerateView.test.tsx
@@ -56,8 +56,10 @@ describe("GenerateView", () => {
     fireEvent.click(screen.getByRole("button", { name: /Generate site/i }));
 
     await waitFor(() => expect(onGenerate).toHaveBeenCalledTimes(1));
-    const site = onGenerate.mock.calls[0][0];
+    const [site, wasAiGenerated] = onGenerate.mock.calls[0];
     expect(site.title).toBe("Fresh Cafe");
+    // A real parse must report wasAiGenerated=true so it's tagged ai-generated.
+    expect(wasAiGenerated).toBe(true);
     expect(screen.queryByText(/could not be parsed/)).not.toBeInTheDocument();
   });
 
@@ -72,8 +74,11 @@ describe("GenerateView", () => {
     fireEvent.click(screen.getByRole("button", { name: /Generate site/i }));
 
     await waitFor(() => expect(onGenerate).toHaveBeenCalledTimes(1));
-    const site = onGenerate.mock.calls[0][0];
+    const [site, wasAiGenerated] = onGenerate.mock.calls[0];
     expect(site.sections.length).toBeGreaterThan(0);
+    // A matched-template fallback must report wasAiGenerated=false so the
+    // caller tags it user-uploaded, not ai-generated.
+    expect(wasAiGenerated).toBe(false);
     expect(screen.getByText(/could not be parsed/)).toBeInTheDocument();
   });
 

--- a/desktop/src/apps/webstudio/GenerateView.tsx
+++ b/desktop/src/apps/webstudio/GenerateView.tsx
@@ -10,7 +10,13 @@ const PROMPT_IDEAS = [
   "An event page for a tech meetup",
 ];
 
-export function GenerateView({ onGenerate }: { onGenerate: (site: Site) => void }) {
+export function GenerateView({
+  onGenerate,
+}: {
+  /** wasAiGenerated is false when we fell back to a matched template, so the
+   *  caller can tag provenance honestly (ai-generated vs user-authored). */
+  onGenerate: (site: Site, wasAiGenerated: boolean) => void;
+}) {
   const [prompt, setPrompt] = useState("");
   const [palette, setPalette] = useState<PaletteId | null>(null);
   const [font, setFont] = useState<FontId | null>(null);
@@ -56,7 +62,7 @@ export function GenerateView({ onGenerate }: { onGenerate: (site: Site) => void 
         { signal: controller.signal },
       );
       if (result.usedFallback && mountedRef.current) setNotice(result.parseNotice);
-      onGenerate(applyOverrides(result.site));
+      onGenerate(applyOverrides(result.site), !result.usedFallback);
     } catch (e) {
       if (!(e instanceof DOMException && e.name === "AbortError") && mountedRef.current) {
         setError(e instanceof Error ? e.message : String(e));

--- a/desktop/src/apps/webstudio/GenerateView.tsx
+++ b/desktop/src/apps/webstudio/GenerateView.tsx
@@ -1,7 +1,6 @@
-import { useState } from "react";
-import { Sparkles, Wand2, Info } from "lucide-react";
-import { matchTemplate } from "./match-template";
-import { siteFromTemplate } from "./templates";
+import { useEffect, useRef, useState } from "react";
+import { Sparkles, Wand2, Info, Loader2 } from "lucide-react";
+import { generateSite, type GenerateProgress } from "./generate-site";
 import { PALETTES, FONTS, type Site, type PaletteId, type FontId } from "./types";
 
 const PROMPT_IDEAS = [
@@ -15,20 +14,69 @@ export function GenerateView({ onGenerate }: { onGenerate: (site: Site) => void 
   const [prompt, setPrompt] = useState("");
   const [palette, setPalette] = useState<PaletteId | null>(null);
   const [font, setFont] = useState<FontId | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [progress, setProgress] = useState<GenerateProgress | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
 
-  const generate = () => {
-    const tpl = matchTemplate(prompt);
-    const site = siteFromTemplate(tpl, prompt.trim() ? prompt.trim().slice(0, 60) : undefined);
-    if (palette) site.theme.palette = palette;
-    if (font) site.theme.font = font;
-    onGenerate(site);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const applyOverrides = (site: Site): Site => {
+    const theme = { ...site.theme };
+    if (palette) theme.palette = palette;
+    if (font) theme.font = font;
+    return { ...site, theme };
   };
+
+  const generate = async () => {
+    if (busy) return;
+    setError(null);
+    setNotice(null);
+    setBusy(true);
+    setProgress({ stage: "streaming", detail: "Starting..." });
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const result = await generateSite(
+        prompt,
+        (p) => {
+          if (mountedRef.current) setProgress(p);
+        },
+        { signal: controller.signal },
+      );
+      if (result.usedFallback && mountedRef.current) setNotice(result.parseNotice);
+      onGenerate(applyOverrides(result.site));
+    } catch (e) {
+      if (!(e instanceof DOMException && e.name === "AbortError") && mountedRef.current) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    } finally {
+      if (abortRef.current === controller) abortRef.current = null;
+      if (mountedRef.current) {
+        setBusy(false);
+        setProgress(null);
+      }
+    }
+  };
+
+  const cancel = () => abortRef.current?.abort();
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
         <h2 className="text-[17px] font-bold tracking-[-0.02em]">Generate</h2>
-        <span className="text-[12px] text-shell-text-tertiary">Describe your site, we scaffold it</span>
+        <span className="text-[12px] text-shell-text-tertiary">Describe your site, the taOS agent designs it</span>
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto">
@@ -40,8 +88,9 @@ export function GenerateView({ onGenerate }: { onGenerate: (site: Site) => void 
             id="ws-prompt"
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
+            disabled={busy}
             placeholder="e.g. A landing page for a meal-planning app for busy families"
-            className="h-28 w-full resize-none rounded-xl border border-shell-border bg-shell-surface px-4 py-3 text-[13px] text-shell-text placeholder:text-shell-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+            className="h-28 w-full resize-none rounded-xl border border-shell-border bg-shell-surface px-4 py-3 text-[13px] text-shell-text placeholder:text-shell-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:opacity-60"
           />
 
           <div className="mt-3 flex flex-wrap gap-2" role="group" aria-label="Prompt ideas">
@@ -49,8 +98,9 @@ export function GenerateView({ onGenerate }: { onGenerate: (site: Site) => void 
               <button
                 key={idea}
                 type="button"
+                disabled={busy}
                 onClick={() => setPrompt(idea)}
-                className="rounded-full border border-shell-border bg-shell-surface px-3 py-1.5 text-[11.5px] font-medium text-shell-text-secondary transition-colors hover:border-shell-border-strong hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                className="rounded-full border border-shell-border bg-shell-surface px-3 py-1.5 text-[11.5px] font-medium text-shell-text-secondary transition-colors hover:border-shell-border-strong hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {idea}
               </button>
@@ -66,8 +116,9 @@ export function GenerateView({ onGenerate }: { onGenerate: (site: Site) => void 
                   key={id}
                   type="button"
                   aria-pressed={on}
+                  disabled={busy}
                   onClick={() => setPalette(on ? null : id)}
-                  className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-[11.5px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  className={`flex items-center gap-2 rounded-full border px-3 py-1.5 text-[11.5px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-60 ${
                     on ? "border-accent bg-accent-soft text-accent" : "border-shell-border bg-shell-surface text-shell-text-secondary hover:bg-shell-surface-active"
                   }`}
                 >
@@ -87,8 +138,9 @@ export function GenerateView({ onGenerate }: { onGenerate: (site: Site) => void 
                   key={id}
                   type="button"
                   aria-pressed={on}
+                  disabled={busy}
                   onClick={() => setFont(on ? null : id)}
-                  className={`rounded-full border px-3 py-1.5 text-[11.5px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                  className={`rounded-full border px-3 py-1.5 text-[11.5px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-60 ${
                     on ? "border-accent bg-accent-soft text-accent" : "border-shell-border bg-shell-surface text-shell-text-secondary hover:bg-shell-surface-active"
                   }`}
                   style={{ fontFamily: FONTS[id].stack }}
@@ -99,22 +151,54 @@ export function GenerateView({ onGenerate }: { onGenerate: (site: Site) => void 
             })}
           </div>
 
-          <button
-            type="button"
-            onClick={generate}
-            className="mt-7 flex h-10 w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-accent to-accent/70 text-[13px] font-bold text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
-          >
-            <Wand2 size={16} />
-            Generate site
-          </button>
-
-          <div className="mt-4 flex items-start gap-2 rounded-xl border border-accent/30 bg-accent-soft px-3.5 py-3 text-[12px] text-shell-text-secondary" role="status">
-            <Info size={15} className="mt-0.5 shrink-0 text-accent" />
-            <span>
-              Phase 1 matches your prompt to the closest starter template and seeds it into the editor, ready to
-              edit. Full offline-model generation that writes bespoke copy and layout arrives in a later phase.
-            </span>
+          <div className="mt-7 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void generate()}
+              disabled={busy}
+              className="flex h-10 flex-1 items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-accent to-accent/70 text-[13px] font-bold text-white transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {busy ? <Loader2 size={16} className="animate-spin" /> : <Wand2 size={16} />}
+              {busy ? "Generating..." : "Generate site"}
+            </button>
+            {busy && (
+              <button
+                type="button"
+                onClick={cancel}
+                className="flex h-10 items-center rounded-xl border border-shell-border px-3.5 text-[12.5px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+              >
+                Cancel
+              </button>
+            )}
           </div>
+
+          {progress && (
+            <div
+              role="status"
+              className="mt-3 flex items-start gap-2.5 rounded-xl border border-accent/30 bg-accent-soft px-3.5 py-3"
+            >
+              <Loader2 size={16} className="mt-0.5 flex-none animate-spin text-accent" />
+              <div className="min-w-0 flex-1 text-[12.5px] leading-relaxed text-shell-text-secondary">
+                <span className="font-semibold text-shell-text">Designing your site.</span> {progress.detail}
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div role="alert" className="mt-3 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3 text-[12.5px] text-red-200">
+              {error}
+            </div>
+          )}
+
+          {notice && (
+            <div
+              role="status"
+              className="mt-3 flex items-start gap-2.5 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3.5 py-3"
+            >
+              <Info size={16} className="mt-0.5 flex-none text-amber-400" />
+              <p className="text-[12.5px] leading-relaxed text-amber-200">{notice}</p>
+            </div>
+          )}
 
           <div className="mt-3 flex items-center gap-1.5 text-[11.5px] text-shell-text-tertiary">
             <Sparkles size={13} />

--- a/desktop/src/apps/webstudio/PreviewView.test.tsx
+++ b/desktop/src/apps/webstudio/PreviewView.test.tsx
@@ -2,27 +2,46 @@ import { render, screen, cleanup } from "@testing-library/react";
 import { describe, it, expect, afterEach } from "vitest";
 import { PreviewView } from "./PreviewView";
 import { emptySite } from "./templates";
+import type { Site } from "./types";
 
 afterEach(() => cleanup());
 
+/** A site with no sections at all (e.g. every section deleted). */
+function siteWithNoSections(): Site {
+  return { ...emptySite(), sections: [] };
+}
+
 describe("PreviewView", () => {
-  it("points the iframe at the backend preview URL when the site is saved and clean", () => {
-    render(<PreviewView site={emptySite()} siteId="site-abc123" dirty={false} />);
+  it("points the iframe at the backend preview URL when saved, clean, and rendered", () => {
+    render(<PreviewView site={emptySite()} siteId="site-abc123" dirty={false} hasRender />);
     const iframe = screen.getByTitle("Site preview") as HTMLIFrameElement;
     expect(iframe.getAttribute("src")).toBe("/api/web/sites/site-abc123/preview");
     expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
   });
 
   it("falls back to a sandboxed srcDoc of the live export when the site is unsaved", () => {
-    render(<PreviewView site={emptySite()} siteId={null} dirty={false} />);
+    render(<PreviewView site={emptySite()} siteId={null} dirty={false} hasRender={false} />);
     const iframe = screen.getByTitle("Site preview (unsaved)") as HTMLIFrameElement;
     expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
     expect(iframe.hasAttribute("src")).toBe(false);
   });
 
   it("falls back to srcDoc when a saved site has unsaved (dirty) edits", () => {
-    render(<PreviewView site={emptySite()} siteId="site-abc123" dirty />);
+    render(<PreviewView site={emptySite()} siteId="site-abc123" dirty hasRender />);
     expect(screen.getByTitle("Site preview (unsaved)")).toBeInTheDocument();
     expect(screen.queryByTitle("Site preview")).not.toBeInTheDocument();
+  });
+
+  it("falls back to srcDoc for a legacy saved row with no stored render (no 404 blank frame)", () => {
+    render(<PreviewView site={emptySite()} siteId="site-legacy" dirty={false} hasRender={false} />);
+    expect(screen.getByTitle("Site preview (unsaved)")).toBeInTheDocument();
+    expect(screen.queryByTitle("Site preview")).not.toBeInTheDocument();
+  });
+
+  it("shows an explicit empty state (not a blank iframe) when the site has no sections", () => {
+    render(<PreviewView site={siteWithNoSections()} siteId="site-abc123" dirty={false} hasRender />);
+    expect(screen.getByText("Nothing to preview yet")).toBeInTheDocument();
+    expect(screen.queryByTitle("Site preview")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Site preview (unsaved)")).not.toBeInTheDocument();
   });
 });

--- a/desktop/src/apps/webstudio/PreviewView.test.tsx
+++ b/desktop/src/apps/webstudio/PreviewView.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { PreviewView } from "./PreviewView";
+import { emptySite } from "./templates";
+
+afterEach(() => cleanup());
+
+describe("PreviewView", () => {
+  it("points the iframe at the backend preview URL when the site is saved and clean", () => {
+    render(<PreviewView site={emptySite()} siteId="site-abc123" dirty={false} />);
+    const iframe = screen.getByTitle("Site preview") as HTMLIFrameElement;
+    expect(iframe.getAttribute("src")).toBe("/api/web/sites/site-abc123/preview");
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+  });
+
+  it("falls back to a sandboxed srcDoc of the live export when the site is unsaved", () => {
+    render(<PreviewView site={emptySite()} siteId={null} dirty={false} />);
+    const iframe = screen.getByTitle("Site preview (unsaved)") as HTMLIFrameElement;
+    expect(iframe.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe.hasAttribute("src")).toBe(false);
+  });
+
+  it("falls back to srcDoc when a saved site has unsaved (dirty) edits", () => {
+    render(<PreviewView site={emptySite()} siteId="site-abc123" dirty />);
+    expect(screen.getByTitle("Site preview (unsaved)")).toBeInTheDocument();
+    expect(screen.queryByTitle("Site preview")).not.toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/webstudio/PreviewView.tsx
+++ b/desktop/src/apps/webstudio/PreviewView.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Monitor, Tablet, Smartphone } from "lucide-react";
-import { SectionBlock } from "./SectionBlock";
-import { PALETTES, FONTS, type Site, type DevicePreview } from "./types";
+import { exportSiteHtml } from "./export";
+import { sitePreviewUrl } from "./web-sites-api";
+import type { Site, DevicePreview } from "./types";
 
 const DEVICES: { id: DevicePreview; label: string; icon: typeof Monitor; maxW: number | null }[] = [
   { id: "desktop", label: "Desktop", icon: Monitor, maxW: null },
@@ -9,11 +10,18 @@ const DEVICES: { id: DevicePreview; label: string; icon: typeof Monitor; maxW: n
   { id: "mobile", label: "Mobile", icon: Smartphone, maxW: 380 },
 ];
 
-export function PreviewView({ site }: { site: Site }) {
+/** siteId is the saved site's id (activeId), dirty is true when the in-memory
+ *  `site` has unsaved edits. Preview is served two ways, both opaque-origin
+ *  (`sandbox="allow-scripts"`, no allow-same-origin -- the one real security
+ *  upgrade over the old direct-React render):
+ *   - saved + clean: an iframe pointed at the real, backend-rendered
+ *     `/api/web/sites/{id}/preview` (also carries the CSP in routes/web.py).
+ *   - unsaved or never-saved: `srcDoc` of a fresh client-side export, so the
+ *     preview always reflects the current edits without a round-trip. */
+export function PreviewView({ site, siteId, dirty }: { site: Site; siteId: string | null; dirty: boolean }) {
   const [device, setDevice] = useState<DevicePreview>("desktop");
-  const colors = PALETTES[site.theme.palette].colors;
-  const fontStack = FONTS[site.theme.font].stack;
   const maxW = DEVICES.find((d) => d.id === device)?.maxW ?? undefined;
+  const useLiveUrl = Boolean(siteId) && !dirty;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -46,9 +54,23 @@ export function PreviewView({ site }: { site: Site }) {
           className="mx-auto overflow-hidden rounded-xl border border-shell-border transition-all"
           style={{ maxWidth: maxW }}
         >
-          {site.sections.map((s) => (
-            <SectionBlock key={s.id} section={s} colors={colors} fontStack={fontStack} editable={false} />
-          ))}
+          {useLiveUrl ? (
+            <iframe
+              key={siteId}
+              title="Site preview"
+              src={sitePreviewUrl(siteId!)}
+              sandbox="allow-scripts"
+              className="h-[70vh] w-full border-0 bg-white"
+            />
+          ) : (
+            <iframe
+              key="unsaved-preview"
+              title="Site preview (unsaved)"
+              srcDoc={exportSiteHtml(site)}
+              sandbox="allow-scripts"
+              className="h-[70vh] w-full border-0 bg-white"
+            />
+          )}
         </div>
       </div>
     </div>

--- a/desktop/src/apps/webstudio/PreviewView.tsx
+++ b/desktop/src/apps/webstudio/PreviewView.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Monitor, Tablet, Smartphone } from "lucide-react";
+import { Monitor, Tablet, Smartphone, Eye } from "lucide-react";
 import { exportSiteHtml } from "./export";
 import { sitePreviewUrl } from "./web-sites-api";
 import type { Site, DevicePreview } from "./types";
@@ -11,17 +11,32 @@ const DEVICES: { id: DevicePreview; label: string; icon: typeof Monitor; maxW: n
 ];
 
 /** siteId is the saved site's id (activeId), dirty is true when the in-memory
- *  `site` has unsaved edits. Preview is served two ways, both opaque-origin
- *  (`sandbox="allow-scripts"`, no allow-same-origin -- the one real security
- *  upgrade over the old direct-React render):
- *   - saved + clean: an iframe pointed at the real, backend-rendered
+ *  `site` has unsaved edits, hasRender is true when the saved row carries a
+ *  stored index.html the /preview route can serve. Preview is served two ways,
+ *  both opaque-origin (`sandbox="allow-scripts"`, no allow-same-origin -- the
+ *  one real security upgrade over the old direct-React render):
+ *   - saved + clean + hasRender: an iframe pointed at the real, backend-rendered
  *     `/api/web/sites/{id}/preview` (also carries the CSP in routes/web.py).
- *   - unsaved or never-saved: `srcDoc` of a fresh client-side export, so the
- *     preview always reflects the current edits without a round-trip. */
-export function PreviewView({ site, siteId, dirty }: { site: Site; siteId: string | null; dirty: boolean }) {
+ *   - otherwise (unsaved, dirty, or a legacy row with no stored render): a
+ *     `srcDoc` of a fresh client-side export, so the preview always reflects
+ *     the current edits and a legacy row never 404s into a blank/JSON frame.
+ *  A site with no sections has nothing to render, so an explicit empty state
+ *  is shown instead of a near-blank iframe. */
+export function PreviewView({
+  site,
+  siteId,
+  dirty,
+  hasRender,
+}: {
+  site: Site;
+  siteId: string | null;
+  dirty: boolean;
+  hasRender: boolean;
+}) {
   const [device, setDevice] = useState<DevicePreview>("desktop");
   const maxW = DEVICES.find((d) => d.id === device)?.maxW ?? undefined;
-  const useLiveUrl = Boolean(siteId) && !dirty;
+  const isEmpty = site.sections.length === 0;
+  const useLiveUrl = Boolean(siteId) && !dirty && hasRender;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -37,8 +52,9 @@ export function PreviewView({ site, siteId, dirty }: { site: Site; siteId: strin
                 type="button"
                 aria-label={d.label}
                 aria-pressed={on}
+                disabled={isEmpty}
                 onClick={() => setDevice(d.id)}
-                className={`flex h-7 items-center gap-1.5 rounded-md px-2.5 text-[11.5px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+                className={`flex h-7 items-center gap-1.5 rounded-md px-2.5 text-[11.5px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:cursor-not-allowed disabled:opacity-50 ${
                   on ? "bg-shell-surface-active text-shell-text" : "text-shell-text-tertiary hover:text-shell-text-secondary"
                 }`}
               >
@@ -50,28 +66,41 @@ export function PreviewView({ site, siteId, dirty }: { site: Site; siteId: strin
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto bg-shell-bg-deep p-6">
-        <div
-          className="mx-auto overflow-hidden rounded-xl border border-shell-border transition-all"
-          style={{ maxWidth: maxW }}
-        >
-          {useLiveUrl ? (
-            <iframe
-              key={siteId}
-              title="Site preview"
-              src={sitePreviewUrl(siteId!)}
-              sandbox="allow-scripts"
-              className="h-[70vh] w-full border-0 bg-white"
-            />
-          ) : (
-            <iframe
-              key="unsaved-preview"
-              title="Site preview (unsaved)"
-              srcDoc={exportSiteHtml(site)}
-              sandbox="allow-scripts"
-              className="h-[70vh] w-full border-0 bg-white"
-            />
-          )}
-        </div>
+        {isEmpty ? (
+          <div
+            className="mx-auto flex h-[70vh] max-w-[520px] flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-shell-border text-center"
+            role="status"
+          >
+            <Eye size={28} className="text-shell-text-tertiary" />
+            <p className="text-[13px] font-semibold text-shell-text-secondary">Nothing to preview yet</p>
+            <p className="max-w-[320px] text-[12px] text-shell-text-tertiary">
+              Add a section in the Edit view, then come back here to see your site.
+            </p>
+          </div>
+        ) : (
+          <div
+            className="mx-auto overflow-hidden rounded-xl border border-shell-border transition-all"
+            style={{ maxWidth: maxW }}
+          >
+            {useLiveUrl ? (
+              <iframe
+                key={siteId}
+                title="Site preview"
+                src={sitePreviewUrl(siteId!)}
+                sandbox="allow-scripts"
+                className="h-[70vh] w-full border-0 bg-white"
+              />
+            ) : (
+              <iframe
+                key="unsaved-preview"
+                title="Site preview (unsaved)"
+                srcDoc={exportSiteHtml(site)}
+                sandbox="allow-scripts"
+                className="h-[70vh] w-full border-0 bg-white"
+              />
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/desktop/src/apps/webstudio/ShareView.test.tsx
+++ b/desktop/src/apps/webstudio/ShareView.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ShareView } from "./ShareView";
+
+const SITE = {
+  id: "share-site",
+  title: "Share Site",
+  content: '{"sections": []}',
+  index_html: "<!doctype html><p>Hi</p>",
+  created_at: 1,
+  updated_at: 2,
+};
+
+function makeFetchMock(opts?: {
+  installStatus?: number;
+  installBody?: unknown;
+  findings?: unknown[];
+}) {
+  const installCalls: FormData[] = [];
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url === "/api/web/sites/share-site" && method === "GET") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(SITE) } as Response);
+    }
+    if (url === "/api/userspace-apps/analyze" && method === "POST") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ findings: opts?.findings ?? [], blocked: false }),
+      } as Response);
+    }
+    if (url === "/api/web/sites/share-site/package" && method === "GET") {
+      return Promise.resolve({ ok: true, blob: () => Promise.resolve(new Blob(["zip-bytes"])) } as Response);
+    }
+    if (url === "/api/userspace-apps/install" && method === "POST") {
+      installCalls.push(init?.body as FormData);
+      const status = opts?.installStatus ?? 200;
+      return Promise.resolve({
+        ok: status < 400,
+        status,
+        json: () =>
+          Promise.resolve(
+            opts?.installBody ?? { app_id: "share-site", permissions_requested: [], needs_consent: false, new_permissions: [] },
+          ),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  });
+  return { fetchMock, installCalls };
+}
+
+describe("ShareView", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows an empty state with no active site", () => {
+    vi.stubGlobal("fetch", vi.fn() as unknown as typeof fetch);
+    render(<ShareView siteId={null} />);
+    expect(screen.getByText(/Save a site in the Edit view first/)).toBeDefined();
+  });
+
+  it("builds the site's .taosapp package and installs it via the existing userspace-apps endpoint, tagged ai-generated", async () => {
+    const { fetchMock, installCalls } = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /Install on this taOS/ })).toBeDefined());
+    await waitFor(() => expect(screen.getByText(/No security issues found/)).toBeDefined());
+
+    fireEvent.click(screen.getByRole("button", { name: /Install on this taOS/ }));
+
+    await waitFor(() => expect(installCalls.length).toBe(1));
+    const form = installCalls[0]!;
+    expect(form.get("package")).toBeInstanceOf(File);
+    expect((form.get("package") as File).name).toBe("share-site.taosapp");
+    expect(form.get("provenance")).toBe("ai-generated");
+
+    await waitFor(() => expect(screen.getByText(/Installed\. Find it in Launchpad/)).toBeDefined());
+  });
+
+  it("surfaces an install error instead of faking success", async () => {
+    const { fetchMock } = makeFetchMock({ installStatus: 422, installBody: { error: "blocked_by_security_analysis" } });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" />);
+    await waitFor(() => expect(screen.getByText(/No security issues found/)).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: /Install on this taOS/ }));
+
+    await waitFor(() => expect(screen.getByText("blocked_by_security_analysis")).toBeDefined());
+  });
+
+  it("blocks install (but not export) when the analyzer finds a critical issue", async () => {
+    // Mock analyzer finding used only as inert fixture text (never executed)
+    // to exercise the UI's block-on-critical path.
+    const { fetchMock, installCalls } = makeFetchMock({
+      findings: [{ severity: "critical", rule_id: "eval-use", file: "index.html", line: 3, message: "uses eval()" }],
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" />);
+    const installButton = await screen.findByRole("button", { name: /Blocked by security scan/ });
+    expect(installButton).toBeDisabled();
+
+    fireEvent.click(installButton);
+    expect(installCalls.length).toBe(0);
+  });
+
+  it("prompts to save first when the site has no rendered index_html yet", async () => {
+    const unsavedFetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/web/sites/draft-site") {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ ...SITE, id: "draft-site", index_html: "" }) } as Response);
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+    });
+    vi.stubGlobal("fetch", unsavedFetch as unknown as typeof fetch);
+
+    render(<ShareView siteId="draft-site" />);
+    await waitFor(() => expect(screen.getByText(/hasn't been saved with rendered content/)).toBeDefined());
+    expect(screen.queryByRole("button", { name: /Install on this taOS/ })).not.toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/webstudio/ShareView.test.tsx
+++ b/desktop/src/apps/webstudio/ShareView.test.tsx
@@ -57,15 +57,15 @@ describe("ShareView", () => {
 
   it("shows an empty state with no active site", () => {
     vi.stubGlobal("fetch", vi.fn() as unknown as typeof fetch);
-    render(<ShareView siteId={null} />);
+    render(<ShareView siteId={null} provenance="user-uploaded" />);
     expect(screen.getByText(/Save a site in the Edit view first/)).toBeDefined();
   });
 
-  it("builds the site's .taosapp package and installs it via the existing userspace-apps endpoint, tagged ai-generated", async () => {
+  it("builds the site's .taosapp package and installs it via the existing userspace-apps endpoint, tagged with the provenance it was given", async () => {
     const { fetchMock, installCalls } = makeFetchMock();
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    render(<ShareView siteId="share-site" />);
+    render(<ShareView siteId="share-site" provenance="ai-generated" />);
     await waitFor(() => expect(screen.getByRole("button", { name: /Install on this taOS/ })).toBeDefined());
     await waitFor(() => expect(screen.getByText(/No security issues found/)).toBeDefined());
 
@@ -80,11 +80,23 @@ describe("ShareView", () => {
     await waitFor(() => expect(screen.getByText(/Installed\. Find it in Launchpad/)).toBeDefined());
   });
 
+  it("tags a hand-built site as user-uploaded, not ai-generated", async () => {
+    const { fetchMock, installCalls } = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<ShareView siteId="share-site" provenance="user-uploaded" />);
+    await waitFor(() => expect(screen.getByText(/No security issues found/)).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: /Install on this taOS/ }));
+
+    await waitFor(() => expect(installCalls.length).toBe(1));
+    expect(installCalls[0]!.get("provenance")).toBe("user-uploaded");
+  });
+
   it("surfaces an install error instead of faking success", async () => {
     const { fetchMock } = makeFetchMock({ installStatus: 422, installBody: { error: "blocked_by_security_analysis" } });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    render(<ShareView siteId="share-site" />);
+    render(<ShareView siteId="share-site" provenance="ai-generated" />);
     await waitFor(() => expect(screen.getByText(/No security issues found/)).toBeDefined());
     fireEvent.click(screen.getByRole("button", { name: /Install on this taOS/ }));
 
@@ -99,7 +111,7 @@ describe("ShareView", () => {
     });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
-    render(<ShareView siteId="share-site" />);
+    render(<ShareView siteId="share-site" provenance="ai-generated" />);
     const installButton = await screen.findByRole("button", { name: /Blocked by security scan/ });
     expect(installButton).toBeDisabled();
 
@@ -117,7 +129,7 @@ describe("ShareView", () => {
     });
     vi.stubGlobal("fetch", unsavedFetch as unknown as typeof fetch);
 
-    render(<ShareView siteId="draft-site" />);
+    render(<ShareView siteId="draft-site" provenance="user-uploaded" />);
     await waitFor(() => expect(screen.getByText(/hasn't been saved with rendered content/)).toBeDefined());
     expect(screen.queryByRole("button", { name: /Install on this taOS/ })).not.toBeInTheDocument();
   });

--- a/desktop/src/apps/webstudio/ShareView.tsx
+++ b/desktop/src/apps/webstudio/ShareView.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useState } from "react";
+import { Share2, Download, Loader2, CheckCircle2, AlertCircle, Globe2 } from "lucide-react";
+import { analyzeAppSource, type Finding } from "../appstudio/analyze-source";
+import { FindingsPanel } from "../appstudio/FindingsPanel";
+import { installUserspaceApp, USERSPACE_APPS_CHANGED } from "@/lib/userspace-apps";
+import { emitAppEvent } from "@/lib/app-event-bus";
+import { fetchSitePackage, getSiteRow } from "./web-sites-api";
+import type { SiteRow } from "./web-sites-api";
+
+/* ------------------------------------------------------------------ */
+/*  ShareView -- install locally or export a .taosapp package           */
+/*                                                                     */
+/*  Both actions build the SAME package: GET /api/web/sites/{id}/package */
+/*  returns a real .taosapp zip (manifest.yaml + the site's rendered      */
+/*  index.html) built by the backend's build_package() -- the exact same  */
+/*  pipeline Game Studio's ShareView uses. "Install" POSTs that file to    */
+/*  the existing, unmodified /api/userspace-apps/install endpoint tagged   */
+/*  provenance "ai-generated"; the static security analyzer runs on         */
+/*  install same as any other userspace app, and its findings are shown     */
+/*  honestly here too (previewed via the same analyze endpoint App Studio   */
+/*  and Game Studio use). "Export" downloads the identical package.         */
+/*                                                                          */
+/*  A site must be saved at least once (it needs a rendered index_html)     */
+/*  before it can be shared -- there is no unsaved-site install path.       */
+/* ------------------------------------------------------------------ */
+
+export interface ShareViewProps {
+  siteId: string | null;
+}
+
+export function ShareView({ siteId }: ShareViewProps) {
+  const [site, setSite] = useState<SiteRow | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [findings, setFindings] = useState<Finding[]>([]);
+  const [scanning, setScanning] = useState(true);
+  const [scanError, setScanError] = useState<string | null>(null);
+
+  const [installing, setInstalling] = useState(false);
+  const [installResult, setInstallResult] = useState<"ok" | "consent" | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!siteId) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+    setInstallResult(null);
+    setInstallError(null);
+    setExportError(null);
+    getSiteRow(siteId)
+      .then((s) => {
+        if (cancelled) return;
+        setSite(s);
+        if (!s.index_html) {
+          setScanning(false);
+          return;
+        }
+        setScanning(true);
+        setScanError(null);
+        return analyzeAppSource({ "index.html": s.index_html })
+          .then((result) => {
+            if (!cancelled) setFindings(result.findings);
+          })
+          .catch((e) => {
+            if (!cancelled) setScanError(e instanceof Error ? e.message : String(e));
+          })
+          .finally(() => {
+            if (!cancelled) setScanning(false);
+          });
+      })
+      .catch((e) => {
+        if (!cancelled) setLoadError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [siteId]);
+
+  const needsSave = !loading && !loadError && site !== null && !site.index_html;
+  const blocked = !scanning && !scanError && findings.some((f) => f.severity === "critical");
+  const actionsDisabled = loading || scanning || blocked || !site || needsSave;
+
+  const handleInstall = useCallback(async () => {
+    if (!site) return;
+    setInstalling(true);
+    setInstallError(null);
+    setInstallResult(null);
+    try {
+      const file = await fetchSitePackage(site.id);
+      const result = await installUserspaceApp(file, "ai-generated");
+      emitAppEvent(USERSPACE_APPS_CHANGED);
+      setInstallResult(result.needs_consent ? "consent" : "ok");
+    } catch (e) {
+      setInstallError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setInstalling(false);
+    }
+  }, [site]);
+
+  const handleExport = useCallback(async () => {
+    if (!site) return;
+    setExporting(true);
+    setExportError(null);
+    try {
+      const file = await fetchSitePackage(site.id);
+      const url = URL.createObjectURL(file);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = file.name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setExportError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setExporting(false);
+    }
+  }, [site]);
+
+  if (!siteId) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-shell-text-tertiary">
+        <Globe2 size={28} />
+        <p className="text-[13px]">Save a site in the Edit view first.</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-[13px] text-shell-text-tertiary">
+        <Loader2 size={16} className="mr-2 animate-spin" />
+        Loading site...
+      </div>
+    );
+  }
+
+  if (loadError || !site) {
+    return (
+      <div className="flex flex-1 items-center justify-center gap-2 text-[13px] text-red-400">
+        <AlertCircle size={16} />
+        {loadError ?? "Site not found"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div
+        className="flex flex-col gap-3.5 p-[22px]"
+        style={{ paddingBottom: "calc(22px + env(safe-area-inset-bottom, 0px))" }}
+      >
+        <header>
+          <h2 className="text-[17px] font-bold tracking-[-0.02em]">Share "{site.title}"</h2>
+          <p className="mt-1 text-[12.5px] text-shell-text-secondary">
+            Install it on this taOS or export a .taosapp package to share elsewhere.
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="flex flex-col gap-4 rounded-2xl border border-shell-border bg-shell-surface p-4 shadow-card">
+            {needsSave ? (
+              <div role="status" className="flex items-start gap-2.5 rounded-xl border border-accent/30 bg-accent-soft px-3.5 py-3">
+                <AlertCircle size={16} className="mt-0.5 flex-none text-accent" />
+                <p className="text-[12.5px] leading-relaxed text-shell-text-secondary">
+                  This site hasn't been saved with rendered content yet. Save it from the Edit view, then come back
+                  here to share it.
+                </p>
+              </div>
+            ) : (
+              <>
+                <FindingsPanel loading={scanning} error={scanError} findings={findings} />
+
+                <div className="flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => void handleInstall()}
+                    disabled={actionsDisabled || installing}
+                    title={blocked ? "Fix the critical security findings before installing" : undefined}
+                    className="flex h-[44px] items-center gap-2 rounded-full bg-gradient-to-br from-accent to-accent/70 px-5 text-[13px] font-bold text-white shadow-lg shadow-accent/20 transition-all hover:-translate-y-0.5 hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {installing ? <Loader2 size={17} className="animate-spin" /> : <Share2 size={17} />}
+                    {blocked ? "Blocked by security scan" : installing ? "Installing..." : "Install on this taOS"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleExport()}
+                    disabled={actionsDisabled || exporting}
+                    className="flex h-[44px] items-center gap-2 rounded-full border border-shell-border bg-shell-surface px-5 text-[13px] font-bold text-shell-text disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {exporting ? <Loader2 size={17} className="animate-spin" /> : <Download size={17} />}
+                    Export .taosapp
+                  </button>
+                </div>
+              </>
+            )}
+
+            {installResult === "ok" && (
+              <div role="status" className="flex items-start gap-2.5 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3.5 py-3">
+                <CheckCircle2 size={16} className="mt-0.5 flex-none text-emerald-400" />
+                <p className="text-[12.5px] leading-relaxed text-emerald-200">
+                  Installed. Find it in Launchpad, sandboxed like any other app.
+                </p>
+              </div>
+            )}
+            {installResult === "consent" && (
+              <div role="status" className="flex items-start gap-2.5 rounded-xl border border-accent/30 bg-accent-soft px-3.5 py-3">
+                <CheckCircle2 size={16} className="mt-0.5 flex-none text-accent" />
+                <p className="text-[12.5px] leading-relaxed text-shell-text-secondary">
+                  Installed. It requests extra permissions -- review them from Settings &rarr; Apps.
+                </p>
+              </div>
+            )}
+            {installError && (
+              <div role="alert" className="flex items-start gap-2.5 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3">
+                <AlertCircle size={16} className="mt-0.5 flex-none text-red-400" />
+                <p className="text-[12.5px] leading-relaxed text-red-200">{installError}</p>
+              </div>
+            )}
+            {exportError && (
+              <div role="alert" className="flex items-start gap-2.5 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3">
+                <AlertCircle size={16} className="mt-0.5 flex-none text-red-400" />
+                <p className="text-[12.5px] leading-relaxed text-red-200">{exportError}</p>
+              </div>
+            )}
+
+            <p className="text-[11px] text-shell-text-tertiary">
+              Distribution to the public Store goes through review; that flow isn't part of this release. A site
+              that needs a real backend (not just static HTML) is a later phase -- v1 only ships static-HTML sites.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-4">
+            <div className="rounded-2xl border border-shell-border bg-shell-surface p-4 shadow-card">
+              <dl className="flex flex-col gap-2.5 text-[12.5px]">
+                <MetaRow label="Package format" value=".taosapp (web app)" />
+                <MetaRow label="Rendered size" value={`${(new Blob([site.index_html]).size / 1024).toFixed(1)} KB`} />
+              </dl>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between">
+      <dt className="text-shell-text-secondary">{label}</dt>
+      <dd>{value}</dd>
+    </div>
+  );
+}

--- a/desktop/src/apps/webstudio/ShareView.tsx
+++ b/desktop/src/apps/webstudio/ShareView.tsx
@@ -26,9 +26,14 @@ import type { SiteRow } from "./web-sites-api";
 
 export interface ShareViewProps {
   siteId: string | null;
+  /** Honest origin of the current site: "ai-generated" only when the agent
+   *  actually authored it, else "user-uploaded" (templates, manual edits,
+   *  matched fallback, reopened site). Both tiers share a capability ceiling;
+   *  this keeps the install tag truthful rather than always "ai-generated". */
+  provenance: "ai-generated" | "user-uploaded";
 }
 
-export function ShareView({ siteId }: ShareViewProps) {
+export function ShareView({ siteId, provenance }: ShareViewProps) {
   const [site, setSite] = useState<SiteRow | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -97,7 +102,7 @@ export function ShareView({ siteId }: ShareViewProps) {
     setInstallResult(null);
     try {
       const file = await fetchSitePackage(site.id);
-      const result = await installUserspaceApp(file, "ai-generated");
+      const result = await installUserspaceApp(file, provenance);
       emitAppEvent(USERSPACE_APPS_CHANGED);
       setInstallResult(result.needs_consent ? "consent" : "ok");
     } catch (e) {
@@ -105,7 +110,7 @@ export function ShareView({ siteId }: ShareViewProps) {
     } finally {
       setInstalling(false);
     }
-  }, [site]);
+  }, [site, provenance]);
 
   const handleExport = useCallback(async () => {
     if (!site) return;

--- a/desktop/src/apps/webstudio/generate-site.test.ts
+++ b/desktop/src/apps/webstudio/generate-site.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { generateSite } from "./generate-site";
+
+/** Encode a mock /api/taos-agent/chat NDJSON stream response from a list of
+ *  text deltas -- mirrors the {delta} shape streamTaosAgentChat parses. */
+function ndjsonResponse(deltas: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const d of deltas) {
+        controller.enqueue(encoder.encode(JSON.stringify({ delta: d }) + "\n"));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+function makeFetchMock(chatResponse: () => Response) {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url === "/api/taos-agent/chat") {
+      return Promise.resolve(chatResponse());
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  });
+}
+
+const VALID_SITE_JSON = JSON.stringify({
+  title: "Fresh Cafe",
+  theme: { palette: "sand", font: "serif" },
+  sections: [
+    {
+      id: "hero-1",
+      type: "hero",
+      content: {
+        eyebrow: "Now open",
+        heading: "Coffee worth the walk",
+        subheading: "A neighborhood cafe.",
+        ctaLabel: "See the menu",
+        image: "",
+      },
+    },
+    {
+      id: "footer-1",
+      type: "footer",
+      content: { businessName: "Fresh Cafe", tagline: "Made with taOS Web Studio" },
+    },
+  ],
+});
+
+describe("generateSite", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("parses a mocked AI JSON response into a valid Site", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock(() => ndjsonResponse([`Here you go:\n\n\`\`\`json\n${VALID_SITE_JSON}\n\`\`\``])) as unknown as typeof fetch,
+    );
+
+    const progress: string[] = [];
+    const result = await generateSite("a cafe landing page", (p) => progress.push(p.stage));
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.parseNotice).toBeNull();
+    expect(result.site.title).toBe("Fresh Cafe");
+    expect(result.site.theme.palette).toBe("sand");
+    expect(result.site.sections).toHaveLength(2);
+    expect(progress).toEqual(["streaming", "parsing", "done"]);
+  });
+
+  it("parses a bare JSON response with no code fence", async () => {
+    vi.stubGlobal("fetch", makeFetchMock(() => ndjsonResponse([VALID_SITE_JSON])) as unknown as typeof fetch);
+
+    const result = await generateSite("a cafe landing page", () => {});
+    expect(result.usedFallback).toBe(false);
+    expect(result.site.title).toBe("Fresh Cafe");
+  });
+
+  it("falls back to matchTemplate when the response has no JSON object", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock(() => ndjsonResponse(["Sorry, I can't help with that request."])) as unknown as typeof fetch,
+    );
+
+    const result = await generateSite("a landing page for a saas product", () => {});
+    expect(result.usedFallback).toBe(true);
+    expect(result.parseNotice).toMatch(/starter template/);
+    expect(result.site.sections.length).toBeGreaterThan(0);
+  });
+
+  it("falls back when the JSON parses but doesn't match the Site shape", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock(() => ndjsonResponse(['{"foo": "bar"}'])) as unknown as typeof fetch,
+    );
+
+    const result = await generateSite("a portfolio site", () => {});
+    expect(result.usedFallback).toBe(true);
+    expect(result.parseNotice).toMatch(/starter template/);
+  });
+
+  it("falls back when the model invents an unknown palette/font id", async () => {
+    const badSite = JSON.stringify({
+      title: "X",
+      theme: { palette: "neon", font: "sans" },
+      sections: [{ id: "a", type: "footer", content: { businessName: "X", tagline: "" } }],
+    });
+    vi.stubGlobal("fetch", makeFetchMock(() => ndjsonResponse([badSite])) as unknown as typeof fetch);
+
+    const result = await generateSite("a landing page", () => {});
+    expect(result.usedFallback).toBe(true);
+  });
+
+  it("propagates a stream error instead of silently falling back", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve("boom") } as Response)) as unknown as typeof fetch,
+    );
+
+    await expect(generateSite("anything", () => {})).rejects.toThrow();
+  });
+});

--- a/desktop/src/apps/webstudio/generate-site.ts
+++ b/desktop/src/apps/webstudio/generate-site.ts
@@ -1,0 +1,105 @@
+import { streamTaosAgentChat } from "../appstudio/stream-chat";
+import { matchTemplate } from "./match-template";
+import { siteFromTemplate } from "./templates";
+import { buildWebGenerationSystemPrompt } from "./web-authoring-prompt";
+import { PALETTES, FONTS, isValidSite, type Site } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  Real AI site generation                                            */
+/*                                                                     */
+/*  Streams the taos-agent the same way Game Studio's generateGame()    */
+/*  does, asking it for a single JSON `Site` document. The response is  */
+/*  tolerant-parsed (strips code fences / surrounding prose), then      */
+/*  validated with isValidSite() plus a palette/font enum check. On any  */
+/*  failure -- empty stream, unparsable JSON, or a shape that doesn't    */
+/*  match -- the caller gets the honest, already-working matchTemplate() */
+/*  fallback instead, never a fake "generated" result.                   */
+/* ------------------------------------------------------------------ */
+
+export type GenerateStage = "streaming" | "parsing" | "done";
+
+export interface GenerateProgress {
+  stage: GenerateStage;
+  detail: string;
+}
+
+export interface GenerateSiteResult {
+  site: Site;
+  usedFallback: boolean;
+  parseNotice: string | null;
+}
+
+/** Pull the JSON object out of a model response that may wrap it in a
+ *  markdown code fence and/or surrounding prose. Returns null if no
+ *  plausible `{ ... }` object can be found. */
+export function extractJsonObject(raw: string): string | null {
+  const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1]! : raw;
+  const start = candidate.indexOf("{");
+  const end = candidate.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  return candidate.slice(start, end + 1);
+}
+
+function parseSite(raw: string): Site | null {
+  const jsonText = extractJsonObject(raw);
+  if (!jsonText) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return null;
+  }
+  if (!isValidSite(parsed)) return null;
+  // isValidSite only checks shape; also require the theme ids the app
+  // actually knows how to render, so an unrecognized value from the model
+  // never crashes PALETTES[palette]/FONTS[font] lookups downstream.
+  if (!(parsed.theme.palette in PALETTES) || !(parsed.theme.font in FONTS)) return null;
+  return parsed;
+}
+
+function fallbackSite(prompt: string): Site {
+  const tpl = matchTemplate(prompt);
+  return siteFromTemplate(tpl, prompt.trim() ? prompt.trim().slice(0, 60) : undefined);
+}
+
+export async function generateSite(
+  prompt: string,
+  onProgress: (p: GenerateProgress) => void,
+  opts?: { signal?: AbortSignal },
+): Promise<GenerateSiteResult> {
+  onProgress({ stage: "streaming", detail: "Asking the taOS agent to design your site..." });
+
+  let raw = "";
+  let streamError: string | null = null;
+  await streamTaosAgentChat(
+    [
+      { role: "system", content: buildWebGenerationSystemPrompt() },
+      { role: "user", content: prompt },
+    ],
+    (delta) => {
+      raw += delta;
+    },
+    (message) => {
+      streamError = message;
+    },
+    opts,
+  );
+  if (streamError) throw new Error(streamError);
+
+  onProgress({ stage: "parsing", detail: "Reading the response..." });
+  const site = parseSite(raw);
+
+  if (site) {
+    onProgress({ stage: "done", detail: "Ready." });
+    return { site, usedFallback: false, parseNotice: null };
+  }
+
+  onProgress({ stage: "done", detail: "Ready." });
+  return {
+    site: fallbackSite(prompt),
+    usedFallback: true,
+    parseNotice:
+      "The agent's response could not be parsed into a site, so the closest starter template was used instead.",
+  };
+}

--- a/desktop/src/apps/webstudio/types.ts
+++ b/desktop/src/apps/webstudio/types.ts
@@ -1,14 +1,13 @@
 /* ------------------------------------------------------------------ */
-/*  Web Studio - shared types (phase 1)                                */
+/*  Web Studio - shared types                                          */
 /*                                                                     */
-/*  A section-based website builder. Phase 1 ships a genuinely usable  */
-/*  editor: template-matched scaffolding, a visual sections editor,    */
-/*  a live device preview and a self-contained static-HTML export.     */
-/*  Full offline-LLM generation and publish-to-host are later phases,  */
-/*  surfaced as honest "coming" affordances, never faked.              */
+/*  A section-based website builder: real AI generation (streamed via   */
+/*  the taos-agent, with an honest template-match fallback), a visual   */
+/*  sections editor, a sandboxed live device preview, a self-contained  */
+/*  static-HTML export and install-as-a-taOS-app packaging.             */
 /* ------------------------------------------------------------------ */
 
-export type StudioView = "generate" | "templates" | "edit" | "preview" | "export";
+export type StudioView = "generate" | "templates" | "edit" | "preview" | "export" | "share";
 
 /** Device the preview stage emulates. All three resize the same render. */
 export type DevicePreview = "desktop" | "tablet" | "mobile";

--- a/desktop/src/apps/webstudio/web-authoring-prompt.ts
+++ b/desktop/src/apps/webstudio/web-authoring-prompt.ts
@@ -1,0 +1,71 @@
+/** System prompt for the web-authoring agent -- used by generate-site.ts to
+ *  turn a free-text prompt into a real `Site` document (see ./types) via the
+ *  taos-agent chat stream, instead of only keyword-matching a template.
+ *
+ *  The model must respond with a SINGLE JSON object matching `Site` exactly
+ *  so the response can be parsed and validated with `isValidSite()` the same
+ *  way a saved/opened site is. Anything that fails to parse or validate is
+ *  never shown as a success -- the caller falls back to matchTemplate(). */
+
+const SECTION_SCHEMA = `Each entry in "sections" is one of these 7 types (exact field names, all required):
+
+- {"id": string, "type": "hero", "content": {"eyebrow": string, "heading": string, "subheading": string, "ctaLabel": string, "image": ""}}
+- {"id": string, "type": "features", "content": {"heading": string, "items": [{"title": string, "body": string}, ...] }} (3 items)
+- {"id": string, "type": "textBlock", "content": {"heading": string, "body": string}}
+- {"id": string, "type": "gallery", "content": {"heading": string, "images": ["", "", "", "", "", ""]}}
+- {"id": string, "type": "cta", "content": {"heading": string, "body": string, "buttonLabel": string}}
+- {"id": string, "type": "contact", "content": {"heading": string, "email": string, "phone": string, "address": string}}
+- {"id": string, "type": "footer", "content": {"businessName": string, "tagline": string}}
+
+Never invent an "image" or "images" value -- always leave them as empty strings ("" / ["", "", ...]); the user adds real images later in the editor.`;
+
+const EXAMPLE = `{
+  "title": "Fresh Cafe",
+  "theme": { "palette": "sand", "font": "serif" },
+  "sections": [
+    {
+      "id": "hero-1",
+      "type": "hero",
+      "content": {
+        "eyebrow": "Now open",
+        "heading": "Coffee worth the walk",
+        "subheading": "A neighborhood cafe serving single-origin coffee and fresh pastries every morning.",
+        "ctaLabel": "See the menu",
+        "image": ""
+      }
+    },
+    {
+      "id": "features-1",
+      "type": "features",
+      "content": {
+        "heading": "Why people come back",
+        "items": [
+          { "title": "Roasted weekly", "body": "Small batches, always fresh." },
+          { "title": "Cozy space", "body": "Room to work or catch up." },
+          { "title": "Local pastries", "body": "Baked next door every morning." }
+        ]
+      }
+    },
+    {
+      "id": "footer-1",
+      "type": "footer",
+      "content": { "businessName": "Fresh Cafe", "tagline": "Made with taOS Web Studio" }
+    }
+  ]
+}`;
+
+/** Build the system prompt for the Generate view's real (non-template) site
+ *  generation. Kept as a single exported function (mirrors
+ *  gamestudio/game-authoring-prompt.ts) so both the prompt text and the
+ *  schema it teaches live in one reviewable place. */
+export function buildWebGenerationSystemPrompt(): string {
+  return [
+    "You are the web-authoring agent for taOS Web Studio. You design a small marketing/landing website from the user's description.",
+    "Respond with ONLY a single JSON object -- no prose, no markdown code fence, no explanation before or after it -- matching this schema exactly:",
+    `{"title": string, "theme": {"palette": one of "midnight"|"sand"|"forest"|"rose"|"mono", "font": one of "sans"|"serif"|"rounded"|"mono"}, "sections": [ ...section objects... ]}`,
+    SECTION_SCHEMA,
+    "Pick a palette and font that match the mood of the site (e.g. midnight/sans for a tech product, sand/serif for a cafe). Use 3 to 6 sections, always ending with a footer section. Write real, specific copy for every heading/body/eyebrow field -- never leave them blank or as placeholder text.",
+    "Example of a complete, valid response:",
+    EXAMPLE,
+  ].join("\n\n");
+}

--- a/desktop/src/apps/webstudio/web-sites-api.ts
+++ b/desktop/src/apps/webstudio/web-sites-api.ts
@@ -1,0 +1,49 @@
+/** Thin client for the preview/package endpoints of tinyagentos/routes/web.py.
+ *  CRUD (create/list/get/update/delete) stays inline in WebStudioApp.tsx,
+ *  matching the existing pattern; this module only covers the two routes
+ *  added for the sandboxed preview and the install/export package (mirrors
+ *  gamestudio/games-api.ts's gamePreviewUrl/gamePackageUrl/fetchGamePackage). */
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = await res.json();
+    if (body?.error) return String(body.error);
+  } catch {
+    // non-JSON error body; fall through to the status-based message
+  }
+  return `Request failed (${res.status})`;
+}
+
+export interface SiteRow {
+  id: string;
+  title: string;
+  content: string;
+  index_html: string;
+  created_at: number;
+  updated_at: number;
+}
+
+/** Fetch a saved site's full row (including its rendered index_html), used
+ *  by ShareView to run the security analyzer over the exported HTML. */
+export async function getSiteRow(id: string): Promise<SiteRow> {
+  const res = await fetch(`/api/web/sites/${encodeURIComponent(id)}`, { credentials: "include" });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as SiteRow;
+}
+
+export function sitePreviewUrl(id: string): string {
+  return `/api/web/sites/${encodeURIComponent(id)}/preview`;
+}
+
+export function sitePackageUrl(id: string): string {
+  return `/api/web/sites/${encodeURIComponent(id)}/package`;
+}
+
+/** Fetch a site's .taosapp package as a downloadable File -- used both to
+ *  install it (POST to /api/userspace-apps/install) and to export it. */
+export async function fetchSitePackage(id: string): Promise<File> {
+  const res = await fetch(sitePackageUrl(id));
+  if (!res.ok) throw new Error(await readError(res));
+  const blob = await res.blob();
+  return new File([blob], `${id}.taosapp`, { type: "application/zip" });
+}

--- a/tests/test_routes_web.py
+++ b/tests/test_routes_web.py
@@ -117,3 +117,128 @@ async def test_update_rejects_oversized_content(client):
         json={"content": "x" * (MAX_CONTENT_BYTES + 1)},
     )
     assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_create_and_update_store_index_html(client):
+    resp = await client.post(
+        "/api/web/sites",
+        json={"title": "Landing", "content": "{}", "index_html": "<p>v1</p>"},
+    )
+    assert resp.status_code == 200
+    site_id = resp.json()["id"]
+    assert resp.json()["index_html"] == "<p>v1</p>"
+
+    resp = await client.put(
+        f"/api/web/sites/{site_id}",
+        json={"index_html": "<p>v2</p>"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["index_html"] == "<p>v2</p>"
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_oversized_index_html(client):
+    resp = await client.post(
+        "/api/web/sites",
+        json={"title": "Landing", "content": "{}", "index_html": "x" * (MAX_CONTENT_BYTES + 1)},
+    )
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+class TestWebSitePreview:
+    async def test_preview_serves_stored_html_with_csp(self, client):
+        resp = await client.post(
+            "/api/web/sites",
+            json={"title": "Landing", "content": "{}", "index_html": "<!doctype html><p>Hi</p>"},
+        )
+        site_id = resp.json()["id"]
+
+        resp = await client.get(f"/api/web/sites/{site_id}/preview")
+        assert resp.status_code == 200
+        assert resp.text == "<!doctype html><p>Hi</p>"
+        csp = resp.headers["content-security-policy"]
+        assert "sandbox allow-scripts" in csp
+        assert "allow-same-origin" not in csp
+        assert "default-src 'none'" in csp
+        assert resp.headers["x-content-type-options"] == "nosniff"
+
+    async def test_preview_nonexistent_site_404(self, client):
+        resp = await client.get("/api/web/sites/site-nope/preview")
+        assert resp.status_code == 404
+
+    async def test_preview_unsaved_render_404s(self, client):
+        # Created with no index_html yet (matches a pre-migration/legacy row).
+        resp = await client.post("/api/web/sites", json={"title": "Landing", "content": "{}"})
+        site_id = resp.json()["id"]
+        resp = await client.get(f"/api/web/sites/{site_id}/preview")
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestWebSitePackage:
+    async def test_package_builds_valid_taosapp_zip(self, client):
+        resp = await client.post(
+            "/api/web/sites",
+            json={"title": "My Landing", "content": "{}", "index_html": "<!doctype html><p>Hi</p>"},
+        )
+        site_id = resp.json()["id"]
+
+        resp = await client.get(f"/api/web/sites/{site_id}/package")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/zip"
+        assert f"{site_id}.taosapp" in resp.headers["content-disposition"]
+
+        import io
+        import zipfile
+        import yaml
+
+        zf = zipfile.ZipFile(io.BytesIO(resp.content))
+        assert set(zf.namelist()) == {"manifest.yaml", "index.html"}
+        manifest = yaml.safe_load(zf.read("manifest.yaml").decode())
+        assert manifest["id"] == site_id
+        assert manifest["name"] == "My Landing"
+        assert manifest["app_type"] == "web"
+        assert manifest["entry"] == "index.html"
+        assert zf.read("index.html").decode() == "<!doctype html><p>Hi</p>"
+
+    async def test_package_nonexistent_site_404(self, client):
+        resp = await client.get("/api/web/sites/site-nope/package")
+        assert resp.status_code == 404
+
+    async def test_package_unsaved_render_rejected(self, client):
+        resp = await client.post("/api/web/sites", json={"title": "Landing", "content": "{}"})
+        site_id = resp.json()["id"]
+        resp = await client.get(f"/api/web/sites/{site_id}/package")
+        assert resp.status_code == 400
+
+    async def test_package_installs_via_userspace_apps_endpoint(self, client):
+        """The package this endpoint builds must be installable through the
+        existing, unmodified userspace-apps install pipeline -- this is the
+        actual reuse the Share flow depends on."""
+        app = client._transport.app
+        store = app.state.userspace_apps
+        if store._db is not None:
+            await store.close()
+        await store.init()
+        data_store = app.state.userspace_data
+        if data_store._db is not None:
+            await data_store.close()
+        await data_store.init()
+
+        resp = await client.post(
+            "/api/web/sites",
+            json={"title": "Installable", "content": "{}", "index_html": "<!doctype html><p>Hi</p>"},
+        )
+        site_id = resp.json()["id"]
+        pkg_resp = await client.get(f"/api/web/sites/{site_id}/package")
+        assert pkg_resp.status_code == 200
+
+        install_resp = await client.post(
+            "/api/userspace-apps/install",
+            files={"package": (f"{site_id}.taosapp", pkg_resp.content, "application/zip")},
+            data={"provenance": "ai-generated"},
+        )
+        assert install_resp.status_code == 200
+        assert install_resp.json()["app_id"] == site_id

--- a/tests/test_routes_web.py
+++ b/tests/test_routes_web.py
@@ -147,6 +147,39 @@ async def test_create_rejects_oversized_index_html(client):
 
 
 @pytest.mark.asyncio
+async def test_create_treats_explicit_null_content_and_index_html_as_empty(client):
+    # An explicit JSON null (not just a missing key) must be coerced to "" and
+    # NOT rejected as a spurious 400 by the string type-check (Kilo finding).
+    resp = await client.post(
+        "/api/web/sites",
+        json={"title": "Landing", "content": None, "index_html": None},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] == ""
+    assert body["index_html"] == ""
+
+
+@pytest.mark.asyncio
+async def test_update_treats_explicit_null_as_keep_existing(client):
+    resp = await client.post(
+        "/api/web/sites",
+        json={"title": "Landing", "content": '{"sections": []}', "index_html": "<p>v1</p>"},
+    )
+    site_id = resp.json()["id"]
+
+    # Explicit nulls must fall back to the existing values, not 400 or wipe them.
+    resp = await client.put(
+        f"/api/web/sites/{site_id}",
+        json={"content": None, "index_html": None},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] == '{"sections": []}'
+    assert body["index_html"] == "<p>v1</p>"
+
+
+@pytest.mark.asyncio
 class TestWebSitePreview:
     async def test_preview_serves_stored_html_with_csp(self, client):
         resp = await client.post(

--- a/tests/test_web_sites.py
+++ b/tests/test_web_sites.py
@@ -38,6 +38,22 @@ async def test_create_happy_path(web_site_store):
 
 
 @pytest.mark.asyncio
+async def test_create_defaults_index_html_to_empty(web_site_store):
+    row = await web_site_store.create(title="My Site", content="{}")
+    assert row["index_html"] == ""
+
+
+@pytest.mark.asyncio
+async def test_create_stores_index_html(web_site_store):
+    html = "<!doctype html><html><body>Hi</body></html>"
+    row = await web_site_store.create(title="My Site", content="{}", index_html=html)
+    assert row["index_html"] == html
+    fetched = await web_site_store.get(row["id"])
+    assert fetched is not None
+    assert fetched["index_html"] == html
+
+
+@pytest.mark.asyncio
 async def test_list_excludes_content(web_site_store):
     await web_site_store.create(title="T", content='{"secret": true}')
     rows = await web_site_store.list()
@@ -69,6 +85,14 @@ async def test_update_changes_content_and_timestamp(web_site_store):
     assert updated["title"] == "T2"
     assert updated["content"] == '{"sections": [1]}'
     assert updated["updated_at"] >= created["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_update_changes_index_html(web_site_store):
+    created = await web_site_store.create(title="T", content="{}", index_html="<p>v1</p>")
+    updated = await web_site_store.update(created["id"], title="T", content="{}", index_html="<p>v2</p>")
+    assert updated is not None
+    assert updated["index_html"] == "<p>v2</p>"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/web.py
+++ b/tinyagentos/routes/web.py
@@ -58,6 +58,15 @@ def _validate_content(content: Any) -> JSONResponse | None:
     return _validate_text_field(content, "content")
 
 
+def _field_or_default(body: dict, key: str, default: str) -> str:
+    """Resolve an optional text field, treating a MISSING key or an explicit
+    JSON ``null`` the same way: fall back to ``default``. Without this, a body
+    like ``{"index_html": null}`` would yield None from ``dict.get`` and then
+    fail the string type-check as a spurious 400 (Kilo finding)."""
+    value = body.get(key)
+    return default if value is None else value
+
+
 @router.post("/api/web/sites")
 async def create_site(request: Request):
     body = await _parse_json(request)
@@ -66,11 +75,11 @@ async def create_site(request: Request):
     title = _validate_title(body.get("title"))
     if title is None:
         return JSONResponse({"error": "title is required"}, status_code=400)
-    content = body.get("content", "")
+    content = _field_or_default(body, "content", "")
     content_error = _validate_content(content)
     if content_error is not None:
         return content_error
-    index_html = body.get("index_html", "")
+    index_html = _field_or_default(body, "index_html", "")
     index_html_error = _validate_text_field(index_html, "index_html")
     if index_html_error is not None:
         return index_html_error
@@ -111,12 +120,12 @@ async def update_site(request: Request, site_id: str):
     if title is None:
         return JSONResponse({"error": "title is required"}, status_code=400)
 
-    content = body.get("content", existing["content"])
+    content = _field_or_default(body, "content", existing["content"])
     content_error = _validate_content(content)
     if content_error is not None:
         return content_error
 
-    index_html = body.get("index_html", existing.get("index_html", ""))
+    index_html = _field_or_default(body, "index_html", existing.get("index_html", ""))
     index_html_error = _validate_text_field(index_html, "index_html")
     if index_html_error is not None:
         return index_html_error
@@ -139,6 +148,11 @@ async def delete_site(request: Request, site_id: str):
 # routes/games.py's _GAME_PREVIEW_CSP). A site export has no <script> tags
 # and only ever embeds images as data: URIs, so script-src/connect-src are
 # left at 'none' rather than widened for content that doesn't need them.
+#
+# NB: `sandbox` here is the CSP *directive* (Content-Security-Policy: sandbox
+# ...), not the iframe sandbox attribute -- it is a legitimate first directive
+# in a single Content-Security-Policy header value, semicolon-separated from
+# the rest, and is what enforces the opaque origin. Not a malformed header.
 _WEB_PREVIEW_CSP = (
     "sandbox allow-scripts; "
     "default-src 'none'; "

--- a/tinyagentos/routes/web.py
+++ b/tinyagentos/routes/web.py
@@ -4,14 +4,17 @@ import json
 from typing import Any
 
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
+from tinyagentos.userspace.package import PackageError, build_package
 from tinyagentos.web_sites import WebSiteStore
 
 router = APIRouter()
 
 # Sites can embed image data URIs in `content`; cap the row so a single
-# oversized upload can't bloat the SQLite database unboundedly.
+# oversized upload can't bloat the SQLite database unboundedly. The same cap
+# applies to `index_html` (the rendered export of `content`, always smaller
+# or comparable in size).
 MAX_CONTENT_BYTES = 5 * 1024 * 1024  # 5 MB
 
 
@@ -39,16 +42,20 @@ async def _parse_json(request: Request) -> dict | JSONResponse:
     return body
 
 
-def _validate_content(content: Any) -> JSONResponse | None:
-    """Returns an error response if `content` is invalid, else None."""
-    if not isinstance(content, str):
-        return JSONResponse({"error": "content must be a string"}, status_code=400)
-    if len(content.encode("utf-8")) > MAX_CONTENT_BYTES:
+def _validate_text_field(value: Any, field_name: str) -> JSONResponse | None:
+    """Returns an error response if `value` is not an acceptably-sized string, else None."""
+    if not isinstance(value, str):
+        return JSONResponse({"error": f"{field_name} must be a string"}, status_code=400)
+    if len(value.encode("utf-8")) > MAX_CONTENT_BYTES:
         return JSONResponse(
-            {"error": f"content exceeds the {MAX_CONTENT_BYTES} byte limit"},
+            {"error": f"{field_name} exceeds the {MAX_CONTENT_BYTES} byte limit"},
             status_code=413,
         )
     return None
+
+
+def _validate_content(content: Any) -> JSONResponse | None:
+    return _validate_text_field(content, "content")
 
 
 @router.post("/api/web/sites")
@@ -63,9 +70,13 @@ async def create_site(request: Request):
     content_error = _validate_content(content)
     if content_error is not None:
         return content_error
+    index_html = body.get("index_html", "")
+    index_html_error = _validate_text_field(index_html, "index_html")
+    if index_html_error is not None:
+        return index_html_error
 
     store = _get_store(request)
-    site = await store.create(title=title, content=content)
+    site = await store.create(title=title, content=content, index_html=index_html)
     return site
 
 
@@ -105,7 +116,12 @@ async def update_site(request: Request, site_id: str):
     if content_error is not None:
         return content_error
 
-    site = await store.update(site_id=site_id, title=title, content=content)
+    index_html = body.get("index_html", existing.get("index_html", ""))
+    index_html_error = _validate_text_field(index_html, "index_html")
+    if index_html_error is not None:
+        return index_html_error
+
+    site = await store.update(site_id=site_id, title=title, content=content, index_html=index_html)
     return site
 
 
@@ -116,3 +132,75 @@ async def delete_site(request: Request, site_id: str):
     if not deleted:
         return JSONResponse({"error": "not found"}, status_code=404)
     return {"status": "deleted", "id": site_id}
+
+
+# Sandbox CSP for the live preview response: `sandbox allow-scripts` with NO
+# allow-same-origin forces an opaque origin (same posture as
+# routes/games.py's _GAME_PREVIEW_CSP). A site export has no <script> tags
+# and only ever embeds images as data: URIs, so script-src/connect-src are
+# left at 'none' rather than widened for content that doesn't need them.
+_WEB_PREVIEW_CSP = (
+    "sandbox allow-scripts; "
+    "default-src 'none'; "
+    "style-src 'unsafe-inline'; "
+    "img-src data: blob:; "
+    "font-src data:; "
+    "connect-src 'none'; "
+    "frame-ancestors 'self'; base-uri 'none'"
+)
+
+
+@router.get("/api/web/sites/{site_id}/preview")
+async def preview_site(request: Request, site_id: str):
+    """Serve a site's stored, rendered index.html for the live-preview iframe,
+    under a strict CSP. 404s until the site has been saved at least once --
+    an unsaved in-editor site is previewed client-side via srcDoc instead."""
+    store = _get_store(request)
+    site = await store.get(site_id)
+    if site is None or not site.get("index_html"):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    resp = Response(content=site["index_html"], media_type="text/html")
+    resp.headers["Content-Security-Policy"] = _WEB_PREVIEW_CSP
+    resp.headers["X-Content-Type-Options"] = "nosniff"
+    return resp
+
+
+@router.get("/api/web/sites/{site_id}/package")
+async def package_site(request: Request, site_id: str):
+    """Build a .taosapp package (manifest.yaml + the rendered index.html) and
+    return it as a downloadable zip -- reused both for "Export .taosapp"
+    (download as-is) and "Install on this taOS" (the frontend fetches this,
+    then POSTs the bytes to the existing /api/userspace-apps/install
+    endpoint), mirroring routes/games.py's package route.
+
+    Phase 2 (not implemented here): a site whose content needs a real
+    backend would instead emit an app_type: "container" manifest and reuse
+    userspace/container_deploy.py -- v1 is static-HTML only.
+    """
+    store = _get_store(request)
+    site = await store.get(site_id)
+    if site is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    index_html = site.get("index_html") or ""
+    if not index_html:
+        return JSONResponse(
+            {"error": "this site has no rendered content yet; save it first"}, status_code=400
+        )
+    manifest = {
+        "id": site_id,
+        "name": site["title"],
+        "version": "1.0.0",
+        "app_type": "web",
+        "entry": "index.html",
+        "icon": "",
+        "permissions": [],
+    }
+    try:
+        data = build_package(manifest, {"index.html": index_html})
+    except PackageError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+    return Response(
+        content=data,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{site_id}.taosapp"'},
+    )

--- a/tinyagentos/web_sites.py
+++ b/tinyagentos/web_sites.py
@@ -31,8 +31,17 @@ def _new_site_id() -> str:
 
 async def _migration_add_index_html(conn: aiosqlite.Connection) -> None:
     """Add the `index_html` column (idempotent). Added after initial release,
-    so existing databases must be migrated rather than assumed to have it --
-    see base_store.py's warning about SCHEMA vs. later columns."""
+    so existing databases must be migrated rather than assumed to have it.
+
+    This deliberately uses a guarded _post_init (PRAGMA table_info check +
+    conditional ALTER, committing its own change) rather than the MIGRATIONS
+    list: db_migrations.py footgun #2 documents that the MIGRATIONS runner
+    baseline-stamps pre-existing DBs at the latest version WITHOUT executing
+    any SQL, so a retrofit column added there would be silently skipped on
+    exactly the legacy rows that need it. The manual commit here is the same
+    sanctioned pattern as agent_registry_store._migration_v1_add_status and
+    knowledge_store's user_id retrofit, and is safely idempotent: the
+    ALTER only runs when the column is absent."""
     existing_cols = {row[1] for row in await (await conn.execute("PRAGMA table_info(sites)")).fetchall()}
     if "index_html" not in existing_cols:
         await conn.execute("ALTER TABLE sites ADD COLUMN index_html TEXT NOT NULL DEFAULT ''")

--- a/tinyagentos/web_sites.py
+++ b/tinyagentos/web_sites.py
@@ -29,11 +29,25 @@ def _new_site_id() -> str:
     return f"site-{suffix}"
 
 
+async def _migration_add_index_html(conn: aiosqlite.Connection) -> None:
+    """Add the `index_html` column (idempotent). Added after initial release,
+    so existing databases must be migrated rather than assumed to have it --
+    see base_store.py's warning about SCHEMA vs. later columns."""
+    existing_cols = {row[1] for row in await (await conn.execute("PRAGMA table_info(sites)")).fetchall()}
+    if "index_html" not in existing_cols:
+        await conn.execute("ALTER TABLE sites ADD COLUMN index_html TEXT NOT NULL DEFAULT ''")
+        await conn.commit()
+
+
 class WebSiteStore(BaseStore):
     """Persists website-builder documents.
 
-    ``content`` holds the site model serialized as JSON. The store treats it
-    as an opaque TEXT blob; validation of the model lives in the frontend.
+    ``content`` holds the site model serialized as JSON -- the editable
+    source of truth; the store treats it as an opaque TEXT blob, validation
+    of the model lives in the frontend. ``index_html`` holds the exported,
+    self-contained static HTML rendered from that model (export.ts's
+    exportSiteHtml), a derived artifact kept alongside it so the preview and
+    package routes have something servable without re-rendering client-side.
     """
 
     SCHEMA = WEB_SITES_SCHEMA
@@ -41,7 +55,10 @@ class WebSiteStore(BaseStore):
     def __init__(self, db_path: Path):
         super().__init__(db_path)
 
-    async def create(self, title: str, content: str) -> dict:
+    async def _post_init(self) -> None:
+        await _migration_add_index_html(self._db)
+
+    async def create(self, title: str, content: str, index_html: str = "") -> dict:
         now = int(time.time())
         # The id is generated and inserted speculatively; the PRIMARY KEY
         # constraint is the actual source of truth for uniqueness, not a
@@ -55,14 +72,22 @@ class WebSiteStore(BaseStore):
                 "id": site_id,
                 "title": title,
                 "content": content,
+                "index_html": index_html,
                 "created_at": now,
                 "updated_at": now,
             }
             try:
                 await self._db.execute(
-                    """INSERT INTO sites (id, title, content, created_at, updated_at)
-                       VALUES (?, ?, ?, ?, ?)""",
-                    (row["id"], row["title"], row["content"], row["created_at"], row["updated_at"]),
+                    """INSERT INTO sites (id, title, content, index_html, created_at, updated_at)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        row["id"],
+                        row["title"],
+                        row["content"],
+                        row["index_html"],
+                        row["created_at"],
+                        row["updated_at"],
+                    ),
                 )
                 await self._db.commit()
                 return row
@@ -85,7 +110,7 @@ class WebSiteStore(BaseStore):
 
     async def get(self, site_id: str) -> dict | None:
         async with self._db.execute(
-            "SELECT id, title, content, created_at, updated_at FROM sites WHERE id = ?",
+            "SELECT id, title, content, index_html, created_at, updated_at FROM sites WHERE id = ?",
             (site_id,),
         ) as cur:
             row = await cur.fetchone()
@@ -95,15 +120,16 @@ class WebSiteStore(BaseStore):
             "id": row[0],
             "title": row[1],
             "content": row[2],
-            "created_at": row[3],
-            "updated_at": row[4],
+            "index_html": row[3],
+            "created_at": row[4],
+            "updated_at": row[5],
         }
 
-    async def update(self, site_id: str, title: str, content: str) -> dict | None:
+    async def update(self, site_id: str, title: str, content: str, index_html: str = "") -> dict | None:
         now = int(time.time())
         await self._db.execute(
-            "UPDATE sites SET title = ?, content = ?, updated_at = ? WHERE id = ?",
-            (title, content, now, site_id),
+            "UPDATE sites SET title = ?, content = ?, index_html = ?, updated_at = ? WHERE id = ?",
+            (title, content, index_html, now, site_id),
         )
         await self._db.commit()
         return await self.get(site_id)


### PR DESCRIPTION
Makes Web Studio actually functional (static-first v1), fixing three dead ends while **keeping the existing structured section-based `Site` model and WYSIWYG editor** (not converted to a raw-files/code model).

## The three fixes

### 1. Real AI generation (was: keyword template-match only)
- New `webstudio/web-authoring-prompt.ts`: a schema-constrained system prompt (enum lists for the 5 palettes / 4 fonts, the 7 section shapes, a compact example) instructing the model to return a **single JSON `Site` object**.
- New `webstudio/generate-site.ts`: streams the taos-agent via `streamTaosAgentChat`, tolerant-extracts the JSON object (strips code fences / surrounding prose), `JSON.parse`s it, validates with `isValidSite()` **plus** a palette/font enum guard so an unknown id can never crash `PALETTES[...]`/`FONTS[...]`.
- **Honest fallback:** on empty stream / parse fail / shape mismatch it falls back to the existing `matchTemplate()` path and surfaces a `parseNotice` ("could not be parsed... closest starter template was used instead") — never a faked success. Stream errors propagate (no silent fallback). `GenerateView` keeps a Cancel/`AbortSignal` and progress states.

### 2. Sandboxed preview (was: direct un-sandboxed React render — the security gap)
- Saving now also persists the rendered `index.html` (`exportSiteHtml(site)`) alongside the editable Site JSON — new `index_html` column with an idempotent `_post_init` migration (safe for pre-existing DBs; verified).
- New `GET /api/web/sites/{id}/preview` serves the stored HTML under a strict CSP copied from `games.py`'s posture: `sandbox allow-scripts` (opaque origin, no `allow-same-origin`), `default-src 'none'`, `style-src 'unsafe-inline'` (the export uses inline styles), `img-src data: blob:`, `connect-src 'none'`, `X-Content-Type-Options: nosniff`. 404s until first save.
- `PreviewView` renders an `<iframe sandbox="allow-scripts">` (no `allow-same-origin`) — the backend `/preview` URL when the site is saved and clean, else `srcDoc={exportSiteHtml(site)}` for live/unsaved edits. **No un-sandboxed render remains.** Device-width toggle preserved.

### 3. Share / install as a taOS app (was: nothing)
- New `GET /api/web/sites/{id}/package` → `build_package(manifest{app_type:"web", entry:"index.html", ...}, {"index.html": <stored html>})` returning a `.taosapp` zip (mirrors `games.py`).
- New `webstudio/ShareView.tsx` (ported from `gamestudio/ShareView.tsx`): runs `analyze-source.ts` on the rendered HTML, **blocks Install on any `critical` finding**, else POSTs the package to `/api/userspace-apps/install` tagged provenance `ai-generated`; Export downloads the same `.taosapp`. Wired into a new **Share** rail entry. The single-file `.html` download stays in Export as the secondary option.

## Preserved
The structured `Site` model + section editor are untouched; `index.html` is a derived artifact, Site JSON stays the editable source of truth.

## Out of scope (Phase 2)
The LXC/container dynamic tier — left as a code comment in `routes/web.py` where a future `app_type:"container"` manifest would reuse `userspace/container_deploy.py`. No implementation.

## Tests
- Frontend (co-located): generation success (valid JSON → editor), fallback (bad JSON → matchTemplate + notice), stream-error surfaced; preview iframe URL vs. sandboxed `srcDoc` attrs; ShareView analyzer-gate blocks on critical + install tagged `ai-generated`.
- Backend: `/preview` (serves HTML + CSP headers), `/package` (valid `.taosapp`, installs through the real userspace-apps pipeline), `index_html` store round-trip.
- `npx vitest run src/apps/webstudio src/apps/WebStudioApp.test.tsx` → 5 files / 34 tests green. `npm run build` clean (0 TS errors). `pytest -k "web or userspace or package"` → 301 passed.

Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Share** view for saving, installing, and exporting sites.
  * Preview now supports a more polished live view, including an empty state when nothing is ready yet.
  * Site generation now shows progress, supports canceling, and can stream results as they arrive.

* **Bug Fixes**
  * Improved handling for saved previews and exports so sites display more reliably after editing or reopening.
  * Added clearer guidance when a site needs to be saved before sharing or installing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->