### PR TITLE
fix(models): rkllama downloads report real progress + show installed (#1648)

### DIFF
--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -600,3 +600,42 @@ class TestStartInstallerTask:
         await dm._running["dl-installer"]
         assert task.status == "error"
         assert task.error == "connection refused"
+
+    @pytest.mark.asyncio
+    async def test_progress_callback_updates_task_bytes(self):
+        # A caller may pass a factory (callable taking on_progress) instead
+        # of a bare coroutine, so an installer that streams incremental
+        # progress (e.g. RkllamaInstaller.install()) can update this task's
+        # downloaded_bytes/total_bytes as it goes, instead of leaving
+        # percent stuck at 0 until the task finishes.
+        dm = DownloadManager()
+
+        def _install_factory(on_progress):
+            async def _run():
+                on_progress(50, 200)
+                on_progress(200, 200)
+                return {"success": True}
+            return _run()
+
+        task = dm.start_installer_task("dl-installer", _install_factory)
+        assert task.downloaded_bytes == 0
+        assert task.total_bytes == 0
+        await dm._running["dl-installer"]
+        assert task.status == "complete"
+        assert task.downloaded_bytes == 200
+        assert task.total_bytes == 200
+
+    @pytest.mark.asyncio
+    async def test_bare_coroutine_without_progress_still_works(self):
+        # Backward compatibility: a plain coroutine (no progress reporting)
+        # must keep working exactly as before.
+        dm = DownloadManager()
+
+        async def _install():
+            return {"success": True}
+
+        task = dm.start_installer_task("dl-installer", _install())
+        await dm._running["dl-installer"]
+        assert task.status == "complete"
+        assert task.downloaded_bytes == 0
+        assert task.total_bytes == 0

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -225,6 +225,74 @@ async def _no_sleep(*_a, **_k):
     return None
 
 
+class TestInstallProgress:
+    """install() must forward /api/pull's ndjson progress lines to an
+    optional on_progress callback, and never let a malformed line raise.
+    """
+
+    def _installer(self):
+        return RkllamaInstaller(rkllama_url="http://localhost:7833")
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_progress_lines_forwarded_to_callback(self):
+        pull_body = (
+            '{"status":"downloading","completed":1000,"total":10000}\n'
+            '{"status":"downloading","completed":5000,"total":10000}\n'
+            '{"status":"downloading","completed":10000,"total":10000}\n'
+            '{"status":"success"}\n'
+        )
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text=pull_body)
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": [{"name": "rkllama-x"}]})
+        )
+        calls = []
+        res = await self._installer().install(
+            "rkllama-x", {}, variant=_VARIANT, on_progress=lambda c, t: calls.append((c, t))
+        )
+        assert res["success"] is True
+        assert calls == [(1000, 10000), (5000, 10000), (10000, 10000)]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_malformed_lines_ignored_not_raised(self):
+        pull_body = (
+            "not json at all\n"
+            '{"status":"downloading"}\n'
+            '{"status":"downloading","completed":"oops","total":10000}\n'
+            '{"status":"downloading","completed":250,"total":1000}\n'
+        )
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text=pull_body)
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": [{"name": "rkllama-x"}]})
+        )
+        calls = []
+        res = await self._installer().install(
+            "rkllama-x", {}, variant=_VARIANT, on_progress=lambda c, t: calls.append((c, t))
+        )
+        assert res["success"] is True
+        assert calls == [(250, 1000)]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_no_callback_still_works(self):
+        # Default on_progress=None must not change existing behaviour.
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(
+                200, text='{"status":"downloading","completed":1,"total":2}\n'
+            )
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": [{"name": "rkllama-x"}]})
+        )
+        res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
+        assert res["success"] is True
+
+
 class TestRkllamaServiceManifest:
     """The rkllama service manifest (install.method: script) must point at a
     script that actually exists. ScriptInstaller resolves install.script

--- a/tests/test_routes_models.py
+++ b/tests/test_routes_models.py
@@ -328,6 +328,65 @@ class TestModelDownload:
         assert task.status == "error"
         assert task.error == "pull failed"
 
+    async def test_rkllama_variant_success_records_registry_and_refreshes_catalog(
+        self, models_app, models_client
+    ):
+        """rkllama pulls the weight into its own model store, not
+        models_dir, so a successful install must leave a breadcrumb (the
+        install registry) and force an immediate catalog refresh -- otherwise
+        the model would show as not-downloaded until the next 30s poll tick
+        (#1648).
+        """
+        fake_catalog = MagicMock()
+        fake_catalog.refresh = AsyncMock()
+        # Live evidence for the manifest id only (not the full variant id) so
+        # this exercises registry_corroborated's has_live_evidence path
+        # rather than the pre-existing _matches_live_backend exact match.
+        fake_catalog.all_models = MagicMock(return_value=[{"name": "test-model:latest"}])
+        models_app.state.backend_catalog = fake_catalog
+
+        with patch(
+            "tinyagentos.installers.rkllama_installer.RkllamaInstaller.install",
+            new=AsyncMock(return_value={"success": True, "app_id": "test-model"}),
+        ):
+            resp = await models_client.post(
+                "/api/models/download",
+                json={"app_id": "test-model", "variant_id": "npu"},
+            )
+        download_id = resp.json()["download_id"]
+        await models_app.state.download_manager._running[download_id]
+
+        fake_catalog.refresh.assert_awaited_once()
+        installed = models_app.state.registry.list_installed()
+        assert any(row["id"] == "test-model" for row in installed)
+
+        list_resp = await models_client.get("/api/models")
+        model = next(m for m in list_resp.json()["models"] if m["id"] == "test-model")
+        npu_variant = next(v for v in model["variants"] if v["id"] == "npu")
+        assert npu_variant["downloaded"] is True
+
+    async def test_rkllama_variant_failure_skips_registry_and_catalog_refresh(
+        self, models_app, models_client
+    ):
+        fake_catalog = MagicMock()
+        fake_catalog.refresh = AsyncMock()
+        models_app.state.backend_catalog = fake_catalog
+
+        with patch(
+            "tinyagentos.installers.rkllama_installer.RkllamaInstaller.install",
+            new=AsyncMock(return_value={"success": False, "error": "pull failed"}),
+        ):
+            resp = await models_client.post(
+                "/api/models/download",
+                json={"app_id": "test-model", "variant_id": "npu"},
+            )
+        download_id = resp.json()["download_id"]
+        await models_app.state.download_manager._running[download_id]
+
+        fake_catalog.refresh.assert_not_awaited()
+        installed = models_app.state.registry.list_installed()
+        assert not any(row["id"] == "test-model" for row in installed)
+
 
 @pytest.mark.asyncio
 class TestModelRecommendations:

--- a/tinyagentos/download_manager.py
+++ b/tinyagentos/download_manager.py
@@ -93,12 +93,25 @@ class DownloadManager:
         coroutine (e.g. ``RkllamaInstaller.install()``, which pulls the
         weight via the backend's own ``/api/pull`` instead of a raw HTTP/
         torrent transfer) using the same DownloadTask the caller already
-        polls via :meth:`get_progress`. These installers don't report
-        incremental byte progress, so ``percent`` stays at 0 until the
-        task finishes.
+        polls via :meth:`get_progress`.
+
+        ``coro`` is either a plain coroutine (no progress reporting -- the
+        task's ``percent`` stays at 0 until it finishes), or a callable
+        accepting a single ``on_progress(completed, total)`` callback and
+        returning the coroutine to run. The callable form lets an installer
+        that streams incremental progress (e.g. rkllama's ndjson ``/api/pull``)
+        update this task's ``downloaded_bytes``/``total_bytes`` as it goes.
         """
         task = DownloadTask(id=download_id, url="", dest=Path())
         self._tasks[download_id] = task
+
+        def _on_progress(completed: int, total: int) -> None:
+            task.downloaded_bytes = completed
+            task.total_bytes = total
+
+        if callable(coro) and not asyncio.iscoroutine(coro):
+            coro = coro(_on_progress)
+
         self._running[download_id] = asyncio.create_task(self._run_installer(task, coro))
         return task
 

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -15,11 +15,12 @@ URL), so we don't need any extra fields on the manifest.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import re
 import socket
 import urllib.request
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 import httpx
@@ -95,6 +96,28 @@ def default_rkllama_url() -> str:
     return f"http://localhost:{_DEFAULT_RKLLAMA_PORT}"
 
 
+def _report_pull_progress(line: str, on_progress: Callable[[int, int], None]) -> None:
+    """Parse one ndjson line from rkllama's /api/pull stream and forward
+    ``(completed, total)`` to ``on_progress``.
+
+    rkllama's pull endpoint is Ollama-style ndjson, e.g.
+    ``{"status":"downloading","completed":1234,"total":56789}``. Lines
+    without both numeric fields (status-only messages, blank keepalives) are
+    silently ignored -- a stray or malformed line must never abort the
+    install.
+    """
+    try:
+        data = json.loads(line)
+    except (TypeError, ValueError):
+        return
+    if not isinstance(data, dict):
+        return
+    completed = data.get("completed")
+    total = data.get("total")
+    if isinstance(completed, (int, float)) and isinstance(total, (int, float)) and total > 0:
+        on_progress(int(completed), int(total))
+
+
 def parse_hf_resolve_url(url: str) -> tuple[str, str, str]:
     """Return (user, repo, filename) for an HF resolve URL.
 
@@ -130,6 +153,7 @@ class RkllamaInstaller(AppInstaller):
         app_id: str,
         install_config: dict,
         variant: dict | None = None,
+        on_progress: Callable[[int, int], None] | None = None,
         **_: Any,
     ) -> dict:
         if not variant:
@@ -174,6 +198,8 @@ class RkllamaInstaller(AppInstaller):
                     async for line in resp.aiter_lines():
                         if line:
                             last_line = line
+                            if on_progress is not None:
+                                _report_pull_progress(line, on_progress)
                     logger.info(
                         "rkllama install: pull complete for %s (last line: %s)",
                         app_id, last_line[:200],

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -365,10 +365,40 @@ async def download_model(request: Request, body: DownloadRequest):
         )
 
         installer = RkllamaInstaller(rkllama_url=resolve_rkllama_url(None))
-        dm.start_installer_task(
-            download_id,
-            installer.install(body.app_id, {}, variant=variant),
-        )
+        catalog = getattr(request.app.state, "backend_catalog", None)
+
+        async def _install_and_record(on_progress):
+            result = await installer.install(
+                body.app_id, {}, variant=variant, on_progress=on_progress
+            )
+            if result.get("success"):
+                # rkllama pulls the weight into its own model store, not
+                # models_dir, so the disk scan in list_models() never sees it.
+                # Record the install as a registry breadcrumb (corroborated by
+                # live-backend evidence, see _model_to_dict) and force an
+                # immediate catalog refresh so the newly pulled model shows up
+                # in all_models() right away instead of waiting for the next
+                # poll tick.
+                try:
+                    registry.mark_installed(
+                        body.app_id, variant.get("id") or "latest", state="installed"
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to record rkllama install for %s in registry",
+                        body.app_id, exc_info=True,
+                    )
+                if catalog is not None:
+                    try:
+                        await catalog.refresh()
+                    except Exception:
+                        logger.warning(
+                            "Backend catalog refresh after rkllama install failed for %s",
+                            body.app_id, exc_info=True,
+                        )
+            return result
+
+        dm.start_installer_task(download_id, _install_and_record)
         return {
             "status": "started",
             "download_id": download_id,


### PR DESCRIPTION
## Summary

Fixes #1648 — a **beta.27 regression on RK3588** (rkllama backend): model downloads sit at 0% forever and never show as installed, even though the weight downloads fine. Blocking a community tester.

Root cause: variants declaring `requires.backends: [{id: rkllama}]` install via `RkllamaInstaller.install()` (not the byte-tracking `start_download`), which exposed two defects.

## Defect 1 — progress stuck at 0%

`RkllamaInstaller.install` opened `/api/pull` and drained `aiter_lines()` but **threw every line away**. rkllama streams Ollama-style ndjson (`{"status":"downloading","completed":N,"total":M}`). Meanwhile `DownloadManager._run_installer` only flipped `task.status`, never `total_bytes`/`downloaded_bytes`, so `_task_to_dict` computed `percent=0` for the entire pull.

**Fix:**
- `start_installer_task` now also accepts a coroutine *factory* that receives an `on_progress(completed, total)` callback which updates the task's byte counters. Bare coroutines still work unchanged.
- `install()` gained an optional `on_progress` kwarg. Each ndjson line is `json.loads`-ed defensively; lines with numeric `completed`+`total` call the callback. Malformed lines are ignored, never raised. Final `/api/tags` verification is unchanged.
- `download_model` wires the callback through.

## Defect 2 — never shows installed

rkllama pulls the weight into its **own** model store, not taOS's `models_dir`, so the disk scan never finds it. A model only shows installed via live-backend evidence or a corroborated registry entry — but after a fresh pull the catalog live list is stale and nothing recorded the install.

**Fix:** after a successful rkllama install, `download_model` now:
1. Records the install via `registry.mark_installed(app_id, variant_id, state="installed")` (a breadcrumb, corroborated by live evidence per `_model_to_dict`).
2. Forces `backend_catalog.refresh()` so the newly registered model appears in `all_models()` immediately instead of waiting for the next 30s poll tick.

Frontend unchanged: `ModelsApp`'s `onComplete` already re-fetches `/api/models`, which now reports the variant as downloaded, and `_task_to_dict` percent now reflects real bytes.

## Testing

Mock-tested only — **no real RK3588 hardware**; all rkllama HTTP is mocked (respx/AsyncMock).

- `tests/test_rkllama_installer.py` — progress lines forwarded to callback; malformed lines ignored; no-callback path still works.
- `tests/test_download_manager.py` — factory form updates task bytes to reach 100%; bare-coroutine backward compatibility.
- `tests/test_routes_models.py` — successful rkllama install records registry + triggers catalog refresh and the variant reports `downloaded: true` via `/api/models`; failed install skips both.

```
python3 -m pytest tests/test_rkllama_installer.py tests/test_download_manager.py tests/test_routes_models.py -q
93 passed in 7.18s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installer progress now updates download status as it runs, and malformed progress messages are safely ignored.
  * Rkllama model installs are now recorded immediately after success, and model listings refresh right away so new installs appear sooner.
  * Downloads without progress reporting continue to finish normally with zeroed progress values.

* **Tests**
  * Added coverage for progress reporting, backward compatibility, and successful/failed model install flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->