### PR TITLE
feat(music-studio): playable browser DAW — Tone.js engine, timeline, piano-roll, mixer, song persistence (Phase 1)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -35,6 +35,7 @@
         "@tiptap/starter-kit": "^3.26.1",
         "@tldraw/assets": "4.5.12",
         "@tldraw/tldraw": "^4.5.10",
+        "@tonejs/midi": "^2.0.28",
         "@tsparticles/engine": "^3.9.1",
         "@tsparticles/react": "^3.0.0",
         "@tsparticles/slim": "^3.9.1",
@@ -63,8 +64,10 @@
         "rehype-highlight": "^7.0.2",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "smplr": "^1.0.0",
         "tailwind-merge": "^3.6.0",
         "three": "0.184.0",
+        "tone": "^15.1.22",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -6605,6 +6608,16 @@
         "@tldraw/utils": "4.5.12"
       }
     },
+    "node_modules/@tonejs/midi": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@tonejs/midi/-/midi-2.0.28.tgz",
+      "integrity": "sha512-RII6YpInPsOZ5t3Si/20QKpNqB1lZ2OCFJSOzJxz38YdY/3zqDr3uaml4JuCWkdixuPqP1/TBnXzhQ39csyoVg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-flatten": "^3.0.0",
+        "midi-file": "^1.2.2"
+      }
+    },
     "node_modules/@tsparticles/basic": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-3.9.1.tgz",
@@ -7961,6 +7974,12 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -7970,6 +7989,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/automation-events": {
+      "version": "7.1.19",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.19.tgz",
+      "integrity": "sha512-cD+TLhJTI0q4AI3ktd353lrGZiVa9AchowSDzQzzGjSoYe22js4vlS32VUtWuaulghi1Yq0KYNWKk9wWuGymPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
+    "node_modules/automation-events/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -11338,6 +11376,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/midi-file": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/midi-file/-/midi-file-1.2.4.tgz",
+      "integrity": "sha512-B5SnBC6i2bwJIXTY9MElIydJwAmnKx+r5eJ1jknTLetzLflEl0GWveuBB6ACrQpecSRkOB6fhTx1PwXk2BVxnA==",
+      "license": "MIT"
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -12969,6 +13013,15 @@
       "deprecated": "Unsupported",
       "license": "MIT"
     },
+    "node_modules/smplr": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/smplr/-/smplr-1.0.0.tgz",
+      "integrity": "sha512-mCggf1Ex9oNOMl3LJNq7qlc3/aotKsH4DRFz0WgB7g7H4P1qUxmENkoqZ8FKj5vFY6CeweGNk7Uz8vOU/exQ7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -13004,6 +13057,23 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/standardized-audio-context/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/std-env": {
       "version": "4.1.0",
@@ -13238,6 +13308,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/tough-cookie": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -39,6 +39,7 @@
     "@tiptap/starter-kit": "^3.26.1",
     "@tldraw/assets": "4.5.12",
     "@tldraw/tldraw": "^4.5.10",
+    "@tonejs/midi": "^2.0.28",
     "@tsparticles/engine": "^3.9.1",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.9.1",
@@ -67,8 +68,10 @@
     "rehype-highlight": "^7.0.2",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "smplr": "^1.0.0",
     "tailwind-merge": "^3.6.0",
     "three": "0.184.0",
+    "tone": "^15.1.22",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/desktop/src/apps/MusicStudioApp.test.tsx
+++ b/desktop/src/apps/MusicStudioApp.test.tsx
@@ -1,5 +1,79 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+/* Tone.js and smplr both require a real AudioContext, which jsdom does not
+ * implement -- mock both so the Studio Engine can mount without them.
+ * (Kept in sync with audio-engine.test.ts's mock.) */
+vi.mock("tone", () => {
+  class FakeChannel {
+    volume: { value: number };
+    pan: { value: number };
+    mute: boolean;
+    solo: boolean;
+    constructor(opts: { volume?: number; pan?: number; mute?: boolean; solo?: boolean } = {}) {
+      this.volume = { value: opts.volume ?? 0 };
+      this.pan = { value: opts.pan ?? 0 };
+      this.mute = opts.mute ?? false;
+      this.solo = opts.solo ?? false;
+    }
+    connect() {
+      return this;
+    }
+    toDestination() {
+      return this;
+    }
+    dispose() {}
+  }
+  class FakeSynth {
+    constructor(_opts?: unknown) {}
+    connect() {
+      return this;
+    }
+    triggerAttackRelease() {}
+    dispose() {}
+  }
+  let idCounter = 0;
+  const transport = {
+    bpm: { value: 120 },
+    position: "0:0:0" as string | number,
+    state: "stopped" as "stopped" | "started",
+    schedule: vi.fn(() => {
+      idCounter += 1;
+      return idCounter;
+    }),
+    clear: vi.fn(),
+    cancel: vi.fn(),
+    start: vi.fn(() => {
+      transport.state = "started";
+    }),
+    stop: vi.fn(() => {
+      transport.state = "stopped";
+    }),
+  };
+  return {
+    start: vi.fn(async () => {}),
+    now: vi.fn(() => 0),
+    getTransport: () => transport,
+    getContext: () => ({ rawContext: { createGain: () => ({ connect() {}, disconnect() {} }) } }),
+    getDestination: () => ({ volume: { value: 0 } }),
+    connect: vi.fn(),
+    gainToDb: (gain: number) => (gain <= 0 ? -Infinity : 20 * Math.log10(gain)),
+    Midi: (pitch: number) => ({ toFrequency: () => 440 * 2 ** ((pitch - 69) / 12) }),
+    Channel: FakeChannel,
+    MembraneSynth: FakeSynth,
+    NoiseSynth: FakeSynth,
+    MonoSynth: FakeSynth,
+    PolySynth: FakeSynth,
+    AMSynth: FakeSynth,
+    Synth: FakeSynth,
+  };
+});
+
+vi.mock("smplr", () => ({
+  SplendidGrandPiano: () => ({ ready: Promise.resolve(), start: vi.fn(), dispose: vi.fn() }),
+  Soundfont: () => ({ ready: Promise.resolve(), start: vi.fn(), dispose: vi.fn() }),
+}));
+
 import { MusicStudioApp } from "./MusicStudioApp";
 
 function renderApp() {
@@ -30,7 +104,6 @@ describe("MusicStudioApp", () => {
     renderApp();
     expect(screen.getByRole("button", { name: "Stop" })).toBeDefined();
     expect(screen.getByRole("button", { name: "Play" })).toBeDefined();
-    expect(screen.getByRole("button", { name: "Record" })).toBeDefined();
   });
 
   it("Studio view shows a track in the track list", () => {

--- a/desktop/src/apps/MusicStudioApp.tsx
+++ b/desktop/src/apps/MusicStudioApp.tsx
@@ -1,10 +1,15 @@
 import { useState, useEffect, useCallback } from "react";
-import { LayoutList, Sparkles, Music2, LayoutGrid, Download } from "lucide-react";
+import { LayoutList, Sparkles, Music2, LayoutGrid, Download, FolderOpen } from "lucide-react";
 import { StudioView } from "./musicstudio/StudioView";
 import { ComposeView, type ComposedTrack } from "./musicstudio/ComposeView";
 import { SoundsView } from "./musicstudio/SoundsView";
+import { MixerView } from "./musicstudio/MixerView";
+import { LibraryView } from "./musicstudio/LibraryView";
+import { useStudioEngine } from "./musicstudio/use-studio-engine";
+import { saveSong, exportSongFile } from "./musicstudio/songs-api";
+import { exportSongMidiFile } from "./musicstudio/midi-export";
 
-type MusicView = "studio" | "compose" | "sounds" | "mixer" | "export";
+type MusicView = "studio" | "compose" | "sounds" | "mixer" | "export" | "library";
 
 const RAIL_MAIN: { id: MusicView; label: string; icon: typeof LayoutList }[] = [
   { id: "studio", label: "Studio", icon: LayoutList },
@@ -15,6 +20,10 @@ const RAIL_MAIN: { id: MusicView; label: string; icon: typeof LayoutList }[] = [
 
 export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
   const [view, setView] = useState<MusicView>("studio");
+  const engine = useStudioEngine();
+
+  const [saving, setSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
 
   const [composePrompt, setComposePrompt] = useState("");
   const [composeStyle, setComposeStyle] = useState<string | null>(null);
@@ -95,6 +104,20 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
     );
   }, []);
 
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setSaveStatus("idle");
+    try {
+      const saved = await saveSong(engine.song);
+      engine.loadSongRecord(saved);
+      setSaveStatus("saved");
+    } catch {
+      setSaveStatus("error");
+    } finally {
+      setSaving(false);
+    }
+  }, [engine]);
+
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
       <div className="flex min-h-0 flex-1">
@@ -128,6 +151,21 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
 
           <button
             type="button"
+            aria-label="Library"
+            aria-current={view === "library" ? "page" : undefined}
+            onClick={() => setView("library")}
+            className={`flex h-[46px] w-[46px] flex-col items-center justify-center gap-0.5 rounded-xl text-[9px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+              view === "library"
+                ? "bg-gradient-to-b from-accent/25 to-transparent text-accent"
+                : "text-shell-text-tertiary hover:bg-white/10 hover:text-shell-text-secondary"
+            }`}
+          >
+            <FolderOpen size={21} />
+            Library
+          </button>
+
+          <button
+            type="button"
             aria-label="Export"
             onClick={() => setView("export")}
             className={`flex h-[46px] w-[46px] flex-col items-center justify-center gap-0.5 rounded-xl text-[9px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
@@ -142,7 +180,7 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
         </nav>
 
         <div className="flex min-w-0 flex-1 flex-col">
-          {view === "studio" && <StudioView />}
+          {view === "studio" && <StudioView engine={engine} onSave={() => void handleSave()} saving={saving} saveStatus={saveStatus} />}
           {view === "compose" && (
             <ComposeView
               prompt={composePrompt}
@@ -158,15 +196,46 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
               onOpenStore={openStore}
             />
           )}
-          {view === "sounds" && <SoundsView />}
-          {view === "mixer" && (
-            <div className="flex flex-1 items-center justify-center text-shell-text-secondary text-[13px]">
-              Mixer coming soon
-            </div>
+          {view === "sounds" && <SoundsView engine={engine} />}
+          {view === "mixer" && <MixerView engine={engine} />}
+          {view === "library" && (
+            <LibraryView
+              onOpenSong={(song) => {
+                engine.loadSongRecord(song);
+                setView("studio");
+              }}
+              onCreateNew={() => {
+                engine.newSong();
+                setView("studio");
+              }}
+            />
           )}
           {view === "export" && (
-            <div className="flex flex-1 items-center justify-center text-shell-text-secondary text-[13px]">
-              Export coming soon
+            <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+              <p className="text-[14px] font-bold">{engine.song.name}</p>
+              <p className="max-w-[360px] text-[12.5px] text-shell-text-secondary">
+                Export downloads this song as a portable <span className="font-mono">.taosong</span> JSON file --
+                tempo, tracks, clips and notes, ready to re-import later.
+              </p>
+              <div className="flex gap-2.5">
+                <button
+                  type="button"
+                  onClick={() => exportSongFile(engine.song)}
+                  className="flex items-center gap-2 rounded-[14px] border-0 px-6 py-3 text-[14px] font-bold text-white"
+                  style={{ background: "linear-gradient(135deg, var(--color-accent-strong, #a9b0c2), var(--color-accent, #8b92a3))" }}
+                >
+                  <Download size={16} />
+                  Download .taosong
+                </button>
+                <button
+                  type="button"
+                  onClick={() => exportSongMidiFile(engine.song)}
+                  className="flex items-center gap-2 rounded-[14px] border border-shell-border bg-shell-surface px-6 py-3 text-[14px] font-bold text-shell-text"
+                >
+                  <Download size={16} />
+                  Download .mid
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/desktop/src/apps/musicstudio/LibraryView.tsx
+++ b/desktop/src/apps/musicstudio/LibraryView.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useState } from "react";
+import { FolderOpen, Pencil, Trash2, Loader2, AlertCircle, Music2, Plus } from "lucide-react";
+import { deleteSong, getSong, listSongs, renameSong, type SongMeta } from "./songs-api";
+import type { Song } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  LibraryView -- list of saved songs. Mirrors gamestudio/LibraryView:  */
+/*  delete is backend-confirmed (list only drops a row after the DELETE  */
+/*  call has actually succeeded, never optimistically).                 */
+/* ------------------------------------------------------------------ */
+
+export interface LibraryViewProps {
+  onOpenSong: (song: Song) => void;
+  onCreateNew: () => void;
+}
+
+function relativeTime(epochSeconds: number): string {
+  const diffMs = Date.now() - epochSeconds * 1000;
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function LibraryView({ onOpenSong, onCreateNew }: LibraryViewProps) {
+  const [songs, setSongs] = useState<SongMeta[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setSongs(await listSongs());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleOpen = useCallback(
+    async (meta: SongMeta) => {
+      setBusyId(meta.id);
+      try {
+        onOpenSong(await getSong(meta.id));
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [onOpenSong],
+  );
+
+  const handleRename = useCallback(
+    async (meta: SongMeta) => {
+      const next = window.prompt("Rename song:", meta.name);
+      if (!next?.trim() || next.trim() === meta.name) return;
+      setBusyId(meta.id);
+      try {
+        await renameSong(meta.id, next.trim());
+        await load();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [load],
+  );
+
+  const handleDelete = useCallback(
+    async (meta: SongMeta) => {
+      const ok = window.confirm(`Delete "${meta.name}"? This can't be undone.`);
+      if (!ok) return;
+      setBusyId(meta.id);
+      try {
+        await deleteSong(meta.id);
+        await load();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [load],
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-col gap-3.5 p-[22px]">
+        <header className="flex items-center justify-between">
+          <div>
+            <h2 className="text-[17px] font-bold tracking-[-0.02em]">Your songs</h2>
+            <p className="mt-1 text-[12.5px] text-shell-text-secondary">
+              Every song saved on this taOS.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onCreateNew}
+            className="flex items-center gap-1.5 rounded-lg border border-shell-border bg-shell-surface px-3 py-1.5 text-[12px] font-bold text-shell-text hover:bg-white/10"
+          >
+            <Plus size={14} />
+            New song
+          </button>
+        </header>
+
+        {error && (
+          <div role="alert" className="flex items-center gap-2 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3 text-[12.5px] text-red-200">
+            <AlertCircle size={15} />
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center gap-2 py-8 text-[13px] text-shell-text-tertiary">
+            <Loader2 size={16} className="animate-spin" />
+            Loading your songs...
+          </div>
+        ) : songs.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 rounded-2xl border border-dashed border-shell-border py-14 text-center text-shell-text-tertiary">
+            <Music2 size={28} />
+            <p className="text-[13px]">No songs saved yet. Save one from the Studio to see it here.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3.5">
+            {songs.map((s) => {
+              const busy = busyId === s.id;
+              return (
+                <div
+                  key={s.id}
+                  className="flex flex-col overflow-hidden rounded-2xl border border-shell-border bg-shell-surface shadow-card"
+                >
+                  <div className="relative flex h-[92px] items-end p-3" style={{ background: "linear-gradient(140deg,#2c3142,#171a24)" }}>
+                    <span className="text-[14px] font-extrabold text-white" style={{ textShadow: "0 2px 8px rgba(0,0,0,0.6)" }}>
+                      {s.name}
+                    </span>
+                  </div>
+                  <div className="flex flex-1 flex-col gap-2 p-3">
+                    <span className="text-[11px] text-shell-text-tertiary">updated {relativeTime(s.updated_at)}</span>
+                    <div className="mt-1 flex items-center gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => void handleOpen(s)}
+                        disabled={busy}
+                        aria-label={`Open ${s.name}`}
+                        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-shell-border bg-shell-surface-active px-2.5 py-1.5 text-[11.5px] font-bold text-shell-text hover:bg-white/10 disabled:opacity-50"
+                      >
+                        {busy ? <Loader2 size={13} className="animate-spin" /> : <FolderOpen size={13} />}
+                        Open
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleRename(s)}
+                        disabled={busy}
+                        aria-label={`Rename ${s.name}`}
+                        className="flex h-8 w-8 flex-none items-center justify-center rounded-lg border border-shell-border text-shell-text-secondary hover:bg-white/10 disabled:opacity-50"
+                      >
+                        <Pencil size={13} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleDelete(s)}
+                        disabled={busy}
+                        aria-label={`Delete ${s.name}`}
+                        className="flex h-8 w-8 flex-none items-center justify-center rounded-lg border border-shell-border text-red-400 hover:bg-red-500/10 disabled:opacity-50"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/musicstudio/MixerView.tsx
+++ b/desktop/src/apps/musicstudio/MixerView.tsx
@@ -1,0 +1,101 @@
+import { instrumentColor } from "./instruments";
+import type { StudioEngineApi } from "./use-studio-engine";
+
+/* ------------------------------------------------------------------ */
+/*  MixerView -- one channel strip per track (volume fader, pan, mute/    */
+/*  solo) plus a master fader, all bound directly to the live engine.    */
+/* ------------------------------------------------------------------ */
+
+export interface MixerViewProps {
+  engine: StudioEngineApi;
+}
+
+function Fader({ value, onChange, label }: { value: number; onChange: (v: number) => void; label: string }) {
+  return (
+    <label className="flex flex-1 flex-col items-center gap-2">
+      <input
+        aria-label={label}
+        type="range"
+        min={0}
+        max={100}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="h-32 w-6 [writing-mode:vertical-lr] direction-rtl"
+        style={{ writingMode: "vertical-lr", direction: "rtl" }}
+      />
+      <span className="text-[10.5px] tabular-nums text-shell-text-tertiary">{value}</span>
+    </label>
+  );
+}
+
+export function MixerView({ engine }: MixerViewProps) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex flex-none items-center gap-3 border-b border-shell-border px-[22px]" style={{ height: "54px" }}>
+        <h2 className="text-[17px] font-bold tracking-[-0.02em]">Mixer</h2>
+        <span className="text-[12px] text-shell-text-tertiary">Volume, pan, mute and solo for every track</span>
+      </div>
+
+      <div className="flex flex-1 items-stretch gap-4 overflow-auto p-[22px]">
+        {engine.song.tracks.map((track) => (
+          <div key={track.id} className="flex w-[104px] flex-none flex-col items-center gap-3 rounded-2xl border border-shell-border bg-shell-surface p-3">
+            <span className="h-[9px] w-[9px] flex-none rounded-[3px]" style={{ background: instrumentColor(track.instrument) }} />
+            <span className="max-w-full truncate text-[12px] font-bold">{track.name}</span>
+
+            <Fader
+              label={`${track.name} volume`}
+              value={track.volume}
+              onChange={(v) => engine.updateTrack(track.id, { volume: v })}
+            />
+
+            <label className="flex w-full flex-col items-center gap-1 text-[10px] text-shell-text-tertiary">
+              Pan
+              <input
+                aria-label={`${track.name} pan`}
+                type="range"
+                min={-1}
+                max={1}
+                step={0.05}
+                value={track.pan}
+                onChange={(e) => engine.updateTrack(track.id, { pan: Number(e.target.value) })}
+                className="w-full"
+              />
+            </label>
+
+            <div className="flex gap-1.5">
+              <button
+                type="button"
+                aria-label={`${track.muted ? "Unmute" : "Mute"} ${track.name}`}
+                aria-pressed={track.muted}
+                onClick={() => engine.updateTrack(track.id, { muted: !track.muted })}
+                className={`flex h-6 w-6 items-center justify-center rounded-md text-[10px] font-extrabold ${track.muted ? "bg-accent text-white" : "bg-shell-surface-active text-shell-text-tertiary"}`}
+              >
+                M
+              </button>
+              <button
+                type="button"
+                aria-label={`${track.soloed ? "Unsolo" : "Solo"} ${track.name}`}
+                aria-pressed={track.soloed}
+                onClick={() => engine.updateTrack(track.id, { soloed: !track.soloed })}
+                className={`flex h-6 w-6 items-center justify-center rounded-md text-[10px] font-extrabold ${track.soloed ? "bg-accent text-white" : "bg-shell-surface-active text-shell-text-tertiary"}`}
+              >
+                S
+              </button>
+            </div>
+          </div>
+        ))}
+
+        {engine.song.tracks.length === 0 && (
+          <div className="flex flex-1 items-center justify-center text-[13px] text-shell-text-tertiary">
+            Add tracks in Studio to mix them here.
+          </div>
+        )}
+
+        <div className="ml-auto flex w-[104px] flex-none flex-col items-center gap-3 rounded-2xl border border-shell-border-strong bg-shell-surface-active p-3">
+          <span className="text-[12px] font-bold">Master</span>
+          <Fader label="Master volume" value={engine.masterVolume} onChange={engine.setMasterVolume} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/musicstudio/PianoRoll.tsx
+++ b/desktop/src/apps/musicstudio/PianoRoll.tsx
@@ -1,10 +1,18 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { TICKS_PER_BEAT, localId, type Clip, type Note } from "./types";
 
 /* ------------------------------------------------------------------ */
-/*  PianoRoll -- click an empty cell to add a note, click a note to      */
-/*  remove it, drag a note to move it. Grid: 36px per sixteenth note,    */
-/*  16px per semitone row (matches the original mock's pixel scale).    */
+/*  PianoRoll                                                           */
+/*                                                                     */
+/*  Interaction (non-destructive on a single click):                    */
+/*   - click an empty grid cell  -> ADD a note (and select it)          */
+/*   - click an existing note    -> SELECT it (never deletes)           */
+/*   - drag a selected note      -> MOVE it (past a small pixel          */
+/*                                  threshold, so a jittery click is a   */
+/*                                  select, not a move)                  */
+/*   - Delete / Backspace        -> delete the selected note            */
+/*                                                                     */
+/*  Grid: 36px per sixteenth note, 16px per semitone row.               */
 /* ------------------------------------------------------------------ */
 
 const ROW_HEIGHT = 16;
@@ -12,6 +20,9 @@ const COL_WIDTH = 36;
 const SIXTEENTH = TICKS_PER_BEAT / 4;
 const LOWEST_PITCH = 36; // C2
 const HIGHEST_PITCH = 96; // C7
+/** Pointer must move at least this many px before a note drag mutates the
+ *  model; below it the gesture is treated as a plain click (select only). */
+const DRAG_THRESHOLD_PX = 4;
 
 const NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
 function pitchLabel(pitch: number): string {
@@ -32,15 +43,25 @@ export function PianoRoll({ clip, onChangeNotes, color = "var(--ms-tk-bass, #6f8
   for (let p = HIGHEST_PITCH; p >= LOWEST_PITCH; p--) rows.push(p);
 
   const gridRef = useRef<HTMLDivElement>(null);
-  const dragState = useRef<{ noteId: string; startX: number; startY: number; origTick: number; origPitch: number } | null>(null);
+  const dragState = useRef<{ noteId: string; startX: number; startY: number; origTick: number; origPitch: number; moved: boolean } | null>(null);
   const [dragPreview, setDragPreview] = useState<{ noteId: string; startTick: number; pitch: number } | null>(null);
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+
+  // The pointer handlers below are registered once per gesture but may outlive
+  // a change of the selected clip -- read the live clip through a ref so a
+  // mid-drag clip switch never mutates the wrong clip's notes.
+  const clipRef = useRef(clip);
+  clipRef.current = clip;
+  const onChangeRef = useRef(onChangeNotes);
+  onChangeRef.current = onChangeNotes;
 
   const lengthTicks = (clip?.lengthBars ?? 1) * 4 * TICKS_PER_BEAT;
   const totalCols = Math.max(1, Math.round(lengthTicks / SIXTEENTH));
 
   const handleGridClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      if (!clip || dragState.current) return;
+      const live = clipRef.current;
+      if (!live || dragState.current) return;
       const rect = gridRef.current!.getBoundingClientRect();
       const x = e.clientX - rect.left;
       const y = e.clientY - rect.top;
@@ -50,28 +71,35 @@ export function PianoRoll({ clip, onChangeNotes, color = "var(--ms-tk-bass, #6f8
       const startTick = col * SIXTEENTH;
       if (pitch < LOWEST_PITCH || pitch > HIGHEST_PITCH || col < 0 || col >= totalCols) return;
 
-      const existing = clip.notes.find((n) => n.pitch === pitch && n.startTick === startTick);
+      const existing = live.notes.find((n) => n.pitch === pitch && n.startTick === startTick);
       if (existing) {
-        onChangeNotes(clip.notes.filter((n) => n.id !== existing.id));
-      } else {
-        onChangeNotes([...clip.notes, { id: localId("note"), pitch, startTick, durationTicks: SIXTEENTH, velocity: 0.85 }]);
+        // Click on an existing note: SELECT it (deletion is explicit -- see
+        // the Delete/Backspace handler). Never destructive on a click.
+        setSelectedNoteId(existing.id);
+        return;
       }
+      const newNote: Note = { id: localId("note"), pitch, startTick, durationTicks: SIXTEENTH, velocity: 0.85 };
+      setSelectedNoteId(newNote.id);
+      onChangeRef.current([...live.notes, newNote]);
     },
-    [clip, onChangeNotes, totalCols],
+    [totalCols],
   );
 
   const handleNotePointerDown = useCallback((e: React.PointerEvent, note: Note) => {
     e.stopPropagation();
-    let moved = false;
-    dragState.current = { noteId: note.id, startX: e.clientX, startY: e.clientY, origTick: note.startTick, origPitch: note.pitch };
+    setSelectedNoteId(note.id);
+    dragState.current = { noteId: note.id, startX: e.clientX, startY: e.clientY, origTick: note.startTick, origPitch: note.pitch, moved: false };
     setDragPreview({ noteId: note.id, startTick: note.startTick, pitch: note.pitch });
 
     const handleMove = (ev: PointerEvent) => {
       const drag = dragState.current;
       if (!drag) return;
-      const deltaCols = Math.round((ev.clientX - drag.startX) / COL_WIDTH);
-      const deltaRows = Math.round((ev.clientY - drag.startY) / ROW_HEIGHT);
-      if (deltaCols !== 0 || deltaRows !== 0) moved = true;
+      const dx = ev.clientX - drag.startX;
+      const dy = ev.clientY - drag.startY;
+      if (!drag.moved && Math.abs(dx) < DRAG_THRESHOLD_PX && Math.abs(dy) < DRAG_THRESHOLD_PX) return;
+      drag.moved = true;
+      const deltaCols = Math.round(dx / COL_WIDTH);
+      const deltaRows = Math.round(dy / ROW_HEIGHT);
       const nextTick = Math.max(0, drag.origTick + deltaCols * SIXTEENTH);
       const nextPitch = Math.max(LOWEST_PITCH, Math.min(HIGHEST_PITCH, drag.origPitch - deltaRows));
       setDragPreview({ noteId: drag.noteId, startTick: nextTick, pitch: nextPitch });
@@ -81,28 +109,48 @@ export function PianoRoll({ clip, onChangeNotes, color = "var(--ms-tk-bass, #6f8
       window.removeEventListener("pointerup", handleUp);
       const drag = dragState.current;
       dragState.current = null;
-      if (!clip || !drag) {
+      const live = clipRef.current;
+      // Only a real drag (past the threshold) mutates; a plain click just
+      // leaves the note selected. No deletion happens here.
+      if (live && drag && drag.moved) {
+        setDragPreview((current) => {
+          if (current && current.noteId === drag.noteId) {
+            onChangeRef.current(
+              live.notes.map((n) => (n.id === drag.noteId ? { ...n, startTick: current.startTick, pitch: current.pitch } : n)),
+            );
+          }
+          return null;
+        });
+      } else {
         setDragPreview(null);
-        return;
       }
-      if (!moved) {
-        // A plain click (no drag): remove the note.
-        onChangeNotes(clip.notes.filter((n) => n.id !== drag.noteId));
-        setDragPreview(null);
-        return;
-      }
-      setDragPreview((current) => {
-        if (current && current.noteId === drag.noteId) {
-          onChangeNotes(
-            clip.notes.map((n) => (n.id === drag.noteId ? { ...n, startTick: current.startTick, pitch: current.pitch } : n)),
-          );
-        }
-        return null;
-      });
     };
     window.addEventListener("pointermove", handleMove);
     window.addEventListener("pointerup", handleUp);
-  }, [clip, onChangeNotes]);
+  }, []);
+
+  const deleteSelected = useCallback(() => {
+    const live = clipRef.current;
+    if (!live || !selectedNoteId) return;
+    onChangeRef.current(live.notes.filter((n) => n.id !== selectedNoteId));
+    setSelectedNoteId(null);
+  }, [selectedNoteId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Delete" || e.key === "Backspace") {
+        e.preventDefault();
+        deleteSelected();
+      }
+    },
+    [deleteSelected],
+  );
+
+  // Clear the selection when the clip changes so a stale id can't be deleted
+  // against a different clip.
+  useEffect(() => {
+    setSelectedNoteId(null);
+  }, [clip?.id]);
 
   return (
     <div className="flex h-[128px] flex-none border-t border-shell-border bg-shell-bg-deep">
@@ -127,9 +175,11 @@ export function PianoRoll({ clip, onChangeNotes, color = "var(--ms-tk-bass, #6f8
           <div
             ref={gridRef}
             role="grid"
+            tabIndex={0}
             aria-label={`Piano roll for ${clip.name}`}
             onClick={handleGridClick}
-            className="relative cursor-pointer"
+            onKeyDown={handleKeyDown}
+            className="relative cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent/40"
             style={{
               width: totalCols * COL_WIDTH,
               height: rows.length * ROW_HEIGHT,
@@ -144,14 +194,16 @@ export function PianoRoll({ clip, onChangeNotes, color = "var(--ms-tk-bass, #6f8
               const left = (startTick / SIXTEENTH) * COL_WIDTH;
               const top = (HIGHEST_PITCH - pitch) * ROW_HEIGHT + 1.5;
               const width = Math.max(COL_WIDTH - 2, (n.durationTicks / SIXTEENTH) * COL_WIDTH - 2);
+              const selected = n.id === selectedNoteId;
               return (
                 <span
                   key={n.id}
                   role="button"
                   aria-label={`Note ${pitchLabel(pitch)}`}
+                  aria-pressed={selected}
                   onPointerDown={(e) => handleNotePointerDown(e, n)}
                   onClick={(e) => e.stopPropagation()}
-                  className="absolute rounded-[3px]"
+                  className={`absolute rounded-[3px] ${selected ? "outline outline-2 outline-white" : ""}`}
                   style={{
                     left,
                     top,

--- a/desktop/src/apps/musicstudio/PianoRoll.tsx
+++ b/desktop/src/apps/musicstudio/PianoRoll.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useRef, useState } from "react";
+import { TICKS_PER_BEAT, localId, type Clip, type Note } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  PianoRoll -- click an empty cell to add a note, click a note to      */
+/*  remove it, drag a note to move it. Grid: 36px per sixteenth note,    */
+/*  16px per semitone row (matches the original mock's pixel scale).    */
+/* ------------------------------------------------------------------ */
+
+const ROW_HEIGHT = 16;
+const COL_WIDTH = 36;
+const SIXTEENTH = TICKS_PER_BEAT / 4;
+const LOWEST_PITCH = 36; // C2
+const HIGHEST_PITCH = 96; // C7
+
+const NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+function pitchLabel(pitch: number): string {
+  return `${NOTE_NAMES[pitch % 12]}${Math.floor(pitch / 12) - 1}`;
+}
+function isBlackKey(pitch: number): boolean {
+  return [1, 3, 6, 8, 10].includes(pitch % 12);
+}
+
+export interface PianoRollProps {
+  clip: Clip | null;
+  onChangeNotes: (notes: Note[]) => void;
+  color?: string;
+}
+
+export function PianoRoll({ clip, onChangeNotes, color = "var(--ms-tk-bass, #6f8aa8)" }: PianoRollProps) {
+  const rows = [];
+  for (let p = HIGHEST_PITCH; p >= LOWEST_PITCH; p--) rows.push(p);
+
+  const gridRef = useRef<HTMLDivElement>(null);
+  const dragState = useRef<{ noteId: string; startX: number; startY: number; origTick: number; origPitch: number } | null>(null);
+  const [dragPreview, setDragPreview] = useState<{ noteId: string; startTick: number; pitch: number } | null>(null);
+
+  const lengthTicks = (clip?.lengthBars ?? 1) * 4 * TICKS_PER_BEAT;
+  const totalCols = Math.max(1, Math.round(lengthTicks / SIXTEENTH));
+
+  const handleGridClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!clip || dragState.current) return;
+      const rect = gridRef.current!.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const col = Math.floor(x / COL_WIDTH);
+      const rowIndex = Math.floor(y / ROW_HEIGHT);
+      const pitch = HIGHEST_PITCH - rowIndex;
+      const startTick = col * SIXTEENTH;
+      if (pitch < LOWEST_PITCH || pitch > HIGHEST_PITCH || col < 0 || col >= totalCols) return;
+
+      const existing = clip.notes.find((n) => n.pitch === pitch && n.startTick === startTick);
+      if (existing) {
+        onChangeNotes(clip.notes.filter((n) => n.id !== existing.id));
+      } else {
+        onChangeNotes([...clip.notes, { id: localId("note"), pitch, startTick, durationTicks: SIXTEENTH, velocity: 0.85 }]);
+      }
+    },
+    [clip, onChangeNotes, totalCols],
+  );
+
+  const handleNotePointerDown = useCallback((e: React.PointerEvent, note: Note) => {
+    e.stopPropagation();
+    let moved = false;
+    dragState.current = { noteId: note.id, startX: e.clientX, startY: e.clientY, origTick: note.startTick, origPitch: note.pitch };
+    setDragPreview({ noteId: note.id, startTick: note.startTick, pitch: note.pitch });
+
+    const handleMove = (ev: PointerEvent) => {
+      const drag = dragState.current;
+      if (!drag) return;
+      const deltaCols = Math.round((ev.clientX - drag.startX) / COL_WIDTH);
+      const deltaRows = Math.round((ev.clientY - drag.startY) / ROW_HEIGHT);
+      if (deltaCols !== 0 || deltaRows !== 0) moved = true;
+      const nextTick = Math.max(0, drag.origTick + deltaCols * SIXTEENTH);
+      const nextPitch = Math.max(LOWEST_PITCH, Math.min(HIGHEST_PITCH, drag.origPitch - deltaRows));
+      setDragPreview({ noteId: drag.noteId, startTick: nextTick, pitch: nextPitch });
+    };
+    const handleUp = () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+      const drag = dragState.current;
+      dragState.current = null;
+      if (!clip || !drag) {
+        setDragPreview(null);
+        return;
+      }
+      if (!moved) {
+        // A plain click (no drag): remove the note.
+        onChangeNotes(clip.notes.filter((n) => n.id !== drag.noteId));
+        setDragPreview(null);
+        return;
+      }
+      setDragPreview((current) => {
+        if (current && current.noteId === drag.noteId) {
+          onChangeNotes(
+            clip.notes.map((n) => (n.id === drag.noteId ? { ...n, startTick: current.startTick, pitch: current.pitch } : n)),
+          );
+        }
+        return null;
+      });
+    };
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+  }, [clip, onChangeNotes]);
+
+  return (
+    <div className="flex h-[128px] flex-none border-t border-shell-border bg-shell-bg-deep">
+      <div className="flex w-[54px] flex-none flex-col overflow-hidden border-r border-shell-border font-mono">
+        {rows.map((p) => (
+          <div
+            key={p}
+            className={`flex items-center border-b border-shell-border px-[5px] py-[1px] text-[8px] text-shell-text-tertiary ${isBlackKey(p) ? "bg-black/[0.18]" : ""}`}
+            style={{ height: ROW_HEIGHT }}
+          >
+            {pitchLabel(p)}
+          </div>
+        ))}
+      </div>
+
+      <div className="relative flex-1 overflow-auto">
+        {!clip ? (
+          <div className="flex h-full items-center justify-center text-[11.5px] text-shell-text-tertiary">
+            Select or add a clip to edit notes
+          </div>
+        ) : (
+          <div
+            ref={gridRef}
+            role="grid"
+            aria-label={`Piano roll for ${clip.name}`}
+            onClick={handleGridClick}
+            className="relative cursor-pointer"
+            style={{
+              width: totalCols * COL_WIDTH,
+              height: rows.length * ROW_HEIGHT,
+              background:
+                "linear-gradient(90deg, var(--color-shell-border, rgba(255,255,255,0.08)) 1px, transparent 1px) 0 0 / 36px 100%, linear-gradient(0deg, var(--color-shell-border, rgba(255,255,255,0.08)) 1px, transparent 1px) 0 0 / 100% 16px",
+            }}
+          >
+            {clip.notes.map((n) => {
+              const preview = dragPreview?.noteId === n.id ? dragPreview : null;
+              const pitch = preview?.pitch ?? n.pitch;
+              const startTick = preview?.startTick ?? n.startTick;
+              const left = (startTick / SIXTEENTH) * COL_WIDTH;
+              const top = (HIGHEST_PITCH - pitch) * ROW_HEIGHT + 1.5;
+              const width = Math.max(COL_WIDTH - 2, (n.durationTicks / SIXTEENTH) * COL_WIDTH - 2);
+              return (
+                <span
+                  key={n.id}
+                  role="button"
+                  aria-label={`Note ${pitchLabel(pitch)}`}
+                  onPointerDown={(e) => handleNotePointerDown(e, n)}
+                  onClick={(e) => e.stopPropagation()}
+                  className="absolute rounded-[3px]"
+                  style={{
+                    left,
+                    top,
+                    width,
+                    height: 13,
+                    background: color,
+                    boxShadow: "0 1px 3px rgba(0,0,0,0.4)",
+                    cursor: "grab",
+                  }}
+                />
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/musicstudio/SoundsView.tsx
+++ b/desktop/src/apps/musicstudio/SoundsView.tsx
@@ -1,97 +1,39 @@
-const FILTER_PILLS = ["All", "Drums", "Bass", "Keys", "Synths", "FX"];
+import { useState } from "react";
+import { Play } from "lucide-react";
+import { INSTRUMENTS, instrumentColor, type InstrumentCategory } from "./instruments";
+import type { StudioEngineApi } from "./use-studio-engine";
 
-interface SoundCard {
-  name: string;
-  category: string;
-  detail: string;
-  padGradient: string;
-  bars: number[];
+const FILTER_PILLS: (InstrumentCategory | "All")[] = ["All", "Drums", "Bass", "Keys", "Synths", "FX"];
+
+export interface SoundsViewProps {
+  engine: StudioEngineApi;
 }
 
-const SOUNDS: SoundCard[] = [
-  {
-    name: "Boom Bap Kit",
-    category: "Drums",
-    detail: "24 hits",
-    padGradient: "linear-gradient(140deg, #3a2c24, #1d1611)",
-    bars: [40, 90, 30, 70, 45, 95, 35],
-  },
-  {
-    name: "Analog Bass",
-    category: "Bass",
-    detail: "synth",
-    padGradient: "linear-gradient(140deg, #23303f, #121b24)",
-    bars: [70, 50, 85, 45, 65],
-  },
-  {
-    name: "Rhodes Mk I",
-    category: "Keys",
-    detail: "electric piano",
-    padGradient: "linear-gradient(140deg, #223529, #101c15)",
-    bars: [55, 65, 50, 75, 55, 60],
-  },
-  {
-    name: "Warm Pad",
-    category: "Synths",
-    detail: "ambient",
-    padGradient: "linear-gradient(140deg, #2f2839, #171320)",
-    bars: [35, 45, 40, 50, 42],
-  },
-  {
-    name: "Pluck Lead",
-    category: "Synths",
-    detail: "mono",
-    padGradient: "linear-gradient(140deg, #3a3526, #1d1a11)",
-    bars: [80, 45, 90, 55, 70],
-  },
-  {
-    name: "Vinyl FX",
-    category: "FX",
-    detail: "texture",
-    padGradient: "linear-gradient(140deg, #34232c, #1a1116)",
-    bars: [30, 60, 35, 55],
-  },
-  {
-    name: "Sub 808",
-    category: "Bass",
-    detail: "808",
-    padGradient: "linear-gradient(140deg, #23303f, #121b24)",
-    bars: [60, 80, 50, 70, 55],
-  },
-  {
-    name: "Felt Piano",
-    category: "Keys",
-    detail: "acoustic",
-    padGradient: "linear-gradient(140deg, #223529, #101c15)",
-    bars: [50, 55, 65, 45, 60],
-  },
-];
+export function SoundsView({ engine }: SoundsViewProps) {
+  const [filter, setFilter] = useState<(typeof FILTER_PILLS)[number]>("All");
+  const selectedTrack = engine.song.tracks.find((t) => t.id === engine.selectedTrackId) ?? null;
 
-export function SoundsView() {
+  const visible = filter === "All" ? INSTRUMENTS : INSTRUMENTS.filter((i) => i.category === filter);
+
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      {/* view header */}
-      <div
-        className="flex flex-none items-center gap-3 border-b border-shell-border px-[22px]"
-        style={{ height: "54px" }}
-      >
+      <div className="flex flex-none items-center gap-3 border-b border-shell-border px-[22px]" style={{ height: "54px" }}>
         <h2 className="text-[17px] font-bold tracking-[-0.02em]">Sounds</h2>
         <span className="text-[12px] text-shell-text-tertiary">
-          Instruments and samples, all offline
+          {selectedTrack ? `Click to preview, "Use" to assign to ${selectedTrack.name}` : "Select a track in Studio to assign an instrument"}
         </span>
       </div>
 
       <div className="flex-1 overflow-auto p-[22px]">
-        {/* filter pills */}
         <div className="mb-[18px] flex flex-wrap gap-[9px]">
-          {FILTER_PILLS.map((pill, i) => (
+          {FILTER_PILLS.map((pill) => (
             <button
               key={pill}
               type="button"
+              onClick={() => setFilter(pill)}
+              aria-pressed={filter === pill}
               className={`rounded-full border px-3.5 py-[7px] text-[12px] font-semibold ${
-                i === 0
-                  ? "border-transparent bg-accent text-white"
-                  : "border-shell-border bg-shell-surface text-shell-text-secondary"
+                filter === pill ? "border-transparent bg-accent text-white" : "border-shell-border bg-shell-surface text-shell-text-secondary"
               }`}
             >
               {pill}
@@ -99,30 +41,43 @@ export function SoundsView() {
           ))}
         </div>
 
-        {/* sound card grid */}
         <div className="grid grid-cols-4 gap-[13px]">
-          {SOUNDS.map((sound) => (
+          {visible.map((sound) => (
             <div
-              key={sound.name}
+              key={sound.id}
+              role="button"
+              tabIndex={0}
+              aria-label={`Preview ${sound.name}`}
+              onClick={() => engine.previewInstrument(sound.id)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") engine.previewInstrument(sound.id);
+              }}
               className="flex cursor-pointer flex-col gap-[11px] rounded-[14px] border border-shell-border bg-shell-surface p-[14px] transition-all hover:-translate-y-[3px] hover:border-shell-border-strong"
             >
-              {/* pad preview */}
               <div
-                className="flex items-end gap-[2px] rounded-[10px] p-2"
-                style={{ height: "54px", background: sound.padGradient }}
+                className="flex items-center justify-center gap-[2px] rounded-[10px]"
+                style={{ height: "54px", background: `linear-gradient(140deg, ${instrumentColor(sound.id)}, rgba(0,0,0,0.35))` }}
               >
-                {sound.bars.map((h, i) => (
-                  <span
-                    key={i}
-                    className="flex-1 rounded-[1px]"
-                    style={{ height: `${h}%`, background: "rgba(255,255,255,0.8)" }}
-                  />
-                ))}
+                <Play size={20} className="text-white/85" fill="currentColor" />
               </div>
 
               <div className="text-[13px] font-bold">{sound.name}</div>
-              <div className="mt-[-6px] text-[11px] text-shell-text-tertiary">
-                {sound.category} - {sound.detail}
+              <div className="mt-[-6px] flex items-center justify-between text-[11px] text-shell-text-tertiary">
+                <span>
+                  {sound.category} - {sound.detail}
+                </span>
+                {selectedTrack && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      engine.updateTrack(selectedTrack.id, { instrument: sound.id });
+                    }}
+                    className="rounded-md border border-shell-border px-2 py-0.5 text-[10.5px] font-bold text-accent hover:bg-accent/10"
+                  >
+                    Use
+                  </button>
+                )}
               </div>
             </div>
           ))}

--- a/desktop/src/apps/musicstudio/StepSequencer.tsx
+++ b/desktop/src/apps/musicstudio/StepSequencer.tsx
@@ -1,0 +1,70 @@
+import { TICKS_PER_BEAT, localId, type Clip, type Note } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  StepSequencer -- a 16-step grid for drum tracks. Writes to the same */
+/*  Clip/Note model as the piano roll, just fixed to 3 GM drum pitches. */
+/* ------------------------------------------------------------------ */
+
+const SIXTEENTH = TICKS_PER_BEAT / 4;
+const STEPS = 16;
+const ROWS: { pitch: number; label: string }[] = [
+  { pitch: 36, label: "Kick" },
+  { pitch: 41, label: "Snare" },
+  { pitch: 42, label: "Hat" },
+];
+
+export interface StepSequencerProps {
+  clip: Clip | null;
+  onChangeNotes: (notes: Note[]) => void;
+}
+
+export function StepSequencer({ clip, onChangeNotes }: StepSequencerProps) {
+  if (!clip) {
+    return (
+      <div className="flex h-[128px] flex-none items-center justify-center border-t border-shell-border bg-shell-bg-deep text-[11.5px] text-shell-text-tertiary">
+        Select or add a clip to program steps
+      </div>
+    );
+  }
+
+  const toggle = (pitch: number, step: number) => {
+    const startTick = step * SIXTEENTH;
+    const existing = clip.notes.find((n) => n.pitch === pitch && n.startTick === startTick);
+    if (existing) {
+      onChangeNotes(clip.notes.filter((n) => n.id !== existing.id));
+    } else {
+      onChangeNotes([...clip.notes, { id: localId("note"), pitch, startTick, durationTicks: SIXTEENTH, velocity: 0.9 }]);
+    }
+  };
+
+  return (
+    <div className="flex h-[128px] flex-none flex-col justify-center gap-[6px] border-t border-shell-border bg-shell-bg-deep px-4 py-2">
+      {ROWS.map((row) => (
+        <div key={row.pitch} className="flex items-center gap-2">
+          <span className="w-11 flex-none text-[10px] font-semibold uppercase tracking-[0.04em] text-shell-text-tertiary">
+            {row.label}
+          </span>
+          <div className="flex flex-1 gap-[3px]">
+            {Array.from({ length: STEPS }, (_, step) => {
+              const on = clip.notes.some((n) => n.pitch === row.pitch && n.startTick === step * SIXTEENTH);
+              return (
+                <button
+                  key={step}
+                  type="button"
+                  aria-pressed={on}
+                  aria-label={`${row.label} step ${step + 1}`}
+                  onClick={() => toggle(row.pitch, step)}
+                  className={`h-6 flex-1 rounded-[4px] border ${
+                    on
+                      ? "border-transparent bg-accent"
+                      : `border-shell-border ${step % 4 === 0 ? "bg-shell-surface-active" : "bg-shell-surface"}`
+                  }`}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/desktop/src/apps/musicstudio/StudioView.test.tsx
+++ b/desktop/src/apps/musicstudio/StudioView.test.tsx
@@ -111,7 +111,7 @@ describe("StudioView", () => {
     expect(notesAfter).toBe(notesBefore + 1);
   });
 
-  it("clicking an existing note removes it", () => {
+  it("clicking an existing note SELECTS it (does not delete)", () => {
     render(<Harness />);
     fireEvent.click(screen.getByText("Bass"));
 
@@ -122,6 +122,27 @@ describe("StudioView", () => {
     const firstNote = within(grid).getAllByRole("button", { name: /^Note /i })[0];
     fireEvent.pointerDown(firstNote);
     fireEvent.pointerUp(window);
+
+    // Single click is non-destructive: the note count is unchanged and the
+    // clicked note is now selected.
+    const after = within(grid).getAllByRole("button", { name: /^Note /i });
+    expect(after).toHaveLength(before);
+    expect(after[0]).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("deletes the selected note only on an explicit Delete key press", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByText("Bass"));
+
+    const grid = screen.getByRole("grid", { name: /Piano roll for/i });
+    const before = within(grid).getAllByRole("button", { name: /^Note /i }).length;
+    expect(before).toBeGreaterThan(0);
+
+    // Select the first note (click is non-destructive), then Delete removes it.
+    const firstNote = within(grid).getAllByRole("button", { name: /^Note /i })[0];
+    fireEvent.pointerDown(firstNote);
+    fireEvent.pointerUp(window);
+    fireEvent.keyDown(grid, { key: "Delete" });
 
     const after = within(grid).getAllByRole("button", { name: /^Note /i }).length;
     expect(after).toBe(before - 1);

--- a/desktop/src/apps/musicstudio/StudioView.test.tsx
+++ b/desktop/src/apps/musicstudio/StudioView.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+
+/* Tone.js and smplr both require a real AudioContext, which jsdom does not
+ * implement -- mock both so useStudioEngine's wiring can run without them.
+ * (Kept in sync with audio-engine.test.ts's mock; vi.mock factories can't
+ * import a shared helper because vi.mock calls are hoisted above imports.) */
+vi.mock("tone", () => {
+  class FakeChannel {
+    volume: { value: number };
+    pan: { value: number };
+    mute: boolean;
+    solo: boolean;
+    constructor(opts: { volume?: number; pan?: number; mute?: boolean; solo?: boolean } = {}) {
+      this.volume = { value: opts.volume ?? 0 };
+      this.pan = { value: opts.pan ?? 0 };
+      this.mute = opts.mute ?? false;
+      this.solo = opts.solo ?? false;
+    }
+    connect() {
+      return this;
+    }
+    toDestination() {
+      return this;
+    }
+    dispose() {}
+  }
+  class FakeSynth {
+    constructor(_opts?: unknown) {}
+    connect() {
+      return this;
+    }
+    triggerAttackRelease() {}
+    dispose() {}
+  }
+  let idCounter = 0;
+  const transport = {
+    bpm: { value: 120 },
+    position: "0:0:0" as string | number,
+    state: "stopped" as "stopped" | "started",
+    schedule: vi.fn(() => {
+      idCounter += 1;
+      return idCounter;
+    }),
+    clear: vi.fn(),
+    cancel: vi.fn(),
+    start: vi.fn(() => {
+      transport.state = "started";
+    }),
+    stop: vi.fn(() => {
+      transport.state = "stopped";
+    }),
+  };
+  return {
+    start: vi.fn(async () => {}),
+    now: vi.fn(() => 0),
+    getTransport: () => transport,
+    getContext: () => ({ rawContext: { createGain: () => ({ connect() {}, disconnect() {} }) } }),
+    getDestination: () => ({ volume: { value: 0 } }),
+    connect: vi.fn(),
+    gainToDb: (gain: number) => (gain <= 0 ? -Infinity : 20 * Math.log10(gain)),
+    Midi: (pitch: number) => ({ toFrequency: () => 440 * 2 ** ((pitch - 69) / 12) }),
+    Channel: FakeChannel,
+    MembraneSynth: FakeSynth,
+    NoiseSynth: FakeSynth,
+    MonoSynth: FakeSynth,
+    PolySynth: FakeSynth,
+    AMSynth: FakeSynth,
+    Synth: FakeSynth,
+  };
+});
+
+vi.mock("smplr", () => ({
+  SplendidGrandPiano: () => ({ ready: Promise.resolve(), start: vi.fn(), dispose: vi.fn() }),
+  Soundfont: () => ({ ready: Promise.resolve(), start: vi.fn(), dispose: vi.fn() }),
+}));
+
+import { StudioView } from "./StudioView";
+import { useStudioEngine } from "./use-studio-engine";
+
+function Harness() {
+  const engine = useStudioEngine();
+  return <StudioView engine={engine} onSave={() => {}} saving={false} saveStatus="idle" />;
+}
+
+describe("StudioView", () => {
+  it("adding a track increases the track list", () => {
+    render(<Harness />);
+
+    const tracksBefore = screen.getAllByLabelText(/^Mute /).length;
+    fireEvent.click(screen.getByLabelText("Add track"));
+    const tracksAfter = screen.getAllByLabelText(/^Mute /).length;
+
+    expect(tracksAfter).toBe(tracksBefore + 1);
+  });
+
+  it("clicking an empty piano-roll cell adds a note to the selected clip", () => {
+    render(<Harness />);
+
+    // The default seed selects the Drums track (which uses the step
+    // sequencer, not the piano roll) -- switch to Bass, a melodic track.
+    fireEvent.click(screen.getByText("Bass"));
+
+    const grid = screen.getByRole("grid", { name: /Piano roll for/i });
+    const notesBefore = within(grid).getAllByRole("button", { name: /^Note /i }).length;
+
+    // Column 5 (empty), a pitch (A3=57) not used by the seeded bassline.
+    fireEvent.click(grid, { clientX: 5 * 36 + 2, clientY: (96 - 57) * 16 + 2 });
+
+    const notesAfter = within(grid).getAllByRole("button", { name: /^Note /i }).length;
+    expect(notesAfter).toBe(notesBefore + 1);
+  });
+
+  it("clicking an existing note removes it", () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByText("Bass"));
+
+    const grid = screen.getByRole("grid", { name: /Piano roll for/i });
+    const before = within(grid).getAllByRole("button", { name: /^Note /i }).length;
+    expect(before).toBeGreaterThan(0);
+
+    const firstNote = within(grid).getAllByRole("button", { name: /^Note /i })[0];
+    fireEvent.pointerDown(firstNote);
+    fireEvent.pointerUp(window);
+
+    const after = within(grid).getAllByRole("button", { name: /^Note /i }).length;
+    expect(after).toBe(before - 1);
+  });
+
+  it("toggling a step sequencer cell adds a note for the drum track", () => {
+    render(<Harness />);
+    // Drums is selected by default -- the step sequencer should be visible.
+    const step = screen.getByLabelText("Kick step 2");
+    expect(step).toHaveAttribute("aria-pressed", "false");
+
+    fireEvent.click(step);
+    expect(step).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(step);
+    expect(step).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/desktop/src/apps/musicstudio/StudioView.tsx
+++ b/desktop/src/apps/musicstudio/StudioView.tsx
@@ -1,85 +1,70 @@
-import { Square, Play, Circle, Check } from "lucide-react";
+import { useMemo } from "react";
+import { Square, Play, Check, Loader2, Plus, Trash2 } from "lucide-react";
+import { INSTRUMENTS, instrumentColor } from "./instruments";
+import { PianoRoll } from "./PianoRoll";
+import { StepSequencer } from "./StepSequencer";
+import type { Note } from "./types";
+import type { StudioEngineApi } from "./use-studio-engine";
 
-/* Muted track color palette -- content, not chrome */
-const TRACK_COLORS = {
-  drum: "var(--ms-tk-drum, #c98b6b)",
-  bass: "var(--ms-tk-bass, #6f8aa8)",
-  keys: "var(--ms-tk-keys, #7faa90)",
-  pad: "var(--ms-tk-pad, #9a87b0)",
-  lead: "var(--ms-tk-lead, #c0a86a)",
-} as const;
-
-type TrackColor = keyof typeof TRACK_COLORS;
-
-interface Track {
-  id: string;
-  label: string;
-  color: TrackColor;
-  volume: number;
-  muted: boolean;
+export interface StudioViewProps {
+  engine: StudioEngineApi;
+  onSave: () => void;
+  saving: boolean;
+  saveStatus: "idle" | "saved" | "error";
 }
 
-const TRACKS: Track[] = [
-  { id: "drum", label: "Drums", color: "drum", volume: 72, muted: false },
-  { id: "bass", label: "Bass", color: "bass", volume: 60, muted: false },
-  { id: "keys", label: "Keys", color: "keys", volume: 54, muted: false },
-  { id: "pad", label: "Pad", color: "pad", volume: 48, muted: true },
-  { id: "lead", label: "Lead", color: "lead", volume: 66, muted: false },
-];
+const BAR_WIDTH = 72;
 
-interface Clip {
-  trackId: string;
-  label: string;
-  left: number;
-  width: number;
-  opacity?: number;
-  bars: number[];
-}
+export function StudioView({ engine, onSave, saving, saveStatus }: StudioViewProps) {
+  const {
+    song,
+    playing,
+    positionLabel,
+    play,
+    stop,
+    setTempo,
+    setSongName,
+    selectedTrackId,
+    setSelectedTrackId,
+    selectedClipId,
+    setSelectedClipId,
+    addTrack,
+    removeTrack,
+    updateTrack,
+    addClip,
+    updateClipNotes,
+  } = engine;
 
-const CLIPS: Clip[] = [
-  { trackId: "drum", label: "Drums", left: 0, width: 288, bars: [40, 90, 30, 70, 40, 95, 30, 60, 40, 88, 30, 70] },
-  { trackId: "bass", label: "Bassline", left: 72, width: 216, bars: [60, 50, 80, 45, 70, 55, 85, 50] },
-  { trackId: "keys", label: "Rhodes", left: 144, width: 288, bars: [50, 65, 40, 75, 55, 60] },
-  { trackId: "pad", label: "Pad (muted)", left: 216, width: 360, opacity: 0.5, bars: [30, 35, 32, 38] },
-  { trackId: "lead", label: "Lead", left: 288, width: 180, bars: [80, 45, 90, 55, 70] },
-];
+  const selectedTrack = song.tracks.find((t) => t.id === selectedTrackId) ?? null;
+  const selectedClip = selectedTrack
+    ? (selectedTrack.clips.find((c) => c.id === selectedClipId) ?? selectedTrack.clips[0] ?? null)
+    : null;
 
-const RULER_BARS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const totalBars = useMemo(() => {
+    const furthest = song.tracks
+      .flatMap((t) => t.clips)
+      .reduce((max, c) => Math.max(max, c.startBar + c.lengthBars), 0);
+    return Math.max(12, furthest + 4);
+  }, [song.tracks]);
+  const ruler = useMemo(() => Array.from({ length: totalBars }, (_, i) => i + 1), [totalBars]);
 
-const PIANO_KEYS = [
-  { label: "C4", black: false },
-  { label: "B3", black: true },
-  { label: "A3", black: false },
-  { label: "G3", black: true },
-  { label: "F3", black: false },
-  { label: "E3", black: true },
-  { label: "D3", black: false },
-];
+  const handleLaneClick = (trackId: string, bar: number, existingClipId: string | undefined) => {
+    setSelectedTrackId(trackId);
+    if (existingClipId) {
+      setSelectedClipId(existingClipId);
+    } else {
+      const newClipId = addClip(trackId, bar);
+      setSelectedClipId(newClipId);
+    }
+  };
 
-interface PianoNote {
-  left: number;
-  top: number;
-  width: number;
-}
+  const handleChangeNotes = (notes: Note[]) => {
+    if (!selectedTrack || !selectedClip) return;
+    updateClipNotes(selectedTrack.id, selectedClip.id, notes);
+  };
 
-const PIANO_NOTES: PianoNote[] = [
-  { left: 8, top: 14, width: 32 },
-  { left: 44, top: 46, width: 64 },
-  { left: 112, top: 14, width: 32 },
-  { left: 148, top: 78, width: 48 },
-  { left: 200, top: 46, width: 64 },
-  { left: 268, top: 30, width: 32 },
-  { left: 304, top: 62, width: 80 },
-];
+  const isDrumTrack = selectedTrack ? INSTRUMENTS.find((i) => i.id === selectedTrack.instrument)?.category === "Drums" : false;
 
-const KNOBS = ["Swing", "Drive", "Tone", "Width"];
-const FX_ROWS = [
-  { label: "Reverb", on: true },
-  { label: "Tape delay", on: false },
-  { label: "Sidechain", on: true },
-];
-
-export function StudioView() {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {/* transport bar */}
@@ -88,56 +73,72 @@ export function StudioView() {
         style={{ height: "58px" }}
       >
         <div className="flex items-center gap-2">
-          {/* stop */}
           <button
             type="button"
             aria-label="Stop"
+            onClick={stop}
             className="flex h-9 w-9 items-center justify-center rounded-[10px] border border-shell-border bg-shell-surface text-shell-text"
           >
             <Square size={16} />
           </button>
-          {/* play */}
           <button
             type="button"
-            aria-label="Play"
+            aria-label={playing ? "Playing" : "Play"}
+            aria-pressed={playing}
+            onClick={play}
             className="flex h-9 w-9 items-center justify-center rounded-[10px] text-white"
             style={{ background: "linear-gradient(135deg, var(--color-accent-strong, #a9b0c2), var(--color-accent, #8b92a3))" }}
           >
             <Play size={16} fill="currentColor" />
           </button>
-          {/* record */}
-          <button
-            type="button"
-            aria-label="Record"
-            className="flex h-9 w-9 items-center justify-center rounded-[10px] border border-shell-border bg-shell-surface"
-          >
-            <Circle size={16} fill="#e06464" className="text-[#e06464]" />
-          </button>
         </div>
 
         <div className="ml-1.5 flex items-center gap-4">
-          <span className="font-mono text-[19px] font-bold tracking-[-0.01em] tabular-nums">
-            003 . 2 . 1
-          </span>
+          <span className="font-mono text-[19px] font-bold tracking-[-0.01em] tabular-nums">{positionLabel}</span>
           <div className="flex flex-col leading-[1.1]">
-            <span className="text-[14px] font-bold tabular-nums">92</span>
+            <input
+              aria-label="Tempo (BPM)"
+              type="number"
+              min={20}
+              max={300}
+              value={song.tempo}
+              onChange={(e) => setTempo(Number(e.target.value))}
+              className="w-11 bg-transparent text-[14px] font-bold tabular-nums outline-none"
+            />
             <span className="text-[9.5px] uppercase tracking-[0.06em] text-shell-text-tertiary">BPM</span>
           </div>
           <div className="flex flex-col leading-[1.1]">
-            <span className="text-[14px] font-bold tabular-nums">4/4</span>
+            <span className="text-[14px] font-bold tabular-nums">{song.timeSig}</span>
             <span className="text-[9.5px] uppercase tracking-[0.06em] text-shell-text-tertiary">Time</span>
           </div>
           <div className="flex flex-col leading-[1.1]">
-            <span className="text-[14px] font-bold">A min</span>
+            <span className="text-[14px] font-bold">{song.key}</span>
             <span className="text-[9.5px] uppercase tracking-[0.06em] text-shell-text-tertiary">Key</span>
           </div>
+          <input
+            aria-label="Song name"
+            value={song.name}
+            onChange={(e) => setSongName(e.target.value)}
+            className="w-40 bg-transparent text-[13px] font-semibold text-shell-text-secondary outline-none"
+          />
         </div>
 
         <div className="ml-auto">
-          <div className="flex items-center gap-1.5 rounded-[10px] border border-shell-border bg-shell-surface px-3 py-[7px]">
-            <Check size={14} className="text-shell-text-secondary" />
-            <span className="text-[11.5px] font-semibold text-shell-text-secondary">Saved to Workspace</span>
-          </div>
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={saving}
+            className="flex items-center gap-1.5 rounded-[10px] border border-shell-border bg-shell-surface px-3 py-[7px] disabled:opacity-60"
+          >
+            {saving ? (
+              <Loader2 size={14} className="animate-spin text-shell-text-secondary" />
+            ) : (
+              <Check size={14} className="text-shell-text-secondary" />
+            )}
+            <span className="text-[11.5px] font-semibold text-shell-text-secondary">
+              {saving ? "Saving..." : saveStatus === "error" ? "Save failed -- retry" : "Save"}
+            </span>
+          </button>
         </div>
       </div>
 
@@ -145,39 +146,66 @@ export function StudioView() {
       <div className="flex min-h-0 flex-1">
         {/* track list column */}
         <div className="w-[188px] flex-none overflow-auto border-r border-shell-border bg-shell-bg-deep">
-          {/* ruler label */}
-          <div className="flex h-7 items-center border-b border-shell-border px-3">
-            <span className="text-[10px] font-bold uppercase tracking-[0.05em] text-shell-text-tertiary">
-              Tracks
-            </span>
+          <div className="flex h-7 items-center justify-between border-b border-shell-border px-3">
+            <span className="text-[10px] font-bold uppercase tracking-[0.05em] text-shell-text-tertiary">Tracks</span>
+            <button type="button" aria-label="Add track" onClick={() => addTrack()} className="text-shell-text-tertiary hover:text-shell-text">
+              <Plus size={13} />
+            </button>
           </div>
 
-          {TRACKS.map((track, i) => (
+          {song.tracks.map((track) => (
             <div
               key={track.id}
-              className={`flex flex-col justify-center gap-1.5 border-b border-shell-border px-3 py-[9px] ${i === 0 ? "bg-shell-surface" : ""}`}
+              onClick={() => setSelectedTrackId(track.id)}
+              className={`flex cursor-pointer flex-col justify-center gap-1.5 border-b border-shell-border px-3 py-[9px] ${track.id === selectedTrackId ? "bg-shell-surface" : ""}`}
               style={{ height: "62px" }}
             >
               <div className="flex items-center gap-2">
-                <span
-                  className="h-[9px] w-[9px] flex-none rounded-[3px]"
-                  style={{ background: TRACK_COLORS[track.color] }}
-                />
-                <span className="text-[12.5px] font-semibold">{track.label}</span>
+                <span className="h-[9px] w-[9px] flex-none rounded-[3px]" style={{ background: instrumentColor(track.instrument) }} />
+                <span className="truncate text-[12.5px] font-semibold">{track.name}</span>
                 <div className="ml-auto flex gap-1">
-                  <span className={`flex h-[18px] w-[18px] items-center justify-center rounded-[5px] text-[9.5px] font-extrabold ${track.muted ? "bg-accent text-white" : "bg-shell-surface-active text-shell-text-tertiary"}`}>
+                  <button
+                    type="button"
+                    aria-label={`${track.muted ? "Unmute" : "Mute"} ${track.name}`}
+                    aria-pressed={track.muted}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      updateTrack(track.id, { muted: !track.muted });
+                    }}
+                    className={`flex h-[18px] w-[18px] items-center justify-center rounded-[5px] text-[9.5px] font-extrabold ${track.muted ? "bg-accent text-white" : "bg-shell-surface-active text-shell-text-tertiary"}`}
+                  >
                     M
-                  </span>
-                  <span className="flex h-[18px] w-[18px] items-center justify-center rounded-[5px] bg-shell-surface-active text-[9.5px] font-extrabold text-shell-text-tertiary">
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`${track.soloed ? "Unsolo" : "Solo"} ${track.name}`}
+                    aria-pressed={track.soloed}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      updateTrack(track.id, { soloed: !track.soloed });
+                    }}
+                    className={`flex h-[18px] w-[18px] items-center justify-center rounded-[5px] text-[9.5px] font-extrabold ${track.soloed ? "bg-accent text-white" : "bg-shell-surface-active text-shell-text-tertiary"}`}
+                  >
                     S
-                  </span>
+                  </button>
                 </div>
               </div>
-              <div className="relative h-1 rounded-full bg-shell-surface-active">
-                <span
-                  className="absolute inset-y-0 left-0 rounded-full bg-shell-text-tertiary"
-                  style={{ width: `${track.volume}%` }}
-                />
+              <div
+                role="slider"
+                aria-label={`${track.name} volume`}
+                aria-valuenow={track.volume}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const rect = e.currentTarget.getBoundingClientRect();
+                  const pct = Math.round(((e.clientX - rect.left) / rect.width) * 100);
+                  updateTrack(track.id, { volume: Math.max(0, Math.min(100, pct)) });
+                }}
+                className="relative h-1 cursor-pointer rounded-full bg-shell-surface-active"
+              >
+                <span className="absolute inset-y-0 left-0 rounded-full bg-shell-text-tertiary" style={{ width: `${track.volume}%` }} />
               </div>
             </div>
           ))}
@@ -187,165 +215,115 @@ export function StudioView() {
         <div
           className="relative min-w-0 flex-1 overflow-auto"
           style={{
-            background:
-              "linear-gradient(90deg, var(--color-shell-border, rgba(255,255,255,0.08)) 1px, transparent 1px) 0 0 / 72px 100%, var(--color-shell-bg, #1d1d1f)",
+            background: `linear-gradient(90deg, var(--color-shell-border, rgba(255,255,255,0.08)) 1px, transparent 1px) 0 0 / ${BAR_WIDTH}px 100%, var(--color-shell-bg, #1d1d1f)`,
           }}
         >
-          {/* bar ruler */}
           <div className="sticky top-0 z-10 flex h-7 border-b border-shell-border bg-shell-bg-deep">
-            {RULER_BARS.map((b) => (
-              <div
-                key={b}
-                className="flex w-[72px] flex-none items-center border-r border-shell-border pl-[7px] text-[10px] font-bold text-shell-text-tertiary"
-              >
+            {ruler.map((b) => (
+              <div key={b} className="flex flex-none items-center border-r border-shell-border pl-[7px] text-[10px] font-bold text-shell-text-tertiary" style={{ width: BAR_WIDTH }}>
                 {b}
               </div>
             ))}
           </div>
 
-          {/* lanes */}
-          {TRACKS.map((track) => {
-            const clip = CLIPS.find((c) => c.trackId === track.id);
-            return (
-              <div
-                key={track.id}
-                className="relative border-b border-shell-border"
-                style={{ height: "62px" }}
-              >
-                {clip && (
-                  <div
-                    className={`absolute top-[9px] flex items-end overflow-hidden rounded-[8px] border border-white/[0.18] px-[7px] pb-[5px] ${track.id === "drum" ? "outline outline-2 outline-offset-[-1px] outline-white" : ""}`}
-                    style={{
-                      left: `${clip.left}px`,
-                      width: `${clip.width}px`,
-                      height: "44px",
-                      background: TRACK_COLORS[track.color],
-                      opacity: clip.opacity ?? 1,
-                      boxShadow: "0 3px 10px rgba(0,0,0,0.3)",
-                    }}
-                  >
-                    <span className="absolute left-2 top-[5px] text-[9.5px] font-bold text-white/90">
-                      {clip.label}
-                    </span>
-                    <div className="flex h-[18px] w-full items-end gap-[1.5px] opacity-65">
-                      {clip.bars.map((h, idx) => (
-                        <span
-                          key={idx}
-                          className="flex-1 rounded-[1px] bg-white/85"
-                          style={{ height: `${h}%` }}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            );
-          })}
+          {song.tracks.map((track) => (
+            <div
+              key={track.id}
+              className="relative cursor-pointer border-b border-shell-border"
+              style={{ height: "62px", width: totalBars * BAR_WIDTH }}
+              onClick={(e) => {
+                const rect = e.currentTarget.getBoundingClientRect();
+                const bar = Math.floor((e.clientX - rect.left) / BAR_WIDTH);
+                const clip = track.clips.find((c) => bar >= c.startBar && bar < c.startBar + c.lengthBars);
+                handleLaneClick(track.id, bar, clip?.id);
+              }}
+            >
+              {track.clips.map((clip) => (
+                <div
+                  key={clip.id}
+                  className={`absolute top-[9px] flex items-end overflow-hidden rounded-[8px] border border-white/[0.18] px-[7px] pb-[5px] ${clip.id === selectedClip?.id && track.id === selectedTrackId ? "outline outline-2 outline-offset-[-1px] outline-white" : ""}`}
+                  style={{
+                    left: clip.startBar * BAR_WIDTH,
+                    width: clip.lengthBars * BAR_WIDTH,
+                    height: "44px",
+                    background: instrumentColor(track.instrument),
+                    opacity: track.muted ? 0.5 : 1,
+                    boxShadow: "0 3px 10px rgba(0,0,0,0.3)",
+                  }}
+                >
+                  <span className="absolute left-2 top-[5px] text-[9.5px] font-bold text-white/90">
+                    {clip.name}
+                    {track.muted ? " (muted)" : ""}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ))}
 
-          {/* playhead */}
-          <div
-            className="pointer-events-none absolute inset-y-0 z-20 w-[2px]"
-            style={{
-              left: "230px",
-              background: "var(--color-accent-strong, #a9b0c2)",
-              boxShadow: "0 0 8px var(--color-accent-glow, rgba(139,146,163,0.35))",
-            }}
-          >
-            <span
-              className="absolute left-[-4px] top-0 block h-0 w-0 border-[5px] border-transparent"
-              style={{ borderTopColor: "var(--color-accent-strong, #a9b0c2)" }}
-            />
-          </div>
+          {song.tracks.length === 0 && (
+            <div className="flex h-40 items-center justify-center text-[13px] text-shell-text-tertiary">
+              No tracks yet -- add one from the track list.
+            </div>
+          )}
         </div>
 
         {/* right inspector */}
         <div className="flex w-[236px] flex-none flex-col gap-4 overflow-auto border-l border-shell-border p-4">
-          <div className="flex items-center gap-[9px] text-[14px] font-bold tracking-[-0.01em]">
-            <span
-              className="h-[11px] w-[11px] flex-none rounded-[4px]"
-              style={{ background: TRACK_COLORS.drum }}
-            />
-            Drums
-          </div>
-          <p className="mt-[-10px] text-[11px] text-shell-text-tertiary">
-            taOS Drum Kit - Boom Bap
-          </p>
-
-          <div className="grid grid-cols-2 gap-3.5">
-            {KNOBS.map((label) => (
-              <div key={label} className="flex flex-col items-center gap-[7px]">
-                <div className="relative h-[54px] w-[54px] rounded-full border border-shell-border bg-shell-surface">
-                  <span
-                    className="absolute left-1/2 top-[7px] h-[18px] w-[3px] -translate-x-1/2 origin-bottom rounded-[2px] bg-accent"
-                    style={{ transform: "translateX(-50%) rotate(38deg)", transformOrigin: "bottom center" }}
-                  />
-                </div>
-                <span className="text-[10.5px] font-semibold uppercase tracking-[0.04em] text-shell-text-tertiary">
-                  {label}
-                </span>
+          {selectedTrack ? (
+            <>
+              <div className="flex items-center gap-[9px] text-[14px] font-bold tracking-[-0.01em]">
+                <span className="h-[11px] w-[11px] flex-none rounded-[4px]" style={{ background: instrumentColor(selectedTrack.instrument) }} />
+                {selectedTrack.name}
               </div>
-            ))}
-          </div>
 
-          <div className="flex flex-col gap-2">
-            {FX_ROWS.map((fx) => (
-              <div
-                key={fx.label}
-                className="flex items-center gap-2.5 rounded-[11px] border border-shell-border bg-shell-surface px-3 py-2.5"
-              >
-                <span className="text-[12.5px] font-semibold">{fx.label}</span>
-                <div
-                  className="relative ml-auto h-[19px] w-[34px] rounded-full"
-                  style={{ background: fx.on ? "var(--color-accent, #8b92a3)" : "var(--color-shell-surface-active, rgba(255,255,255,0.10))" }}
+              <label className="flex flex-col gap-1.5 text-[11px] text-shell-text-tertiary">
+                Instrument
+                <select
+                  value={selectedTrack.instrument}
+                  onChange={(e) => updateTrack(selectedTrack.id, { instrument: e.target.value })}
+                  className="rounded-lg border border-shell-border bg-shell-surface px-2 py-1.5 text-[12.5px] text-shell-text"
                 >
-                  <span
-                    className="absolute top-[2px] h-[15px] w-[15px] rounded-full bg-white transition-all"
-                    style={{ left: fx.on ? "17px" : "2px" }}
-                  />
-                </div>
-              </div>
-            ))}
-          </div>
+                  {INSTRUMENTS.map((i) => (
+                    <option key={i.id} value={i.id}>
+                      {i.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="flex flex-col gap-1.5 text-[11px] text-shell-text-tertiary">
+                Pan
+                <input
+                  type="range"
+                  min={-1}
+                  max={1}
+                  step={0.05}
+                  value={selectedTrack.pan}
+                  onChange={(e) => updateTrack(selectedTrack.id, { pan: Number(e.target.value) })}
+                />
+              </label>
+
+              <button
+                type="button"
+                onClick={() => removeTrack(selectedTrack.id)}
+                className="mt-auto flex items-center justify-center gap-1.5 rounded-lg border border-shell-border px-3 py-2 text-[12px] font-semibold text-red-400 hover:bg-red-500/10"
+              >
+                <Trash2 size={13} />
+                Remove track
+              </button>
+            </>
+          ) : (
+            <p className="text-[12px] text-shell-text-tertiary">Select a track to edit it.</p>
+          )}
         </div>
       </div>
 
-      {/* piano roll strip */}
-      <div className="flex h-[128px] flex-none border-t border-shell-border bg-shell-bg-deep">
-        {/* key labels */}
-        <div className="flex w-[54px] flex-none flex-col border-r border-shell-border font-mono">
-          {PIANO_KEYS.map((k) => (
-            <div
-              key={k.label}
-              className={`flex flex-1 items-center border-b border-shell-border px-[5px] py-[1px] text-[8px] text-shell-text-tertiary ${k.black ? "bg-black/[0.18]" : ""}`}
-            >
-              {k.label}
-            </div>
-          ))}
-        </div>
-
-        {/* note grid */}
-        <div
-          className="relative flex-1 overflow-hidden"
-          style={{
-            background:
-              "linear-gradient(90deg, var(--color-shell-border, rgba(255,255,255,0.08)) 1px, transparent 1px) 0 0 / 36px 100%, linear-gradient(0deg, var(--color-shell-border, rgba(255,255,255,0.08)) 1px, transparent 1px) 0 0 / 100% 16px",
-          }}
-        >
-          {PIANO_NOTES.map((note, i) => (
-            <span
-              key={i}
-              className="absolute h-[13px] rounded-[3px]"
-              style={{
-                left: `${note.left}px`,
-                top: `${note.top}px`,
-                width: `${note.width}px`,
-                background: TRACK_COLORS.bass,
-                boxShadow: "0 1px 3px rgba(0,0,0,0.4)",
-              }}
-            />
-          ))}
-        </div>
-      </div>
+      {/* bottom editor: piano roll for melodic tracks, step sequencer for drums */}
+      {isDrumTrack ? (
+        <StepSequencer clip={selectedClip} onChangeNotes={handleChangeNotes} />
+      ) : (
+        <PianoRoll clip={selectedClip} onChangeNotes={handleChangeNotes} color={selectedTrack ? instrumentColor(selectedTrack.instrument) : undefined} />
+      )}
     </div>
   );
 }

--- a/desktop/src/apps/musicstudio/audio-engine.test.ts
+++ b/desktop/src/apps/musicstudio/audio-engine.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TICKS_PER_BEAT, TICKS_PER_BAR, createDefaultSong } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  Tone.js and smplr both require a real AudioContext, which jsdom      */
+/*  does not implement -- both modules are mocked here so we can test    */
+/*  the engine's MODEL -> schedule logic (tick math, per-track fan-out,  */
+/*  mixer param plumbing) without touching real audio.                   */
+/* ------------------------------------------------------------------ */
+
+interface ScheduledEvent {
+  time: string;
+  cb: (t: number) => void;
+}
+
+const scheduledEvents: ScheduledEvent[] = [];
+const channelInstances: any[] = [];
+
+vi.mock("tone", () => {
+  class FakeChannel {
+    volume: { value: number };
+    pan: { value: number };
+    mute: boolean;
+    solo: boolean;
+    constructor(opts: { volume?: number; pan?: number; mute?: boolean; solo?: boolean } = {}) {
+      this.volume = { value: opts.volume ?? 0 };
+      this.pan = { value: opts.pan ?? 0 };
+      this.mute = opts.mute ?? false;
+      this.solo = opts.solo ?? false;
+      channelInstances.push(this);
+    }
+    connect() {
+      return this;
+    }
+    toDestination() {
+      return this;
+    }
+    dispose() {}
+  }
+
+  class FakeSynth {
+    constructor(_opts?: unknown) {}
+    connect() {
+      return this;
+    }
+    triggerAttackRelease() {}
+    dispose() {}
+  }
+
+  let idCounter = 0;
+  const transport = {
+    bpm: { value: 120 },
+    position: "0:0:0" as string,
+    state: "stopped" as "stopped" | "started",
+    schedule: vi.fn((cb: (t: number) => void, time: string) => {
+      idCounter += 1;
+      scheduledEvents.push({ time, cb });
+      return idCounter;
+    }),
+    clear: vi.fn(),
+    cancel: vi.fn(),
+    start: vi.fn(function (this: typeof transport) {
+      transport.state = "started";
+    }),
+    stop: vi.fn(function (this: typeof transport) {
+      transport.state = "stopped";
+    }),
+  };
+
+  return {
+    start: vi.fn(async () => {}),
+    now: vi.fn(() => 0),
+    getTransport: () => transport,
+    getContext: () => ({ rawContext: { createGain: () => ({ connect() {}, disconnect() {} }) } }),
+    getDestination: () => ({ volume: { value: 0 } }),
+    connect: vi.fn(),
+    gainToDb: (gain: number) => (gain <= 0 ? -Infinity : 20 * Math.log10(gain)),
+    Midi: (pitch: number) => ({ toFrequency: () => 440 * 2 ** ((pitch - 69) / 12) }),
+    Channel: FakeChannel,
+    MembraneSynth: FakeSynth,
+    NoiseSynth: FakeSynth,
+    MonoSynth: FakeSynth,
+    PolySynth: FakeSynth,
+    AMSynth: FakeSynth,
+    Synth: FakeSynth,
+  };
+});
+
+vi.mock("smplr", () => ({
+  SplendidGrandPiano: () => ({ ready: Promise.resolve(), start: vi.fn(), dispose: vi.fn() }),
+  Soundfont: () => ({ ready: Promise.resolve(), start: vi.fn(), dispose: vi.fn() }),
+}));
+
+import { AudioEngine, ticksToTransportPosition, volumeToDb } from "./audio-engine";
+import * as Tone from "tone";
+
+beforeEach(() => {
+  scheduledEvents.length = 0;
+  channelInstances.length = 0;
+});
+
+describe("ticksToTransportPosition", () => {
+  it("converts tick 0 to the start of bar 0", () => {
+    expect(ticksToTransportPosition(0)).toBe("0:0:0");
+  });
+
+  it("converts one beat to beat 1 of bar 0", () => {
+    expect(ticksToTransportPosition(TICKS_PER_BEAT)).toBe("0:1:0");
+  });
+
+  it("converts one bar to bar 1", () => {
+    expect(ticksToTransportPosition(TICKS_PER_BAR)).toBe("1:0:0");
+  });
+
+  it("converts a sixteenth note to the sixteenth column", () => {
+    expect(ticksToTransportPosition(TICKS_PER_BEAT / 4)).toBe("0:0:1");
+  });
+});
+
+describe("volumeToDb", () => {
+  it("maps 100 (full volume) to 0dB", () => {
+    expect(volumeToDb(100)).toBeCloseTo(0, 5);
+  });
+
+  it("maps 0 to a very low (but finite) dB floor rather than -Infinity", () => {
+    expect(volumeToDb(0)).toBeLessThan(-60);
+    expect(Number.isFinite(volumeToDb(0))).toBe(true);
+  });
+
+  it("clamps out-of-range input", () => {
+    expect(volumeToDb(1000)).toBeCloseTo(volumeToDb(100), 5);
+  });
+});
+
+describe("AudioEngine.loadSong", () => {
+  it("sets the transport tempo from the song", () => {
+    const engine = new AudioEngine();
+    const song = createDefaultSong();
+    song.tempo = 140;
+    engine.loadSong(song);
+    expect(Tone.getTransport().bpm.value).toBe(140);
+  });
+
+  it("schedules exactly one transport event per note across all tracks", () => {
+    const engine = new AudioEngine();
+    const song = createDefaultSong();
+    const totalNotes = song.tracks.flatMap((t) => t.clips).flatMap((c) => c.notes).length;
+    engine.loadSong(song);
+    expect(scheduledEvents.length).toBe(totalNotes);
+  });
+
+  it("builds one Channel per track with its initial volume/pan/mute", () => {
+    const engine = new AudioEngine();
+    const song = createDefaultSong();
+    engine.loadSong(song);
+    expect(channelInstances.length).toBe(song.tracks.length);
+    const drumChannel = channelInstances[0];
+    expect(drumChannel.volume.value).toBeCloseTo(volumeToDb(song.tracks[0].volume), 5);
+  });
+
+  it("rebuilding for a new song clears the previous schedule", () => {
+    const engine = new AudioEngine();
+    engine.loadSong(createDefaultSong());
+    const firstCount = scheduledEvents.length;
+    expect(firstCount).toBeGreaterThan(0);
+    engine.loadSong(createDefaultSong());
+    // cancel() should have been invoked to drop the old schedule before rebuilding
+    expect(Tone.getTransport().cancel).toHaveBeenCalled();
+  });
+});
+
+describe("AudioEngine.setTrackParam", () => {
+  it("updates the live channel without rebuilding the schedule", () => {
+    const engine = new AudioEngine();
+    const song = createDefaultSong();
+    engine.loadSong(song);
+    scheduledEvents.length = 0;
+
+    const trackId = song.tracks[0].id;
+    engine.setTrackParam(trackId, { volume: 10, pan: 0.5, muted: true, soloed: true });
+
+    const channel = channelInstances[0];
+    expect(channel.volume.value).toBeCloseTo(volumeToDb(10), 5);
+    expect(channel.pan.value).toBe(0.5);
+    expect(channel.mute).toBe(true);
+    expect(channel.solo).toBe(true);
+    // no new notes scheduled just from a mixer tweak
+    expect(scheduledEvents.length).toBe(0);
+  });
+
+  it("is a no-op for an unknown track id", () => {
+    const engine = new AudioEngine();
+    engine.loadSong(createDefaultSong());
+    expect(() => engine.setTrackParam("does-not-exist", { volume: 50 })).not.toThrow();
+  });
+});
+
+describe("AudioEngine transport controls", () => {
+  it("play() starts the AudioContext and the transport", async () => {
+    const engine = new AudioEngine();
+    engine.loadSong(createDefaultSong());
+    await engine.play();
+    expect(Tone.start).toHaveBeenCalled();
+    expect(Tone.getTransport().start).toHaveBeenCalled();
+  });
+
+  it("stop() stops the transport and resets position", () => {
+    const engine = new AudioEngine();
+    engine.loadSong(createDefaultSong());
+    engine.stop();
+    expect(Tone.getTransport().stop).toHaveBeenCalled();
+    expect(Tone.getTransport().position).toBe(0);
+  });
+
+  it("getPositionLabel formats bar:beat:sixteenth as a 1-indexed label", () => {
+    const engine = new AudioEngine();
+    Tone.getTransport().position = "2:1:3";
+    expect(engine.getPositionLabel()).toBe("003.2.4");
+  });
+});

--- a/desktop/src/apps/musicstudio/audio-engine.test.ts
+++ b/desktop/src/apps/musicstudio/audio-engine.test.ts
@@ -22,6 +22,7 @@ vi.mock("tone", () => {
     pan: { value: number };
     mute: boolean;
     solo: boolean;
+    disposed = false;
     constructor(opts: { volume?: number; pan?: number; mute?: boolean; solo?: boolean } = {}) {
       this.volume = { value: opts.volume ?? 0 };
       this.pan = { value: opts.pan ?? 0 };
@@ -35,7 +36,9 @@ vi.mock("tone", () => {
     toDestination() {
       return this;
     }
-    dispose() {}
+    dispose() {
+      this.disposed = true;
+    }
   }
 
   class FakeSynth {
@@ -67,12 +70,14 @@ vi.mock("tone", () => {
     }),
   };
 
+  const destination = { volume: { value: 0 } };
+
   return {
     start: vi.fn(async () => {}),
     now: vi.fn(() => 0),
     getTransport: () => transport,
     getContext: () => ({ rawContext: { createGain: () => ({ connect() {}, disconnect() {} }) } }),
-    getDestination: () => ({ volume: { value: 0 } }),
+    getDestination: () => destination,
     connect: vi.fn(),
     gainToDb: (gain: number) => (gain <= 0 ? -Infinity : 20 * Math.log10(gain)),
     Midi: (pitch: number) => ({ toFrequency: () => 440 * 2 ** ((pitch - 69) / 12) }),
@@ -216,5 +221,75 @@ describe("AudioEngine transport controls", () => {
     const engine = new AudioEngine();
     Tone.getTransport().position = "2:1:3";
     expect(engine.getPositionLabel()).toBe("003.2.4");
+  });
+
+  it("getPositionLabel returns the reset label when the transport reads a bare number (stopped)", () => {
+    const engine = new AudioEngine();
+    // After stop() Tone can report `position` as bare seconds (no colons);
+    // that must not be parsed as bar:beat:sixteenth.
+    (Tone.getTransport() as unknown as { position: string | number }).position = 12.5;
+    expect(engine.getPositionLabel()).toBe("001.1.1");
+  });
+});
+
+describe("AudioEngine.rescheduleTrack (incremental note edits)", () => {
+  it("reschedules a single track WITHOUT stopping the transport or rebuilding instruments", () => {
+    const engine = new AudioEngine();
+    const song = createDefaultSong();
+    engine.loadSong(song);
+
+    const channelsAfterLoad = channelInstances.length;
+    (Tone.getTransport().stop as ReturnType<typeof vi.fn>).mockClear();
+    scheduledEvents.length = 0;
+
+    // Edit the bass track's notes (add one) and reschedule just that track.
+    const bass = { ...song.tracks[1] };
+    bass.clips = bass.clips.map((c) => ({
+      ...c,
+      notes: [...c.notes, { id: "extra", pitch: 40, startTick: 0, durationTicks: 120, velocity: 0.8 }],
+    }));
+
+    engine.rescheduleTrack(bass);
+
+    // Transport was NOT stopped and no new Channel/instrument was created.
+    expect(Tone.getTransport().stop).not.toHaveBeenCalled();
+    expect(channelInstances.length).toBe(channelsAfterLoad);
+    // The track's notes were re-scheduled (its old events cleared, new ones added).
+    expect(Tone.getTransport().clear).toHaveBeenCalled();
+    expect(scheduledEvents.length).toBe(bass.clips.reduce((n, c) => n + c.notes.length, 0));
+  });
+
+  it("is a no-op for a track the engine has no nodes for", () => {
+    const engine = new AudioEngine();
+    engine.loadSong(createDefaultSong());
+    expect(engine.hasTrack("ghost")).toBe(false);
+    expect(() =>
+      engine.rescheduleTrack({ id: "ghost", name: "x", instrument: "synth-keys", clips: [], volume: 70, pan: 0, muted: false, soloed: false }),
+    ).not.toThrow();
+  });
+});
+
+describe("AudioEngine.setMasterVolume", () => {
+  it("re-applies the stored master volume after a loadSong() rebuild", () => {
+    const engine = new AudioEngine();
+    engine.loadSong(createDefaultSong());
+    engine.setMasterVolume(30);
+    expect(Tone.getDestination().volume.value).toBeCloseTo(volumeToDb(30), 5);
+
+    // Switching songs rebuilds the graph; the master fader must not reset.
+    engine.loadSong(createDefaultSong());
+    expect(Tone.getDestination().volume.value).toBeCloseTo(volumeToDb(30), 5);
+  });
+});
+
+describe("AudioEngine.previewInstrument", () => {
+  it("disposes the previous preview before starting a new one (no leak)", async () => {
+    const engine = new AudioEngine();
+    await engine.previewInstrument("synth-lead");
+    const firstPreviewChannel = channelInstances[channelInstances.length - 1];
+    expect(firstPreviewChannel.disposed).toBe(false);
+
+    await engine.previewInstrument("synth-keys");
+    expect(firstPreviewChannel.disposed).toBe(true);
   });
 });

--- a/desktop/src/apps/musicstudio/audio-engine.ts
+++ b/desktop/src/apps/musicstudio/audio-engine.ts
@@ -160,6 +160,13 @@ function buildInstrument(instrumentId: string, channel: Tone.Channel): Instrumen
 export class AudioEngine {
   private started = false;
   private tracks = new Map<string, TrackNodes>();
+  /** Stored so it survives a full `loadSong()` rebuild (which recreates every
+   *  track Channel and would otherwise leave the shared Destination at its
+   *  previous, possibly default, level). */
+  private masterVolume = 80;
+  /** The single in-flight Sounds-library preview, so a rapid second click
+   *  can dispose the first's nodes and cancel its cleanup timer. */
+  private preview: { instrument: InstrumentHandle; channel: Tone.Channel; timeout: ReturnType<typeof setTimeout> } | null = null;
 
   /** Must be called from a user gesture handler (browser autoplay policy). */
   async ensureStarted(): Promise<void> {
@@ -178,20 +185,27 @@ export class AudioEngine {
     for (const track of song.tracks) {
       this.buildTrack(track);
     }
+    // The Destination is shared and untouched by teardown, but re-apply the
+    // stored master level anyway so a load never silently resets the fader.
+    Tone.getDestination().volume.value = volumeToDb(this.masterVolume);
   }
 
-  private buildTrack(track: Track): void {
-    const channel = new Tone.Channel({
-      volume: volumeToDb(track.volume),
-      pan: track.pan,
-      mute: track.muted,
-      solo: track.soloed,
-    }).toDestination();
+  /** Re-schedule one track's notes in place, WITHOUT stopping the transport or
+   *  re-instantiating its instrument/channel. This is the hot path for note
+   *  edits: editing a note during playback keeps playing and never re-fetches
+   *  smplr samples. No-op (falls back to a rebuild caller-side) if the track
+   *  has no engine nodes yet. */
+  rescheduleTrack(track: Track): void {
+    const nodes = this.tracks.get(track.id);
+    if (!nodes) return;
+    const transport = Tone.getTransport();
+    for (const id of nodes.eventIds) transport.clear(id);
+    nodes.eventIds = this.scheduleTrackNotes(track, nodes.instrument);
+  }
 
-    const instrument = buildInstrument(track.instrument, channel);
+  private scheduleTrackNotes(track: Track, instrument: InstrumentHandle): number[] {
     const eventIds: number[] = [];
     const transport = Tone.getTransport();
-
     for (const clip of track.clips) {
       for (const note of clip.notes) {
         const absoluteTicks = clip.startBar * BEATS_PER_BAR * TICKS_PER_BEAT + note.startTick;
@@ -204,7 +218,25 @@ export class AudioEngine {
         eventIds.push(eventId);
       }
     }
+    return eventIds;
+  }
 
+  /** True when the engine already has nodes for this track (so a note edit can
+   *  go through the incremental `rescheduleTrack` path). */
+  hasTrack(trackId: string): boolean {
+    return this.tracks.has(trackId);
+  }
+
+  private buildTrack(track: Track): void {
+    const channel = new Tone.Channel({
+      volume: volumeToDb(track.volume),
+      pan: track.pan,
+      mute: track.muted,
+      solo: track.soloed,
+    }).toDestination();
+
+    const instrument = buildInstrument(track.instrument, channel);
+    const eventIds = this.scheduleTrackNotes(track, instrument);
     this.tracks.set(track.id, { channel, instrument, eventIds });
   }
 
@@ -233,9 +265,11 @@ export class AudioEngine {
 
   /** "bar.beat.sixteenth", 1-indexed, e.g. "003.2.1" -- matches the original
    *  transport readout. Parsed from Tone.Transport's "bar:beat:sixteenth"
-   *  position string. */
+   *  position string. When stopped, `position` can read back as a bare number
+   *  (seconds) with no colons -- guard that so we don't render it as bar 1e6. */
   getPositionLabel(): string {
     const raw = String(Tone.getTransport().position);
+    if (!raw.includes(":")) return "001.1.1";
     const [barStr = "0", beatStr = "0", sixteenthStr = "0"] = raw.split(":");
     const bar = Math.trunc(Number(barStr)) + 1;
     const beat = Math.trunc(Number(beatStr)) + 1;
@@ -257,28 +291,44 @@ export class AudioEngine {
   }
 
   /** 0-100, applied to Tone's shared Destination (every track's Channel
-   *  feeds into it via `.toDestination()`). */
+   *  feeds into it via `.toDestination()`). Stored so `loadSong()` can
+   *  re-apply it after rebuilding the graph. */
   setMasterVolume(volume: number): void {
+    this.masterVolume = volume;
     Tone.getDestination().volume.value = volumeToDb(volume);
   }
 
+  private disposePreview(): void {
+    if (!this.preview) return;
+    clearTimeout(this.preview.timeout);
+    this.preview.instrument.dispose();
+    this.preview.channel.dispose();
+    this.preview = null;
+  }
+
   /** Preview a single note on an instrument without touching the loaded
-   *  song's schedule -- used by the Sounds library. */
+   *  song's schedule -- used by the Sounds library. A second click disposes
+   *  the previous preview (and cancels its cleanup timer) before starting the
+   *  next, so rapid clicks can't leak channels or cut off the newest note. */
   async previewInstrument(instrumentId: string, pitch = 60): Promise<void> {
     await this.ensureStarted();
+    this.disposePreview();
     const channel = new Tone.Channel({ volume: volumeToDb(80) }).toDestination();
     const instrument = buildInstrument(instrumentId, channel);
     const now = Tone.now();
     instrument.trigger(pitch, 0.7, now, 0.85);
-    setTimeout(() => {
+    const timeout = setTimeout(() => {
       instrument.dispose();
       channel.dispose();
+      this.preview = null;
     }, 1500);
+    this.preview = { instrument, channel, timeout };
   }
 
   dispose(): void {
     Tone.getTransport().stop();
     Tone.getTransport().cancel(0);
+    this.disposePreview();
     this.teardownTracks();
   }
 }

--- a/desktop/src/apps/musicstudio/audio-engine.ts
+++ b/desktop/src/apps/musicstudio/audio-engine.ts
@@ -1,0 +1,284 @@
+/* ------------------------------------------------------------------ */
+/*  Music Studio -- audio engine                                       */
+/*                                                                     */
+/*  A thin wrapper around Tone.js. One Tone.Channel per track owns      */
+/*  volume/pan/mute/solo; every clip's notes are scheduled on            */
+/*  Tone.Transport so tempo changes retime already-scheduled notes       */
+/*  automatically (bar:beat:sixteenth position strings, not raw          */
+/*  seconds). Instruments are either Tone.js synths (fully offline) or   */
+/*  smplr sampled instruments (fetch samples from smplr's CDN on first   */
+/*  use -- see instruments.ts).                                         */
+/*                                                                     */
+/*  Browser autoplay policy: the AudioContext must be started from a     */
+/*  user gesture, so `ensureStarted()` is called lazily on the first     */
+/*  `play()` rather than at construction time.                          */
+/* ------------------------------------------------------------------ */
+
+import * as Tone from "tone";
+import { SplendidGrandPiano, Soundfont } from "smplr";
+import { findInstrument } from "./instruments";
+import { BEATS_PER_BAR, TICKS_PER_BEAT, type Song, type Track } from "./types";
+
+type TriggerFn = (pitch: number, durationSeconds: number, time: number, velocity: number) => void;
+
+interface InstrumentHandle {
+  trigger: TriggerFn;
+  dispose: () => void;
+}
+
+interface TrackNodes {
+  channel: Tone.Channel;
+  instrument: InstrumentHandle;
+  eventIds: number[];
+}
+
+/** 0-100 (mixer-style, like the existing UI's volume bars) -> decibels. */
+export function volumeToDb(volume: number): number {
+  const gain = Math.max(0, Math.min(100, volume)) / 100;
+  return Tone.gainToDb(Math.max(gain, 0.0001));
+}
+
+/** Convert an absolute tick count (from the start of the song) into a Tone
+ *  "bar:beat:sixteenth" transport position string. All 0-indexed, matching
+ *  Tone.Transport's own position notation. */
+export function ticksToTransportPosition(absoluteTicks: number): string {
+  const ticksPerSixteenth = TICKS_PER_BEAT / 4;
+  const totalSixteenths = absoluteTicks / ticksPerSixteenth;
+  const totalBeats = Math.floor(totalSixteenths / 4);
+  const bar = Math.floor(totalBeats / BEATS_PER_BAR);
+  const beat = totalBeats - bar * BEATS_PER_BAR;
+  const sixteenth = totalSixteenths - totalBeats * 4;
+  return `${bar}:${beat}:${sixteenth}`;
+}
+
+function toneTrigger(synth: { triggerAttackRelease: (...args: any[]) => unknown; dispose: () => void }): InstrumentHandle {
+  return {
+    trigger: (pitch, duration, time, velocity) => {
+      synth.triggerAttackRelease(Tone.Midi(pitch).toFrequency(), duration, time, velocity);
+    },
+    dispose: () => synth.dispose(),
+  };
+}
+
+/** Build a fully-offline Tone.js synth instrument, connected to `channel`. */
+function buildSynthInstrument(instrumentId: string, channel: Tone.Channel): InstrumentHandle {
+  switch (instrumentId) {
+    case "drum-kit": {
+      const kick = new Tone.MembraneSynth().connect(channel);
+      const snare = new Tone.NoiseSynth({
+        noise: { type: "white" },
+        envelope: { attack: 0.001, decay: 0.15, sustain: 0 },
+      }).connect(channel);
+      const hat = new Tone.NoiseSynth({
+        noise: { type: "white" },
+        envelope: { attack: 0.001, decay: 0.04, sustain: 0 },
+      }).connect(channel);
+      return {
+        trigger: (pitch, duration, time, velocity) => {
+          if (pitch <= 40) kick.triggerAttackRelease("C1", duration, time, velocity);
+          else if (pitch === 41) snare.triggerAttackRelease(duration, time, velocity);
+          else hat.triggerAttackRelease(duration, time, velocity);
+        },
+        dispose: () => {
+          kick.dispose();
+          snare.dispose();
+          hat.dispose();
+        },
+      };
+    }
+    case "synth-bass": {
+      const synth = new Tone.MonoSynth({
+        oscillator: { type: "sawtooth" },
+        envelope: { attack: 0.02, decay: 0.2, sustain: 0.4, release: 0.3 },
+        filterEnvelope: { baseFrequency: 200, octaves: 2, attack: 0.02, decay: 0.2, sustain: 0.4, release: 0.3 },
+      }).connect(channel);
+      return toneTrigger(synth);
+    }
+    case "synth-pad": {
+      const synth = new Tone.PolySynth(Tone.AMSynth, {
+        envelope: { attack: 0.6, decay: 0.4, sustain: 0.8, release: 1.5 },
+      }).connect(channel);
+      return toneTrigger(synth);
+    }
+    case "synth-lead": {
+      const synth = new Tone.Synth({
+        oscillator: { type: "sawtooth" },
+        envelope: { attack: 0.01, decay: 0.1, sustain: 0.6, release: 0.2 },
+      }).connect(channel);
+      return toneTrigger(synth);
+    }
+    case "synth-fx": {
+      const synth = new Tone.NoiseSynth({
+        noise: { type: "pink" },
+        envelope: { attack: 0.01, decay: 0.5, sustain: 0 },
+      }).connect(channel);
+      return {
+        trigger: (_pitch, duration, time, velocity) => synth.triggerAttackRelease(duration, time, velocity),
+        dispose: () => synth.dispose(),
+      };
+    }
+    case "synth-keys":
+    default: {
+      const synth = new Tone.PolySynth(Tone.Synth, {
+        oscillator: { type: "triangle" },
+        envelope: { attack: 0.01, decay: 0.3, sustain: 0.2, release: 0.6 },
+      }).connect(channel);
+      return toneTrigger(synth);
+    }
+  }
+}
+
+/** Build an smplr sampled instrument, bridged into `channel` via a plain
+ *  native GainNode (smplr instruments take a native `destination` AudioNode;
+ *  `Tone.connect` accepts native nodes as either side of the connection). */
+function buildSampledInstrument(instrumentId: string, channel: Tone.Channel): InstrumentHandle {
+  const context = Tone.getContext().rawContext as unknown as AudioContext;
+  const bridge = context.createGain();
+  Tone.connect(bridge, channel);
+
+  const inst =
+    instrumentId === "sampled-bass"
+      ? Soundfont(context, { instrument: "electric_bass_finger", destination: bridge })
+      : SplendidGrandPiano(context, { destination: bridge });
+
+  return {
+    trigger: (pitch, duration, time, velocity) => {
+      inst.start({ note: pitch, time, duration, velocity: Math.round(Math.max(0, Math.min(1, velocity)) * 127) });
+    },
+    dispose: () => {
+      inst.dispose();
+      bridge.disconnect();
+    },
+  };
+}
+
+function buildInstrument(instrumentId: string, channel: Tone.Channel): InstrumentHandle {
+  const def = findInstrument(instrumentId);
+  return def.kind === "sampled" ? buildSampledInstrument(def.id, channel) : buildSynthInstrument(def.id, channel);
+}
+
+export class AudioEngine {
+  private started = false;
+  private tracks = new Map<string, TrackNodes>();
+
+  /** Must be called from a user gesture handler (browser autoplay policy). */
+  async ensureStarted(): Promise<void> {
+    if (this.started) return;
+    await Tone.start();
+    this.started = true;
+  }
+
+  /** Tear down any existing tracks and rebuild the engine graph for `song`. */
+  loadSong(song: Song): void {
+    Tone.getTransport().stop();
+    Tone.getTransport().cancel(0);
+    this.teardownTracks();
+
+    Tone.getTransport().bpm.value = song.tempo;
+    for (const track of song.tracks) {
+      this.buildTrack(track);
+    }
+  }
+
+  private buildTrack(track: Track): void {
+    const channel = new Tone.Channel({
+      volume: volumeToDb(track.volume),
+      pan: track.pan,
+      mute: track.muted,
+      solo: track.soloed,
+    }).toDestination();
+
+    const instrument = buildInstrument(track.instrument, channel);
+    const eventIds: number[] = [];
+    const transport = Tone.getTransport();
+
+    for (const clip of track.clips) {
+      for (const note of clip.notes) {
+        const absoluteTicks = clip.startBar * BEATS_PER_BAR * TICKS_PER_BEAT + note.startTick;
+        const position = ticksToTransportPosition(absoluteTicks);
+        const eventId = transport.schedule((time) => {
+          const bpm = transport.bpm.value;
+          const durationSeconds = (note.durationTicks / TICKS_PER_BEAT) * (60 / bpm);
+          instrument.trigger(note.pitch, durationSeconds, time, note.velocity);
+        }, position);
+        eventIds.push(eventId);
+      }
+    }
+
+    this.tracks.set(track.id, { channel, instrument, eventIds });
+  }
+
+  private teardownTracks(): void {
+    for (const nodes of this.tracks.values()) {
+      for (const id of nodes.eventIds) Tone.getTransport().clear(id);
+      nodes.instrument.dispose();
+      nodes.channel.dispose();
+    }
+    this.tracks.clear();
+  }
+
+  async play(): Promise<void> {
+    await this.ensureStarted();
+    Tone.getTransport().start();
+  }
+
+  stop(): void {
+    Tone.getTransport().stop();
+    Tone.getTransport().position = 0;
+  }
+
+  isPlaying(): boolean {
+    return Tone.getTransport().state === "started";
+  }
+
+  /** "bar.beat.sixteenth", 1-indexed, e.g. "003.2.1" -- matches the original
+   *  transport readout. Parsed from Tone.Transport's "bar:beat:sixteenth"
+   *  position string. */
+  getPositionLabel(): string {
+    const raw = String(Tone.getTransport().position);
+    const [barStr = "0", beatStr = "0", sixteenthStr = "0"] = raw.split(":");
+    const bar = Math.trunc(Number(barStr)) + 1;
+    const beat = Math.trunc(Number(beatStr)) + 1;
+    const sixteenth = Math.trunc(Number(sixteenthStr)) + 1;
+    return `${String(bar).padStart(3, "0")}.${beat}.${sixteenth}`;
+  }
+
+  setTempo(bpm: number): void {
+    Tone.getTransport().bpm.value = bpm;
+  }
+
+  setTrackParam(trackId: string, params: Partial<{ volume: number; pan: number; muted: boolean; soloed: boolean }>): void {
+    const nodes = this.tracks.get(trackId);
+    if (!nodes) return;
+    if (params.volume !== undefined) nodes.channel.volume.value = volumeToDb(params.volume);
+    if (params.pan !== undefined) nodes.channel.pan.value = params.pan;
+    if (params.muted !== undefined) nodes.channel.mute = params.muted;
+    if (params.soloed !== undefined) nodes.channel.solo = params.soloed;
+  }
+
+  /** 0-100, applied to Tone's shared Destination (every track's Channel
+   *  feeds into it via `.toDestination()`). */
+  setMasterVolume(volume: number): void {
+    Tone.getDestination().volume.value = volumeToDb(volume);
+  }
+
+  /** Preview a single note on an instrument without touching the loaded
+   *  song's schedule -- used by the Sounds library. */
+  async previewInstrument(instrumentId: string, pitch = 60): Promise<void> {
+    await this.ensureStarted();
+    const channel = new Tone.Channel({ volume: volumeToDb(80) }).toDestination();
+    const instrument = buildInstrument(instrumentId, channel);
+    const now = Tone.now();
+    instrument.trigger(pitch, 0.7, now, 0.85);
+    setTimeout(() => {
+      instrument.dispose();
+      channel.dispose();
+    }, 1500);
+  }
+
+  dispose(): void {
+    Tone.getTransport().stop();
+    Tone.getTransport().cancel(0);
+    this.teardownTracks();
+  }
+}

--- a/desktop/src/apps/musicstudio/instruments.ts
+++ b/desktop/src/apps/musicstudio/instruments.ts
@@ -1,0 +1,52 @@
+/* ------------------------------------------------------------------ */
+/*  Music Studio -- instrument catalog                                 */
+/*                                                                     */
+/*  Two kinds of instrument, both driven through the same per-track     */
+/*  Tone.Channel (see audio-engine.ts):                                 */
+/*   - "synth": built from Tone.js oscillator synths, fully offline.    */
+/*   - "sampled": built from smplr (soundfont/sample players). These     */
+/*     fetch sample audio from smplr's public CDN on first use, so they  */
+/*     are NOT offline -- see the Phase 1 deviation note in the PR.      */
+/* ------------------------------------------------------------------ */
+
+import type { InstrumentId } from "./types";
+
+export type InstrumentKind = "synth" | "sampled";
+export type InstrumentCategory = "Drums" | "Bass" | "Keys" | "Synths" | "FX";
+
+export interface InstrumentDef {
+  id: string;
+  name: string;
+  category: InstrumentCategory;
+  kind: InstrumentKind;
+  detail: string;
+}
+
+export const INSTRUMENTS: InstrumentDef[] = [
+  { id: "drum-kit", name: "Boom Bap Kit", category: "Drums", kind: "synth", detail: "24 hits" },
+  { id: "synth-bass", name: "Analog Bass", category: "Bass", kind: "synth", detail: "synth" },
+  { id: "sampled-piano", name: "Rhodes Mk I", category: "Keys", kind: "sampled", detail: "electric piano" },
+  { id: "synth-pad", name: "Warm Pad", category: "Synths", kind: "synth", detail: "ambient" },
+  { id: "synth-lead", name: "Pluck Lead", category: "Synths", kind: "synth", detail: "mono" },
+  { id: "synth-fx", name: "Vinyl FX", category: "FX", kind: "synth", detail: "texture" },
+  { id: "sampled-bass", name: "Sub 808", category: "Bass", kind: "sampled", detail: "808" },
+  { id: "synth-keys", name: "Felt Piano", category: "Keys", kind: "synth", detail: "acoustic" },
+];
+
+export function findInstrument(id: InstrumentId): InstrumentDef {
+  return INSTRUMENTS.find((i) => i.id === id) ?? INSTRUMENTS[0]!;
+}
+
+/** Muted per-category colors -- content, not chrome (same palette as the
+ *  original static mock's TRACK_COLORS). */
+export const CATEGORY_COLORS: Record<InstrumentCategory, string> = {
+  Drums: "var(--ms-tk-drum, #c98b6b)",
+  Bass: "var(--ms-tk-bass, #6f8aa8)",
+  Keys: "var(--ms-tk-keys, #7faa90)",
+  Synths: "var(--ms-tk-pad, #9a87b0)",
+  FX: "var(--ms-tk-lead, #c0a86a)",
+};
+
+export function instrumentColor(instrumentId: InstrumentId): string {
+  return CATEGORY_COLORS[findInstrument(instrumentId).category];
+}

--- a/desktop/src/apps/musicstudio/midi-export.test.ts
+++ b/desktop/src/apps/musicstudio/midi-export.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { Midi } from "@tonejs/midi";
+import { songToMidiBytes } from "./midi-export";
+import { createDefaultSong } from "./types";
+
+describe("songToMidiBytes", () => {
+  it("round-trips tempo, track count and note positions through @tonejs/midi", () => {
+    const song = createDefaultSong();
+    const bytes = songToMidiBytes(song);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
+
+    const parsed = new Midi(bytes);
+    expect(Math.round(parsed.header.tempos[0].bpm)).toBe(song.tempo);
+    expect(parsed.tracks).toHaveLength(song.tracks.length);
+    expect(parsed.tracks[0].name).toBe(song.tracks[0].name);
+
+    const totalNotes = song.tracks.flatMap((t) => t.clips).flatMap((c) => c.notes).length;
+    const parsedNotes = parsed.tracks.flatMap((t) => t.notes).length;
+    expect(parsedNotes).toBe(totalNotes);
+
+    // Bass track's first note starts at bar 0, tick 0.
+    const bassTrack = parsed.tracks.find((t) => t.name === "Bass")!;
+    expect(bassTrack.notes[0].ticks).toBe(0);
+    expect(bassTrack.notes[0].midi).toBe(33);
+  });
+
+  it("offsets note ticks by the clip's startBar", () => {
+    const song = createDefaultSong();
+    // Move the lead clip to bar 2 and verify the exported ticks shift accordingly.
+    const leadTrack = song.tracks.find((t) => t.name === "Lead")!;
+    leadTrack.clips[0].startBar = 2;
+
+    const bytes = songToMidiBytes(song);
+    const parsed = new Midi(bytes);
+    const leadOut = parsed.tracks.find((t) => t.name === "Lead")!;
+    // bar 2 * 4 beats/bar * 480 ticks/beat = 3840 ticks offset
+    expect(leadOut.notes[0].ticks).toBe(3840);
+  });
+});

--- a/desktop/src/apps/musicstudio/midi-export.ts
+++ b/desktop/src/apps/musicstudio/midi-export.ts
@@ -1,0 +1,45 @@
+import { Midi } from "@tonejs/midi";
+import { BEATS_PER_BAR, TICKS_PER_BEAT, type Song } from "./types";
+import { slugify } from "./songs-api";
+
+/* ------------------------------------------------------------------ */
+/*  Standard MIDI file export. @tonejs/midi's default header uses 480    */
+/*  ticks per quarter note -- the same as our own TICKS_PER_BEAT -- so    */
+/*  clip/note ticks translate directly with no conversion.               */
+/* ------------------------------------------------------------------ */
+
+export function songToMidiBytes(song: Song): Uint8Array {
+  const midi = new Midi();
+  midi.header.setTempo(song.tempo);
+
+  for (const track of song.tracks) {
+    const midiTrack = midi.addTrack();
+    midiTrack.name = track.name;
+    for (const clip of track.clips) {
+      const clipStartTicks = clip.startBar * BEATS_PER_BAR * TICKS_PER_BEAT;
+      for (const note of clip.notes) {
+        midiTrack.addNote({
+          midi: note.pitch,
+          ticks: clipStartTicks + note.startTick,
+          durationTicks: Math.max(1, note.durationTicks),
+          velocity: Math.max(0, Math.min(1, note.velocity)),
+        });
+      }
+    }
+  }
+
+  return midi.toArray();
+}
+
+export function exportSongMidiFile(song: Song): void {
+  const bytes = songToMidiBytes(song);
+  // Uint8Array's `buffer` is typed as ArrayBufferLike (may include
+  // SharedArrayBuffer) under the current DOM lib, which BlobPart rejects.
+  const blob = new Blob([bytes as unknown as BlobPart], { type: "audio/midi" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${slugify(song.name)}.mid`;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/desktop/src/apps/musicstudio/songs-api.test.ts
+++ b/desktop/src/apps/musicstudio/songs-api.test.ts
@@ -43,6 +43,28 @@ describe("songs-api", () => {
     expect(song).toEqual({ id: "song-1", name: "A", tempo: 100, key: "C maj", timeSig: "4/4", tracks: [] });
   });
 
+  it("getSong surfaces a friendly error (not a raw SyntaxError) when content is corrupt", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({ id: "song-1", name: "Broken", content: "{not valid json", created_at: 1, updated_at: 2 }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getSong("song-1")).rejects.toThrow(/couldn't load/i);
+  });
+
+  it("saveSong rejects an over-cap song before hitting the network", async () => {
+    const song = createDefaultSong();
+    // A single note whose JSON blows past the 5 MB content cap.
+    song.tracks[0].clips[0].notes[0].id = "x".repeat(6 * 1024 * 1024);
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({})));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(saveSong(song)).rejects.toThrow(/too large/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("saveSong POSTs a not-yet-persisted (local-) song and returns the server id", async () => {
     const song = createDefaultSong();
     const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {

--- a/desktop/src/apps/musicstudio/songs-api.test.ts
+++ b/desktop/src/apps/musicstudio/songs-api.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { deleteSong, getSong, listSongs, renameSong, saveSong, slugify } from "./songs-api";
+import { createDefaultSong } from "./types";
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 400): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe("songs-api", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("listSongs GETs /api/songs and returns the array", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse([{ id: "song-1", name: "A", created_at: 1, updated_at: 2 }])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const songs = await listSongs();
+    expect(fetchMock).toHaveBeenCalledWith("/api/songs");
+    expect(songs).toEqual([{ id: "song-1", name: "A", created_at: 1, updated_at: 2 }]);
+  });
+
+  it("getSong GETs the record and reconstructs a Song from its JSON content", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({
+          id: "song-1",
+          name: "A",
+          content: JSON.stringify({ tempo: 100, key: "C maj", timeSig: "4/4", tracks: [] }),
+          created_at: 1,
+          updated_at: 2,
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const song = await getSong("song-1");
+    expect(fetchMock).toHaveBeenCalledWith("/api/songs/song-1");
+    expect(song).toEqual({ id: "song-1", name: "A", tempo: 100, key: "C maj", timeSig: "4/4", tracks: [] });
+  });
+
+  it("saveSong POSTs a not-yet-persisted (local-) song and returns the server id", async () => {
+    const song = createDefaultSong();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe("/api/songs");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(String(init?.body));
+      expect(body.name).toBe(song.name);
+      const content = JSON.parse(body.content);
+      expect(content.tempo).toBe(song.tempo);
+      expect(content.tracks).toHaveLength(song.tracks.length);
+      return Promise.resolve(
+        jsonResponse({ id: "song-server1", name: song.name, content: body.content, created_at: 1, updated_at: 1 }),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const saved = await saveSong(song);
+    expect(saved.id).toBe("song-server1");
+  });
+
+  it("saveSong PUTs an already-persisted song", async () => {
+    const song = { ...createDefaultSong(), id: "song-existing" };
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe("/api/songs/song-existing");
+      expect(init?.method).toBe("PUT");
+      return Promise.resolve(
+        jsonResponse({ id: "song-existing", name: song.name, content: "{}", created_at: 1, updated_at: 2 }),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await saveSong(song);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renameSong fetches the current song then saves it with the new name", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/songs/song-1" && (!init || init.method === undefined)) {
+        return Promise.resolve(
+          jsonResponse({ id: "song-1", name: "Old", content: JSON.stringify({ tempo: 90, key: "A min", timeSig: "4/4", tracks: [] }), created_at: 1, updated_at: 1 }),
+        );
+      }
+      if (url === "/api/songs/song-1" && init?.method === "PUT") {
+        const body = JSON.parse(String(init.body));
+        expect(body.name).toBe("New");
+        return Promise.resolve(jsonResponse({ id: "song-1", name: "New", content: body.content, created_at: 1, updated_at: 2 }));
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const renamed = await renameSong("song-1", "New");
+    expect(renamed.name).toBe("New");
+  });
+
+  it("deleteSong DELETEs the song", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe("/api/songs/song-1");
+      expect(init?.method).toBe("DELETE");
+      return Promise.resolve(jsonResponse({ status: "deleted", id: "song-1" }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteSong("song-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws the server error message on a failed request", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({ error: "name is required" }, false, 400)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(listSongs()).rejects.toThrow("name is required");
+  });
+
+  it("slugify lowercases, strips non-alphanumerics and falls back to 'song'", () => {
+    expect(slugify("My Cool Track!!")).toBe("my-cool-track");
+    expect(slugify("   ")).toBe("song");
+  });
+});

--- a/desktop/src/apps/musicstudio/songs-api.ts
+++ b/desktop/src/apps/musicstudio/songs-api.ts
@@ -1,6 +1,11 @@
-import type { Song } from "./types";
+import { isLocalSongId, type Song } from "./types";
 
 /** Thin client for tinyagentos/routes/songs.py's persistence endpoints. */
+
+/** Client-side mirror of routes/songs.py's MAX_CONTENT_BYTES (5 MB), so an
+ *  oversized song fails with a friendly message before the network round-trip
+ *  rather than as a raw 413. */
+const MAX_CONTENT_BYTES = 5 * 1024 * 1024;
 
 export interface SongMeta {
   id: string;
@@ -30,7 +35,15 @@ function songToContent(song: Song): string {
 }
 
 function recordToSong(record: SongRecord): Song {
-  const parsed = JSON.parse(record.content || "{}") as Partial<Song>;
+  let parsed: Partial<Song>;
+  try {
+    parsed = JSON.parse(record.content || "{}") as Partial<Song>;
+  } catch {
+    // Corrupt/truncated content shouldn't throw a raw SyntaxError at the UI;
+    // surface a friendly, catchable error the caller can render as an
+    // "couldn't load this song" state.
+    throw new Error(`Couldn't load "${record.name}" — its saved data is corrupt.`);
+  }
   return {
     id: record.id,
     name: record.name,
@@ -56,8 +69,12 @@ export async function getSong(id: string): Promise<Song> {
 /** Create or update a song. Returns the song with its (possibly new,
  *  server-assigned) id. */
 export async function saveSong(song: Song): Promise<Song> {
-  const body = JSON.stringify({ name: song.name, content: songToContent(song) });
-  const isNew = song.id.startsWith("local-");
+  const content = songToContent(song);
+  if (new Blob([content]).size > MAX_CONTENT_BYTES) {
+    throw new Error("This song is too large to save (over 5 MB). Try removing some tracks or notes.");
+  }
+  const body = JSON.stringify({ name: song.name, content });
+  const isNew = isLocalSongId(song.id);
   const res = await fetch(isNew ? "/api/songs" : `/api/songs/${encodeURIComponent(song.id)}`, {
     method: isNew ? "POST" : "PUT",
     headers: { "Content-Type": "application/json" },

--- a/desktop/src/apps/musicstudio/songs-api.ts
+++ b/desktop/src/apps/musicstudio/songs-api.ts
@@ -1,0 +1,100 @@
+import type { Song } from "./types";
+
+/** Thin client for tinyagentos/routes/songs.py's persistence endpoints. */
+
+export interface SongMeta {
+  id: string;
+  name: string;
+  created_at: number;
+  updated_at: number;
+}
+
+interface SongRecord extends SongMeta {
+  content: string;
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = await res.json();
+    if (body?.error) return String(body.error);
+  } catch {
+    // non-JSON error body; fall through to the status-based message
+  }
+  return `Request failed (${res.status})`;
+}
+
+/** The persisted `content` column holds everything but id/name (those are
+ *  first-class columns on the songs table, mirroring OfficeDocStore). */
+function songToContent(song: Song): string {
+  return JSON.stringify({ tempo: song.tempo, key: song.key, timeSig: song.timeSig, tracks: song.tracks });
+}
+
+function recordToSong(record: SongRecord): Song {
+  const parsed = JSON.parse(record.content || "{}") as Partial<Song>;
+  return {
+    id: record.id,
+    name: record.name,
+    tempo: parsed.tempo ?? 92,
+    key: parsed.key ?? "C maj",
+    timeSig: parsed.timeSig ?? "4/4",
+    tracks: parsed.tracks ?? [],
+  };
+}
+
+export async function listSongs(): Promise<SongMeta[]> {
+  const res = await fetch("/api/songs");
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as SongMeta[];
+}
+
+export async function getSong(id: string): Promise<Song> {
+  const res = await fetch(`/api/songs/${encodeURIComponent(id)}`);
+  if (!res.ok) throw new Error(await readError(res));
+  return recordToSong((await res.json()) as SongRecord);
+}
+
+/** Create or update a song. Returns the song with its (possibly new,
+ *  server-assigned) id. */
+export async function saveSong(song: Song): Promise<Song> {
+  const body = JSON.stringify({ name: song.name, content: songToContent(song) });
+  const isNew = song.id.startsWith("local-");
+  const res = await fetch(isNew ? "/api/songs" : `/api/songs/${encodeURIComponent(song.id)}`, {
+    method: isNew ? "POST" : "PUT",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return recordToSong((await res.json()) as SongRecord);
+}
+
+export async function renameSong(id: string, name: string): Promise<Song> {
+  const current = await getSong(id);
+  return saveSong({ ...current, id, name });
+}
+
+export async function deleteSong(id: string): Promise<void> {
+  const res = await fetch(`/api/songs/${encodeURIComponent(id)}`, { method: "DELETE" });
+  if (!res.ok) throw new Error(await readError(res));
+}
+
+/** Phase 1's "share" affordance: download the song as a plain JSON file
+ *  rather than a self-contained player package -- see the TODO in
+ *  routes/songs.py for why the .taosapp player was deferred. */
+export function exportSongFile(song: Song): void {
+  const blob = new Blob([JSON.stringify(song, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${slugify(song.name)}.taosong`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export function slugify(text: string): string {
+  const base = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  return base || "song";
+}

--- a/desktop/src/apps/musicstudio/types.ts
+++ b/desktop/src/apps/musicstudio/types.ts
@@ -59,9 +59,24 @@ export interface Song {
   tracks: Track[];
 }
 
+/** A song that has never been saved to the server carries a client-minted id
+ *  with this prefix. `songs-api.saveSong` uses `isLocalSongId` to decide POST
+ *  (create) vs PUT (update) -- the one documented place this convention lives.
+ *  The server never mints ids with this prefix (it uses "song-…"). */
+export const LOCAL_ID_PREFIX = "local-";
+
+export function newLocalSongId(): string {
+  return `${LOCAL_ID_PREFIX}${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** True for an in-memory song that has not yet been persisted server-side. */
+export function isLocalSongId(id: string): boolean {
+  return id.startsWith(LOCAL_ID_PREFIX);
+}
+
 export function createEmptySong(name = "Untitled Song"): Song {
   return {
-    id: `local-${Math.random().toString(36).slice(2, 10)}`,
+    id: newLocalSongId(),
     name,
     tempo: 92,
     key: "A min",
@@ -88,7 +103,7 @@ function note(pitch: number, startTick: number, durationTicks: number, velocity 
 export function createDefaultSong(): Song {
   const beat = TICKS_PER_BEAT;
   return {
-    id: `local-${Math.random().toString(36).slice(2, 10)}`,
+    id: newLocalSongId(),
     name: "Untitled Song",
     tempo: 92,
     key: "A min",

--- a/desktop/src/apps/musicstudio/types.ts
+++ b/desktop/src/apps/musicstudio/types.ts
@@ -1,0 +1,198 @@
+/* ------------------------------------------------------------------ */
+/*  Music Studio -- shared types                                       */
+/*                                                                     */
+/*  A Song is a real, saved thing: tempo/key/time signature plus a set  */
+/*  of tracks, each holding clips of notes. It is plain JSON so it can  */
+/*  round-trip through SongStore's `content` column untouched -- see    */
+/*  songs-api.ts and tinyagentos/music_songs.py.                        */
+/* ------------------------------------------------------------------ */
+
+/** Ticks per quarter note (beat). Fixed for Phase 1 -- all bars are 4/4   */
+/** for scheduling math regardless of the display-only `timeSig` string.  */
+export const TICKS_PER_BEAT = 480;
+export const BEATS_PER_BAR = 4;
+export const TICKS_PER_BAR = TICKS_PER_BEAT * BEATS_PER_BAR;
+
+/** An instrument id resolved by the INSTRUMENTS catalog in instruments.ts. */
+export type InstrumentId = string;
+
+/** A single note inside a clip. `pitch` is a MIDI note number (0-127).    */
+/** `startTick`/`durationTicks` are relative to the clip's own start, in   */
+/** TICKS_PER_BEAT units. `velocity` is normalized 0-1.                    */
+export interface Note {
+  id: string;
+  pitch: number;
+  startTick: number;
+  durationTicks: number;
+  velocity: number;
+}
+
+/** A clip is a bar-aligned region of notes on one track. `startBar` is    */
+/** 0-indexed (bar 0 is the first bar; the UI ruler displays startBar+1).  */
+export interface Clip {
+  id: string;
+  name: string;
+  startBar: number;
+  lengthBars: number;
+  notes: Note[];
+}
+
+export interface Track {
+  id: string;
+  name: string;
+  instrument: InstrumentId;
+  clips: Clip[];
+  /** 0-100, mixer-style. Converted to decibels by the audio engine. */
+  volume: number;
+  /** -1 (hard left) to 1 (hard right). */
+  pan: number;
+  muted: boolean;
+  soloed: boolean;
+}
+
+export interface Song {
+  id: string;
+  name: string;
+  tempo: number;
+  key: string;
+  timeSig: string;
+  tracks: Track[];
+}
+
+export function createEmptySong(name = "Untitled Song"): Song {
+  return {
+    id: `local-${Math.random().toString(36).slice(2, 10)}`,
+    name,
+    tempo: 92,
+    key: "A min",
+    timeSig: "4/4",
+    tracks: [],
+  };
+}
+
+let _idCounter = 0;
+/** Small, collision-safe id generator for client-created tracks/clips/notes.
+ *  Not persisted-id format (that's the server's job for songs themselves). */
+export function localId(prefix: string): string {
+  _idCounter += 1;
+  return `${prefix}-${Date.now().toString(36)}-${_idCounter}`;
+}
+
+function note(pitch: number, startTick: number, durationTicks: number, velocity = 0.85): Note {
+  return { id: localId("note"), pitch, startTick, durationTicks, velocity };
+}
+
+/** A small, fully-offline demo song (Tone.js synths only, no smplr/CDN
+ *  instruments) so a freshly-opened Studio has something real to play,
+ *  mirroring the original static mock's Drums/Bass/Keys/Pad/Lead tracks. */
+export function createDefaultSong(): Song {
+  const beat = TICKS_PER_BEAT;
+  return {
+    id: `local-${Math.random().toString(36).slice(2, 10)}`,
+    name: "Untitled Song",
+    tempo: 92,
+    key: "A min",
+    timeSig: "4/4",
+    tracks: [
+      {
+        id: localId("track"),
+        name: "Drums",
+        instrument: "drum-kit",
+        volume: 72,
+        pan: 0,
+        muted: false,
+        soloed: false,
+        clips: [
+          {
+            id: localId("clip"),
+            name: "Drums",
+            startBar: 0,
+            lengthBars: 1,
+            notes: [
+              note(36, 0, beat / 2), // kick, beat 1
+              note(42, 0, beat / 4), note(42, beat / 2, beat / 4), // hats
+              note(41, beat, beat / 2), // snare, beat 2
+              note(42, beat, beat / 4), note(42, beat * 1.5, beat / 4),
+              note(36, beat * 2, beat / 2), // kick, beat 3
+              note(42, beat * 2, beat / 4), note(42, beat * 2.5, beat / 4),
+              note(41, beat * 3, beat / 2), // snare, beat 4
+              note(42, beat * 3, beat / 4), note(42, beat * 3.5, beat / 4),
+            ],
+          },
+        ],
+      },
+      {
+        id: localId("track"),
+        name: "Bass",
+        instrument: "synth-bass",
+        volume: 60,
+        pan: 0,
+        muted: false,
+        soloed: false,
+        clips: [
+          {
+            id: localId("clip"),
+            name: "Bassline",
+            startBar: 0,
+            lengthBars: 1,
+            notes: [note(33, 0, beat), note(33, beat * 2, beat)], // A1
+          },
+        ],
+      },
+      {
+        id: localId("track"),
+        name: "Keys",
+        instrument: "synth-keys",
+        volume: 54,
+        pan: 0,
+        muted: false,
+        soloed: false,
+        clips: [
+          {
+            id: localId("clip"),
+            name: "Rhodes",
+            startBar: 0,
+            lengthBars: 1,
+            notes: [note(57, 0, beat * 2), note(60, 0, beat * 2), note(64, 0, beat * 2)], // A minor triad
+          },
+        ],
+      },
+      {
+        id: localId("track"),
+        name: "Pad",
+        instrument: "synth-pad",
+        volume: 48,
+        pan: 0,
+        muted: true,
+        soloed: false,
+        clips: [
+          {
+            id: localId("clip"),
+            name: "Pad",
+            startBar: 0,
+            lengthBars: 1,
+            notes: [note(45, 0, beat * 4), note(52, 0, beat * 4)],
+          },
+        ],
+      },
+      {
+        id: localId("track"),
+        name: "Lead",
+        instrument: "synth-lead",
+        volume: 66,
+        pan: 0,
+        muted: false,
+        soloed: false,
+        clips: [
+          {
+            id: localId("clip"),
+            name: "Lead",
+            startBar: 0,
+            lengthBars: 1,
+            notes: [note(69, 0, beat / 2), note(72, beat, beat / 2), note(76, beat * 2.5, beat / 2)],
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/desktop/src/apps/musicstudio/use-studio-engine.ts
+++ b/desktop/src/apps/musicstudio/use-studio-engine.ts
@@ -10,8 +10,11 @@ import { findInstrument } from "./instruments";
 /*   - track mixer params (volume/pan/mute/solo) are pushed straight to  */
 /*     the live engine (no rebuild) so sliders feel instant and don't    */
 /*     re-fetch smplr samples on every drag tick.                       */
-/*   - structural changes (tracks/instruments/clips/notes) bump          */
-/*     `structureVersion`, which triggers a full `engine.loadSong()`.    */
+/*   - note/clip edits reschedule ONLY the affected track in place        */
+/*     (`engine.rescheduleTrack`), so editing a note during playback      */
+/*     never stops the transport or re-instantiates smplr instruments.    */
+/*   - track-graph changes (add/remove track, instrument swap) bump        */
+/*     `structureVersion`, which triggers a full `engine.loadSong()`.     */
 /* ------------------------------------------------------------------ */
 
 export function useStudioEngine() {
@@ -120,40 +123,67 @@ export function useStudioEngine() {
     [],
   );
 
-  const addClip = useCallback((trackId: string, startBar: number) => {
-    const clipId = localId("clip");
-    setSong((prev) => ({
-      ...prev,
-      tracks: prev.tracks.map((t) =>
-        t.id === trackId
-          ? { ...t, clips: [...t.clips, { id: clipId, name: t.name, startBar, lengthBars: 1, notes: [] }] }
-          : t,
-      ),
-    }));
-    setStructureVersion((v) => v + 1);
-    return clipId;
+  /** Commit a single-track edit: update the model and reschedule ONLY that
+   *  track in the engine (no transport stop, no instrument re-instantiation).
+   *  Falls back to a full reload if the engine has no nodes for the track yet
+   *  (e.g. it was just added structurally this tick). */
+  const applyTrackEdit = useCallback((updated: Song, trackId: string) => {
+    setSong(updated);
+    const track = updated.tracks.find((t) => t.id === trackId);
+    const engine = engineRef.current!;
+    if (track && engine.hasTrack(trackId)) {
+      engine.rescheduleTrack(track);
+    } else {
+      setStructureVersion((v) => v + 1);
+    }
   }, []);
 
-  const removeClip = useCallback((trackId: string, clipId: string) => {
-    setSong((prev) => ({
-      ...prev,
-      tracks: prev.tracks.map((t) => (t.id === trackId ? { ...t, clips: t.clips.filter((c) => c.id !== clipId) } : t)),
-    }));
-    setStructureVersion((v) => v + 1);
-    setSelectedClipId((prev) => (prev === clipId ? null : prev));
-  }, []);
+  const addClip = useCallback(
+    (trackId: string, startBar: number) => {
+      const clipId = localId("clip");
+      const prev = songRef.current;
+      const updated: Song = {
+        ...prev,
+        tracks: prev.tracks.map((t) =>
+          t.id === trackId
+            ? { ...t, clips: [...t.clips, { id: clipId, name: t.name, startBar, lengthBars: 1, notes: [] }] }
+            : t,
+        ),
+      };
+      applyTrackEdit(updated, trackId);
+      return clipId;
+    },
+    [applyTrackEdit],
+  );
 
-  const updateClipNotes = useCallback((trackId: string, clipId: string, notes: Note[]) => {
-    setSong((prev) => ({
-      ...prev,
-      tracks: prev.tracks.map((t) =>
-        t.id === trackId
-          ? { ...t, clips: t.clips.map((c: Clip) => (c.id === clipId ? { ...c, notes } : c)) }
-          : t,
-      ),
-    }));
-    setStructureVersion((v) => v + 1);
-  }, []);
+  const removeClip = useCallback(
+    (trackId: string, clipId: string) => {
+      const prev = songRef.current;
+      const updated: Song = {
+        ...prev,
+        tracks: prev.tracks.map((t) => (t.id === trackId ? { ...t, clips: t.clips.filter((c) => c.id !== clipId) } : t)),
+      };
+      applyTrackEdit(updated, trackId);
+      setSelectedClipId((cur) => (cur === clipId ? null : cur));
+    },
+    [applyTrackEdit],
+  );
+
+  const updateClipNotes = useCallback(
+    (trackId: string, clipId: string, notes: Note[]) => {
+      const prev = songRef.current;
+      const updated: Song = {
+        ...prev,
+        tracks: prev.tracks.map((t) =>
+          t.id === trackId
+            ? { ...t, clips: t.clips.map((c: Clip) => (c.id === clipId ? { ...c, notes } : c)) }
+            : t,
+        ),
+      };
+      applyTrackEdit(updated, trackId);
+    },
+    [applyTrackEdit],
+  );
 
   const previewInstrument = useCallback((instrumentId: string, pitch?: number) => {
     void engineRef.current!.previewInstrument(instrumentId, pitch);

--- a/desktop/src/apps/musicstudio/use-studio-engine.ts
+++ b/desktop/src/apps/musicstudio/use-studio-engine.ts
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AudioEngine } from "./audio-engine";
+import { createDefaultSong, localId, type Clip, type InstrumentId, type Note, type Song, type Track } from "./types";
+import { findInstrument } from "./instruments";
+
+/* ------------------------------------------------------------------ */
+/*  useStudioEngine -- owns the Song model + a single AudioEngine        */
+/*  instance for the lifetime of the Music Studio app, and mediates      */
+/*  between the two:                                                    */
+/*   - track mixer params (volume/pan/mute/solo) are pushed straight to  */
+/*     the live engine (no rebuild) so sliders feel instant and don't    */
+/*     re-fetch smplr samples on every drag tick.                       */
+/*   - structural changes (tracks/instruments/clips/notes) bump          */
+/*     `structureVersion`, which triggers a full `engine.loadSong()`.    */
+/* ------------------------------------------------------------------ */
+
+export function useStudioEngine() {
+  const engineRef = useRef<AudioEngine | null>(null);
+  if (!engineRef.current) engineRef.current = new AudioEngine();
+
+  const [song, setSong] = useState<Song>(() => createDefaultSong());
+  const songRef = useRef(song);
+  songRef.current = song;
+
+  const [structureVersion, setStructureVersion] = useState(0);
+  const [selectedTrackId, setSelectedTrackId] = useState<string | null>(null);
+  const [selectedClipId, setSelectedClipId] = useState<string | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [positionLabel, setPositionLabel] = useState("001.1.1");
+  const [masterVolume, setMasterVolumeState] = useState(80);
+
+  useEffect(() => {
+    engineRef.current!.loadSong(songRef.current);
+    setSelectedTrackId((prev) => prev ?? songRef.current.tracks[0]?.id ?? null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [structureVersion]);
+
+  useEffect(() => {
+    const engine = engineRef.current!;
+    return () => engine.dispose();
+  }, []);
+
+  useEffect(() => {
+    if (!playing) return;
+    const id = window.setInterval(() => {
+      setPositionLabel(engineRef.current!.getPositionLabel());
+    }, 120);
+    return () => window.clearInterval(id);
+  }, [playing]);
+
+  const play = useCallback(() => {
+    void engineRef.current!.play().then(() => setPlaying(true));
+  }, []);
+
+  const stop = useCallback(() => {
+    engineRef.current!.stop();
+    setPlaying(false);
+    setPositionLabel("001.1.1");
+  }, []);
+
+  const setTempo = useCallback((bpm: number) => {
+    const clamped = Math.max(20, Math.min(300, Math.round(bpm)));
+    engineRef.current!.setTempo(clamped);
+    setSong((prev) => ({ ...prev, tempo: clamped }));
+  }, []);
+
+  const loadSongRecord = useCallback((next: Song) => {
+    setSong(next);
+    setSelectedTrackId(next.tracks[0]?.id ?? null);
+    setSelectedClipId(null);
+    setStructureVersion((v) => v + 1);
+  }, []);
+
+  const newSong = useCallback(() => {
+    loadSongRecord(createDefaultSong());
+  }, [loadSongRecord]);
+
+  const updateTrack = useCallback(
+    (trackId: string, patch: Partial<Pick<Track, "name" | "instrument" | "volume" | "pan" | "muted" | "soloed">>) => {
+      setSong((prev) => ({
+        ...prev,
+        tracks: prev.tracks.map((t) => (t.id === trackId ? { ...t, ...patch } : t)),
+      }));
+      const structural = "instrument" in patch || "name" in patch;
+      if (structural) {
+        setStructureVersion((v) => v + 1);
+      } else {
+        engineRef.current!.setTrackParam(trackId, patch);
+      }
+    },
+    [],
+  );
+
+  const addTrack = useCallback((instrument: InstrumentId = "synth-keys") => {
+    setSong((prev) => ({
+      ...prev,
+      tracks: [
+        ...prev.tracks,
+        {
+          id: localId("track"),
+          name: findInstrument(instrument).name,
+          instrument,
+          clips: [],
+          volume: 70,
+          pan: 0,
+          muted: false,
+          soloed: false,
+        },
+      ],
+    }));
+    setStructureVersion((v) => v + 1);
+  }, []);
+
+  const removeTrack = useCallback(
+    (trackId: string) => {
+      setSong((prev) => ({ ...prev, tracks: prev.tracks.filter((t) => t.id !== trackId) }));
+      setStructureVersion((v) => v + 1);
+      setSelectedTrackId((prev) => (prev === trackId ? null : prev));
+    },
+    [],
+  );
+
+  const addClip = useCallback((trackId: string, startBar: number) => {
+    const clipId = localId("clip");
+    setSong((prev) => ({
+      ...prev,
+      tracks: prev.tracks.map((t) =>
+        t.id === trackId
+          ? { ...t, clips: [...t.clips, { id: clipId, name: t.name, startBar, lengthBars: 1, notes: [] }] }
+          : t,
+      ),
+    }));
+    setStructureVersion((v) => v + 1);
+    return clipId;
+  }, []);
+
+  const removeClip = useCallback((trackId: string, clipId: string) => {
+    setSong((prev) => ({
+      ...prev,
+      tracks: prev.tracks.map((t) => (t.id === trackId ? { ...t, clips: t.clips.filter((c) => c.id !== clipId) } : t)),
+    }));
+    setStructureVersion((v) => v + 1);
+    setSelectedClipId((prev) => (prev === clipId ? null : prev));
+  }, []);
+
+  const updateClipNotes = useCallback((trackId: string, clipId: string, notes: Note[]) => {
+    setSong((prev) => ({
+      ...prev,
+      tracks: prev.tracks.map((t) =>
+        t.id === trackId
+          ? { ...t, clips: t.clips.map((c: Clip) => (c.id === clipId ? { ...c, notes } : c)) }
+          : t,
+      ),
+    }));
+    setStructureVersion((v) => v + 1);
+  }, []);
+
+  const previewInstrument = useCallback((instrumentId: string, pitch?: number) => {
+    void engineRef.current!.previewInstrument(instrumentId, pitch);
+  }, []);
+
+  const setMasterVolume = useCallback((volume: number) => {
+    const clamped = Math.max(0, Math.min(100, volume));
+    engineRef.current!.setMasterVolume(clamped);
+    setMasterVolumeState(clamped);
+  }, []);
+
+  return {
+    song,
+    setSongName: useCallback((name: string) => setSong((prev) => ({ ...prev, name })), []),
+    playing,
+    positionLabel,
+    play,
+    stop,
+    setTempo,
+    selectedTrackId,
+    setSelectedTrackId,
+    selectedClipId,
+    setSelectedClipId,
+    addTrack,
+    removeTrack,
+    updateTrack,
+    addClip,
+    removeClip,
+    updateClipNotes,
+    previewInstrument,
+    masterVolume,
+    setMasterVolume,
+    loadSongRecord,
+    newSong,
+  };
+}
+
+export type StudioEngineApi = ReturnType<typeof useStudioEngine>;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -350,6 +350,10 @@ async def client(app, tmp_data_dir):
     if web_sites._db is not None:
         await web_sites.close()
     await web_sites.init()
+    song_store = app.state.song_store
+    if song_store._db is not None:
+        await song_store.close()
+    await song_store.init()
     # app_grants ledger (per-app capability grants) is lifespan-owned; tests that
     # bypass the lifespan must init it so the userspace broker can consult it.
     await app.state.app_grants.init()
@@ -416,6 +420,7 @@ async def client(app, tmp_data_dir):
     await store.close()
     await office_docs.close()
     await web_sites.close()
+    await song_store.close()
     await coding_session_store.close()
     await feedback_store.close()
     await client_log_store.close()

--- a/tests/test_music_songs.py
+++ b/tests/test_music_songs.py
@@ -1,0 +1,138 @@
+import pytest
+import pytest_asyncio
+
+from tinyagentos.music_songs import _new_song_id, SongStore
+
+
+@pytest_asyncio.fixture
+async def song_store(tmp_path):
+    store = SongStore(tmp_path / "songs.db")
+    await store.init()
+    yield store
+    await store.close()
+
+
+class TestNewSongId:
+    def test_format(self):
+        song_id = _new_song_id()
+        assert song_id.startswith("song-")
+        suffix = song_id[5:]
+        assert len(suffix) == 8
+        alphabet = "abcdefghijklmnopqrstuvwxyz234567"
+        for ch in suffix:
+            assert ch in alphabet
+
+    def test_uniqueness(self):
+        ids = {_new_song_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+@pytest.mark.asyncio
+async def test_create_happy_path(song_store):
+    row = await song_store.create(name="My Song", content='{"tempo":92}')
+    assert row["name"] == "My Song"
+    assert row["content"] == '{"tempo":92}'
+    assert row["id"].startswith("song-")
+    assert row["created_at"] == row["updated_at"]
+    assert isinstance(row["created_at"], int)
+
+
+@pytest.mark.asyncio
+async def test_get_existing(song_store):
+    created = await song_store.create(name="T", content="C")
+    fetched = await song_store.get(created["id"])
+    assert fetched is not None
+    assert fetched["id"] == created["id"]
+    assert fetched["name"] == "T"
+    assert fetched["content"] == "C"
+    assert "created_at" in fetched
+    assert "updated_at" in fetched
+
+
+@pytest.mark.asyncio
+async def test_get_nonexistent(song_store):
+    result = await song_store.get("song-nonexistent")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_list_empty(song_store):
+    rows = await song_store.list()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_list_returns_all(song_store):
+    await song_store.create(name="A", content="a")
+    await song_store.create(name="B", content="b")
+    rows = await song_store.list()
+    assert len(rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_order_desc_updated_at(song_store):
+    import asyncio
+
+    r1 = await song_store.create(name="First", content="1")
+    await asyncio.sleep(1.1)
+    r2 = await song_store.create(name="Second", content="2")
+    rows = await song_store.list()
+    assert rows[0]["id"] == r2["id"]
+    assert rows[1]["id"] == r1["id"]
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_content(song_store):
+    await song_store.create(name="T", content="secret")
+    rows = await song_store.list()
+    assert len(rows) == 1
+    assert "content" not in rows[0]
+
+
+@pytest.mark.asyncio
+async def test_update_name_and_content(song_store):
+    created = await song_store.create(name="Old", content="old")
+    updated = await song_store.update(created["id"], name="New", content="new")
+    assert updated is not None
+    assert updated["name"] == "New"
+    assert updated["content"] == "new"
+    assert updated["updated_at"] >= created["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_update_nonexistent(song_store):
+    result = await song_store.update("song-noexist", name="X", content="Y")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_delete_existing(song_store):
+    created = await song_store.create(name="T", content="C")
+    deleted = await song_store.delete(created["id"])
+    assert deleted is True
+    assert await song_store.get(created["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent(song_store):
+    result = await song_store.delete("song-noexist")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_create_get_update_delete_roundtrip(song_store):
+    created = await song_store.create(name="Start", content="orig")
+    song_id = created["id"]
+
+    fetched = await song_store.get(song_id)
+    assert fetched["name"] == "Start"
+
+    updated = await song_store.update(song_id, name="Edited", content="changed")
+    assert updated["name"] == "Edited"
+
+    rows = await song_store.list()
+    assert len(rows) == 1
+
+    assert await song_store.delete(song_id) is True
+    assert await song_store.get(song_id) is None
+    assert await song_store.list() == []

--- a/tests/test_routes_songs.py
+++ b/tests/test_routes_songs.py
@@ -79,6 +79,28 @@ async def test_update_missing_song_returns_404(client):
 
 
 @pytest.mark.asyncio
+async def test_create_rejects_oversize_content(client):
+    resp = await client.post(
+        "/api/songs",
+        json={"name": "Big", "content": "x" * (5 * 1024 * 1024 + 1)},
+    )
+    assert resp.status_code == 413
+    assert "content" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_oversize_content(client):
+    resp = await client.post("/api/songs", json={"name": "S", "content": "{}"})
+    song_id = resp.json()["id"]
+
+    resp = await client.put(
+        f"/api/songs/{song_id}",
+        json={"content": "x" * (5 * 1024 * 1024 + 1)},
+    )
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
 async def test_delete_missing_song_returns_404(client):
     resp = await client.delete("/api/songs/missing-id")
     assert resp.status_code == 404

--- a/tests/test_routes_songs.py
+++ b/tests/test_routes_songs.py
@@ -1,0 +1,104 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_create_list_get_update_delete_song(client):
+    resp = await client.post(
+        "/api/songs",
+        json={"name": "My Track", "content": '{"tempo":92,"tracks":[]}'},
+    )
+    assert resp.status_code == 200
+    created = resp.json()
+    song_id = created["id"]
+    assert created["name"] == "My Track"
+    assert created["content"] == '{"tempo":92,"tracks":[]}'
+    assert isinstance(created["updated_at"], int)
+
+    resp = await client.get("/api/songs")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["id"] == song_id
+    assert "content" not in items[0]
+
+    resp = await client.get(f"/api/songs/{song_id}")
+    assert resp.status_code == 200
+    assert resp.json()["content"] == '{"tempo":92,"tracks":[]}'
+
+    resp = await client.put(
+        f"/api/songs/{song_id}",
+        json={"name": "Renamed", "content": '{"tempo":100,"tracks":[]}'},
+    )
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["name"] == "Renamed"
+    assert updated["content"] == '{"tempo":100,"tracks":[]}'
+    assert updated["updated_at"] >= created["updated_at"]
+
+    resp = await client.delete(f"/api/songs/{song_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+
+    resp = await client.get(f"/api/songs/{song_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_missing_name(client):
+    resp = await client.post(
+        "/api/songs",
+        json={"name": "   ", "content": ""},
+    )
+    assert resp.status_code == 400
+    assert "name" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_non_string_content(client):
+    resp = await client.post(
+        "/api/songs",
+        json={"name": "X", "content": 42},
+    )
+    assert resp.status_code == 400
+    assert "content" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_missing_song_returns_404(client):
+    resp = await client.get("/api/songs/does-not-exist")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_missing_song_returns_404(client):
+    resp = await client.put(
+        "/api/songs/does-not-exist",
+        json={"name": "Nope"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_song_returns_404(client):
+    resp = await client.delete("/api/songs/missing-id")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_persists_content(client):
+    resp = await client.post(
+        "/api/songs",
+        json={"name": "Doc", "content": "body"},
+    )
+    song_id = resp.json()["id"]
+
+    resp = await client.put(
+        f"/api/songs/{song_id}",
+        json={"content": "revised body"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "revised body"
+
+    # The change is persisted, not just echoed.
+    resp = await client.get(f"/api/songs/{song_id}")
+    assert resp.json()["content"] == "revised body"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -97,6 +97,7 @@ from tinyagentos.installed_apps import InstalledAppsStore
 from tinyagentos.skills import SkillStore
 from tinyagentos.office_docs import OfficeDocStore
 from tinyagentos.web_sites import WebSiteStore
+from tinyagentos.music_songs import SongStore
 from tinyagentos.knowledge_store import KnowledgeStore
 from tinyagentos.knowledge_ingest import IngestPipeline
 from tinyagentos.knowledge_categories import CategoryEngine
@@ -404,6 +405,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     userspace_data = UserspaceDataStore(data_dir / "userspace_data.db")
     office_docs = OfficeDocStore(data_dir / "office_docs.db")
     web_sites = WebSiteStore(data_dir / "web_sites.db")
+    song_store = SongStore(data_dir / "songs.db")
     coding_workspaces_store = CodingWorkspaceStore(
         data_dir / "coding_workspaces.db",
         data_dir / "coding-workspaces",
@@ -524,6 +526,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.office_docs = office_docs
         await web_sites.init()
         app.state.web_sites = web_sites
+        await song_store.init()
+        app.state.song_store = song_store
         await coding_workspaces_store.init()
         app.state.coding_workspaces = coding_workspaces_store
         await install_registry_store.init()
@@ -830,6 +834,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.userspace_data = userspace_data
         app.state.office_docs = office_docs
         app.state.web_sites = web_sites
+        app.state.song_store = song_store
         app.state.coding_workspaces = coding_workspaces_store
         app.state.install_registry = install_registry_store
         app.state.store_submissions = store_submissions
@@ -1313,6 +1318,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await userspace_data.close()
         await office_docs.close()
         await web_sites.close()
+        await song_store.close()
         await coding_workspaces_store.close()
         await install_registry_store.close()
         await user_memory.close()
@@ -1506,6 +1512,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.userspace_data = userspace_data
     app.state.office_docs = office_docs
     app.state.web_sites = web_sites
+    app.state.song_store = song_store
     app.state.coding_workspaces = coding_workspaces_store
     app.state.install_registry = install_registry_store
     app.state.store_submissions = store_submissions

--- a/tinyagentos/music_songs.py
+++ b/tinyagentos/music_songs.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import secrets
+import time
+from pathlib import Path
+
+from tinyagentos.base_store import BaseStore
+
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+SONGS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS songs (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+"""
+
+
+def _new_song_id() -> str:
+    suffix = "".join(secrets.choice(_ALPHABET) for _ in range(8))
+    return f"song-{suffix}"
+
+
+class SongStore(BaseStore):
+    """Persistence for Music Studio songs (Phase 1). Mirrors OfficeDocStore:
+    `content` holds the song's tempo/key/timeSig/tracks as opaque JSON --
+    the frontend (musicstudio/types.ts) owns that shape, not this store."""
+
+    SCHEMA = SONGS_SCHEMA
+
+    def __init__(self, db_path: Path):
+        super().__init__(db_path)
+
+    async def create(self, name: str, content: str) -> dict:
+        for _ in range(8):
+            song_id = _new_song_id()
+            async with self._db.execute(
+                "SELECT 1 FROM songs WHERE id = ?", (song_id,)
+            ) as cur:
+                if await cur.fetchone() is None:
+                    break
+        else:
+            raise RuntimeError("could not allocate song id")
+
+        now = int(time.time())
+        row = {
+            "id": song_id,
+            "name": name,
+            "content": content,
+            "created_at": now,
+            "updated_at": now,
+        }
+        await self._db.execute(
+            """INSERT INTO songs (id, name, content, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (row["id"], row["name"], row["content"], row["created_at"], row["updated_at"]),
+        )
+        await self._db.commit()
+        return row
+
+    async def list(self) -> list[dict]:
+        async with self._db.execute(
+            "SELECT id, name, created_at, updated_at FROM songs ORDER BY updated_at DESC"
+        ) as cur:
+            rows = await cur.fetchall()
+        return [
+            {"id": r[0], "name": r[1], "created_at": r[2], "updated_at": r[3]}
+            for r in rows
+        ]
+
+    async def get(self, song_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT id, name, content, created_at, updated_at FROM songs WHERE id = ?",
+            (song_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "name": row[1],
+            "content": row[2],
+            "created_at": row[3],
+            "updated_at": row[4],
+        }
+
+    async def update(self, song_id: str, name: str, content: str) -> dict | None:
+        now = int(time.time())
+        await self._db.execute(
+            "UPDATE songs SET name = ?, content = ?, updated_at = ? WHERE id = ?",
+            (name, content, now, song_id),
+        )
+        await self._db.commit()
+        return await self.get(song_id)
+
+    async def delete(self, song_id: str) -> bool:
+        async with self._db.execute(
+            "SELECT 1 FROM songs WHERE id = ?", (song_id,)
+        ) as cur:
+            exists = await cur.fetchone() is not None
+        if not exists:
+            return False
+        await self._db.execute("DELETE FROM songs WHERE id = ?", (song_id,))
+        await self._db.commit()
+        return True

--- a/tinyagentos/music_songs.py
+++ b/tinyagentos/music_songs.py
@@ -88,12 +88,17 @@ class SongStore(BaseStore):
         }
 
     async def update(self, song_id: str, name: str, content: str) -> dict | None:
+        # Use the affected rowcount to tell a real update from a missing row so
+        # callers get None (-> 404) instead of a silent no-op that reads back as
+        # a fresh SELECT.
         now = int(time.time())
-        await self._db.execute(
+        cursor = await self._db.execute(
             "UPDATE songs SET name = ?, content = ?, updated_at = ? WHERE id = ?",
             (name, content, now, song_id),
         )
         await self._db.commit()
+        if cursor.rowcount == 0:
+            return None
         return await self.get(song_id)
 
     async def delete(self, song_id: str) -> bool:

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -332,6 +332,8 @@ def register_all_routers(app):
 
     from tinyagentos.routes.office import router as office_router
     app.include_router(office_router)
+    from tinyagentos.routes.songs import router as songs_router
+    app.include_router(songs_router)
     from tinyagentos.routes.web import router as web_router
     app.include_router(web_router)
     from tinyagentos.routes.coding import router as coding_router

--- a/tinyagentos/routes/songs.py
+++ b/tinyagentos/routes/songs.py
@@ -9,6 +9,11 @@ from tinyagentos.music_songs import SongStore
 
 router = APIRouter()
 
+# A song's `content` holds its serialized tracks/clips/notes JSON. Cap the row
+# so a client can't store an arbitrary-size blob (unbounded SQLite growth /
+# DoS). Same cap and posture as routes/web.py's MAX_CONTENT_BYTES.
+MAX_CONTENT_BYTES = 5 * 1024 * 1024  # 5 MB
+
 # --------------------------------------------------------------------------
 # Music Studio song persistence (Phase 1) -- mirrors routes/office.py's CRUD
 # pattern. Share-as-app (a self-contained .taosapp player bundle, mirroring
@@ -29,6 +34,18 @@ def _validate_name(name: Any) -> str | None:
     return name.strip()
 
 
+def _validate_content(content: Any) -> JSONResponse | None:
+    """Return an error response if `content` is not an acceptably-sized string, else None."""
+    if not isinstance(content, str):
+        return JSONResponse({"error": "content must be a string"}, status_code=400)
+    if len(content.encode("utf-8")) > MAX_CONTENT_BYTES:
+        return JSONResponse(
+            {"error": f"content exceeds the {MAX_CONTENT_BYTES} byte limit"},
+            status_code=413,
+        )
+    return None
+
+
 @router.post("/api/songs")
 async def create_song(request: Request):
     body = await request.json()
@@ -36,8 +53,9 @@ async def create_song(request: Request):
     if name is None:
         return JSONResponse({"error": "name is required"}, status_code=400)
     content = body.get("content", "")
-    if not isinstance(content, str):
-        return JSONResponse({"error": "content must be a string"}, status_code=400)
+    err = _validate_content(content)
+    if err is not None:
+        return err
 
     store = _get_store(request)
     song = await store.create(name=name, content=content)
@@ -73,10 +91,13 @@ async def update_song(request: Request, song_id: str):
         return JSONResponse({"error": "name is required"}, status_code=400)
 
     content = body.get("content", existing["content"])
-    if not isinstance(content, str):
-        return JSONResponse({"error": "content must be a string"}, status_code=400)
+    err = _validate_content(content)
+    if err is not None:
+        return err
 
     song = await store.update(song_id=song_id, name=name, content=content)
+    if song is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
     return song
 
 

--- a/tinyagentos/routes/songs.py
+++ b/tinyagentos/routes/songs.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from tinyagentos.music_songs import SongStore
+
+router = APIRouter()
+
+# --------------------------------------------------------------------------
+# Music Studio song persistence (Phase 1) -- mirrors routes/office.py's CRUD
+# pattern. Share-as-app (a self-contained .taosapp player bundle, mirroring
+# routes/games.py's GET /{id}/package) is deferred: Phase 1 ships "Export" as
+# a plain song-JSON download instead (musicstudio/songs-api.ts's
+# exportSongFile), which needs no new backend endpoint. Revisit once there is
+# a lightweight static Tone.js player shell worth embedding in a package.
+# --------------------------------------------------------------------------
+
+
+def _get_store(request: Request) -> SongStore:
+    return request.app.state.song_store
+
+
+def _validate_name(name: Any) -> str | None:
+    if not isinstance(name, str) or not name.strip():
+        return None
+    return name.strip()
+
+
+@router.post("/api/songs")
+async def create_song(request: Request):
+    body = await request.json()
+    name = _validate_name(body.get("name"))
+    if name is None:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+    content = body.get("content", "")
+    if not isinstance(content, str):
+        return JSONResponse({"error": "content must be a string"}, status_code=400)
+
+    store = _get_store(request)
+    song = await store.create(name=name, content=content)
+    return song
+
+
+@router.get("/api/songs")
+async def list_songs(request: Request):
+    store = _get_store(request)
+    return await store.list()
+
+
+@router.get("/api/songs/{song_id}")
+async def get_song(request: Request, song_id: str):
+    store = _get_store(request)
+    song = await store.get(song_id)
+    if song is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return song
+
+
+@router.put("/api/songs/{song_id}")
+async def update_song(request: Request, song_id: str):
+    body = await request.json()
+    store = _get_store(request)
+
+    existing = await store.get(song_id)
+    if existing is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    name = _validate_name(body.get("name", existing["name"]))
+    if name is None:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+
+    content = body.get("content", existing["content"])
+    if not isinstance(content, str):
+        return JSONResponse({"error": "content must be a string"}, status_code=400)
+
+    song = await store.update(song_id=song_id, name=name, content=content)
+    return song
+
+
+@router.delete("/api/songs/{song_id}")
+async def delete_song(request: Request, song_id: str):
+    store = _get_store(request)
+    deleted = await store.delete(song_id)
+    if not deleted:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return {"status": "deleted", "id": song_id}


### PR DESCRIPTION
## Summary

Turns Music Studio from a static mockup into a real, playable browser DAW (Phase 1).

**Song model** (`musicstudio/types.ts`): `Song { id, name, tempo, key, timeSig, tracks }`, `Track { instrument, clips, volume, pan, muted, soloed }`, `Clip { startBar, lengthBars, notes }`, `Note { pitch, startTick, durationTicks, velocity }`. 480 ticks/beat, 4/4 fixed for Phase 1 scheduling math. Fully JSON-serializable — this is the persisted `content`.

**Audio engine** (`musicstudio/audio-engine.ts`): a thin `Tone.js` wrapper. One `Tone.Channel` per track (volume/pan/mute/solo) → destination. Instruments are either offline Tone.js synths (drum kit, bass, keys, pad, lead, fx) or `smplr` sampled instruments (piano, 808) bridged into the track's Channel via a native `GainNode` + `Tone.connect`. Every clip's notes are scheduled on `Tone.Transport` using bar:beat:sixteenth position strings (not raw seconds), so tempo changes retime already-scheduled notes correctly. `ensureStarted()` lazily starts the AudioContext on the first `play()` call (autoplay policy).

**What's wired**:
- **Studio**: working transport (play/stop, editable tempo, live position readout), multi-track timeline (add/remove track, click to add a clip, per-track mute/solo/volume), a piano-roll editor (click empty cell to add a note, click a note to remove it, drag to move — snapped to the 16th-note/semitone grid) for melodic tracks, and a step sequencer (16 steps × kick/snare/hat) for drum tracks. Both write into the same `Clip.notes` model.
- **Sounds**: a real instrument library (`instruments.ts`) — click a card to preview it through the engine, "Use" to assign it to the selected track.
- **Mixer**: per-track fader + pan + mute/solo bound live to the engine's Channels, plus a master fader (`Tone.getDestination().volume`).
- **Persistence**: `tinyagentos/music_songs.py` (`SongStore`, mirrors `OfficeDocStore`) + `tinyagentos/routes/songs.py` (`/api/songs` CRUD), wired into `app.py` the same way as `web_sites`/`office_docs` (6 touch points: instantiate, lifespan init+state, second state block, close, eager pre-lifespan state). Frontend `musicstudio/songs-api.ts` + a `LibraryView` (open/rename/delete/create).
- **Compose** (existing audio-gen backend) is untouched.

**Share/export decision**: a self-contained `.taosapp` player package (mirroring `routes/games.py`) was judged too heavy for Phase 1. Export instead downloads the song as JSON (`.taosong`) and, since `@tonejs/midi` was already a dependency, also as a standard `.mid` file (`musicstudio/midi-export.ts`) — both are pure client-side, no new backend endpoint. The player-package path is left as a TODO comment in `routes/songs.py`.

**Deps added** (pinned to recent stable): `tone@15.1.22`, `@tonejs/midi@2.0.28`, `smplr@1.0.0` — all MIT.

**Known Phase 1 limitations** (by design, not oversight):
- `smplr` instruments (Rhodes/Sub 808) fetch samples from smplr's public CDN on first use, so they are not offline — the Sounds header copy was updated to stop claiming "all offline".
- Clips can be added but not resized/dragged on the timeline (only note-level drag, inside the piano roll).
- Recording, mic capture, effects and AI generation are explicitly out of scope (Phases 2/3); Compose's existing generation flow is untouched.

## Test plan
- [x] `cd desktop && npx vitest run src/apps/musicstudio` — 38 tests (model→schedule logic, mocked Tone/smplr since jsdom lacks AudioContext)
- [x] `cd desktop && npx vitest run src/apps/MusicStudioApp.test.tsx` — 8 tests (pre-existing suite, updated for the real engine + dropped the removed Record button)
- [x] `cd desktop && npm run build` — 0 TS errors
- [x] `python -m pytest tests/test_music_songs.py tests/test_routes_songs.py -q` — 21 tests
- [x] Full repo suites (`vitest run`, 2523 tests; `pytest`, office/games regressions) — all green, no regressions
- [x] Live-browser smoke test (Playwright against a temporary standalone harness, not committed): play/stop advances the position readout in real time, piano-roll add/remove/drag, step sequencer toggle, Sounds preview (synth + smplr), Mixer faders — all confirmed working with **zero non-preexisting console errors**. This caught and fixed a real bug mocked tests couldn't: clicking a piano-roll note bubbled a native `click` to the grid's `onClick`, potentially re-adding the just-deleted note (fixed with `stopPropagation` on the note's `onClick`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full Music Studio workflow with library browsing, saving, exporting, and a dedicated mixer.
  * Introduced interactive note editing tools, including piano-roll and step-sequencer views.
  * Added support for exporting songs as MIDI and downloadable project files.
  * Expanded song management with create, load, rename, delete, and list capabilities.
* **Bug Fixes**
  * Improved playback and editor behavior with better state handling and more reliable transport controls.
  * Added coverage to help ensure song editing, export, and library actions work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->