### PR TITLE
release: 1.0.0-beta.30 (rkllama download fix, agent budget hard-stops, frontend security bumps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.30] - 2026-07-05
+
+### Fixed
+- Model downloads on RK3588 (rkllama backend) no longer sit at 0% forever. Downloads that install through rkllama now report real progress as the weight is pulled, and a completed model is recorded and shown as installed immediately instead of looking stuck. Reported by @mandresve (#1648).
+
+### Added
+- Agent governance: per-agent LLM budget hard-stops. You can set a spend cap per agent; once an agent reaches its cap its model calls are rejected with a clear over-budget error before any request is dispatched. Spend accrues from real usage and the cap is settable and resettable via an admin API (#160).
+
+### Security
+- Updated frontend dependencies to clear known advisories (lodash-es code-injection and prototype-pollution, uuid, nanoid) via a grouped lockfile bump (#1655).
+
 ## [1.0.0-beta.29] - 2026-07-05
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.29",
+  "version": "1.0.0-beta.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.29",
+      "version": "1.0.0-beta.30",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.29",
+  "version": "1.0.0-beta.30",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.29"
+version = "1.0.0-beta.30"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.29"
+__version__ = "1.0.0-beta.30"

--- a/uv.lock
+++ b/uv.lock
@@ -3004,7 +3004,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b29"
+version = "1.0.0b30"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts 1.0.0-beta.30.

- fix(models): rkllama model downloads report real progress + show installed on RK3588 (#1648, #1658) — was stuck at 0% + never marked installed.
- feat(governance): per-agent LLM budget hard-stops (#160, #1657).
- security: frontend dependency advisories cleared via grouped spa-deps bump (#1655).

Versions bumped across pyproject.toml, tinyagentos/__init__.py, desktop/package.json, package-lock.json, uv.lock (normalized 1.0.0b30), CHANGELOG. test_version_lock_sync green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-agent spending caps for LLM usage; once a limit is reached, further calls are blocked with a clear over-budget message.

* **Bug Fixes**
  * Fixed RK3588 model downloads on the rkllama backend to show accurate progress and mark installs complete immediately when finished.

* **Security**
  * Updated several frontend dependencies to address known security advisories.

* **Chores**
  * Bumped the release version to 1.0.0-beta.30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->