### PR TITLE
release: 1.0.0-beta.29 (Coding Studio live preview, Music WAV bounce, Game Studio templates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.29] - 2026-07-05
+
+### Added
+- Coding Studio has a real live preview: it renders your workspace's actual index.html in a sandboxed iframe, with local CSS, JS and images inlined and nothing fetched over the network, plus working desktop/tablet/phone size toggles. This replaces the old static mock.
+- Music Studio can bounce a song to a downloadable WAV file, rendered offline via Tone.Offline so the export matches what you hear.
+- Game Studio ships four new playable starter templates (endless runner, neon snake, sky tapper, asteroid miner), each a self-contained canvas game you can generate from, edit and share.
+
 ## [1.0.0-beta.28] - 2026-07-05
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.28",
+  "version": "1.0.0-beta.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.28",
+      "version": "1.0.0-beta.29",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.28",
+  "version": "1.0.0-beta.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.28"
+version = "1.0.0-beta.29"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.28"
+__version__ = "1.0.0-beta.29"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b28"
+version = "1.0.0b29"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts 1.0.0-beta.29. Studio-gap batch, all merged to dev and folded past bot review:

- Coding Studio real sandboxed live preview (#1652, #86) - renders the workspace's real index.html in a sandbox=allow-scripts iframe, local assets inlined, no network fetch.
- Music Studio WAV bounce (#1650) - offline render via Tone.Offline.
- Game Studio 4 playable templates (#1651) - endless runner, neon snake, sky tapper, asteroid miner, each live-verified in a browser.

Version bumped across pyproject.toml, tinyagentos/__init__.py, desktop/package.json, package-lock.json, uv.lock (normalized 1.0.0b29), CHANGELOG. test_version_lock_sync green locally.