### PR TITLE
fix(video-studio): async generation job (enqueue + poll) instead of blocking sync POST

### DIFF
--- a/desktop/src/apps/VideoStudioApp.test.tsx
+++ b/desktop/src/apps/VideoStudioApp.test.tsx
@@ -54,20 +54,28 @@ describe("VideoStudioApp", () => {
     expect(screen.getByPlaceholderText(/describe the video/i)).toBeTruthy();
   });
 
-  it("posts the prompt and generation params to /api/video/generate", async () => {
+  it("posts the prompt, enqueues a job, and polls it to done", async () => {
     const fetchMock = mockFetch({
       "GET /api/video": { ok: true, body: { videos: [] } },
       "POST /api/video/generate": {
         ok: true,
+        status: 202,
+        body: { job_id: "job-1", status: "queued" },
+      },
+      "GET /api/video/jobs/job-1": {
+        ok: true,
         body: {
-          status: "generated",
-          filename: "123_456.mp4",
-          path: "/data/videos/123_456.mp4",
-          prompt: "a cat riding a skateboard",
-          model: "wan2.1-1.3b",
-          duration: 5,
-          resolution: "480x832",
-          seed: 456,
+          job_id: "job-1",
+          status: "done",
+          result: {
+            filename: "123_456.mp4",
+            path: "/data/videos/123_456.mp4",
+            prompt: "a cat riding a skateboard",
+            model: "wan2.1-1.3b",
+            duration: 5,
+            resolution: "480x832",
+            seed: 456,
+          },
         },
       },
     });
@@ -96,6 +104,50 @@ describe("VideoStudioApp", () => {
     // No seed pinned by the user, so it should be omitted (backend randomizes).
     expect(body.seed).toBeUndefined();
 
+    // The job endpoint was polled.
+    expect(
+      fetchMock.mock.calls.some(([url]: [string]) => url === "/api/video/jobs/job-1"),
+    ).toBe(true);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Generate$/)).toBeTruthy();
+    });
+
+    // The completed result is rendered in the stage.
+    const video = document.querySelector("video");
+    expect(video?.getAttribute("src")).toBe("/api/video/123_456.mp4");
+  });
+
+  it("shows the job's error message when the poll reports a failure", async () => {
+    const fetchMock = mockFetch({
+      "GET /api/video": { ok: true, body: { videos: [] } },
+      "POST /api/video/generate": {
+        ok: true,
+        status: 202,
+        body: { job_id: "job-2", status: "queued" },
+      },
+      "GET /api/video/jobs/job-2": {
+        ok: true,
+        body: {
+          job_id: "job-2",
+          status: "error",
+          error: "Cannot connect to video backend at http://localhost:9000. Is it running?",
+        },
+      },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderApp();
+    await flush();
+
+    fireEvent.change(screen.getByPlaceholderText(/describe the video/i), {
+      target: { value: "a dog surfing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^Generate$/ }));
+    await flush();
+
+    expect(
+      await screen.findByText(/Cannot connect to video backend/),
+    ).toBeTruthy();
     await waitFor(() => {
       expect(screen.getByText(/Generate$/)).toBeTruthy();
     });

--- a/desktop/src/apps/VideoStudioApp.tsx
+++ b/desktop/src/apps/VideoStudioApp.tsx
@@ -32,6 +32,14 @@ function randomSeed(): number {
 // random.randint(0, 2**32 - 1) range).
 const MAX_SEED = 2 ** 32 - 1;
 
+// Generation is an async job now: POST /api/video/generate enqueues and
+// returns a job id immediately, and GET /api/video/jobs/{job_id} is polled
+// until it reports done/error. POLL_INTERVAL_MS/MAX_POLL_ATTEMPTS bound how
+// long the UI keeps polling before giving up (the video still finishes and
+// lands in the Library -- the user can find it there).
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLL_ATTEMPTS = 600; // ~20 minutes at POLL_INTERVAL_MS
+
 function toGeneratedVideo(raw: Record<string, unknown>): GeneratedVideo {
   const filename = (raw.filename as string) ?? "";
   return {
@@ -73,6 +81,8 @@ export function VideoStudioApp({ windowId: _windowId }: { windowId: string }) {
   const [needsBackend, setNeedsBackend] = useState(false);
   const [latest, setLatest] = useState<GeneratedVideo | null>(null);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollAbortRef = useRef<AbortController | null>(null);
 
   /* ----------------------------- videos --------------------------- */
 
@@ -107,6 +117,21 @@ export function VideoStudioApp({ windowId: _windowId }: { windowId: string }) {
 
   /* ----------------------------- generate ------------------------- */
 
+  const stopPolling = useCallback(() => {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+    pollAbortRef.current?.abort();
+    pollAbortRef.current = null;
+  }, []);
+
+  const finishGenerating = useCallback(() => {
+    if (timerRef.current) clearInterval(timerRef.current);
+    stopPolling();
+    setGenerating(false);
+  }, [stopPolling]);
+
   const runGenerate = useCallback(async () => {
     const usePrompt = prompt.trim();
     if (!usePrompt) return;
@@ -116,6 +141,7 @@ export function VideoStudioApp({ windowId: _windowId }: { windowId: string }) {
     setNeedsBackend(false);
     setElapsedSeconds(0);
     setLatest(null);
+    stopPolling();
     if (timerRef.current) clearInterval(timerRef.current);
     timerRef.current = setInterval(() => {
       setElapsedSeconds((s) => s + 1);
@@ -142,12 +168,8 @@ export function VideoStudioApp({ windowId: _windowId }: { windowId: string }) {
         body: JSON.stringify(body),
       });
       const data = await res.json().catch(() => ({}));
-      if (res.ok && data.filename) {
-        const video = toGeneratedVideo(data);
-        setLatest(video);
-        await fetchVideos();
-        setSelectedLibraryId(video.filename);
-      } else {
+
+      if (!res.ok || !data.job_id) {
         const message =
           (data as { error?: string }).error ??
           `Generation failed (${res.status})`;
@@ -155,21 +177,81 @@ export function VideoStudioApp({ windowId: _windowId }: { windowId: string }) {
         // The backend returns 503 specifically when no video backend is
         // configured or reachable -- that's the "install a backend" case.
         setNeedsBackend(res.status === 503);
+        finishGenerating();
+        return;
+      }
+
+      const jobId = data.job_id as string;
+      const abortController = new AbortController();
+      pollAbortRef.current = abortController;
+      let attempts = 0;
+
+      const poll = async () => {
+        attempts += 1;
+        try {
+          const statusRes = await fetch(
+            `/api/video/jobs/${encodeURIComponent(jobId)}`,
+            { headers: { Accept: "application/json" }, signal: abortController.signal },
+          );
+          const statusData = await statusRes.json().catch(() => ({}));
+
+          if (!statusRes.ok) {
+            setGenerateError(
+              (statusData as { error?: string }).error ??
+                `Job status failed (${statusRes.status})`,
+            );
+            finishGenerating();
+            return;
+          }
+
+          if (statusData.status === "done") {
+            const video = toGeneratedVideo(statusData.result ?? {});
+            setLatest(video);
+            await fetchVideos();
+            setSelectedLibraryId(video.filename);
+            finishGenerating();
+            return;
+          }
+
+          if (statusData.status === "error") {
+            setGenerateError(statusData.error ?? "Video generation failed");
+            finishGenerating();
+            return;
+          }
+
+          // Still queued/running -- keep polling until the attempt cap.
+          if (attempts >= MAX_POLL_ATTEMPTS) {
+            setGenerateError(
+              "Video generation is taking longer than expected. Check the Library later.",
+            );
+            finishGenerating();
+          }
+        } catch (e) {
+          if ((e as Error).name === "AbortError") return;
+          setGenerateError(`Generation error: ${(e as Error).message}`);
+          finishGenerating();
+        }
+      };
+
+      await poll();
+      // Only arm the interval if the first poll didn't already resolve
+      // (finishGenerating clears pollAbortRef.current on any terminal state).
+      if (pollAbortRef.current) {
+        pollTimerRef.current = setInterval(poll, POLL_INTERVAL_MS);
       }
     } catch (e) {
       setGenerateError(`Generation error: ${(e as Error).message}`);
       setNeedsBackend(false);
+      finishGenerating();
     }
-
-    if (timerRef.current) clearInterval(timerRef.current);
-    setGenerating(false);
-  }, [prompt, modelId, duration, resolution, seed, fetchVideos]);
+  }, [prompt, modelId, duration, resolution, seed, fetchVideos, stopPolling, finishGenerating]);
 
   useEffect(() => {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
+      stopPolling();
     };
-  }, []);
+  }, [stopPolling]);
 
   const handleReroll = useCallback(() => {
     setSeed(String(randomSeed()));

--- a/desktop/src/apps/videostudio/CreateView.tsx
+++ b/desktop/src/apps/videostudio/CreateView.tsx
@@ -18,10 +18,10 @@ import {
 /* ------------------------------------------------------------------ */
 /*  CreateView — prompt bar + controls + latest result                 */
 /*                                                                     */
-/*  The backend (routes/video.py) generates synchronously: the POST    */
-/*  resolves only once the clip is done (or errors), with no job id or  */
-/*  status endpoint to poll. So instead of faking a progress bar, the   */
-/*  stage shows a spinner with a real elapsed-time counter.             */
+/*  Generation is an async job: VideoStudioApp posts to enqueue, then   */
+/*  polls the job's status until done/error. There's no real progress   */
+/*  percentage from the backend, so instead of faking a progress bar,   */
+/*  the stage shows a spinner with a real elapsed-time counter.         */
 /* ------------------------------------------------------------------ */
 
 export interface CreateViewProps {

--- a/tests/test_routes_video.py
+++ b/tests/test_routes_video.py
@@ -211,12 +211,51 @@ class TestVideoGenerate:
         del video_app.state.config.server["video_backend_url"]
 
 
+    async def test_generate_unexpected_exception_marks_job_error(self, video_app, video_client):
+        """An unexpected (non-httpx) backend exception still ends the job in a
+        terminal 'error' state -- never stuck in 'running'."""
+        video_app.state.config.server["video_backend_url"] = "http://localhost:9000"
+
+        with patch("tinyagentos.routes.video.httpx.AsyncClient") as MockClient:
+            mock_instance = AsyncMock()
+            mock_instance.post.side_effect = RuntimeError("boom")
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
+            MockClient.return_value = mock_instance
+
+            resp = await video_client.post("/api/video/generate", json={"prompt": "test"})
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
+
+            await _drain_background_tasks(video_app)
+
+        status_resp = await video_client.get(f"/api/video/jobs/{job_id}")
+        status = status_resp.json()
+        assert status["status"] == "error"
+        assert "boom" in status["error"]
+
+        del video_app.state.config.server["video_backend_url"]
+
+
 @pytest.mark.asyncio
 class TestVideoJobStatus:
     async def test_job_not_found_returns_404(self, video_client):
         resp = await video_client.get("/api/video/jobs/does-not-exist")
         assert resp.status_code == 404
         assert "error" in resp.json()
+
+    async def test_rapid_jobs_get_distinct_ids(self, video_app, video_client):
+        """Two jobs created back-to-back must get distinct (full-length) ids --
+        a truncated id would risk a PRIMARY KEY collision."""
+        from tinyagentos.routes.video import _get_video_job_store
+
+        job_store = await _get_video_job_store(video_app)
+        id1 = await job_store.create_job()
+        id2 = await job_store.create_job()
+        assert id1 != id2
+        # Full uuid4 hex is 32 chars -- not truncated.
+        assert len(id1) == 32
+        assert len(id2) == 32
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_video.py
+++ b/tests/test_routes_video.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -6,6 +7,15 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient, Request as HttpxRequest, Response
 
 from tinyagentos.app import create_app
+
+
+async def _drain_background_tasks(app) -> None:
+    """Wait for the video generation background task(s) spawned by the last
+    request to finish, so a job status poll immediately after sees the
+    terminal state instead of racing the still-running task."""
+    pending = [t for t in app.state._background_tasks if not t.done()]
+    if pending:
+        await asyncio.gather(*pending)
 
 
 @pytest.fixture
@@ -63,8 +73,9 @@ class TestVideoGenerate:
         await app.state.qmd_client.close()
         await app.state.http_client.aclose()
 
-    async def test_generate_with_mocked_backend_b64(self, video_app, video_client):
-        """Generate a video using a mocked backend returning base64 data."""
+    async def test_generate_returns_job_id_then_completes(self, video_app, video_client):
+        """Generate enqueues a job (202 + job_id) and, once the background
+        task finishes, the job's status flips to done with the saved video."""
         import base64
 
         # Set video_backend_url in config
@@ -89,13 +100,22 @@ class TestVideoGenerate:
                 "prompt": "a test video",
                 "seed": 99,
             })
+            assert resp.status_code == 202
+            data = resp.json()
+            assert data["status"] == "queued"
+            job_id = data["job_id"]
+            assert job_id
 
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["status"] == "generated"
-        assert data["prompt"] == "a test video"
-        assert data["seed"] == 99
-        assert data["filename"].endswith("_99.mp4")
+            await _drain_background_tasks(video_app)
+
+        status_resp = await video_client.get(f"/api/video/jobs/{job_id}")
+        assert status_resp.status_code == 200
+        status = status_resp.json()
+        assert status["status"] == "done"
+        result = status["result"]
+        assert result["prompt"] == "a test video"
+        assert result["seed"] == 99
+        assert result["filename"].endswith("_99.mp4")
 
         # Verify file was saved
         videos_dir = video_app.state.config.config_path.parent / "videos"
@@ -124,9 +144,15 @@ class TestVideoGenerate:
             MockClient.return_value = mock_instance
 
             resp = await video_client.post("/api/video/generate", json={"prompt": "test"})
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
 
-        assert resp.status_code == 503
-        assert "Cannot connect" in resp.json()["error"]
+            await _drain_background_tasks(video_app)
+
+        status_resp = await video_client.get(f"/api/video/jobs/{job_id}")
+        status = status_resp.json()
+        assert status["status"] == "error"
+        assert "Cannot connect" in status["error"]
 
         del video_app.state.config.server["video_backend_url"]
 
@@ -142,9 +168,15 @@ class TestVideoGenerate:
             MockClient.return_value = mock_instance
 
             resp = await video_client.post("/api/video/generate", json={"prompt": "test"})
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
 
-        assert resp.status_code == 504
-        assert "timed out" in resp.json()["error"]
+            await _drain_background_tasks(video_app)
+
+        status_resp = await video_client.get(f"/api/video/jobs/{job_id}")
+        status = status_resp.json()
+        assert status["status"] == "error"
+        assert "timed out" in status["error"]
 
         del video_app.state.config.server["video_backend_url"]
 
@@ -166,11 +198,25 @@ class TestVideoGenerate:
             MockClient.return_value = mock_instance
 
             resp = await video_client.post("/api/video/generate", json={"prompt": "test"})
+            assert resp.status_code == 202
+            job_id = resp.json()["job_id"]
 
-        assert resp.status_code == 502
-        assert "Unexpected response format" in resp.json()["error"]
+            await _drain_background_tasks(video_app)
+
+        status_resp = await video_client.get(f"/api/video/jobs/{job_id}")
+        status = status_resp.json()
+        assert status["status"] == "error"
+        assert "Unexpected response format" in status["error"]
 
         del video_app.state.config.server["video_backend_url"]
+
+
+@pytest.mark.asyncio
+class TestVideoJobStatus:
+    async def test_job_not_found_returns_404(self, video_client):
+        resp = await video_client.get("/api/video/jobs/does-not-exist")
+        assert resp.status_code == 404
+        assert "error" in resp.json()
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/video.py
+++ b/tinyagentos/routes/video.py
@@ -1,7 +1,18 @@
 # tinyagentos/routes/video.py
+"""Video generation routes.
+
+POST /api/video/generate used to block for the full multi-minute generation
+(no job id, no progress, dead on any client timeout/disconnect). It now
+enqueues a VideoJobStore row, runs the actual backend call in a background
+task (tracked in app.state._background_tasks, same pattern as
+agent_chat_router.py's dispatch()), and returns {job_id, status: "queued"}
+immediately. Callers poll GET /api/video/jobs/{job_id} for status/result.
+"""
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 import random
 import time
 from pathlib import Path
@@ -10,6 +21,11 @@ import httpx
 from fastapi import APIRouter, Request
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
+
+from tinyagentos.task_utils import _create_supervised_task
+from tinyagentos.video_jobs import VideoJobStore
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -24,15 +40,46 @@ class VideoGenerateRequest(BaseModel):
     seed: int | None = None
 
 
-def _videos_dir(request: Request) -> Path:
-    """Return the videos directory, creating it if needed."""
-    data_dir = getattr(request.app.state, "data_dir", None)
+class _VideoGenerationError(Exception):
+    """Raised by _generate_and_save for known failure modes; the message is
+    surfaced verbatim as the job's error field."""
+
+
+def _videos_dir_from_app(app) -> Path:
+    """Return the videos directory, creating it if needed.
+
+    Takes the FastAPI ``app`` directly (rather than a Request) so the
+    background generation task -- which outlives the originating request --
+    can resolve the same directory.
+    """
+    data_dir = getattr(app.state, "data_dir", None)
     if data_dir:
         d = Path(data_dir) / VIDEOS_DIR_NAME
     else:
         d = Path(__file__).parent.parent.parent / "data" / VIDEOS_DIR_NAME
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+def _videos_dir(request: Request) -> Path:
+    """Return the videos directory, creating it if needed."""
+    return _videos_dir_from_app(request.app)
+
+
+async def _get_video_job_store(app) -> VideoJobStore:
+    """Get or create the VideoJobStore singleton on app.state.
+
+    Mirrors routes/jobs.py's ``_get_queue`` -- a lazily-created, request-scoped
+    singleton so no lifespan wiring is needed in app.py.
+    """
+    store = getattr(app.state, "video_jobs", None)
+    if store is None:
+        data_dir = getattr(app.state, "data_dir", None)
+        base = Path(data_dir) if data_dir else Path(__file__).parent.parent.parent / "data"
+        store = VideoJobStore(base / "video_jobs.db")
+        await store.init()
+        app.state.video_jobs = store
+    return store
 
 
 def _get_video_backend(request: Request) -> str | None:
@@ -81,18 +128,11 @@ def _list_videos(videos_dir: Path) -> list[dict]:
     return results
 
 
-@router.post("/api/video/generate")
-async def generate_video(request: Request, body: VideoGenerateRequest):
-    """Generate a video from a text prompt using any configured video backend."""
-    backend_url = _get_video_backend(request)
-    if not backend_url:
-        return JSONResponse(
-            {"error": "No video generation backend configured. Connect a GPU worker or set video_backend_url in config."},
-            status_code=503,
-        )
-
-    seed = body.seed if body.seed is not None else random.randint(0, 2**32 - 1)
-
+async def _generate_and_save(app, body: VideoGenerateRequest, seed: int, backend_url: str) -> dict:
+    """Call the video backend, save the resulting clip + metadata sidecar, and
+    return the same result shape the old synchronous endpoint used to return.
+    Raises _VideoGenerationError on any known failure mode; the message is
+    used verbatim as the job's error field."""
     # Generic OpenAI-compatible video generation endpoint
     payload = {
         "prompt": body.prompt,
@@ -111,24 +151,16 @@ async def generate_video(request: Request, body: VideoGenerateRequest):
             resp.raise_for_status()
             data = resp.json()
     except httpx.ConnectError:
-        return JSONResponse(
-            {"error": f"Cannot connect to video backend at {backend_url}. Is it running?"},
-            status_code=503,
+        raise _VideoGenerationError(
+            f"Cannot connect to video backend at {backend_url}. Is it running?"
         )
     except httpx.TimeoutException:
-        return JSONResponse(
-            {"error": "Video generation timed out (>300s). The backend may be busy or overloaded."},
-            status_code=504,
+        raise _VideoGenerationError(
+            "Video generation timed out (>300s). The backend may be busy or overloaded."
         )
     except httpx.HTTPStatusError as e:
-        return JSONResponse(
-            {"error": f"Video backend returned error: {e.response.status_code}"},
-            status_code=502,
-        )
-    except Exception as e:
-        return JSONResponse(
-            {"error": f"Unexpected error: {str(e)}"},
-            status_code=500,
+        raise _VideoGenerationError(
+            f"Video backend returned error: {e.response.status_code}"
         )
 
     # Expect response with video URL or base64 data
@@ -137,12 +169,9 @@ async def generate_video(request: Request, body: VideoGenerateRequest):
         video_url = video_entry.get("url")
         video_b64 = video_entry.get("b64_mp4") or video_entry.get("b64_json")
     except (KeyError, IndexError):
-        return JSONResponse(
-            {"error": "Unexpected response format from video backend"},
-            status_code=502,
-        )
+        raise _VideoGenerationError("Unexpected response format from video backend")
 
-    videos_dir = _videos_dir(request)
+    videos_dir = _videos_dir_from_app(app)
     timestamp = int(time.time())
     filename = f"{timestamp}_{seed}.mp4"
     video_path = videos_dir / filename
@@ -158,15 +187,9 @@ async def generate_video(request: Request, body: VideoGenerateRequest):
                 dl_resp.raise_for_status()
                 video_path.write_bytes(dl_resp.content)
         except Exception as e:
-            return JSONResponse(
-                {"error": f"Failed to download generated video: {str(e)}"},
-                status_code=502,
-            )
+            raise _VideoGenerationError(f"Failed to download generated video: {str(e)}")
     else:
-        return JSONResponse(
-            {"error": "Video backend returned neither url nor b64 data"},
-            status_code=502,
-        )
+        raise _VideoGenerationError("Video backend returned neither url nor b64 data")
 
     metadata = {
         "prompt": body.prompt,
@@ -179,11 +202,87 @@ async def generate_video(request: Request, body: VideoGenerateRequest):
     meta_path.write_text(json.dumps(metadata, indent=2))
 
     return {
-        "status": "generated",
         "filename": filename,
         "path": f"/data/videos/{filename}",
         **metadata,
     }
+
+
+async def _run_generation_job(app, job_id: str, body: VideoGenerateRequest, seed: int, backend_url: str) -> None:
+    """Background task: run the generation and record the outcome on the job.
+    Never raises -- every failure mode (known or not) is recorded as the
+    job's error status so a poller always sees a terminal state."""
+    store = await _get_video_job_store(app)
+    await store.update_job(job_id, status="running")
+    try:
+        result = await _generate_and_save(app, body, seed, backend_url)
+    except _VideoGenerationError as exc:
+        await store.update_job(job_id, status="error", error=str(exc), completed_at=time.time())
+        return
+    except Exception as exc:
+        logger.exception("video generation job %s crashed", job_id)
+        await store.update_job(
+            job_id, status="error", error=f"Unexpected error: {exc}", completed_at=time.time()
+        )
+        return
+    await store.update_job(
+        job_id, status="done", progress=1.0, result_json=json.dumps(result), completed_at=time.time()
+    )
+
+
+@router.post("/api/video/generate")
+async def generate_video(request: Request, body: VideoGenerateRequest):
+    """Enqueue a video generation job and return its id immediately.
+
+    Fails fast with the existing 503 when no backend is configured at all --
+    there's nothing to enqueue in that case. Once a backend is configured,
+    the actual generation (and any backend-side failure) happens in a
+    background task; poll GET /api/video/jobs/{job_id} for the outcome.
+    """
+    backend_url = _get_video_backend(request)
+    if not backend_url:
+        return JSONResponse(
+            {"error": "No video generation backend configured. Connect a GPU worker or set video_backend_url in config."},
+            status_code=503,
+        )
+
+    seed = body.seed if body.seed is not None else random.randint(0, 2**32 - 1)
+
+    store = await _get_video_job_store(request.app)
+    job_id = await store.create_job()
+
+    task_set = getattr(request.app.state, "_background_tasks", None)
+    coro = _run_generation_job(request.app, job_id, body, seed, backend_url)
+    if task_set is None:
+        asyncio.create_task(coro)
+    else:
+        _create_supervised_task(coro, task_set)
+
+    return JSONResponse({"job_id": job_id, "status": "queued"}, status_code=202)
+
+
+@router.get("/api/video/jobs/{job_id}")
+async def get_video_job(request: Request, job_id: str):
+    """Poll a video generation job's status.
+
+    Returns ``{status: queued|running|done|error, progress?, result?, error?}``.
+    ``result`` (present when done) is the same shape the old synchronous
+    endpoint used to return -- the video is already saved to the library by
+    the time status flips to "done".
+    """
+    store = await _get_video_job_store(request.app)
+    job = await store.get_job(job_id)
+    if not job:
+        return JSONResponse({"error": f"Job '{job_id}' not found"}, status_code=404)
+
+    response: dict = {"job_id": job["id"], "status": job["status"]}
+    if job.get("progress") is not None:
+        response["progress"] = job["progress"]
+    if job["status"] == "done" and job.get("result_json"):
+        response["result"] = json.loads(job["result_json"])
+    if job["status"] == "error" and job.get("error"):
+        response["error"] = job["error"]
+    return response
 
 
 @router.get("/api/video")

--- a/tinyagentos/routes/video.py
+++ b/tinyagentos/routes/video.py
@@ -208,26 +208,41 @@ async def _generate_and_save(app, body: VideoGenerateRequest, seed: int, backend
     }
 
 
+async def _record_job_error(store, job_id: str, message: str) -> None:
+    """Best-effort: mark a job errored. If the update itself fails (e.g. the
+    store's db is gone at shutdown), log it -- but never raise, so the caller's
+    terminal-state guarantee holds even when the DB write can't."""
+    try:
+        await store.update_job(job_id, status="error", error=message, completed_at=time.time())
+    except Exception:
+        logger.exception("video job %s: failed to record error status", job_id)
+
+
 async def _run_generation_job(app, job_id: str, body: VideoGenerateRequest, seed: int, backend_url: str) -> None:
     """Background task: run the generation and record the outcome on the job.
-    Never raises -- every failure mode (known or not) is recorded as the
-    job's error status so a poller always sees a terminal state."""
+    Never raises, and always leaves the job in a terminal state (done/error)
+    -- never stuck in "running" -- so a poller always sees a final status."""
     store = await _get_video_job_store(app)
     await store.update_job(job_id, status="running")
     try:
         result = await _generate_and_save(app, body, seed, backend_url)
     except _VideoGenerationError as exc:
-        await store.update_job(job_id, status="error", error=str(exc), completed_at=time.time())
+        await _record_job_error(store, job_id, str(exc))
         return
     except Exception as exc:
         logger.exception("video generation job %s crashed", job_id)
-        await store.update_job(
-            job_id, status="error", error=f"Unexpected error: {exc}", completed_at=time.time()
-        )
+        await _record_job_error(store, job_id, f"Unexpected error: {exc}")
         return
-    await store.update_job(
-        job_id, status="done", progress=1.0, result_json=json.dumps(result), completed_at=time.time()
-    )
+    try:
+        await store.update_job(
+            job_id, status="done", progress=1.0, result_json=json.dumps(result), completed_at=time.time()
+        )
+    except Exception:
+        # The video is saved to the library regardless; only the job row failed
+        # to flip to done. Record an error so the poller doesn't hang on
+        # "running" forever, and the user can still find the clip in Library.
+        logger.exception("video job %s: failed to record done status", job_id)
+        await _record_job_error(store, job_id, "Generation finished but the job status could not be saved. Check the Library.")
 
 
 @router.post("/api/video/generate")
@@ -279,7 +294,14 @@ async def get_video_job(request: Request, job_id: str):
     if job.get("progress") is not None:
         response["progress"] = job["progress"]
     if job["status"] == "done" and job.get("result_json"):
-        response["result"] = json.loads(job["result_json"])
+        try:
+            response["result"] = json.loads(job["result_json"])
+        except (json.JSONDecodeError, TypeError):
+            # A corrupt result blob shouldn't 500 the poller. Downgrade to an
+            # error status with a clear message -- the clip is still in Library.
+            logger.warning("video job %s: result_json is not valid JSON", job_id)
+            response["status"] = "error"
+            response["error"] = "Job result is corrupt. Check the Library for the video."
     if job["status"] == "error" and job.get("error"):
         response["error"] = job["error"]
     return response

--- a/tinyagentos/video_jobs.py
+++ b/tinyagentos/video_jobs.py
@@ -12,10 +12,15 @@ from __future__ import annotations
 import time
 import uuid
 
+import aiosqlite
+
 from tinyagentos.base_store import BaseStore
 
 VIDEO_JOBS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS video_jobs (
+    -- id is a full uuid4 hex (32 chars). It must NOT be truncated: the id is a
+    -- persistent PRIMARY KEY, and a shortened id collides (a collision would
+    -- raise IntegrityError and surface as a 500 to the enqueue caller).
     id TEXT PRIMARY KEY,
     status TEXT NOT NULL DEFAULT 'queued',
     progress REAL DEFAULT 0.0,
@@ -31,7 +36,7 @@ class VideoJobStore(BaseStore):
     SCHEMA = VIDEO_JOBS_SCHEMA
 
     async def create_job(self) -> str:
-        job_id = str(uuid.uuid4())[:8]
+        job_id = uuid.uuid4().hex
         await self._db.execute(
             "INSERT INTO video_jobs (id, status, created_at) VALUES (?, 'queued', ?)",
             (job_id, time.time()),
@@ -40,13 +45,14 @@ class VideoJobStore(BaseStore):
         return job_id
 
     async def get_job(self, job_id: str) -> dict | None:
+        # Map columns by name via a dict row factory rather than zipping
+        # cursor.description positionally -- decoupled from column order.
+        self._db.row_factory = aiosqlite.Row
         async with self._db.execute(
             "SELECT * FROM video_jobs WHERE id = ?", (job_id,)
         ) as cursor:
             row = await cursor.fetchone()
-            if not row:
-                return None
-            return dict(zip([d[0] for d in cursor.description], row))
+            return dict(row) if row else None
 
     async def update_job(self, job_id: str, **kwargs) -> None:
         fields = [f for f in ("status", "progress", "result_json", "error", "completed_at") if f in kwargs]

--- a/tinyagentos/video_jobs.py
+++ b/tinyagentos/video_jobs.py
@@ -1,0 +1,59 @@
+# tinyagentos/video_jobs.py
+"""Persistent store for async video generation jobs.
+
+Mirrors tinyagentos/conversion.py's ConversionManager: a thin BaseStore
+subclass that tracks job status/result so a status poll survives across
+requests (and controller restarts). routes/video.py enqueues a job here,
+runs the actual generation in a background task, and updates the row as the
+job progresses -- see routes/video.py's module docstring for the full flow.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+
+from tinyagentos.base_store import BaseStore
+
+VIDEO_JOBS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS video_jobs (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL DEFAULT 'queued',
+    progress REAL DEFAULT 0.0,
+    result_json TEXT DEFAULT '',
+    error TEXT DEFAULT '',
+    created_at REAL NOT NULL,
+    completed_at REAL
+);
+"""
+
+
+class VideoJobStore(BaseStore):
+    SCHEMA = VIDEO_JOBS_SCHEMA
+
+    async def create_job(self) -> str:
+        job_id = str(uuid.uuid4())[:8]
+        await self._db.execute(
+            "INSERT INTO video_jobs (id, status, created_at) VALUES (?, 'queued', ?)",
+            (job_id, time.time()),
+        )
+        await self._db.commit()
+        return job_id
+
+    async def get_job(self, job_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM video_jobs WHERE id = ?", (job_id,)
+        ) as cursor:
+            row = await cursor.fetchone()
+            if not row:
+                return None
+            return dict(zip([d[0] for d in cursor.description], row))
+
+    async def update_job(self, job_id: str, **kwargs) -> None:
+        fields = [f for f in ("status", "progress", "result_json", "error", "completed_at") if f in kwargs]
+        if not fields:
+            return
+        await self._db.execute(
+            f"UPDATE video_jobs SET {', '.join(f'{f} = ?' for f in fields)} WHERE id = ?",
+            (*(kwargs[f] for f in fields), job_id),
+        )
+        await self._db.commit()


### PR DESCRIPTION
## The footgun

POST /api/video/generate was a synchronous, multi-minute HTTP call: no job id, no progress, and no way to recover from any client timeout or disconnect. Any proxy/browser timeout shorter than a generation run (which can take several minutes) killed the request with no way to check whether the video actually finished on the backend.

## The job model

- POST /api/video/generate now enqueues a job and returns `{job_id, status: "queued"}` (202) immediately.
- The actual backend call runs in a background task tracked in `app.state._background_tasks`, the same fire-and-forget pattern `agent_chat_router.py`'s `dispatch()` already uses.
- GET /api/video/jobs/{job_id} reports `{status: queued|running|done|error, progress?, result?, error?}`. `result` (on done) is the same shape the old synchronous response used to return, and the video is already saved to the library by the time status flips to done.
- If no backend is configured at all, generate still fails fast with the existing 503 rather than enqueueing a doomed job. Once a backend is configured, backend-side failures (connect error, timeout, bad response format, download failure) now surface on the job instead of on the original request.

## What was reused

- `VideoJobStore(BaseStore)` mirrors `ConversionManager`/`TrainingManager` (both existing job-tracking stores).
- The store is a lazily-created singleton on `app.state`, mirroring `routes/jobs.py`'s `_get_queue` -- no `app.py` lifespan wiring needed.
- Background task dispatch mirrors `agent_chat_router.py`'s `dispatch()`: grab `app.state._background_tasks`, fall back to a bare `asyncio.create_task` if absent, else use `_create_supervised_task`.

## Poll flow (frontend)

`VideoStudioApp.tsx` posts to enqueue, then polls the job endpoint every 2s (capped at ~20 minutes) without blocking the UI thread. On done it refreshes the library and shows the result exactly as before; on error it shows the message; the existing amber "no backend" state and elapsed-time spinner are unchanged.

## Tests

- Backend (`tests/test_routes_video.py`): enqueue returns 202 + job_id; job transitions queued -> done with the saved video (mocked backend); connect/timeout/bad-format errors surface on the job instead of the request; missing job id -> 404; no-backend-configured still fails fast at 503.
- Frontend (`VideoStudioApp.test.tsx`): generate posts params, polls the job endpoint, and renders the result on done; shows the job's error message on failure; existing 503 "install a backend" test unchanged.

## Verification (all run in the foreground)

- `python -m pytest tests/ -k "video" -q` -- 25 passed
- `cd desktop && npx vitest run src/apps/videostudio src/apps/VideoStudioApp.test.tsx` -- 7 passed
- `cd desktop && npm run build` (`tsc -b && vite build`) -- 0 TypeScript errors

Not merging -- opening for review per instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video generation now runs as an asynchronous job, with progress you can monitor while it renders.
  * Added job status polling so completed renders appear in the studio automatically for preview.
* **Bug Fixes**
  * Improved robustness of error handling: failed jobs surface clear error messages in the UI.
  * Polling now handles missing/invalid jobs gracefully instead of breaking the generation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->