### PR TITLE
feat(music-studio): render/bounce a song to a downloadable WAV (Tone.Offline)

### DIFF
--- a/desktop/src/apps/MusicStudioApp.tsx
+++ b/desktop/src/apps/MusicStudioApp.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { LayoutList, Sparkles, Music2, LayoutGrid, Download, FolderOpen } from "lucide-react";
+import { LayoutList, Sparkles, Music2, LayoutGrid, Download, FolderOpen, Loader2 } from "lucide-react";
 import { StudioView } from "./musicstudio/StudioView";
 import { ComposeView, type ComposedTrack } from "./musicstudio/ComposeView";
 import { SoundsView } from "./musicstudio/SoundsView";
@@ -8,6 +8,7 @@ import { LibraryView } from "./musicstudio/LibraryView";
 import { useStudioEngine } from "./musicstudio/use-studio-engine";
 import { saveSong, exportSongFile } from "./musicstudio/songs-api";
 import { exportSongMidiFile } from "./musicstudio/midi-export";
+import { exportSongWavFile } from "./musicstudio/wav-export";
 
 type MusicView = "studio" | "compose" | "sounds" | "mixer" | "export" | "library";
 
@@ -24,6 +25,10 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
 
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saved" | "error">("idle");
+
+  const [renderingWav, setRenderingWav] = useState(false);
+  const [wavError, setWavError] = useState<string | null>(null);
+  const [wavNotice, setWavNotice] = useState<string | null>(null);
 
   const [composePrompt, setComposePrompt] = useState("");
   const [composeStyle, setComposeStyle] = useState<string | null>(null);
@@ -117,6 +122,24 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
       setSaving(false);
     }
   }, [engine]);
+
+  const handleExportWav = useCallback(async () => {
+    setRenderingWav(true);
+    setWavError(null);
+    setWavNotice(null);
+    try {
+      const result = await exportSongWavFile(engine.song);
+      if (result.substitutedTracks.length > 0) {
+        setWavNotice(
+          `Rendered with synth substitutes for ${result.substitutedTracks.join(", ")} -- sampled instruments can't render offline.`,
+        );
+      }
+    } catch (e) {
+      setWavError((e as Error).message || "Couldn't render this song to WAV.");
+    } finally {
+      setRenderingWav(false);
+    }
+  }, [engine.song]);
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-shell-bg text-shell-text select-none">
@@ -235,6 +258,20 @@ export function MusicStudioApp({ windowId: _windowId }: { windowId: string }) {
                   <Download size={16} />
                   Download .mid
                 </button>
+                <button
+                  type="button"
+                  onClick={() => void handleExportWav()}
+                  disabled={renderingWav}
+                  aria-busy={renderingWav}
+                  className="flex items-center gap-2 rounded-[14px] border border-shell-border bg-shell-surface px-6 py-3 text-[14px] font-bold text-shell-text disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {renderingWav ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
+                  {renderingWav ? "Rendering..." : "Download .wav"}
+                </button>
+              </div>
+              <div role="status" aria-live="polite" className="max-w-[360px] text-[12px]">
+                {wavError && <p className="text-red-400">{wavError}</p>}
+                {wavNotice && <p className="text-shell-text-secondary">{wavNotice}</p>}
               </div>
             </div>
           )}

--- a/desktop/src/apps/musicstudio/audio-engine.ts
+++ b/desktop/src/apps/musicstudio/audio-engine.ts
@@ -21,7 +21,9 @@ import { BEATS_PER_BAR, TICKS_PER_BEAT, type Song, type Track } from "./types";
 
 type TriggerFn = (pitch: number, durationSeconds: number, time: number, velocity: number) => void;
 
-interface InstrumentHandle {
+/** Exported so the offline WAV renderer (wav-export.ts) can build the same
+ *  kind of instrument handle it schedules notes onto -- see scheduleTrackNotes. */
+export interface InstrumentHandle {
   trigger: TriggerFn;
   dispose: () => void;
 }
@@ -60,8 +62,11 @@ function toneTrigger(synth: { triggerAttackRelease: (...args: any[]) => unknown;
   };
 }
 
-/** Build a fully-offline Tone.js synth instrument, connected to `channel`. */
-function buildSynthInstrument(instrumentId: string, channel: Tone.Channel): InstrumentHandle {
+/** Build a fully-offline Tone.js synth instrument, connected to `channel`.
+ *  Exported so the WAV renderer can build the same synths for tracks whose
+ *  sampled (smplr) instrument can't render inside an OfflineAudioContext --
+ *  see the fallback note in wav-export.ts. */
+export function buildSynthInstrument(instrumentId: string, channel: Tone.Channel): InstrumentHandle {
   switch (instrumentId) {
     case "drum-kit": {
       const kick = new Tone.MembraneSynth().connect(channel);
@@ -157,6 +162,31 @@ function buildInstrument(instrumentId: string, channel: Tone.Channel): Instrumen
   return def.kind === "sampled" ? buildSampledInstrument(def.id, channel) : buildSynthInstrument(def.id, channel);
 }
 
+/** Schedule every note in `track`'s clips onto the CURRENT Tone.Transport
+ *  (`Tone.getTransport()`), triggering `instrument` at each note's
+ *  bar:beat:sixteenth position. A plain function rather than a method so the
+ *  offline WAV renderer (wav-export.ts) can call it verbatim from inside a
+ *  `Tone.Offline()` callback -- Tone swaps the global context for the
+ *  callback's duration, so `Tone.getTransport()` there resolves to the
+ *  offline transport and the bounce schedules identically to live playback. */
+export function scheduleTrackNotes(track: Track, instrument: InstrumentHandle): number[] {
+  const eventIds: number[] = [];
+  const transport = Tone.getTransport();
+  for (const clip of track.clips) {
+    for (const note of clip.notes) {
+      const absoluteTicks = clip.startBar * BEATS_PER_BAR * TICKS_PER_BEAT + note.startTick;
+      const position = ticksToTransportPosition(absoluteTicks);
+      const eventId = transport.schedule((time) => {
+        const bpm = transport.bpm.value;
+        const durationSeconds = (note.durationTicks / TICKS_PER_BEAT) * (60 / bpm);
+        instrument.trigger(note.pitch, durationSeconds, time, note.velocity);
+      }, position);
+      eventIds.push(eventId);
+    }
+  }
+  return eventIds;
+}
+
 export class AudioEngine {
   private started = false;
   private tracks = new Map<string, TrackNodes>();
@@ -200,25 +230,7 @@ export class AudioEngine {
     if (!nodes) return;
     const transport = Tone.getTransport();
     for (const id of nodes.eventIds) transport.clear(id);
-    nodes.eventIds = this.scheduleTrackNotes(track, nodes.instrument);
-  }
-
-  private scheduleTrackNotes(track: Track, instrument: InstrumentHandle): number[] {
-    const eventIds: number[] = [];
-    const transport = Tone.getTransport();
-    for (const clip of track.clips) {
-      for (const note of clip.notes) {
-        const absoluteTicks = clip.startBar * BEATS_PER_BAR * TICKS_PER_BEAT + note.startTick;
-        const position = ticksToTransportPosition(absoluteTicks);
-        const eventId = transport.schedule((time) => {
-          const bpm = transport.bpm.value;
-          const durationSeconds = (note.durationTicks / TICKS_PER_BEAT) * (60 / bpm);
-          instrument.trigger(note.pitch, durationSeconds, time, note.velocity);
-        }, position);
-        eventIds.push(eventId);
-      }
-    }
-    return eventIds;
+    nodes.eventIds = scheduleTrackNotes(track, nodes.instrument);
   }
 
   /** True when the engine already has nodes for this track (so a note edit can
@@ -236,7 +248,7 @@ export class AudioEngine {
     }).toDestination();
 
     const instrument = buildInstrument(track.instrument, channel);
-    const eventIds = this.scheduleTrackNotes(track, instrument);
+    const eventIds = scheduleTrackNotes(track, instrument);
     this.tracks.set(track.id, { channel, instrument, eventIds });
   }
 

--- a/desktop/src/apps/musicstudio/audio-engine.ts
+++ b/desktop/src/apps/musicstudio/audio-engine.ts
@@ -174,11 +174,14 @@ export function scheduleTrackNotes(track: Track, instrument: InstrumentHandle): 
   const transport = Tone.getTransport();
   for (const clip of track.clips) {
     for (const note of clip.notes) {
-      const absoluteTicks = clip.startBar * BEATS_PER_BAR * TICKS_PER_BEAT + note.startTick;
+      // Clamp to non-negative so a malformed note can't produce a negative
+      // transport position (which Tone rejects) or a negative duration.
+      const absoluteTicks = Math.max(0, clip.startBar * BEATS_PER_BAR * TICKS_PER_BEAT + note.startTick);
+      const durationTicks = Math.max(0, note.durationTicks);
       const position = ticksToTransportPosition(absoluteTicks);
       const eventId = transport.schedule((time) => {
         const bpm = transport.bpm.value;
-        const durationSeconds = (note.durationTicks / TICKS_PER_BEAT) * (60 / bpm);
+        const durationSeconds = (durationTicks / TICKS_PER_BEAT) * (60 / bpm);
         instrument.trigger(note.pitch, durationSeconds, time, note.velocity);
       }, position);
       eventIds.push(eventId);

--- a/desktop/src/apps/musicstudio/wav-export.test.ts
+++ b/desktop/src/apps/musicstudio/wav-export.test.ts
@@ -205,6 +205,12 @@ describe("renderSongToWav", () => {
     await expect(renderSongToWav(makeSong([]))).rejects.toThrow("no notes to export");
     expect(offlineCalls).toHaveLength(0);
   });
+
+  it("rejects a song whose only notes are on muted tracks (nothing audible to render)", async () => {
+    const song = makeSong([makeTrack("muted", { muted: true, clips: [makeClip(0, [makeNote(0, 480)])] })]);
+    await expect(renderSongToWav(song)).rejects.toThrow("no notes to export");
+    expect(offlineCalls).toHaveLength(0);
+  });
 });
 
 describe("audioBufferToWavBlob", () => {

--- a/desktop/src/apps/musicstudio/wav-export.test.ts
+++ b/desktop/src/apps/musicstudio/wav-export.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Clip, Note, Song, Track } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  Tone.js and smplr both require a real AudioContext, which jsdom      */
+/*  does not implement -- both modules are mocked here, kept in sync     */
+/*  with audio-engine.test.ts's mock, plus a fake Tone.Offline that       */
+/*  invokes the render callback against a fake offline transport so we   */
+/*  can assert what gets scheduled without touching real audio.          */
+/* ------------------------------------------------------------------ */
+
+const scheduledEvents: { time: string }[] = [];
+const channelInstances: { volume: { value: number }; pan: { value: number } }[] = [];
+const offlineCalls: { duration: number; channels?: number; sampleRate?: number }[] = [];
+
+vi.mock("tone", () => {
+  class FakeChannel {
+    volume: { value: number };
+    pan: { value: number };
+    constructor(opts: { volume?: number; pan?: number } = {}) {
+      this.volume = { value: opts.volume ?? 0 };
+      this.pan = { value: opts.pan ?? 0 };
+      channelInstances.push(this);
+    }
+    connect() {
+      return this;
+    }
+    toDestination() {
+      return this;
+    }
+    dispose() {}
+  }
+
+  class FakeSynth {
+    constructor(_opts?: unknown) {}
+    connect() {
+      return this;
+    }
+    triggerAttackRelease() {}
+    dispose() {}
+  }
+
+  let idCounter = 0;
+  function makeOfflineTransport() {
+    return {
+      bpm: { value: 120 },
+      schedule: vi.fn((_cb: (t: number) => void, time: string) => {
+        idCounter += 1;
+        scheduledEvents.push({ time });
+        return idCounter;
+      }),
+      start: vi.fn(),
+    };
+  }
+
+  // Mirrors real Tone.Offline: it swaps the module's "current context" for the
+  // callback's duration, so Tone.getTransport() called from inside the
+  // callback (scheduleTrackNotes does exactly this) resolves to the offline
+  // transport rather than a real one.
+  let currentTransport: ReturnType<typeof makeOfflineTransport> | null = null;
+
+  return {
+    now: vi.fn(() => 0),
+    getContext: () => ({ sampleRate: 44100, rawContext: { createGain: () => ({ connect() {}, disconnect() {} }) } }),
+    getTransport: () => currentTransport,
+    gainToDb: (gain: number) => (gain <= 0 ? -Infinity : 20 * Math.log10(gain)),
+    Midi: (pitch: number) => ({ toFrequency: () => 440 * 2 ** ((pitch - 69) / 12) }),
+    Channel: FakeChannel,
+    MembraneSynth: FakeSynth,
+    NoiseSynth: FakeSynth,
+    MonoSynth: FakeSynth,
+    PolySynth: FakeSynth,
+    AMSynth: FakeSynth,
+    Synth: FakeSynth,
+    Offline: vi.fn(
+      async (
+        callback: (ctx: { transport: ReturnType<typeof makeOfflineTransport> }) => void | Promise<void>,
+        duration: number,
+        channels = 2,
+        sampleRate = 44100,
+      ) => {
+        offlineCalls.push({ duration, channels, sampleRate });
+        currentTransport = makeOfflineTransport();
+        await callback({ transport: currentTransport });
+        currentTransport = null;
+        return {
+          get: () => ({
+            numberOfChannels: 2,
+            sampleRate,
+            length: 8,
+            getChannelData: (_c: number) => new Float32Array(8),
+          }),
+        };
+      },
+    ),
+  };
+});
+
+vi.mock("smplr", () => ({
+  SplendidGrandPiano: () => ({ ready: Promise.resolve(), start: vi.fn(), dispose: vi.fn() }),
+  Soundfont: () => ({ ready: Promise.resolve(), start: vi.fn(), dispose: vi.fn() }),
+}));
+
+import { renderSongToWav, computeSongDurationSeconds, audioBufferToWavBlob } from "./wav-export";
+
+beforeEach(() => {
+  scheduledEvents.length = 0;
+  channelInstances.length = 0;
+  offlineCalls.length = 0;
+});
+
+function makeNote(startTick: number, durationTicks: number, pitch = 60): Note {
+  return { id: `n-${pitch}-${startTick}`, pitch, startTick, durationTicks, velocity: 0.8 };
+}
+
+function makeClip(startBar: number, notes: Note[]): Clip {
+  return { id: `clip-${startBar}`, name: "clip", startBar, lengthBars: 1, notes };
+}
+
+function makeTrack(id: string, overrides: Partial<Track> = {}): Track {
+  return {
+    id,
+    name: id,
+    instrument: "synth-keys",
+    clips: [],
+    volume: 70,
+    pan: 0,
+    muted: false,
+    soloed: false,
+    ...overrides,
+  };
+}
+
+function makeSong(tracks: Track[], tempo = 120): Song {
+  return { id: "song-test", name: "Test Song", tempo, key: "C maj", timeSig: "4/4", tracks };
+}
+
+describe("computeSongDurationSeconds", () => {
+  it("computes seconds from the last note-off across all tracks, plus the release tail", () => {
+    // tempo 120 => 0.5s per beat (480 ticks). One note ending at tick 480 (1 beat).
+    const song = makeSong([makeTrack("t1", { clips: [makeClip(0, [makeNote(0, 480)])] })], 120);
+    // 1 beat * 0.5s + 2s tail
+    expect(computeSongDurationSeconds(song)).toBeCloseTo(2.5, 5);
+  });
+
+  it("offsets by the clip's startBar", () => {
+    // clip at bar 1 (1920 ticks) + note starting at tick 240, lasting 240 ticks => ends at 2400 ticks = 5 beats = 2.5s @120bpm
+    const song = makeSong([makeTrack("t1", { clips: [makeClip(1, [makeNote(240, 240)])] })], 120);
+    expect(computeSongDurationSeconds(song)).toBeCloseTo(4.5, 5);
+  });
+
+  it("returns just the release tail for a song with no notes", () => {
+    expect(computeSongDurationSeconds(makeSong([]))).toBeCloseTo(2, 5);
+  });
+});
+
+describe("renderSongToWav", () => {
+  it("invokes Tone.Offline with the song's full duration and a stereo channel count", async () => {
+    const song = makeSong([makeTrack("t1", { clips: [makeClip(0, [makeNote(0, 480)])] })], 120);
+    await renderSongToWav(song);
+    expect(offlineCalls).toHaveLength(1);
+    expect(offlineCalls[0]!.duration).toBeCloseTo(computeSongDurationSeconds(song), 5);
+    expect(offlineCalls[0]!.channels).toBe(2);
+  });
+
+  it("schedules notes only for unmuted tracks when nothing is soloed", async () => {
+    const song = makeSong([
+      makeTrack("audible-1", { clips: [makeClip(0, [makeNote(0, 100), makeNote(200, 100)])] }),
+      makeTrack("muted", { muted: true, clips: [makeClip(0, [makeNote(0, 100), makeNote(200, 100), makeNote(400, 100)])] }),
+      makeTrack("audible-2", { clips: [makeClip(0, [makeNote(0, 100)])] }),
+    ]);
+    await renderSongToWav(song);
+    // 2 notes (audible-1) + 1 note (audible-2); the muted track's 3 notes are skipped.
+    expect(scheduledEvents).toHaveLength(3);
+    expect(channelInstances).toHaveLength(2);
+  });
+
+  it("schedules only the soloed track's notes when a track is soloed", async () => {
+    const song = makeSong([
+      makeTrack("unsoloed", { clips: [makeClip(0, [makeNote(0, 100), makeNote(200, 100)])] }),
+      makeTrack("soloed", { soloed: true, clips: [makeClip(0, [makeNote(0, 100), makeNote(200, 100), makeNote(400, 100)])] }),
+      makeTrack("muted-not-soloed", { muted: true, clips: [makeClip(0, [makeNote(0, 100)])] }),
+    ]);
+    await renderSongToWav(song);
+    expect(scheduledEvents).toHaveLength(3);
+    expect(channelInstances).toHaveLength(1);
+  });
+
+  it("falls back to a synth for a sampled instrument track and reports it as substituted", async () => {
+    const song = makeSong([
+      makeTrack("rhodes", { instrument: "sampled-piano", clips: [makeClip(0, [makeNote(0, 480)])] }),
+    ]);
+    const result = await renderSongToWav(song);
+    expect(result.substitutedTracks).toEqual(["rhodes"]);
+    expect(result.blob).toBeInstanceOf(Blob);
+  });
+
+  it("does not report a substitution for a plain synth track", async () => {
+    const song = makeSong([makeTrack("keys", { clips: [makeClip(0, [makeNote(0, 480)])] })]);
+    const result = await renderSongToWav(song);
+    expect(result.substitutedTracks).toEqual([]);
+  });
+
+  it("rejects a song with no notes instead of rendering an empty file", async () => {
+    await expect(renderSongToWav(makeSong([]))).rejects.toThrow("no notes to export");
+    expect(offlineCalls).toHaveLength(0);
+  });
+});
+
+describe("audioBufferToWavBlob", () => {
+  it("writes a well-formed RIFF/WAVE/fmt/data header for a small synthetic buffer", async () => {
+    const numChannels = 2;
+    const sampleRate = 44100;
+    const numFrames = 4;
+    const left = new Float32Array([0, 0.5, -0.5, 1]);
+    const right = new Float32Array([0, -1, 0.25, -0.25]);
+    const fakeBuffer = {
+      numberOfChannels: numChannels,
+      sampleRate,
+      length: numFrames,
+      getChannelData: (c: number) => (c === 0 ? left : right),
+    } as unknown as AudioBuffer;
+
+    const blob = audioBufferToWavBlob(fakeBuffer);
+    expect(blob.type).toBe("audio/wav");
+
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    const view = new DataView(bytes.buffer);
+    const readStr = (offset: number, len: number) => String.fromCharCode(...bytes.slice(offset, offset + len));
+
+    const dataSize = numFrames * numChannels * 2;
+    expect(readStr(0, 4)).toBe("RIFF");
+    expect(view.getUint32(4, true)).toBe(36 + dataSize);
+    expect(readStr(8, 4)).toBe("WAVE");
+    expect(readStr(12, 4)).toBe("fmt ");
+    expect(view.getUint32(16, true)).toBe(16); // PCM fmt chunk size
+    expect(view.getUint16(20, true)).toBe(1); // PCM format
+    expect(view.getUint16(22, true)).toBe(numChannels);
+    expect(view.getUint32(24, true)).toBe(sampleRate);
+    expect(view.getUint16(34, true)).toBe(16); // bits per sample
+    expect(readStr(36, 4)).toBe("data");
+    expect(view.getUint32(40, true)).toBe(dataSize);
+    expect(bytes.length).toBe(44 + dataSize);
+
+    // Round-trip the first interleaved frame (left then right) back to [-1, 1].
+    const firstLeft = view.getInt16(44, true) / 0x7fff;
+    const firstRight = view.getInt16(46, true) / 0x7fff;
+    expect(firstLeft).toBeCloseTo(0, 3);
+    expect(firstRight).toBeCloseTo(0, 3);
+    const secondLeft = view.getInt16(48, true) / 0x7fff;
+    expect(secondLeft).toBeCloseTo(0.5, 3);
+  });
+});

--- a/desktop/src/apps/musicstudio/wav-export.ts
+++ b/desktop/src/apps/musicstudio/wav-export.ts
@@ -1,0 +1,165 @@
+/* ------------------------------------------------------------------ */
+/*  Music Studio -- offline WAV bounce                                 */
+/*                                                                     */
+/*  Renders a Song to a 16-bit PCM WAV Blob using Tone.Offline, which    */
+/*  swaps Tone's global AudioContext for an OfflineAudioContext for the  */
+/*  duration of its callback. That means the exact same building blocks  */
+/*  the live engine uses -- volumeToDb, buildSynthInstrument, and         */
+/*  scheduleTrackNotes (all exported from audio-engine.ts) -- resolve to  */
+/*  the offline context automatically when called inside that callback,  */
+/*  so the bounce is scheduled identically to live playback rather than   */
+/*  a re-implementation of it.                                          */
+/*                                                                     */
+/*  Deviation from live playback: smplr sampled instruments (Rhodes,     */
+/*  808) fetch sample audio from a CDN and drive playback off the real    */
+/*  wall clock, neither of which works inside an OfflineAudioContext.     */
+/*  Tracks using them are rendered with their closest Tone.js synth       */
+/*  instead -- see SAMPLED_FALLBACK below -- and the caller is told       */
+/*  which tracks were substituted so the UI can surface a one-line        */
+/*  notice rather than silently changing the sound.                     */
+/* ------------------------------------------------------------------ */
+
+import * as Tone from "tone";
+import {
+  buildSynthInstrument,
+  scheduleTrackNotes,
+  volumeToDb,
+  type InstrumentHandle,
+} from "./audio-engine";
+import { findInstrument } from "./instruments";
+import { BEATS_PER_BAR, TICKS_PER_BEAT, type InstrumentId, type Song, type Track } from "./types";
+import { slugify } from "./songs-api";
+
+/** Extra time rendered past the last note-off so synth releases (and the
+ *  808/Rhodes fallback synths' envelopes) ring out instead of being cut off. */
+const RELEASE_TAIL_SECONDS = 2;
+
+const SAMPLED_FALLBACK: Record<string, InstrumentId> = {
+  "sampled-piano": "synth-keys",
+  "sampled-bass": "synth-bass",
+};
+
+/** A sampled instrument's closest offline-renderable synth substitute. */
+function offlineInstrumentId(instrumentId: InstrumentId): InstrumentId {
+  const def = findInstrument(instrumentId);
+  if (def.kind !== "sampled") return instrumentId;
+  return SAMPLED_FALLBACK[instrumentId] ?? "synth-keys";
+}
+
+/** Tracks actually audible in a mixdown: soloed tracks only when any track is
+ *  soloed, otherwise every unmuted track -- matching how Tone.Channel's
+ *  solo/mute would sound during live playback. */
+function audibleTracks(song: Song): Track[] {
+  const hasSolo = song.tracks.some((t) => t.soloed);
+  return song.tracks.filter((t) => (hasSolo ? t.soloed : !t.muted));
+}
+
+/** Seconds from the start of the song to its last note-off, across every
+ *  track (audible or not -- duration shouldn't change if you mute a track),
+ *  plus a short release tail. */
+export function computeSongDurationSeconds(song: Song): number {
+  let lastEndTicks = 0;
+  for (const track of song.tracks) {
+    for (const clip of track.clips) {
+      const clipStartTicks = clip.startBar * BEATS_PER_BAR * TICKS_PER_BEAT;
+      for (const note of clip.notes) {
+        const endTicks = clipStartTicks + note.startTick + note.durationTicks;
+        if (endTicks > lastEndTicks) lastEndTicks = endTicks;
+      }
+    }
+  }
+  const seconds = (lastEndTicks / TICKS_PER_BEAT) * (60 / song.tempo);
+  return seconds + RELEASE_TAIL_SECONDS;
+}
+
+export interface RenderResult {
+  blob: Blob;
+  /** Names of tracks whose sampled instrument was substituted with a synth
+   *  for this render (empty if the song used no sampled instruments). */
+  substitutedTracks: string[];
+}
+
+/** Render `song` to a WAV Blob via Tone.Offline. Rejects if the song has no
+ *  notes at all (nothing to render). */
+export async function renderSongToWav(song: Song): Promise<RenderResult> {
+  const tracks = audibleTracks(song);
+  const duration = computeSongDurationSeconds(song);
+  if (duration <= RELEASE_TAIL_SECONDS) {
+    throw new Error("This song has no notes to export.");
+  }
+
+  const substitutedTracks: string[] = [];
+  const sampleRate = Tone.getContext().sampleRate;
+
+  const buffer = await Tone.Offline(({ transport }) => {
+    transport.bpm.value = song.tempo;
+    for (const track of tracks) {
+      const channel = new Tone.Channel({ volume: volumeToDb(track.volume), pan: track.pan }).toDestination();
+      const renderInstrumentId = offlineInstrumentId(track.instrument);
+      if (renderInstrumentId !== track.instrument) substitutedTracks.push(track.name);
+      const instrument: InstrumentHandle = buildSynthInstrument(renderInstrumentId, channel);
+      scheduleTrackNotes(track, instrument);
+    }
+    transport.start(0);
+  }, duration, 2, sampleRate);
+
+  return { blob: audioBufferToWavBlob(buffer.get()!), substitutedTracks };
+}
+
+/** Encode a native AudioBuffer as a 16-bit PCM WAV Blob (standard RIFF/WAVE
+ *  header, interleaved samples -- no external encoder dependency). */
+export function audioBufferToWavBlob(buffer: AudioBuffer): Blob {
+  const numChannels = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const numFrames = buffer.length;
+  const bytesPerSample = 2;
+  const blockAlign = numChannels * bytesPerSample;
+  const dataSize = numFrames * blockAlign;
+
+  const arrayBuffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(arrayBuffer);
+
+  const writeString = (offset: number, str: string) => {
+    for (let i = 0; i < str.length; i++) view.setUint8(offset + i, str.charCodeAt(i));
+  };
+
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true); // fmt chunk size (PCM)
+  view.setUint16(20, 1, true); // audio format: 1 = PCM
+  view.setUint16(22, numChannels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * blockAlign, true); // byte rate
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, 8 * bytesPerSample, true); // bits per sample
+  writeString(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  const channelData: Float32Array[] = [];
+  for (let c = 0; c < numChannels; c++) channelData.push(buffer.getChannelData(c));
+
+  let offset = 44;
+  for (let i = 0; i < numFrames; i++) {
+    for (let c = 0; c < numChannels; c++) {
+      const sample = Math.max(-1, Math.min(1, channelData[c]![i] ?? 0));
+      view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+      offset += bytesPerSample;
+    }
+  }
+
+  return new Blob([arrayBuffer], { type: "audio/wav" });
+}
+
+/** Render `song` and trigger a browser download of `<songname>.wav`. */
+export async function exportSongWavFile(song: Song): Promise<RenderResult> {
+  const result = await renderSongToWav(song);
+  const url = URL.createObjectURL(result.blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${slugify(song.name)}.wav`;
+  a.click();
+  URL.revokeObjectURL(url);
+  return result;
+}

--- a/desktop/src/apps/musicstudio/wav-export.ts
+++ b/desktop/src/apps/musicstudio/wav-export.ts
@@ -79,14 +79,15 @@ export interface RenderResult {
   substitutedTracks: string[];
 }
 
-/** Render `song` to a WAV Blob via Tone.Offline. Rejects if the song has no
- *  notes at all (nothing to render). */
+/** Render `song` to a WAV Blob via Tone.Offline. Rejects if no audible track
+ *  has any notes (nothing to render), rather than bouncing silence. */
 export async function renderSongToWav(song: Song): Promise<RenderResult> {
   const tracks = audibleTracks(song);
-  const duration = computeSongDurationSeconds(song);
-  if (duration <= RELEASE_TAIL_SECONDS) {
+  const hasNotes = tracks.some((t) => t.clips.some((c) => c.notes.length > 0));
+  if (!hasNotes) {
     throw new Error("This song has no notes to export.");
   }
+  const duration = computeSongDurationSeconds(song);
 
   const substitutedTracks: string[] = [];
   const sampleRate = Tone.getContext().sampleRate;
@@ -103,7 +104,15 @@ export async function renderSongToWav(song: Song): Promise<RenderResult> {
     transport.start(0);
   }, duration, 2, sampleRate);
 
-  return { blob: audioBufferToWavBlob(buffer.get()!), substitutedTracks };
+  // ToneAudioBuffer.get() is AudioBuffer | undefined; surface the friendly UI
+  // error path rather than crashing on a null assertion if a render yields no
+  // buffer.
+  const rendered = buffer.get();
+  if (!rendered) {
+    throw new Error("The audio renderer produced no output. Please try again.");
+  }
+
+  return { blob: audioBufferToWavBlob(rendered), substitutedTracks };
 }
 
 /** Encode a native AudioBuffer as a 16-bit PCM WAV Blob (standard RIFF/WAVE


### PR DESCRIPTION
## Summary

Music Studio could play a song live and export MIDI + `.taosong` JSON, but had no way to produce an actual audio file. This adds an offline render to a downloadable WAV.

- `desktop/src/apps/musicstudio/wav-export.ts`: `renderSongToWav(song)` renders via `Tone.Offline`, encodes the result as 16-bit PCM WAV (RIFF/WAVE/fmt/data header, interleaved samples, no new dependency), and `exportSongWavFile(song)` triggers a browser download of `<songname>.wav`.
- `desktop/src/apps/musicstudio/audio-engine.ts`: extracted `scheduleTrackNotes` from a private `AudioEngine` method into a top-level exported function, and exported `buildSynthInstrument` and `InstrumentHandle`.

### Offline render approach

`Tone.Offline` swaps Tone's global context for an `OfflineAudioContext` for the duration of its callback, so calls to `Tone.getTransport()`, `new Tone.Channel(...)`, etc. inside that callback resolve to the offline context automatically. That means the bounce reuses the exact same scheduling code the live engine uses (`scheduleTrackNotes`, `buildSynthInstrument`, `volumeToDb`) rather than a parallel re-implementation, so a rendered WAV matches live playback.

Duration is computed from the last note's end tick across every track (regardless of mute/solo, matching how long the transport actually runs) plus a 2s release tail so synth envelopes aren't cut off.

Only audible tracks are scheduled into the render: if any track is soloed, only soloed tracks; otherwise every unmuted track. Muted/non-soloed tracks are skipped entirely rather than scheduled-and-silenced, which also means they don't spend render time instantiating instruments.

### smplr-in-offline fallback

Sampled (smplr) instruments fetch sample audio from a CDN and drive playback off the real wall clock -- neither works inside an `OfflineAudioContext`. Tracks using a sampled instrument (Rhodes Mk I, Sub 808) are rendered with their closest Tone.js synth substitute instead (`sampled-piano` -> `synth-keys`, `sampled-bass` -> `synth-bass`). The render result reports which tracks were substituted, and the UI surfaces a one-line notice rather than silently changing the sound.

### WAV encoding

Standard 16-bit PCM WAV: 44-byte RIFF/WAVE/fmt/data header, samples clamped to [-1, 1] and interleaved per channel, no external encoder library.

### UI

Added a "Download .wav" action next to the existing MIDI/JSON export buttons in the Export view, with a rendering/progress state (spinner + disabled button while the offline render runs) and an `aria-live` status region for the substitution notice or a render error.

## Test plan

- [x] `cd desktop && npx vitest run src/apps/musicstudio` -- 56 tests passing (new `wav-export.test.ts` covers duration calculation, Tone.Offline invocation/duration, solo/mute scheduling filters, sampled-instrument fallback + substitution reporting, and WAV header byte correctness against a synthetic buffer)
- [x] `npx vitest run src/apps/MusicStudioApp.test.tsx` -- 8 tests passing
- [x] `npm run build` (`tsc -b && vite build`) -- 0 TypeScript errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WAV export to the music app, including a new download option in the Export view.
  * Exporting now shows progress while rendering and provides clear status messages when instruments are substituted.

* **Bug Fixes**
  * Improved export behavior for solo/mute playback, ensuring only the intended tracks are included.
  * Added support for exporting songs with accurate timing and proper handling of empty or invalid exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->