### PR TITLE
feat(app-studio): real build->package->analyze->install->sandbox-render pipeline (mock to functional)

### DIFF
--- a/desktop/src/apps/AppStudioApp.test.tsx
+++ b/desktop/src/apps/AppStudioApp.test.tsx
@@ -40,20 +40,13 @@ describe("AppStudioApp", () => {
     expect(screen.getByText("Blank")).toBeInTheDocument();
   });
 
-  it("switches to Publish view and shows capability rows", () => {
+  it("switches to Publish view and shows the empty state before an app is built", () => {
     const { container } = render(<AppStudioApp windowId="test" />);
     const nav = container.querySelector("nav[aria-label='App Studio views']")!;
     const publishBtn = Array.from(nav.querySelectorAll("button")).find(
       (b) => b.getAttribute("aria-label") === "Publish"
     )!;
     fireEvent.click(publishBtn);
-    // app identity
-    expect(screen.getAllByText("Chore Quest").length).toBeGreaterThan(0);
-    // capability row labels
-    expect(screen.getByTestId("perm-row-workspace")).toBeInTheDocument();
-    expect(screen.getByTestId("perm-row-notifications")).toBeInTheDocument();
-    expect(screen.getByTestId("perm-row-household")).toBeInTheDocument();
-    // publish button
-    expect(screen.getByRole("button", { name: /publish to my store/i })).toBeInTheDocument();
+    expect(screen.getByText(/generate an app in the build view first/i)).toBeInTheDocument();
   });
 });

--- a/desktop/src/apps/appstudio/BuildView.test.tsx
+++ b/desktop/src/apps/appstudio/BuildView.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { BuildView } from "./BuildView";
+import { setBuildSession, getBuildSession } from "./build-state";
+
+function ndjsonResponse(deltas: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const d of deltas) {
+        controller.enqueue(encoder.encode(JSON.stringify({ delta: d }) + "\n"));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+const APP_RESPONSE = [
+  "### FILE: index.html",
+  "```html",
+  "<!doctype html><html><body>Chore tracker</body></html>",
+  "```",
+].join("\n");
+
+function makeFetchMock(opts?: { findings?: unknown[] }) {
+  const installCalls: FormData[] = [];
+  const packageCalls: unknown[] = [];
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url === "/api/taos-agent/settings") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ model: "test-model" }) } as Response);
+    }
+    if (url === "/api/taos-agent/chat" && method === "POST") {
+      return Promise.resolve(ndjsonResponse([APP_RESPONSE]));
+    }
+    if (url === "/api/userspace-apps/analyze" && method === "POST") {
+      const findings = opts?.findings ?? [];
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ findings, blocked: findings.length > 0 }),
+      } as Response);
+    }
+    if (url === "/api/userspace-apps/package" && method === "POST") {
+      packageCalls.push(JSON.parse(String(init?.body ?? "{}")));
+      return Promise.resolve({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(["zip-bytes"])),
+        headers: new Headers({ "content-disposition": 'attachment; filename="chore-tracker-ab12.taosapp"' }),
+      } as Response);
+    }
+    if (url === "/api/userspace-apps/install" && method === "POST") {
+      installCalls.push(init?.body as FormData);
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            app_id: "chore-tracker-ab12",
+            permissions_requested: [],
+            needs_consent: false,
+            new_permissions: [],
+          }),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  });
+  return { fetchMock, installCalls, packageCalls };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  setBuildSession(null);
+});
+
+describe("BuildView", () => {
+  it("runs generate -> analyze -> package -> install and renders the installed app", async () => {
+    const { fetchMock, installCalls } = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<BuildView />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /^build$/i })).not.toBeDisabled());
+
+    fireEvent.click(screen.getByRole("button", { name: /^build$/i }));
+
+    await waitFor(() => expect(installCalls.length).toBe(1));
+    expect(installCalls[0]!.get("provenance")).toBe("ai-generated");
+
+    await waitFor(() => expect(screen.getByTestId("provenance-badge")).toHaveAttribute("data-provenance", "ai-generated"));
+    // the build session is handed off for PublishView to pick up
+    await waitFor(() => expect(getBuildSession()?.appId).toBe("chore-tracker-ab12"));
+  });
+
+  it("blocks the pipeline before packaging when the scan finds a critical issue", async () => {
+    const { fetchMock, packageCalls, installCalls } = makeFetchMock({
+      findings: [
+        { severity: "critical", rule_id: "eval-like-execution", file: "index.html", line: 1, message: "unsafe" },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<BuildView />);
+    await waitFor(() => expect(screen.getByRole("button", { name: /^build$/i })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole("button", { name: /^build$/i }));
+
+    await waitFor(() => expect(screen.getByTestId("security-findings-blocked")).toBeInTheDocument());
+    expect(packageCalls.length).toBe(0);
+    expect(installCalls.length).toBe(0);
+    expect(getBuildSession()).toBeNull();
+  });
+});

--- a/desktop/src/apps/appstudio/BuildView.tsx
+++ b/desktop/src/apps/appstudio/BuildView.tsx
@@ -1,34 +1,44 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CheckCircle2, Folder, Bell, Loader2, Sparkles } from "lucide-react";
-import { PROMPT_SEEDED_EVENT, takePendingPrompt } from "./build-state";
-import { streamTaosAgentChat } from "./stream-chat";
+import { CheckCircle2, Loader2, Sparkles, XCircle } from "lucide-react";
+import { PROMPT_SEEDED_EVENT, takePendingPrompt, setBuildSession } from "./build-state";
+import { generateApp } from "./generate-app";
+import { analyzeAppSource, type Finding } from "./analyze-source";
+import { FindingsPanel } from "./FindingsPanel";
+import { installUserspaceApp, packageUserspaceApp, USERSPACE_APPS_CHANGED } from "@/lib/userspace-apps";
+import { emitAppEvent } from "@/lib/app-event-bus";
+import { SandboxedAppWindow } from "../SandboxedAppWindow";
 
 /* ------------------------------------------------------------------ */
-/*  BuildView -- sandbox preview + build log + prompt bar              */
+/*  BuildView -- generate -> analyze -> package -> install -> render    */
+/*                                                                     */
+/*  A single Build click drives the whole pipeline: generateApp()       */
+/*  streams the taos-agent and parses its ### FILE: blocks the same way */
+/*  Game Studio does, analyzeAppSource() runs the same server-side       */
+/*  static security gate Publish/Share use (a critical finding blocks    */
+/*  the rest of the pipeline), a clean result is packaged via the new    */
+/*  generic /api/userspace-apps/package route, and installed through the */
+/*  existing /api/userspace-apps/install endpoint tagged "ai-generated". */
+/*  The preview panel then renders the REAL installed app through        */
+/*  SandboxedAppWindow -- the same bundle/CSP/broker and server-side      */
+/*  gate every other userspace app goes through, install-then-render.    */
 /* ------------------------------------------------------------------ */
 
-const CHORES = [
-  { who: "M", task: "Take out the bins", sub: "Mara · Mon", done: true },
-  { who: "B", task: "Walk the dog", sub: "Ben · daily", pts: 5, done: false },
-  { who: "I", task: "Load dishwasher", sub: "Ivo · today", pts: 3, done: false },
-  { who: "M", task: "Water the plants", sub: "Mara · Wed", pts: 2, done: false },
-];
+type Stage = "idle" | "generating" | "analyzing" | "blocked" | "packaging" | "installing" | "installed";
 
-const CAPS = [
-  { icon: Folder, label: "Workspace files" },
-  { icon: Bell, label: "Send notifications" },
-];
+const DEFAULT_PROMPT = "a weekly chore tracker with points and a family leaderboard";
 
-const DEFAULT_PROMPT = "give each person a weekly points total and a little leaderboard";
+const BUSY_STAGES: readonly Stage[] = ["generating", "analyzing", "packaging", "installing"];
 
 export function BuildView() {
   const [prompt, setPrompt] = useState(DEFAULT_PROMPT);
-  const [output, setOutput] = useState("");
+  const [stage, setStage] = useState<Stage>("idle");
+  const [logLines, setLogLines] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [streaming, setStreaming] = useState(false);
+  const [findings, setFindings] = useState<Finding[]>([]);
+  const [installedAppId, setInstalledAppId] = useState<string | null>(null);
+  const [appName, setAppName] = useState<string | null>(null);
   const [model, setModel] = useState<string | null>(null);
   const logEndRef = useRef<HTMLDivElement>(null);
-  const outputChunksRef = useRef<string[]>([]);
   const abortRef = useRef<AbortController | null>(null);
   const mountedRef = useRef(true);
 
@@ -62,51 +72,85 @@ export function BuildView() {
   }, []);
 
   useEffect(() => {
-    if (!streaming || error) {
-      logEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }
-  }, [streaming, error]);
+    logEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [logLines, error]);
+
+  const busy = BUSY_STAGES.includes(stage);
 
   const handleBuild = useCallback(async () => {
-    if (streaming || !model) return;
+    if (busy || !model) return;
+    const text = prompt.trim();
+    if (!text) return;
+
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
 
-    const text = prompt.trim();
-    if (!text) return;
-
-    outputChunksRef.current = [];
-    setOutput("");
     setError(null);
-    setStreaming(true);
+    setFindings([]);
+    setInstalledAppId(null);
+    setAppName(null);
+    setLogLines([]);
+    setStage("generating");
 
-    const buildPrompt =
-      `Help me build a taOS SDK app in App Studio. User request: ${text}`;
+    const appendLog = (line: string) => {
+      if (mountedRef.current) setLogLines((prev) => [...prev, line]);
+    };
 
     try {
-      await streamTaosAgentChat(
-        [{ role: "user", content: buildPrompt }],
-        (delta) => {
-          if (!mountedRef.current) return;
-          outputChunksRef.current.push(delta);
-          setOutput(outputChunksRef.current.join(""));
-        },
-        (message) => {
-          if (!mountedRef.current) return;
-          setError(message);
-        },
-        { signal: controller.signal },
-      );
+      const generated = await generateApp(text, (p) => appendLog(p.detail), {
+        signal: controller.signal,
+      });
+      if (!mountedRef.current) return;
+      if (generated.parseNotice) appendLog(generated.parseNotice);
+
+      setStage("analyzing");
+      appendLog("Scanning for security issues...");
+      const analysis = await analyzeAppSource(generated.files);
+      if (!mountedRef.current) return;
+      setFindings(analysis.findings);
+      if (analysis.blocked) {
+        appendLog("Blocked: fix the critical security findings before this app can be installed.");
+        setStage("blocked");
+        return;
+      }
+      appendLog("No security issues found.");
+
+      setStage("packaging");
+      appendLog("Packaging your app...");
+      const name = text.slice(0, 60);
+      const file = await packageUserspaceApp(name, generated.files);
+      if (!mountedRef.current) return;
+
+      setStage("installing");
+      appendLog("Installing...");
+      const install = await installUserspaceApp(file, "ai-generated");
+      if (!mountedRef.current) return;
+
+      emitAppEvent(USERSPACE_APPS_CHANGED);
+      setBuildSession({ name, files: generated.files, appId: install.app_id });
+      setAppName(name);
+      setInstalledAppId(install.app_id);
+      appendLog("Installed. Your app is running below.");
+      setStage("installed");
     } catch (e) {
-      if (!(e instanceof DOMException && e.name === "AbortError") && mountedRef.current) {
-        setError(String(e));
+      if (e instanceof DOMException && e.name === "AbortError") {
+        if (mountedRef.current) setStage("idle");
+        return;
+      }
+      if (mountedRef.current) {
+        setError(e instanceof Error ? e.message : String(e));
+        setStage("idle");
       }
     } finally {
       if (abortRef.current === controller) abortRef.current = null;
-      if (mountedRef.current) setStreaming(false);
     }
-  }, [prompt, streaming, model]);
+  }, [prompt, busy, model]);
+
+  const handleCancel = useCallback(() => {
+    abortRef.current?.abort();
+    setStage("idle");
+  }, []);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -119,7 +163,7 @@ export function BuildView() {
   );
 
   const noModel = !model;
-  const showIdleLog = !streaming && !output && !error;
+  const showFindings = stage !== "idle" && stage !== "generating";
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -127,7 +171,7 @@ export function BuildView() {
       <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
         <h2 className="text-[17px] font-bold tracking-[-0.02em]">Build</h2>
         <span className="text-[12px] text-shell-text-tertiary">
-          Chore Quest &middot; taOS app &middot; sandboxed
+          {appName ? `${appName} · taOS app · sandboxed` : "Describe your app in plain words"}
         </span>
       </div>
 
@@ -143,7 +187,14 @@ export function BuildView() {
         >
           {/* chip row */}
           <div className="mb-[14px] flex items-center gap-[9px]">
-            <Chip icon={<CheckCircle2 size={13} className="text-[#5fbf78]" />} label="Live preview" />
+            <Chip
+              icon={
+                stage === "installed" ? (
+                  <CheckCircle2 size={13} className="text-[#5fbf78]" />
+                ) : undefined
+              }
+              label="Live preview"
+            />
             <Chip label="Sandboxed" />
             <span className="ml-auto text-[11px] text-shell-text-tertiary">
               taOS SDK 1.0 &middot; no network
@@ -166,61 +217,49 @@ export function BuildView() {
                   />
                 ))}
               </div>
-              <span className="text-[12px] font-bold">Chore Quest</span>
+              <span className="text-[12px] font-bold">{appName ?? "Preview"}</span>
             </div>
 
             {/* app body */}
-            <div
-              className="flex-1 overflow-auto p-[18px_20px]"
-              style={{ background: "#202024", color: "#e8eaed" }}
-            >
-              <div className="mb-0.5 text-[18px] font-extrabold tracking-[-0.02em] text-white">
-                This week
+            {installedAppId ? (
+              <div className="min-h-0 flex-1">
+                <SandboxedAppWindow
+                  windowId="app-studio-build-preview"
+                  appId={installedAppId}
+                  appType="web"
+                  provenance="ai-generated"
+                  grantedCapabilities={[]}
+                />
               </div>
-              <div className="mb-4 text-[12px]" style={{ color: "#aab" }}>
-                3 of 6 done &middot; Team Henderson
+            ) : (
+              <div
+                className="flex flex-1 flex-col items-center justify-center gap-2 p-[18px_20px] text-center"
+                style={{ background: "#202024", color: "#aab" }}
+              >
+                {busy ? (
+                  <>
+                    <Loader2 size={22} className="animate-spin text-white/70" />
+                    <p className="text-[12.5px]">{logLines[logLines.length - 1] ?? "Working..."}</p>
+                  </>
+                ) : stage === "blocked" ? (
+                  <>
+                    <XCircle size={22} className="text-red-400" />
+                    <p className="text-[12.5px]">Blocked by the security scan. See findings on the right.</p>
+                  </>
+                ) : (
+                  <p className="text-[12.5px]">
+                    Describe your app below and press Build to generate, scan, install, and run it here.
+                  </p>
+                )}
               </div>
-
-              {CHORES.map((c) => (
-                <div
-                  key={c.task}
-                  className="mb-[9px] flex items-center gap-3 rounded-[11px] p-[11px_12px]"
-                  style={{ background: "rgba(255,255,255,0.05)" }}
-                >
-                  <div
-                    className="flex h-[30px] w-[30px] flex-none items-center justify-center rounded-full text-[12px] font-bold text-white"
-                    style={{ background: "linear-gradient(135deg,#7c8ba1,#aab4c9)" }}
-                  >
-                    {c.who}
-                  </div>
-                  <div>
-                    <div className="text-[13.5px] font-semibold" style={{ color: "#f4f5f7" }}>
-                      {c.task}
-                    </div>
-                    <div className="text-[11px]" style={{ color: "#99a" }}>
-                      {c.sub}
-                    </div>
-                  </div>
-                  {c.done ? (
-                    <CheckCircle2 size={20} className="ml-auto" style={{ color: "#5fbf78" }} />
-                  ) : (
-                    <span
-                      className="ml-auto rounded-full px-[10px] py-1 text-[11px] font-bold"
-                      style={{ color: "#cdd3df", background: "rgba(255,255,255,0.08)" }}
-                    >
-                      +{c.pts}
-                    </span>
-                  )}
-                </div>
-              ))}
-            </div>
+            )}
           </div>
         </div>
 
         {/* build log panel */}
         <div className="flex w-[300px] flex-none flex-col border-l border-shell-border">
           <div className="flex items-center gap-2 px-[18px] pb-2 pt-4 text-[13px] font-bold">
-            {streaming ? (
+            {busy ? (
               <Loader2 size={16} className="animate-spin text-accent" />
             ) : (
               <CheckCircle2 size={16} className="text-accent" />
@@ -229,9 +268,9 @@ export function BuildView() {
           </div>
 
           <div className="min-h-0 flex-1 overflow-auto px-[14px] pb-2">
-            {showIdleLog && (
+            {stage === "idle" && logLines.length === 0 && !error && (
               <p className="px-1 py-2 text-[12px] text-shell-text-tertiary">
-                Describe your app below and press Build to stream the agent&apos;s plan and output here.
+                Describe your app below and press Build to stream the pipeline's progress here.
               </p>
             )}
             {error && (
@@ -242,34 +281,17 @@ export function BuildView() {
                 {error}
               </div>
             )}
-            {output && (
-              <pre className="whitespace-pre-wrap break-words rounded-[11px] bg-shell-surface p-[10px] text-[12px] leading-relaxed text-shell-text-secondary">
-                {output}
-              </pre>
+            {logLines.length > 0 && (
+              <ul className="mb-2 flex flex-col gap-1.5 rounded-[11px] bg-shell-surface p-[10px] text-[12px] leading-relaxed text-shell-text-secondary">
+                {logLines.map((line, i) => (
+                  <li key={i}>{line}</li>
+                ))}
+              </ul>
             )}
-            {streaming && !output && !error && (
-              <div className="flex items-center gap-2 px-1 py-2 text-[12px] text-shell-text-tertiary">
-                <Loader2 size={14} className="animate-spin" />
-                Building...
-              </div>
+            {showFindings && (
+              <FindingsPanel loading={stage === "analyzing"} error={null} findings={findings} />
             )}
             <div ref={logEndRef} />
-          </div>
-
-          {/* capabilities */}
-          <div className="mx-[14px] border-t border-shell-border pt-3">
-            <div className="mb-[9px] text-[10.5px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
-              Capabilities requested
-            </div>
-            {CAPS.map(({ icon: Icon, label }) => (
-              <div key={label} className="flex items-center gap-[9px] px-0.5 py-1.5 text-[12px] text-shell-text-secondary">
-                <Icon size={14} className="text-accent" />
-                {label}
-                <span className="ml-auto text-[10.5px] font-bold" style={{ color: "#5fbf78" }}>
-                  Granted
-                </span>
-              </div>
-            ))}
           </div>
 
           {/* model pill */}
@@ -299,19 +321,28 @@ export function BuildView() {
           onChange={(e) => setPrompt(e.target.value)}
           onKeyDown={handleKeyDown}
           rows={2}
-          disabled={streaming}
+          disabled={busy}
           placeholder="Describe what your app should do..."
           className="flex min-h-[50px] flex-1 resize-none items-center rounded-[15px] border border-shell-border bg-shell-surface px-4 py-3 text-[13.5px] text-shell-text-secondary placeholder:text-shell-text-tertiary focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20 disabled:opacity-60"
         />
+        {busy && (
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="flex h-[50px] flex-none items-center gap-[9px] rounded-[15px] border border-shell-border bg-shell-surface px-6 text-[14px] font-bold text-shell-text"
+          >
+            Cancel
+          </button>
+        )}
         <button
           type="button"
           onClick={() => void handleBuild()}
-          disabled={streaming || !prompt.trim() || noModel}
+          disabled={busy || !prompt.trim() || noModel}
           className="flex h-[50px] flex-none items-center gap-[9px] rounded-[15px] border-none px-6 text-[14px] font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
           style={{ background: "linear-gradient(135deg,var(--color-accent),var(--color-accent))" }}
         >
-          {streaming ? <Loader2 size={18} className="animate-spin" /> : <Sparkles size={18} />}
-          {streaming ? "Building..." : "Build"}
+          {busy ? <Loader2 size={18} className="animate-spin" /> : <Sparkles size={18} />}
+          {busy ? "Building..." : "Build"}
         </button>
       </div>
     </div>

--- a/desktop/src/apps/appstudio/PublishView.test.tsx
+++ b/desktop/src/apps/appstudio/PublishView.test.tsx
@@ -1,103 +1,165 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/react";
 import { PublishView } from "./PublishView";
+import { setBuildSession } from "./build-state";
+
+const SESSION = {
+  name: "Chore Tracker",
+  appId: "chore-tracker-ab12",
+  files: {
+    "index.html": "<!doctype html><html><body>hi</body></html>",
+  },
+};
 
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  setBuildSession(null);
 });
 
-describe("PublishView security scan wiring", () => {
-  it("calls the analyze endpoint on mount and shows a clean state when no findings", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ findings: [], blocked: false }),
-      text: async () => "",
-    }));
-    vi.stubGlobal("fetch", fetchMock);
+function makeFetchMock(opts?: { installStatus?: number; installBody?: unknown; findings?: unknown[] }) {
+  const installCalls: FormData[] = [];
+  const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url === "/api/userspace-apps/analyze" && method === "POST") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ findings: opts?.findings ?? [], blocked: (opts?.findings?.length ?? 0) > 0 }),
+      } as Response);
+    }
+    if (url === "/api/userspace-apps/package" && method === "POST") {
+      return Promise.resolve({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(["zip-bytes"])),
+        headers: new Headers({ "content-disposition": 'attachment; filename="chore-tracker-ab12.taosapp"' }),
+      } as Response);
+    }
+    if (url === "/api/userspace-apps/install" && method === "POST") {
+      installCalls.push(init?.body as FormData);
+      const status = opts?.installStatus ?? 200;
+      return Promise.resolve({
+        ok: status < 400,
+        status,
+        json: () =>
+          Promise.resolve(
+            opts?.installBody ?? {
+              app_id: "chore-tracker-ab12",
+              permissions_requested: [],
+              needs_consent: false,
+              new_permissions: [],
+            },
+          ),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  });
+  return { fetchMock, installCalls };
+}
+
+describe("PublishView", () => {
+  it("shows an empty state when no app has been built yet", () => {
+    vi.stubGlobal("fetch", vi.fn() as unknown as typeof fetch);
+    render(<PublishView />);
+    expect(screen.getByText(/generate an app in the build view first/i)).toBeInTheDocument();
+  });
+
+  it("scans the built app's files and shows a clean state", async () => {
+    setBuildSession(SESSION);
+    const { fetchMock } = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     render(<PublishView />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId("security-findings-clean")).toBeInTheDocument();
-    });
+    expect(screen.getAllByText("Chore Tracker").length).toBeGreaterThan(0);
+    await waitFor(() => expect(screen.getByTestId("security-findings-clean")).toBeInTheDocument());
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/userspace-apps/analyze",
       expect.objectContaining({ method: "POST" }),
     );
-    const publishButton = screen.getByRole("button", { name: /publish to my store/i });
-    expect(publishButton).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /publish to my store/i })).not.toBeDisabled();
   });
 
-  it("blocks the publish button when the scan returns a critical finding", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        findings: [
-          {
-            severity: "critical",
-            rule_id: "eval-like-execution",
-            file: "app.js",
-            line: 5,
-            message: "Use of eval() executes arbitrary strings as code.",
-          },
-        ],
-        blocked: true,
-      }),
-      text: async () => "",
-    }));
-    vi.stubGlobal("fetch", fetchMock);
+  it("blocks publish and share when the scan finds a critical issue", async () => {
+    setBuildSession(SESSION);
+    const { fetchMock } = makeFetchMock({
+      findings: [
+        { severity: "critical", rule_id: "eval-like-execution", file: "index.html", line: 1, message: "eval()" },
+      ],
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     render(<PublishView />);
 
-    await waitFor(() => {
-      expect(screen.getByTestId("security-findings-blocked")).toBeInTheDocument();
-    });
-    const publishButton = screen.getByRole("button", { name: /blocked by security scan/i });
-    expect(publishButton).toBeDisabled();
+    await waitFor(() => expect(screen.getByTestId("security-findings-blocked")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /blocked by security scan/i })).toBeDisabled();
   });
 
-  it("allows publishing when only warnings are returned", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        findings: [
-          {
-            severity: "warning",
-            rule_id: "some-warning-rule",
-            file: "app.js",
-            line: 2,
-            message: "A non-blocking warning.",
-          },
-        ],
-        blocked: false,
-      }),
-      text: async () => "",
-    }));
-    vi.stubGlobal("fetch", fetchMock);
+  it("packages and installs the built app when Publish to my Store is clicked", async () => {
+    setBuildSession(SESSION);
+    const { fetchMock, installCalls } = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     render(<PublishView />);
+    await waitFor(() => expect(screen.getByTestId("security-findings-clean")).toBeInTheDocument());
 
-    await waitFor(() => {
-      expect(screen.getByTestId("finding-warning")).toBeInTheDocument();
-    });
-    const publishButton = screen.getByRole("button", { name: /publish to my store/i });
-    expect(publishButton).not.toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /publish to my store/i }));
+
+    await waitFor(() => expect(installCalls.length).toBe(1));
+    const form = installCalls[0]!;
+    expect(form.get("package")).toBeInstanceOf(File);
+    expect(form.get("provenance")).toBe("ai-generated");
+    await waitFor(() => expect(screen.getByText(/Installed\. Find it in Launchpad/)).toBeInTheDocument());
   });
 
-  it("shows a scan error state when the analyze request fails", async () => {
-    const fetchMock = vi.fn(async () => ({
-      ok: false,
-      status: 500,
-      json: async () => ({}),
-      text: async () => "internal error",
-    }));
-    vi.stubGlobal("fetch", fetchMock);
+  it("packages and installs the built app when Share with family is clicked", async () => {
+    setBuildSession(SESSION);
+    const { fetchMock, installCalls } = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     render(<PublishView />);
+    await waitFor(() => expect(screen.getByTestId("security-findings-clean")).toBeInTheDocument());
 
-    await waitFor(() => {
-      expect(screen.getByTestId("security-findings-error")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /share with family/i }));
+
+    await waitFor(() => expect(installCalls.length).toBe(1));
+    expect(installCalls[0]!.get("provenance")).toBe("ai-generated");
+  });
+
+  it("surfaces an install error instead of faking success", async () => {
+    setBuildSession(SESSION);
+    const { fetchMock } = makeFetchMock({ installStatus: 422, installBody: { error: "blocked_by_security_analysis" } });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<PublishView />);
+    await waitFor(() => expect(screen.getByTestId("security-findings-clean")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /publish to my store/i }));
+
+    await waitFor(() => expect(screen.getByText("blocked_by_security_analysis")).toBeInTheDocument());
+  });
+
+  it("exports the built app as a downloadable .taosapp package", async () => {
+    setBuildSession(SESSION);
+    const { fetchMock } = makeFetchMock();
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const clickSpy = vi.fn();
+    const createObjectURLSpy = vi.fn(() => "blob:mock-url");
+    vi.stubGlobal("URL", { ...URL, createObjectURL: createObjectURLSpy, revokeObjectURL: vi.fn() });
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag);
+      if (tag === "a") el.click = clickSpy;
+      return el;
     });
+
+    render(<PublishView />);
+    await waitFor(() => expect(screen.getByTestId("security-findings-clean")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /export package/i }));
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled());
+    expect(createObjectURLSpy).toHaveBeenCalled();
+    vi.restoreAllMocks();
   });
 });

--- a/desktop/src/apps/appstudio/PublishView.tsx
+++ b/desktop/src/apps/appstudio/PublishView.tsx
@@ -1,100 +1,54 @@
-import { useEffect, useState } from "react";
-import { Folder, Bell, Users, Shield, Sparkles, Upload, Share2, Download, CheckSquare } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Sparkles, Upload, Share2, Download, Shield, CheckCircle2, AlertCircle, Loader2, LayoutGrid } from "lucide-react";
 import { analyzeAppSource, type Finding } from "./analyze-source";
 import { FindingsPanel } from "./FindingsPanel";
+import { BUILD_SESSION_CHANGED_EVENT, SHOW_BUILD_VIEW_EVENT, getBuildSession, type BuildSession } from "./build-state";
+import { installUserspaceApp, packageUserspaceApp, USERSPACE_APPS_CHANGED } from "@/lib/userspace-apps";
+import { emitAppEvent } from "@/lib/app-event-bus";
 
 /* ------------------------------------------------------------------ */
-/*  PublishView -- app identity + capabilities + side publish panel    */
+/*  PublishView -- review, security scan, and install/export the app    */
+/*  most recently built in the Build view.                             */
+/*                                                                     */
+/*  "Publish to my Store" and "Share with family" both install the      */
+/*  same real package through the existing, unmodified                */
+/*  /api/userspace-apps/install endpoint (there is no separate public   */
+/*  Store submission or family-sharing backend yet -- both actions are  */
+/*  "install this app here", same as Game/Web Studio's Share flow).     */
+/*  "Export package" downloads the identical .taosapp. All three stay   */
+/*  behind the same critical-findings security gate.                   */
 /* ------------------------------------------------------------------ */
-
-// Placeholder source for the "Chore Quest" demo app shown throughout App
-// Studio. App Studio does not yet persist the agent's generated files (the
-// Build view only streams a chat transcript, see BuildView.tsx) -- once that
-// pipeline lands, this should be replaced with the actual generated source
-// for the app being published. Wiring the analyzer against this in the
-// meantime keeps the publish-time security gate exercised end to end: the
-// backend runs the exact same analyze_app_source() call it runs on the real
-// install/publish path.
-const DEMO_APP_SOURCE: Record<string, string> = {
-  "index.html": [
-    "<!doctype html>",
-    "<html>",
-    "  <head><title>Chore Quest</title></head>",
-    "  <body>",
-    '    <div id="app"></div>',
-    '    <script src="app.js"></script>',
-    "  </body>",
-    "</html>",
-  ].join("\n"),
-  "app.js": [
-    "const chores = [",
-    '  { who: "Mara", task: "Take out the bins", done: true },',
-    '  { who: "Ben", task: "Walk the dog", done: false },',
-    "];",
-    "",
-    "function render() {",
-    '  const root = document.getElementById("app");',
-    '  const list = document.createElement("ul");',
-    "  chores.forEach((c) => {",
-    '    const item = document.createElement("li");',
-    "    item.textContent = `${c.who}: ${c.task}`;",
-    "    list.appendChild(item);",
-    "  });",
-    "  root.replaceChildren(list);",
-    "}",
-    "",
-    "render();",
-  ].join("\n"),
-};
-
-interface PermRow {
-  key: string;
-  icon: React.ElementType;
-  label: string;
-  desc: string;
-  defaultOn: boolean;
-}
-
-const PERMS: PermRow[] = [
-  {
-    key: "workspace",
-    icon: Folder,
-    label: "Workspace files",
-    desc: "Read and write the app's own folder",
-    defaultOn: true,
-  },
-  {
-    key: "notifications",
-    icon: Bell,
-    label: "Notifications",
-    desc: "Send reminders for due chores",
-    defaultOn: true,
-  },
-  {
-    key: "household",
-    icon: Users,
-    label: "Household members",
-    desc: "See names and avatars of your people",
-    defaultOn: false,
-  },
-];
 
 export function PublishView() {
-  const [enabled, setEnabled] = useState<Record<string, boolean>>(
-    Object.fromEntries(PERMS.map((p) => [p.key, p.defaultOn]))
-  );
+  const [session, setSession] = useState<BuildSession | null>(() => getBuildSession());
   const [findings, setFindings] = useState<Finding[]>([]);
   const [scanning, setScanning] = useState(true);
   const [scanError, setScanError] = useState<string | null>(null);
 
-  const toggle = (key: string) =>
-    setEnabled((prev) => ({ ...prev, [key]: !prev[key] }));
+  const [installing, setInstalling] = useState(false);
+  const [installResult, setInstallResult] = useState<"ok" | "consent" | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
 
   useEffect(() => {
+    const onSessionChanged = () => setSession(getBuildSession());
+    window.addEventListener(BUILD_SESSION_CHANGED_EVENT, onSessionChanged);
+    return () => window.removeEventListener(BUILD_SESSION_CHANGED_EVENT, onSessionChanged);
+  }, []);
+
+  useEffect(() => {
+    if (!session) {
+      setScanning(false);
+      return;
+    }
     let cancelled = false;
     setScanning(true);
     setScanError(null);
-    analyzeAppSource(DEMO_APP_SOURCE)
+    setInstallResult(null);
+    setInstallError(null);
+    setExportError(null);
+    analyzeAppSource(session.files)
       .then((result) => {
         if (cancelled) return;
         setFindings(result.findings);
@@ -109,17 +63,71 @@ export function PublishView() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [session]);
 
   const blocked = !scanning && !scanError && findings.some((f) => f.severity === "critical");
-  const publishDisabled = scanning || blocked;
+  const actionsDisabled = !session || scanning || blocked;
+
+  const handleInstall = useCallback(async () => {
+    if (!session) return;
+    setInstalling(true);
+    setInstallError(null);
+    setInstallResult(null);
+    try {
+      const file = await packageUserspaceApp(session.name, session.files);
+      const result = await installUserspaceApp(file, "ai-generated");
+      emitAppEvent(USERSPACE_APPS_CHANGED);
+      setInstallResult(result.needs_consent ? "consent" : "ok");
+    } catch (e) {
+      setInstallError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setInstalling(false);
+    }
+  }, [session]);
+
+  const handleExport = useCallback(async () => {
+    if (!session) return;
+    setExporting(true);
+    setExportError(null);
+    try {
+      const file = await packageUserspaceApp(session.name, session.files);
+      const url = URL.createObjectURL(file);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = file.name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setExportError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setExporting(false);
+    }
+  }, [session]);
+
+  if (!session) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 text-shell-text-tertiary">
+        <LayoutGrid size={28} />
+        <p className="text-[13px]">Generate an app in the Build view first.</p>
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new CustomEvent(SHOW_BUILD_VIEW_EVENT))}
+          className="rounded-[11px] border border-shell-border bg-shell-surface px-4 py-2 text-[12.5px] font-semibold text-shell-text"
+        >
+          Go to Build
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       {/* view header */}
       <div className="flex h-[54px] flex-none items-center gap-3 border-b border-shell-border px-[22px]">
         <h2 className="text-[17px] font-bold tracking-[-0.02em]">Publish</h2>
-        <span className="text-[12px] text-shell-text-tertiary">Review, set permissions, share</span>
+        <span className="text-[12px] text-shell-text-tertiary">Review, scan, share</span>
       </div>
 
       <div className="flex min-h-0 flex-1">
@@ -132,11 +140,11 @@ export function PublishView() {
                 className="flex h-[62px] w-[62px] flex-none items-center justify-center rounded-[16px] text-white shadow-[0_8px_22px_rgba(0,0,0,0.35)]"
                 style={{ background: "linear-gradient(135deg,#6f7687,#474d5e)" }}
               >
-                <CheckSquare size={30} />
+                <LayoutGrid size={30} />
               </div>
               <div>
                 <div className="flex items-center gap-[8px]">
-                  <span className="text-[19px] font-extrabold tracking-[-0.02em]">Chore Quest</span>
+                  <span className="text-[19px] font-extrabold tracking-[-0.02em]">{session.name}</span>
                   <span
                     data-testid="provenance-badge"
                     data-provenance="ai-generated"
@@ -147,55 +155,14 @@ export function PublishView() {
                   </span>
                 </div>
                 <div className="mt-[3px] text-[12.5px] text-shell-text-secondary">
-                  A weekly chore tracker with points and a family leaderboard.
+                  Built in App Studio &middot; {Object.keys(session.files).length} file
+                  {Object.keys(session.files).length === 1 ? "" : "s"}
                 </div>
               </div>
             </div>
 
             {/* security scan panel */}
             <FindingsPanel loading={scanning} error={scanError} findings={findings} />
-
-            {/* capabilities section */}
-            <div className="mb-[11px] text-[11px] font-bold uppercase tracking-[0.06em] text-shell-text-tertiary">
-              Capabilities
-            </div>
-
-            {PERMS.map((p) => {
-              const Icon = p.icon;
-              const on = enabled[p.key];
-              return (
-                <div
-                  key={p.key}
-                  className="mb-[9px] flex items-center gap-3 rounded-[13px] border border-shell-border bg-shell-surface p-[13px_14px]"
-                  data-testid={`perm-row-${p.key}`}
-                >
-                  <div className="flex h-[34px] w-[34px] items-center justify-center rounded-[10px] bg-shell-surface-active text-accent">
-                    <Icon size={17} />
-                  </div>
-                  <div>
-                    <div className="text-[13px] font-semibold">{p.label}</div>
-                    <div className="mt-[1px] text-[11px] text-shell-text-tertiary">{p.desc}</div>
-                  </div>
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={on}
-                    aria-label={`Toggle ${p.label}`}
-                    onClick={() => toggle(p.key)}
-                    className="relative ml-auto h-[21px] w-[38px] flex-none rounded-full transition-colors"
-                    style={{ background: on ? "var(--color-accent)" : undefined }}
-                  >
-                    {!on && (
-                      <span className="block h-full w-full rounded-full bg-shell-surface-active" />
-                    )}
-                    <span
-                      className="absolute top-[2px] h-[17px] w-[17px] rounded-full bg-white transition-[left]"
-                      style={{ left: on ? "19px" : "2px" }}
-                    />
-                  </button>
-                </div>
-              );
-            })}
 
             {/* safety note */}
             <div
@@ -207,8 +174,8 @@ export function PublishView() {
             >
               <Shield size={17} className="mt-[1px] flex-none" style={{ color: "#5fbf78" }} />
               <p className="text-[12px] leading-relaxed text-shell-text-secondary">
-                Runs sandboxed with no network access. It can only touch what you grant above, and
-                you can change these any time.
+                Runs sandboxed with no network access. It can only touch what you grant, and you can
+                change that any time.
               </p>
             </div>
           </div>
@@ -218,27 +185,30 @@ export function PublishView() {
         <div className="flex w-[280px] flex-none flex-col gap-[13px] border-l border-shell-border bg-shell-bg-deep p-[22px_20px]">
           {/* preview tile */}
           <div
-            className="flex aspect-[16/10] items-center justify-center overflow-hidden rounded-[13px] border border-shell-border font-bold text-white"
+            className="flex aspect-[16/10] items-center justify-center overflow-hidden rounded-[13px] border border-shell-border p-3 text-center font-bold text-white"
             style={{ background: "linear-gradient(140deg,#2c3142,#171a24)" }}
           >
-            Chore Quest
+            {session.name}
           </div>
 
           <button
             type="button"
-            disabled={publishDisabled}
-            aria-disabled={publishDisabled}
+            onClick={() => void handleInstall()}
+            disabled={actionsDisabled || installing}
+            aria-disabled={actionsDisabled || installing}
             title={blocked ? "Fix the critical security findings before publishing" : undefined}
             className="flex h-[46px] items-center justify-center gap-[9px] rounded-[13px] text-[13.5px] font-bold text-white shadow-[0_8px_22px_-8px_rgba(139,146,163,0.35)] disabled:cursor-not-allowed disabled:opacity-50"
             style={{ background: "linear-gradient(135deg,var(--color-accent),var(--color-accent))" }}
           >
-            <Upload size={16} />
-            {blocked ? "Blocked by security scan" : "Publish to my Store"}
+            {installing ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
+            {blocked ? "Blocked by security scan" : installing ? "Publishing..." : "Publish to my Store"}
           </button>
 
           <button
             type="button"
-            className="flex h-[46px] items-center justify-center gap-[9px] rounded-[13px] border border-shell-border bg-shell-surface text-[13.5px] font-bold text-shell-text"
+            onClick={() => void handleInstall()}
+            disabled={actionsDisabled || installing}
+            className="flex h-[46px] items-center justify-center gap-[9px] rounded-[13px] border border-shell-border bg-shell-surface text-[13.5px] font-bold text-shell-text disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Share2 size={16} />
             Share with family
@@ -246,11 +216,42 @@ export function PublishView() {
 
           <button
             type="button"
-            className="flex h-[46px] items-center justify-center gap-[9px] rounded-[13px] border border-shell-border bg-shell-surface text-[13.5px] font-bold text-shell-text"
+            onClick={() => void handleExport()}
+            disabled={actionsDisabled || exporting}
+            className="flex h-[46px] items-center justify-center gap-[9px] rounded-[13px] border border-shell-border bg-shell-surface text-[13.5px] font-bold text-shell-text disabled:cursor-not-allowed disabled:opacity-50"
           >
-            <Download size={16} />
+            {exporting ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
             Export package
           </button>
+
+          {installResult === "ok" && (
+            <div role="status" className="flex items-start gap-2.5 rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3.5 py-3">
+              <CheckCircle2 size={16} className="mt-0.5 flex-none text-emerald-400" />
+              <p className="text-[12.5px] leading-relaxed text-emerald-200">
+                Installed. Find it in Launchpad, sandboxed like any other app.
+              </p>
+            </div>
+          )}
+          {installResult === "consent" && (
+            <div role="status" className="flex items-start gap-2.5 rounded-xl border border-accent/30 bg-accent-soft px-3.5 py-3">
+              <CheckCircle2 size={16} className="mt-0.5 flex-none text-accent" />
+              <p className="text-[12.5px] leading-relaxed text-shell-text-secondary">
+                Installed. It requests extra permissions &rarr; review them from Settings &rarr; Apps.
+              </p>
+            </div>
+          )}
+          {installError && (
+            <div role="alert" className="flex items-start gap-2.5 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3">
+              <AlertCircle size={16} className="mt-0.5 flex-none text-red-400" />
+              <p className="text-[12.5px] leading-relaxed text-red-200">{installError}</p>
+            </div>
+          )}
+          {exportError && (
+            <div role="alert" className="flex items-start gap-2.5 rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3">
+              <AlertCircle size={16} className="mt-0.5 flex-none text-red-400" />
+              <p className="text-[12.5px] leading-relaxed text-red-200">{exportError}</p>
+            </div>
+          )}
 
           <p className="text-center text-[11px] leading-relaxed text-shell-text-tertiary">
             Community submissions are reviewed before they appear in the public Store.

--- a/desktop/src/apps/appstudio/__tests__/PublishView.test.tsx
+++ b/desktop/src/apps/appstudio/__tests__/PublishView.test.tsx
@@ -1,9 +1,20 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { PublishView } from "../PublishView";
+import { setBuildSession } from "../build-state";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setBuildSession(null);
+});
 
 describe("PublishView -- provenance badge", () => {
-  it("shows an AI-generated provenance badge next to the app name", () => {
+  it("shows an AI-generated provenance badge next to the app name once an app has been built", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ findings: [], blocked: false }) })) as unknown as typeof fetch,
+    );
+    setBuildSession({ name: "Chore Tracker", appId: "chore-tracker-ab12", files: { "index.html": "<html></html>" } });
     render(<PublishView />);
     const badge = screen.getByTestId("provenance-badge");
     expect(badge.getAttribute("data-provenance")).toBe("ai-generated");

--- a/desktop/src/apps/appstudio/app-authoring-prompt.ts
+++ b/desktop/src/apps/appstudio/app-authoring-prompt.ts
@@ -1,0 +1,25 @@
+/** System prompt for the app-authoring agent -- App Studio's Build flow.
+ *  Shares the file-block convention with Game Studio (see
+ *  gamestudio/file-blocks.ts) so the same parser works for both. */
+
+const FILE_BLOCK_CONVENTION = `Respond using this exact convention for every file you create:
+
+### FILE: <filename>
+\`\`\`<language>
+<the complete contents of that file>
+\`\`\`
+
+Rules:
+- Always include an "index.html" file -- it is the app's entry point.
+- Each block must contain the COMPLETE contents of the file, never a diff or a partial snippet.
+- Filenames must be flat: no "/", no "\\\\", no "..".
+- You may write plain explanation text outside the blocks; it is shown to the user but ignored when packaging the app.`;
+
+/** System prompt for the initial Build flow: author a self-contained web app. */
+export function buildAppGenerationSystemPrompt(): string {
+  return [
+    "You are the app-authoring agent for taOS App Studio. You build a small, self-contained web app (plain HTML/CSS/JavaScript, no build step, no external network access, no external CDN scripts or fonts) from the user's plain-language description.",
+    "The app runs inside a sandboxed iframe that can only load its own files -- it has no network access and no access to the rest of the system beyond what the taOS SDK explicitly grants.",
+    FILE_BLOCK_CONVENTION,
+  ].join("\n\n");
+}

--- a/desktop/src/apps/appstudio/build-state.ts
+++ b/desktop/src/apps/appstudio/build-state.ts
@@ -1,7 +1,12 @@
-/** Shared prompt seeding between TemplatesView and BuildView. */
+/** Shared prompt seeding between TemplatesView and BuildView, and the
+ *  hand-off of the most recently built app from BuildView to PublishView.
+ *  AppStudioApp only ever mounts one view at a time (see AppStudioApp.tsx),
+ *  so a plain module-level value -- not React state -- is what survives the
+ *  switch between tabs. */
 
 export const PROMPT_SEEDED_EVENT = "appstudio:prompt-seeded";
 export const SHOW_BUILD_VIEW_EVENT = "appstudio:show-build";
+export const BUILD_SESSION_CHANGED_EVENT = "appstudio:build-session-changed";
 
 let pendingPrompt: string | null = null;
 
@@ -17,4 +22,23 @@ export function takePendingPrompt(): string | null {
   const prompt = pendingPrompt;
   pendingPrompt = null;
   return prompt;
+}
+
+/** The app most recently built (generated, analyzed clean, and installed) by
+ *  BuildView -- the source PublishView shows and re-shares. */
+export interface BuildSession {
+  name: string;
+  files: Record<string, string>;
+  appId: string;
+}
+
+let buildSession: BuildSession | null = null;
+
+export function setBuildSession(session: BuildSession | null): void {
+  buildSession = session;
+  window.dispatchEvent(new CustomEvent(BUILD_SESSION_CHANGED_EVENT));
+}
+
+export function getBuildSession(): BuildSession | null {
+  return buildSession;
 }

--- a/desktop/src/apps/appstudio/generate-app.test.ts
+++ b/desktop/src/apps/appstudio/generate-app.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { generateApp } from "./generate-app";
+
+/** Encode a mock /api/taos-agent/chat NDJSON stream response from a list of
+ *  text deltas -- mirrors the {delta} shape streamTaosAgentChat parses. */
+function ndjsonResponse(deltas: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const d of deltas) {
+        controller.enqueue(encoder.encode(JSON.stringify({ delta: d }) + "\n"));
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
+describe("generateApp", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("parses a mocked AI file-set response into a file map", async () => {
+    const responseText = [
+      "Here's your app:",
+      "",
+      "### FILE: index.html",
+      "```html",
+      "<!doctype html><html><body>Hello</body></html>",
+      "```",
+      "",
+      "### FILE: app.js",
+      "```js",
+      "console.log('hi');",
+      "```",
+    ].join("\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(ndjsonResponse([responseText]))) as unknown as typeof fetch,
+    );
+
+    const progress: string[] = [];
+    const result = await generateApp("a simple greeter", (p) => progress.push(p.stage));
+
+    expect(result.usedFallback).toBe(false);
+    expect(result.parseNotice).toBeNull();
+    expect(result.files["index.html"]).toContain("Hello");
+    expect(result.files["app.js"]).toContain("console.log");
+    expect(progress).toEqual(["streaming", "parsing", "done"]);
+  });
+
+  it("falls back to a starter page when the response has no file blocks", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(ndjsonResponse(["Sorry, I can't help with that request."])),
+      ) as unknown as typeof fetch,
+    );
+
+    const result = await generateApp("do something impossible", () => {});
+
+    expect(result.usedFallback).toBe(true);
+    expect(result.parseNotice).toMatch(/could not be parsed/);
+    expect(result.files["index.html"]).toContain("<!doctype html>");
+  });
+
+  it("falls back to a starter page when the response never emits an index.html", async () => {
+    const responseText = ["### FILE: app.js", "```js", "console.log('no entry point');", "```"].join("\n");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(ndjsonResponse([responseText]))) as unknown as typeof fetch,
+    );
+
+    const result = await generateApp("build something", () => {});
+
+    expect(result.usedFallback).toBe(true);
+    expect(result.parseNotice).toMatch(/index\.html entry point/);
+    expect(result.files["index.html"]).toContain("<!doctype html>");
+  });
+
+  it("propagates a stream error instead of silently falling back", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(null, { status: 500, statusText: "Internal Server Error" }),
+        ),
+      ) as unknown as typeof fetch,
+    );
+
+    await expect(generateApp("anything", () => {})).rejects.toThrow();
+  });
+});

--- a/desktop/src/apps/appstudio/generate-app.ts
+++ b/desktop/src/apps/appstudio/generate-app.ts
@@ -1,0 +1,88 @@
+import { streamTaosAgentChat } from "./stream-chat";
+import { parseFileBlocks } from "../gamestudio/file-blocks";
+import { buildAppGenerationSystemPrompt } from "./app-authoring-prompt";
+
+/* ------------------------------------------------------------------ */
+/*  Real AI app generation                                             */
+/*                                                                     */
+/*  Streams the taos-agent the same way Game Studio's generateGame()    */
+/*  does, asking it to author a self-contained web app as one         */
+/*  ### FILE: block per file (file-blocks.ts). On a parse failure, or  */
+/*  a response that never emits an index.html entry point, the caller  */
+/*  gets a minimal honest starter page instead -- never a fake         */
+/*  "generated" result.                                                 */
+/* ------------------------------------------------------------------ */
+
+export type GenerateStage = "streaming" | "parsing" | "done";
+
+export interface GenerateProgress {
+  stage: GenerateStage;
+  detail: string;
+}
+
+export interface GenerateAppResult {
+  files: Record<string, string>;
+  usedFallback: boolean;
+  parseNotice: string | null;
+}
+
+const FALLBACK_INDEX_HTML = [
+  "<!doctype html>",
+  "<html>",
+  "  <head><title>App</title></head>",
+  "  <body>",
+  "    <p>The agent's response could not be turned into an app. Try describing it again.</p>",
+  "  </body>",
+  "</html>",
+  "",
+].join("\n");
+
+export async function generateApp(
+  prompt: string,
+  onProgress: (p: GenerateProgress) => void,
+  opts?: { signal?: AbortSignal },
+): Promise<GenerateAppResult> {
+  onProgress({ stage: "streaming", detail: "Asking the taOS agent to build your app..." });
+
+  let raw = "";
+  let streamError: string | null = null;
+  await streamTaosAgentChat(
+    [
+      { role: "system", content: buildAppGenerationSystemPrompt() },
+      { role: "user", content: prompt },
+    ],
+    (delta) => {
+      raw += delta;
+    },
+    (message) => {
+      streamError = message;
+    },
+    opts,
+  );
+  if (streamError) throw new Error(streamError);
+
+  onProgress({ stage: "parsing", detail: "Reading the response..." });
+  const parsed = parseFileBlocks(raw);
+  const files: Record<string, string> = {};
+  for (const f of parsed) files[f.path] = f.content;
+
+  onProgress({ stage: "done", detail: "Ready." });
+
+  if (parsed.length === 0) {
+    return {
+      files: { "index.html": FALLBACK_INDEX_HTML },
+      usedFallback: true,
+      parseNotice:
+        "The agent's response could not be parsed into app files, so a minimal starter page was used instead.",
+    };
+  }
+  if (!files["index.html"]) {
+    return {
+      files: { "index.html": FALLBACK_INDEX_HTML },
+      usedFallback: true,
+      parseNotice:
+        "The agent's response did not include an index.html entry point, so a minimal starter page was used instead.",
+    };
+  }
+  return { files, usedFallback: false, parseNotice: null };
+}

--- a/desktop/src/lib/userspace-apps.ts
+++ b/desktop/src/lib/userspace-apps.ts
@@ -89,6 +89,34 @@ export async function installUserspaceApp(file: File, provenance?: string): Prom
   return (await res.json()) as InstallResult;
 }
 
+/** Build a .taosapp package from an in-memory {filename: content} map via
+ * POST /api/userspace-apps/package, returning it as a downloadable File --
+ * used by App Studio's Build/Publish views, which generate an app's files
+ * client-side with no server-side project store of their own (unlike Game
+ * Studio / Web Studio, which package an already-saved project). */
+export async function packageUserspaceApp(name: string, files: Record<string, string>): Promise<File> {
+  const res = await fetch("/api/userspace-apps/package", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, files }),
+  });
+  if (!res.ok) {
+    let detail = `package build failed (${res.status})`;
+    try {
+      const body = await res.json();
+      if (body?.error) detail = body.error;
+    } catch {
+      // non-JSON error body; keep the status-based message
+    }
+    throw new Error(detail);
+  }
+  const blob = await res.blob();
+  const disposition = res.headers.get("content-disposition") ?? "";
+  const match = disposition.match(/filename="([^"]+)"/);
+  return new File([blob], match?.[1] ?? "app.taosapp", { type: "application/zip" });
+}
+
 export async function grantUserspacePermissions(appId: string, granted: string[]): Promise<void> {
   const res = await fetch(`/api/userspace-apps/${encodeURIComponent(appId)}/permissions`, {
     method: "POST",

--- a/tests/test_routes_userspace_apps.py
+++ b/tests/test_routes_userspace_apps.py
@@ -345,6 +345,132 @@ async def test_install_clean_app_still_succeeds(client):
 
 
 # ---------------------------------------------------------------------------
+# POST /api/userspace-apps/package
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_package_builds_valid_taosapp_zip(client):
+    resp = await client.post(
+        "/api/userspace-apps/package",
+        json={"name": "My Cool App", "files": {"index.html": "<html>hi</html>", "app.js": "const x = 1;"}},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+    disposition = resp.headers["content-disposition"]
+    assert ".taosapp" in disposition
+
+    import io
+    import zipfile
+
+    import yaml
+
+    zf = zipfile.ZipFile(io.BytesIO(resp.content))
+    assert set(zf.namelist()) == {"manifest.yaml", "index.html", "app.js"}
+    manifest = yaml.safe_load(zf.read("manifest.yaml").decode())
+    assert manifest["name"] == "My Cool App"
+    assert manifest["app_type"] == "web"
+    assert manifest["entry"] == "index.html"
+    assert manifest["permissions"] == []
+    assert manifest["id"].startswith("my-cool-app-")
+    assert zf.read("index.html").decode() == "<html>hi</html>"
+
+
+@pytest.mark.asyncio
+async def test_package_two_calls_get_different_app_ids(client):
+    """Each build gets a unique id (random suffix), even for the same name --
+    two apps generated from the same prompt must not collide on install."""
+    resp1 = await client.post(
+        "/api/userspace-apps/package", json={"name": "Same Name", "files": {"index.html": "<html></html>"}}
+    )
+    resp2 = await client.post(
+        "/api/userspace-apps/package", json={"name": "Same Name", "files": {"index.html": "<html></html>"}}
+    )
+    import io
+    import zipfile
+
+    import yaml
+
+    id1 = yaml.safe_load(zipfile.ZipFile(io.BytesIO(resp1.content)).read("manifest.yaml").decode())["id"]
+    id2 = yaml.safe_load(zipfile.ZipFile(io.BytesIO(resp2.content)).read("manifest.yaml").decode())["id"]
+    assert id1 != id2
+
+
+@pytest.mark.asyncio
+async def test_package_empty_name_returns_400(client):
+    resp = await client.post(
+        "/api/userspace-apps/package", json={"name": "   ", "files": {"index.html": "<html></html>"}}
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_package_empty_files_returns_400(client):
+    resp = await client.post("/api/userspace-apps/package", json={"name": "App", "files": {}})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_package_missing_index_html_returns_400(client):
+    resp = await client.post(
+        "/api/userspace-apps/package", json={"name": "App", "files": {"app.js": "const x = 1;"}}
+    )
+    assert resp.status_code == 400
+    assert "index.html" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_package_unsafe_filename_returns_400(client):
+    resp = await client.post(
+        "/api/userspace-apps/package",
+        json={"name": "App", "files": {"index.html": "<html></html>", "../evil.js": "x"}},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_package_too_many_files_returns_413(client):
+    files = {"index.html": "<html></html>"}
+    for i in range(45):
+        files[f"file{i}.js"] = "x"
+    resp = await client.post("/api/userspace-apps/package", json={"name": "App", "files": files})
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_package_oversize_file_returns_413(client):
+    resp = await client.post(
+        "/api/userspace-apps/package",
+        json={"name": "App", "files": {"index.html": "x" * (2 * 1024 * 1024 + 1)}},
+    )
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_package_installs_via_userspace_apps_endpoint(client):
+    """The package this endpoint builds must be installable through the
+    existing, unmodified userspace-apps install pipeline -- this is the
+    actual reuse App Studio's build flow depends on."""
+    app = client._transport.app
+    await _init_userspace_stores(app, app.state.data_dir)
+
+    pkg_resp = await client.post(
+        "/api/userspace-apps/package",
+        json={"name": "Installable App", "files": {"index.html": "<html>ok</html>"}},
+    )
+    assert pkg_resp.status_code == 200
+
+    install_resp = await client.post(
+        "/api/userspace-apps/install",
+        files={"package": ("app.taosapp", pkg_resp.content, "application/zip")},
+        data={"provenance": "ai-generated"},
+    )
+    assert install_resp.status_code == 200
+    data = install_resp.json()
+    assert data["app_id"].startswith("installable-app-")
+
+
+# ---------------------------------------------------------------------------
 # POST /api/userspace-apps/analyze
 # ---------------------------------------------------------------------------
 

--- a/tinyagentos/routes/userspace_apps.py
+++ b/tinyagentos/routes/userspace_apps.py
@@ -2,20 +2,24 @@ from __future__ import annotations
 
 import json
 import logging
+import random
+import re
 import shutil
+import string
 from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Form, Request, UploadFile, File
 from fastapi.responses import JSONResponse, FileResponse, RedirectResponse, Response, StreamingResponse
+from pydantic import BaseModel
 from starlette.background import BackgroundTask
 
 from tinyagentos.code_analyzer import analyze_app_source, has_critical
 from tinyagentos.userspace.broker import handle_capability, GATED_CAPS
 from tinyagentos.userspace.capabilities import capability_ceiling, default_provenance_for_trust
 from tinyagentos.userspace.container_deploy import deploy_app_container, destroy_app_container
-from tinyagentos.userspace.package import extract_package, parse_manifest, PackageError
+from tinyagentos.userspace.package import build_package, extract_package, parse_manifest, PackageError
 from tinyagentos.userspace.url_guard import resolve_safe_public_ip
 
 # Provenance values a caller may set through the PUBLIC install endpoint. Never
@@ -243,6 +247,75 @@ async def install_app(
         "needs_consent": bool(existing and new_perms),
         "new_permissions": new_perms,
     }
+
+
+# Caps for building a package from an in-memory file map -- mirrors
+# routes/games.py's save-time limits (games are always web apps with a
+# handful of small files, same posture applies here).
+_MAX_BUILD_FILES = 40
+_MAX_BUILD_FILE_BYTES = 2 * 1024 * 1024
+
+
+def _is_safe_filename(name: str) -> bool:
+    return bool(name) and name not in (".", "..") and "/" not in name and "\\" not in name and ".." not in name
+
+
+def _slugify(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")[:40]
+    return slug or "app"
+
+
+class PackageBuildRequest(BaseModel):
+    name: str
+    files: dict[str, str]
+
+
+@router.post("/api/userspace-apps/package")
+async def package_app(body: PackageBuildRequest):
+    """Build a .taosapp package (manifest.yaml + files) from an in-memory file
+    map and return it as a downloadable zip. Generic counterpart to
+    routes/games.py's package_game, for callers (App Studio) that generate an
+    app's files client-side with no server-side project store of their own.
+    """
+    name = body.name.strip()
+    if not name:
+        return JSONResponse({"error": "name must not be empty"}, status_code=400)
+    if not body.files:
+        return JSONResponse(
+            {"error": "files must be a non-empty map of filename to text content"}, status_code=400
+        )
+    if len(body.files) > _MAX_BUILD_FILES:
+        return JSONResponse({"error": f"too many files (max {_MAX_BUILD_FILES})"}, status_code=413)
+    if "index.html" not in body.files:
+        return JSONResponse({"error": "files must include an index.html entry point"}, status_code=400)
+    for fname, content in body.files.items():
+        if not _is_safe_filename(fname):
+            return JSONResponse({"error": f"invalid filename: {fname!r}"}, status_code=400)
+        if len(content.encode("utf-8")) > _MAX_BUILD_FILE_BYTES:
+            return JSONResponse(
+                {"error": f"file '{fname}' exceeds the {_MAX_BUILD_FILE_BYTES}-byte limit"}, status_code=413
+            )
+
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    app_id = f"{_slugify(name)}-{suffix}"
+    manifest = {
+        "id": app_id,
+        "name": name,
+        "version": "1.0.0",
+        "app_type": "web",
+        "entry": "index.html",
+        "icon": "",
+        "permissions": [],
+    }
+    try:
+        data = build_package(manifest, body.files)
+    except PackageError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=500)
+    return Response(
+        content=data,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{app_id}.taosapp"'},
+    )
 
 
 # DoS guards for this endpoint: it has no auth gate of its own (a preview


### PR DESCRIPTION
## Summary

Turns App Studio's Build/Publish views from a hardcoded mockup into a working pipeline: generate -> package -> security-gate -> install -> live sandbox render. About 90% reuse of the existing Game Studio / userspace-apps machinery (same file-block generation convention, same static analyzer + FindingsPanel gate, same `build_package`/`extract_package`/install endpoint, same `SandboxedAppWindow` renderer).

### Pipeline

1. **Generate** (`desktop/src/apps/appstudio/generate-app.ts`): streams the taos-agent with a file-block system prompt (`app-authoring-prompt.ts`), parses the response with Game Studio's existing `parseFileBlocks()` (the `### FILE: <name>` convention, flat filenames). An empty parse, or a response missing an `index.html` entry point, falls back to a minimal honest starter page with a visible notice instead of faking success.
2. **Package** (new generic route `POST /api/userspace-apps/package` in `routes/userspace_apps.py`): builds a `.taosapp` (manifest.yaml + files) from an in-memory `{name, files}` map, mirroring `routes/games.py`'s `package_game` but for callers (App Studio) with no server-side project store of their own. Validates flat filenames, file count/size caps, requires an `index.html` entry, generates a unique slug+suffix id.
3. **Analyze**: reuses the existing `POST /api/userspace-apps/analyze` + `FindingsPanel` -- a critical finding blocks the rest of the pipeline.
4. **Install**: reuses the existing, unmodified `POST /api/userspace-apps/install`, tagged `provenance=ai-generated`.
5. **Render**: install-then-render -- the preview panel shows the REAL installed app through `SandboxedAppWindow`, so the actual bundle/CSP/broker and the server-side install gate all apply, not a client-side preview.

BuildView now runs this whole chain on a single Build click, replacing the old flow that just streamed a generic chat transcript into a `<pre>` and rendered a hardcoded "Chore Quest" mock with cosmetic capability chips.

PublishView now shows the app actually built in the Build view (handed off via a small module-level "build session" in `build-state.ts`, since `AppStudioApp` only ever mounts one view at a time -- not a persisted project store) instead of a hardcoded `DEMO_APP_SOURCE`. The three previously-inert buttons are wired: "Publish to my Store" and "Share with family" both install the real package (there is no separate public-store or family-sharing backend yet -- same posture as Game/Web Studio's Share flow, which also just installs locally), "Export package" downloads it. The old cosmetic permission toggles (Workspace files / Notifications / Household members) are removed: the pipeline always packages `permissions: []` in v1, so toggles that controlled nothing would now be actively misleading sitting next to a real install action.

### Deferred (noted in code/PR, not silently dropped)
- Permission inference from the generated app's actual behavior (manifest always requests no permissions in v1).
- An editable, persisted project store for in-progress builds (v1 persistence = the installed userspace app itself).

## Test plan

- [x] `cd desktop && npx vitest run` -- 315 files / 2546 tests passed (includes new `generate-app.test.ts`, `BuildView.test.tsx`, rewritten `PublishView.test.tsx`, updated `AppStudioApp.test.tsx` and `appstudio/__tests__/PublishView.test.tsx`)
- [x] `cd desktop && npm run build` -- 0 TypeScript errors
- [x] `python -m pytest tests/ -k "userspace or package or app_studio" -q --ignore=tests/e2e` -- 211 passed (new `tests/test_routes_userspace_apps.py` package-route tests: valid zip, unique ids, empty name/files, missing index.html, unsafe filename, oversize/too-many files, install-pipeline round-trip)