### PR TITLE
fix(settings): dock-setting change no longer resets wallpaper (merge partial saves) (#1603, #1601)

### DIFF
--- a/desktop/src/hooks/__tests__/use-session-persistence.test.ts
+++ b/desktop/src/hooks/__tests__/use-session-persistence.test.ts
@@ -216,3 +216,76 @@ describe("useSessionPersistence — persistence survives a logout/login cycle (#
     });
   });
 });
+
+describe("useSessionPersistence — Dock and wallpaper auto-save write to separate endpoints (#1603, #1601)", () => {
+  // Regression: a Dock-only change (position/icon size) was reported to reset
+  // the saved wallpaper back to default on the next login. The auto-save
+  // effects below must PUT to their own endpoint with only their own field(s)
+  // — never touching the other setting — so one can never clobber the other.
+  function putCallsTo(path: string) {
+    return (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([input, init]) =>
+        (typeof input === "string" ? input : input.toString()).includes(path) &&
+        (init as RequestInit | undefined)?.method === "PUT",
+    );
+  }
+
+  it("a Dock-only change never PUTs to /api/desktop/settings and leaves the wallpaper out of its own payload", async () => {
+    mockFetchWith({
+      "/api/desktop/dock": { iconSize: "medium", position: "bottom" },
+      "/api/desktop/settings": { wallpaper: "ocean" },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      expect(useThemeStore.getState().wallpaperId).toBe("ocean");
+    });
+
+    act(() => {
+      useDockStore.getState().setIconSize("large");
+      useDockStore.getState().setPosition("left");
+    });
+
+    // Past the 1s dock auto-save debounce.
+    await waitFor(() => expect(putCallsTo("/api/desktop/dock")).not.toHaveLength(0), {
+      timeout: 2000,
+    });
+
+    expect(putCallsTo("/api/desktop/settings")).toHaveLength(0);
+
+    const dockPuts = putCallsTo("/api/desktop/dock");
+    const lastBody = JSON.parse((dockPuts[dockPuts.length - 1]![1] as RequestInit).body as string);
+    expect(lastBody).not.toHaveProperty("wallpaper");
+  });
+
+  it("a wallpaper-only change never PUTs to /api/desktop/dock and its payload carries only the wallpaper", async () => {
+    mockFetchWith({
+      "/api/desktop/dock": { iconSize: "large", position: "left" },
+      "/api/desktop/settings": { wallpaper: "midnight" },
+    });
+
+    renderHook(() => useSessionPersistence());
+
+    await waitFor(() => {
+      expect(useDockStore.getState().iconSize).toBe("large");
+    });
+
+    act(() => {
+      useThemeStore.getState().setWallpaper("aurora");
+    });
+
+    // Past the 500ms wallpaper auto-save debounce.
+    await waitFor(() => expect(putCallsTo("/api/desktop/settings")).not.toHaveLength(0), {
+      timeout: 2000,
+    });
+
+    expect(putCallsTo("/api/desktop/dock")).toHaveLength(0);
+
+    const settingsPuts = putCallsTo("/api/desktop/settings");
+    const lastBody = JSON.parse(
+      (settingsPuts[settingsPuts.length - 1]![1] as RequestInit).body as string,
+    );
+    expect(lastBody).toEqual({ wallpaper: "aurora" });
+  });
+});

--- a/tests/test_desktop_settings.py
+++ b/tests/test_desktop_settings.py
@@ -54,6 +54,29 @@ async def test_update_dock_icon_size_and_position(store):
 
 
 @pytest.mark.asyncio
+async def test_dock_update_does_not_clear_a_saved_wallpaper(store):
+    """Regression (#1603, #1601): a Dock-only save (position/icon size) must not
+    reset the wallpaper. Dock and settings are stored under separate keys and
+    each save is a read-merge-write, so a partial Dock update can only ever
+    touch the "dock" row, never the "settings" row the wallpaper lives in."""
+    await store.update_settings("user", {"wallpaper": "aurora"})
+    await store.update_dock("user", {"iconSize": "large", "position": "left"})
+    settings = await store.get_settings("user")
+    assert settings["wallpaper"] == "aurora"
+
+
+@pytest.mark.asyncio
+async def test_settings_update_does_not_clear_saved_dock_layout(store):
+    """The inverse of the above: a wallpaper-only save must not reset the
+    previously-saved Dock position/icon size."""
+    await store.update_dock("user", {"iconSize": "large", "position": "left"})
+    await store.update_settings("user", {"wallpaper": "aurora"})
+    dock = await store.get_dock("user")
+    assert dock["iconSize"] == "large"
+    assert dock["position"] == "left"
+
+
+@pytest.mark.asyncio
 async def test_window_positions_roundtrip(store):
     positions = [{"appId": "messages", "x": 100, "y": 200, "w": 900, "h": 600}]
     await store.save_windows("user", positions)

--- a/tinyagentos/desktop_settings.py
+++ b/tinyagentos/desktop_settings.py
@@ -61,6 +61,10 @@ class DesktopSettingsStore(BaseStore):
         return settings
 
     async def update_settings(self, user_id: str, updates: dict) -> None:
+        # Read-merge-write, not replace: a partial payload (e.g. only
+        # {"wallpaper": ...}) must never wipe other saved settings fields.
+        # Dock lives in its own separate row (see update_dock below), so a
+        # Dock-only save can never reach this row at all (#1603, #1601).
         current = await self._get(user_id, "settings", DEFAULT_SETTINGS)
         current.update(updates)
         await self._set(user_id, "settings", current)
@@ -69,6 +73,9 @@ class DesktopSettingsStore(BaseStore):
         return await self._get(user_id, "dock", DEFAULT_DOCK)
 
     async def update_dock(self, user_id: str, updates: dict) -> None:
+        # Read-merge-write, not replace, and its own row separate from
+        # "settings" — a partial Dock save can never clear the wallpaper (or
+        # any other settings field) and vice versa (#1603, #1601).
         current = await self.get_dock(user_id)
         current.update(updates)
         await self._set(user_id, "dock", current)


### PR DESCRIPTION
## Root cause (as reported on #1603)

A follow-up comment on #1603 reported that after the Dock persistence fix landed, changing a Dock setting (position or icon size) resets the desktop wallpaper back to default on the next login. jaylfc diagnosed this as a partial settings save overwriting the whole persisted settings object instead of merging into it, so a Dock-only change wipes the wallpaper field.

## Investigation

I reproduced the reported flow against `tinyagentos/desktop_settings.py` and `desktop/src/hooks/use-session-persistence.ts` on current dev and could not make the wipe happen:

- `DesktopSettingsStore` already stores Dock and Settings under two separate DB rows (`key="dock"` vs `key="settings"`), each keyed by `user_id`.
- `update_settings` and `update_dock` are both read-merge-write (`current.update(updates)` against the existing row), never a blind replace.
- The frontend auto-save hook (`use-session-persistence.ts`) sends narrow, single-purpose payloads: the Dock effect PUTs only `{pinned, iconSize, position}` to `/api/desktop/dock`, and the wallpaper effect PUTs only `{wallpaper}` to `/api/desktop/settings`. Neither ever touches the other's endpoint or field.

I confirmed this directly: `update_settings("user", {"wallpaper": "aurora"})` followed by `update_dock("user", {"iconSize": "large", "position": "left"})` leaves `get_settings("user")["wallpaper"] == "aurora"`.

This tells me the regression was already closed as a side effect of the separate-key architecture from #1611/#1617, but the invariant ("a Dock save can never touch the wallpaper, and vice versa") had zero dedicated regression coverage, so it could silently break again the next time either save path changes. #1603 was also still open awaiting confirmation.

## Fix

Merge-not-replace, matching the codebase's existing pattern:

- Backend: `update_settings`/`update_dock` already merge into per-key rows. No behavior change needed; added comments documenting the invariant so a future refactor doesn't accidentally collapse the two rows into one blob.
- Tests (this is the actual deliverable):
  - `tests/test_desktop_settings.py`: two store-level regression tests, `test_dock_update_does_not_clear_a_saved_wallpaper` and `test_settings_update_does_not_clear_saved_dock_layout`, exercising the exact save order from the report.
  - `desktop/src/hooks/__tests__/use-session-persistence.test.ts`: two tests asserting the debounced Dock auto-save never PUTs to `/api/desktop/settings` (and its payload never carries `wallpaper`), and the wallpaper auto-save never PUTs to `/api/desktop/dock` (and its payload is exactly `{wallpaper}`).

## Test plan

- [x] `python3 -m pytest tests/ -k "desktop_settings or settings" -q --ignore=tests/e2e` -> 133 passed
- [x] `cd desktop && npx vitest run src/hooks/__tests__/use-session-persistence.test.ts` -> 9 passed
- [x] `cd desktop && npx vitest run src/apps/SettingsApp/__tests__/DesktopDockSection.test.tsx src/stores/dock-store.test.ts src/stores/theme-store.test.ts` -> 23 passed
- [x] `cd desktop && npm run build` -> green
- [x] `python3 scripts/check_doc_gate.py diff-gate --staged` -> clean (no doc trailer required, no structural file adds/removes)