### PR TITLE
feat(governance): agent org model - roles/titles/reporting lines + gated delegation (#161)

### DIFF
--- a/tests/governance/test_policy_store.py
+++ b/tests/governance/test_policy_store.py
@@ -24,6 +24,9 @@ class TestActionClasses:
         assert classify("file_read") is None
         assert classify("nonexistent_tool") is None
 
+    def test_delegate_classified(self):
+        assert classify("delegate") == "delegate"
+
 
 @pytest.mark.asyncio
 class TestConservativeSeed:
@@ -39,6 +42,12 @@ class TestConservativeSeed:
 
     async def test_unclassified_action_class_defaults_to_allow(self, store):
         assert await store.effective_effect("agent-a", "some-harmless-class") == "allow"
+
+    async def test_delegate_is_sensitive_and_defaults_to_require_approval(self, store):
+        """#161 gated delegation: the delegate action class is part of the
+        conservative default posture, same as code-exec/deploy/etc."""
+        assert "delegate" in SENSITIVE_ACTION_CLASSES
+        assert await store.effective_effect("agent-a", "delegate") == "require_approval"
 
     async def test_reinit_does_not_duplicate_seed(self, tmp_path):
         db_path = tmp_path / "policies.db"

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -11,6 +11,7 @@ from tinyagentos.agent_registry_store import (
     _b64url_decode,
     _b64url_encode,
     _migration_v2_strip_at_display_name,
+    _migration_v3_add_org_fields,
     _row_to_dict,
     _slugify,
     load_or_create_signing_keypair,
@@ -885,3 +886,254 @@ class TestMigrationV2StripAtDisplayName:
         after = await s2.get(row["canonical_id"])
         assert after["display_name"] == "auto-migrated"
         await s2.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration v3: add title + reports_to columns (#161 org model)
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationV3AddOrgFields:
+    @pytest.mark.asyncio
+    async def test_columns_added_without_data_loss(self, store):
+        """Running the guarded migration on an existing DB adds title +
+        reports_to without touching any pre-existing row data."""
+        row = await store.register(
+            framework="openclaw",
+            display_name="Pre-existing Agent",
+            user_id="user-1",
+            capabilities=["read"],
+        )
+        cid = row["canonical_id"]
+
+        # The migration already ran once via _post_init on store init; run it
+        # again directly to prove it's idempotent and non-destructive.
+        await _migration_v3_add_org_fields(store._db)
+
+        after = await store.get(cid)
+        assert after["display_name"] == "Pre-existing Agent"
+        assert after["user_id"] == "user-1"
+        assert after["capabilities"] == ["read"]
+        assert after["title"] is None
+        assert after["reports_to"] is None
+
+    @pytest.mark.asyncio
+    async def test_adds_columns_on_reopen(self, tmp_path):
+        """A pre-existing DB (created before title/reports_to existed)
+        gains both columns on the next store init with no data loss."""
+        db_path = tmp_path / "reopen_test.db"
+        s1 = AgentRegistryStore(db_path)
+        await s1.init()
+        row = await s1.register(framework="openclaw", display_name="Survivor")
+        await s1.close()
+
+        s2 = AgentRegistryStore(db_path)
+        await s2.init()
+        after = await s2.get(row["canonical_id"])
+        assert after["display_name"] == "Survivor"
+        assert "title" in after
+        assert "reports_to" in after
+        await s2.close()
+
+
+# ---------------------------------------------------------------------------
+# Org model: register/update accept title + reports_to
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAndUpdateOrgFields:
+    @pytest.mark.asyncio
+    async def test_register_with_title_and_reports_to(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        row = await store.register(
+            framework="openclaw",
+            display_name="Report",
+            title="Staff Engineer",
+            reports_to=manager["canonical_id"],
+        )
+        assert row["title"] == "Staff Engineer"
+        assert row["reports_to"] == manager["canonical_id"]
+
+    @pytest.mark.asyncio
+    async def test_update_title(self, store):
+        row = await store.register(framework="openclaw", display_name="Titled")
+        updated = await store.update(row["canonical_id"], title="Lead")
+        assert updated["title"] == "Lead"
+
+
+# ---------------------------------------------------------------------------
+# set_role_title
+# ---------------------------------------------------------------------------
+
+
+class TestSetRoleTitle:
+    @pytest.mark.asyncio
+    async def test_sets_role_and_title(self, store):
+        row = await store.register(framework="openclaw", display_name="A")
+        updated = await store.set_role_title(row["canonical_id"], role="manager", title="VP")
+        assert updated["role"] == "manager"
+        assert updated["title"] == "VP"
+
+    @pytest.mark.asyncio
+    async def test_sets_only_title(self, store):
+        row = await store.register(framework="openclaw", display_name="A", role="worker")
+        updated = await store.set_role_title(row["canonical_id"], title="Senior Worker")
+        assert updated["role"] == "worker"
+        assert updated["title"] == "Senior Worker"
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_returns_none(self, store):
+        result = await store.set_role_title("no-such-20260101-000000", title="X")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# set_reporting
+# ---------------------------------------------------------------------------
+
+
+class TestSetReporting:
+    @pytest.mark.asyncio
+    async def test_sets_manager(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        report = await store.register(framework="openclaw", display_name="Report")
+        updated = await store.set_reporting(report["canonical_id"], manager["canonical_id"])
+        assert updated["reports_to"] == manager["canonical_id"]
+
+    @pytest.mark.asyncio
+    async def test_clears_manager_with_none(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        report = await store.register(framework="openclaw", display_name="Report")
+        await store.set_reporting(report["canonical_id"], manager["canonical_id"])
+        cleared = await store.set_reporting(report["canonical_id"], None)
+        assert cleared["reports_to"] is None
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_agent_raises_key_error(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        with pytest.raises(KeyError):
+            await store.set_reporting("no-such-20260101-000000", manager["canonical_id"])
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_manager_raises_value_error(self, store):
+        report = await store.register(framework="openclaw", display_name="Report")
+        with pytest.raises(ValueError, match="reports_to manager not found"):
+            await store.set_reporting(report["canonical_id"], "no-such-manager-20260101-000000")
+
+    @pytest.mark.asyncio
+    async def test_self_report_raises_value_error(self, store):
+        row = await store.register(framework="openclaw", display_name="Solo")
+        with pytest.raises(ValueError, match="cannot report to itself"):
+            await store.set_reporting(row["canonical_id"], row["canonical_id"])
+
+    @pytest.mark.asyncio
+    async def test_direct_cycle_raises_value_error(self, store):
+        """A -> B, then trying B -> A must be rejected (2-node cycle)."""
+        a = await store.register(framework="openclaw", display_name="A")
+        b = await store.register(framework="openclaw", display_name="B")
+        await store.set_reporting(a["canonical_id"], b["canonical_id"])
+        with pytest.raises(ValueError, match="reporting cycle"):
+            await store.set_reporting(b["canonical_id"], a["canonical_id"])
+
+    @pytest.mark.asyncio
+    async def test_longer_cycle_raises_value_error(self, store):
+        """A -> B -> C, then trying C -> A must be rejected (3-node cycle)."""
+        a = await store.register(framework="openclaw", display_name="A")
+        b = await store.register(framework="openclaw", display_name="B")
+        c = await store.register(framework="openclaw", display_name="C")
+        await store.set_reporting(a["canonical_id"], b["canonical_id"])
+        await store.set_reporting(b["canonical_id"], c["canonical_id"])
+        with pytest.raises(ValueError, match="reporting cycle"):
+            await store.set_reporting(c["canonical_id"], a["canonical_id"])
+
+    @pytest.mark.asyncio
+    async def test_reassign_manager_is_allowed(self, store):
+        """Changing an existing manager (no cycle involved) succeeds."""
+        m1 = await store.register(framework="openclaw", display_name="M1")
+        m2 = await store.register(framework="openclaw", display_name="M2")
+        report = await store.register(framework="openclaw", display_name="Report")
+        await store.set_reporting(report["canonical_id"], m1["canonical_id"])
+        updated = await store.set_reporting(report["canonical_id"], m2["canonical_id"])
+        assert updated["reports_to"] == m2["canonical_id"]
+
+
+# ---------------------------------------------------------------------------
+# direct_reports / get_org_tree
+# ---------------------------------------------------------------------------
+
+
+class TestDirectReportsAndOrgTree:
+    @pytest.mark.asyncio
+    async def test_direct_reports_empty(self, store):
+        row = await store.register(framework="openclaw", display_name="Lonely")
+        assert await store.direct_reports(row["canonical_id"]) == []
+
+    @pytest.mark.asyncio
+    async def test_direct_reports_returns_children(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        r1 = await store.register(framework="openclaw", display_name="R1")
+        r2 = await store.register(framework="openclaw", display_name="R2")
+        await store.set_reporting(r1["canonical_id"], manager["canonical_id"])
+        await store.set_reporting(r2["canonical_id"], manager["canonical_id"])
+        reports = await store.direct_reports(manager["canonical_id"])
+        ids = {r["canonical_id"] for r in reports}
+        assert ids == {r1["canonical_id"], r2["canonical_id"]}
+
+    @pytest.mark.asyncio
+    async def test_org_tree_flat_when_no_managers(self, store):
+        await store.register(framework="openclaw", display_name="A")
+        await store.register(framework="openclaw", display_name="B")
+        tree = await store.get_org_tree()
+        assert len(tree) == 2
+        assert all(node["reports"] == [] for node in tree)
+
+    @pytest.mark.asyncio
+    async def test_org_tree_nests_reports(self, store):
+        manager = await store.register(
+            framework="openclaw", display_name="Manager", role="lead", title="Team Lead"
+        )
+        report = await store.register(framework="openclaw", display_name="Report")
+        await store.set_reporting(report["canonical_id"], manager["canonical_id"])
+
+        tree = await store.get_org_tree()
+        assert len(tree) == 1
+        root = tree[0]
+        assert root["canonical_id"] == manager["canonical_id"]
+        assert root["display_name"] == "Manager"
+        assert root["role"] == "lead"
+        assert root["title"] == "Team Lead"
+        assert len(root["reports"]) == 1
+        assert root["reports"][0]["canonical_id"] == report["canonical_id"]
+        assert root["reports"][0]["reports"] == []
+
+    @pytest.mark.asyncio
+    async def test_org_tree_multi_level(self, store):
+        top = await store.register(framework="openclaw", display_name="Top")
+        mid = await store.register(framework="openclaw", display_name="Mid")
+        leaf = await store.register(framework="openclaw", display_name="Leaf")
+        await store.set_reporting(mid["canonical_id"], top["canonical_id"])
+        await store.set_reporting(leaf["canonical_id"], mid["canonical_id"])
+
+        tree = await store.get_org_tree()
+        assert len(tree) == 1
+        root = tree[0]
+        assert root["canonical_id"] == top["canonical_id"]
+        assert len(root["reports"]) == 1
+        mid_node = root["reports"][0]
+        assert mid_node["canonical_id"] == mid["canonical_id"]
+        assert len(mid_node["reports"]) == 1
+        assert mid_node["reports"][0]["canonical_id"] == leaf["canonical_id"]
+
+    @pytest.mark.asyncio
+    async def test_org_tree_dangling_reports_to_becomes_root(self, store):
+        """A row whose reports_to points at a non-existent/removed manager is
+        treated as a root rather than dropped or crashing the tree build."""
+        row = await store.register(framework="openclaw", display_name="Orphan")
+        await store._db.execute(
+            "UPDATE agent_registry SET reports_to = ? WHERE canonical_id = ?",
+            ("no-such-manager-20260101-000000", row["canonical_id"]),
+        )
+        await store._db.commit()
+        tree = await store.get_org_tree()
+        ids = {node["canonical_id"] for node in tree}
+        assert row["canonical_id"] in ids

--- a/tests/test_routes_agent_org.py
+++ b/tests/test_routes_agent_org.py
@@ -1,0 +1,224 @@
+"""Org API routes (#161): GET /api/agents/org, PUT /api/agents/{canonical_id}/org.
+
+Mirrors the gov_client fixture pattern in test_registry_governance_lifecycle.py:
+the shared `client` fixture in conftest.py never initialises agent_registry
+(it is lifespan-owned), so these routes need their own fixture that inits it.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def org_client(app):
+    """Async HTTP client with admin session + agent_registry initialised."""
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": token},
+    ) as c:
+        yield c, uid
+
+    await registry_store.close()
+
+
+@pytest_asyncio.fixture
+async def org_member_client(app):
+    """Async HTTP client with a non-admin member session, same registry init."""
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    admin_record = app.state.auth.find_user("admin")
+    admin_uid = admin_record["id"] if admin_record else ""
+    invite_code = app.state.auth.add_user_invite("member", admin_uid)
+    app.state.auth.complete_invite("member", invite_code, "Test Member", "", "memberpass123")
+    member_record = app.state.auth.find_user("member")
+    member_uid = member_record["id"] if member_record else ""
+    token = app.state.auth.create_session(user_id=member_uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": token},
+    ) as c:
+        yield c, member_uid
+
+    await registry_store.close()
+
+
+@pytest.mark.asyncio
+class TestGetOrgChart:
+    async def test_admin_sees_full_tree(self, org_client):
+        client, admin_uid = org_client
+        manager = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Manager"},
+        )
+        manager_id = manager.json()["canonical_id"]
+        report = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Report"},
+        )
+        report_id = report.json()["canonical_id"]
+
+        put_resp = await client.put(
+            f"/api/agents/{report_id}/org", json={"reports_to": manager_id}
+        )
+        assert put_resp.status_code == 200
+
+        resp = await client.get("/api/agents/org")
+        assert resp.status_code == 200
+        tree = resp.json()["tree"]
+        root = next(n for n in tree if n["canonical_id"] == manager_id)
+        assert root["reports"][0]["canonical_id"] == report_id
+
+    async def test_member_forbidden(self, org_member_client):
+        client, _uid = org_member_client
+        resp = await client.get("/api/agents/org")
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestUpdateOrgFields:
+    async def test_set_role_and_title(self, org_client):
+        client, _uid = org_client
+        reg = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Worker"},
+        )
+        cid = reg.json()["canonical_id"]
+
+        resp = await client.put(
+            f"/api/agents/{cid}/org", json={"role": "engineer", "title": "Staff Engineer"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["role"] == "engineer"
+        assert body["title"] == "Staff Engineer"
+
+    async def test_set_reports_to(self, org_client):
+        client, _uid = org_client
+        manager = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Manager"},
+        )).json()
+        report = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Report"},
+        )).json()
+
+        resp = await client.put(
+            f"/api/agents/{report['canonical_id']}/org",
+            json={"reports_to": manager["canonical_id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["reports_to"] == manager["canonical_id"]
+
+    async def test_clear_reports_to_with_empty_string(self, org_client):
+        client, _uid = org_client
+        manager = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Manager"},
+        )).json()
+        report = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Report"},
+        )).json()
+        await client.put(
+            f"/api/agents/{report['canonical_id']}/org",
+            json={"reports_to": manager["canonical_id"]},
+        )
+
+        resp = await client.put(
+            f"/api/agents/{report['canonical_id']}/org", json={"reports_to": ""}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["reports_to"] is None
+
+    async def test_self_report_is_400(self, org_client):
+        client, _uid = org_client
+        reg = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Solo"},
+        )).json()
+        resp = await client.put(
+            f"/api/agents/{reg['canonical_id']}/org",
+            json={"reports_to": reg["canonical_id"]},
+        )
+        assert resp.status_code == 400
+
+    async def test_nonexistent_manager_is_400(self, org_client):
+        client, _uid = org_client
+        reg = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Solo"},
+        )).json()
+        resp = await client.put(
+            f"/api/agents/{reg['canonical_id']}/org",
+            json={"reports_to": "no-such-manager-20260101-000000"},
+        )
+        assert resp.status_code == 400
+
+    async def test_cycle_is_400(self, org_client):
+        client, _uid = org_client
+        a = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "A"},
+        )).json()
+        b = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "B"},
+        )).json()
+        await client.put(f"/api/agents/{a['canonical_id']}/org", json={"reports_to": b["canonical_id"]})
+
+        resp = await client.put(
+            f"/api/agents/{b['canonical_id']}/org", json={"reports_to": a["canonical_id"]}
+        )
+        assert resp.status_code == 400
+
+    async def test_not_found_canonical_id_is_404(self, org_client):
+        client, _uid = org_client
+        resp = await client.put(
+            "/api/agents/no-such-agent-20260101-000000/org", json={"role": "x"}
+        )
+        assert resp.status_code == 404
+
+    async def test_member_cannot_update_others_entry(self, org_client, app):
+        """Builds its own member session on top of org_client's admin (rather
+        than also depending on org_member_client), since both client fixtures
+        call auth.setup_user("admin", ...) on the same underlying `app` and a
+        second call raises "a user is already configured"."""
+        admin_client, _admin_uid = org_client
+        reg = (await admin_client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "AdminOwned"},
+        )).json()
+
+        invite_code = app.state.auth.add_user_invite("member", "admin")
+        app.state.auth.complete_invite("member", invite_code, "Test Member", "", "memberpass123")
+        member = app.state.auth.find_user("member")
+        token = app.state.auth.create_session(user_id=member["id"], long_lived=True)
+
+        member_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test", cookies={"taos_session": token},
+        )
+        try:
+            resp = await member_client.put(
+                f"/api/agents/{reg['canonical_id']}/org", json={"title": "hijacked"}
+            )
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403

--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -1,0 +1,355 @@
+"""Gated agent delegation (#161): POST /api/agents/{from_agent}/delegate.
+
+Mirrors the structure of test_skill_exec_governance.py: governance applies
+only to AGENT (local-token) callers, so every gating assertion uses a
+local-token client, not the admin-session `client` fixture (an admin session
+bypasses governance the same way it does for skill-exec).
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+def _local_token_client(app) -> AsyncClient:
+    """A bare client (no session cookie) presenting the host local token --
+    the way a deployed agent calls this endpoint. Governance applies here."""
+    local_token = app.state.auth.get_local_token()
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {local_token}"},
+    )
+
+
+async def _make_project_and_task(app, *, title="Do the thing", created_by="from-agent"):
+    project = await app.state.project_store.create_project(
+        name="Delegation Test Project", slug="delegation-test", created_by=created_by,
+    )
+    task = await app.state.project_task_store.create_task(
+        project_id=project["id"], title=title, created_by=created_by,
+    )
+    return project, task
+
+
+@pytest.fixture(autouse=True)
+def _seed_agents(app):
+    """Two config agents so from_agent/to_agent resolve via find_agent."""
+    app.state.config.agents.append(
+        {"name": "from-agent", "host": "", "qmd_index": "from-agent", "color": "#111111"}
+    )
+    app.state.config.agents.append(
+        {"name": "to-agent", "host": "", "qmd_index": "to-agent", "color": "#222222"}
+    )
+
+
+@pytest.mark.asyncio
+class TestDelegationGateDeny:
+    async def test_deny_policy_returns_403_and_does_not_assign(self, client, app):
+        await app.state.execution_policies.set_policy("delegate", "deny", agent_name="from-agent")
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "forbidden_by_policy"
+
+        unchanged = await app.state.project_task_store.get_task(task["id"])
+        assert unchanged["assignee_id"] is None
+
+
+@pytest.mark.asyncio
+class TestDelegationGateRequireApproval:
+    async def test_conservative_default_is_pending_approval(self, client, app):
+        """delegate is a seeded conservative-default action class -- with no
+        override and no live grant, an agent's delegation queues a Decision
+        instead of running immediately."""
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"], "note": "please pick this up"},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "pending_approval"
+        assert body["action_class"] == "delegate"
+        assert body["decision_id"]
+
+        decision = await app.state.decision_store.get(body["decision_id"])
+        assert decision is not None
+        assert decision["status"] == "pending"
+        assert decision["priority"] == "blocking"
+        assert decision["metadata"]["kind"] == "delegation_gate"
+        assert decision["metadata"]["from_agent"] == "from-agent"
+        assert decision["metadata"]["to_agent"] == "to-agent"
+        assert decision["metadata"]["task_id"] == task["id"]
+        assert decision["metadata"]["note"] == "please pick this up"
+
+        # The task must not be assigned until the decision is approved.
+        still_open = await app.state.project_task_store.get_task(task["id"])
+        assert still_open["assignee_id"] is None
+
+    async def test_live_grant_allows_immediate_delegation(self, client, app):
+        _project, task = await _make_project_and_task(app)
+        await app.state.execution_policies.add_grant("from-agent", "delegate", "dec-x")
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "delegated"
+        assert body["task_id"] == task["id"]
+        assert body["to_agent"] == "to-agent"
+
+        updated = await app.state.project_task_store.get_task(task["id"])
+        assert updated["assignee_id"] == "to-agent"
+
+    async def test_grant_is_scoped_per_agent(self, client, app):
+        """A grant for one agent does not authorize a different agent's delegation."""
+        _project, task = await _make_project_and_task(app)
+        await app.state.execution_policies.add_grant("someone-else", "delegate", "dec-x")
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "pending_approval"
+
+
+@pytest.mark.asyncio
+class TestDelegationAllowPolicy:
+    async def test_allow_policy_delegates_immediately(self, client, app):
+        await app.state.execution_policies.set_policy("delegate", "allow", agent_name="from-agent")
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "delegated"
+
+
+@pytest.mark.asyncio
+class TestDelegationApprovalFlow:
+    async def test_approving_decision_completes_delegation(self, client, app):
+        """The full round trip: an ungranted delegation queues a Decision;
+        answering it 'approve' assigns the task, grants the action class for
+        next time, and notifies to_agent on the project's A2A channel."""
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"], "note": "handoff"},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 202
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "approve"}
+        )
+        assert answer_resp.status_code == 200
+
+        completed = await app.state.project_task_store.get_task(task["id"])
+        assert completed["assignee_id"] == "to-agent"
+
+        # The action class is now granted for from-agent, so a follow-up
+        # delegation by the same agent proceeds without another approval.
+        assert await app.state.execution_policies.has_live_grant("from-agent", "delegate")
+
+    async def test_denying_decision_does_not_delegate(self, client, app):
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "deny"}
+        )
+        assert answer_resp.status_code == 200
+
+        still_open = await app.state.project_task_store.get_task(task["id"])
+        assert still_open["assignee_id"] is None
+        assert not await app.state.execution_policies.has_live_grant("from-agent", "delegate")
+
+    async def test_approving_decision_creates_task_from_title(self, client, app):
+        """Same approval round trip, but the original request had no task_id
+        -- only a task_title + project_id -- so approval must create it."""
+        project, _existing_task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={
+                    "to_agent": "to-agent",
+                    "task_title": "Brand new task",
+                    "project_id": project["id"],
+                },
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 202
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "approve"}
+        )
+        assert answer_resp.status_code == 200
+
+        tasks = await app.state.project_task_store.list_tasks(project["id"])
+        new_task = next(t for t in tasks if t["title"] == "Brand new task")
+        assert new_task["assignee_id"] == "to-agent"
+
+
+@pytest.mark.asyncio
+class TestDelegationTaskTitleCreatesTask:
+    async def test_allow_policy_creates_task_from_title(self, client, app):
+        await app.state.execution_policies.set_policy("delegate", "allow", agent_name="from-agent")
+        project = await app.state.project_store.create_project(
+            name="New Task Project", slug="new-task-project", created_by="from-agent",
+        )
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_title": "Write the docs", "project_id": project["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "delegated"
+
+        tasks = await app.state.project_task_store.list_tasks(project["id"])
+        created = next(t for t in tasks if t["title"] == "Write the docs")
+        assert created["assignee_id"] == "to-agent"
+
+    async def test_task_title_without_project_id_is_400(self, client, app):
+        await app.state.execution_policies.set_policy("delegate", "allow", agent_name="from-agent")
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_title": "Orphan task"},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+class TestDelegationValidation:
+    async def test_missing_task_id_and_task_title_is_400(self, client, app):
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate", json={"to_agent": "to-agent"}
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 400
+
+    async def test_unknown_from_agent_is_404(self, client, app):
+        _project, task = await _make_project_and_task(app)
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/no-such-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 404
+
+    async def test_unknown_to_agent_is_404(self, client, app):
+        _project, task = await _make_project_and_task(app)
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "no-such-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 404
+
+    async def test_unknown_task_id_is_404(self, client, app):
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": "no-such-task"},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 404
+
+    async def test_plain_non_admin_session_is_forbidden(self, client, app):
+        """A bare non-admin member session must never reach the gate --
+        mirrors _is_admin_or_local_token's guard in skill_exec.py. The
+        `client` fixture already set up the admin user + startup_complete;
+        this just adds a non-admin member on top of it."""
+        auth_mgr = app.state.auth
+        invite_code = auth_mgr.add_user_invite("member", "admin")
+        auth_mgr.complete_invite("member", invite_code, "Test Member", "", "memberpass123")
+        member = auth_mgr.find_user("member")
+        token = auth_mgr.create_session(user_id=member["id"], long_lived=True)
+
+        member_client = AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"taos_session": token},
+        )
+        try:
+            resp = await member_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_title": "x", "project_id": "p1"},
+            )
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -567,16 +567,15 @@ class AgentRegistryStore(BaseStore):
         handle: Optional[str] = None,
         role: Optional[str] = None,
         title: Optional[str] = None,
-        reports_to: Optional[str] = None,
         capabilities: Optional[list[str]] = None,
     ) -> Optional[dict]:
         """Update mutable metadata fields on *canonical_id*.
 
         Only the provided (non-None) fields are changed.
         Status, user_id, framework, canonical_id, and timestamps are immutable.
-        ``reports_to`` here is a raw setter with no validation (mirroring the
-        other plain fields) - use ``set_reporting`` when the caller needs the
-        self-report/cycle/manager-exists checks.
+        ``reports_to`` is deliberately NOT settable here: all reporting-line
+        changes must go through ``set_reporting`` so the self-report, cycle,
+        and manager-exists checks can never be bypassed.
         Returns the updated record, or None if *canonical_id* does not exist.
         """
         if self._db is None:
@@ -599,9 +598,6 @@ class AgentRegistryStore(BaseStore):
         if title is not None:
             cols.append("title = ?")
             vals.append(title)
-        if reports_to is not None:
-            cols.append("reports_to = ?")
-            vals.append(reports_to)
         if capabilities is not None:
             cols.append("capabilities = ?")
             vals.append(json.dumps(capabilities))

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -119,6 +119,25 @@ async def _migration_v2_strip_at_display_name(conn) -> None:
     )
     await conn.commit()
 
+
+async def _migration_v3_add_org_fields(conn) -> None:
+    """Add title + reports_to columns (idempotent) for the org model (#161).
+
+    ``reports_to`` references another row's canonical_id (the agent's
+    manager); NULL means the agent has no manager (an org-tree root).
+    """
+    existing_cols = {
+        row[1]
+        for row in await (
+            await conn.execute("PRAGMA table_info(agent_registry)")
+        ).fetchall()
+    }
+    if "title" not in existing_cols:
+        await conn.execute("ALTER TABLE agent_registry ADD COLUMN title TEXT")
+    if "reports_to" not in existing_cols:
+        await conn.execute("ALTER TABLE agent_registry ADD COLUMN reports_to TEXT")
+    await conn.commit()
+
 # ---------------------------------------------------------------------------
 # Signing-key helpers (Ed25519, persisted to disk)
 # ---------------------------------------------------------------------------
@@ -317,6 +336,7 @@ class AgentRegistryStore(BaseStore):
         """Idempotently ensure the status column exists and is backfilled."""
         await _migration_v1_add_status(self._db)
         await _migration_v2_strip_at_display_name(self._db)
+        await _migration_v3_add_org_fields(self._db)
 
     # ------------------------------------------------------------------
     # Registration
@@ -331,9 +351,15 @@ class AgentRegistryStore(BaseStore):
         origin: str = "taos-deployed",
         handle: str = "",
         role: Optional[str] = None,
+        title: Optional[str] = None,
+        reports_to: Optional[str] = None,
         capabilities: Optional[list[str]] = None,
     ) -> dict:
         """Mint a canonical_id, persist the record, and return it.
+
+        ``reports_to`` is stored as-is with no validation here (the row does
+        not exist yet, so it cannot be part of an existing cycle) — use
+        ``set_reporting`` after registration to validate a manager change.
 
         Raises ``RuntimeError`` if the store is not initialised.
         """
@@ -368,11 +394,11 @@ class AgentRegistryStore(BaseStore):
             """
             INSERT INTO agent_registry
                 (canonical_id, display_name, framework, user_id, origin,
-                 handle, role, capabilities, created_ts, status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 handle, role, title, reports_to, capabilities, created_ts, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (canonical_id, display_name, framework, user_id, origin,
-             handle, role, caps_json, created_ts, initial_status),
+             handle, role, title, reports_to, caps_json, created_ts, initial_status),
         )
         await self._db.commit()
 
@@ -540,12 +566,17 @@ class AgentRegistryStore(BaseStore):
         display_name: Optional[str] = None,
         handle: Optional[str] = None,
         role: Optional[str] = None,
+        title: Optional[str] = None,
+        reports_to: Optional[str] = None,
         capabilities: Optional[list[str]] = None,
     ) -> Optional[dict]:
         """Update mutable metadata fields on *canonical_id*.
 
         Only the provided (non-None) fields are changed.
         Status, user_id, framework, canonical_id, and timestamps are immutable.
+        ``reports_to`` here is a raw setter with no validation (mirroring the
+        other plain fields) — use ``set_reporting`` when the caller needs the
+        self-report/cycle/manager-exists checks.
         Returns the updated record, or None if *canonical_id* does not exist.
         """
         if self._db is None:
@@ -565,6 +596,12 @@ class AgentRegistryStore(BaseStore):
         if role is not None:
             cols.append("role = ?")
             vals.append(role)
+        if title is not None:
+            cols.append("title = ?")
+            vals.append(title)
+        if reports_to is not None:
+            cols.append("reports_to = ?")
+            vals.append(reports_to)
         if capabilities is not None:
             cols.append("capabilities = ?")
             vals.append(json.dumps(capabilities))
@@ -598,3 +635,134 @@ class AgentRegistryStore(BaseStore):
         )
         await self._db.commit()
         return await self.get(canonical_id)
+
+    # ------------------------------------------------------------------
+    # Org model (#161): reporting lines, roles/titles, org tree
+    # ------------------------------------------------------------------
+
+    # Cap on the reports_to chain walk used by both the cycle guard in
+    # set_reporting and the tree-building recursion in get_org_tree — bounds
+    # the cost of a corrupt or pathological chain instead of looping forever.
+    _MAX_REPORTS_TO_WALK = 50
+
+    async def set_role_title(
+        self,
+        canonical_id: str,
+        *,
+        role: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Set *role* and/or *title* on *canonical_id* (free-form strings).
+
+        Only the provided (non-None) fields are changed.  Returns the updated
+        record, or None if *canonical_id* does not exist.
+        """
+        return await self.update(canonical_id, role=role, title=title)
+
+    async def set_reporting(
+        self, canonical_id: str, reports_to: Optional[str]
+    ) -> dict:
+        """Set (or, with ``None``, clear) *canonical_id*'s manager.
+
+        Validates:
+          - *canonical_id* exists (``KeyError`` otherwise)
+          - *reports_to* (when not ``None``) refers to an existing agent
+            (``ValueError`` otherwise)
+          - *reports_to* is not *canonical_id* itself (no self-report)
+          - assigning *reports_to* does not create a reporting cycle — walked
+            by following the candidate manager's own reports_to chain and
+            checking whether it ever reaches back to *canonical_id*
+
+        Returns the updated record.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        record = await self.get(canonical_id)
+        if record is None:
+            raise KeyError(canonical_id)
+
+        if reports_to is not None:
+            if reports_to == canonical_id:
+                raise ValueError("an agent cannot report to itself")
+            manager = await self.get(reports_to)
+            if manager is None:
+                raise ValueError(f"reports_to manager not found: {reports_to!r}")
+
+            # Cycle guard: walk the candidate manager's existing reports_to
+            # chain; if it ever reaches canonical_id, this edge would close a
+            # loop. `seen` guards against looping forever on an already-
+            # corrupt chain independent of the depth cap.
+            seen: set[str] = set()
+            current: Optional[str] = reports_to
+            depth = 0
+            while current is not None and depth < self._MAX_REPORTS_TO_WALK:
+                if current == canonical_id:
+                    raise ValueError(
+                        f"assigning reports_to={reports_to!r} would create "
+                        f"a reporting cycle"
+                    )
+                if current in seen:
+                    break
+                seen.add(current)
+                current_record = await self.get(current)
+                current = current_record.get("reports_to") if current_record else None
+                depth += 1
+
+        await self._db.execute(
+            "UPDATE agent_registry SET reports_to = ? WHERE canonical_id = ?",
+            (reports_to, canonical_id),
+        )
+        await self._db.commit()
+        return await self.get(canonical_id)  # type: ignore[return-value]
+
+    async def direct_reports(self, canonical_id: str) -> list[dict]:
+        """Return the agents whose reports_to is *canonical_id*, oldest first."""
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM agent_registry WHERE reports_to = ? ORDER BY id",
+            (canonical_id,),
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    async def get_org_tree(self) -> list[dict]:
+        """Return the reporting forest: agents with no manager (or whose
+        manager row does not exist) are roots; each node nests its direct
+        reports recursively.
+
+        Each node: {canonical_id, display_name, role, title, reports_to,
+        reports: [...]}.  Depth-capped and cycle-guarded so a corrupt chain
+        (written outside ``set_reporting``) cannot recurse forever.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        all_rows = await self.list_all()
+        by_id = {r["canonical_id"]: r for r in all_rows}
+        children: dict[str, list[dict]] = {}
+        roots: list[dict] = []
+        for row in all_rows:
+            reports_to = row.get("reports_to")
+            if reports_to and reports_to in by_id:
+                children.setdefault(reports_to, []).append(row)
+            else:
+                roots.append(row)
+
+        def _node(row: dict, depth: int, seen: frozenset) -> dict:
+            cid = row["canonical_id"]
+            seen = seen | {cid}
+            kids: list[dict] = []
+            if depth < self._MAX_REPORTS_TO_WALK:
+                for child in children.get(cid, []):
+                    if child["canonical_id"] not in seen:
+                        kids.append(_node(child, depth + 1, seen))
+            return {
+                "canonical_id": cid,
+                "display_name": row.get("display_name"),
+                "role": row.get("role"),
+                "title": row.get("title"),
+                "reports_to": row.get("reports_to"),
+                "reports": kids,
+            }
+
+        return [_node(r, 0, frozenset()) for r in roots]

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Agent Registry store — canonical agent-identity persistence.
+"""Agent Registry store - canonical agent-identity persistence.
 
 Each registered agent gets a unique canonical_id minted once (immutable) and
 a signed JWT-style token issued at registration time.  The signing key is an
@@ -63,7 +63,7 @@ _VALID_TRANSITIONS: frozenset[tuple[str, str]] = frozenset({
     ("active",    "revoked"),     # revoke (terminal)
     ("suspended", "revoked"),     # revoke (terminal)
     ("pending",   "revoked"),     # revoke (terminal)
-    ("rejected",  "revoked"),     # revoke (terminal) — any non-terminal → revoked
+    ("rejected",  "revoked"),     # revoke (terminal) - any non-terminal → revoked
     ("rejected",  "pending"),     # undo denial → re-open
     ("rejected",  "active"),      # undo denial → directly approve
 })
@@ -86,7 +86,7 @@ def _assert_valid_transition(before: str, after: str) -> None:
 async def _migration_v1_add_status(conn) -> None:
     """Add status column (idempotent) and backfill existing rows."""
     # Check if the column already exists (SQLite has no IF NOT EXISTS for ADD COLUMN
-    # prior to 3.37 — use PRAGMA instead for broad compatibility).
+    # prior to 3.37 - use PRAGMA instead for broad compatibility).
     existing_cols = {
         row[1]
         for row in await (
@@ -108,7 +108,7 @@ async def _migration_v2_strip_at_display_name(conn) -> None:
     """Strip a leading '@' from display_name for all rows (idempotent).
 
     The '@' sigil is bus-addressing syntax only; it must never be stored
-    in display_name.  Safe to run every startup — rows without a leading
+    in display_name.  Safe to run every startup - rows without a leading
     '@' are untouched by the WHERE clause.
     """
     # '@_%' requires at least one character after '@', so bare '@'-only rows
@@ -151,7 +151,7 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
     Generates an Ed25519 keypair on first call and persists the private key
     PEM to ``<data_dir>/agent_registry_signing.pem`` with mode 0600.
     Subsequent calls load and return the same keypair.  Idempotent under
-    concurrent processes — the writer uses O_EXCL so only one process
+    concurrent processes - the writer uses O_EXCL so only one process
     creates the file.
     """
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -180,7 +180,7 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
             finally:
                 os.close(fd)
         except FileExistsError:
-            # Lost the race — load the winner's key instead.
+            # Lost the race - load the winner's key instead.
             private_key = load_pem_private_key(pem_path.read_bytes(), password=None)
 
     private_pem = private_key.private_bytes(
@@ -193,7 +193,7 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
 
 
 # ---------------------------------------------------------------------------
-# Token minting (compact JWT-style — header.payload.signature, base64url)
+# Token minting (compact JWT-style - header.payload.signature, base64url)
 # ---------------------------------------------------------------------------
 
 def _b64url_encode(data: bytes) -> str:
@@ -224,12 +224,12 @@ def mint_registry_token(
     can verify it without importing tinyagentos code.
 
     Claims:
-      sub        — canonical_id (immutable agent identity)
-      iss        — "taos-registry"
-      iat        — unix timestamp of issuance
-      user_id    — owning user_id at registration time
-      framework  — agent framework at registration time
-      project_id — project binding, present only when non-empty; absent means
+      sub        - canonical_id (immutable agent identity)
+      iss        - "taos-registry"
+      iat        - unix timestamp of issuance
+      user_id    - owning user_id at registration time
+      framework  - agent framework at registration time
+      project_id - project binding, present only when non-empty; absent means
                    the token is global (not bound to any project)
 
     Signed with Ed25519 over the UTF-8 bytes of ``<header_b64url>.<payload_b64url>``.
@@ -358,13 +358,13 @@ class AgentRegistryStore(BaseStore):
         """Mint a canonical_id, persist the record, and return it.
 
         ``reports_to`` is stored as-is with no validation here (the row does
-        not exist yet, so it cannot be part of an existing cycle) — use
+        not exist yet, so it cannot be part of an existing cycle) - use
         ``set_reporting`` after registration to validate a manager change.
 
         Raises ``RuntimeError`` if the store is not initialised.
         """
         if self._db is None:
-            raise RuntimeError("AgentRegistryStore not initialised — call init() first")
+            raise RuntimeError("AgentRegistryStore not initialised - call init() first")
 
         capabilities = capabilities or []
         now_utc = datetime.now(timezone.utc)
@@ -532,7 +532,7 @@ class AgentRegistryStore(BaseStore):
         now = datetime.now(timezone.utc).isoformat()
         # Atomic: the UPDATE is conditional on the status still being
         # ``before_status``, so two concurrent transitions cannot both win a
-        # read/validate/write race — the loser's WHERE matches 0 rows. This
+        # read/validate/write race - the loser's WHERE matches 0 rows. This
         # also guarantees the returned/audited before_status is accurate.
         if new_status == "revoked":
             cur = await self._db.execute(
@@ -575,7 +575,7 @@ class AgentRegistryStore(BaseStore):
         Only the provided (non-None) fields are changed.
         Status, user_id, framework, canonical_id, and timestamps are immutable.
         ``reports_to`` here is a raw setter with no validation (mirroring the
-        other plain fields) — use ``set_reporting`` when the caller needs the
+        other plain fields) - use ``set_reporting`` when the caller needs the
         self-report/cycle/manager-exists checks.
         Returns the updated record, or None if *canonical_id* does not exist.
         """
@@ -623,7 +623,7 @@ class AgentRegistryStore(BaseStore):
         if record is None:
             return None
         if record.get("revoked_at"):
-            # Already revoked — return the existing record unchanged.
+            # Already revoked - return the existing record unchanged.
             return record
         now = datetime.now(timezone.utc).isoformat()
         # Atomic: only the first concurrent revoke matches (revoked_at IS NULL);
@@ -641,7 +641,7 @@ class AgentRegistryStore(BaseStore):
     # ------------------------------------------------------------------
 
     # Cap on the reports_to chain walk used by both the cycle guard in
-    # set_reporting and the tree-building recursion in get_org_tree — bounds
+    # set_reporting and the tree-building recursion in get_org_tree - bounds
     # the cost of a corrupt or pathological chain instead of looping forever.
     _MAX_REPORTS_TO_WALK = 50
 
@@ -669,7 +669,7 @@ class AgentRegistryStore(BaseStore):
           - *reports_to* (when not ``None``) refers to an existing agent
             (``ValueError`` otherwise)
           - *reports_to* is not *canonical_id* itself (no self-report)
-          - assigning *reports_to* does not create a reporting cycle — walked
+          - assigning *reports_to* does not create a reporting cycle - walked
             by following the candidate manager's own reports_to chain and
             checking whether it ever reaches back to *canonical_id*
 

--- a/tinyagentos/governance/action_classes.py
+++ b/tinyagentos/governance/action_classes.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 # default posture (see governance/policy_store.py). Everything else defaults
 # to "allow" by the absence of a policy row.
 SENSITIVE_ACTION_CLASSES = frozenset(
-    {"code-exec", "external-network", "deploy", "file-write-external", "spend"}
+    {"code-exec", "external-network", "deploy", "file-write-external", "spend", "delegate"}
 )
 
 # tool/skill id -> action_class. file_write/file_read/list_files are scoped to
@@ -24,6 +24,10 @@ SENSITIVE_ACTION_CLASSES = frozenset(
 TOOL_ACTION_CLASSES: dict[str, str] = {
     "code_exec": "code-exec",
     "http_request": "external-network",
+    # Not a skill-exec tool today (delegation has its own dedicated route,
+    # routes/delegation.py) — listed here so a future skill wrapping the same
+    # capability inherits the conservative default automatically.
+    "delegate": "delegate",
 }
 
 

--- a/tinyagentos/governance/action_classes.py
+++ b/tinyagentos/governance/action_classes.py
@@ -25,7 +25,7 @@ TOOL_ACTION_CLASSES: dict[str, str] = {
     "code_exec": "code-exec",
     "http_request": "external-network",
     # Not a skill-exec tool today (delegation has its own dedicated route,
-    # routes/delegation.py) — listed here so a future skill wrapping the same
+    # routes/delegation.py) - listed here so a future skill wrapping the same
     # capability inherits the conservative default automatically.
     "delegate": "delegate",
 }

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -19,12 +19,12 @@ def register_all_routers(app):
     from tinyagentos.routes.agent_registry import router as agent_registry_router
     app.include_router(agent_registry_router)
 
-    # Consent loop — registered before /api/agents/{name} so that
+    # Consent loop - registered before /api/agents/{name} so that
     # /api/agents/auth-requests/* paths are not captured as an agent name.
     from tinyagentos.routes.agent_auth_requests import router as agent_auth_requests_router
     app.include_router(agent_auth_requests_router)
 
-    # Gated delegation (#161) — registered before /api/agents/{name} so that
+    # Gated delegation (#161) - registered before /api/agents/{name} so that
     # /api/agents/{from_agent}/delegate is unambiguous even though it shares
     # the {name} path segment (path length differs so this isn't strictly
     # required, but it keeps every /api/agents/... override grouped here).
@@ -281,7 +281,7 @@ def register_all_routers(app):
     from tinyagentos.routes import framework as framework_routes
     app.include_router(framework_routes.router)
 
-    # Lobby demo (internal only — not included in public builds)
+    # Lobby demo (internal only - not included in public builds)
     try:
         from tinyagentos.lobby.routes import router as lobby_router
         app.include_router(lobby_router)

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -24,6 +24,13 @@ def register_all_routers(app):
     from tinyagentos.routes.agent_auth_requests import router as agent_auth_requests_router
     app.include_router(agent_auth_requests_router)
 
+    # Gated delegation (#161) — registered before /api/agents/{name} so that
+    # /api/agents/{from_agent}/delegate is unambiguous even though it shares
+    # the {name} path segment (path length differs so this isn't strictly
+    # required, but it keeps every /api/agents/... override grouped here).
+    from tinyagentos.routes.delegation import router as delegation_router
+    app.include_router(delegation_router)
+
     from tinyagentos.routes.agents import router as agents_router
     app.include_router(agents_router)
 

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 """Routes for the Agent Registry (SP-A, taOS side).
 
-POST   /api/agents/registry/register         — register an agent, mint canonical_id, issue token
-GET    /api/agents/registry/pubkey           — public key for token verification (exempt, no auth)
-GET    /api/agents/registry/revoked          — global revocation feed (admin/local-token only)
-GET    /api/agents/registry/inactive         — all non-active entries for the bus (admin only)
-GET    /api/agents/registry/grants           — active grant feed for @taOSmd enforcement (admin only)
-GET    /api/agents/registry                  — list registry entries (admin: all; member: own)
-GET    /api/agents/registry/{id}             — read a single entry (owner or admin; else 404)
-PATCH  /api/agents/registry/{id}             — update mutable fields (owner or admin)
-DELETE /api/agents/registry/{id}             — revoke an entry (owner or admin)
-POST   /api/agents/registry/{id}/approve     — lifecycle: pending → active (admin only)
-POST   /api/agents/registry/{id}/reject      — lifecycle: pending → rejected (admin only)
-POST   /api/agents/registry/{id}/suspend     — lifecycle: active → suspended (admin only)
-POST   /api/agents/registry/{id}/reactivate  — lifecycle: suspended → active (admin only)
+POST   /api/agents/registry/register         - register an agent, mint canonical_id, issue token
+GET    /api/agents/registry/pubkey           - public key for token verification (exempt, no auth)
+GET    /api/agents/registry/revoked          - global revocation feed (admin/local-token only)
+GET    /api/agents/registry/inactive         - all non-active entries for the bus (admin only)
+GET    /api/agents/registry/grants           - active grant feed for @taOSmd enforcement (admin only)
+GET    /api/agents/registry                  - list registry entries (admin: all; member: own)
+GET    /api/agents/registry/{id}             - read a single entry (owner or admin; else 404)
+PATCH  /api/agents/registry/{id}             - update mutable fields (owner or admin)
+DELETE /api/agents/registry/{id}             - revoke an entry (owner or admin)
+POST   /api/agents/registry/{id}/approve     - lifecycle: pending → active (admin only)
+POST   /api/agents/registry/{id}/reject      - lifecycle: pending → rejected (admin only)
+POST   /api/agents/registry/{id}/suspend     - lifecycle: active → suspended (admin only)
+POST   /api/agents/registry/{id}/reactivate  - lifecycle: suspended → active (admin only)
 
 Route ordering matters: /pubkey, /revoked, and /inactive are declared before
 /{canonical_id} so the literal strings are not captured as a path parameter.
@@ -227,7 +227,7 @@ async def register_agent(
 ):
     """Register an agent and issue a signed identity token.
 
-    The minted token's user_id is the authenticated caller's id — not
+    The minted token's user_id is the authenticated caller's id - not
     a value from the request body, so identity cannot be spoofed.
     """
     store = _get_store(request)
@@ -464,7 +464,7 @@ async def list_inactive_entries(
 
     Response: {"inactive": [{canonical_id, status}, ...]}
 
-    Admin only — covers pending/suspended/rejected/revoked.
+    Admin only - covers pending/suspended/rejected/revoked.
     The bus polls this to reject any canonical_id present.
     """
     if not user.is_admin:
@@ -542,7 +542,7 @@ async def get_registry_entry(
     """Fetch a single registry entry by canonical_id.
 
     Returns 404 for unknown entries and for entries the caller does not own
-    (existence-hiding — avoids disclosing whether an id exists to non-owners).
+    (existence-hiding - avoids disclosing whether an id exists to non-owners).
     """
     store = _get_store(request)
     record = await store.get(canonical_id)
@@ -721,7 +721,7 @@ async def get_org_chart(
     request: Request,
     user: CurrentUser = Depends(current_user),
 ):
-    """Return the full reporting forest (org chart). Admin only — the tree
+    """Return the full reporting forest (org chart). Admin only - the tree
     spans every agent's manager regardless of owner, which is an operator/
     admin concern (mirrors the admin-only registry feeds above)."""
     if not user.is_admin:
@@ -741,7 +741,7 @@ async def update_org_fields(
 
     Only the owning user or an admin may update an entry (mirrors PATCH
     /api/agents/registry/{canonical_id}). ``reports_to`` is validated via
-    ``set_reporting`` — 400 on a nonexistent manager, self-report, or a
+    ``set_reporting`` - 400 on a nonexistent manager, self-report, or a
     reporting cycle.
     """
     store = _get_store(request)

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -70,6 +70,19 @@ class PatchRegistryRequest(BaseModel):
     capabilities: Optional[list[str]] = None
 
 
+class OrgUpdateRequest(BaseModel):
+    """Body for PUT /api/agents/{canonical_id}/org.
+
+    ``reports_to`` follows the same clear-with-empty-string convention as
+    ``emoji`` elsewhere in the agent routes: omit the field (None) to leave
+    the manager untouched, pass "" to clear it (make the agent an org-tree
+    root), or pass a canonical_id to set/change it.
+    """
+    role: Optional[str] = None
+    title: Optional[str] = None
+    reports_to: Optional[str] = None
+
+
 # Scopes an operator may grant when minting an internal agent. Mirrors the
 # consent-flow VALID_SCOPES; the mint route must not be a back door to invent
 # arbitrary scopes that the rest of the system does not understand.
@@ -691,3 +704,60 @@ async def reactivate_agent(
 ):
     """Reactivate a suspended agent (suspended → active). Admin only."""
     return await _transition(request, canonical_id, "reactivate", "active", user)
+
+
+# ---------------------------------------------------------------------------
+# Org model (#161): reporting lines, roles/titles, org tree
+#
+# Registered here (not routes/agents.py) so this file remains the single
+# owner of the registry's read/write surface. Both routes live under
+# /api/agents/... but this router is included before the generic
+# /api/agents/{name} route in routes/__init__.py, so /api/agents/org is not
+# shadowed (same reasoning as /api/agents/registry/*).
+# ---------------------------------------------------------------------------
+
+@router.get("/api/agents/org")
+async def get_org_chart(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Return the full reporting forest (org chart). Admin only — the tree
+    spans every agent's manager regardless of owner, which is an operator/
+    admin concern (mirrors the admin-only registry feeds above)."""
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    store = _get_store(request)
+    return {"tree": await store.get_org_tree()}
+
+
+@router.put("/api/agents/{canonical_id}/org")
+async def update_org_fields(
+    request: Request,
+    canonical_id: str,
+    body: OrgUpdateRequest,
+    user: CurrentUser = Depends(current_user),
+):
+    """Set role/title and/or reporting line on a registry entry.
+
+    Only the owning user or an admin may update an entry (mirrors PATCH
+    /api/agents/registry/{canonical_id}). ``reports_to`` is validated via
+    ``set_reporting`` — 400 on a nonexistent manager, self-report, or a
+    reporting cycle.
+    """
+    store = _get_store(request)
+    record = await store.get(canonical_id)
+    if record is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, record["user_id"])
+
+    if body.role is not None or body.title is not None:
+        await store.set_role_title(canonical_id, role=body.role, title=body.title)
+
+    if body.reports_to is not None:
+        manager_id = body.reports_to or None  # "" clears the manager
+        try:
+            await store.set_reporting(canonical_id, manager_id)
+        except (ValueError, KeyError) as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+
+    return await store.get(canonical_id)

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -251,6 +251,7 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
     await _apply_app_grant(request, updated, body.value)
     await _apply_execution_grant(request, updated, body.value)
+    await _apply_delegation_grant(request, updated, body.value)
     await _route_answer_to_agent(updated, body.value)
     return updated
 
@@ -289,6 +290,53 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> Non
     await _route_answer_to_agent(
         decision,
         "you may retry the action now" if approved else "your action was denied",
+    )
+
+
+async def _apply_delegation_grant(request: Request, decision: dict, value) -> None:
+    """Side effect for a delegation-gate Decision (#161 gated delegation): the
+    decision's metadata carries {kind: "delegation_gate", from_agent, to_agent,
+    task_id, task_title, note}. Approving it writes a short-lived delegate
+    grant (so a future delegation by the same agent doesn't re-ask until the
+    grant expires) AND completes THIS delegation (assign the task + notify
+    to_agent); denying just routes the answer. Mirrors
+    ``_apply_execution_grant``: the answer is already persisted, so a
+    grant-store or delegation-completion hiccup must not fail the answer."""
+    meta = decision.get("metadata") or {}
+    if meta.get("kind") != "delegation_gate":
+        return
+    policies = getattr(request.app.state, "execution_policies", None)
+    from_agent = meta.get("from_agent")
+    to_agent = meta.get("to_agent")
+    if policies is None or not from_agent or not to_agent:
+        return
+    approved = value == "approve"
+    if approved:
+        try:
+            await policies.add_grant(from_agent, "delegate", decision.get("id"))
+        except Exception:
+            logger.warning(
+                "delegate grant write failed for agent %s (decision %s)",
+                from_agent, decision.get("id"), exc_info=True,
+            )
+        try:
+            from tinyagentos.routes.delegation import complete_delegation
+            await complete_delegation(
+                request,
+                from_agent=from_agent,
+                to_agent=to_agent,
+                task_id=meta.get("task_id"),
+                task_title=meta.get("task_title"),
+                project_id=decision.get("project_id"),
+                note=meta.get("note") or "",
+            )
+        except Exception:
+            logger.warning(
+                "delegation completion failed for decision %s", decision.get("id"), exc_info=True,
+            )
+    await _route_answer_to_agent(
+        decision,
+        "delegation approved — the task has been assigned" if approved else "delegation denied",
     )
 
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -336,7 +336,7 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> No
             )
     await _route_answer_to_agent(
         decision,
-        "delegation approved — the task has been assigned" if approved else "delegation denied",
+        "delegation approved - the task has been assigned" if approved else "delegation denied",
     )
 
 

--- a/tinyagentos/routes/delegation.py
+++ b/tinyagentos/routes/delegation.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+"""Gated agent-to-agent delegation (#161, option A: org metadata + gated
+delegation, no approval rerouting).
+
+``POST /api/agents/{from_agent}/delegate`` lets one agent hand a task to
+another. The reporting line on the agent registry (see
+``agent_registry_store.set_reporting``) is org metadata only here — it does
+NOT change who approves a delegation. Every delegation is gated by the same
+governance layer as ``routes/skill_exec.py``'s tool-execution gate: the
+``delegate`` action class defaults to ``require_approval`` (see
+``governance/action_classes.SENSITIVE_ACTION_CLASSES``), so an ungranted
+delegation queues a blocking Decision instead of running immediately.
+
+The gate/decision-creation flow below mirrors
+``routes.skill_exec._check_execution_policy`` closely but is not a direct
+call into it — that function is keyed on a ``skill_id`` classified via
+``governance.action_classes.classify``, whereas delegation is not a skill
+call. Keeping a small, self-contained mirror here avoids reshaping the
+well-tested skill-exec gate for a caller it was never designed around.
+"""
+
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.agent_db import find_agent
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+ACTION_CLASS = "delegate"
+
+
+def _is_admin_or_local_token(request: Request) -> bool:
+    """True if the caller is an admin session or presented the host's local
+    token. Mirrors ``routes.skill_exec._is_admin_or_local_token`` — delegation
+    is an agent action, gated the same way skill execution is."""
+    if getattr(request.state, "is_admin", False):
+        return True
+    return getattr(request.state, "via", None) == "local_token"
+
+
+async def _resolve_agent_name(request: Request, ref: str) -> str | None:
+    """Resolve *ref* to the config agent slug (the identity used everywhere
+    else for policy grants, task assignee_id, A2A membership, board audit).
+
+    Accepts either the slug itself or a registry canonical_id: a canonical_id
+    is looked up in the agent registry and its display_name/handle matched
+    back to a config agent. Returns None if *ref* does not resolve.
+    """
+    if not ref:
+        return None
+    config = request.app.state.config
+    agent = find_agent(config, ref)
+    if agent is not None:
+        return agent["name"]
+
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is None or getattr(registry, "_db", None) is None:
+        # Not wired/initialised in this deployment -- fall back to "not
+        # found via registry" rather than raising, since the common case
+        # (a plain config-agent slug) never needs the registry at all.
+        return None
+    record = await registry.get(ref)
+    if record is None:
+        return None
+    for candidate in (record.get("display_name"), (record.get("handle") or "").lstrip("@")):
+        if candidate:
+            agent = find_agent(config, candidate)
+            if agent is not None:
+                return agent["name"]
+    return None
+
+
+class DelegateRequest(BaseModel):
+    to_agent: str
+    task_id: str | None = None
+    task_title: str | None = None
+    # Required only when creating a brand-new task from task_title (an
+    # existing task_id already carries its project). Not part of the
+    # original design note's body shape, but tasks cannot exist outside a
+    # project in this codebase — see projects/task_store.py.
+    project_id: str | None = None
+    note: str = ""
+
+
+async def _check_delegation_policy(
+    request: Request,
+    *,
+    from_agent: str,
+    to_agent: str,
+    task_id: str | None,
+    task_title: str | None,
+    project_id: str | None,
+    note: str,
+) -> JSONResponse | None:
+    """Agent governance gate for delegation. Returns a JSONResponse to
+    short-circuit the call (deny / pending-approval), or None to let the
+    caller proceed with the delegation."""
+    # Mirrors routes.skill_exec._check_execution_policy: governance applies
+    # only to AGENT callers (local-token). An admin HUMAN session is the
+    # approval authority themselves, so self-gating their own delegation is
+    # noise -- it never substitutes for the _is_admin_or_local_token check in
+    # delegate_task, which already keeps out plain non-admin sessions.
+    if (
+        getattr(request.state, "via", None) == "session"
+        and getattr(request.state, "is_admin", False)
+    ):
+        return None
+
+    policies = getattr(request.app.state, "execution_policies", None)
+    if policies is None:
+        # Not wired in this deployment; fail open rather than break
+        # delegation over an additive, not-yet-present store.
+        return None
+
+    effect = await policies.effective_effect(from_agent, ACTION_CLASS)
+    if effect == "allow":
+        return None
+
+    if effect == "deny":
+        board_audit = getattr(request.app.state, "board_audit", None)
+        if board_audit is not None:
+            try:
+                await board_audit.record(
+                    task_id=f"agent:{from_agent}",
+                    event="delegation_policy_deny",
+                    actor=from_agent,
+                    detail={"to_agent": to_agent, "action_class": ACTION_CLASS},
+                )
+            except Exception:
+                logger.warning(
+                    "board_audit record failed for delegation deny by %s", from_agent, exc_info=True
+                )
+        receipt_store = getattr(request.app.state, "receipt_store", None)
+        if receipt_store is not None:
+            try:
+                await receipt_store.record(
+                    from_agent, tool_name="delegate", stop_reason="policy_deny"
+                )
+            except Exception:
+                logger.warning(
+                    "receipt capture failed for delegation deny by %s", from_agent, exc_info=True
+                )
+        return JSONResponse(
+            {"error": "forbidden_by_policy", "action_class": ACTION_CLASS},
+            status_code=403,
+        )
+
+    # effect == "require_approval"
+    if await policies.has_live_grant(from_agent, ACTION_CLASS):
+        return None
+
+    decision_id = ""
+    decision_store = getattr(request.app.state, "decision_store", None)
+    if decision_store is not None:
+        try:
+            target = f'"{task_title}"' if task_title else (task_id or "")
+            decision = await decision_store.create(
+                from_agent=from_agent,
+                question=f"Agent {from_agent} wants to delegate {target} to {to_agent}".strip(),
+                type="approve_deny",
+                priority="blocking",
+                project_id=project_id,
+                metadata={
+                    "kind": "delegation_gate",
+                    "from_agent": from_agent,
+                    "to_agent": to_agent,
+                    "task_id": task_id,
+                    "task_title": task_title,
+                    "note": note,
+                },
+            )
+            decision_id = decision["id"]
+        except Exception:
+            logger.warning(
+                "decision create failed for delegation gate (%s -> %s)",
+                from_agent, to_agent, exc_info=True,
+            )
+
+    return JSONResponse(
+        {"status": "pending_approval", "decision_id": decision_id, "action_class": ACTION_CLASS},
+        status_code=202,
+    )
+
+
+async def _notify_delegate(
+    request: Request, *, from_agent: str, to_agent: str, task: dict, note: str
+) -> None:
+    """Best-effort: post a mention in the project's A2A channel so to_agent
+    sees the handoff. Never raises — the delegation has already completed
+    (task assigned) by the time this is called."""
+    try:
+        from tinyagentos.projects.a2a import ensure_a2a_channel
+
+        channel = await ensure_a2a_channel(
+            request.app.state.chat_channels,
+            request.app.state.project_store,
+            task["project_id"],
+            config=getattr(request.app.state, "config", None),
+        )
+        content = f'@{to_agent} {from_agent} delegated "{task["title"]}" to you.'
+        if note:
+            content += f" Note: {note}"
+        msg_store = request.app.state.chat_messages
+        await msg_store.send_message(
+            channel_id=channel["id"],
+            author_id=from_agent,
+            author_type="agent",
+            content=content,
+        )
+        await request.app.state.chat_channels.update_last_message_at(channel["id"])
+    except Exception:
+        logger.warning(
+            "delegation notify failed (%s -> %s, task %s)",
+            from_agent, to_agent, task.get("id"), exc_info=True,
+        )
+
+
+async def complete_delegation(
+    request: Request,
+    *,
+    from_agent: str,
+    to_agent: str,
+    task_id: str | None,
+    task_title: str | None,
+    project_id: str | None,
+    note: str,
+) -> dict:
+    """Assign the task to to_agent (creating it from task_title if no task_id
+    was given) and notify to_agent. Called both from the direct-allow path in
+    ``delegate_task`` below and from the approved-decision path in
+    ``routes.decisions._apply_delegation_grant``.
+
+    Raises ``ValueError`` on a bad task reference — the caller maps that to a
+    4xx in the direct path; the approval path logs it (the answer is already
+    persisted by then).
+    """
+    task_store = request.app.state.project_task_store
+    if task_id:
+        task = await task_store.get_task(task_id)
+        if task is None:
+            raise ValueError(f"task '{task_id}' not found")
+        await task_store.update_task(task_id, assignee_id=to_agent)
+        task = await task_store.get_task(task_id)
+    else:
+        if not task_title:
+            raise ValueError("task_id or task_title is required")
+        if not project_id:
+            raise ValueError("project_id is required to create a new task")
+        task = await task_store.create_task(
+            project_id=project_id, title=task_title, created_by=from_agent, assignee_id=to_agent,
+        )
+
+    await _notify_delegate(request, from_agent=from_agent, to_agent=to_agent, task=task, note=note)
+    return {"status": "delegated", "task_id": task["id"], "to_agent": to_agent}
+
+
+@router.post("/api/agents/{from_agent}/delegate")
+async def delegate_task(request: Request, from_agent: str, body: DelegateRequest):
+    """Delegate a task from from_agent to to_agent, gated by the delegate
+    action class (conservative default: require_approval).
+
+    On require_approval with no live grant, returns 202 pending_approval and
+    queues a blocking Decision; approving it (routes/decisions.py) grants the
+    action and completes the delegation.
+    """
+    if not _is_admin_or_local_token(request):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    from_name = await _resolve_agent_name(request, from_agent)
+    if from_name is None:
+        return JSONResponse({"error": f"agent '{from_agent}' not found"}, status_code=404)
+    to_name = await _resolve_agent_name(request, body.to_agent)
+    if to_name is None:
+        return JSONResponse({"error": f"agent '{body.to_agent}' not found"}, status_code=404)
+
+    if not body.task_id and not body.task_title:
+        return JSONResponse({"error": "task_id or task_title is required"}, status_code=400)
+
+    project_id = body.project_id
+    if body.task_id:
+        task_store = request.app.state.project_task_store
+        existing_task = await task_store.get_task(body.task_id)
+        if existing_task is None:
+            return JSONResponse({"error": f"task '{body.task_id}' not found"}, status_code=404)
+        project_id = existing_task["project_id"]
+    elif not project_id:
+        return JSONResponse(
+            {"error": "project_id is required when delegating a new task_title"},
+            status_code=400,
+        )
+
+    gate_response = await _check_delegation_policy(
+        request,
+        from_agent=from_name,
+        to_agent=to_name,
+        task_id=body.task_id,
+        task_title=body.task_title,
+        project_id=project_id,
+        note=body.note or "",
+    )
+    if gate_response is not None:
+        return gate_response
+
+    try:
+        return await complete_delegation(
+            request,
+            from_agent=from_name,
+            to_agent=to_name,
+            task_id=body.task_id,
+            task_title=body.task_title,
+            project_id=project_id,
+            note=body.note or "",
+        )
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)

--- a/tinyagentos/routes/delegation.py
+++ b/tinyagentos/routes/delegation.py
@@ -155,35 +155,44 @@ async def _check_delegation_policy(
     if await policies.has_live_grant(from_agent, ACTION_CLASS):
         return None
 
-    decision_id = ""
     decision_store = getattr(request.app.state, "decision_store", None)
-    if decision_store is not None:
-        try:
-            target = f'"{task_title}"' if task_title else (task_id or "")
-            decision = await decision_store.create(
-                from_agent=from_agent,
-                question=f"Agent {from_agent} wants to delegate {target} to {to_agent}".strip(),
-                type="approve_deny",
-                priority="blocking",
-                project_id=project_id,
-                metadata={
-                    "kind": "delegation_gate",
-                    "from_agent": from_agent,
-                    "to_agent": to_agent,
-                    "task_id": task_id,
-                    "task_title": task_title,
-                    "note": note,
-                },
-            )
-            decision_id = decision["id"]
-        except Exception:
-            logger.warning(
-                "decision create failed for delegation gate (%s -> %s)",
-                from_agent, to_agent, exc_info=True,
-            )
+    if decision_store is None:
+        # The action needs approval but there is no inbox to raise it in; fail
+        # loud rather than returning a fake pending_approval the caller cannot
+        # poll.
+        return JSONResponse(
+            {"error": "approval required but no decision store is available"},
+            status_code=503,
+        )
+    try:
+        target = f'"{task_title}"' if task_title else (task_id or "")
+        decision = await decision_store.create(
+            from_agent=from_agent,
+            question=f"Agent {from_agent} wants to delegate {target} to {to_agent}".strip(),
+            type="approve_deny",
+            priority="blocking",
+            project_id=project_id,
+            metadata={
+                "kind": "delegation_gate",
+                "from_agent": from_agent,
+                "to_agent": to_agent,
+                "task_id": task_id,
+                "task_title": task_title,
+                "note": note,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "decision create failed for delegation gate (%s -> %s)",
+            from_agent, to_agent, exc_info=True,
+        )
+        return JSONResponse(
+            {"error": "failed to create the delegation approval request"},
+            status_code=503,
+        )
 
     return JSONResponse(
-        {"status": "pending_approval", "decision_id": decision_id, "action_class": ACTION_CLASS},
+        {"status": "pending_approval", "decision_id": decision["id"], "action_class": ACTION_CLASS},
         status_code=202,
     )
 

--- a/tinyagentos/routes/delegation.py
+++ b/tinyagentos/routes/delegation.py
@@ -5,7 +5,7 @@ delegation, no approval rerouting).
 
 ``POST /api/agents/{from_agent}/delegate`` lets one agent hand a task to
 another. The reporting line on the agent registry (see
-``agent_registry_store.set_reporting``) is org metadata only here — it does
+``agent_registry_store.set_reporting``) is org metadata only here - it does
 NOT change who approves a delegation. Every delegation is gated by the same
 governance layer as ``routes/skill_exec.py``'s tool-execution gate: the
 ``delegate`` action class defaults to ``require_approval`` (see
@@ -14,7 +14,7 @@ delegation queues a blocking Decision instead of running immediately.
 
 The gate/decision-creation flow below mirrors
 ``routes.skill_exec._check_execution_policy`` closely but is not a direct
-call into it — that function is keyed on a ``skill_id`` classified via
+call into it - that function is keyed on a ``skill_id`` classified via
 ``governance.action_classes.classify``, whereas delegation is not a skill
 call. Keeping a small, self-contained mirror here avoids reshaping the
 well-tested skill-exec gate for a caller it was never designed around.
@@ -37,7 +37,7 @@ ACTION_CLASS = "delegate"
 
 def _is_admin_or_local_token(request: Request) -> bool:
     """True if the caller is an admin session or presented the host's local
-    token. Mirrors ``routes.skill_exec._is_admin_or_local_token`` — delegation
+    token. Mirrors ``routes.skill_exec._is_admin_or_local_token`` - delegation
     is an agent action, gated the same way skill execution is."""
     if getattr(request.state, "is_admin", False):
         return True
@@ -83,7 +83,7 @@ class DelegateRequest(BaseModel):
     # Required only when creating a brand-new task from task_title (an
     # existing task_id already carries its project). Not part of the
     # original design note's body shape, but tasks cannot exist outside a
-    # project in this codebase — see projects/task_store.py.
+    # project in this codebase - see projects/task_store.py.
     project_id: str | None = None
     note: str = ""
 
@@ -192,7 +192,7 @@ async def _notify_delegate(
     request: Request, *, from_agent: str, to_agent: str, task: dict, note: str
 ) -> None:
     """Best-effort: post a mention in the project's A2A channel so to_agent
-    sees the handoff. Never raises — the delegation has already completed
+    sees the handoff. Never raises - the delegation has already completed
     (task assigned) by the time this is called."""
     try:
         from tinyagentos.projects.a2a import ensure_a2a_channel
@@ -236,7 +236,7 @@ async def complete_delegation(
     ``delegate_task`` below and from the approved-decision path in
     ``routes.decisions._apply_delegation_grant``.
 
-    Raises ``ValueError`` on a bad task reference — the caller maps that to a
+    Raises ``ValueError`` on a bad task reference - the caller maps that to a
     4xx in the direct path; the approval path logs it (the answer is already
     persisted by then).
     """


### PR DESCRIPTION
## What

Backend for #161 (option A: org structure + gated delegation, no approval rerouting).

### Data model (agent registry)
- Adds `title` and `reports_to` columns to the agent registry via a guarded `_post_init` migration (PRAGMA `table_info` check + `ALTER TABLE`, mirroring the existing status migration; never touched `SCHEMA`).
- `register()` / `update()` accept and return `title` + `reports_to`.
- New store methods:
  - `set_reporting(canonical_id, reports_to)`: validates the manager exists, rejects self-report, and walks the `reports_to` chain (bounded + cycle-guarded) to reject reporting cycles.
  - `set_role_title(canonical_id, role=None, title=None)`.
  - `get_org_tree()`: the reporting forest (dangling `reports_to` becomes a root); `direct_reports(canonical_id)`.

### Org API
- `GET /api/agents/org`: the reporting tree (admin only, matching the registry feed routes).
- `PUT /api/agents/{canonical_id}/org`: body `{role?, title?, reports_to?}`; owner-or-admin; `reports_to` validated via `set_reporting` (400 on self/cycle/nonexistent-manager, `""` clears it). Registered in `agent_registry.py` before the generic `/api/agents/{name}` route so it is not shadowed.

### `delegate` action class + gated delegation
- Adds a `delegate` action class to the conservative default posture (`SENSITIVE_ACTION_CLASSES` + `classify` map), so it defaults to `require_approval`.
- `POST /api/agents/{from_agent}/delegate`: body `{to_agent, task_id?, task_title?, project_id?, note?}`. Resolves agents by slug or canonical_id, then runs the same governance gate as `skill_exec._check_execution_policy`:
  - `deny` -> 403 + board audit + receipt.
  - `require_approval` -> live grant proceeds; otherwise a blocking `delegation_gate` Decision is queued and `202 {status: pending_approval, decision_id}` is returned.
  - `allow` / live grant -> assign the referenced task to `to_agent` (or create it from `task_title`) via the Projects task store, then notify `to_agent` on the project's A2A channel.
- Approving the Decision (`decisions._apply_delegation_grant`) grants the `delegate` action and completes the delegation (assign + notify), mirroring the `execution_gate` approval path and leaving it intact.

The reporting line is **org metadata only** in this slice: it does **not** reroute approvals. The org-chart **UI** and **approval-rerouting** (manager-as-approver) are follow-ups.

## Tests
- `tests/test_agent_registry_store.py`: guarded migration adds `title`/`reports_to` without data loss; `set_reporting` validates manager-exists and rejects self/direct/longer cycles; `get_org_tree`/`direct_reports` shape.
- `tests/governance/test_policy_store.py`: `delegate` is in `SENSITIVE_ACTION_CLASSES` and defaults to `require_approval`; `classify("delegate")`.
- `tests/test_routes_delegation.py`: deny -> 403 (task unassigned); require_approval -> 202 + Decision; live grant / allow -> delegated + task assigned; approving the Decision completes it (assign + grant); deny path; create-from-title; validation/404s; non-admin session forbidden.
- `tests/test_routes_agent_org.py`: org tree (admin only, member 403); set role/title/reports_to; clear with `""`; self/cycle/nonexistent-manager -> 400; 404; member cannot edit another owner's entry.

Targeted suites run green: 260 passed (`test_agent_registry_store` + `test_routes_delegation` + `test_routes_agent_org` + `governance/test_policy_store` + `test_routes_decisions` + `test_skill_exec_governance` + `test_registry_governance_lifecycle`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent org chart support, including viewing reporting hierarchies and updating role, title, and manager relationships.
  * Added delegated task routing between agents, including approval-gated delegation flows when restricted.
* **Bug Fixes**
  * Improved governance handling for delegation and ensured sensitive delegation actions require approval by default.
  * Added stronger validation for reporting relationships (missing managers, self-reporting, and cycle prevention), with clearer error responses.
* **Tests**
  * Added comprehensive unit and API route tests covering org fields, delegation gating, and delegation approval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->