### PR TITLE
feat(game-studio): add 4 playable game templates (runner, snake, tapper, asteroids)

### DIFF
--- a/desktop/public/gamestudio-seeds/asteroid-miner/game.js
+++ b/desktop/public/gamestudio-seeds/asteroid-miner/game.js
@@ -1,0 +1,336 @@
+// Asteroid Miner - 2D wraparound asteroids-style shooter, plain canvas 2D, no libraries.
+// Rotate and thrust a ship, blast drifting asteroids, wrap at every edge.
+// Keyboard (rotate/thrust/fire) and on-screen touch buttons both drive the
+// same input state, so touch devices get real controls without a second
+// code path.
+
+const container = document.getElementById("scene");
+const scoreEl = document.getElementById("score");
+const livesEl = document.getElementById("lives");
+const overlayEl = document.getElementById("overlay");
+const restartBtn = document.getElementById("restartBtn");
+
+const canvas = document.createElement("canvas");
+canvas.style.display = "block";
+const ctx = canvas.getContext("2d");
+container.appendChild(canvas);
+
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener("resize", resizeCanvas);
+resizeCanvas();
+
+// ---------- Constants ----------
+
+const SHIP_RADIUS = 14;
+const ROTATE_SPEED = 3.2; // rad/sec
+const THRUST_ACCEL = 260; // px/sec^2
+const DRAG = 0.55; // velocity multiplier per second (soft space friction)
+const MAX_SPEED = 340;
+const BULLET_SPEED = 460;
+const BULLET_LIFE = 1.1; // seconds
+const ASTEROID_RADIUS = 26;
+const ASTEROID_SPEED_MIN = 40;
+const ASTEROID_SPEED_MAX = 110;
+const SPAWN_INTERVAL = 1.6;
+const INVULN_TIME = 1.5;
+
+// ---------- Input state ----------
+
+const input = { left: false, right: false, thrust: false };
+
+function bindHold(el, key) {
+  const set = (v) => (input[key] = v);
+  el.addEventListener("pointerdown", (e) => {
+    e.preventDefault();
+    set(true);
+  });
+  el.addEventListener("pointerup", () => set(false));
+  el.addEventListener("pointerleave", () => set(false));
+  el.addEventListener("pointercancel", () => set(false));
+}
+bindHold(document.getElementById("btn-left"), "left");
+bindHold(document.getElementById("btn-right"), "right");
+bindHold(document.getElementById("btn-thrust"), "thrust");
+document.getElementById("btn-fire").addEventListener("pointerdown", (e) => {
+  e.preventDefault();
+  fireBullet();
+});
+
+window.addEventListener("keydown", (e) => {
+  if (e.code === "ArrowLeft" || e.code === "KeyA") input.left = true;
+  if (e.code === "ArrowRight" || e.code === "KeyD") input.right = true;
+  if (e.code === "ArrowUp" || e.code === "KeyW") input.thrust = true;
+  if (e.code === "Space") fireBullet();
+});
+window.addEventListener("keyup", (e) => {
+  if (e.code === "ArrowLeft" || e.code === "KeyA") input.left = false;
+  if (e.code === "ArrowRight" || e.code === "KeyD") input.right = false;
+  if (e.code === "ArrowUp" || e.code === "KeyW") input.thrust = false;
+});
+canvas.addEventListener("click", () => fireBullet());
+
+// ---------- Game state ----------
+
+let ship;
+let bullets;
+let asteroids;
+let score;
+let lives;
+let gameOver;
+let spawnTimer;
+
+function resetGame() {
+  ship = {
+    x: canvas.width / 2,
+    y: canvas.height / 2,
+    angle: 0,
+    vx: 0,
+    vy: 0,
+    invuln: INVULN_TIME,
+  };
+  bullets = [];
+  asteroids = [];
+  score = 0;
+  lives = 3;
+  gameOver = false;
+  spawnTimer = 0;
+  for (let i = 0; i < 4; i++) spawnAsteroid();
+  updateHud();
+  overlayEl.style.display = "none";
+}
+
+function updateHud() {
+  scoreEl.textContent = `Score: ${score}`;
+  livesEl.textContent = `Lives: ${lives}`;
+}
+
+function wrap(pos, max) {
+  if (pos < 0) return pos + max;
+  if (pos > max) return pos - max;
+  return pos;
+}
+
+function spawnAsteroid() {
+  // Spawn just outside a random edge, drifting inward-ish.
+  const edge = Math.floor(Math.random() * 4);
+  let x, y;
+  if (edge === 0) { x = -ASTEROID_RADIUS; y = Math.random() * canvas.height; }
+  else if (edge === 1) { x = canvas.width + ASTEROID_RADIUS; y = Math.random() * canvas.height; }
+  else if (edge === 2) { x = Math.random() * canvas.width; y = -ASTEROID_RADIUS; }
+  else { x = Math.random() * canvas.width; y = canvas.height + ASTEROID_RADIUS; }
+
+  const speed = ASTEROID_SPEED_MIN + Math.random() * (ASTEROID_SPEED_MAX - ASTEROID_SPEED_MIN);
+  const dir = Math.random() * Math.PI * 2;
+  asteroids.push({
+    x, y,
+    vx: Math.cos(dir) * speed,
+    vy: Math.sin(dir) * speed,
+    radius: ASTEROID_RADIUS * (0.7 + Math.random() * 0.5),
+    rotation: Math.random() * Math.PI * 2,
+    spin: (Math.random() - 0.5) * 2,
+  });
+}
+
+function fireBullet() {
+  if (gameOver) {
+    resetGame();
+    return;
+  }
+  const noseX = ship.x + Math.sin(ship.angle) * SHIP_RADIUS;
+  const noseY = ship.y - Math.cos(ship.angle) * SHIP_RADIUS;
+  bullets.push({
+    x: noseX,
+    y: noseY,
+    vx: Math.sin(ship.angle) * BULLET_SPEED,
+    vy: -Math.cos(ship.angle) * BULLET_SPEED,
+    life: BULLET_LIFE,
+  });
+}
+
+restartBtn.addEventListener("click", resetGame);
+resetGame();
+
+// ---------- Update ----------
+
+function updateShip(dt) {
+  if (input.left) ship.angle -= ROTATE_SPEED * dt;
+  if (input.right) ship.angle += ROTATE_SPEED * dt;
+
+  if (input.thrust) {
+    ship.vx += Math.sin(ship.angle) * THRUST_ACCEL * dt;
+    ship.vy -= Math.cos(ship.angle) * THRUST_ACCEL * dt;
+  }
+
+  const dragFactor = Math.pow(DRAG, dt);
+  ship.vx *= dragFactor;
+  ship.vy *= dragFactor;
+
+  const speed = Math.hypot(ship.vx, ship.vy);
+  if (speed > MAX_SPEED) {
+    ship.vx = (ship.vx / speed) * MAX_SPEED;
+    ship.vy = (ship.vy / speed) * MAX_SPEED;
+  }
+
+  ship.x = wrap(ship.x + ship.vx * dt, canvas.width);
+  ship.y = wrap(ship.y + ship.vy * dt, canvas.height);
+
+  if (ship.invuln > 0) ship.invuln -= dt;
+}
+
+function updateBullets(dt) {
+  for (let i = bullets.length - 1; i >= 0; i--) {
+    const b = bullets[i];
+    b.x += b.vx * dt;
+    b.y += b.vy * dt;
+    b.life -= dt;
+    if (b.life <= 0 || b.x < 0 || b.x > canvas.width || b.y < 0 || b.y > canvas.height) {
+      bullets.splice(i, 1);
+    }
+  }
+}
+
+function updateAsteroids(dt) {
+  for (const a of asteroids) {
+    a.x = wrap(a.x + a.vx * dt, canvas.width);
+    a.y = wrap(a.y + a.vy * dt, canvas.height);
+    a.rotation += a.spin * dt;
+  }
+
+  spawnTimer -= dt;
+  if (spawnTimer <= 0) {
+    spawnAsteroid();
+    spawnTimer = SPAWN_INTERVAL;
+  }
+}
+
+function checkCollisions() {
+  // Bullet vs asteroid
+  for (let i = asteroids.length - 1; i >= 0; i--) {
+    const a = asteroids[i];
+    for (let j = bullets.length - 1; j >= 0; j--) {
+      const b = bullets[j];
+      if (Math.hypot(a.x - b.x, a.y - b.y) < a.radius) {
+        asteroids.splice(i, 1);
+        bullets.splice(j, 1);
+        score += 10;
+        updateHud();
+        break;
+      }
+    }
+  }
+  while (asteroids.length < 3) spawnAsteroid();
+
+  // Ship vs asteroid
+  if (ship.invuln <= 0) {
+    for (const a of asteroids) {
+      if (Math.hypot(a.x - ship.x, a.y - ship.y) < a.radius + SHIP_RADIUS * 0.7) {
+        lives -= 1;
+        updateHud();
+        if (lives <= 0) {
+          gameOver = true;
+          overlayEl.style.display = "flex";
+        } else {
+          ship.x = canvas.width / 2;
+          ship.y = canvas.height / 2;
+          ship.vx = 0;
+          ship.vy = 0;
+          ship.invuln = INVULN_TIME;
+        }
+        break;
+      }
+    }
+  }
+}
+
+// ---------- Draw ----------
+
+function draw() {
+  ctx.fillStyle = "#0a0a14";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Ship
+  ctx.save();
+  ctx.translate(ship.x, ship.y);
+  ctx.rotate(ship.angle);
+  ctx.globalAlpha = ship.invuln > 0 ? 0.5 + 0.4 * Math.sin(performance.now() / 80) : 1;
+  ctx.fillStyle = "#8fd6ff";
+  ctx.beginPath();
+  ctx.moveTo(0, -SHIP_RADIUS);
+  ctx.lineTo(SHIP_RADIUS * 0.75, SHIP_RADIUS * 0.85);
+  ctx.lineTo(0, SHIP_RADIUS * 0.45);
+  ctx.lineTo(-SHIP_RADIUS * 0.75, SHIP_RADIUS * 0.85);
+  ctx.closePath();
+  ctx.fill();
+  if (input.thrust) {
+    ctx.fillStyle = "#ffae42";
+    ctx.beginPath();
+    ctx.moveTo(-SHIP_RADIUS * 0.3, SHIP_RADIUS * 0.6);
+    ctx.lineTo(0, SHIP_RADIUS * 1.3);
+    ctx.lineTo(SHIP_RADIUS * 0.3, SHIP_RADIUS * 0.6);
+    ctx.closePath();
+    ctx.fill();
+  }
+  ctx.restore();
+  ctx.globalAlpha = 1;
+
+  // Bullets
+  ctx.fillStyle = "#ffee55";
+  for (const b of bullets) {
+    ctx.beginPath();
+    ctx.arc(b.x, b.y, 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  // Asteroids
+  ctx.strokeStyle = "#c9a877";
+  ctx.lineWidth = 2;
+  ctx.fillStyle = "#7a6244";
+  for (const a of asteroids) {
+    ctx.save();
+    ctx.translate(a.x, a.y);
+    ctx.rotate(a.rotation);
+    ctx.beginPath();
+    const spikes = 8;
+    for (let i = 0; i < spikes; i++) {
+      const r = a.radius * (0.8 + 0.2 * Math.sin(i * 137.5));
+      const theta = (i / spikes) * Math.PI * 2;
+      const px = Math.cos(theta) * r;
+      const py = Math.sin(theta) * r;
+      if (i === 0) ctx.moveTo(px, py);
+      else ctx.lineTo(px, py);
+    }
+    ctx.closePath();
+    ctx.fill();
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  if (gameOver) {
+    ctx.fillStyle = "rgba(0, 0, 0, 0.45)";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+}
+
+// ---------- Loop ----------
+
+let lastTime = performance.now();
+
+function loop(now) {
+  const dt = Math.min((now - lastTime) / 1000, 0.05);
+  lastTime = now;
+
+  if (!gameOver) {
+    updateShip(dt);
+    updateBullets(dt);
+    updateAsteroids(dt);
+    checkCollisions();
+  }
+
+  draw();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);

--- a/desktop/public/gamestudio-seeds/asteroid-miner/index.html
+++ b/desktop/public/gamestudio-seeds/asteroid-miner/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Asteroid Miner</title>
+    <style>
+      html, body { margin: 0; height: 100%; background: #0a0a14; overflow: hidden; font-family: -apple-system, system-ui, sans-serif; color: #fff; touch-action: none; }
+      #scene { position: absolute; inset: 0; }
+      #hud { position: absolute; top: 12px; left: 12px; pointer-events: none; text-shadow: 0 1px 3px rgba(0,0,0,0.8); font-size: 18px; font-weight: 600; }
+      #help { position: absolute; bottom: 12px; left: 12px; font-size: 13px; opacity: 0.75; pointer-events: none; text-shadow: 0 1px 3px rgba(0,0,0,0.8); }
+      #overlay { position: absolute; inset: 0; display: none; align-items: center; justify-content: center; flex-direction: column; gap: 14px; background: rgba(0,0,0,0.6); text-align: center; }
+      #overlay h1 { margin: 0; font-size: 30px; }
+      #restartBtn { pointer-events: auto; padding: 10px 22px; border-radius: 999px; border: none; background: #7dc3ff; color: #071018; font-weight: 700; font-size: 15px; cursor: pointer; }
+
+      /* Touch controls: hidden HUD layer with individually-interactive buttons,
+         so mouse/keyboard play is unaffected while touch devices get real controls. */
+      #touch-controls { position: absolute; inset: 0; pointer-events: none; }
+      .touch-btn { position: absolute; width: 64px; height: 64px; border-radius: 999px; border: 1px solid rgba(255,255,255,0.35); background: rgba(255,255,255,0.08); color: #fff; font-size: 22px; display: flex; align-items: center; justify-content: center; pointer-events: auto; user-select: none; -webkit-user-select: none; }
+      .touch-btn:active { background: rgba(255,255,255,0.22); }
+      #btn-left { left: 16px; bottom: 24px; }
+      #btn-right { left: 92px; bottom: 24px; }
+      #btn-thrust { left: 54px; bottom: 100px; }
+      #btn-fire { right: 24px; bottom: 40px; width: 80px; height: 80px; font-size: 16px; font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <div id="scene"></div>
+    <div id="hud"><span id="score">Score: 0</span> &nbsp; <span id="lives">Lives: 3</span></div>
+    <div id="help">A/D or Left/Right to rotate &middot; W/Up to thrust &middot; Space or click to fire</div>
+    <div id="touch-controls">
+      <div id="btn-left" class="touch-btn">&#8630;</div>
+      <div id="btn-right" class="touch-btn">&#8631;</div>
+      <div id="btn-thrust" class="touch-btn">&#9650;</div>
+      <div id="btn-fire" class="touch-btn">FIRE</div>
+    </div>
+    <div id="overlay">
+      <h1>Game Over</h1>
+      <button id="restartBtn" type="button">Restart</button>
+    </div>
+    <script type="module" src="./game.js"></script>
+  </body>
+</html>

--- a/desktop/public/gamestudio-seeds/endless-runner/game.js
+++ b/desktop/public/gamestudio-seeds/endless-runner/game.js
@@ -1,0 +1,191 @@
+// Endless Runner - side-scrolling jumper, plain canvas 2D, no libraries.
+// Jump over obstacles as the pace keeps climbing. Distance is the score.
+
+const canvas = document.getElementById("game");
+const ctx = canvas.getContext("2d");
+
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener("resize", resizeCanvas);
+resizeCanvas();
+
+// ---------- Constants ----------
+
+const PLAYER_X = 110;
+const PLAYER_SIZE = 36;
+const GRAVITY = 2200;
+const JUMP_SPEED = 780;
+const BASE_SPEED = 320; // px/sec, ground scroll speed
+const SPEED_RAMP = 6; // px/sec gained per second survived
+const MIN_GAP = 0.7; // seconds
+const MAX_GAP = 1.5; // seconds
+
+function groundY() {
+  return canvas.height * 0.75;
+}
+
+// ---------- Input ----------
+
+let jumpQueued = false;
+
+window.addEventListener("keydown", (e) => {
+  if (e.code === "Space" || e.code === "ArrowUp" || e.code === "KeyW") {
+    e.preventDefault();
+    jumpQueued = true;
+  }
+  if (e.code === "KeyR" && gameOver) resetGame();
+});
+
+window.addEventListener("pointerdown", () => {
+  if (gameOver) {
+    resetGame();
+  } else {
+    jumpQueued = true;
+  }
+});
+
+// ---------- Game state ----------
+
+let player;
+let obstacles;
+let speed;
+let elapsed;
+let nextSpawnIn;
+let score;
+let gameOver;
+
+function resetGame() {
+  player = { y: groundY() - PLAYER_SIZE, vy: 0, onGround: true };
+  obstacles = [];
+  speed = BASE_SPEED;
+  elapsed = 0;
+  nextSpawnIn = MIN_GAP + Math.random() * (MAX_GAP - MIN_GAP);
+  score = 0;
+  gameOver = false;
+}
+
+resetGame();
+
+// ---------- Update ----------
+
+function spawnObstacle() {
+  const height = 30 + Math.random() * 40;
+  obstacles.push({ x: canvas.width + 20, width: 26, height, passed: false });
+  nextSpawnIn = MIN_GAP + Math.random() * (MAX_GAP - MIN_GAP);
+}
+
+function updatePlayer(dt) {
+  if (jumpQueued && player.onGround) {
+    player.vy = -JUMP_SPEED;
+    player.onGround = false;
+  }
+  jumpQueued = false;
+
+  player.vy += GRAVITY * dt;
+  player.y += player.vy * dt;
+
+  const floor = groundY() - PLAYER_SIZE;
+  if (player.y >= floor) {
+    player.y = floor;
+    player.vy = 0;
+    player.onGround = true;
+  }
+}
+
+function updateObstacles(dt) {
+  for (const o of obstacles) {
+    o.x -= speed * dt;
+    if (!o.passed && o.x + o.width < PLAYER_X) {
+      o.passed = true;
+    }
+  }
+  while (obstacles.length && obstacles[0].x + obstacles[0].width < -20) {
+    obstacles.shift();
+  }
+}
+
+function checkCollisions() {
+  const px1 = PLAYER_X;
+  const px2 = PLAYER_X + PLAYER_SIZE;
+  const py1 = player.y;
+  const py2 = player.y + PLAYER_SIZE;
+  for (const o of obstacles) {
+    const oy2 = groundY();
+    const oy1 = oy2 - o.height;
+    if (px2 > o.x && px1 < o.x + o.width && py2 > oy1 && py1 < oy2) {
+      gameOver = true;
+    }
+  }
+}
+
+// ---------- Draw ----------
+
+function draw() {
+  ctx.fillStyle = "#14101f";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Ground line
+  ctx.strokeStyle = "#4a3f66";
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  ctx.moveTo(0, groundY());
+  ctx.lineTo(canvas.width, groundY());
+  ctx.stroke();
+
+  // Obstacles
+  ctx.fillStyle = "#ff5fa8";
+  for (const o of obstacles) {
+    ctx.fillRect(o.x, groundY() - o.height, o.width, o.height);
+  }
+
+  // Player
+  ctx.fillStyle = "#8fd6ff";
+  ctx.fillRect(PLAYER_X, player.y, PLAYER_SIZE, PLAYER_SIZE);
+
+  // Score
+  ctx.fillStyle = "#ffffff";
+  ctx.font = "20px -apple-system, system-ui, sans-serif";
+  ctx.fillText(`Score: ${score}`, 16, 30);
+
+  if (gameOver) {
+    ctx.fillStyle = "rgba(0, 0, 0, 0.55)";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#ffffff";
+    ctx.textAlign = "center";
+    ctx.font = "bold 32px -apple-system, system-ui, sans-serif";
+    ctx.fillText(`Game Over — score: ${score}`, canvas.width / 2, canvas.height / 2 - 10);
+    ctx.font = "18px -apple-system, system-ui, sans-serif";
+    ctx.fillText("press R or tap to restart", canvas.width / 2, canvas.height / 2 + 22);
+    ctx.textAlign = "left";
+  }
+}
+
+// ---------- Loop ----------
+
+let lastTime = performance.now();
+
+function loop(now) {
+  const dt = Math.min((now - lastTime) / 1000, 0.05);
+  lastTime = now;
+
+  if (!gameOver) {
+    elapsed += dt;
+    speed = BASE_SPEED + elapsed * SPEED_RAMP;
+    score = Math.floor(elapsed * 10);
+
+    updatePlayer(dt);
+    updateObstacles(dt);
+
+    nextSpawnIn -= dt;
+    if (nextSpawnIn <= 0) spawnObstacle();
+
+    checkCollisions();
+  }
+
+  draw();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);

--- a/desktop/public/gamestudio-seeds/endless-runner/game.js
+++ b/desktop/public/gamestudio-seeds/endless-runner/game.js
@@ -116,6 +116,7 @@ function checkCollisions() {
     const oy1 = oy2 - o.height;
     if (px2 > o.x && px1 < o.x + o.width && py2 > oy1 && py1 < oy2) {
       gameOver = true;
+      break;
     }
   }
 }

--- a/desktop/public/gamestudio-seeds/endless-runner/index.html
+++ b/desktop/public/gamestudio-seeds/endless-runner/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Endless Runner</title>
+    <style>
+      html, body { margin: 0; height: 100%; background: #14101f; overflow: hidden; font-family: -apple-system, system-ui, sans-serif; color: #fff; touch-action: none; }
+      #game { display: block; }
+      #help { position: absolute; bottom: 12px; left: 12px; font-size: 13px; opacity: 0.75; text-shadow: 0 1px 3px rgba(0,0,0,0.8); }
+    </style>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <div id="help">Space / Up / tap to jump &middot; dodge the obstacles</div>
+    <script type="module" src="./game.js"></script>
+  </body>
+</html>

--- a/desktop/public/gamestudio-seeds/neon-snake/game.js
+++ b/desktop/public/gamestudio-seeds/neon-snake/game.js
@@ -1,0 +1,210 @@
+// Neon Snake - classic grid snake, plain canvas 2D, no libraries.
+// Steer with arrows/WASD or a swipe. Eat food to grow. Don't hit the wall or yourself.
+
+const canvas = document.getElementById("game");
+const ctx = canvas.getContext("2d");
+
+// ---------- Constants ----------
+
+const CELL = 24;
+const COLS = 22;
+const ROWS = 18;
+const START_TICK_MS = 130;
+const MIN_TICK_MS = 70;
+const TICK_SPEEDUP_PER_FOOD = 3;
+
+canvas.width = COLS * CELL;
+canvas.height = ROWS * CELL;
+
+const DIRS = {
+  up: { x: 0, y: -1 },
+  down: { x: 0, y: 1 },
+  left: { x: -1, y: 0 },
+  right: { x: 1, y: 0 },
+};
+
+// ---------- Game state ----------
+
+let snake;
+let direction;
+let pendingDirection;
+let food;
+let score;
+let tickMs;
+let gameOver;
+
+function randomFoodSpot() {
+  let spot;
+  do {
+    spot = { x: Math.floor(Math.random() * COLS), y: Math.floor(Math.random() * ROWS) };
+  } while (snake.some((s) => s.x === spot.x && s.y === spot.y));
+  return spot;
+}
+
+function resetGame() {
+  const startX = Math.floor(COLS / 2);
+  const startY = Math.floor(ROWS / 2);
+  snake = [
+    { x: startX, y: startY },
+    { x: startX - 1, y: startY },
+    { x: startX - 2, y: startY },
+  ];
+  direction = DIRS.right;
+  pendingDirection = DIRS.right;
+  score = 0;
+  tickMs = START_TICK_MS;
+  gameOver = false;
+  food = randomFoodSpot();
+}
+
+resetGame();
+
+// ---------- Input ----------
+
+function isOpposite(a, b) {
+  return a.x === -b.x && a.y === -b.y;
+}
+
+function queueDirection(next) {
+  if (!isOpposite(next, direction)) pendingDirection = next;
+}
+
+window.addEventListener("keydown", (e) => {
+  if (e.code === "KeyR" && gameOver) {
+    resetGame();
+    return;
+  }
+  if (e.code === "ArrowUp" || e.code === "KeyW") queueDirection(DIRS.up);
+  else if (e.code === "ArrowDown" || e.code === "KeyS") queueDirection(DIRS.down);
+  else if (e.code === "ArrowLeft" || e.code === "KeyA") queueDirection(DIRS.left);
+  else if (e.code === "ArrowRight" || e.code === "KeyD") queueDirection(DIRS.right);
+});
+
+let touchStart = null;
+window.addEventListener("pointerdown", (e) => {
+  if (gameOver) {
+    resetGame();
+    return;
+  }
+  touchStart = { x: e.clientX, y: e.clientY };
+});
+window.addEventListener("pointerup", (e) => {
+  if (!touchStart) return;
+  const dx = e.clientX - touchStart.x;
+  const dy = e.clientY - touchStart.y;
+  touchStart = null;
+  if (Math.hypot(dx, dy) < 12) return; // ignore taps, only swipes steer
+  if (Math.abs(dx) > Math.abs(dy)) {
+    queueDirection(dx > 0 ? DIRS.right : DIRS.left);
+  } else {
+    queueDirection(dy > 0 ? DIRS.down : DIRS.up);
+  }
+});
+
+// ---------- Update ----------
+
+function step() {
+  direction = pendingDirection;
+  const head = { x: snake[0].x + direction.x, y: snake[0].y + direction.y };
+
+  if (head.x < 0 || head.x >= COLS || head.y < 0 || head.y >= ROWS) {
+    gameOver = true;
+    return;
+  }
+  if (snake.some((s) => s.x === head.x && s.y === head.y)) {
+    gameOver = true;
+    return;
+  }
+
+  snake.unshift(head);
+
+  if (head.x === food.x && head.y === food.y) {
+    score += 1;
+    tickMs = Math.max(MIN_TICK_MS, START_TICK_MS - score * TICK_SPEEDUP_PER_FOOD);
+    food = randomFoodSpot();
+  } else {
+    snake.pop();
+  }
+}
+
+// ---------- Draw ----------
+
+function draw() {
+  ctx.fillStyle = "#05070a";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Grid
+  ctx.strokeStyle = "rgba(255,255,255,0.04)";
+  ctx.lineWidth = 1;
+  for (let x = 0; x <= COLS; x++) {
+    ctx.beginPath();
+    ctx.moveTo(x * CELL, 0);
+    ctx.lineTo(x * CELL, canvas.height);
+    ctx.stroke();
+  }
+  for (let y = 0; y <= ROWS; y++) {
+    ctx.beginPath();
+    ctx.moveTo(0, y * CELL);
+    ctx.lineTo(canvas.width, y * CELL);
+    ctx.stroke();
+  }
+
+  // Food
+  ctx.fillStyle = "#ff4fb0";
+  ctx.beginPath();
+  ctx.arc(food.x * CELL + CELL / 2, food.y * CELL + CELL / 2, CELL * 0.35, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Snake
+  for (let i = 0; i < snake.length; i++) {
+    const s = snake[i];
+    ctx.fillStyle = i === 0 ? "#7dffb3" : "#39c97a";
+    ctx.fillRect(s.x * CELL + 1, s.y * CELL + 1, CELL - 2, CELL - 2);
+  }
+
+  // Score
+  ctx.fillStyle = "#ffffff";
+  ctx.font = "18px -apple-system, system-ui, sans-serif";
+  ctx.fillText(`Score: ${score}`, 10, 22);
+
+  if (gameOver) {
+    ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#ffffff";
+    ctx.textAlign = "center";
+    ctx.font = "bold 26px -apple-system, system-ui, sans-serif";
+    ctx.fillText(`Game Over — score: ${score}`, canvas.width / 2, canvas.height / 2 - 10);
+    ctx.font = "15px -apple-system, system-ui, sans-serif";
+    ctx.fillText("press R or tap to restart", canvas.width / 2, canvas.height / 2 + 18);
+    ctx.textAlign = "left";
+  }
+}
+
+// ---------- Loop ----------
+// Snake advances on a fixed tick (not every animation frame), so its speed
+// stays framerate-independent and readable regardless of tickMs.
+
+let accumulator = 0;
+let lastTime = performance.now();
+
+function loop(now) {
+  const dt = Math.min(now - lastTime, 200);
+  lastTime = now;
+
+  if (!gameOver) {
+    accumulator += dt;
+    while (accumulator >= tickMs) {
+      step();
+      accumulator -= tickMs;
+      if (gameOver) {
+        accumulator = 0;
+        break;
+      }
+    }
+  }
+
+  draw();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);

--- a/desktop/public/gamestudio-seeds/neon-snake/index.html
+++ b/desktop/public/gamestudio-seeds/neon-snake/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Neon Snake</title>
+    <style>
+      html, body { margin: 0; height: 100%; background: #05070a; overflow: hidden; font-family: -apple-system, system-ui, sans-serif; color: #fff; touch-action: none; }
+      body { display: flex; align-items: center; justify-content: center; }
+      #game { display: block; box-shadow: 0 0 40px rgba(80, 255, 170, 0.15); }
+      #help { position: absolute; bottom: 12px; left: 12px; font-size: 13px; opacity: 0.75; text-shadow: 0 1px 3px rgba(0,0,0,0.8); }
+    </style>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <div id="help">Arrow keys / WASD or swipe to steer &middot; eat the pink food, don't hit yourself or the wall</div>
+    <script type="module" src="./game.js"></script>
+  </body>
+</html>

--- a/desktop/public/gamestudio-seeds/sky-tapper/game.js
+++ b/desktop/public/gamestudio-seeds/sky-tapper/game.js
@@ -1,0 +1,182 @@
+// Sky Tapper - flappy-style tapper, plain canvas 2D, no libraries.
+// Flap to stay aloft and thread every gap. One life, real gravity.
+
+const canvas = document.getElementById("game");
+const ctx = canvas.getContext("2d");
+
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener("resize", resizeCanvas);
+resizeCanvas();
+
+// ---------- Constants ----------
+
+const BIRD_X_RATIO = 0.28;
+const BIRD_RADIUS = 16;
+const GRAVITY = 1500;
+const FLAP_SPEED = -480;
+const PIPE_WIDTH = 74;
+const PIPE_GAP = 190;
+const PIPE_SPEED = 220;
+const PIPE_SPACING = 320; // px between pipe pairs
+
+// ---------- Game state ----------
+
+let bird;
+let pipes;
+let score;
+let gameOver;
+let started;
+
+function resetGame() {
+  bird = { y: window.innerHeight / 2, vy: 0 };
+  pipes = [];
+  score = 0;
+  gameOver = false;
+  started = false;
+  spawnPipe(canvas.width + 100);
+}
+
+function spawnPipe(x) {
+  const margin = 80;
+  const gapY = margin + Math.random() * Math.max(1, canvas.height - margin * 2 - PIPE_GAP);
+  pipes.push({ x, gapY, passed: false });
+}
+
+resetGame();
+
+// ---------- Input ----------
+
+function flap() {
+  if (gameOver) {
+    resetGame();
+    return;
+  }
+  started = true;
+  bird.vy = FLAP_SPEED;
+}
+
+window.addEventListener("keydown", (e) => {
+  if (e.code === "Space" || e.code === "ArrowUp" || e.code === "KeyW") {
+    e.preventDefault();
+    flap();
+  }
+  if (e.code === "KeyR" && gameOver) resetGame();
+});
+window.addEventListener("pointerdown", flap);
+
+// ---------- Update ----------
+
+function updateBird(dt) {
+  if (!started) return;
+  bird.vy += GRAVITY * dt;
+  bird.y += bird.vy * dt;
+
+  if (bird.y - BIRD_RADIUS < 0) {
+    bird.y = BIRD_RADIUS;
+    bird.vy = 0;
+  }
+  if (bird.y + BIRD_RADIUS > canvas.height) {
+    bird.y = canvas.height - BIRD_RADIUS;
+    gameOver = true;
+  }
+}
+
+function updatePipes(dt) {
+  if (!started) return;
+  for (const p of pipes) {
+    p.x -= PIPE_SPEED * dt;
+  }
+  while (pipes.length && pipes[0].x < -PIPE_WIDTH) pipes.shift();
+
+  const last = pipes[pipes.length - 1];
+  if (last && last.x < canvas.width - PIPE_SPACING) {
+    spawnPipe(canvas.width + PIPE_WIDTH);
+  }
+}
+
+function checkCollisions() {
+  if (!started) return;
+  const birdX = canvas.width * BIRD_X_RATIO;
+  for (const p of pipes) {
+    if (!p.passed && p.x + PIPE_WIDTH < birdX) {
+      p.passed = true;
+      score += 1;
+    }
+    const withinX = birdX + BIRD_RADIUS > p.x && birdX - BIRD_RADIUS < p.x + PIPE_WIDTH;
+    if (withinX) {
+      const inGap = bird.y - BIRD_RADIUS > p.gapY && bird.y + BIRD_RADIUS < p.gapY + PIPE_GAP;
+      if (!inGap) gameOver = true;
+    }
+  }
+}
+
+// ---------- Draw ----------
+
+function draw() {
+  ctx.fillStyle = "#0e1b2b";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Pipes
+  ctx.fillStyle = "#4fd67a";
+  for (const p of pipes) {
+    ctx.fillRect(p.x, 0, PIPE_WIDTH, p.gapY);
+    ctx.fillRect(p.x, p.gapY + PIPE_GAP, PIPE_WIDTH, canvas.height - (p.gapY + PIPE_GAP));
+  }
+
+  // Bird
+  const birdX = canvas.width * BIRD_X_RATIO;
+  ctx.fillStyle = "#ffd84a";
+  ctx.beginPath();
+  ctx.arc(birdX, bird.y, BIRD_RADIUS, 0, Math.PI * 2);
+  ctx.fill();
+
+  // Score
+  ctx.fillStyle = "#ffffff";
+  ctx.font = "24px -apple-system, system-ui, sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText(`${score}`, canvas.width / 2, 50);
+  ctx.textAlign = "left";
+
+  if (!started && !gameOver) {
+    ctx.fillStyle = "#ffffff";
+    ctx.textAlign = "center";
+    ctx.font = "bold 24px -apple-system, system-ui, sans-serif";
+    ctx.fillText("Tap, click or press Space to start", canvas.width / 2, canvas.height / 2);
+    ctx.textAlign = "left";
+  }
+
+  if (gameOver) {
+    ctx.fillStyle = "rgba(0, 0, 0, 0.55)";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = "#ffffff";
+    ctx.textAlign = "center";
+    ctx.font = "bold 32px -apple-system, system-ui, sans-serif";
+    ctx.fillText(`Game Over — score: ${score}`, canvas.width / 2, canvas.height / 2 - 10);
+    ctx.font = "18px -apple-system, system-ui, sans-serif";
+    ctx.fillText("press R, tap or click to restart", canvas.width / 2, canvas.height / 2 + 22);
+    ctx.textAlign = "left";
+  }
+}
+
+// ---------- Loop ----------
+
+let lastTime = performance.now();
+
+function loop(now) {
+  const dt = Math.min((now - lastTime) / 1000, 0.05);
+  lastTime = now;
+
+  if (!gameOver) {
+    updateBird(dt);
+    updatePipes(dt);
+    checkCollisions();
+  }
+
+  draw();
+  requestAnimationFrame(loop);
+}
+
+requestAnimationFrame(loop);

--- a/desktop/public/gamestudio-seeds/sky-tapper/game.js
+++ b/desktop/public/gamestudio-seeds/sky-tapper/game.js
@@ -31,7 +31,7 @@ let gameOver;
 let started;
 
 function resetGame() {
-  bird = { y: window.innerHeight / 2, vy: 0 };
+  bird = { y: canvas.height / 2, vy: 0 };
   pipes = [];
   score = 0;
   gameOver = false;

--- a/desktop/public/gamestudio-seeds/sky-tapper/index.html
+++ b/desktop/public/gamestudio-seeds/sky-tapper/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sky Tapper</title>
+    <style>
+      html, body { margin: 0; height: 100%; background: #0e1b2b; overflow: hidden; font-family: -apple-system, system-ui, sans-serif; color: #fff; touch-action: none; }
+      #game { display: block; }
+      #help { position: absolute; bottom: 12px; left: 12px; font-size: 13px; opacity: 0.75; text-shadow: 0 1px 3px rgba(0,0,0,0.8); }
+    </style>
+  </head>
+  <body>
+    <canvas id="game"></canvas>
+    <div id="help">Space / Up / tap or click to flap &middot; thread every gap</div>
+    <script type="module" src="./game.js"></script>
+  </body>
+</html>

--- a/desktop/src/apps/gamestudio/match-template.ts
+++ b/desktop/src/apps/gamestudio/match-template.ts
@@ -6,7 +6,7 @@ const HINTS: Record<string, string[]> = {
   "top-down-collector": ["top-down", "top down", "collect", "collector", "gem", "arena", "dodge", "2d"],
   breakout: ["breakout", "arkanoid", "brick", "paddle", "ball", "puzzle"],
   "orbit-shooter": ["shooter", "shoot", "turret", "orbit", "enemy", "enemies", "space", "blaster"],
-  "endless-runner": ["runner", "run", "endless", "dodge", "obstacle", "side-scroller", "sidescroller"],
+  "endless-runner": ["runner", "endless", "obstacle", "side-scroller", "sidescroller"],
   "neon-snake": ["snake", "grid", "worm", "food", "grow"],
   "sky-tapper": ["flappy", "tapper", "tap", "flap", "bird", "pipe", "pipes"],
   "asteroid-miner": ["asteroid", "asteroids", "miner", "spaceship", "rotate", "thrust", "twin-stick"],

--- a/desktop/src/apps/gamestudio/match-template.ts
+++ b/desktop/src/apps/gamestudio/match-template.ts
@@ -6,6 +6,10 @@ const HINTS: Record<string, string[]> = {
   "top-down-collector": ["top-down", "top down", "collect", "collector", "gem", "arena", "dodge", "2d"],
   breakout: ["breakout", "arkanoid", "brick", "paddle", "ball", "puzzle"],
   "orbit-shooter": ["shooter", "shoot", "turret", "orbit", "enemy", "enemies", "space", "blaster"],
+  "endless-runner": ["runner", "run", "endless", "dodge", "obstacle", "side-scroller", "sidescroller"],
+  "neon-snake": ["snake", "grid", "worm", "food", "grow"],
+  "sky-tapper": ["flappy", "tapper", "tap", "flap", "bird", "pipe", "pipes"],
+  "asteroid-miner": ["asteroid", "asteroids", "miner", "spaceship", "rotate", "thrust", "twin-stick"],
 };
 
 function scoreTemplate(template: Template, text: string): number {

--- a/desktop/src/apps/gamestudio/templates.test.ts
+++ b/desktop/src/apps/gamestudio/templates.test.ts
@@ -19,7 +19,6 @@ describe("TEMPLATES", () => {
     expect(t.desc.length).toBeGreaterThan(0);
     expect(t.cover.length).toBeGreaterThan(0);
     expect(t.files).toContain("index.html");
-    expect(t.files.length).toBeGreaterThan(0);
   });
 
   it.each(TEMPLATES)("$id's seed files exist on disk under gamestudio-seeds/", (t) => {

--- a/desktop/src/apps/gamestudio/templates.test.ts
+++ b/desktop/src/apps/gamestudio/templates.test.ts
@@ -1,0 +1,45 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { DEFAULT_TEMPLATE, TEMPLATES, findTemplate } from "./templates";
+
+// Vitest's root is the `desktop/` package, so this resolves relative to cwd.
+const SEEDS_DIR = path.resolve(process.cwd(), "public/gamestudio-seeds");
+
+describe("TEMPLATES", () => {
+  it("has no duplicate ids", () => {
+    const ids = TEMPLATES.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it.each(TEMPLATES)("$id has valid metadata and includes index.html", (t) => {
+    expect(t.id).toMatch(/^[a-z0-9-]+$/);
+    expect(t.title.length).toBeGreaterThan(0);
+    expect(t.genre.length).toBeGreaterThan(0);
+    expect(t.desc.length).toBeGreaterThan(0);
+    expect(t.cover.length).toBeGreaterThan(0);
+    expect(t.files).toContain("index.html");
+    expect(t.files.length).toBeGreaterThan(0);
+  });
+
+  it.each(TEMPLATES)("$id's seed files exist on disk under gamestudio-seeds/", (t) => {
+    for (const file of t.files) {
+      const filePath = path.join(SEEDS_DIR, t.id, file);
+      expect(existsSync(filePath), `expected ${filePath} to exist`).toBe(true);
+    }
+  });
+
+  it("findTemplate resolves every registered id", () => {
+    for (const t of TEMPLATES) {
+      expect(findTemplate(t.id)).toBe(t);
+    }
+  });
+
+  it("findTemplate returns undefined for an unknown id", () => {
+    expect(findTemplate("does-not-exist")).toBeUndefined();
+  });
+
+  it("DEFAULT_TEMPLATE is the first template", () => {
+    expect(DEFAULT_TEMPLATE).toBe(TEMPLATES[0]);
+  });
+});

--- a/desktop/src/apps/gamestudio/templates.ts
+++ b/desktop/src/apps/gamestudio/templates.ts
@@ -47,6 +47,42 @@ export const TEMPLATES: Template[] = [
       "radial-gradient(120% 120% at 40% 30%, #16607a, transparent 60%), linear-gradient(140deg,#0e2230,#0a1620)",
     files: ["index.html", "game.js", "three.module.js"],
   },
+  {
+    id: "endless-runner",
+    title: "Endless Runner",
+    genre: "Runner",
+    desc: "Jump over obstacles as the pace keeps climbing in an endless 2D side-scroller. Real canvas physics, no libraries.",
+    cover:
+      "radial-gradient(120% 120% at 35% 25%, #6a2fa0, transparent 60%), linear-gradient(140deg,#1c1430,#120c1f)",
+    files: ["index.html", "game.js"],
+  },
+  {
+    id: "neon-snake",
+    title: "Neon Snake",
+    genre: "Snake",
+    desc: "Classic grid snake with neon styling. Steer with arrows or a swipe, eat food to grow, don't hit yourself or the wall.",
+    cover:
+      "radial-gradient(120% 120% at 55% 25%, #1f8a4a, transparent 60%), linear-gradient(140deg,#0d1f14,#05100a)",
+    files: ["index.html", "game.js"],
+  },
+  {
+    id: "sky-tapper",
+    title: "Sky Tapper",
+    genre: "Tapper",
+    desc: "Flap through the gap in every pipe. One tap or key at a time, real gravity, pixel-precise collision.",
+    cover:
+      "radial-gradient(120% 120% at 45% 25%, #1f6a8a, transparent 60%), linear-gradient(140deg,#0e2233,#081420)",
+    files: ["index.html", "game.js"],
+  },
+  {
+    id: "asteroid-miner",
+    title: "Asteroid Miner",
+    genre: "Space",
+    desc: "Rotate, thrust and blast drifting asteroids in a wraparound 2D arena. Keyboard or on-screen touch controls.",
+    cover:
+      "radial-gradient(120% 120% at 40% 25%, #5a2a6a, transparent 60%), linear-gradient(140deg,#1c1226,#100a17)",
+    files: ["index.html", "game.js"],
+  },
 ];
 
 export const DEFAULT_TEMPLATE: Template = TEMPLATES[0]!;


### PR DESCRIPTION
## Summary

Adds 4 new starter templates to Game Studio, going from 4 to 8, on the existing generate/preview/share pipeline (no pipeline changes).

- **Endless Runner** (`endless-runner`): side scrolling jumper, gravity + jump physics, obstacles speed up over time, score is distance survived.
- **Neon Snake** (`neon-snake`): classic grid snake, arrow/WASD or swipe to steer, food grows the snake and speeds up the tick rate.
- **Sky Tapper** (`sky-tapper`): flappy style tapper, gravity + flap impulse, scrolling pipe gaps, score per pipe passed.
- **Asteroid Miner** (`asteroid-miner`): 2D wraparound asteroids shooter, rotate/thrust/fire, on-screen touch buttons in addition to keyboard, 3 lives.

All 4 are plain canvas 2D (no three.js needed, lighter and offline safe), self contained `index.html` + `game.js` with no external assets, no CDN, no network calls, matching the sandboxed preview CSP (`sandbox allow-scripts`, `default-src 'none'`, `connect-src 'self'`).

Each template is registered in `templates.ts` with the same metadata shape as the existing 4 (id, title, genre, desc, cover, files), and `match-template.ts`'s prompt-matching hints were extended so "Generate with AI" without an explicit template pick still resolves to a sensible starter for prompts like "snake game" or "flappy bird style".

## Live verification

Every new template was loaded and played in a real headless browser (Playwright, served over local HTTP so ES modules work) before being called done:

- **Endless Runner**: canvas renders, no console errors, Space/tap jump moves the player and avoids obstacles (survived past several obstacles with jump input vs instant collision without it), collision correctly triggers "Game Over" with the right score, R key restarts and resumes live scoring.
- **Neon Snake**: canvas renders, no console errors, arrow-key steering redirects the snake off its default path (confirmed visually), wall collision correctly ends the game with the right score, R key restarts to a fresh board.
- **Sky Tapper**: canvas renders, no console errors, Space/tap flaps keep the bird aloft against gravity (survived multiple pipe spawns vs instant fall without input), ground collision correctly ends the game, click/tap restarts to the fresh idle state.
- **Asteroid Miner**: canvas renders, no console errors, rotation (keyboard) visibly turns the ship, thrust (keyboard) moves the ship off center (verified via pixel sampling), fire increases score and destroys asteroids, ship-asteroid collision decrements lives, on-screen touch buttons (rotate/thrust/fire) are wired via pointer events and work the same as keyboard, lives reaching 0 shows the Game Over overlay, and the Restart button resets cleanly (verified twice).

Only console noise across all 4 was a harmless favicon 404, no real errors.

## Test plan

- [x] `cd desktop && npx vitest run src/apps/gamestudio` -- 46/46 passing (added `templates.test.ts`: metadata validity, seed files exist on disk, `findTemplate`/`DEFAULT_TEMPLATE` behavior for all 8 templates)
- [x] `npm run build` -- 0 TypeScript errors
- [x] doc-gate -- flagged the new files under `desktop/src/apps/gamestudio/` as a structural "apps" change; addressed with a `Docs-Reviewed:` trailer on the commit since this is pure content on the existing template registry, not a new app or pipeline change
- [ ] Not merging this PR, per instructions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new playable game templates: Asteroid Miner, Endless Runner, Neon Snake, and Sky Tapper.
  * Each game includes a dedicated start page, gameplay controls, scoring, and game-over/restart flows.
  * Added touch-friendly controls and responsive canvas behavior for better play on different devices.

* **Tests**
  * Added checks to verify game templates are listed correctly and their seed files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->