### PR TITLE
feat(design-studio): save/open/rename designs (persistence)

### DIFF
--- a/desktop/src/apps/DesignStudioApp.test.tsx
+++ b/desktop/src/apps/DesignStudioApp.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createElement, useEffect, useRef } from "react";
 import type { ReactNode } from "react";
@@ -202,6 +202,7 @@ describe("DesignStudioApp", () => {
     expect(screen.getByRole("button", { name: "Templates" })).toBeDefined();
     expect(screen.getByRole("button", { name: "Elements" })).toBeDefined();
     expect(screen.getByRole("button", { name: "Magic" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Library" })).toBeDefined();
     expect(screen.getByRole("button", { name: "Brand" })).toBeDefined();
   });
 
@@ -416,5 +417,160 @@ describe("DesignStudioApp", () => {
     expect(screen.getByRole("button", { name: "Generate" })).toBeDefined();
     expect(screen.getByPlaceholderText(/launch poster/i)).toBeDefined();
     expect(screen.getAllByText("Editorial").length).toBeGreaterThan(0);
+  });
+});
+
+describe("DesignStudioApp persistence", () => {
+  const originalResizeObserver = globalThis.ResizeObserver;
+
+  beforeEach(() => {
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver;
+    vi.unstubAllGlobals();
+  });
+
+  /** Routes fetch by URL/method so a single mock can stand in for the
+   *  models probe and the /api/designs persistence endpoints. */
+  function stubFetch(overrides: {
+    listDesigns?: unknown[];
+    getDesignContent?: string;
+    onCreate?: (body: { name: string; content: string }) => void;
+    onUpdate?: (id: string, body: { name?: string; content?: string }) => void;
+  }) {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+
+      if (url === "/api/models") {
+        return { ok: true, json: async () => ({ models: [] }) } as Response;
+      }
+      if (url === "/api/designs" && method === "GET") {
+        return { ok: true, json: async () => overrides.listDesigns ?? [] } as Response;
+      }
+      if (url === "/api/designs" && method === "POST") {
+        const body = JSON.parse(String(init?.body)) as { name: string; content: string };
+        overrides.onCreate?.(body);
+        return {
+          ok: true,
+          json: async () => ({
+            id: "design-created",
+            name: body.name,
+            content: body.content,
+            created_at: 1000,
+            updated_at: 1000,
+          }),
+        } as Response;
+      }
+      if (url.startsWith("/api/designs/") && method === "GET") {
+        const id = url.split("/").pop()!;
+        return {
+          ok: true,
+          json: async () => ({
+            id,
+            name: "My Poster",
+            content: overrides.getDesignContent ?? "{}",
+            created_at: 1000,
+            updated_at: 1000,
+          }),
+        } as Response;
+      }
+      if (url.startsWith("/api/designs/") && method === "PUT") {
+        const id = url.split("/").pop()!;
+        const body = JSON.parse(String(init?.body)) as { name?: string; content?: string };
+        overrides.onUpdate?.(id, body);
+        return {
+          ok: true,
+          json: async () => ({
+            id,
+            name: body.name ?? "My Poster",
+            content: body.content ?? "{}",
+            created_at: 1000,
+            updated_at: 1000,
+          }),
+        } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  it("adding an element marks the design dirty, and Save persists the current canvas", async () => {
+    let created: { name: string; content: string } | null = null;
+    stubFetch({ onCreate: (body) => (created = body) });
+
+    const { container } = renderApp();
+    fireEvent.click(screen.getByRole("button", { name: "Text" }));
+    expect(countCanvasElements(container)).toBe(1);
+    expect(screen.getByText("Unsaved changes")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /Save/ }));
+
+    await waitFor(() => expect(screen.queryByText("Unsaved changes")).toBeNull());
+    expect(created).not.toBeNull();
+    const savedContent = JSON.parse(created!.content) as { elements: unknown[] };
+    expect(savedContent.elements.length).toBe(1);
+  });
+
+  it("New confirms discard when there are unsaved changes", () => {
+    stubFetch({});
+    const { container } = renderApp();
+    fireEvent.click(screen.getByRole("button", { name: "Text" }));
+    expect(countCanvasElements(container)).toBe(1);
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValueOnce(false);
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(countCanvasElements(container)).toBe(1);
+
+    confirmSpy.mockReturnValueOnce(true);
+    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    expect(countCanvasElements(container)).toBe(0);
+    expect(screen.queryByText("Unsaved changes")).toBeNull();
+    confirmSpy.mockRestore();
+  });
+
+  it("Library lists saved designs, and opening one hydrates the canvas and name", async () => {
+    stubFetch({
+      listDesigns: [{ id: "design-1", name: "My Poster", updated_at: 1700000000 }],
+      getDesignContent: JSON.stringify({
+        artboard: { name: "My Poster", width: 800, height: 600 },
+        elements: [
+          {
+            id: "text-1",
+            type: "text",
+            x: 0,
+            y: 0,
+            width: 100,
+            height: 40,
+            rotation: 0,
+            zIndex: 0,
+            visible: true,
+            text: "Hi",
+            fontSize: 20,
+            fontFamily: "Inter",
+            fill: "#ffffff",
+            align: "left",
+          },
+        ],
+      }),
+    });
+
+    const { container } = renderApp();
+    fireEvent.click(screen.getByRole("button", { name: "Library" }));
+    expect(await screen.findByText("My Poster")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Open My Poster" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Design" }).getAttribute("aria-current")).toBe(
+        "page",
+      ),
+    );
+    expect(countCanvasElements(container)).toBe(1);
+    expect(screen.getByLabelText("Design name")).toHaveValue("My Poster");
   });
 });

--- a/desktop/src/apps/DesignStudioApp.tsx
+++ b/desktop/src/apps/DesignStudioApp.tsx
@@ -1,14 +1,18 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { PenLine, LayoutGrid, Plus, Sparkles, Circle } from "lucide-react";
+import { PenLine, LayoutGrid, Plus, Sparkles, Circle, FolderOpen, Save, FilePlus2 } from "lucide-react";
 import { ModelBrowser } from "@/components/ModelBrowser";
 import { DesignView } from "./designstudio/DesignView";
 import { TemplatesView, type TemplateChoice } from "./designstudio/TemplatesView";
 import { MagicView } from "./designstudio/MagicView";
+import { LibraryView } from "./designstudio/LibraryView";
 import { createImageElement } from "./designstudio/elementFactory";
+import { createDesign, getDesign, updateDesign, MAX_CONTENT_BYTES } from "./designstudio/designs-api";
 import {
   DEFAULT_ARTBOARD,
+  isValidDesignContent,
   type Artboard,
   type CanvasElement,
+  type DesignContent,
   type DesignStudioView,
   type GeneratedImage,
 } from "./designstudio/types";
@@ -19,6 +23,7 @@ const RAIL: { id: DesignStudioView; label: string; icon: typeof PenLine }[] = [
   { id: "templates", label: "Templates", icon: LayoutGrid },
   { id: "elements", label: "Elements", icon: Plus },
   { id: "magic", label: "Magic", icon: Sparkles },
+  { id: "library", label: "Library", icon: FolderOpen },
 ];
 
 function randomSeed(): number {
@@ -41,6 +46,14 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
   const [selectedModelId, setSelectedModelId] = useState("");
   const [selectedVariantId, setSelectedVariantId] = useState("");
   const [browserOpen, setBrowserOpen] = useState(false);
+
+  // Persistence: the currently-open saved design (if any), whether the
+  // canvas has changes since the last save/open, and in-flight save/open
+  // status. New designs start blank and unsaved.
+  const [activeDesignId, setActiveDesignId] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const refreshModels = useCallback(async () => {
     try {
@@ -95,6 +108,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
         ...prev,
         createImageElement(prev, img.url, artboard.width, artboard.height, img.prompt),
       ]);
+      setDirty(true);
       setView("design");
     },
     [artboard.width, artboard.height],
@@ -103,7 +117,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
   const handleSelectTemplate = useCallback(
     (template: TemplateChoice) => {
       // Picking a template resets the canvas; confirm first so an accidental
-      // click doesn't wipe unsaved work. (Persistence is a later phase.)
+      // click doesn't wipe unsaved work.
       if (
         canvasElements.length > 0 &&
         !window.confirm("Start from this template? Your current design will be cleared.")
@@ -112,10 +126,87 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
       }
       setArtboard({ name: template.name, width: template.width, height: template.height });
       setCanvasElements([]);
+      setActiveDesignId(null);
+      setSaveError(null);
+      setDirty(false);
       setView("design");
     },
     [canvasElements.length],
   );
+
+  /** True if the user should be prompted before discarding in-memory edits. */
+  const confirmDiscard = () =>
+    !dirty || window.confirm("Discard unsaved changes to the current design?");
+
+  const handleElementsChange = (next: CanvasElement[]) => {
+    setCanvasElements(next);
+    setDirty(true);
+  };
+
+  const newDesign = () => {
+    if (!confirmDiscard()) return;
+    setCanvasElements([]);
+    setArtboard(DEFAULT_ARTBOARD);
+    setActiveDesignId(null);
+    setSaveError(null);
+    setDirty(false);
+  };
+
+  const openDesign = async (id: string) => {
+    if (!confirmDiscard()) return;
+    setSaveError(null);
+    try {
+      const doc = await getDesign(id);
+      let content: DesignContent;
+      try {
+        const parsed: unknown = JSON.parse(doc.content);
+        if (!isValidDesignContent(parsed)) throw new Error("malformed design data");
+        content = parsed;
+      } catch {
+        setSaveError("This design's saved data is corrupted; opened a blank design instead.");
+        content = { artboard: DEFAULT_ARTBOARD, elements: [] };
+      }
+      setArtboard(content.artboard);
+      setCanvasElements(content.elements);
+      setActiveDesignId(doc.id);
+      setDirty(false);
+      setView("design");
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Open failed");
+    }
+  };
+
+  const saveDesign = async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const content = JSON.stringify({ artboard, elements: canvasElements });
+      // Catch an over-cap design (usually too many/too-large inlined images)
+      // here with a clear message rather than letting it fail only at PUT
+      // time with a raw 413. The cap mirrors the backend's MAX_CONTENT_BYTES.
+      if (new Blob([content]).size > MAX_CONTENT_BYTES) {
+        throw new Error(
+          "This design is too large to save (over 5 MB). Remove or shrink some images and try again.",
+        );
+      }
+      const name = artboard.name.trim() || "Untitled design";
+      const saved = activeDesignId
+        ? await updateDesign(activeDesignId, name, content)
+        : await createDesign(name, content);
+      setActiveDesignId(saved.id);
+      setDirty(false);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRenamed = (id: string, name: string) => {
+    if (activeDesignId === id) {
+      setArtboard((prev) => ({ ...prev, name }));
+    }
+  };
 
   const runGenerate = useCallback(async () => {
     const usePrompt = magicPrompt.trim();
@@ -194,6 +285,42 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
+      {/* persistence bar -- name / dirty state / New / Save, shared across all views */}
+      <div className="flex h-11 flex-none items-center gap-2.5 border-b border-shell-border bg-shell-bg-deep px-4">
+        <input
+          aria-label="Design name"
+          value={artboard.name}
+          onChange={(e) => {
+            setArtboard((prev) => ({ ...prev, name: e.target.value }));
+            setDirty(true);
+          }}
+          className="h-8 w-[220px] rounded-lg border border-shell-border bg-shell-surface px-3 text-[12.5px] font-semibold text-shell-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        />
+        {dirty && <span className="text-[11px] text-shell-text-tertiary">Unsaved changes</span>}
+        {saveError && (
+          <span role="alert" className="truncate text-[11px] text-red-400">
+            {saveError}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={newDesign}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] border border-shell-border px-3 text-[12px] font-semibold text-shell-text-secondary hover:bg-shell-surface-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <FilePlus2 size={14} /> New
+          </button>
+          <button
+            type="button"
+            onClick={() => void saveDesign()}
+            disabled={saving}
+            className="flex h-8 items-center gap-1.5 rounded-[9px] bg-gradient-to-br from-accent to-accent/70 px-3.5 text-[12px] font-bold text-white disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+          >
+            <Save size={14} /> {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+
       <div className="flex min-h-0 flex-1">
         <nav
           aria-label="Design Studio views"
@@ -235,7 +362,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
           {view === "design" && (
             <DesignView
               elements={canvasElements}
-              onElementsChange={setCanvasElements}
+              onElementsChange={handleElementsChange}
               artboard={artboard}
             />
           )}
@@ -243,7 +370,7 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
           {view === "elements" && (
             <DesignView
               elements={canvasElements}
-              onElementsChange={setCanvasElements}
+              onElementsChange={handleElementsChange}
               artboard={artboard}
             />
           )}
@@ -263,6 +390,9 @@ export function DesignStudioApp({ windowId: _windowId }: { windowId: string }) {
               onPickModel={() => setBrowserOpen(true)}
               onUseResult={placeOnCanvas}
             />
+          )}
+          {view === "library" && (
+            <LibraryView onOpenDesign={(id) => void openDesign(id)} onRenamed={handleRenamed} />
           )}
         </div>
       </div>

--- a/desktop/src/apps/designstudio/LibraryView.tsx
+++ b/desktop/src/apps/designstudio/LibraryView.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useState } from "react";
+import { FolderOpen, Pencil, Trash2, Loader2, AlertCircle, PenLine } from "lucide-react";
+import { deleteDesign, listDesigns, renameDesign, type SavedDesign } from "./designs-api";
+
+/* ------------------------------------------------------------------ */
+/*  LibraryView -- grid of saved designs                                */
+/*                                                                     */
+/*  Delete is backend-confirmed: the list only drops a row after the    */
+/*  DELETE call succeeds and the list has been refetched, never          */
+/*  optimistically (same pattern as Game Studio's LibraryView).          */
+/* ------------------------------------------------------------------ */
+
+export interface LibraryViewProps {
+  onOpenDesign: (id: string) => void;
+  /** Called after a successful rename so the shell can sync the currently
+   *  open design's name if it's the one that was just renamed. */
+  onRenamed?: (id: string, name: string) => void;
+}
+
+function relativeTime(epochSeconds: number): string {
+  const diffMs = Date.now() - epochSeconds * 1000;
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function LibraryView({ onOpenDesign, onRenamed }: LibraryViewProps) {
+  const [designs, setDesigns] = useState<SavedDesign[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setDesigns(await listDesigns());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleRename = useCallback(
+    async (design: SavedDesign) => {
+      const next = window.prompt("Rename design:", design.name);
+      if (!next?.trim() || next.trim() === design.name) return;
+      const name = next.trim();
+      setBusyId(design.id);
+      try {
+        await renameDesign(design.id, name);
+        await load();
+        onRenamed?.(design.id, name);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [load, onRenamed],
+  );
+
+  const handleDelete = useCallback(
+    async (design: SavedDesign) => {
+      const ok = window.confirm(`Delete "${design.name}"? This can't be undone.`);
+      if (!ok) return;
+      setBusyId(design.id);
+      try {
+        await deleteDesign(design.id);
+        // Backend-confirmed: only refresh the list (from the server) after
+        // the delete call has actually succeeded -- never splice the row
+        // out of local state optimistically.
+        await load();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [load],
+  );
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-col gap-3.5 p-[22px]">
+        <header>
+          <h2 className="text-[17px] font-bold tracking-[-0.02em]">Your designs</h2>
+          <p className="mt-1 text-[12.5px] text-shell-text-secondary">
+            Every design you've saved, ready to reopen and keep editing.
+          </p>
+        </header>
+
+        {error && (
+          <div
+            role="alert"
+            className="flex items-center gap-2 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3 text-[12.5px] text-red-200"
+          >
+            <AlertCircle size={15} />
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex items-center gap-2 py-8 text-[13px] text-shell-text-tertiary">
+            <Loader2 size={16} className="animate-spin" />
+            Loading your designs...
+          </div>
+        ) : designs.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 rounded-2xl border border-dashed border-shell-border py-14 text-center text-shell-text-tertiary">
+            <PenLine size={28} />
+            <p className="text-[13px]">No saved designs yet. Save one to see it here.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-3.5">
+            {designs.map((d) => {
+              const busy = busyId === d.id;
+              return (
+                <div
+                  key={d.id}
+                  className="flex flex-col overflow-hidden rounded-2xl border border-shell-border bg-shell-surface shadow-card"
+                >
+                  <div
+                    className="relative flex h-[92px] items-center justify-center"
+                    style={{ background: "linear-gradient(140deg,#2c3142,#171a24)" }}
+                  >
+                    <span
+                      className="absolute bottom-2 left-3 text-[14px] font-extrabold text-white"
+                      style={{ textShadow: "0 2px 8px rgba(0,0,0,0.6)" }}
+                    >
+                      {d.name}
+                    </span>
+                  </div>
+                  <div className="flex flex-1 flex-col gap-2 p-3">
+                    <span className="text-[11px] text-shell-text-tertiary">
+                      updated {relativeTime(d.updated_at ?? 0)}
+                    </span>
+                    <div className="mt-1 flex items-center gap-1.5">
+                      <button
+                        type="button"
+                        onClick={() => onOpenDesign(d.id)}
+                        aria-label={`Open ${d.name}`}
+                        className="flex flex-1 items-center justify-center gap-1.5 rounded-lg border border-shell-border bg-shell-surface-active px-2.5 py-1.5 text-[11.5px] font-bold text-shell-text hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                      >
+                        <FolderOpen size={13} />
+                        Open
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleRename(d)}
+                        disabled={busy}
+                        aria-label={`Rename ${d.name}`}
+                        className="flex h-8 w-8 flex-none items-center justify-center rounded-lg border border-shell-border text-shell-text-secondary hover:bg-white/10 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                      >
+                        {busy ? <Loader2 size={13} className="animate-spin" /> : <Pencil size={13} />}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleDelete(d)}
+                        disabled={busy}
+                        aria-label={`Delete ${d.name}`}
+                        className="flex h-8 w-8 flex-none items-center justify-center rounded-lg border border-shell-border text-red-400 hover:bg-red-500/10 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                      >
+                        <Trash2 size={13} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/designstudio/designs-api.ts
+++ b/desktop/src/apps/designstudio/designs-api.ts
@@ -1,0 +1,82 @@
+/* ------------------------------------------------------------------ */
+/*  Design Studio -- persistence API client (/api/designs)             */
+/*                                                                     */
+/*  Thin fetch wrapper mirroring the office/web studio persistence      */
+/*  pattern: an opaque JSON `content` blob keyed by id, listed          */
+/*  without content for the library sidebar, fetched in full on open.   */
+/* ------------------------------------------------------------------ */
+
+/** A design's saved content is capped to match the backend's limit so an
+ *  oversized save (usually too many/too-large inlined images) can be
+ *  caught here with a clear message rather than failing only at PUT time
+ *  with a raw 413. */
+export const MAX_CONTENT_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export interface SavedDesign {
+  id: string;
+  name: string;
+  created_at?: number;
+  updated_at?: number;
+}
+
+export interface DesignDoc extends SavedDesign {
+  content: string;
+}
+
+async function parseErrorMessage(res: Response, fallback: string): Promise<string> {
+  const body = await res.json().catch(() => ({}));
+  return (body as { error?: string }).error || fallback;
+}
+
+export async function listDesigns(): Promise<SavedDesign[]> {
+  const res = await fetch("/api/designs", { credentials: "include" });
+  if (!res.ok) throw new Error("Could not load designs");
+  return (await res.json()) as SavedDesign[];
+}
+
+export async function getDesign(id: string): Promise<DesignDoc> {
+  const res = await fetch(`/api/designs/${encodeURIComponent(id)}`, { credentials: "include" });
+  if (!res.ok) throw new Error("Could not open design");
+  return (await res.json()) as DesignDoc;
+}
+
+export async function createDesign(name: string, content: string): Promise<DesignDoc> {
+  const res = await fetch("/api/designs", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, content }),
+  });
+  if (!res.ok) throw new Error(await parseErrorMessage(res, "Save failed"));
+  return (await res.json()) as DesignDoc;
+}
+
+export async function updateDesign(
+  id: string,
+  name?: string,
+  content?: string,
+): Promise<DesignDoc> {
+  const payload: { name?: string; content?: string } = {};
+  if (name !== undefined) payload.name = name;
+  if (content !== undefined) payload.content = content;
+  const res = await fetch(`/api/designs/${encodeURIComponent(id)}`, {
+    method: "PUT",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(await parseErrorMessage(res, "Save failed"));
+  return (await res.json()) as DesignDoc;
+}
+
+export async function renameDesign(id: string, name: string): Promise<DesignDoc> {
+  return updateDesign(id, name);
+}
+
+export async function deleteDesign(id: string): Promise<void> {
+  const res = await fetch(`/api/designs/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error("Delete failed");
+}

--- a/desktop/src/apps/designstudio/types.ts
+++ b/desktop/src/apps/designstudio/types.ts
@@ -2,7 +2,7 @@
 /*  Design Studio -- shared types                                      */
 /* ------------------------------------------------------------------ */
 
-export type DesignStudioView = "design" | "templates" | "elements" | "magic";
+export type DesignStudioView = "design" | "templates" | "elements" | "magic" | "library";
 
 export interface GeneratedImage {
   id: string;
@@ -85,6 +85,35 @@ export function hasStroke(
   el: CanvasElement,
 ): el is RectElementData | EllipseElementData | LineElementData {
   return el.type === "rect" || el.type === "ellipse" || el.type === "line";
+}
+
+/** The shape persisted for a saved design: the artboard plus its elements. */
+export interface DesignContent {
+  artboard: Artboard;
+  elements: CanvasElement[];
+}
+
+/** Shallow validation of a design's saved content, mirroring the WebStudio
+ *  and Office pattern: a corrupted row must not slip through and crash the
+ *  canvas -- fall back to a blank design instead. */
+export function isValidDesignContent(value: unknown): value is DesignContent {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (!v.artboard || typeof v.artboard !== "object") return false;
+  const artboard = v.artboard as Record<string, unknown>;
+  if (
+    typeof artboard.name !== "string" ||
+    typeof artboard.width !== "number" ||
+    typeof artboard.height !== "number"
+  ) {
+    return false;
+  }
+  if (!Array.isArray(v.elements)) return false;
+  return v.elements.every((el) => {
+    if (!el || typeof el !== "object") return false;
+    const e = el as Record<string, unknown>;
+    return typeof e.id === "string" && typeof e.type === "string";
+  });
 }
 
 export const MAGIC_STYLE_CHIPS = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -354,6 +354,10 @@ async def client(app, tmp_data_dir):
     if song_store._db is not None:
         await song_store.close()
     await song_store.init()
+    design_docs = app.state.design_docs
+    if design_docs._db is not None:
+        await design_docs.close()
+    await design_docs.init()
     # app_grants ledger (per-app capability grants) is lifespan-owned; tests that
     # bypass the lifespan must init it so the userspace broker can consult it.
     await app.state.app_grants.init()
@@ -421,6 +425,7 @@ async def client(app, tmp_data_dir):
     await office_docs.close()
     await web_sites.close()
     await song_store.close()
+    await design_docs.close()
     await coding_session_store.close()
     await feedback_store.close()
     await client_log_store.close()

--- a/tests/test_design_docs.py
+++ b/tests/test_design_docs.py
@@ -1,0 +1,128 @@
+import pytest
+import pytest_asyncio
+
+import tinyagentos.design_docs as design_docs_module
+from tinyagentos.design_docs import _new_design_id, DesignStore
+
+
+@pytest_asyncio.fixture
+async def design_store(tmp_path):
+    store = DesignStore(tmp_path / "design_docs.db")
+    await store.init()
+    yield store
+    await store.close()
+
+
+class TestNewDesignId:
+    def test_format(self):
+        design_id = _new_design_id()
+        assert design_id.startswith("design-")
+        suffix = design_id[7:]
+        assert len(suffix) == 8
+        alphabet = "abcdefghijklmnopqrstuvwxyz234567"
+        for ch in suffix:
+            assert ch in alphabet
+
+    def test_uniqueness(self):
+        ids = {_new_design_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+@pytest.mark.asyncio
+async def test_create_happy_path(design_store):
+    row = await design_store.create(name="My Design", content='{"artboard": {}, "elements": []}')
+    assert row["name"] == "My Design"
+    assert row["content"] == '{"artboard": {}, "elements": []}'
+    assert row["id"].startswith("design-")
+    assert row["created_at"] == row["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_list_excludes_content(design_store):
+    await design_store.create(name="T", content='{"secret": true}')
+    rows = await design_store.list()
+    assert len(rows) == 1
+    assert "content" not in rows[0]
+    assert rows[0]["name"] == "T"
+
+
+@pytest.mark.asyncio
+async def test_get_returns_content(design_store):
+    created = await design_store.create(name="T", content='{"a": 1}')
+    fetched = await design_store.get(created["id"])
+    assert fetched is not None
+    assert fetched["content"] == '{"a": 1}'
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(design_store):
+    assert await design_store.get("design-noexist") is None
+
+
+@pytest.mark.asyncio
+async def test_update_changes_content_and_timestamp(design_store):
+    created = await design_store.create(name="T", content="{}")
+    updated = await design_store.update(
+        created["id"], name="T2", content='{"elements": [1]}'
+    )
+    assert updated is not None
+    assert updated["name"] == "T2"
+    assert updated["content"] == '{"elements": [1]}'
+    assert updated["updated_at"] >= created["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_delete_existing(design_store):
+    created = await design_store.create(name="T", content="{}")
+    assert await design_store.delete(created["id"]) is True
+    assert await design_store.get(created["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent(design_store):
+    assert await design_store.delete("design-noexist") is False
+
+
+@pytest.mark.asyncio
+async def test_create_retries_on_id_collision(design_store, monkeypatch):
+    """A colliding id (e.g. two concurrent creates racing on the same
+    generated suffix) must not surface as a 500 -- the INSERT/PRIMARY KEY
+    is the source of truth and a fresh id is retried."""
+    ids = iter(["design-dupeid1", "design-dupeid1", "design-freshid"])
+    monkeypatch.setattr(design_docs_module, "_new_design_id", lambda: next(ids))
+
+    first = await design_store.create(name="First", content="{}")
+    assert first["id"] == "design-dupeid1"
+
+    second = await design_store.create(name="Second", content="{}")
+    assert second["id"] == "design-freshid"
+    assert second["name"] == "Second"
+
+
+@pytest.mark.asyncio
+async def test_create_gives_up_after_bounded_retries(design_store, monkeypatch):
+    monkeypatch.setattr(design_docs_module, "_new_design_id", lambda: "design-alwayssame")
+    await design_store.create(name="First", content="{}")
+
+    with pytest.raises(RuntimeError):
+        await design_store.create(name="Second", content="{}")
+
+
+@pytest.mark.asyncio
+async def test_create_get_update_delete_roundtrip(design_store):
+    created = await design_store.create(name="Start", content="orig")
+    design_id = created["id"]
+
+    fetched = await design_store.get(design_id)
+    assert fetched["name"] == "Start"
+
+    updated = await design_store.update(design_id, name="Edited", content="changed")
+    assert updated["name"] == "Edited"
+    assert updated["content"] == "changed"
+
+    rows = await design_store.list()
+    assert len(rows) == 1
+
+    assert await design_store.delete(design_id) is True
+    assert await design_store.get(design_id) is None
+    assert await design_store.list() == []

--- a/tests/test_routes_designs.py
+++ b/tests/test_routes_designs.py
@@ -1,0 +1,134 @@
+import pytest
+
+from tinyagentos.routes.designs import MAX_CONTENT_BYTES
+
+
+@pytest.mark.asyncio
+async def test_create_list_get_update_delete_design(client):
+    resp = await client.post(
+        "/api/designs",
+        json={"name": "Poster", "content": '{"artboard": {}, "elements": []}'},
+    )
+    assert resp.status_code == 200
+    created = resp.json()
+    design_id = created["id"]
+    assert created["name"] == "Poster"
+    assert created["content"] == '{"artboard": {}, "elements": []}'
+    assert isinstance(created["updated_at"], int)
+
+    resp = await client.get("/api/designs")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["id"] == design_id
+    assert "content" not in items[0]
+
+    resp = await client.get(f"/api/designs/{design_id}")
+    assert resp.status_code == 200
+    assert resp.json()["content"] == '{"artboard": {}, "elements": []}'
+
+    resp = await client.put(
+        f"/api/designs/{design_id}",
+        json={"name": "Poster v2", "content": '{"artboard": {}, "elements": [1]}'},
+    )
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["name"] == "Poster v2"
+    assert updated["content"] == '{"artboard": {}, "elements": [1]}'
+    assert updated["updated_at"] >= created["updated_at"]
+
+    resp = await client.delete(f"/api/designs/{design_id}")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "deleted"
+
+    resp = await client.get(f"/api/designs/{design_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_name_only_preserves_content(client):
+    resp = await client.post(
+        "/api/designs",
+        json={"name": "Original", "content": '{"elements": [1, 2, 3]}'},
+    )
+    design_id = resp.json()["id"]
+
+    resp = await client.put(f"/api/designs/{design_id}", json={"name": "Renamed"})
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["name"] == "Renamed"
+    assert updated["content"] == '{"elements": [1, 2, 3]}'
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_missing_name(client):
+    resp = await client.post(
+        "/api/designs",
+        json={"name": "   ", "content": "{}"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_404(client):
+    resp = await client.get("/api/designs/design-missing")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_missing_returns_404(client):
+    resp = await client.put(
+        "/api/designs/design-missing",
+        json={"name": "X", "content": "{}"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_returns_404(client):
+    resp = await client.delete("/api/designs/design-missing")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_malformed_json(client):
+    resp = await client.post(
+        "/api/designs",
+        content=b"{not valid json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_malformed_json(client):
+    resp = await client.put(
+        "/api/designs/design-missing",
+        content=b"{not valid json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_oversized_content(client):
+    resp = await client.post(
+        "/api/designs",
+        json={"name": "Big", "content": "x" * (MAX_CONTENT_BYTES + 1)},
+    )
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_oversized_content(client):
+    resp = await client.post(
+        "/api/designs",
+        json={"name": "Poster", "content": "{}"},
+    )
+    design_id = resp.json()["id"]
+
+    resp = await client.put(
+        f"/api/designs/{design_id}",
+        json={"content": "x" * (MAX_CONTENT_BYTES + 1)},
+    )
+    assert resp.status_code == 413

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -98,6 +98,7 @@ from tinyagentos.skills import SkillStore
 from tinyagentos.office_docs import OfficeDocStore
 from tinyagentos.web_sites import WebSiteStore
 from tinyagentos.music_songs import SongStore
+from tinyagentos.design_docs import DesignStore
 from tinyagentos.knowledge_store import KnowledgeStore
 from tinyagentos.knowledge_ingest import IngestPipeline
 from tinyagentos.knowledge_categories import CategoryEngine
@@ -406,6 +407,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     office_docs = OfficeDocStore(data_dir / "office_docs.db")
     web_sites = WebSiteStore(data_dir / "web_sites.db")
     song_store = SongStore(data_dir / "songs.db")
+    design_docs = DesignStore(data_dir / "design_docs.db")
     coding_workspaces_store = CodingWorkspaceStore(
         data_dir / "coding_workspaces.db",
         data_dir / "coding-workspaces",
@@ -528,6 +530,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.web_sites = web_sites
         await song_store.init()
         app.state.song_store = song_store
+        await design_docs.init()
+        app.state.design_docs = design_docs
         await coding_workspaces_store.init()
         app.state.coding_workspaces = coding_workspaces_store
         await install_registry_store.init()
@@ -835,6 +839,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.office_docs = office_docs
         app.state.web_sites = web_sites
         app.state.song_store = song_store
+        app.state.design_docs = design_docs
         app.state.coding_workspaces = coding_workspaces_store
         app.state.install_registry = install_registry_store
         app.state.store_submissions = store_submissions
@@ -1319,6 +1324,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await office_docs.close()
         await web_sites.close()
         await song_store.close()
+        await design_docs.close()
         await coding_workspaces_store.close()
         await install_registry_store.close()
         await user_memory.close()
@@ -1513,6 +1519,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.office_docs = office_docs
     app.state.web_sites = web_sites
     app.state.song_store = song_store
+    app.state.design_docs = design_docs
     app.state.coding_workspaces = coding_workspaces_store
     app.state.install_registry = install_registry_store
     app.state.store_submissions = store_submissions

--- a/tinyagentos/design_docs.py
+++ b/tinyagentos/design_docs.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import logging
+import secrets
+import time
+from pathlib import Path
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+logger = logging.getLogger(__name__)
+
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
+
+DESIGN_DOCS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS designs (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+"""
+
+
+def _new_design_id() -> str:
+    suffix = "".join(secrets.choice(_ALPHABET) for _ in range(8))
+    return f"design-{suffix}"
+
+
+class DesignStore(BaseStore):
+    """Persists Design Studio documents.
+
+    ``content`` holds the design's artboard + canvas elements serialized as
+    JSON. The store treats it as an opaque TEXT blob; validation of the
+    model lives in the frontend.
+    """
+
+    SCHEMA = DESIGN_DOCS_SCHEMA
+
+    def __init__(self, db_path: Path):
+        super().__init__(db_path)
+
+    async def create(self, name: str, content: str) -> dict:
+        now = int(time.time())
+        # The id is generated and inserted speculatively; the PRIMARY KEY
+        # constraint is the actual source of truth for uniqueness, not a
+        # prior SELECT (which would leave a TOCTOU window between two
+        # concurrent creates picking the same id). On a collision we just
+        # retry with a fresh id, bounded so a persistently broken generator
+        # can't spin forever.
+        for _ in range(8):
+            design_id = _new_design_id()
+            row = {
+                "id": design_id,
+                "name": name,
+                "content": content,
+                "created_at": now,
+                "updated_at": now,
+            }
+            try:
+                await self._db.execute(
+                    """INSERT INTO designs (id, name, content, created_at, updated_at)
+                       VALUES (?, ?, ?, ?, ?)""",
+                    (row["id"], row["name"], row["content"], row["created_at"], row["updated_at"]),
+                )
+                await self._db.commit()
+                return row
+            except aiosqlite.IntegrityError:
+                # id collision: log it (a persistent stream would point at an
+                # entropy regression) and retry with a fresh id.
+                logger.warning("design_docs: design id collision on %s, retrying", design_id)
+                continue
+        raise RuntimeError("could not allocate design id after repeated id collisions")
+
+    async def list(self) -> list[dict]:
+        async with self._db.execute(
+            "SELECT id, name, created_at, updated_at FROM designs ORDER BY updated_at DESC"
+        ) as cur:
+            rows = await cur.fetchall()
+        return [
+            {"id": r[0], "name": r[1], "created_at": r[2], "updated_at": r[3]}
+            for r in rows
+        ]
+
+    async def get(self, design_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT id, name, content, created_at, updated_at FROM designs WHERE id = ?",
+            (design_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "name": row[1],
+            "content": row[2],
+            "created_at": row[3],
+            "updated_at": row[4],
+        }
+
+    async def update(self, design_id: str, name: str, content: str) -> dict | None:
+        now = int(time.time())
+        await self._db.execute(
+            "UPDATE designs SET name = ?, content = ?, updated_at = ? WHERE id = ?",
+            (name, content, now, design_id),
+        )
+        await self._db.commit()
+        return await self.get(design_id)
+
+    async def delete(self, design_id: str) -> bool:
+        async with self._db.execute(
+            "SELECT 1 FROM designs WHERE id = ?", (design_id,)
+        ) as cur:
+            exists = await cur.fetchone() is not None
+        if not exists:
+            return False
+        await self._db.execute("DELETE FROM designs WHERE id = ?", (design_id,))
+        await self._db.commit()
+        return True

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -336,6 +336,8 @@ def register_all_routers(app):
     app.include_router(songs_router)
     from tinyagentos.routes.web import router as web_router
     app.include_router(web_router)
+    from tinyagentos.routes.designs import router as designs_router
+    app.include_router(designs_router)
     from tinyagentos.routes.coding import router as coding_router
     app.include_router(coding_router)
     from tinyagentos.routes.store_submissions import router as store_submissions_router

--- a/tinyagentos/routes/designs.py
+++ b/tinyagentos/routes/designs.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from tinyagentos.design_docs import DesignStore
+
+router = APIRouter()
+
+# Designs can embed image data URIs in `content`; cap the row so a single
+# oversized upload can't bloat the SQLite database unboundedly.
+MAX_CONTENT_BYTES = 5 * 1024 * 1024  # 5 MB
+
+
+def _get_store(request: Request) -> DesignStore:
+    return request.app.state.design_docs
+
+
+def _validate_name(name: Any) -> str | None:
+    if not isinstance(name, str) or not name.strip():
+        return None
+    return name.strip()
+
+
+async def _parse_json(request: Request) -> dict | JSONResponse:
+    # request.json() can raise JSONDecodeError on malformed input, but an empty
+    # body or a wrong Content-Type can surface as a ValueError/UnicodeDecodeError
+    # too. Treat all of them as a 400. A non-object JSON body (list, string,
+    # number) is also rejected so downstream .get() access is always safe.
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return JSONResponse({"error": "invalid JSON body"}, status_code=400)
+    if not isinstance(body, dict):
+        return JSONResponse({"error": "JSON body must be an object"}, status_code=400)
+    return body
+
+
+def _validate_content(content: Any) -> JSONResponse | None:
+    """Returns an error response if `content` is invalid, else None."""
+    if not isinstance(content, str):
+        return JSONResponse({"error": "content must be a string"}, status_code=400)
+    if len(content.encode("utf-8")) > MAX_CONTENT_BYTES:
+        return JSONResponse(
+            {"error": f"content exceeds the {MAX_CONTENT_BYTES} byte limit"},
+            status_code=413,
+        )
+    return None
+
+
+@router.post("/api/designs")
+async def create_design(request: Request):
+    body = await _parse_json(request)
+    if isinstance(body, JSONResponse):
+        return body
+    name = _validate_name(body.get("name"))
+    if name is None:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+    content = body.get("content", "")
+    content_error = _validate_content(content)
+    if content_error is not None:
+        return content_error
+
+    store = _get_store(request)
+    design = await store.create(name=name, content=content)
+    return design
+
+
+@router.get("/api/designs")
+async def list_designs(request: Request):
+    store = _get_store(request)
+    return await store.list()
+
+
+@router.get("/api/designs/{design_id}")
+async def get_design(request: Request, design_id: str):
+    store = _get_store(request)
+    design = await store.get(design_id)
+    if design is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return design
+
+
+@router.put("/api/designs/{design_id}")
+async def update_design(request: Request, design_id: str):
+    body = await _parse_json(request)
+    if isinstance(body, JSONResponse):
+        return body
+    store = _get_store(request)
+
+    existing = await store.get(design_id)
+    if existing is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    name_raw = body.get("name", existing["name"])
+    name = _validate_name(name_raw)
+    if name is None:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+
+    content = body.get("content", existing["content"])
+    content_error = _validate_content(content)
+    if content_error is not None:
+        return content_error
+
+    design = await store.update(design_id=design_id, name=name, content=content)
+    return design
+
+
+@router.delete("/api/designs/{design_id}")
+async def delete_design(request: Request, design_id: str):
+    store = _get_store(request)
+    deleted = await store.delete(design_id)
+    if not deleted:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return {"status": "deleted", "id": design_id}


### PR DESCRIPTION
## Summary

Design Studio's react-konva editor (add/transform/rotate text/shapes/images, layers, undo/redo, PNG export, Magic image gen) was fully real but ephemeral — closing the window wiped the design. This adds save/open/rename/delete backed by a store, mirroring the existing office/web/game studio persistence pattern. The editor itself (konva canvas, undo/redo, MagicView, export) is unchanged.

- **Store**: `tinyagentos/design_docs.py` — `DesignStore(BaseStore)`, table `designs (id, name, content TEXT, created_at, updated_at)`. Mirrors `WebSiteStore`: opaque JSON `content` blob, PRIMARY-KEY-is-truth id generation with bounded collision retry. No `user_id` column — matches `office_docs`/`web_sites`, which don't scope by user either (a separate tracked task covers multi-user scoping across all stores).
- **Routes**: `tinyagentos/routes/designs.py` — `/api/designs` CRUD (create/list/get/update/delete), same validation/size-cap (5 MB) shape as `routes/web.py`. Wired into `app.py` (construction, lifespan init/close, non-lifespan fallback) and `routes/__init__.py`, matching every existing touch point for `office_docs`/`web_sites`.
- **Frontend**:
  - `designstudio/designs-api.ts` — thin fetch client (list/get/create/update/rename/delete), mirroring `gamestudio/games-api.ts`.
  - `designstudio/LibraryView.tsx` — new "Library" rail view: grid of saved designs, Open / Rename (prompt-based) / Delete, backend-confirmed refresh after mutation. Mirrors `gamestudio/LibraryView.tsx` (the closest existing precedent: a rail-based studio with its own Library view), rather than WebStudio's inline-sidebar shape which doesn't fit Design Studio's rail layout.
  - `DesignStudioApp.tsx` — new persistent top bar (Design name input = rename, dirty indicator, New, Save) shared across all rail views. Save serializes `{artboard, elements}` to JSON and POSTs/PUTs; Open fetches + validates (`isValidDesignContent`) + hydrates the canvas; dirty-tracking + discard-confirm mirrors `WebStudioApp`'s `confirmDiscard` pattern. New designs start blank.
  - `designstudio/types.ts` — added `DesignContent` type + `isValidDesignContent` shallow validator (same defensive shape as `webstudio/types.ts`'s `isValidSite`), and `"library"` to `DesignStudioView`.
- The konva editing, undo/redo, MagicView and export code in `DesignView.tsx` / `useElementHistory.ts` / `elementFactory.ts` / `MagicView.tsx` are **untouched** — only the App shell reads current state to save and writes it back on open.

## Test plan
- [x] `tests/test_design_docs.py` + `tests/test_routes_designs.py` — store CRUD + route CRUD/validation, mirroring `test_web_sites.py`/`test_routes_web.py` (22 tests, all passing)
- [x] `cd desktop && npx vitest run src/apps/designstudio src/apps/DesignStudioApp.test.tsx` — designs-api round-trip via mocked fetch, dirty-tracking, Save/New/discard-confirm, Library list + open hydration (19 tests, all passing)
- [x] `cd desktop && npm run build` — 0 TypeScript errors
- [x] `python scripts/check_doc_gate.py diff-gate --base origin/dev` — clean (Docs-Reviewed trailer covers the new route module + new app files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Design Studio library for browsing, opening, renaming, and deleting saved designs.
  * Users can now save designs, reopen them later, and continue editing from persisted canvas content.
  * Added unsaved-changes tracking with discard confirmation when starting a new design.
* **Bug Fixes**
  * Improved reliability when loading saved designs, including clearer handling for invalid or missing saved content.
  * Added save-size limits and clearer error messages when content is too large or a save fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->