### PR TITLE
feat(governance): per-agent LLM budget hard-stops (#160 Slice 2)

### DIFF
--- a/tests/test_agent_budget_store.py
+++ b/tests/test_agent_budget_store.py
@@ -1,0 +1,145 @@
+"""Tests for the cross-process per-agent LLM budget store."""
+from __future__ import annotations
+
+from tinyagentos.agent_budget_store import AgentBudgetStore, default_budget_path
+
+
+def test_get_missing_returns_none(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    assert store.get("agent-a") is None
+
+
+def test_set_budget_then_get(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.set_budget("agent-a", 10.0)
+    rec = store.get("agent-a")
+    assert rec == {"agent": "agent-a", "max_budget_usd": 10.0, "spend_usd": 0.0}
+
+
+def test_set_budget_preserves_existing_spend(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.add_spend("agent-a", 3.0)
+    store.set_budget("agent-a", 10.0)
+    rec = store.get("agent-a")
+    assert rec["spend_usd"] == 3.0
+    assert rec["max_budget_usd"] == 10.0
+
+
+def test_set_budget_none_clears_cap(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.set_budget("agent-a", 10.0)
+    store.set_budget("agent-a", None)
+    assert store.get("agent-a")["max_budget_usd"] is None
+
+
+def test_add_spend_accumulates_and_returns_total(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    total1 = store.add_spend("agent-a", 1.5)
+    assert total1 == 1.5
+    total2 = store.add_spend("agent-a", 2.5)
+    assert total2 == 4.0
+    assert store.get("agent-a")["spend_usd"] == 4.0
+
+
+def test_add_spend_creates_row_with_no_cap(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.add_spend("agent-a", 1.0)
+    rec = store.get("agent-a")
+    assert rec["max_budget_usd"] is None
+    assert rec["spend_usd"] == 1.0
+
+
+def test_add_spend_ignores_non_positive_delta(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    assert store.add_spend("agent-a", 0.0) == 0.0
+    assert store.get("agent-a") is None
+    assert store.add_spend("agent-a", -5.0) == 0.0
+    assert store.get("agent-a") is None
+
+
+def test_add_spend_ignores_non_positive_delta_after_existing_spend(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.add_spend("agent-a", 2.0)
+    assert store.add_spend("agent-a", -1.0) == 2.0
+    assert store.get("agent-a")["spend_usd"] == 2.0
+
+
+def test_reset_spend_zeroes_but_keeps_cap(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.set_budget("agent-a", 10.0)
+    store.add_spend("agent-a", 8.0)
+    store.reset_spend("agent-a")
+    rec = store.get("agent-a")
+    assert rec["spend_usd"] == 0.0
+    assert rec["max_budget_usd"] == 10.0
+
+
+def test_reset_spend_noop_when_no_row(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.reset_spend("agent-a")  # must not raise
+    assert store.get("agent-a") is None
+
+
+def test_is_over_budget_true_when_spend_reaches_cap(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.set_budget("agent-a", 5.0)
+    store.add_spend("agent-a", 5.0)
+    assert store.is_over_budget("agent-a") is True
+
+
+def test_is_over_budget_true_when_spend_exceeds_cap(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.set_budget("agent-a", 5.0)
+    store.add_spend("agent-a", 6.0)
+    assert store.is_over_budget("agent-a") is True
+
+
+def test_is_over_budget_false_when_under_cap(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.set_budget("agent-a", 5.0)
+    store.add_spend("agent-a", 1.0)
+    assert store.is_over_budget("agent-a") is False
+
+
+def test_is_over_budget_false_when_unlimited(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.add_spend("agent-a", 1_000_000.0)
+    assert store.is_over_budget("agent-a") is False
+
+
+def test_is_over_budget_false_when_no_row(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    assert store.is_over_budget("agent-a") is False
+
+
+def test_list_returns_all_agents(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.set_budget("agent-a", 5.0)
+    store.add_spend("agent-b", 2.0)
+    agents = {rec["agent"] for rec in store.list()}
+    assert agents == {"agent-a", "agent-b"}
+
+
+def test_delete_agent(tmp_path):
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    store.set_budget("agent-a", 5.0)
+    assert store.delete_agent("agent-a") is True
+    assert store.get("agent-a") is None
+    assert store.delete_agent("agent-a") is False
+
+
+def test_cross_process_handle_sees_writes(tmp_path):
+    """A second handle (e.g. the auth hook's reader) sees the writer's data."""
+    path = tmp_path / "budgets.db"
+    writer = AgentBudgetStore(path)
+    writer.set_budget("agent-a", 10.0)
+    writer.add_spend("agent-a", 4.0)
+
+    reader = AgentBudgetStore(path)
+    rec = reader.get("agent-a")
+    assert rec["max_budget_usd"] == 10.0
+    assert rec["spend_usd"] == 4.0
+
+
+def test_default_budget_path(tmp_path):
+    assert default_budget_path(tmp_path) == tmp_path / ".agent_budgets.db"

--- a/tests/test_agent_budget_store.py
+++ b/tests/test_agent_budget_store.py
@@ -1,12 +1,25 @@
 """Tests for the cross-process per-agent LLM budget store."""
 from __future__ import annotations
 
+import pytest
+
 from tinyagentos.agent_budget_store import AgentBudgetStore, default_budget_path
 
 
 def test_get_missing_returns_none(tmp_path):
     store = AgentBudgetStore(tmp_path / "budgets.db")
     assert store.get("agent-a") is None
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_set_budget_rejects_non_finite(tmp_path, bad):
+    # A NaN cap would make is_over_budget always False and silently disable
+    # enforcement, so the store must refuse to persist a non-finite cap.
+    store = AgentBudgetStore(tmp_path / "budgets.db")
+    with pytest.raises(ValueError):
+        store.set_budget("agent-a", bad)
+    assert store.get("agent-a") is None
+    assert store.is_over_budget("agent-a") is False
 
 
 def test_set_budget_then_get(tmp_path):

--- a/tests/test_litellm_auth.py
+++ b/tests/test_litellm_auth.py
@@ -1,0 +1,122 @@
+"""Tests for tinyagentos.litellm_auth.user_api_key_auth, including the
+per-agent budget hard-stop (agent governance Slice 2).
+
+litellm is an optional "proxy" extra not installed in the default dev
+environment (see pyproject.toml / CI), so every call into
+``user_api_key_auth`` is wrapped to skip when litellm's proxy types are
+unavailable, mirroring the pattern already used in test_litellm_callback.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.agent_budget_store import AgentBudgetStore
+from tinyagentos.litellm_keystore import LiteLLMKeyStore
+import tinyagentos.litellm_auth as auth_mod
+
+
+class _FakeRequest:
+    """Minimal stand-in for the starlette Request used by _requested_model."""
+
+    def __init__(self, body: dict | None = None):
+        self._body = body or {}
+
+    async def json(self):
+        return self._body
+
+
+async def _auth(request, api_key: str):
+    try:
+        return await auth_mod.user_api_key_auth(request, api_key)
+    except ModuleNotFoundError:
+        pytest.skip("litellm not installed")
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_caches(monkeypatch):
+    """Isolate the lazily-cached store handles between tests."""
+    monkeypatch.setattr(auth_mod, "_store", None)
+    monkeypatch.setattr(auth_mod, "_store_path", None)
+    monkeypatch.setattr(auth_mod, "_budget_store_cache", None)
+    monkeypatch.setattr(auth_mod, "_budget_store_cache_path", None)
+    monkeypatch.delenv("TAOS_LITELLM_KEYSTORE", raising=False)
+    monkeypatch.delenv("TAOS_AGENT_BUDGETS", raising=False)
+    monkeypatch.delenv("LITELLM_MASTER_KEY", raising=False)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_master_key_bypasses_budget_check(tmp_path, monkeypatch):
+    """The master-key admin passthrough must never consult the budget store."""
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "sk-taos-master-123")
+    # Point at a budget store that would reject any real agent lookup — the
+    # master key must never even open it.
+    budgets = AgentBudgetStore(tmp_path / "budgets.db")
+    budgets.set_budget("some-agent", 0.0)
+    budgets.add_spend("some-agent", 1.0)
+    monkeypatch.setenv("TAOS_AGENT_BUDGETS", str(tmp_path / "budgets.db"))
+
+    result = await _auth(_FakeRequest(), "sk-taos-master-123")
+    assert result.api_key == "sk-taos-master-123"
+
+
+@pytest.mark.asyncio
+async def test_agent_over_budget_is_rejected_with_429(tmp_path, monkeypatch):
+    keystore = LiteLLMKeyStore(tmp_path / "keys.db")
+    token = keystore.mint("agent-a", ["default"])
+    monkeypatch.setenv("TAOS_LITELLM_KEYSTORE", str(tmp_path / "keys.db"))
+
+    budgets = AgentBudgetStore(tmp_path / "budgets.db")
+    budgets.set_budget("agent-a", 5.0)
+    budgets.add_spend("agent-a", 5.0)
+    monkeypatch.setenv("TAOS_AGENT_BUDGETS", str(tmp_path / "budgets.db"))
+
+    from fastapi import HTTPException
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await _auth(_FakeRequest(), token)
+    except ModuleNotFoundError:
+        pytest.skip("litellm not installed")
+    assert exc_info.value.status_code == 429
+    assert "agent-a" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_agent_under_budget_passes(tmp_path, monkeypatch):
+    keystore = LiteLLMKeyStore(tmp_path / "keys.db")
+    token = keystore.mint("agent-a", ["default"])
+    monkeypatch.setenv("TAOS_LITELLM_KEYSTORE", str(tmp_path / "keys.db"))
+
+    budgets = AgentBudgetStore(tmp_path / "budgets.db")
+    budgets.set_budget("agent-a", 5.0)
+    budgets.add_spend("agent-a", 1.0)
+    monkeypatch.setenv("TAOS_AGENT_BUDGETS", str(tmp_path / "budgets.db"))
+
+    result = await _auth(_FakeRequest(), token)
+    assert result.metadata["agent"] == "agent-a"
+
+
+@pytest.mark.asyncio
+async def test_agent_with_no_budget_row_passes(tmp_path, monkeypatch):
+    keystore = LiteLLMKeyStore(tmp_path / "keys.db")
+    token = keystore.mint("agent-a", ["default"])
+    monkeypatch.setenv("TAOS_LITELLM_KEYSTORE", str(tmp_path / "keys.db"))
+
+    # Budget store configured but has no row at all for this agent.
+    AgentBudgetStore(tmp_path / "budgets.db")
+    monkeypatch.setenv("TAOS_AGENT_BUDGETS", str(tmp_path / "budgets.db"))
+
+    result = await _auth(_FakeRequest(), token)
+    assert result.metadata["agent"] == "agent-a"
+
+
+@pytest.mark.asyncio
+async def test_budgets_not_configured_fails_open(tmp_path, monkeypatch):
+    """No TAOS_AGENT_BUDGETS at all -> no budget check performed."""
+    keystore = LiteLLMKeyStore(tmp_path / "keys.db")
+    token = keystore.mint("agent-a", ["default"])
+    monkeypatch.setenv("TAOS_LITELLM_KEYSTORE", str(tmp_path / "keys.db"))
+    monkeypatch.delenv("TAOS_AGENT_BUDGETS", raising=False)
+
+    result = await _auth(_FakeRequest(), token)
+    assert result.metadata["agent"] == "agent-a"

--- a/tests/test_litellm_auth.py
+++ b/tests/test_litellm_auth.py
@@ -56,8 +56,11 @@ async def test_master_key_bypasses_budget_check(tmp_path, monkeypatch):
     budgets.add_spend("some-agent", 1.0)
     monkeypatch.setenv("TAOS_AGENT_BUDGETS", str(tmp_path / "budgets.db"))
 
+    # Reaching this assertion at all proves the bypass: an over-budget agent
+    # would have raised HTTPException(429) before returning. We assert a valid
+    # auth object rather than the exact api_key, which litellm hashes.
     result = await _auth(_FakeRequest(), "sk-taos-master-123")
-    assert result.api_key == "sk-taos-master-123"
+    assert result is not None
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm_callback.py
+++ b/tests/test_litellm_callback.py
@@ -278,3 +278,67 @@ async def test_callback_never_raises_on_bad_input():
 def test_taos_callback_importable():
     from tinyagentos.litellm_callback import taos_callback
     assert taos_callback is not None
+
+
+# ---------------------------------------------------------------------------
+# TaosLiteLLMCallback — budget spend increment (agent governance Slice 2)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_budget_store_cache(monkeypatch):
+    """Isolate the callback's lazily-cached budget store handle."""
+    import tinyagentos.litellm_callback as cb_mod
+    monkeypatch.setattr(cb_mod, "_budget_store", None)
+    monkeypatch.setattr(cb_mod, "_budget_store_path", None)
+    monkeypatch.delenv("TAOS_AGENT_BUDGETS", raising=False)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_success_event_with_positive_cost_increments_spend(tmp_path, monkeypatch):
+    try:
+        from tinyagentos.litellm_callback import TaosLiteLLMCallback
+    except ImportError:
+        pytest.skip("litellm not installed")
+
+    from tinyagentos.agent_budget_store import AgentBudgetStore
+    budget_path = tmp_path / "budgets.db"
+    monkeypatch.setenv("TAOS_AGENT_BUDGETS", str(budget_path))
+
+    cb = TaosLiteLLMCallback()
+    cb._post = AsyncMock()
+
+    from datetime import datetime, timezone
+    t0 = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 1, 1, 10, 0, 1, tzinfo=timezone.utc)
+    resp = _make_response()
+    kwargs = _make_kwargs(key_alias="taos-spend-agent")
+
+    await cb.async_log_success_event(kwargs, resp, t0, t1)
+
+    store = AgentBudgetStore(budget_path)
+    rec = store.get("spend-agent")
+    assert rec is not None
+    assert rec["spend_usd"] == pytest.approx(0.001)
+
+
+@pytest.mark.asyncio
+async def test_success_event_without_budget_env_does_not_crash(monkeypatch):
+    try:
+        from tinyagentos.litellm_callback import TaosLiteLLMCallback
+    except ImportError:
+        pytest.skip("litellm not installed")
+
+    monkeypatch.delenv("TAOS_AGENT_BUDGETS", raising=False)
+
+    cb = TaosLiteLLMCallback()
+    cb._post = AsyncMock()
+
+    from datetime import datetime, timezone
+    t0 = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+    t1 = datetime(2024, 1, 1, 10, 0, 1, tzinfo=timezone.utc)
+    resp = _make_response()
+    kwargs = _make_kwargs(key_alias="taos-spend-agent-2")
+
+    # Must not raise even though TAOS_AGENT_BUDGETS is unset.
+    await cb.async_log_success_event(kwargs, resp, t0, t1)

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1428,6 +1428,17 @@ class TestAgentBudgetRoutes:
         resp = await client.put("/api/agents/test-agent/budget", json={"max_budget_usd": -5.0})
         assert resp.status_code == 400
 
+    async def test_put_budget_rejects_non_finite(self, client):
+        # NaN/Infinity would slip past a bare "< 0" check and disable the cap
+        # (spend >= NaN is always False), so they must be rejected with 400.
+        for bad in ("NaN", "Infinity", "-Infinity"):
+            resp = await client.put(
+                "/api/agents/test-agent/budget",
+                content=f'{{"max_budget_usd": {bad}}}',
+                headers={"content-type": "application/json"},
+            )
+            assert resp.status_code == 400, f"{bad} was not rejected"
+
     async def test_put_budget_not_found_agent(self, client):
         resp = await client.put("/api/agents/no-such-agent/budget", json={"max_budget_usd": 10.0})
         assert resp.status_code == 404

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1391,3 +1391,60 @@ class TestDeployRamPreflight:
         assert resp.status_code == 400
         body = resp.json()
         assert "Unknown framework" in body["error"]
+
+
+@pytest.mark.asyncio
+class TestAgentBudgetRoutes:
+    """Agent governance Slice 2 — per-agent LLM budget admin API."""
+
+    async def test_get_budget_defaults_when_unset(self, client):
+        resp = await client.get("/api/agents/test-agent/budget")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["max_budget_usd"] is None
+        assert data["spend_usd"] == 0
+
+    async def test_get_budget_not_found_agent(self, client):
+        resp = await client.get("/api/agents/no-such-agent/budget")
+        assert resp.status_code == 404
+
+    async def test_put_budget_sets_cap(self, client):
+        resp = await client.put("/api/agents/test-agent/budget", json={"max_budget_usd": 25.0})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["max_budget_usd"] == 25.0
+        assert data["spend_usd"] == 0
+
+        resp2 = await client.get("/api/agents/test-agent/budget")
+        assert resp2.json()["max_budget_usd"] == 25.0
+
+    async def test_put_budget_null_clears_cap(self, client):
+        await client.put("/api/agents/test-agent/budget", json={"max_budget_usd": 25.0})
+        resp = await client.put("/api/agents/test-agent/budget", json={"max_budget_usd": None})
+        assert resp.status_code == 200
+        assert resp.json()["max_budget_usd"] is None
+
+    async def test_put_budget_rejects_negative(self, client):
+        resp = await client.put("/api/agents/test-agent/budget", json={"max_budget_usd": -5.0})
+        assert resp.status_code == 400
+
+    async def test_put_budget_not_found_agent(self, client):
+        resp = await client.put("/api/agents/no-such-agent/budget", json={"max_budget_usd": 10.0})
+        assert resp.status_code == 404
+
+    async def test_reset_zeroes_spend_keeps_cap(self, client, app, tmp_data_dir):
+        await client.put("/api/agents/test-agent/budget", json={"max_budget_usd": 10.0})
+
+        from tinyagentos.agent_budget_store import AgentBudgetStore, default_budget_path
+        store = AgentBudgetStore(default_budget_path(tmp_data_dir))
+        store.add_spend("test-agent", 7.5)
+
+        resp = await client.post("/api/agents/test-agent/budget/reset")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["spend_usd"] == 0
+        assert data["max_budget_usd"] == 10.0
+
+    async def test_reset_not_found_agent(self, client):
+        resp = await client.post("/api/agents/no-such-agent/budget/reset")
+        assert resp.status_code == 404

--- a/tinyagentos/agent_budget_store.py
+++ b/tinyagentos/agent_budget_store.py
@@ -1,0 +1,152 @@
+"""Cross-process per-agent LLM spend/budget store.
+
+Mirrors ``tinyagentos.litellm_keystore`` in shape: raw sqlite3 with WAL so
+the controller (writer) and the LiteLLM auth/callback hooks running in the
+proxy subprocess (reader/writer) can share one file with no server process
+and no prisma. This is deliberately its own store rather than an extension
+of the key store: keys and budgets have different lifecycles (a key is
+re-minted on re-scope; a budget persists and accumulates spend across many
+keys/agent restarts).
+
+Scope: set/get a cap, accumulate spend, check whether an agent is over
+budget, reset spend. No period-based auto-reset and no auto-pause — those
+are explicit follow-ups.
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_budgets (
+    agent           TEXT PRIMARY KEY,
+    max_budget_usd  REAL,
+    spend_usd       REAL NOT NULL DEFAULT 0,
+    updated_ts      REAL NOT NULL
+);
+"""
+
+
+class AgentBudgetStore:
+    """SQLite-backed per-agent budget store, safe for cross-process read/write.
+
+    The controller sets/reads caps and can reset spend; the LiteLLM
+    subprocess's callback increments spend on every completion and the auth
+    hook reads ``is_over_budget`` before allowing a call through. WAL mode
+    keeps a concurrent reader from blocking on a writer.
+    """
+
+    def __init__(self, path: str | Path):
+        self.path = str(path)
+        self._init()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=5)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def _init(self) -> None:
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA)
+
+    def get(self, agent: str) -> dict | None:
+        """Return ``{agent, max_budget_usd, spend_usd}``, or None if unset."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT agent, max_budget_usd, spend_usd FROM agent_budgets WHERE agent = ?",
+                (agent,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "agent": row["agent"],
+            "max_budget_usd": row["max_budget_usd"],
+            "spend_usd": row["spend_usd"],
+        }
+
+    def set_budget(self, agent: str, max_budget_usd: float | None) -> None:
+        """Upsert an agent's cap. ``None`` clears it (unlimited).
+
+        Preserves existing spend_usd; creates the row with spend_usd=0 if
+        the agent has no row yet.
+        """
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO agent_budgets (agent, max_budget_usd, spend_usd, updated_ts)
+                VALUES (?, ?, 0, ?)
+                ON CONFLICT(agent) DO UPDATE SET
+                    max_budget_usd = excluded.max_budget_usd,
+                    updated_ts = excluded.updated_ts
+                """,
+                (agent, max_budget_usd, now),
+            )
+
+    def add_spend(self, agent: str, delta_usd: float) -> float:
+        """Atomically increment an agent's spend by ``delta_usd``.
+
+        Creates the row (max_budget_usd=NULL, i.e. unlimited) if absent.
+        Non-positive deltas are ignored; returns the current spend (0 if no
+        row exists) without writing.
+        """
+        if delta_usd <= 0:
+            existing = self.get(agent)
+            return existing["spend_usd"] if existing else 0.0
+        now = time.time()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO agent_budgets (agent, max_budget_usd, spend_usd, updated_ts)
+                VALUES (?, NULL, ?, ?)
+                ON CONFLICT(agent) DO UPDATE SET
+                    spend_usd = agent_budgets.spend_usd + excluded.spend_usd,
+                    updated_ts = excluded.updated_ts
+                """,
+                (agent, delta_usd, now),
+            )
+            row = conn.execute(
+                "SELECT spend_usd FROM agent_budgets WHERE agent = ?",
+                (agent,),
+            ).fetchone()
+        return row["spend_usd"]
+
+    def reset_spend(self, agent: str) -> None:
+        """Zero an agent's spend, keeping its cap. No-op if no row exists."""
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE agent_budgets SET spend_usd = 0, updated_ts = ? WHERE agent = ?",
+                (time.time(), agent),
+            )
+
+    def is_over_budget(self, agent: str) -> bool:
+        """True iff a row exists, has a cap set, and spend has reached it."""
+        rec = self.get(agent)
+        if rec is None or rec["max_budget_usd"] is None:
+            return False
+        return rec["spend_usd"] >= rec["max_budget_usd"]
+
+    def list(self) -> list[dict]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT agent, max_budget_usd, spend_usd FROM agent_budgets ORDER BY agent"
+            ).fetchall()
+        return [
+            {"agent": r["agent"], "max_budget_usd": r["max_budget_usd"], "spend_usd": r["spend_usd"]}
+            for r in rows
+        ]
+
+    def delete_agent(self, agent: str) -> bool:
+        """Remove an agent's budget row. Returns True if it existed."""
+        with self._connect() as conn:
+            cur = conn.execute("DELETE FROM agent_budgets WHERE agent = ?", (agent,))
+            return cur.rowcount > 0
+
+
+def default_budget_path(data_dir: str | Path) -> Path:
+    """Canonical budget store path for a controller data dir."""
+    return Path(data_dir) / ".agent_budgets.db"

--- a/tinyagentos/agent_budget_store.py
+++ b/tinyagentos/agent_budget_store.py
@@ -14,6 +14,7 @@ are explicit follow-ups.
 """
 from __future__ import annotations
 
+import math
 import sqlite3
 import time
 from pathlib import Path
@@ -72,8 +73,12 @@ class AgentBudgetStore:
         """Upsert an agent's cap. ``None`` clears it (unlimited).
 
         Preserves existing spend_usd; creates the row with spend_usd=0 if
-        the agent has no row yet.
+        the agent has no row yet. A non-finite cap (NaN/inf) is rejected: a
+        NaN cap would make ``is_over_budget`` always False and silently
+        disable enforcement, so the store refuses to persist one.
         """
+        if max_budget_usd is not None and not math.isfinite(max_budget_usd):
+            raise ValueError("max_budget_usd must be finite or None")
         now = time.time()
         with self._connect() as conn:
             conn.execute(

--- a/tinyagentos/litellm_auth.py
+++ b/tinyagentos/litellm_auth.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 _store = None
 _store_path = None
+_budget_store_cache = None
+_budget_store_cache_path = None
 
 
 def _keystore():
@@ -39,6 +41,24 @@ def _keystore():
         _store = LiteLLMKeyStore(path)
         _store_path = path
     return _store
+
+
+def _budget_store():
+    """Lazily open (and cache) the budget store from the env-provided path.
+
+    Returns None when the env var is unset — budgets are opt-in, so a
+    deploy that never configured them fails OPEN (no check at all) rather
+    than rejecting every call.
+    """
+    global _budget_store_cache, _budget_store_cache_path
+    path = os.environ.get("TAOS_AGENT_BUDGETS")
+    if not path:
+        return None
+    if _budget_store_cache is None or _budget_store_cache_path != path:
+        from tinyagentos.agent_budget_store import AgentBudgetStore
+        _budget_store_cache = AgentBudgetStore(path)
+        _budget_store_cache_path = path
+    return _budget_store_cache
 
 
 async def _requested_model(request) -> str | None:
@@ -84,6 +104,17 @@ async def user_api_key_auth(request, api_key: str):
 
     agent = rec["agent"]
     allowed = rec["allowed_models"] or []
+
+    # Hard-stop: reject calls for an agent that has exceeded its LLM
+    # budget. Fails open (no check) when budgets are not configured at all
+    # (env var unset), but once TAOS_AGENT_BUDGETS is set, an over-budget
+    # agent is blocked before a completion is ever dispatched.
+    budget_store = _budget_store()
+    if budget_store is not None and budget_store.is_over_budget(agent):
+        raise HTTPException(
+            status_code=429,
+            detail=f"agent '{agent}' has exceeded its LLM budget",
+        )
 
     # Defense in depth: enforce the per-agent model allowlist in-hook so
     # correctness does not depend on LiteLLM's post-auth enforcement (which

--- a/tinyagentos/litellm_callback.py
+++ b/tinyagentos/litellm_callback.py
@@ -47,6 +47,20 @@ def _read_local_token() -> str:
     return ""
 
 
+_budget_store = None
+_budget_store_path = None
+
+
+def _budget_store_for(path: str) -> Any:
+    """Lazily open (and cache) the budget store from the env-provided path."""
+    global _budget_store, _budget_store_path
+    if _budget_store is None or _budget_store_path != path:
+        from tinyagentos.agent_budget_store import AgentBudgetStore
+        _budget_store = AgentBudgetStore(path)
+        _budget_store_path = path
+    return _budget_store
+
+
 def _slug_from_alias(key_alias: str | None) -> str:
     """Extract agent slug from ``taos-<slug>`` key alias."""
     if key_alias and key_alias.startswith("taos-"):
@@ -166,6 +180,16 @@ try:
             slug = _slug_from_alias(key_alias)
             return slug, str(kwargs.get("model") or "")
 
+        def _record_spend(self, agent: str, cost_usd: float) -> None:
+            """Best-effort spend increment; never raises into the caller."""
+            path = os.environ.get("TAOS_AGENT_BUDGETS")
+            if not path:
+                return
+            try:
+                _budget_store_for(path).add_spend(agent, cost_usd)
+            except Exception as exc:
+                logger.warning("litellm_callback: budget spend increment failed: %s", exc)
+
         async def async_log_success_event(self, kwargs: dict, response_obj: Any, start_time: Any, end_time: Any) -> None:
             try:
                 slug, model = self._extract_slug_and_model(kwargs)
@@ -199,6 +223,8 @@ try:
                 })
                 if backend_name:
                     await self._post(self._notify_url, {"backend_name": backend_name})
+                if cost_usd and cost_usd > 0 and slug:
+                    self._record_spend(slug, cost_usd)
             except Exception as exc:
                 logger.warning("litellm_callback: success handler error: %s", exc)
 

--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -113,6 +113,7 @@ class LLMProxy:
         self._data_dir = data_dir
         self._process: subprocess.Popen | None = None
         self._keystore_cache = None
+        self._budget_store_cache = None
         # One-shot guard: if litellm is missing at start() (e.g. a pre-fix
         # update stripped the proxy extra), self-install it once per process
         # rather than retry the slow install on every start() call.
@@ -128,6 +129,17 @@ class LLMProxy:
             base = self._data_dir or self.config_dir
             self._keystore_cache = LiteLLMKeyStore(default_keystore_path(base))
         return self._keystore_cache
+
+    def _budget_store(self):
+        """Lazily open the in-house budget store (controller side)."""
+        if self._budget_store_cache is None:
+            from tinyagentos.agent_budget_store import (
+                AgentBudgetStore,
+                default_budget_path,
+            )
+            base = self._data_dir or self.config_dir
+            self._budget_store_cache = AgentBudgetStore(default_budget_path(base))
+        return self._budget_store_cache
 
     @property
     def url(self) -> str:
@@ -452,6 +464,8 @@ class LLMProxy:
             from tinyagentos.litellm_keystore import default_keystore_path
             base = self._data_dir or self.config_dir
             env["TAOS_LITELLM_KEYSTORE"] = str(default_keystore_path(base))
+            from tinyagentos.agent_budget_store import default_budget_path
+            env["TAOS_AGENT_BUDGETS"] = str(default_budget_path(base))
         elif self.database_url:
             # DATABASE_URL enables Postgres-backed virtual keys. Without it
             # LiteLLM still routes chat/embeddings fine but /key/generate
@@ -548,10 +562,16 @@ class LLMProxy:
                 # agent deployed without an explicit model is scoped to the
                 # default chat alias (still usable), not minted with an empty
                 # allowlist that the auth hook would then deny-all.
-                return self._keystore().mint(agent_name, models or ["default"])
+                token = self._keystore().mint(agent_name, models or ["default"])
             except Exception as e:
                 logger.warning("inhouse key mint failed for %s: %s", agent_name, e)
                 return None
+            if max_budget is not None:
+                try:
+                    self._budget_store().set_budget(agent_name, max_budget)
+                except Exception as e:
+                    logger.warning("inhouse budget set failed for %s: %s", agent_name, e)
+            return token
         if not self.is_running():
             return None
         # LiteLLM virtual keys require a Postgres DB. Without one,

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import time
 from collections import OrderedDict
 
@@ -1247,7 +1248,7 @@ def _budget_store_for_request(request: Request):
 
 def _budget_response(agent_name: str, rec: dict | None) -> dict:
     if rec is None:
-        return {"agent": agent_name, "max_budget_usd": None, "spend_usd": 0}
+        return {"agent": agent_name, "max_budget_usd": None, "spend_usd": 0.0}
     return {"agent": rec["agent"], "max_budget_usd": rec["max_budget_usd"], "spend_usd": rec["spend_usd"]}
 
 
@@ -1273,9 +1274,11 @@ async def set_agent_budget(request: Request, name: str, body: AgentBudgetUpdate)
     agent = find_agent(config, name)
     if not agent:
         return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
-    if body.max_budget_usd is not None and body.max_budget_usd < 0:
+    if body.max_budget_usd is not None and (
+        not math.isfinite(body.max_budget_usd) or body.max_budget_usd < 0
+    ):
         return JSONResponse(
-            {"error": "max_budget_usd must be null or a non-negative number"},
+            {"error": "max_budget_usd must be null or a finite non-negative number"},
             status_code=400,
         )
     store = _budget_store_for_request(request)

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1237,3 +1237,59 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
         "current": agent.get("model"),
         "key_rescoped": key_rescoped,
     }
+
+
+def _budget_store_for_request(request: Request):
+    from tinyagentos.agent_budget_store import AgentBudgetStore, default_budget_path
+    data_dir = request.app.state.data_dir
+    return AgentBudgetStore(default_budget_path(data_dir))
+
+
+def _budget_response(agent_name: str, rec: dict | None) -> dict:
+    if rec is None:
+        return {"agent": agent_name, "max_budget_usd": None, "spend_usd": 0}
+    return {"agent": rec["agent"], "max_budget_usd": rec["max_budget_usd"], "spend_usd": rec["spend_usd"]}
+
+
+@router.get("/api/agents/{name}/budget")
+async def get_agent_budget(request: Request, name: str):
+    """Return an agent's LLM budget cap and current spend."""
+    config = request.app.state.config
+    agent = find_agent(config, name)
+    if not agent:
+        return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
+    store = _budget_store_for_request(request)
+    return _budget_response(name, store.get(name))
+
+
+class AgentBudgetUpdate(BaseModel):
+    max_budget_usd: float | None
+
+
+@router.put("/api/agents/{name}/budget")
+async def set_agent_budget(request: Request, name: str, body: AgentBudgetUpdate):
+    """Set (or clear, with null) an agent's LLM budget cap."""
+    config = request.app.state.config
+    agent = find_agent(config, name)
+    if not agent:
+        return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
+    if body.max_budget_usd is not None and body.max_budget_usd < 0:
+        return JSONResponse(
+            {"error": "max_budget_usd must be null or a non-negative number"},
+            status_code=400,
+        )
+    store = _budget_store_for_request(request)
+    store.set_budget(name, body.max_budget_usd)
+    return _budget_response(name, store.get(name))
+
+
+@router.post("/api/agents/{name}/budget/reset")
+async def reset_agent_budget(request: Request, name: str):
+    """Zero an agent's recorded spend, keeping its cap in place."""
+    config = request.app.state.config
+    agent = find_agent(config, name)
+    if not agent:
+        return JSONResponse({"error": f"Agent '{name}' not found"}, status_code=404)
+    store = _budget_store_for_request(request)
+    store.reset_spend(name)
+    return _budget_response(name, store.get(name))


### PR DESCRIPTION
## Summary

Agent governance Slice 2: per-agent LLM spend caps with a hard-stop, following the same pattern as the existing in-house LiteLLM key store.

- New `tinyagentos/agent_budget_store.py` (`AgentBudgetStore`): raw sqlite3 + WAL, cross-process by design (opened by path from both the controller and the LiteLLM proxy subprocess), mirroring `litellm_keystore.py` exactly. Tracks `max_budget_usd` (null = unlimited) and `spend_usd` per agent.
- Spend increment hook: `litellm_callback.py`'s `async_log_success_event` adds each completion's `cost_usd` to the resolved agent's spend via `TAOS_AGENT_BUDGETS`. Best-effort, never raises.
- Hard-stop hook: `litellm_auth.py`'s `user_api_key_auth` rejects a request with 429 if the resolved agent is over budget, before the call is ever dispatched. Fails open when `TAOS_AGENT_BUDGETS` is unset (budgets are opt-in); the master-key admin passthrough is never budget-checked.
- `llm_proxy.py`: `start()` now exports `TAOS_AGENT_BUDGETS` alongside `TAOS_LITELLM_KEYSTORE`; `create_agent_key()`'s in-house branch now records `max_budget` via `set_budget()` instead of silently dropping it.
- Admin API in `routes/agents.py`: `GET/PUT /api/agents/{name}/budget` and `POST /api/agents/{name}/budget/reset`.

## Follow-ups (explicitly out of scope for this slice)

- No auto-pause of an agent when it exceeds budget (this slice is just the 429 hard-stop on LLM calls).
- No reconciliation of the agent `paused` vs `status` split.
- No frontend/UI.
- No period-based auto-reset (manual reset endpoint only).

## Test plan

- [x] `tests/test_agent_budget_store.py` — set/get, add_spend accumulation + non-positive-delta handling, reset, is_over_budget (capped/unlimited/no-row), cross-process persistence.
- [x] `tests/test_litellm_auth.py` (new) — over-budget agent gets 429, master key never budget-checked, no-row and unconfigured-env both pass through.
- [x] `tests/test_litellm_callback.py` — success event with positive cost increments spend; unset `TAOS_AGENT_BUDGETS` does not crash.
- [x] `tests/test_routes_agents.py` — GET/PUT/reset round-trip, PUT rejects negative.

```
uv run python3 -m pytest tests/test_agent_budget_store.py tests/test_litellm_callback.py tests/test_litellm_master_key.py tests/test_litellm_auth.py tests/test_routes_agents.py -q
103 passed, 16 skipped in 24.28s
```

(The 16 skips are pre-existing: `litellm` is an optional "proxy" extra not installed in the dev test env, matching the existing skip pattern in `test_litellm_callback.py`.)

```
uv run python3 -m pytest tests/ -k "(budget or litellm or agents_route) and not test_poll_loop_continues_after_timeout_abort" -q --ignore=tests/e2e
177 passed, 16 skipped, 8663 deselected in 18.90s
```

One test excluded from that broader run: `tests/test_health_poll_budget.py::test_poll_loop_continues_after_timeout_abort` hangs identically on unmodified `origin/dev` (verified via `git stash`) — pre-existing, unrelated to this change, only matched by the `-k budget` filter's substring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-agent LLM budget controls: view spend/cap, set or clear a cap, and reset spend via agent budget API endpoints.
  * Enforced budget limits during authentication, returning `429` for agents over their cap.
  * Automatically tracked and accumulated spend from successful LLM calls when budget tracking is enabled.
* **Bug Fixes**
  * Budget checks remain non-blocking when budgets aren’t configured or no cap exists for an agent.
  * Gracefully handles missing budget records (e.g., view/reset behave predictably).
* **Tests**
  * Added comprehensive end-to-end coverage for budget storage, routes, authentication, and spend callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->