### PR TITLE
fix(images): surface silent Quality→fast tier downgrade + capability-aware tier picker

### DIFF
--- a/desktop/src/apps/ImagesApp.tsx
+++ b/desktop/src/apps/ImagesApp.tsx
@@ -421,12 +421,14 @@ export function ImagesApp({ windowId: _windowId }: { windowId: string }) {
             <EditView
               image={editImage}
               onApplyAdjust={applyAdjust}
-              onEdited={async ({ url, image_ref }) => {
+              onEdited={async ({ url, image_ref, backend }) => {
                 // Refresh the library and re-select the new result for
-                // further editing.
+                // further editing. `backend` is the tier that actually ran
+                // (may differ from what was requested — see EditView's
+                // downgrade notice), so it replaces the stale value here too.
                 await fetchImages();
                 setEditImage((cur) =>
-                  cur ? { ...cur, id: image_ref, url } : cur,
+                  cur ? { ...cur, id: image_ref, url, backend } : cur,
                 );
                 setLibrarySelectedId(image_ref);
               }}

--- a/desktop/src/apps/images/EditView.test.tsx
+++ b/desktop/src/apps/images/EditView.test.tsx
@@ -132,12 +132,21 @@ describe("EditView — quality tier downgrade honesty", () => {
     render(<EditView image={mockImage} onApplyAdjust={vi.fn()} onEdited={vi.fn()} />);
     fireEvent.click(screen.getByRole("tab", { name: "Extend" }));
 
+    // aria-disabled (not the native disabled attribute) so the option stays
+    // hoverable/focusable and its "Quality model not installed" title tooltip
+    // actually surfaces to the user.
     const qualityOption = await screen.findByRole("radio", { name: "Quality" });
-    await waitFor(() => expect(qualityOption).toBeDisabled());
+    await waitFor(() =>
+      expect(qualityOption).toHaveAttribute("aria-disabled", "true"),
+    );
     expect(qualityOption).toHaveAttribute("title", "Quality model not installed");
 
+    // Clicking the disabled option must not switch the tier.
+    fireEvent.click(qualityOption);
+    expect(qualityOption).toHaveAttribute("aria-checked", "false");
+
     const fastOption = screen.getByRole("radio", { name: "Fast" });
-    expect(fastOption).not.toBeDisabled();
+    expect(fastOption).not.toHaveAttribute("aria-disabled");
   });
 
   it("leaves the Quality tier enabled when its backend is healthy", async () => {
@@ -153,6 +162,8 @@ describe("EditView — quality tier downgrade honesty", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Extend" }));
 
     const qualityOption = await screen.findByRole("radio", { name: "Quality" });
-    await waitFor(() => expect(qualityOption).not.toBeDisabled());
+    await waitFor(() =>
+      expect(qualityOption).not.toHaveAttribute("aria-disabled"),
+    );
   });
 });

--- a/desktop/src/apps/images/EditView.test.tsx
+++ b/desktop/src/apps/images/EditView.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { EditView } from "./EditView";
+import type { GeneratedImage } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  Trust bug regression: the "Quality" edit tier can silently          */
+/*  downgrade to the fast, prompt-ignoring iopaint eraser. The backend  */
+/*  response carries `degraded`/`backend`; these tests confirm the UI   */
+/*  surfaces that instead of dropping it, and hides "Quality" when its   */
+/*  own backend isn't healthy.                                          */
+/* ------------------------------------------------------------------ */
+
+// jsdom has no real canvas backend installed; EditView's outpaint path
+// exports a throwaway canvas via toDataURL, which would otherwise throw.
+if (typeof HTMLCanvasElement !== "undefined") {
+  HTMLCanvasElement.prototype.toDataURL = () => "data:image/png;base64,AAAA";
+}
+
+const mockImage: GeneratedImage = {
+  id: "src.png",
+  url: "/images/src.png",
+  prompt: "a cat on a rug",
+  model: "flux",
+  size: 512,
+  steps: 4,
+  seed: 1,
+  guidance: 7.5,
+  createdAt: new Date().toISOString(),
+};
+
+function makeFetchMock(opts: {
+  qualityHealthy: boolean;
+  editResponse: Record<string, unknown>;
+}) {
+  return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url === "/api/images/edit/capabilities" && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            image_editing: true,
+            background_removal: true,
+            upscale: true,
+            image_editing_tiers: {
+              quality: opts.qualityHealthy,
+              fast: true,
+            },
+          }),
+      } as Response);
+    }
+    if (url === "/api/images/edit" && method === "POST") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(opts.editResponse),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  });
+}
+
+async function applyOutpaint() {
+  // The "Extend" tool posts a throwaway mask itself, so it exercises
+  // callEdit without needing to paint on the mask canvas.
+  fireEvent.click(screen.getByRole("tab", { name: "Extend" }));
+  const applyButton = await screen.findByRole("button", { name: "Apply changes" });
+  fireEvent.click(applyButton);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+});
+
+describe("EditView — quality tier downgrade honesty", () => {
+  it("shows a downgrade notice when the result is degraded", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({
+        qualityHealthy: true,
+        editResponse: {
+          url: "/images/result.png",
+          image_ref: "result.png",
+          degraded: true,
+          backend: "iopaint",
+        },
+      }),
+    );
+
+    render(<EditView image={mockImage} onApplyAdjust={vi.fn()} onEdited={vi.fn()} />);
+    await applyOutpaint();
+
+    expect(
+      await screen.findByText(/Served by the fast eraser/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no notice when the result is not degraded", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({
+        qualityHealthy: true,
+        editResponse: {
+          url: "/images/result.png",
+          image_ref: "result.png",
+          degraded: false,
+          backend: "iopaint",
+        },
+      }),
+    );
+
+    const onEdited = vi.fn();
+    render(<EditView image={mockImage} onApplyAdjust={vi.fn()} onEdited={onEdited} />);
+    await applyOutpaint();
+
+    await waitFor(() => expect(onEdited).toHaveBeenCalled());
+    expect(screen.queryByText(/Served by the fast eraser/i)).not.toBeInTheDocument();
+  });
+
+  it("disables the Quality tier option when only the fast backend is healthy", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({
+        qualityHealthy: false,
+        editResponse: { url: "/images/result.png", image_ref: "result.png" },
+      }),
+    );
+
+    render(<EditView image={mockImage} onApplyAdjust={vi.fn()} onEdited={vi.fn()} />);
+    fireEvent.click(screen.getByRole("tab", { name: "Extend" }));
+
+    const qualityOption = await screen.findByRole("radio", { name: "Quality" });
+    await waitFor(() => expect(qualityOption).toBeDisabled());
+    expect(qualityOption).toHaveAttribute("title", "Quality model not installed");
+
+    const fastOption = screen.getByRole("radio", { name: "Fast" });
+    expect(fastOption).not.toBeDisabled();
+  });
+
+  it("leaves the Quality tier enabled when its backend is healthy", async () => {
+    vi.stubGlobal(
+      "fetch",
+      makeFetchMock({
+        qualityHealthy: true,
+        editResponse: { url: "/images/result.png", image_ref: "result.png" },
+      }),
+    );
+
+    render(<EditView image={mockImage} onApplyAdjust={vi.fn()} onEdited={vi.fn()} />);
+    fireEvent.click(screen.getByRole("tab", { name: "Extend" }));
+
+    const qualityOption = await screen.findByRole("radio", { name: "Quality" });
+    await waitFor(() => expect(qualityOption).not.toBeDisabled());
+  });
+});

--- a/desktop/src/apps/images/EditView.tsx
+++ b/desktop/src/apps/images/EditView.tsx
@@ -12,6 +12,7 @@ import {
   ImageIcon,
   Loader2,
   Store,
+  AlertTriangle,
 } from "lucide-react";
 import { Slider, Chip, GroupLabel, Segmented } from "./controls";
 import {
@@ -96,8 +97,15 @@ export interface EditViewProps {
   image: GeneratedImage | null;
   onApplyAdjust: (filterCss: string) => void;
   /** Called after a backend edit succeeds, with the new image's url + ref so
-   *  the host can refresh the library and re-select the result. */
-  onEdited?: (result: { url: string; image_ref: string }) => void;
+   *  the host can refresh the library and re-select the result.
+   *  ``degraded``/``backend`` surface a silent tier downgrade (a Quality
+   *  request served by the fast iopaint eraser, which ignores the prompt). */
+  onEdited?: (result: {
+    url: string;
+    image_ref: string;
+    degraded?: boolean;
+    backend?: string;
+  }) => void;
 }
 
 const DEFAULT_ADJUST = { brightness: 100, contrast: 100, saturation: 100 };
@@ -114,6 +122,10 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
   const [scale, setScale] = useState<2 | 4>(2);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Set when the last edit result was served by a lower tier than requested
+  // (e.g. Quality asked for flux-fill but iopaint's prompt-ignoring eraser
+  // ran instead), so the result is never presented as if it were Quality.
+  const [downgradeNotice, setDowngradeNotice] = useState<string | null>(null);
 
   const [caps, setCaps] = useState<EditCapabilities | null>(null);
 
@@ -155,6 +167,20 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
   const capAvailable = !requiredCap || (caps ? caps[requiredCap] : false);
   const isMasking = tool === "erase" || tool === "inpaint";
 
+  // Is the Quality tier's own backend (flux-fill) actually healthy? If not,
+  // offering "Quality" would silently downgrade to the fast iopaint eraser,
+  // which ignores the prompt — so it must be disabled, not just offered.
+  const qualityHealthy = caps?.image_editing_tiers
+    ? caps.image_editing_tiers.quality
+    : false;
+
+  // If Quality becomes unavailable (or capabilities load in as unavailable)
+  // while it's selected, fall back to Fast rather than leave a disabled tier
+  // selected that Apply would still submit.
+  useEffect(() => {
+    if (tier === "quality" && caps && !qualityHealthy) setTier("fast");
+  }, [caps, qualityHealthy, tier]);
+
   const dirty =
     tool === "adjust" &&
     (adjust.brightness !== 100 ||
@@ -174,6 +200,14 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
   useEffect(() => {
     resetMask();
   }, [image?.url, tool, resetMask]);
+
+  // Clear the downgrade notice on a tool switch (a stale notice from a
+  // different op would be confusing). NOT keyed on image?.url: a successful
+  // edit updates the displayed image right away, and the notice must survive
+  // that swap so the user actually sees it.
+  useEffect(() => {
+    setDowngradeNotice(null);
+  }, [tool]);
 
   function syncMaskSize() {
     const img = imgRef.current;
@@ -231,6 +265,7 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
     if (tool === "adjust") setAdjust(DEFAULT_ADJUST);
     setReplacePrompt("");
     setError(null);
+    setDowngradeNotice(null);
     resetMask();
   }
 
@@ -240,6 +275,7 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
   ): Promise<void> {
     setBusy(true);
     setError(null);
+    setDowngradeNotice(null);
     try {
       const res = await fetch(path, {
         method: "POST",
@@ -253,9 +289,21 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
         );
         return;
       }
-      const { url, image_ref } = data as { url?: string; image_ref?: string };
+      const { url, image_ref, degraded, backend } = data as {
+        url?: string;
+        image_ref?: string;
+        degraded?: boolean;
+        backend?: string;
+      };
       if (url && image_ref) {
-        onEdited?.({ url, image_ref });
+        // A quality request silently served by the fast iopaint eraser must
+        // never read as a Quality result — surface it instead of dropping it.
+        setDowngradeNotice(
+          degraded
+            ? "Served by the fast eraser — the Quality model isn't available, so the prompt was ignored."
+            : null,
+        );
+        onEdited?.({ url, image_ref, degraded, backend });
         resetMask();
       }
     } catch {
@@ -391,6 +439,19 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
               {busy && (
                 <div className="absolute inset-0 flex items-center justify-center bg-shell-bg-deep/60 backdrop-blur-sm">
                   <Loader2 size={28} className="animate-spin text-accent" />
+                </div>
+              )}
+              {downgradeNotice && (
+                <div
+                  role="status"
+                  className="absolute inset-x-0 top-0 flex items-start gap-1.5 border-b border-amber-500/20 bg-amber-500/10 px-3 py-2 text-[11.5px] font-medium leading-snug text-amber-400/90 backdrop-blur-sm"
+                >
+                  <AlertTriangle
+                    size={13}
+                    className="mt-0.5 shrink-0 text-amber-400"
+                    aria-hidden="true"
+                  />
+                  {downgradeNotice}
                 </div>
               )}
             </div>
@@ -537,7 +598,14 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
                 onChange={setTier}
                 options={[
                   { value: "fast", label: "Fast" },
-                  { value: "quality", label: "Quality" },
+                  {
+                    value: "quality",
+                    label: "Quality",
+                    disabled: !qualityHealthy,
+                    title: qualityHealthy
+                      ? undefined
+                      : "Quality model not installed",
+                  },
                 ]}
               />
             </div>

--- a/desktop/src/apps/images/controls.tsx
+++ b/desktop/src/apps/images/controls.tsx
@@ -34,19 +34,29 @@ export function Segmented<T extends string>({
     >
       {options.map((opt) => {
         const on = opt.value === value;
+        const disabled = opt.disabled ?? false;
         return (
           <button
             key={opt.value}
             type="button"
             role="radio"
             aria-checked={on}
-            disabled={opt.disabled}
+            // aria-disabled (not the native `disabled` attribute) so the
+            // element still receives pointer/focus events and its `title`
+            // tooltip actually surfaces — a truly disabled/pointer-events-none
+            // control never shows its native tooltip. The click is guarded
+            // below instead.
+            aria-disabled={disabled || undefined}
             title={opt.title}
-            onClick={() => onChange(opt.value)}
-            className={`rounded-full px-3 py-[5px] text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:pointer-events-none disabled:opacity-40 ${
-              on
-                ? "bg-shell-surface-active text-shell-text"
-                : "text-shell-text-secondary hover:text-shell-text"
+            onClick={() => {
+              if (!disabled) onChange(opt.value);
+            }}
+            className={`rounded-full px-3 py-[5px] text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+              disabled
+                ? "cursor-not-allowed text-shell-text-secondary opacity-40"
+                : on
+                  ? "bg-shell-surface-active text-shell-text"
+                  : "text-shell-text-secondary hover:text-shell-text"
             }`}
           >
             {opt.label}

--- a/desktop/src/apps/images/controls.tsx
+++ b/desktop/src/apps/images/controls.tsx
@@ -14,7 +14,14 @@ export function Segmented<T extends string>({
   onChange,
   ariaLabel,
 }: {
-  options: readonly { value: T; label: string }[];
+  options: readonly {
+    value: T;
+    label: string;
+    /** Disable this option (e.g. a tier whose backend isn't installed). */
+    disabled?: boolean;
+    /** Tooltip shown on the disabled option. */
+    title?: string;
+  }[];
   value: T;
   onChange: (v: T) => void;
   ariaLabel: string;
@@ -33,8 +40,10 @@ export function Segmented<T extends string>({
             type="button"
             role="radio"
             aria-checked={on}
+            disabled={opt.disabled}
+            title={opt.title}
             onClick={() => onChange(opt.value)}
-            className={`rounded-full px-3 py-[5px] text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 ${
+            className={`rounded-full px-3 py-[5px] text-[11px] font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 disabled:pointer-events-none disabled:opacity-40 ${
               on
                 ? "bg-shell-surface-active text-shell-text"
                 : "text-shell-text-secondary hover:text-shell-text"

--- a/desktop/src/apps/images/types.ts
+++ b/desktop/src/apps/images/types.ts
@@ -93,6 +93,10 @@ export interface EditCapabilities {
   image_editing: boolean;
   background_removal: boolean;
   upscale: boolean;
+  /** Per-tier health for image-editing (quality = flux-fill, fast =
+   *  iopaint), so the UI can disable Quality instead of letting a request
+   *  silently downgrade to the prompt-ignoring iopaint eraser. */
+  image_editing_tiers?: { quality: boolean; fast: boolean };
 }
 
 export const SIZE_OPTIONS = [256, 512, 768, 1024] as const;

--- a/tests/test_routes_images_edit.py
+++ b/tests/test_routes_images_edit.py
@@ -15,6 +15,7 @@ from tinyagentos.routes.images_edit import (
     FluxFillClient,
     _get_edit_backend,
     _require_image,
+    edit_capabilities,
     edit_image,
 )
 
@@ -376,3 +377,43 @@ async def test_save_oserror_maps_to_clean_error(tmp_path):
     assert result.status_code == 500
     payload = _json.loads(bytes(result.body))
     assert "Could not save result" in payload["error"]
+
+
+# --------------------------------------------------------------------------- #
+#  edit_capabilities: per-tier health so the UI can hide Quality when only     #
+#  the fast (iopaint) backend is actually healthy, instead of letting the     #
+#  frontend offer a Quality tier that silently downgrades.                    #
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_capabilities_both_tiers_healthy_when_flux_fill_present():
+    """Both flux-fill and iopaint healthy -> quality and fast both report healthy."""
+    catalog = _FakeCatalog(
+        {"image-editing": [_backend("flux", "flux-fill"), _backend("io", "iopaint")]}
+    )
+    request = _request_with_catalog(catalog)
+    result = await edit_capabilities(request)
+
+    assert result["image_editing"] is True
+    assert result["image_editing_tiers"] == {"quality": True, "fast": True}
+
+
+@pytest.mark.asyncio
+async def test_capabilities_quality_unhealthy_when_only_iopaint_present():
+    """Only iopaint healthy -> quality reports unhealthy (would silently
+    downgrade to the prompt-ignoring eraser), fast still reports healthy."""
+    catalog = _FakeCatalog({"image-editing": [_backend("io", "iopaint")]})
+    request = _request_with_catalog(catalog)
+    result = await edit_capabilities(request)
+
+    assert result["image_editing"] is True  # some backend is healthy
+    assert result["image_editing_tiers"] == {"quality": False, "fast": True}
+
+
+@pytest.mark.asyncio
+async def test_capabilities_no_catalog_reports_all_unhealthy():
+    """No live catalog -> every capability and tier reports unhealthy, never raises."""
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(backend_catalog=None)))
+    result = await edit_capabilities(request)
+
+    assert result["image_editing"] is False
+    assert result["image_editing_tiers"] == {"quality": False, "fast": False}

--- a/tests/test_routes_images_edit.py
+++ b/tests/test_routes_images_edit.py
@@ -410,6 +410,20 @@ async def test_capabilities_quality_unhealthy_when_only_iopaint_present():
 
 
 @pytest.mark.asyncio
+async def test_capabilities_fast_healthy_when_only_flux_fill_present():
+    """Only flux-fill healthy -> fast reports healthy, because the router
+    (via _get_edit_backend's fallback) serves a fast request on flux-fill,
+    which still honours the prompt. The probe must not disable a tier the
+    router would actually serve. Quality is healthy too (its primary ran)."""
+    catalog = _FakeCatalog({"image-editing": [_backend("flux", "flux-fill")]})
+    request = _request_with_catalog(catalog)
+    result = await edit_capabilities(request)
+
+    assert result["image_editing"] is True
+    assert result["image_editing_tiers"] == {"quality": True, "fast": True}
+
+
+@pytest.mark.asyncio
 async def test_capabilities_no_catalog_reports_all_unhealthy():
     """No live catalog -> every capability and tier reports unhealthy, never raises."""
     request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(backend_catalog=None)))

--- a/tinyagentos/routes/images_edit.py
+++ b/tinyagentos/routes/images_edit.py
@@ -522,7 +522,14 @@ async def upscale_image(request: Request, body: UpscaleRequest):
 @router.get("/api/images/edit/capabilities")
 async def edit_capabilities(request: Request):
     """Report which editing capabilities currently have a healthy backend,
-    so the frontend can gate ops."""
+    so the frontend can gate ops.
+
+    ``image_editing_tiers`` additionally reports per-tier health for
+    image-editing (quality = flux-fill, fast = iopaint) so the UI can
+    disable the Quality option when only the fast backend is healthy,
+    instead of silently downgrading a Quality request to the
+    prompt-ignoring iopaint eraser.
+    """
     catalog = getattr(request.app.state, "backend_catalog", None)
 
     def has(capability: str) -> bool:
@@ -530,8 +537,22 @@ async def edit_capabilities(request: Request):
             return False
         return bool(catalog.backends_with_capability(capability))
 
+    def tier_healthy(capability: str, tier: str) -> bool:
+        """True if the tier's *preferred* backend type is actually healthy
+        (not just some fallback type for the capability)."""
+        if catalog is None:
+            return False
+        primary = (_TIER_PREFERENCE.get(capability, {}).get(tier) or [None])[0]
+        if primary is None:
+            return False
+        return any(b.type == primary for b in catalog.backends_with_capability(capability))
+
     return {
         "image_editing": has("image-editing"),
         "background_removal": has("background-removal"),
         "upscale": has("upscale"),
+        "image_editing_tiers": {
+            "quality": tier_healthy("image-editing", "quality"),
+            "fast": tier_healthy("image-editing", "fast"),
+        },
     }

--- a/tinyagentos/routes/images_edit.py
+++ b/tinyagentos/routes/images_edit.py
@@ -525,10 +525,20 @@ async def edit_capabilities(request: Request):
     so the frontend can gate ops.
 
     ``image_editing_tiers`` additionally reports per-tier health for
-    image-editing (quality = flux-fill, fast = iopaint) so the UI can
-    disable the Quality option when only the fast backend is healthy,
-    instead of silently downgrading a Quality request to the
-    prompt-ignoring iopaint eraser.
+    image-editing so the UI can disable a tier the router can't honestly
+    serve, rather than offering one that silently downgrades. Health mirrors
+    what ``_get_edit_backend`` + ``edit_image`` actually do:
+
+    - ``quality`` is healthy only when the router resolves its primary
+      backend (flux-fill). If it would fall back to iopaint, that's the
+      silent, prompt-ignoring downgrade we're preventing, so Quality reports
+      unhealthy (matching ``edit_image``'s ``degraded`` flag).
+    - ``fast`` is healthy whenever the router resolves *any* backend for the
+      tier. Fast's preference falls through to flux-fill when iopaint is
+      absent, and serving a fast request on flux-fill still honours the
+      prompt (never flagged ``degraded``) — so Fast must NOT be disabled just
+      because iopaint is missing, or the UI would gate a tier the router
+      would happily serve.
     """
     catalog = getattr(request.app.state, "backend_catalog", None)
 
@@ -538,14 +548,24 @@ async def edit_capabilities(request: Request):
         return bool(catalog.backends_with_capability(capability))
 
     def tier_healthy(capability: str, tier: str) -> bool:
-        """True if the tier's *preferred* backend type is actually healthy
-        (not just some fallback type for the capability)."""
-        if catalog is None:
+        """True if the router can serve *tier* without a silent downgrade.
+
+        Resolves the backend the same way ``edit_image`` does (via
+        ``_get_edit_backend``) so the probe and the router never diverge.
+        """
+        resolved = _get_edit_backend(request, capability, tier)
+        if resolved is None:
             return False
-        primary = (_TIER_PREFERENCE.get(capability, {}).get(tier) or [None])[0]
-        if primary is None:
-            return False
-        return any(b.type == primary for b in catalog.backends_with_capability(capability))
+        _url, backend_type, _name = resolved
+        # Only "quality" carries a downgrade risk: served by anything other
+        # than its primary (flux-fill) means the prompt is ignored. This is
+        # exactly ``edit_image``'s degraded condition, inverted.
+        quality_primary = (
+            _TIER_PREFERENCE.get(capability, {}).get("quality") or [None]
+        )[0]
+        if tier == "quality":
+            return backend_type == quality_primary
+        return True
 
     return {
         "image_editing": has("image-editing"),


### PR DESCRIPTION
## The trust bug

Images Studio's Edit view offers a "Quality" tier for inpaint/outpaint that's supposed to route to the flux-fill GPU diffusion backend. When no flux-fill backend is healthy, `_get_edit_backend` (`tinyagentos/routes/images_edit.py`) silently falls back to iopaint's LaMa eraser — a fast backend that **ignores the prompt entirely**. The edit response already carried a `degraded` flag (plus the `backend` type that actually ran) marking this, but the frontend read `{ url, image_ref }` from the response and dropped both fields. A user asking for a prompted "Quality" inpaint would get a plain erase with zero indication anything was downgraded.

## The two fixes

1. **Surface the downgrade.** `EditView.tsx`'s `callEdit` (previously ~line 256) now reads `degraded`/`backend` off the edit response and, when `degraded` is true, shows a non-blocking amber notice on the result canvas: "Served by the fast eraser — the Quality model isn't available, so the prompt was ignored." The notice is scoped so it survives the image swap that happens right after a successful edit (a naive implementation tied to the same effect that resets the mask on `image.url` change would have cleared the notice instantly — kept them decoupled). `ImagesApp.tsx`'s `onEdited` handler (previously ~line 424) also now consumes `backend` to keep the edited image's stored backend value honest rather than stale.

2. **Capability-aware tier picker.** `GET /api/images/edit/capabilities` now reports per-tier health for image-editing: `image_editing_tiers: { quality: bool, fast: bool }`, computed from whether each tier's *primary* backend type (flux-fill for quality, iopaint for fast) is actually present in the healthy backend list — not just whether *any* backend for the capability is healthy. `EditView` uses this to disable the "Quality" segmented-control option (with a "Quality model not installed" tooltip) whenever only the fast backend is healthy, and auto-falls-back the selected tier to "fast" if Quality becomes unavailable while selected. "Fast" stays available whenever iopaint is healthy, unchanged.

## Exact backend fields consumed

- `degraded: bool` and `backend: str | None` from `POST /api/images/edit`'s response (`_save_result` in `images_edit.py`).
- `image_editing_tiers: { quality: bool, fast: bool }` — new field added to `GET /api/images/edit/capabilities`'s response.

## Files changed

- `tinyagentos/routes/images_edit.py` — `edit_capabilities` extended with per-tier health.
- `tests/test_routes_images_edit.py` — 3 new tests for the tier-granular capabilities response.
- `desktop/src/apps/images/types.ts` — `EditCapabilities.image_editing_tiers` (optional).
- `desktop/src/apps/images/controls.tsx` — `Segmented` options now support `disabled`/`title` per-option.
- `desktop/src/apps/images/EditView.tsx` — downgrade notice, quality-health gating, tier auto-fallback.
- `desktop/src/apps/images/EditView.test.tsx` — new: 4 tests (notice shown/hidden, Quality disabled/enabled per capability).
- `desktop/src/apps/ImagesApp.tsx` — `onEdited` consumes `backend`.

## Test plan

- [x] `cd desktop && npx vitest run src/apps/images` — 4/4 new tests pass.
- [x] `cd desktop && npm run build` — 0 TS errors.
- [x] `python3 -m pytest tests/ -k "images_edit or images" -q --ignore=tests/e2e` — 56 passed (pre-existing `tests/e2e` collection errors are an unrelated missing-`playwright`-package environment gap, not touched by this change).

No changes to the generation path or the edit ops themselves; the editor UI is otherwise untouched.