### PR TITLE
feat(licensing): weight-license metadata + non-commercial accept gate before install (#169)

### DIFF
--- a/app-catalog/services/flux-fill/manifest.yaml
+++ b/app-catalog/services/flux-fill/manifest.yaml
@@ -6,6 +6,10 @@ version: 1.0.0
 description: "FLUX.1-Fill quality inpaint/outpaint tier - GPU image editing via an A1111-compatible sd.cpp server. Runs on-demand on a shared NVIDIA GPU."
 homepage: https://github.com/leejet/stable-diffusion.cpp
 license: MIT
+# The sd.cpp server is MIT, but this tier pulls the FLUX.1-dev weights,
+# which ship under the FLUX.1-dev non-commercial license.
+weights_license: "flux-1-dev-non-commercial-license"
+license_class: non-commercial
 
 requires:
   ram_mb: 8192

--- a/app-catalog/services/musicgen/manifest.yaml
+++ b/app-catalog/services/musicgen/manifest.yaml
@@ -6,6 +6,10 @@ version: 1.3.0
 description: "Meta's text-to-music — generates 30s clips from prompts. Multiple model sizes (small/medium/large/melody). Conditioning on melody supported."
 homepage: https://github.com/facebookresearch/audiocraft
 license: MIT
+# The wrapper code is MIT, but the pretrained MusicGen weights this service
+# downloads are Meta's CC-BY-NC 4.0 -- non-commercial use only.
+weights_license: "CC-BY-NC 4.0"
+license_class: non-commercial
 
 requires:
   ram_mb: 8192

--- a/app-catalog/services/musicgpt/manifest.yaml
+++ b/app-catalog/services/musicgpt/manifest.yaml
@@ -6,6 +6,10 @@ version: 0.4.0
 description: "Generate music from text prompts — runs locally using Meta's MusicGen, no Python required"
 homepage: https://github.com/gabotechs/MusicGPT
 license: MIT
+# The server binary is MIT, but it runs Meta's MusicGen weights under the
+# hood, which are CC-BY-NC 4.0 -- non-commercial use only.
+weights_license: "CC-BY-NC 4.0"
+license_class: non-commercial
 
 requires:
   ram_mb: 2048

--- a/desktop/src/apps/StoreApp/LicenseAcceptDialog.tsx
+++ b/desktop/src/apps/StoreApp/LicenseAcceptDialog.tsx
@@ -64,7 +64,7 @@ export function LicenseAcceptDialog({
         <div className="px-5 py-4 space-y-2.5">
           <p className="text-[13px] text-shell-text-secondary leading-relaxed">{text}</p>
           <p className="text-[11px] text-shell-text-tertiary">
-            Weights license: <span className="text-shell-text font-medium">{weightsLicense}</span>
+            Weights license: <span className="text-shell-text font-medium">{weightsLicense || "non-commercial (label unavailable)"}</span>
           </p>
         </div>
         {error && (

--- a/desktop/src/apps/StoreApp/LicenseAcceptDialog.tsx
+++ b/desktop/src/apps/StoreApp/LicenseAcceptDialog.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
+
+interface Props {
+  appName: string;
+  weightsLicense: string;
+  text: string;
+  submitting?: boolean;
+  error?: string | null;
+  /** Re-POSTs the install with accepted: true. */
+  onAccept: () => void;
+  onDecline: () => void;
+}
+
+/**
+ * Single-accept license dialog shown before installing a service whose
+ * backend pins non-commercial model weights (#169) -- e.g. musicgen's
+ * MIT wrapper around Meta's CC-BY-NC 4.0 weights. Cloned from
+ * PermissionConsent's modal shell (focus trap, portal, styling) but asks a
+ * single "I agree" question about a weights license instead of a
+ * multi-capability grant.
+ */
+export function LicenseAcceptDialog({
+  appName,
+  weightsLicense,
+  text,
+  submitting = false,
+  error = null,
+  onAccept,
+  onDecline,
+}: Props) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef, true);
+
+  const handleAccept = useCallback(() => {
+    if (!submitting) onAccept();
+  }, [submitting, onAccept]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        if (submitting) return;
+        if (e.target === e.currentTarget) onDecline();
+      }}
+      onKeyDown={(e) => {
+        if (submitting) return;
+        if (e.key === "Escape") onDecline();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${appName} weights license`}
+        className="bg-shell-surface border border-white/10 shadow-2xl rounded-2xl w-[26rem] max-w-[90vw] flex flex-col"
+      >
+        <div className="px-5 py-4 border-b border-white/5">
+          <h2 className="text-sm font-semibold text-shell-text">
+            {appName} uses non-commercial model weights
+          </h2>
+        </div>
+        <div className="px-5 py-4 space-y-2.5">
+          <p className="text-[13px] text-shell-text-secondary leading-relaxed">{text}</p>
+          <p className="text-[11px] text-shell-text-tertiary">
+            Weights license: <span className="text-shell-text font-medium">{weightsLicense}</span>
+          </p>
+        </div>
+        {error && (
+          <div role="alert" className="mx-5 mb-3 text-[12px] text-red-300 bg-red-500/10 border border-red-500/20 rounded px-2 py-1">
+            {error}
+          </div>
+        )}
+        <div className="flex justify-end gap-2 px-5 py-4 border-t border-white/5">
+          <button
+            type="button"
+            onClick={onDecline}
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-[13px] font-semibold text-shell-text-secondary hover:text-shell-text hover:bg-white/[0.04] transition-colors disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleAccept}
+            disabled={submitting}
+            className="px-4 py-1.5 rounded-full text-[13px] font-bold text-white transition-colors disabled:opacity-60"
+            style={{ background: "var(--color-accent)" }}
+          >
+            {submitting ? "Installing…" : "Agree & Install"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export default LicenseAcceptDialog;

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -470,6 +470,10 @@ function AppCard({
 
   const handleLicenseAccept = async () => {
     setLicenseSubmitting(true);
+    // Flip busy back on so the card's install-progress poller (keyed on busy,
+    // and cleared by handleAction when the gate returned) runs during the real
+    // accepted install instead of the card sitting idle behind the dialog.
+    setBusy(true);
     try {
       const outcome = await postInstall(true);
       if (outcome !== "gated") setLicenseGate(null);

--- a/desktop/src/apps/StoreApp/index.tsx
+++ b/desktop/src/apps/StoreApp/index.tsx
@@ -17,6 +17,7 @@ import { loadFilter, saveFilter } from "./storage";
 import { emitAppEvent, APP_INSTALLED } from "@/lib/app-event-bus";
 import { TaosAppsSection } from "./TaosAppsSection";
 import { ImportAppButton } from "./ImportAppButton";
+import { LicenseAcceptDialog } from "./LicenseAcceptDialog";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { MobileStore } from "./MobileStore";
 import { AppIcon, StoreCover } from "./AppIcon";
@@ -419,6 +420,38 @@ function AppCard({
   const showVariantPicker = !app.installed && variantOptions.length > 1;
   const showTargetPicker = !app.installed && installTargets.length > 1;
 
+  interface LicenseGate { weightsLicense: string; name: string; text: string }
+  const [licenseGate, setLicenseGate] = useState<LicenseGate | null>(null);
+  const [licenseSubmitting, setLicenseSubmitting] = useState(false);
+
+  /** POST install-v2. Returns "ok" | "gated" | "error" — "gated" means the
+   * backend returned 412 needs_license_acceptance (non-commercial weights,
+   * #169) and licenseGate state is now set so the accept dialog renders. */
+  const postInstall = async (accepted: boolean): Promise<"ok" | "gated" | "error"> => {
+    const body: Record<string, unknown> = { app_id: app.id, target_remote: selectedTarget };
+    if (selectedVariant !== "auto") body.variant_id = selectedVariant;
+    if (accepted) body.accepted = true;
+    const res = await fetch("/api/store/install-v2", { method: "POST", headers: { "Content-Type": "application/json", Accept: "application/json" }, body: JSON.stringify(body) });
+    if (res.status === 412) {
+      try {
+        const gate = await res.json();
+        if (gate?.needs_license_acceptance) {
+          setLicenseGate({ weightsLicense: String(gate.weights_license ?? ""), name: String(gate.name ?? app.name), text: String(gate.text ?? "") });
+          return "gated";
+        }
+      } catch { /* fall through to generic error below */ }
+    }
+    if (!res.ok) { let msg = `Install failed (${res.status})`; try { const err = await res.json(); if (err?.error) msg = String(err.error); } catch { /* ignore */ } setError(msg); return "error"; }
+    if (isFramework) {
+      try {
+        const data = await res.json();
+        if (data?.prefetch === "started") { setPrefetchStatus("downloading"); setPrefetchActive(true); }
+      } catch { /* no body / not framework prefetch */ }
+    }
+    onInstall(app.id);
+    return "ok";
+  };
+
   const handleAction = async () => {
     setBusy(true); setError(null); setProgress(null);
     try {
@@ -427,22 +460,26 @@ function AppCard({
         if (!res.ok) { let msg = `Uninstall failed (${res.status})`; try { const err = await res.json(); if (err?.error) msg = String(err.error); } catch { /* ignore */ } setError(msg); setBusy(false); return; }
         onUninstall(app.id);
       } else {
-        const body: Record<string, unknown> = { app_id: app.id, target_remote: selectedTarget };
-        if (selectedVariant !== "auto") body.variant_id = selectedVariant;
-        const res = await fetch("/api/store/install-v2", { method: "POST", headers: { "Content-Type": "application/json", Accept: "application/json" }, body: JSON.stringify(body) });
-        if (!res.ok) { let msg = `Install failed (${res.status})`; try { const err = await res.json(); if (err?.error) msg = String(err.error); } catch { /* ignore */ } setError(msg); setBusy(false); return; }
-        if (isFramework) {
-          try {
-            const data = await res.json();
-            if (data?.prefetch === "started") { setPrefetchStatus("downloading"); setPrefetchActive(true); }
-          } catch { /* no body / not framework prefetch */ }
-        }
-        onInstall(app.id);
+        const outcome = await postInstall(false);
+        if (outcome === "gated") { setBusy(false); return; }
       }
     } catch (e) { setError(e instanceof Error ? e.message : "Network error"); }
     setBusy(false);
     setTimeout(() => setProgress(null), 1500);
   };
+
+  const handleLicenseAccept = async () => {
+    setLicenseSubmitting(true);
+    try {
+      const outcome = await postInstall(true);
+      if (outcome !== "gated") setLicenseGate(null);
+    } catch (e) { setError(e instanceof Error ? e.message : "Network error"); setLicenseGate(null); }
+    setLicenseSubmitting(false);
+    setBusy(false);
+    setTimeout(() => setProgress(null), 1500);
+  };
+
+  const handleLicenseDecline = () => { setLicenseGate(null); setBusy(false); };
 
   const handleOpen = () => {
     window.dispatchEvent(new CustomEvent("taos:open-app", { detail: { app: "agents" } }));
@@ -477,6 +514,15 @@ function AppCard({
             <span className="text-[11px] text-shell-text-tertiary leading-none">v{app.version}</span>
           </div>
         </div>
+        {app.license_class === "non-commercial" && (
+          <span
+            className="inline-flex items-center gap-1 self-start text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-yellow-700/30 text-yellow-200"
+            title={`Model weights licensed for non-commercial use${app.weights_license ? ` (${app.weights_license})` : ""}`}
+            aria-label={`${app.name} uses non-commercial model weights${app.weights_license ? `: ${app.weights_license}` : ""}`}
+          >
+            Non-commercial weights
+          </span>
+        )}
         <p className="text-[11.5px] text-shell-text-secondary leading-relaxed flex-1">{app.description}</p>
         <div className="flex items-center justify-between">
           {app.stars ? (
@@ -568,6 +614,17 @@ function AppCard({
           </button>
         )}
       </div>
+      {licenseGate && (
+        <LicenseAcceptDialog
+          appName={licenseGate.name}
+          weightsLicense={licenseGate.weightsLicense}
+          text={licenseGate.text}
+          submitting={licenseSubmitting}
+          error={error}
+          onAccept={handleLicenseAccept}
+          onDecline={handleLicenseDecline}
+        />
+      )}
     </div>
   );
 }
@@ -967,6 +1024,9 @@ export function StoreApp({ windowId: _windowId }: { windowId: string }) {
             tagline: a.tagline ? String(a.tagline) : undefined,
             cover: a.cover ? String(a.cover) : COVER_BY_ID[String(a.id)]?.cover,
             coverImage: a.coverImage ? String(a.coverImage) : COVER_BY_ID[String(a.id)]?.coverImage,
+            license: a.license ? String(a.license) : undefined,
+            weights_license: a.weights_license ? String(a.weights_license) : undefined,
+            license_class: a.license_class ? String(a.license_class) : undefined,
           }));
           // Merge homelab apps: only add those not already in the catalog
           const catalogIds = new Set(normalized.map((a) => a.id));

--- a/desktop/src/apps/StoreApp/license-accept-gate.test.tsx
+++ b/desktop/src/apps/StoreApp/license-accept-gate.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Tests for the non-commercial weights license accept-gate (#169).
+ *
+ * Installing a service whose backend pins non-commercial weights (e.g.
+ * musicgen's CC-BY-NC 4.0 MusicGen weights) must not silently install --
+ * the backend returns 412 needs_license_acceptance, and the Store must show
+ * a license dialog and only proceed once the user agrees (re-POSTing
+ * install-v2 with accepted: true).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { StoreApp } from "./index";
+
+const NC_APP = {
+  id: "musicgen",
+  name: "MusicGen",
+  type: "service",
+  category: "music",
+  version: "1.3.0",
+  description: "Meta's text-to-music",
+  installed: false,
+  compat: "green",
+  license: "MIT",
+  weights_license: "CC-BY-NC 4.0",
+  license_class: "non-commercial",
+};
+
+function makeFetch(opts: { installCalls: Array<Record<string, unknown>> }) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === "/api/store/catalog") {
+      return new Response(JSON.stringify([NC_APP]), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    if (url === "/api/store/install-v2" && init?.method === "POST") {
+      const body = JSON.parse(String(init.body ?? "{}"));
+      opts.installCalls.push(body);
+      if (body.accepted === true) {
+        return new Response(JSON.stringify({ status: "installed", app_id: "musicgen" }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      return new Response(
+        JSON.stringify({
+          needs_license_acceptance: true,
+          license_id: "CC-BY-NC 4.0",
+          weights_license: "CC-BY-NC 4.0",
+          name: "MusicGen",
+          text: "MusicGen downloads model weights licensed under CC-BY-NC 4.0, for non-commercial use only.",
+        }),
+        { status: 412, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (url === "/api/store/install-progress/by-app/musicgen") {
+      return new Response(JSON.stringify({ app_id: "musicgen", active: null }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return new Response(null, { status: 404 });
+  });
+}
+
+beforeEach(() => {
+  if (!Element.prototype.scrollTo) {
+    Element.prototype.scrollTo = (() => {}) as typeof Element.prototype.scrollTo;
+  }
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((q: string) => ({
+        matches: false, media: q, onchange: null,
+        addListener: vi.fn(), removeListener: vi.fn(),
+        addEventListener: vi.fn(), removeEventListener: vi.fn(), dispatchEvent: vi.fn(),
+      })),
+    });
+  }
+});
+
+afterEach(() => { cleanup(); vi.restoreAllMocks(); });
+
+async function goToServicesTab() {
+  const servicesBtn = await screen.findByRole("button", { name: /^services$/i });
+  fireEvent.click(servicesBtn);
+}
+
+describe("Store non-commercial weights license gate (#169)", () => {
+  it("shows a 'Non-commercial weights' badge on the card", async () => {
+    global.fetch = makeFetch({ installCalls: [] }) as any;
+    render(<StoreApp windowId="test" />);
+    await goToServicesTab();
+    await screen.findByRole("button", { name: /install musicgen/i });
+    expect(screen.getByText(/non-commercial weights/i)).toBeInTheDocument();
+  });
+
+  it("blocks install behind a 412 and shows the license dialog", async () => {
+    const installCalls: Array<Record<string, unknown>> = [];
+    global.fetch = makeFetch({ installCalls }) as any;
+
+    render(<StoreApp windowId="test" />);
+    await goToServicesTab();
+
+    const installBtn = await screen.findByRole("button", { name: /install musicgen/i });
+    fireEvent.click(installBtn);
+
+    await screen.findByRole("dialog", { name: /musicgen weights license/i });
+    expect(screen.getAllByText(/CC-BY-NC 4.0/).length).toBeGreaterThan(0);
+    expect(installCalls).toHaveLength(1);
+    expect(installCalls[0].accepted).toBeUndefined();
+
+    // Install must not have gone through yet -- the Install button (not
+    // Uninstall) is still the card's action.
+    expect(screen.queryByRole("button", { name: /uninstall musicgen/i })).not.toBeInTheDocument();
+  });
+
+  it("re-POSTs with accepted: true and installs after Agree & Install", async () => {
+    const installCalls: Array<Record<string, unknown>> = [];
+    global.fetch = makeFetch({ installCalls }) as any;
+
+    render(<StoreApp windowId="test" />);
+    await goToServicesTab();
+
+    const installBtn = await screen.findByRole("button", { name: /install musicgen/i });
+    fireEvent.click(installBtn);
+
+    await screen.findByRole("dialog", { name: /musicgen weights license/i });
+    const agreeBtn = screen.getByRole("button", { name: /agree & install/i });
+    fireEvent.click(agreeBtn);
+
+    await waitFor(() => expect(installCalls).toHaveLength(2));
+    expect(installCalls[1].accepted).toBe(true);
+
+    // Dialog closes and the card flips to installed (Uninstall action).
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: /musicgen weights license/i })).not.toBeInTheDocument());
+  });
+
+  it("Cancel closes the dialog without installing", async () => {
+    const installCalls: Array<Record<string, unknown>> = [];
+    global.fetch = makeFetch({ installCalls }) as any;
+
+    render(<StoreApp windowId="test" />);
+    await goToServicesTab();
+
+    const installBtn = await screen.findByRole("button", { name: /install musicgen/i });
+    fireEvent.click(installBtn);
+
+    await screen.findByRole("dialog", { name: /musicgen weights license/i });
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    expect(screen.queryByRole("dialog", { name: /musicgen weights license/i })).not.toBeInTheDocument();
+    expect(installCalls).toHaveLength(1);
+  });
+});

--- a/desktop/src/apps/StoreApp/types.ts
+++ b/desktop/src/apps/StoreApp/types.ts
@@ -35,6 +35,14 @@ export interface CatalogApp {
   update_available?: boolean;
   /** Studios-specific lifecycle state. "soon" hides install and shows a badge. */
   studioState?: "installed" | "available" | "soon";
+  /** Code license (e.g. "MIT"). Distinct from weights_license/license_class below. */
+  license?: string;
+  /** Model weights license label (e.g. "CC-BY-NC 4.0"), when the backend pins weights
+   * under a different license than the runtime code. */
+  weights_license?: string;
+  /** "permissive" | "non-commercial" | "" (unknown/code-only). Drives the
+   * "Non-commercial weights" badge and the install-time license gate. */
+  license_class?: string;
 }
 
 export interface InstallTarget {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -361,6 +361,9 @@ async def client(app, tmp_data_dir):
     # app_grants ledger (per-app capability grants) is lifespan-owned; tests that
     # bypass the lifespan must init it so the userspace broker can consult it.
     await app.state.app_grants.init()
+    # license_acceptances ledger (non-commercial weights accept-gate, #169) is
+    # also lifespan-owned; same bypass-init requirement.
+    await app.state.license_acceptances.init()
     feedback_store = app.state.feedback_store
     if feedback_store._db is not None:
         await feedback_store.close()

--- a/tests/routes/test_store_install_v2.py
+++ b/tests/routes/test_store_install_v2.py
@@ -323,6 +323,115 @@ class TestDockerServiceAllocatedPort:
             )
 
 
+# ---------------------------------------------------------------------------
+# Non-commercial weights accept-gate (#169)
+# ---------------------------------------------------------------------------
+
+def make_non_commercial_service_manifest():
+    """A type=service manifest whose weights are non-commercial, mirroring
+    the real musicgen/musicgpt/flux-fill manifests post-#169."""
+    m = MagicMock()
+    m.id = "nc-service"
+    m.name = "NC Service"
+    m.type = "service"
+    m.license_class = "non-commercial"
+    m.weights_license = "CC-BY-NC 4.0"
+    m.install = {"method": "docker", "ports": [8080]}
+    m.requires = {}
+    m.hardware_tiers = {}
+    m.version = "1.0.0"
+    return m
+
+
+class TestNonCommercialLicenseGate:
+    @pytest.mark.asyncio
+    async def test_returns_412_when_not_accepted(self, client):
+        manifest = make_non_commercial_service_manifest()
+        registry = MagicMock()
+        registry.get_app = MagicMock(return_value=manifest)
+        registry.get = MagicMock(return_value=manifest)
+        registry.mark_installed = MagicMock()
+        registry.list_available = MagicMock(return_value=[])
+        client._transport.app.state.registry = registry
+
+        r = await client.post("/api/store/install-v2", json={"manifest_id": "nc-service"})
+
+        assert r.status_code == 412
+        body = r.json()
+        assert body["needs_license_acceptance"] is True
+        assert body["license_id"] == "CC-BY-NC 4.0"
+        assert body["weights_license"] == "CC-BY-NC 4.0"
+        assert body["name"] == "NC Service"
+        assert "text" in body
+
+    @pytest.mark.asyncio
+    async def test_accepted_true_installs_and_records_acceptance(self, client):
+        manifest = make_non_commercial_service_manifest()
+        registry = MagicMock()
+        registry.get_app = MagicMock(return_value=manifest)
+        registry.get = MagicMock(return_value=manifest)
+        registry.mark_installed = MagicMock()
+        registry.list_available = MagicMock(return_value=[])
+        client._transport.app.state.registry = registry
+
+        mock_installed_apps = MagicMock()
+        mock_installed_apps.install = AsyncMock(return_value=None)
+        mock_installed_apps.update_runtime_location = AsyncMock(return_value=None)
+        client._transport.app.state.installed_apps = mock_installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(
+            return_value={"success": True, "host_port": 31234, "path": "/opt/apps/nc-service"}
+        )
+        mock_installer.start = AsyncMock(return_value={"success": True})
+        mock_docker_class = MagicMock(return_value=mock_installer)
+
+        with patch("tinyagentos.installers.docker_installer.DockerInstaller", mock_docker_class):
+            r = await client.post(
+                "/api/store/install-v2",
+                json={"manifest_id": "nc-service", "accepted": True},
+            )
+
+        assert r.status_code == 200
+
+        license_store = client._transport.app.state.license_acceptances
+        record = client._transport.app.state.auth.find_user("admin")
+        accepted = await license_store.has_accepted(record["id"], "nc-service", "CC-BY-NC 4.0")
+        assert accepted is True
+
+    @pytest.mark.asyncio
+    async def test_second_install_after_acceptance_does_not_re_gate(self, client):
+        """Once accepted, a later install (accepted omitted) is not re-gated."""
+        manifest = make_non_commercial_service_manifest()
+        registry = MagicMock()
+        registry.get_app = MagicMock(return_value=manifest)
+        registry.get = MagicMock(return_value=manifest)
+        registry.mark_installed = MagicMock()
+        registry.list_available = MagicMock(return_value=[])
+        client._transport.app.state.registry = registry
+
+        record = client._transport.app.state.auth.find_user("admin")
+        license_store = client._transport.app.state.license_acceptances
+        await license_store.record_acceptance(record["id"], "nc-service", "CC-BY-NC 4.0")
+
+        mock_installed_apps = MagicMock()
+        mock_installed_apps.install = AsyncMock(return_value=None)
+        mock_installed_apps.update_runtime_location = AsyncMock(return_value=None)
+        client._transport.app.state.installed_apps = mock_installed_apps
+
+        mock_installer = MagicMock()
+        mock_installer.install = AsyncMock(
+            return_value={"success": True, "host_port": 31235, "path": "/opt/apps/nc-service"}
+        )
+        mock_installer.start = AsyncMock(return_value={"success": True})
+        mock_docker_class = MagicMock(return_value=mock_installer)
+
+        with patch("tinyagentos.installers.docker_installer.DockerInstaller", mock_docker_class):
+            r = await client.post("/api/store/install-v2", json={"manifest_id": "nc-service"})
+
+        assert r.status_code == 200
+
+
 class TestGetDeviceCapabilityDisk:
     """Unit tests for the free-disk probe in get_device_capability."""
 

--- a/tests/test_license_acceptances_store.py
+++ b/tests/test_license_acceptances_store.py
@@ -1,0 +1,79 @@
+"""Tests for LicenseAcceptancesStore — per-user weights-license acceptances (#169)."""
+import pytest
+
+from tinyagentos.license_acceptances_store import LicenseAcceptancesStore
+
+
+@pytest.mark.asyncio
+class TestLicenseAcceptancesStore:
+    async def _store(self, tmp_path):
+        s = LicenseAcceptancesStore(tmp_path / "license_acceptances.db")
+        await s.init()
+        return s
+
+    async def test_has_accepted_false_before_any_record(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            assert await store.has_accepted("u1", "musicgen", "CC-BY-NC 4.0") is False
+        finally:
+            await store.close()
+
+    async def test_record_acceptance_then_has_accepted_true(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            row = await store.record_acceptance("u1", "musicgen", "CC-BY-NC 4.0")
+            assert row["user_id"] == "u1"
+            assert row["app_id"] == "musicgen"
+            assert row["license_id"] == "CC-BY-NC 4.0"
+            assert "accepted_at" in row
+            assert await store.has_accepted("u1", "musicgen", "CC-BY-NC 4.0") is True
+        finally:
+            await store.close()
+
+    async def test_record_acceptance_idempotent(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.record_acceptance("u1", "musicgen", "CC-BY-NC 4.0")
+            await store.record_acceptance("u1", "musicgen", "CC-BY-NC 4.0")
+            # Re-accepting doesn't raise and the acceptance still holds
+            # (INSERT OR REPLACE keeps a single row per unique key, not a
+            # growing duplicate history).
+            assert await store.has_accepted("u1", "musicgen", "CC-BY-NC 4.0") is True
+        finally:
+            await store.close()
+
+    async def test_acceptance_scoped_by_user(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.record_acceptance("u1", "musicgen", "CC-BY-NC 4.0")
+            assert await store.has_accepted("u1", "musicgen", "CC-BY-NC 4.0") is True
+            assert await store.has_accepted("u2", "musicgen", "CC-BY-NC 4.0") is False
+        finally:
+            await store.close()
+
+    async def test_acceptance_scoped_by_app(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.record_acceptance("u1", "musicgen", "CC-BY-NC 4.0")
+            assert await store.has_accepted("u1", "musicgpt", "CC-BY-NC 4.0") is False
+        finally:
+            await store.close()
+
+    async def test_acceptance_scoped_by_license_id(self, tmp_path):
+        """A changed weights_license (new license_id) requires re-acceptance."""
+        store = await self._store(tmp_path)
+        try:
+            await store.record_acceptance("u1", "flux-fill", "flux-1-dev-non-commercial-license")
+            assert await store.has_accepted("u1", "flux-fill", "flux-1-dev-non-commercial-license-v2") is False
+        finally:
+            await store.close()
+
+    async def test_record_acceptance_uninitialised_raises(self, tmp_path):
+        store = LicenseAcceptancesStore(tmp_path / "license_acceptances.db")
+        with pytest.raises(RuntimeError):
+            await store.record_acceptance("u1", "musicgen", "CC-BY-NC 4.0")
+
+    async def test_has_accepted_uninitialised_raises(self, tmp_path):
+        store = LicenseAcceptancesStore(tmp_path / "license_acceptances.db")
+        with pytest.raises(RuntimeError):
+            await store.has_accepted("u1", "musicgen", "CC-BY-NC 4.0")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -82,6 +82,30 @@ class TestAppManifest:
         assert m.is_compatible("cpu-only")
         assert not m.is_compatible("nonexistent-tier")
 
+    def test_weights_license_fields_default_empty(self, catalog_dir):
+        """A manifest with no weights_license/license_class (e.g. gitea)
+        must not silently inherit a non-empty default."""
+        m = AppManifest.from_file(catalog_dir / "services" / "gitea" / "manifest.yaml")
+        assert m.weights_license == ""
+        assert m.license_class == ""
+
+    def test_weights_license_fields_load_when_present(self, tmp_path):
+        d = tmp_path / "services" / "nc-service"
+        d.mkdir(parents=True)
+        (d / "manifest.yaml").write_text(yaml.dump({
+            "id": "nc-service",
+            "name": "NC Service",
+            "type": "service",
+            "version": "1.0.0",
+            "license": "MIT",
+            "weights_license": "CC-BY-NC 4.0",
+            "license_class": "non-commercial",
+        }))
+        m = AppManifest.from_file(d / "manifest.yaml")
+        assert m.license == "MIT"
+        assert m.weights_license == "CC-BY-NC 4.0"
+        assert m.license_class == "non-commercial"
+
 
 class TestAppRegistry:
     def test_load_catalog(self, registry):

--- a/tests/test_services_manifests.py
+++ b/tests/test_services_manifests.py
@@ -1,0 +1,57 @@
+"""Weight-license honesty guard for app-catalog/services manifests (#169).
+
+MusicGen, MusicGPT, and FLUX.1-Fill run permissively-licensed (MIT) wrapper
+code but pull pretrained weights that are non-commercial (Meta's CC-BY-NC 4.0
+MusicGen weights; the FLUX.1-dev non-commercial license). This test guards
+against a manifest's `license: MIT` line quietly implying the weights are
+also permissive, by asserting the explicit `license_class` / `weights_license`
+fields stay set on the services known to bundle non-commercial weights, and
+are not accidentally added to (or dropped from) any other manifest.
+"""
+from pathlib import Path
+
+import yaml
+
+SERVICES_DIR = Path(__file__).parent.parent / "app-catalog" / "services"
+
+# Explicit allowlist rather than inferred from the `license` string: most
+# custom/community model licenses in this catalog (e.g. HunyuanVideo's
+# Tencent Community License, Stability AI's Community License) permit
+# commercial use below a revenue/usage threshold, which is a different legal
+# category from "non-commercial" (CC-BY-NC-style, no commercial use at all).
+NON_COMMERCIAL_WEIGHTS_SERVICES = {"musicgen", "musicgpt", "flux-fill"}
+
+
+class TestServiceManifestsValid:
+    def test_all_manifests_valid_yaml(self):
+        manifests = list(SERVICES_DIR.glob("*/manifest.yaml"))
+        assert len(manifests) >= 70
+        for path in manifests:
+            data = yaml.safe_load(path.read_text())
+            assert "id" in data
+            assert "license" in data
+
+
+class TestNonCommercialWeightsLicensing:
+    def test_known_non_commercial_services_carry_license_class(self):
+        for app_id in NON_COMMERCIAL_WEIGHTS_SERVICES:
+            path = SERVICES_DIR / app_id / "manifest.yaml"
+            data = yaml.safe_load(path.read_text())
+            assert data.get("license_class") == "non-commercial", (
+                f"{app_id} bundles non-commercial weights but manifest "
+                f"license_class is {data.get('license_class')!r}"
+            )
+            assert data.get("weights_license"), f"{app_id} missing weights_license"
+            # The code license stays honest (MIT wrapper) -- only the weights
+            # are restricted, so `license` must not be silently rewritten.
+            assert data.get("license") == "MIT"
+
+    def test_other_services_not_marked_non_commercial(self):
+        for path in SERVICES_DIR.glob("*/manifest.yaml"):
+            data = yaml.safe_load(path.read_text())
+            if data["id"] in NON_COMMERCIAL_WEIGHTS_SERVICES:
+                continue
+            assert data.get("license_class", "") != "non-commercial", (
+                f"{data['id']} unexpectedly marked non-commercial -- "
+                f"add it to NON_COMMERCIAL_WEIGHTS_SERVICES if that's intentional"
+            )

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -264,6 +264,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     agent_grants_store = AgentGrantsStore(data_dir / "agent_grants.db")
     from tinyagentos.app_grants_store import AppGrantsStore
     app_grants_store = AppGrantsStore(data_dir / "app_grants.db")
+    from tinyagentos.license_acceptances_store import LicenseAcceptancesStore
+    license_acceptances_store = LicenseAcceptancesStore(data_dir / "license_acceptances.db")
     from tinyagentos.agent_model_key_store import AgentModelKeyStore
     agent_model_key_store = AgentModelKeyStore(data_dir / "agent_model_keys.db")
     from tinyagentos.cluster.pairing_store import ClusterPairingStore
@@ -468,6 +470,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.agent_grants = agent_grants_store
         await app_grants_store.init()
         app.state.app_grants = app_grants_store
+        await license_acceptances_store.init()
+        app.state.license_acceptances = license_acceptances_store
         await agent_model_key_store.init()
         app.state.agent_model_keys = agent_model_key_store
         await cluster_pairing_store.init()
@@ -1369,6 +1373,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await http_client.aclose()
         await agent_grants_store.close()
         await app_grants_store.close()
+        await license_acceptances_store.close()
         await agent_model_key_store.close()
         await auth_requests_store.close()
         await cluster_pairing_store.close()
@@ -1554,6 +1559,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.auth_requests = auth_requests_store
     app.state.agent_grants = agent_grants_store
     app.state.app_grants = app_grants_store
+    app.state.license_acceptances = license_acceptances_store
     app.state.cluster_pairing = cluster_pairing_store
     app.state.capability_map = capability_map_store
 

--- a/tinyagentos/license_acceptances_store.py
+++ b/tinyagentos/license_acceptances_store.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Store for per-user weights-license acceptances (#169).
+
+Some app-catalog services bundle non-commercial model weights under a code
+license that is otherwise permissive (e.g. musicgen's MIT wrapper around
+Meta's CC-BY-NC 4.0 weights). Before such a service installs, the user must
+explicitly accept the weights license; this store is the durable record of
+that decision, mirroring AppGrantsStore's shape: keyed by
+(user_id, app_id, license_id), last acceptance wins. There is no revoke --
+accepting a license is a point-in-time fact, not a toggle, and if a
+manifest's weights_license ever changes, that's a new license_id, so the old
+acceptance simply no longer matches and re-acceptance is required.
+"""
+
+from datetime import datetime, timezone
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS license_acceptances (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id      TEXT NOT NULL,
+    app_id       TEXT NOT NULL,
+    license_id   TEXT NOT NULL,
+    accepted_at  TEXT NOT NULL,
+    UNIQUE (user_id, app_id, license_id)
+);
+"""
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict:
+    return {k: row[k] for k in row.keys()}
+
+
+class LicenseAcceptancesStore(BaseStore):
+    """Persistent store for per-user weights-license acceptances."""
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    async def record_acceptance(self, user_id: str, app_id: str, license_id: str) -> dict:
+        """Record that user_id accepted license_id for app_id.
+
+        Idempotent via INSERT OR REPLACE: re-accepting the same license just
+        refreshes accepted_at rather than erroring or duplicating a row.
+        """
+        if self._db is None:
+            raise RuntimeError("LicenseAcceptancesStore not initialised — call init() first")
+        now = datetime.now(timezone.utc).isoformat()
+        await self._db.execute(
+            """
+            INSERT OR REPLACE INTO license_acceptances
+                (user_id, app_id, license_id, accepted_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (user_id, app_id, license_id, now),
+        )
+        await self._db.commit()
+        row = await (
+            await self._db.execute(
+                "SELECT * FROM license_acceptances "
+                "WHERE user_id = ? AND app_id = ? AND license_id = ?",
+                (user_id, app_id, license_id),
+            )
+        ).fetchone()
+        return _row_to_dict(row)  # type: ignore[return-value]
+
+    async def has_accepted(self, user_id: str, app_id: str, license_id: str) -> bool:
+        """True if user_id has already accepted license_id for app_id."""
+        if self._db is None:
+            raise RuntimeError("LicenseAcceptancesStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT 1 FROM license_acceptances "
+            "WHERE user_id = ? AND app_id = ? AND license_id = ?",
+            (user_id, app_id, license_id),
+        )
+        return await cursor.fetchone() is not None

--- a/tinyagentos/registry.py
+++ b/tinyagentos/registry.py
@@ -31,6 +31,14 @@ class AppManifest:
     icon: str = ""
     homepage: str = ""
     license: str = ""
+    # Weights license metadata, separate from `license` (the CODE license).
+    # A manifest's runtime can be MIT while the model weights it pulls are
+    # non-commercial (e.g. musicgen's CC-BY-NC 4.0 weights) -- these two
+    # fields make that distinction explicit instead of leaving it implied by
+    # `license` alone. weights_license is a free-text label ("CC-BY-NC 4.0");
+    # license_class is "permissive" | "non-commercial" ("" = unknown/code-only).
+    weights_license: str = ""
+    license_class: str = ""
     requires: dict = field(default_factory=dict)
     install: dict = field(default_factory=dict)
     hardware_tiers: dict = field(default_factory=dict)
@@ -53,6 +61,8 @@ class AppManifest:
             icon=data.get("icon", ""),
             homepage=data.get("homepage", ""),
             license=data.get("license", ""),
+            weights_license=data.get("weights_license", ""),
+            license_class=data.get("license_class", ""),
             requires=data.get("requires", {}),
             install=data.get("install", {}),
             hardware_tiers=data.get("hardware_tiers", {}),

--- a/tinyagentos/routes/store.py
+++ b/tinyagentos/routes/store.py
@@ -151,6 +151,8 @@ async def list_catalog(request: Request, type: str | None = None):
             "id": a.id, "name": a.name, "type": a.type, "category": a.category,
             "version": a.version,
             "description": a.description, "icon": a.icon,
+            "license": a.license, "weights_license": a.weights_license,
+            "license_class": a.license_class,
             "requires": a.requires, "hardware_tiers": a.hardware_tiers,
             "install_method": (a.install.get("method") or a.install.get("backend") or "") if isinstance(a.install, dict) else "",
             "installed": _installed_flag(a.id),

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -699,6 +699,44 @@ async def install_app(request: Request):
         progress.finish(install_id, success=False, error="manifest not found in registry")
         return await _legacy_install(request, body, manifest_id, target_remote)
 
+    # Non-commercial weights gate (#169): a manifest's code license (MIT etc.)
+    # can be permissive while the model weights it downloads are not (e.g.
+    # musicgen pulls Meta's CC-BY-NC 4.0 weights). Block the install until the
+    # user has explicitly accepted the weights license -- either previously
+    # (recorded in license_acceptances) or on this very request (accepted:
+    # true, sent by the frontend after the user clicks Agree in the license
+    # dialog). Applies uniformly, including to admins: license acceptance is
+    # a legal fact about the user, not a permission an admin role bypasses.
+    if getattr(manifest, "license_class", "") == "non-commercial":
+        license_store = getattr(request.app.state, "license_acceptances", None)
+        license_id = getattr(manifest, "weights_license", "") or manifest.id
+        user = _get_current_user(request)
+        user_id = (user or {}).get("id") or "anonymous"
+        already_accepted = (
+            await license_store.has_accepted(user_id, manifest.id, license_id)
+            if license_store is not None else False
+        )
+        accepted_now = bool(body.get("accepted", False))
+        if not already_accepted and not accepted_now:
+            progress.finish(install_id, success=False, error="needs_license_acceptance")
+            return JSONResponse(
+                {
+                    "needs_license_acceptance": True,
+                    "license_id": license_id,
+                    "weights_license": manifest.weights_license,
+                    "name": manifest.name,
+                    "text": (
+                        f"{manifest.name} downloads model weights licensed under "
+                        f"{manifest.weights_license}, for non-commercial use only. "
+                        "Continuing means you agree to that license for the "
+                        "weights this service uses."
+                    ),
+                },
+                status_code=412,
+            )
+        if accepted_now and not already_accepted and license_store is not None:
+            await license_store.record_acceptance(user_id, manifest.id, license_id)
+
     # Non-model manifests use the legacy method-driven path.
     if getattr(manifest, "type", "model") != "model":
         progress.update(install_id, state="unpacking", detail=f"installing {manifest.type}")


### PR DESCRIPTION
## The mislabel

App-catalog service manifests labeled model-backed services with only their CODE license (MIT). That quietly implied the model WEIGHTS were permissive too. For `musicgen`, `musicgpt`, and `flux-fill` the weights are non-commercial (Meta's CC-BY-NC 4.0 MusicGen weights; the FLUX.1-dev non-commercial license), so a user could install and use them commercially without ever seeing the restriction.

## Slice 1 - honesty

- New `AppManifest` fields `weights_license` and `license_class` (`"permissive"` | `"non-commercial"`, default empty = code-license-only), added to both the dataclass and the `from_file` yaml mapping. `license` stays the CODE license.
- Corrected the 3 manifests: kept `license: MIT` (honest code license) and added:
  - `musicgen`, `musicgpt`: `weights_license: "CC-BY-NC 4.0"`, `license_class: non-commercial`
  - `flux-fill`: `weights_license: "flux-1-dev-non-commercial-license"`, `license_class: non-commercial`
- Audited every other `app-catalog/services/*/manifest.yaml` and left them code-license-only: generic runtimes that only run user-chosen weights (diffusers, transformers, sd-webui, iopaint, ...) and services whose custom community licenses permit commercial use below a threshold (HunyuanVideo's Tencent Community License, Stable Audio Open's Stability Community License) - a different legal category from non-commercial, so not flagged.
- `/api/store/catalog` now returns `license`, `weights_license`, `license_class`; the Store renders a theme-aware, a11y "Non-commercial weights" badge on cards where `license_class === "non-commercial"`.
- Tests: new `tests/test_services_manifests.py`; extended `tests/test_registry.py` for the new fields.

## Slice 2 - arms-length accept-gate

- `LicenseAcceptancesStore(BaseStore)` keyed `(user_id, app_id, license_id)` with `record_acceptance` / `has_accepted`, wired onto `app.state` (lifespan init/close + non-lifespan fallback) like the other stores.
- `install-v2` gate: for a `license_class == "non-commercial"` service the user has not accepted (and the request body did not carry `accepted: true`), it returns **412** `{needs_license_acceptance, license_id, weights_license, name, text}` instead of installing. A follow-up install carrying `accepted: true` records the acceptance then proceeds. Not bypassed for admins - admins are shown the accept once too.
- Frontend `LicenseAcceptDialog` (cloned from `PermissionConsent`): on a 412 `needs_license_acceptance`, the Store shows the license dialog (name + weights license + "for non-commercial use") and on Agree re-POSTs `install-v2` with `accepted: true`. Install is blocked until accepted.

## 412 accept-gate flow

1. User clicks Install on a non-commercial-weights service.
2. `install-v2` -> 412 `needs_license_acceptance` (no install performed).
3. Store shows `LicenseAcceptDialog`.
4. On Agree, re-POST `install-v2` with `accepted: true` -> acceptance recorded, install proceeds. On Cancel, nothing installs.
5. A later install by the same user is not re-gated (acceptance persisted).

Also unblocks #115 (RK image-gen flagged install) via the same gate.

## Tests

- Backend: `tests/test_license_acceptances_store.py` (store, mold of `test_base_store`/`test_app_grants_store`); `install_app` gate tests in `tests/routes/test_store_install_v2.py` (no acceptance -> 412; `accepted: true` -> installs + records; second install not re-gated).
- Frontend: `desktop/src/apps/StoreApp/license-accept-gate.test.tsx` mocks the 412 -> accept -> `install-v2` round-trip, plus the badge and Cancel paths.
- `python -m pytest tests/ -k "registry or services_manifests or store_install or license or manifest"` -> 477 passed, 1 skipped.
- `npx vitest run src/apps/StoreApp` -> 72 passed. `npm run build` -> 0 TS errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added license metadata for app listings so non-commercial model weights can be identified in the Store.
  * Introduced an install-time license acceptance step for affected apps, with a dialog to review and accept the weights license before installation continues.
  * Showed a “Non-commercial weights” badge on eligible apps.

* **Tests**
  * Added coverage for catalog parsing, install gating, acceptance persistence, and manifest licensing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->