### PR TITLE
feat(agents): opt-in heartbeat loop - wake idle running agents with their ready tasks (#164)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=82.0.1"]
+requires = ["setuptools>=83.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -18,7 +18,7 @@ dependencies = [
     # mounted APIRouter contributes none of its routes to the app, leaving
     # create_app() with an empty API surface. 0.136.3 is the last good release.
     "fastapi>=0.115.0,<0.137",
-    "uvicorn[standard]>=0.49.0",
+    "uvicorn[standard]>=0.50.0",
     "httpx>=0.27.0",
     "jinja2>=3.1.0",
     "pyyaml>=6.0",
@@ -47,12 +47,12 @@ dependencies = [
     # for the Time Machine history layer (tinyagentos/notes/shared_docs_store.py).
     "diff-match-patch>=20230430",
     # Cron expression parsing for project routines (schedule -> next_fire).
-    "croniter>=3.0.3",
+    "croniter>=6.2.3",
 ]
 
 [project.optional-dependencies]
 worker = ["pystray>=0.19.0", "Pillow>=10.0"]
-proxy = ["litellm[proxy]>=1.90.0", "prisma>=0.11.0"]
+proxy = ["litellm[proxy]>=1.91.0", "prisma>=0.11.0"]
 # Model torrent mesh (optional): libtorrent has no PyPI wheel on most platforms
 # (OS-level libtorrent-rasterbar / python3-libtorrent), so it must not be a core
 # dependency or fresh installs abort. torrent_downloader guards the import and

--- a/tests/governance/test_policy_store.py
+++ b/tests/governance/test_policy_store.py
@@ -24,6 +24,9 @@ class TestActionClasses:
         assert classify("file_read") is None
         assert classify("nonexistent_tool") is None
 
+    def test_delegate_classified(self):
+        assert classify("delegate") == "delegate"
+
 
 @pytest.mark.asyncio
 class TestConservativeSeed:
@@ -39,6 +42,12 @@ class TestConservativeSeed:
 
     async def test_unclassified_action_class_defaults_to_allow(self, store):
         assert await store.effective_effect("agent-a", "some-harmless-class") == "allow"
+
+    async def test_delegate_is_sensitive_and_defaults_to_require_approval(self, store):
+        """#161 gated delegation: the delegate action class is part of the
+        conservative default posture, same as code-exec/deploy/etc."""
+        assert "delegate" in SENSITIVE_ACTION_CLASSES
+        assert await store.effective_effect("agent-a", "delegate") == "require_approval"
 
     async def test_reinit_does_not_duplicate_seed(self, tmp_path):
         db_path = tmp_path / "policies.db"

--- a/tests/test_agent_heartbeat.py
+++ b/tests/test_agent_heartbeat.py
@@ -153,9 +153,12 @@ async def test_debounce_same_task_within_cooldown_wakes_only_once(monkeypatch):
     task = _task()
     state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[task])
 
+    # next(times, default): logging (LogRecord creation) can also call
+    # time.time() under CI, so extra calls must not exhaust the iterator.
     times = iter([1_000.0, 1_000.0 + REWAKE_COOLDOWN / 2])
     monkeypatch.setattr(
-        "tinyagentos.agent_heartbeat.time.time", lambda: next(times)
+        "tinyagentos.agent_heartbeat.time.time",
+        lambda: next(times, 1_000.0 + REWAKE_COOLDOWN / 2),
     )
 
     await _heartbeat_tick(state)
@@ -174,8 +177,12 @@ async def test_failed_wake_is_not_debounced_and_retries_next_tick(monkeypatch):
     state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[task])
     state.bridge_sessions.enqueue_user_message = AsyncMock(side_effect=RuntimeError("queue down"))
 
-    times = iter([1_000.0, 1_000.0 + 60.0])  # two ticks well within cooldown
-    monkeypatch.setattr("tinyagentos.agent_heartbeat.time.time", lambda: next(times))
+    # Two ticks well within cooldown; the warning log's LogRecord also calls
+    # time.time(), so the patch must tolerate extra calls (next default).
+    times = iter([1_000.0, 1_000.0 + 60.0])
+    monkeypatch.setattr(
+        "tinyagentos.agent_heartbeat.time.time", lambda: next(times, 1_000.0 + 60.0)
+    )
 
     await _heartbeat_tick(state)
     await _heartbeat_tick(state)
@@ -193,7 +200,8 @@ async def test_debounce_expires_after_cooldown_rewakes(monkeypatch):
 
     times = iter([1_000.0, 1_000.0 + REWAKE_COOLDOWN + 1])
     monkeypatch.setattr(
-        "tinyagentos.agent_heartbeat.time.time", lambda: next(times)
+        "tinyagentos.agent_heartbeat.time.time",
+        lambda: next(times, 1_000.0 + REWAKE_COOLDOWN + 1),
     )
 
     await _heartbeat_tick(state)

--- a/tests/test_agent_heartbeat.py
+++ b/tests/test_agent_heartbeat.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tinyagentos.agent_heartbeat import (
+    REWAKE_COOLDOWN,
+    _heartbeat_tick,
+    agent_heartbeat_loop,
+)
+
+
+def _make_state(**overrides) -> SimpleNamespace:
+    task_store = MagicMock()
+    task_store.held_task = AsyncMock(return_value=None)
+    task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[])
+    task_store.get_task_context = AsyncMock(
+        return_value={
+            "project": {"id": "prj-1", "name": "Demo", "description": ""},
+            "ancestry": [],
+            "blockers": [],
+            "is_blocked": False,
+        }
+    )
+
+    project_store = MagicMock()
+    project_store.list_members = AsyncMock(return_value=[])
+    project_store.get_project = AsyncMock(return_value={"id": "prj-1", "slug": "demo", "created_by": "u"})
+
+    chat_channels = MagicMock()
+    chat_channels.list_channels = AsyncMock(return_value=[])
+    chat_channels.create_channel = AsyncMock(return_value={"id": "chan-a2a", "members": []})
+
+    chat_messages = MagicMock()
+    chat_messages.send_message = AsyncMock(return_value={"id": "msg-1"})
+
+    bridge_sessions = MagicMock()
+    bridge_sessions.enqueue_user_message = AsyncMock()
+
+    config = overrides.get("config", SimpleNamespace(agents=[], server={"agent_heartbeat_enabled": True}))
+
+    state = SimpleNamespace(
+        project_task_store=overrides.get("project_task_store", task_store),
+        project_store=overrides.get("project_store", project_store),
+        chat_channels=overrides.get("chat_channels", chat_channels),
+        chat_messages=overrides.get("chat_messages", chat_messages),
+        bridge_sessions=overrides.get("bridge_sessions", bridge_sessions),
+        config=config,
+    )
+    return state
+
+
+def _task(**overrides) -> dict:
+    base = {"id": "tsk-1", "project_id": "prj-1", "title": "Do the thing"}
+    base.update(overrides)
+    return base
+
+
+def _agent(**overrides) -> dict:
+    base = {"id": "agent-hex-1", "name": "worker-agent", "status": "running"}
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_disabled_setting_no_wake():
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": False})
+    state = _make_state(config=config)
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[_task()])
+    await _heartbeat_tick(state)
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+    state.chat_messages.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_setting_defaults_disabled():
+    config = SimpleNamespace(agents=[_agent()], server={})
+    state = _make_state(config=config)
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[_task()])
+    await _heartbeat_tick(state)
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_enabled_idle_running_agent_with_ready_task_wakes_once():
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    task = _task()
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[task])
+
+    await _heartbeat_tick(state)
+
+    state.bridge_sessions.enqueue_user_message.assert_awaited_once()
+    args = state.bridge_sessions.enqueue_user_message.call_args.args
+    assert args[0] == "worker-agent"
+    assert args[1]["id"] == "tsk-1"
+    assert "tsk-1" in args[1]["text"]
+
+    state.chat_messages.send_message.assert_awaited_once()
+    kwargs = state.chat_messages.send_message.call_args.kwargs
+    assert kwargs["channel_id"] == "chan-a2a"
+    assert kwargs["content_type"] == "system"
+    assert "tsk-1" in kwargs["content"]
+
+    state.project_task_store.list_ready_tasks_for_assignee.assert_awaited_once_with("agent-hex-1")
+    state.project_task_store.get_task_context.assert_awaited_once_with("tsk-1")
+
+
+@pytest.mark.asyncio
+async def test_agent_holding_a_task_is_not_woken():
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    state.project_task_store.held_task = AsyncMock(return_value="tsk-held")
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[_task()])
+
+    await _heartbeat_tick(state)
+
+    state.project_task_store.list_ready_tasks_for_assignee.assert_not_awaited()
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_running_agent_is_not_woken():
+    config = SimpleNamespace(agents=[_agent(status="stopped")], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[_task()])
+
+    await _heartbeat_tick(state)
+
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_ready_tasks_skips_agent():
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[])
+
+    await _heartbeat_tick(state)
+
+    state.bridge_sessions.enqueue_user_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_debounce_same_task_within_cooldown_wakes_only_once(monkeypatch):
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    task = _task()
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[task])
+
+    times = iter([1_000.0, 1_000.0 + REWAKE_COOLDOWN / 2])
+    monkeypatch.setattr(
+        "tinyagentos.agent_heartbeat.time.time", lambda: next(times)
+    )
+
+    await _heartbeat_tick(state)
+    await _heartbeat_tick(state)
+
+    state.bridge_sessions.enqueue_user_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_debounce_expires_after_cooldown_rewakes(monkeypatch):
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    task = _task()
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[task])
+
+    times = iter([1_000.0, 1_000.0 + REWAKE_COOLDOWN + 1])
+    monkeypatch.setattr(
+        "tinyagentos.agent_heartbeat.time.time", lambda: next(times)
+    )
+
+    await _heartbeat_tick(state)
+    await _heartbeat_tick(state)
+
+    assert state.bridge_sessions.enqueue_user_message.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_one_bad_agent_does_not_break_the_tick():
+    good = _agent(id="agent-good", name="good-agent")
+    bad = _agent(id="agent-bad", name="bad-agent")
+    config = SimpleNamespace(agents=[bad, good], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+
+    async def _ready(assignee_id):
+        if assignee_id == "agent-bad":
+            raise RuntimeError("boom")
+        return [_task(id="tsk-good")]
+
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(side_effect=_ready)
+
+    await _heartbeat_tick(state)
+
+    state.bridge_sessions.enqueue_user_message.assert_awaited_once()
+    args = state.bridge_sessions.enqueue_user_message.call_args.args
+    assert args[0] == "good-agent"
+
+
+@pytest.mark.asyncio
+async def test_agent_heartbeat_loop_ticks_then_sleeps(monkeypatch):
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[_task()])
+
+    sleeps = []
+    import asyncio as _asyncio
+
+    async def _fake_sleep(seconds):
+        sleeps.append(seconds)
+        raise _asyncio.CancelledError()
+
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
+
+    with pytest.raises(_asyncio.CancelledError):
+        await agent_heartbeat_loop(state)
+
+    state.bridge_sessions.enqueue_user_message.assert_awaited_once()
+    assert sleeps == [60]

--- a/tests/test_agent_heartbeat.py
+++ b/tests/test_agent_heartbeat.py
@@ -95,7 +95,10 @@ async def test_enabled_idle_running_agent_with_ready_task_wakes_once():
     state.bridge_sessions.enqueue_user_message.assert_awaited_once()
     args = state.bridge_sessions.enqueue_user_message.call_args.args
     assert args[0] == "worker-agent"
-    assert args[1]["id"] == "tsk-1"
+    # Message id is a fresh uuid (NOT the task id, which would collide across
+    # repeated announcements); the task stays traceable via trace_id.
+    assert args[1]["id"] != "tsk-1"
+    assert args[1]["trace_id"] == "heartbeat-tsk-1"
     assert "tsk-1" in args[1]["text"]
 
     state.chat_messages.send_message.assert_awaited_once()
@@ -159,6 +162,26 @@ async def test_debounce_same_task_within_cooldown_wakes_only_once(monkeypatch):
     await _heartbeat_tick(state)
 
     state.bridge_sessions.enqueue_user_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_wake_is_not_debounced_and_retries_next_tick(monkeypatch):
+    # A wake whose enqueue fails must NOT stamp the debounce; the next tick
+    # retries instead of silencing the agent for the whole cooldown.
+    config = SimpleNamespace(agents=[_agent()], server={"agent_heartbeat_enabled": True})
+    state = _make_state(config=config)
+    task = _task()
+    state.project_task_store.list_ready_tasks_for_assignee = AsyncMock(return_value=[task])
+    state.bridge_sessions.enqueue_user_message = AsyncMock(side_effect=RuntimeError("queue down"))
+
+    times = iter([1_000.0, 1_000.0 + 60.0])  # two ticks well within cooldown
+    monkeypatch.setattr("tinyagentos.agent_heartbeat.time.time", lambda: next(times))
+
+    await _heartbeat_tick(state)
+    await _heartbeat_tick(state)
+
+    # Both ticks attempted the wake (no silencing after the failure).
+    assert state.bridge_sessions.enqueue_user_message.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -11,6 +11,7 @@ from tinyagentos.agent_registry_store import (
     _b64url_decode,
     _b64url_encode,
     _migration_v2_strip_at_display_name,
+    _migration_v3_add_org_fields,
     _row_to_dict,
     _slugify,
     load_or_create_signing_keypair,
@@ -885,3 +886,254 @@ class TestMigrationV2StripAtDisplayName:
         after = await s2.get(row["canonical_id"])
         assert after["display_name"] == "auto-migrated"
         await s2.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration v3: add title + reports_to columns (#161 org model)
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationV3AddOrgFields:
+    @pytest.mark.asyncio
+    async def test_columns_added_without_data_loss(self, store):
+        """Running the guarded migration on an existing DB adds title +
+        reports_to without touching any pre-existing row data."""
+        row = await store.register(
+            framework="openclaw",
+            display_name="Pre-existing Agent",
+            user_id="user-1",
+            capabilities=["read"],
+        )
+        cid = row["canonical_id"]
+
+        # The migration already ran once via _post_init on store init; run it
+        # again directly to prove it's idempotent and non-destructive.
+        await _migration_v3_add_org_fields(store._db)
+
+        after = await store.get(cid)
+        assert after["display_name"] == "Pre-existing Agent"
+        assert after["user_id"] == "user-1"
+        assert after["capabilities"] == ["read"]
+        assert after["title"] is None
+        assert after["reports_to"] is None
+
+    @pytest.mark.asyncio
+    async def test_adds_columns_on_reopen(self, tmp_path):
+        """A pre-existing DB (created before title/reports_to existed)
+        gains both columns on the next store init with no data loss."""
+        db_path = tmp_path / "reopen_test.db"
+        s1 = AgentRegistryStore(db_path)
+        await s1.init()
+        row = await s1.register(framework="openclaw", display_name="Survivor")
+        await s1.close()
+
+        s2 = AgentRegistryStore(db_path)
+        await s2.init()
+        after = await s2.get(row["canonical_id"])
+        assert after["display_name"] == "Survivor"
+        assert "title" in after
+        assert "reports_to" in after
+        await s2.close()
+
+
+# ---------------------------------------------------------------------------
+# Org model: register/update accept title + reports_to
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAndUpdateOrgFields:
+    @pytest.mark.asyncio
+    async def test_register_with_title_and_reports_to(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        row = await store.register(
+            framework="openclaw",
+            display_name="Report",
+            title="Staff Engineer",
+            reports_to=manager["canonical_id"],
+        )
+        assert row["title"] == "Staff Engineer"
+        assert row["reports_to"] == manager["canonical_id"]
+
+    @pytest.mark.asyncio
+    async def test_update_title(self, store):
+        row = await store.register(framework="openclaw", display_name="Titled")
+        updated = await store.update(row["canonical_id"], title="Lead")
+        assert updated["title"] == "Lead"
+
+
+# ---------------------------------------------------------------------------
+# set_role_title
+# ---------------------------------------------------------------------------
+
+
+class TestSetRoleTitle:
+    @pytest.mark.asyncio
+    async def test_sets_role_and_title(self, store):
+        row = await store.register(framework="openclaw", display_name="A")
+        updated = await store.set_role_title(row["canonical_id"], role="manager", title="VP")
+        assert updated["role"] == "manager"
+        assert updated["title"] == "VP"
+
+    @pytest.mark.asyncio
+    async def test_sets_only_title(self, store):
+        row = await store.register(framework="openclaw", display_name="A", role="worker")
+        updated = await store.set_role_title(row["canonical_id"], title="Senior Worker")
+        assert updated["role"] == "worker"
+        assert updated["title"] == "Senior Worker"
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_returns_none(self, store):
+        result = await store.set_role_title("no-such-20260101-000000", title="X")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# set_reporting
+# ---------------------------------------------------------------------------
+
+
+class TestSetReporting:
+    @pytest.mark.asyncio
+    async def test_sets_manager(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        report = await store.register(framework="openclaw", display_name="Report")
+        updated = await store.set_reporting(report["canonical_id"], manager["canonical_id"])
+        assert updated["reports_to"] == manager["canonical_id"]
+
+    @pytest.mark.asyncio
+    async def test_clears_manager_with_none(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        report = await store.register(framework="openclaw", display_name="Report")
+        await store.set_reporting(report["canonical_id"], manager["canonical_id"])
+        cleared = await store.set_reporting(report["canonical_id"], None)
+        assert cleared["reports_to"] is None
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_agent_raises_key_error(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        with pytest.raises(KeyError):
+            await store.set_reporting("no-such-20260101-000000", manager["canonical_id"])
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_manager_raises_value_error(self, store):
+        report = await store.register(framework="openclaw", display_name="Report")
+        with pytest.raises(ValueError, match="reports_to manager not found"):
+            await store.set_reporting(report["canonical_id"], "no-such-manager-20260101-000000")
+
+    @pytest.mark.asyncio
+    async def test_self_report_raises_value_error(self, store):
+        row = await store.register(framework="openclaw", display_name="Solo")
+        with pytest.raises(ValueError, match="cannot report to itself"):
+            await store.set_reporting(row["canonical_id"], row["canonical_id"])
+
+    @pytest.mark.asyncio
+    async def test_direct_cycle_raises_value_error(self, store):
+        """A -> B, then trying B -> A must be rejected (2-node cycle)."""
+        a = await store.register(framework="openclaw", display_name="A")
+        b = await store.register(framework="openclaw", display_name="B")
+        await store.set_reporting(a["canonical_id"], b["canonical_id"])
+        with pytest.raises(ValueError, match="reporting cycle"):
+            await store.set_reporting(b["canonical_id"], a["canonical_id"])
+
+    @pytest.mark.asyncio
+    async def test_longer_cycle_raises_value_error(self, store):
+        """A -> B -> C, then trying C -> A must be rejected (3-node cycle)."""
+        a = await store.register(framework="openclaw", display_name="A")
+        b = await store.register(framework="openclaw", display_name="B")
+        c = await store.register(framework="openclaw", display_name="C")
+        await store.set_reporting(a["canonical_id"], b["canonical_id"])
+        await store.set_reporting(b["canonical_id"], c["canonical_id"])
+        with pytest.raises(ValueError, match="reporting cycle"):
+            await store.set_reporting(c["canonical_id"], a["canonical_id"])
+
+    @pytest.mark.asyncio
+    async def test_reassign_manager_is_allowed(self, store):
+        """Changing an existing manager (no cycle involved) succeeds."""
+        m1 = await store.register(framework="openclaw", display_name="M1")
+        m2 = await store.register(framework="openclaw", display_name="M2")
+        report = await store.register(framework="openclaw", display_name="Report")
+        await store.set_reporting(report["canonical_id"], m1["canonical_id"])
+        updated = await store.set_reporting(report["canonical_id"], m2["canonical_id"])
+        assert updated["reports_to"] == m2["canonical_id"]
+
+
+# ---------------------------------------------------------------------------
+# direct_reports / get_org_tree
+# ---------------------------------------------------------------------------
+
+
+class TestDirectReportsAndOrgTree:
+    @pytest.mark.asyncio
+    async def test_direct_reports_empty(self, store):
+        row = await store.register(framework="openclaw", display_name="Lonely")
+        assert await store.direct_reports(row["canonical_id"]) == []
+
+    @pytest.mark.asyncio
+    async def test_direct_reports_returns_children(self, store):
+        manager = await store.register(framework="openclaw", display_name="Manager")
+        r1 = await store.register(framework="openclaw", display_name="R1")
+        r2 = await store.register(framework="openclaw", display_name="R2")
+        await store.set_reporting(r1["canonical_id"], manager["canonical_id"])
+        await store.set_reporting(r2["canonical_id"], manager["canonical_id"])
+        reports = await store.direct_reports(manager["canonical_id"])
+        ids = {r["canonical_id"] for r in reports}
+        assert ids == {r1["canonical_id"], r2["canonical_id"]}
+
+    @pytest.mark.asyncio
+    async def test_org_tree_flat_when_no_managers(self, store):
+        await store.register(framework="openclaw", display_name="A")
+        await store.register(framework="openclaw", display_name="B")
+        tree = await store.get_org_tree()
+        assert len(tree) == 2
+        assert all(node["reports"] == [] for node in tree)
+
+    @pytest.mark.asyncio
+    async def test_org_tree_nests_reports(self, store):
+        manager = await store.register(
+            framework="openclaw", display_name="Manager", role="lead", title="Team Lead"
+        )
+        report = await store.register(framework="openclaw", display_name="Report")
+        await store.set_reporting(report["canonical_id"], manager["canonical_id"])
+
+        tree = await store.get_org_tree()
+        assert len(tree) == 1
+        root = tree[0]
+        assert root["canonical_id"] == manager["canonical_id"]
+        assert root["display_name"] == "Manager"
+        assert root["role"] == "lead"
+        assert root["title"] == "Team Lead"
+        assert len(root["reports"]) == 1
+        assert root["reports"][0]["canonical_id"] == report["canonical_id"]
+        assert root["reports"][0]["reports"] == []
+
+    @pytest.mark.asyncio
+    async def test_org_tree_multi_level(self, store):
+        top = await store.register(framework="openclaw", display_name="Top")
+        mid = await store.register(framework="openclaw", display_name="Mid")
+        leaf = await store.register(framework="openclaw", display_name="Leaf")
+        await store.set_reporting(mid["canonical_id"], top["canonical_id"])
+        await store.set_reporting(leaf["canonical_id"], mid["canonical_id"])
+
+        tree = await store.get_org_tree()
+        assert len(tree) == 1
+        root = tree[0]
+        assert root["canonical_id"] == top["canonical_id"]
+        assert len(root["reports"]) == 1
+        mid_node = root["reports"][0]
+        assert mid_node["canonical_id"] == mid["canonical_id"]
+        assert len(mid_node["reports"]) == 1
+        assert mid_node["reports"][0]["canonical_id"] == leaf["canonical_id"]
+
+    @pytest.mark.asyncio
+    async def test_org_tree_dangling_reports_to_becomes_root(self, store):
+        """A row whose reports_to points at a non-existent/removed manager is
+        treated as a root rather than dropped or crashing the tree build."""
+        row = await store.register(framework="openclaw", display_name="Orphan")
+        await store._db.execute(
+            "UPDATE agent_registry SET reports_to = ? WHERE canonical_id = ?",
+            ("no-such-manager-20260101-000000", row["canonical_id"]),
+        )
+        await store._db.commit()
+        tree = await store.get_org_tree()
+        ids = {node["canonical_id"] for node in tree}
+        assert row["canonical_id"] in ids

--- a/tests/test_project_task_store.py
+++ b/tests/test_project_task_store.py
@@ -477,6 +477,60 @@ async def test_list_ready_tasks_limit_clamped(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_list_ready_tasks_for_assignee_matches_only_that_assignee(tmp_path):
+    s = await _store(tmp_path)
+    mine = await s.create_task("prj-1", "Mine", "alice", assignee_id="agent-1")
+    theirs = await s.create_task("prj-1", "Theirs", "alice", assignee_id="agent-2")
+    unassigned = await s.create_task("prj-1", "Unassigned", "alice")
+    result = await s.list_ready_tasks_for_assignee("agent-1")
+    ids = [t["id"] for t in result]
+    assert ids == [mine["id"]]
+    assert theirs["id"] not in ids
+    assert unassigned["id"] not in ids
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_list_ready_tasks_for_assignee_excludes_claimed(tmp_path):
+    s = await _store(tmp_path)
+    free = await s.create_task("prj-1", "Free", "alice", assignee_id="agent-1")
+    claimed = await s.create_task("prj-1", "Claimed", "alice", assignee_id="agent-1")
+    await s.claim_task(claimed["id"], "agent-1")
+    result = await s.list_ready_tasks_for_assignee("agent-1")
+    ids = [t["id"] for t in result]
+    assert free["id"] in ids
+    assert claimed["id"] not in ids
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_list_ready_tasks_for_assignee_excludes_blocked(tmp_path):
+    s = await _store(tmp_path)
+    ready = await s.create_task("prj-1", "Ready", "alice", assignee_id="agent-1")
+    blocked = await s.create_task("prj-1", "Blocked", "alice", assignee_id="agent-1")
+    blocker = await s.create_task("prj-1", "Blocker", "alice", assignee_id="agent-1")
+    await s.add_relationship("prj-1", blocked["id"], blocker["id"], "blocks", "alice")
+    result = await s.list_ready_tasks_for_assignee("agent-1")
+    ids = [t["id"] for t in result]
+    assert ready["id"] in ids
+    assert blocked["id"] not in ids
+    assert blocker["id"] in ids
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_list_ready_tasks_for_assignee_ordered_by_priority_then_created(tmp_path):
+    s = await _store(tmp_path)
+    low = await s.create_task("prj-1", "Low", "alice", priority=1, assignee_id="agent-1")
+    high = await s.create_task("prj-1", "High", "alice", priority=10, assignee_id="agent-1")
+    mid = await s.create_task("prj-1", "Mid", "alice", priority=5, assignee_id="agent-1")
+    result = await s.list_ready_tasks_for_assignee("agent-1")
+    ids = [t["id"] for t in result]
+    assert ids == [high["id"], mid["id"], low["id"]]
+    await s.close()
+
+
+@pytest.mark.asyncio
 async def test_add_and_list_comments(tmp_path):
     s = await _store(tmp_path)
     task = await s.create_task("prj-1", "Task", "alice")

--- a/tests/test_routes_agent_org.py
+++ b/tests/test_routes_agent_org.py
@@ -1,0 +1,224 @@
+"""Org API routes (#161): GET /api/agents/org, PUT /api/agents/{canonical_id}/org.
+
+Mirrors the gov_client fixture pattern in test_registry_governance_lifecycle.py:
+the shared `client` fixture in conftest.py never initialises agent_registry
+(it is lifespan-owned), so these routes need their own fixture that inits it.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def org_client(app):
+    """Async HTTP client with admin session + agent_registry initialised."""
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": token},
+    ) as c:
+        yield c, uid
+
+    await registry_store.close()
+
+
+@pytest_asyncio.fixture
+async def org_member_client(app):
+    """Async HTTP client with a non-admin member session, same registry init."""
+    registry_store = app.state.agent_registry
+    if registry_store._db is None:
+        await registry_store.init()
+
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    admin_record = app.state.auth.find_user("admin")
+    admin_uid = admin_record["id"] if admin_record else ""
+    invite_code = app.state.auth.add_user_invite("member", admin_uid)
+    app.state.auth.complete_invite("member", invite_code, "Test Member", "", "memberpass123")
+    member_record = app.state.auth.find_user("member")
+    member_uid = member_record["id"] if member_record else ""
+    token = app.state.auth.create_session(user_id=member_uid, long_lived=True)
+    app.state._startup_complete = True
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport, base_url="http://test", cookies={"taos_session": token},
+    ) as c:
+        yield c, member_uid
+
+    await registry_store.close()
+
+
+@pytest.mark.asyncio
+class TestGetOrgChart:
+    async def test_admin_sees_full_tree(self, org_client):
+        client, admin_uid = org_client
+        manager = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Manager"},
+        )
+        manager_id = manager.json()["canonical_id"]
+        report = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Report"},
+        )
+        report_id = report.json()["canonical_id"]
+
+        put_resp = await client.put(
+            f"/api/agents/{report_id}/org", json={"reports_to": manager_id}
+        )
+        assert put_resp.status_code == 200
+
+        resp = await client.get("/api/agents/org")
+        assert resp.status_code == 200
+        tree = resp.json()["tree"]
+        root = next(n for n in tree if n["canonical_id"] == manager_id)
+        assert root["reports"][0]["canonical_id"] == report_id
+
+    async def test_member_forbidden(self, org_member_client):
+        client, _uid = org_member_client
+        resp = await client.get("/api/agents/org")
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestUpdateOrgFields:
+    async def test_set_role_and_title(self, org_client):
+        client, _uid = org_client
+        reg = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Worker"},
+        )
+        cid = reg.json()["canonical_id"]
+
+        resp = await client.put(
+            f"/api/agents/{cid}/org", json={"role": "engineer", "title": "Staff Engineer"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["role"] == "engineer"
+        assert body["title"] == "Staff Engineer"
+
+    async def test_set_reports_to(self, org_client):
+        client, _uid = org_client
+        manager = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Manager"},
+        )).json()
+        report = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Report"},
+        )).json()
+
+        resp = await client.put(
+            f"/api/agents/{report['canonical_id']}/org",
+            json={"reports_to": manager["canonical_id"]},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["reports_to"] == manager["canonical_id"]
+
+    async def test_clear_reports_to_with_empty_string(self, org_client):
+        client, _uid = org_client
+        manager = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Manager"},
+        )).json()
+        report = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Report"},
+        )).json()
+        await client.put(
+            f"/api/agents/{report['canonical_id']}/org",
+            json={"reports_to": manager["canonical_id"]},
+        )
+
+        resp = await client.put(
+            f"/api/agents/{report['canonical_id']}/org", json={"reports_to": ""}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["reports_to"] is None
+
+    async def test_self_report_is_400(self, org_client):
+        client, _uid = org_client
+        reg = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Solo"},
+        )).json()
+        resp = await client.put(
+            f"/api/agents/{reg['canonical_id']}/org",
+            json={"reports_to": reg["canonical_id"]},
+        )
+        assert resp.status_code == 400
+
+    async def test_nonexistent_manager_is_400(self, org_client):
+        client, _uid = org_client
+        reg = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Solo"},
+        )).json()
+        resp = await client.put(
+            f"/api/agents/{reg['canonical_id']}/org",
+            json={"reports_to": "no-such-manager-20260101-000000"},
+        )
+        assert resp.status_code == 400
+
+    async def test_cycle_is_400(self, org_client):
+        client, _uid = org_client
+        a = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "A"},
+        )).json()
+        b = (await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "B"},
+        )).json()
+        await client.put(f"/api/agents/{a['canonical_id']}/org", json={"reports_to": b["canonical_id"]})
+
+        resp = await client.put(
+            f"/api/agents/{b['canonical_id']}/org", json={"reports_to": a["canonical_id"]}
+        )
+        assert resp.status_code == 400
+
+    async def test_not_found_canonical_id_is_404(self, org_client):
+        client, _uid = org_client
+        resp = await client.put(
+            "/api/agents/no-such-agent-20260101-000000/org", json={"role": "x"}
+        )
+        assert resp.status_code == 404
+
+    async def test_member_cannot_update_others_entry(self, org_client, app):
+        """Builds its own member session on top of org_client's admin (rather
+        than also depending on org_member_client), since both client fixtures
+        call auth.setup_user("admin", ...) on the same underlying `app` and a
+        second call raises "a user is already configured"."""
+        admin_client, _admin_uid = org_client
+        reg = (await admin_client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "AdminOwned"},
+        )).json()
+
+        invite_code = app.state.auth.add_user_invite("member", "admin")
+        app.state.auth.complete_invite("member", invite_code, "Test Member", "", "memberpass123")
+        member = app.state.auth.find_user("member")
+        token = app.state.auth.create_session(user_id=member["id"], long_lived=True)
+
+        member_client = AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test", cookies={"taos_session": token},
+        )
+        try:
+            resp = await member_client.put(
+                f"/api/agents/{reg['canonical_id']}/org", json={"title": "hijacked"}
+            )
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403

--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -1,0 +1,355 @@
+"""Gated agent delegation (#161): POST /api/agents/{from_agent}/delegate.
+
+Mirrors the structure of test_skill_exec_governance.py: governance applies
+only to AGENT (local-token) callers, so every gating assertion uses a
+local-token client, not the admin-session `client` fixture (an admin session
+bypasses governance the same way it does for skill-exec).
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+def _local_token_client(app) -> AsyncClient:
+    """A bare client (no session cookie) presenting the host local token --
+    the way a deployed agent calls this endpoint. Governance applies here."""
+    local_token = app.state.auth.get_local_token()
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {local_token}"},
+    )
+
+
+async def _make_project_and_task(app, *, title="Do the thing", created_by="from-agent"):
+    project = await app.state.project_store.create_project(
+        name="Delegation Test Project", slug="delegation-test", created_by=created_by,
+    )
+    task = await app.state.project_task_store.create_task(
+        project_id=project["id"], title=title, created_by=created_by,
+    )
+    return project, task
+
+
+@pytest.fixture(autouse=True)
+def _seed_agents(app):
+    """Two config agents so from_agent/to_agent resolve via find_agent."""
+    app.state.config.agents.append(
+        {"name": "from-agent", "host": "", "qmd_index": "from-agent", "color": "#111111"}
+    )
+    app.state.config.agents.append(
+        {"name": "to-agent", "host": "", "qmd_index": "to-agent", "color": "#222222"}
+    )
+
+
+@pytest.mark.asyncio
+class TestDelegationGateDeny:
+    async def test_deny_policy_returns_403_and_does_not_assign(self, client, app):
+        await app.state.execution_policies.set_policy("delegate", "deny", agent_name="from-agent")
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "forbidden_by_policy"
+
+        unchanged = await app.state.project_task_store.get_task(task["id"])
+        assert unchanged["assignee_id"] is None
+
+
+@pytest.mark.asyncio
+class TestDelegationGateRequireApproval:
+    async def test_conservative_default_is_pending_approval(self, client, app):
+        """delegate is a seeded conservative-default action class -- with no
+        override and no live grant, an agent's delegation queues a Decision
+        instead of running immediately."""
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"], "note": "please pick this up"},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 202
+        body = resp.json()
+        assert body["status"] == "pending_approval"
+        assert body["action_class"] == "delegate"
+        assert body["decision_id"]
+
+        decision = await app.state.decision_store.get(body["decision_id"])
+        assert decision is not None
+        assert decision["status"] == "pending"
+        assert decision["priority"] == "blocking"
+        assert decision["metadata"]["kind"] == "delegation_gate"
+        assert decision["metadata"]["from_agent"] == "from-agent"
+        assert decision["metadata"]["to_agent"] == "to-agent"
+        assert decision["metadata"]["task_id"] == task["id"]
+        assert decision["metadata"]["note"] == "please pick this up"
+
+        # The task must not be assigned until the decision is approved.
+        still_open = await app.state.project_task_store.get_task(task["id"])
+        assert still_open["assignee_id"] is None
+
+    async def test_live_grant_allows_immediate_delegation(self, client, app):
+        _project, task = await _make_project_and_task(app)
+        await app.state.execution_policies.add_grant("from-agent", "delegate", "dec-x")
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "delegated"
+        assert body["task_id"] == task["id"]
+        assert body["to_agent"] == "to-agent"
+
+        updated = await app.state.project_task_store.get_task(task["id"])
+        assert updated["assignee_id"] == "to-agent"
+
+    async def test_grant_is_scoped_per_agent(self, client, app):
+        """A grant for one agent does not authorize a different agent's delegation."""
+        _project, task = await _make_project_and_task(app)
+        await app.state.execution_policies.add_grant("someone-else", "delegate", "dec-x")
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 202
+        assert resp.json()["status"] == "pending_approval"
+
+
+@pytest.mark.asyncio
+class TestDelegationAllowPolicy:
+    async def test_allow_policy_delegates_immediately(self, client, app):
+        await app.state.execution_policies.set_policy("delegate", "allow", agent_name="from-agent")
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "delegated"
+
+
+@pytest.mark.asyncio
+class TestDelegationApprovalFlow:
+    async def test_approving_decision_completes_delegation(self, client, app):
+        """The full round trip: an ungranted delegation queues a Decision;
+        answering it 'approve' assigns the task, grants the action class for
+        next time, and notifies to_agent on the project's A2A channel."""
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"], "note": "handoff"},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 202
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "approve"}
+        )
+        assert answer_resp.status_code == 200
+
+        completed = await app.state.project_task_store.get_task(task["id"])
+        assert completed["assignee_id"] == "to-agent"
+
+        # The action class is now granted for from-agent, so a follow-up
+        # delegation by the same agent proceeds without another approval.
+        assert await app.state.execution_policies.has_live_grant("from-agent", "delegate")
+
+    async def test_denying_decision_does_not_delegate(self, client, app):
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "deny"}
+        )
+        assert answer_resp.status_code == 200
+
+        still_open = await app.state.project_task_store.get_task(task["id"])
+        assert still_open["assignee_id"] is None
+        assert not await app.state.execution_policies.has_live_grant("from-agent", "delegate")
+
+    async def test_approving_decision_creates_task_from_title(self, client, app):
+        """Same approval round trip, but the original request had no task_id
+        -- only a task_title + project_id -- so approval must create it."""
+        project, _existing_task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={
+                    "to_agent": "to-agent",
+                    "task_title": "Brand new task",
+                    "project_id": project["id"],
+                },
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 202
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "approve"}
+        )
+        assert answer_resp.status_code == 200
+
+        tasks = await app.state.project_task_store.list_tasks(project["id"])
+        new_task = next(t for t in tasks if t["title"] == "Brand new task")
+        assert new_task["assignee_id"] == "to-agent"
+
+
+@pytest.mark.asyncio
+class TestDelegationTaskTitleCreatesTask:
+    async def test_allow_policy_creates_task_from_title(self, client, app):
+        await app.state.execution_policies.set_policy("delegate", "allow", agent_name="from-agent")
+        project = await app.state.project_store.create_project(
+            name="New Task Project", slug="new-task-project", created_by="from-agent",
+        )
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_title": "Write the docs", "project_id": project["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "delegated"
+
+        tasks = await app.state.project_task_store.list_tasks(project["id"])
+        created = next(t for t in tasks if t["title"] == "Write the docs")
+        assert created["assignee_id"] == "to-agent"
+
+    async def test_task_title_without_project_id_is_400(self, client, app):
+        await app.state.execution_policies.set_policy("delegate", "allow", agent_name="from-agent")
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_title": "Orphan task"},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+class TestDelegationValidation:
+    async def test_missing_task_id_and_task_title_is_400(self, client, app):
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate", json={"to_agent": "to-agent"}
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 400
+
+    async def test_unknown_from_agent_is_404(self, client, app):
+        _project, task = await _make_project_and_task(app)
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/no-such-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 404
+
+    async def test_unknown_to_agent_is_404(self, client, app):
+        _project, task = await _make_project_and_task(app)
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "no-such-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 404
+
+    async def test_unknown_task_id_is_404(self, client, app):
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": "no-such-task"},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 404
+
+    async def test_plain_non_admin_session_is_forbidden(self, client, app):
+        """A bare non-admin member session must never reach the gate --
+        mirrors _is_admin_or_local_token's guard in skill_exec.py. The
+        `client` fixture already set up the admin user + startup_complete;
+        this just adds a non-admin member on top of it."""
+        auth_mgr = app.state.auth
+        invite_code = auth_mgr.add_user_invite("member", "admin")
+        auth_mgr.complete_invite("member", invite_code, "Test Member", "", "memberpass123")
+        member = auth_mgr.find_user("member")
+        token = auth_mgr.create_session(user_id=member["id"], long_lived=True)
+
+        member_client = AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"taos_session": token},
+        )
+        try:
+            resp = await member_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_title": "x", "project_id": "p1"},
+            )
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403

--- a/tinyagentos/agent_heartbeat.py
+++ b/tinyagentos/agent_heartbeat.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -52,11 +53,15 @@ def _should_wake(debounce: dict, agent_id: str, task_id: str, now: float) -> boo
     return True
 
 
-async def _wake_agent_with_task(app_state, agent: dict, task: dict) -> None:
+async def _wake_agent_with_task(app_state, agent: dict, task: dict) -> bool:
     """Best-effort wake: enqueue a user_message to the agent's bridge session
     and post a system message into the project's a2a channel. Mirrors
     tinyagentos.projects.routine_runner._wake_and_announce -- each sub-step
-    degrades independently so one failure doesn't skip the other."""
+    degrades independently so one failure doesn't skip the other.
+
+    Returns True only when the primary enqueue reached the agent's queue, so
+    the caller debounces successful wakes and retries failed ones next tick
+    instead of silencing the agent for the whole cooldown."""
     project_task_store = app_state.project_task_store
     config = getattr(app_state, "config", None)
 
@@ -77,14 +82,18 @@ async def _wake_agent_with_task(app_state, agent: dict, task: dict) -> None:
     if why:
         text = f"{text}\n{why}"
 
+    enqueued = False
     bridge_sessions = getattr(app_state, "bridge_sessions", None)
     if bridge_sessions is not None:
         try:
             await bridge_sessions.enqueue_user_message(
                 agent["name"],
                 {
-                    "id": task["id"],
-                    "trace_id": task["id"],
+                    # A fresh message id: reusing the task id would collide in
+                    # any consumer that keys by message id (a task can be
+                    # announced more than once).
+                    "id": uuid.uuid4().hex,
+                    "trace_id": f"heartbeat-{task['id']}",
                     "channel_id": None,
                     "from": "heartbeat",
                     "text": text,
@@ -92,6 +101,7 @@ async def _wake_agent_with_task(app_state, agent: dict, task: dict) -> None:
                     "hops_since_user": 0,
                 },
             )
+            enqueued = True
         except Exception:
             logger.warning(
                 "heartbeat: wake enqueue failed for agent %s", agent.get("name"), exc_info=True,
@@ -118,6 +128,8 @@ async def _wake_agent_with_task(app_state, agent: dict, task: dict) -> None:
             logger.warning(
                 "heartbeat: a2a announce failed for task %s", task["id"], exc_info=True,
             )
+
+    return enqueued
 
 
 async def _heartbeat_tick(app_state) -> None:
@@ -147,8 +159,11 @@ async def _heartbeat_tick(app_state) -> None:
             task = ready[0]
             if not _should_wake(debounce, agent_id, task["id"], now):
                 continue
-            await _wake_agent_with_task(app_state, agent, task)
-            debounce[agent_id] = (task["id"], now)
+            # Debounce only a wake that actually reached the agent's queue; a
+            # failed enqueue retries next tick instead of silencing the agent
+            # for the whole cooldown.
+            if await _wake_agent_with_task(app_state, agent, task):
+                debounce[agent_id] = (task["id"], now)
         except Exception:
             logger.exception("heartbeat: tick failed for agent %s", agent.get("name"))
 

--- a/tinyagentos/agent_heartbeat.py
+++ b/tinyagentos/agent_heartbeat.py
@@ -1,0 +1,168 @@
+"""Agent heartbeat: on a periodic tick, wake idle running agents with their
+next ready task plus that task's relational context, so agents pull and act
+on their queue autonomously rather than waiting to be prompted.
+
+"Act" means notify, not drive: this best-effort enqueues a system message
+onto the agent's own bridge session and posts to the project's a2a channel --
+the exact mechanism tinyagentos.projects.routine_runner uses to wake an
+assignee. It never drives an ACP/LLM turn directly and never deploys or execs
+a non-running agent (status != "running" is skipped entirely).
+
+The tick loop mirrors routine_tick_loop and the other lifespan-owned
+background loops in app.py (e.g. _ephemeral_sweep_loop): a plain `while True`
++ try/except-per-iteration + sleep, registered in app.state._background_tasks
+so the existing bounded cancel_and_wait shutdown path cancels it alongside
+every other loop -- no separate start/stop lifecycle needed.
+
+Opt-in: gated behind config.server["agent_heartbeat_enabled"] (default
+False), re-read every tick from app_state.config so it can be toggled via the
+existing PUT /api/config endpoint without a restart.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+HEARTBEAT_INTERVAL = 60  # seconds between agent queue sweeps
+REWAKE_COOLDOWN = 300  # seconds before the same (agent, task) may be re-woken
+
+
+def _heartbeat_enabled(app_state) -> bool:
+    config = getattr(app_state, "config", None)
+    server = getattr(config, "server", None) or {}
+    return bool(server.get("agent_heartbeat_enabled", False))
+
+
+def _debounce_map(app_state) -> dict:
+    """The in-memory {agent_id: (task_id, last_wake_ts)} dedup, created lazily
+    on app_state so it survives across ticks within a process without a new
+    persistent store."""
+    if not hasattr(app_state, "_heartbeat_last_wake"):
+        app_state._heartbeat_last_wake = {}
+    return app_state._heartbeat_last_wake
+
+
+def _should_wake(debounce: dict, agent_id: str, task_id: str, now: float) -> bool:
+    last = debounce.get(agent_id)
+    if last is not None and last[0] == task_id and now - last[1] < REWAKE_COOLDOWN:
+        return False
+    return True
+
+
+async def _wake_agent_with_task(app_state, agent: dict, task: dict) -> None:
+    """Best-effort wake: enqueue a user_message to the agent's bridge session
+    and post a system message into the project's a2a channel. Mirrors
+    tinyagentos.projects.routine_runner._wake_and_announce -- each sub-step
+    degrades independently so one failure doesn't skip the other."""
+    project_task_store = app_state.project_task_store
+    config = getattr(app_state, "config", None)
+
+    try:
+        context = await project_task_store.get_task_context(task["id"])
+    except Exception:
+        logger.warning(
+            "heartbeat: get_task_context failed for task %s", task["id"], exc_info=True,
+        )
+        context = None
+
+    from tinyagentos.projects.beads_format import format_why
+    why = None
+    if context is not None:
+        why = format_why(context["project"], context["ancestry"])
+
+    text = f"Heartbeat: you have a ready task {task['id']}: {task['title']}"
+    if why:
+        text = f"{text}\n{why}"
+
+    bridge_sessions = getattr(app_state, "bridge_sessions", None)
+    if bridge_sessions is not None:
+        try:
+            await bridge_sessions.enqueue_user_message(
+                agent["name"],
+                {
+                    "id": task["id"],
+                    "trace_id": task["id"],
+                    "channel_id": None,
+                    "from": "heartbeat",
+                    "text": text,
+                    "author_type": "system",
+                    "hops_since_user": 0,
+                },
+            )
+        except Exception:
+            logger.warning(
+                "heartbeat: wake enqueue failed for agent %s", agent.get("name"), exc_info=True,
+            )
+
+    chat_channels = getattr(app_state, "chat_channels", None)
+    chat_messages = getattr(app_state, "chat_messages", None)
+    project_store = getattr(app_state, "project_store", None)
+    if chat_channels is not None and chat_messages is not None and project_store is not None:
+        try:
+            from tinyagentos.projects.a2a import ensure_a2a_channel
+            channel = await ensure_a2a_channel(
+                chat_channels, project_store, task["project_id"], config=config
+            )
+            await chat_messages.send_message(
+                channel_id=channel["id"],
+                author_id="heartbeat",
+                author_type="system",
+                content=text,
+                content_type="system",
+                state="complete",
+            )
+        except Exception:
+            logger.warning(
+                "heartbeat: a2a announce failed for task %s", task["id"], exc_info=True,
+            )
+
+
+async def _heartbeat_tick(app_state) -> None:
+    """One sweep over app_state.config.agents: wake each idle running agent's
+    next ready task, debounced per (agent, task) within REWAKE_COOLDOWN.
+    Failure-isolated per agent so one bad agent never breaks the tick."""
+    if not _heartbeat_enabled(app_state):
+        return
+
+    config = getattr(app_state, "config", None)
+    project_task_store = app_state.project_task_store
+    debounce = _debounce_map(app_state)
+    now = time.time()
+
+    for agent in getattr(config, "agents", None) or []:
+        if agent.get("status") != "running":
+            continue
+        agent_id = agent.get("id")
+        if not agent_id:
+            continue
+        try:
+            if await project_task_store.held_task(agent_id) is not None:
+                continue
+            ready = await project_task_store.list_ready_tasks_for_assignee(agent_id)
+            if not ready:
+                continue
+            task = ready[0]
+            if not _should_wake(debounce, agent_id, task["id"], now):
+                continue
+            await _wake_agent_with_task(app_state, agent, task)
+            debounce[agent_id] = (task["id"], now)
+        except Exception:
+            logger.exception("heartbeat: tick failed for agent %s", agent.get("name"))
+
+
+async def agent_heartbeat_loop(app_state, interval: float = HEARTBEAT_INTERVAL) -> None:
+    """Sweep running agents every *interval* seconds and wake each idle one
+    with its next ready task. No-op (cheap) while
+    config.server["agent_heartbeat_enabled"] is falsy, re-checked every tick
+    so the setting can be toggled without a restart."""
+    while True:
+        try:
+            await _heartbeat_tick(app_state)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("heartbeat: sweep iteration crashed")
+        await asyncio.sleep(interval)

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Agent Registry store — canonical agent-identity persistence.
+"""Agent Registry store - canonical agent-identity persistence.
 
 Each registered agent gets a unique canonical_id minted once (immutable) and
 a signed JWT-style token issued at registration time.  The signing key is an
@@ -63,7 +63,7 @@ _VALID_TRANSITIONS: frozenset[tuple[str, str]] = frozenset({
     ("active",    "revoked"),     # revoke (terminal)
     ("suspended", "revoked"),     # revoke (terminal)
     ("pending",   "revoked"),     # revoke (terminal)
-    ("rejected",  "revoked"),     # revoke (terminal) — any non-terminal → revoked
+    ("rejected",  "revoked"),     # revoke (terminal) - any non-terminal → revoked
     ("rejected",  "pending"),     # undo denial → re-open
     ("rejected",  "active"),      # undo denial → directly approve
 })
@@ -86,7 +86,7 @@ def _assert_valid_transition(before: str, after: str) -> None:
 async def _migration_v1_add_status(conn) -> None:
     """Add status column (idempotent) and backfill existing rows."""
     # Check if the column already exists (SQLite has no IF NOT EXISTS for ADD COLUMN
-    # prior to 3.37 — use PRAGMA instead for broad compatibility).
+    # prior to 3.37 - use PRAGMA instead for broad compatibility).
     existing_cols = {
         row[1]
         for row in await (
@@ -108,7 +108,7 @@ async def _migration_v2_strip_at_display_name(conn) -> None:
     """Strip a leading '@' from display_name for all rows (idempotent).
 
     The '@' sigil is bus-addressing syntax only; it must never be stored
-    in display_name.  Safe to run every startup — rows without a leading
+    in display_name.  Safe to run every startup - rows without a leading
     '@' are untouched by the WHERE clause.
     """
     # '@_%' requires at least one character after '@', so bare '@'-only rows
@@ -117,6 +117,25 @@ async def _migration_v2_strip_at_display_name(conn) -> None:
         "UPDATE agent_registry SET display_name = substr(display_name, 2) "
         "WHERE display_name LIKE '@_%'"
     )
+    await conn.commit()
+
+
+async def _migration_v3_add_org_fields(conn) -> None:
+    """Add title + reports_to columns (idempotent) for the org model (#161).
+
+    ``reports_to`` references another row's canonical_id (the agent's
+    manager); NULL means the agent has no manager (an org-tree root).
+    """
+    existing_cols = {
+        row[1]
+        for row in await (
+            await conn.execute("PRAGMA table_info(agent_registry)")
+        ).fetchall()
+    }
+    if "title" not in existing_cols:
+        await conn.execute("ALTER TABLE agent_registry ADD COLUMN title TEXT")
+    if "reports_to" not in existing_cols:
+        await conn.execute("ALTER TABLE agent_registry ADD COLUMN reports_to TEXT")
     await conn.commit()
 
 # ---------------------------------------------------------------------------
@@ -132,7 +151,7 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
     Generates an Ed25519 keypair on first call and persists the private key
     PEM to ``<data_dir>/agent_registry_signing.pem`` with mode 0600.
     Subsequent calls load and return the same keypair.  Idempotent under
-    concurrent processes — the writer uses O_EXCL so only one process
+    concurrent processes - the writer uses O_EXCL so only one process
     creates the file.
     """
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -161,7 +180,7 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
             finally:
                 os.close(fd)
         except FileExistsError:
-            # Lost the race — load the winner's key instead.
+            # Lost the race - load the winner's key instead.
             private_key = load_pem_private_key(pem_path.read_bytes(), password=None)
 
     private_pem = private_key.private_bytes(
@@ -174,7 +193,7 @@ def load_or_create_signing_keypair(data_dir: Path) -> tuple[bytes, bytes]:
 
 
 # ---------------------------------------------------------------------------
-# Token minting (compact JWT-style — header.payload.signature, base64url)
+# Token minting (compact JWT-style - header.payload.signature, base64url)
 # ---------------------------------------------------------------------------
 
 def _b64url_encode(data: bytes) -> str:
@@ -205,12 +224,12 @@ def mint_registry_token(
     can verify it without importing tinyagentos code.
 
     Claims:
-      sub        — canonical_id (immutable agent identity)
-      iss        — "taos-registry"
-      iat        — unix timestamp of issuance
-      user_id    — owning user_id at registration time
-      framework  — agent framework at registration time
-      project_id — project binding, present only when non-empty; absent means
+      sub        - canonical_id (immutable agent identity)
+      iss        - "taos-registry"
+      iat        - unix timestamp of issuance
+      user_id    - owning user_id at registration time
+      framework  - agent framework at registration time
+      project_id - project binding, present only when non-empty; absent means
                    the token is global (not bound to any project)
 
     Signed with Ed25519 over the UTF-8 bytes of ``<header_b64url>.<payload_b64url>``.
@@ -317,6 +336,7 @@ class AgentRegistryStore(BaseStore):
         """Idempotently ensure the status column exists and is backfilled."""
         await _migration_v1_add_status(self._db)
         await _migration_v2_strip_at_display_name(self._db)
+        await _migration_v3_add_org_fields(self._db)
 
     # ------------------------------------------------------------------
     # Registration
@@ -331,14 +351,20 @@ class AgentRegistryStore(BaseStore):
         origin: str = "taos-deployed",
         handle: str = "",
         role: Optional[str] = None,
+        title: Optional[str] = None,
+        reports_to: Optional[str] = None,
         capabilities: Optional[list[str]] = None,
     ) -> dict:
         """Mint a canonical_id, persist the record, and return it.
 
+        ``reports_to`` is stored as-is with no validation here (the row does
+        not exist yet, so it cannot be part of an existing cycle) - use
+        ``set_reporting`` after registration to validate a manager change.
+
         Raises ``RuntimeError`` if the store is not initialised.
         """
         if self._db is None:
-            raise RuntimeError("AgentRegistryStore not initialised — call init() first")
+            raise RuntimeError("AgentRegistryStore not initialised - call init() first")
 
         capabilities = capabilities or []
         now_utc = datetime.now(timezone.utc)
@@ -368,11 +394,11 @@ class AgentRegistryStore(BaseStore):
             """
             INSERT INTO agent_registry
                 (canonical_id, display_name, framework, user_id, origin,
-                 handle, role, capabilities, created_ts, status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 handle, role, title, reports_to, capabilities, created_ts, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (canonical_id, display_name, framework, user_id, origin,
-             handle, role, caps_json, created_ts, initial_status),
+             handle, role, title, reports_to, caps_json, created_ts, initial_status),
         )
         await self._db.commit()
 
@@ -506,7 +532,7 @@ class AgentRegistryStore(BaseStore):
         now = datetime.now(timezone.utc).isoformat()
         # Atomic: the UPDATE is conditional on the status still being
         # ``before_status``, so two concurrent transitions cannot both win a
-        # read/validate/write race — the loser's WHERE matches 0 rows. This
+        # read/validate/write race - the loser's WHERE matches 0 rows. This
         # also guarantees the returned/audited before_status is accurate.
         if new_status == "revoked":
             cur = await self._db.execute(
@@ -540,12 +566,16 @@ class AgentRegistryStore(BaseStore):
         display_name: Optional[str] = None,
         handle: Optional[str] = None,
         role: Optional[str] = None,
+        title: Optional[str] = None,
         capabilities: Optional[list[str]] = None,
     ) -> Optional[dict]:
         """Update mutable metadata fields on *canonical_id*.
 
         Only the provided (non-None) fields are changed.
         Status, user_id, framework, canonical_id, and timestamps are immutable.
+        ``reports_to`` is deliberately NOT settable here: all reporting-line
+        changes must go through ``set_reporting`` so the self-report, cycle,
+        and manager-exists checks can never be bypassed.
         Returns the updated record, or None if *canonical_id* does not exist.
         """
         if self._db is None:
@@ -565,6 +595,9 @@ class AgentRegistryStore(BaseStore):
         if role is not None:
             cols.append("role = ?")
             vals.append(role)
+        if title is not None:
+            cols.append("title = ?")
+            vals.append(title)
         if capabilities is not None:
             cols.append("capabilities = ?")
             vals.append(json.dumps(capabilities))
@@ -586,7 +619,7 @@ class AgentRegistryStore(BaseStore):
         if record is None:
             return None
         if record.get("revoked_at"):
-            # Already revoked — return the existing record unchanged.
+            # Already revoked - return the existing record unchanged.
             return record
         now = datetime.now(timezone.utc).isoformat()
         # Atomic: only the first concurrent revoke matches (revoked_at IS NULL);
@@ -598,3 +631,134 @@ class AgentRegistryStore(BaseStore):
         )
         await self._db.commit()
         return await self.get(canonical_id)
+
+    # ------------------------------------------------------------------
+    # Org model (#161): reporting lines, roles/titles, org tree
+    # ------------------------------------------------------------------
+
+    # Cap on the reports_to chain walk used by both the cycle guard in
+    # set_reporting and the tree-building recursion in get_org_tree - bounds
+    # the cost of a corrupt or pathological chain instead of looping forever.
+    _MAX_REPORTS_TO_WALK = 50
+
+    async def set_role_title(
+        self,
+        canonical_id: str,
+        *,
+        role: Optional[str] = None,
+        title: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Set *role* and/or *title* on *canonical_id* (free-form strings).
+
+        Only the provided (non-None) fields are changed.  Returns the updated
+        record, or None if *canonical_id* does not exist.
+        """
+        return await self.update(canonical_id, role=role, title=title)
+
+    async def set_reporting(
+        self, canonical_id: str, reports_to: Optional[str]
+    ) -> dict:
+        """Set (or, with ``None``, clear) *canonical_id*'s manager.
+
+        Validates:
+          - *canonical_id* exists (``KeyError`` otherwise)
+          - *reports_to* (when not ``None``) refers to an existing agent
+            (``ValueError`` otherwise)
+          - *reports_to* is not *canonical_id* itself (no self-report)
+          - assigning *reports_to* does not create a reporting cycle - walked
+            by following the candidate manager's own reports_to chain and
+            checking whether it ever reaches back to *canonical_id*
+
+        Returns the updated record.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        record = await self.get(canonical_id)
+        if record is None:
+            raise KeyError(canonical_id)
+
+        if reports_to is not None:
+            if reports_to == canonical_id:
+                raise ValueError("an agent cannot report to itself")
+            manager = await self.get(reports_to)
+            if manager is None:
+                raise ValueError(f"reports_to manager not found: {reports_to!r}")
+
+            # Cycle guard: walk the candidate manager's existing reports_to
+            # chain; if it ever reaches canonical_id, this edge would close a
+            # loop. `seen` guards against looping forever on an already-
+            # corrupt chain independent of the depth cap.
+            seen: set[str] = set()
+            current: Optional[str] = reports_to
+            depth = 0
+            while current is not None and depth < self._MAX_REPORTS_TO_WALK:
+                if current == canonical_id:
+                    raise ValueError(
+                        f"assigning reports_to={reports_to!r} would create "
+                        f"a reporting cycle"
+                    )
+                if current in seen:
+                    break
+                seen.add(current)
+                current_record = await self.get(current)
+                current = current_record.get("reports_to") if current_record else None
+                depth += 1
+
+        await self._db.execute(
+            "UPDATE agent_registry SET reports_to = ? WHERE canonical_id = ?",
+            (reports_to, canonical_id),
+        )
+        await self._db.commit()
+        return await self.get(canonical_id)  # type: ignore[return-value]
+
+    async def direct_reports(self, canonical_id: str) -> list[dict]:
+        """Return the agents whose reports_to is *canonical_id*, oldest first."""
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM agent_registry WHERE reports_to = ? ORDER BY id",
+            (canonical_id,),
+        )
+        rows = await cursor.fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    async def get_org_tree(self) -> list[dict]:
+        """Return the reporting forest: agents with no manager (or whose
+        manager row does not exist) are roots; each node nests its direct
+        reports recursively.
+
+        Each node: {canonical_id, display_name, role, title, reports_to,
+        reports: [...]}.  Depth-capped and cycle-guarded so a corrupt chain
+        (written outside ``set_reporting``) cannot recurse forever.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        all_rows = await self.list_all()
+        by_id = {r["canonical_id"]: r for r in all_rows}
+        children: dict[str, list[dict]] = {}
+        roots: list[dict] = []
+        for row in all_rows:
+            reports_to = row.get("reports_to")
+            if reports_to and reports_to in by_id:
+                children.setdefault(reports_to, []).append(row)
+            else:
+                roots.append(row)
+
+        def _node(row: dict, depth: int, seen: frozenset) -> dict:
+            cid = row["canonical_id"]
+            seen = seen | {cid}
+            kids: list[dict] = []
+            if depth < self._MAX_REPORTS_TO_WALK:
+                for child in children.get(cid, []):
+                    if child["canonical_id"] not in seen:
+                        kids.append(_node(child, depth + 1, seen))
+            return {
+                "canonical_id": cid,
+                "display_name": row.get("display_name"),
+                "role": row.get("role"),
+                "title": row.get("title"),
+                "reports_to": row.get("reports_to"),
+                "reports": kids,
+            }
+
+        return [_node(r, 0, frozenset()) for r in roots]

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1190,6 +1190,12 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         from tinyagentos.projects.routine_runner import routine_tick_loop
         _create_supervised_task(routine_tick_loop(app.state), app.state._background_tasks)
 
+        # Agent heartbeat: every 60s, wakes each idle running agent with its
+        # next ready task (opt-in via config.server["agent_heartbeat_enabled"],
+        # default off). Same supervised-loop pattern as routine_tick_loop above.
+        from tinyagentos.agent_heartbeat import agent_heartbeat_loop
+        _create_supervised_task(agent_heartbeat_loop(app.state), app.state._background_tasks)
+
         try:
             canvas_snapshotter = CanvasSnapshotter(
                 project_store=project_store,

--- a/tinyagentos/governance/action_classes.py
+++ b/tinyagentos/governance/action_classes.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 # default posture (see governance/policy_store.py). Everything else defaults
 # to "allow" by the absence of a policy row.
 SENSITIVE_ACTION_CLASSES = frozenset(
-    {"code-exec", "external-network", "deploy", "file-write-external", "spend"}
+    {"code-exec", "external-network", "deploy", "file-write-external", "spend", "delegate"}
 )
 
 # tool/skill id -> action_class. file_write/file_read/list_files are scoped to
@@ -24,6 +24,10 @@ SENSITIVE_ACTION_CLASSES = frozenset(
 TOOL_ACTION_CLASSES: dict[str, str] = {
     "code_exec": "code-exec",
     "http_request": "external-network",
+    # Not a skill-exec tool today (delegation has its own dedicated route,
+    # routes/delegation.py) - listed here so a future skill wrapping the same
+    # capability inherits the conservative default automatically.
+    "delegate": "delegate",
 }
 
 

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -417,6 +417,23 @@ class ProjectTaskStore(BaseStore):
             desc = cur.description
         return [_row_to_task(r, desc) for r in rows]
 
+    async def list_ready_tasks_for_assignee(self, assignee_id: str, limit: int = 5) -> list[dict]:
+        """Ready tasks (open, unclaimed, unblocked) assigned to *assignee_id*,
+        across all projects. Mirrors list_ready_tasks's ordering but scopes by
+        assignee instead of project - used by the agent heartbeat loop to find
+        an idle agent's next task without a per-project scan."""
+        limit = max(1, min(limit, 200))
+        async with self._db.execute(
+            """SELECT * FROM ready_tasks
+               WHERE assignee_id = ?
+               ORDER BY priority DESC, created_at ASC
+               LIMIT ?""",
+            (assignee_id, limit),
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        return [_row_to_task(r, desc) for r in rows]
+
     async def get_task_context(self, task_id: str) -> dict:
         """Relational context for a task: its goal (project + parent-task
         ancestry) and what's blocking it.

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -19,10 +19,17 @@ def register_all_routers(app):
     from tinyagentos.routes.agent_registry import router as agent_registry_router
     app.include_router(agent_registry_router)
 
-    # Consent loop — registered before /api/agents/{name} so that
+    # Consent loop - registered before /api/agents/{name} so that
     # /api/agents/auth-requests/* paths are not captured as an agent name.
     from tinyagentos.routes.agent_auth_requests import router as agent_auth_requests_router
     app.include_router(agent_auth_requests_router)
+
+    # Gated delegation (#161) - registered before /api/agents/{name} so that
+    # /api/agents/{from_agent}/delegate is unambiguous even though it shares
+    # the {name} path segment (path length differs so this isn't strictly
+    # required, but it keeps every /api/agents/... override grouped here).
+    from tinyagentos.routes.delegation import router as delegation_router
+    app.include_router(delegation_router)
 
     from tinyagentos.routes.agents import router as agents_router
     app.include_router(agents_router)
@@ -274,7 +281,7 @@ def register_all_routers(app):
     from tinyagentos.routes import framework as framework_routes
     app.include_router(framework_routes.router)
 
-    # Lobby demo (internal only — not included in public builds)
+    # Lobby demo (internal only - not included in public builds)
     try:
         from tinyagentos.lobby.routes import router as lobby_router
         app.include_router(lobby_router)

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 """Routes for the Agent Registry (SP-A, taOS side).
 
-POST   /api/agents/registry/register         — register an agent, mint canonical_id, issue token
-GET    /api/agents/registry/pubkey           — public key for token verification (exempt, no auth)
-GET    /api/agents/registry/revoked          — global revocation feed (admin/local-token only)
-GET    /api/agents/registry/inactive         — all non-active entries for the bus (admin only)
-GET    /api/agents/registry/grants           — active grant feed for @taOSmd enforcement (admin only)
-GET    /api/agents/registry                  — list registry entries (admin: all; member: own)
-GET    /api/agents/registry/{id}             — read a single entry (owner or admin; else 404)
-PATCH  /api/agents/registry/{id}             — update mutable fields (owner or admin)
-DELETE /api/agents/registry/{id}             — revoke an entry (owner or admin)
-POST   /api/agents/registry/{id}/approve     — lifecycle: pending → active (admin only)
-POST   /api/agents/registry/{id}/reject      — lifecycle: pending → rejected (admin only)
-POST   /api/agents/registry/{id}/suspend     — lifecycle: active → suspended (admin only)
-POST   /api/agents/registry/{id}/reactivate  — lifecycle: suspended → active (admin only)
+POST   /api/agents/registry/register         - register an agent, mint canonical_id, issue token
+GET    /api/agents/registry/pubkey           - public key for token verification (exempt, no auth)
+GET    /api/agents/registry/revoked          - global revocation feed (admin/local-token only)
+GET    /api/agents/registry/inactive         - all non-active entries for the bus (admin only)
+GET    /api/agents/registry/grants           - active grant feed for @taOSmd enforcement (admin only)
+GET    /api/agents/registry                  - list registry entries (admin: all; member: own)
+GET    /api/agents/registry/{id}             - read a single entry (owner or admin; else 404)
+PATCH  /api/agents/registry/{id}             - update mutable fields (owner or admin)
+DELETE /api/agents/registry/{id}             - revoke an entry (owner or admin)
+POST   /api/agents/registry/{id}/approve     - lifecycle: pending → active (admin only)
+POST   /api/agents/registry/{id}/reject      - lifecycle: pending → rejected (admin only)
+POST   /api/agents/registry/{id}/suspend     - lifecycle: active → suspended (admin only)
+POST   /api/agents/registry/{id}/reactivate  - lifecycle: suspended → active (admin only)
 
 Route ordering matters: /pubkey, /revoked, and /inactive are declared before
 /{canonical_id} so the literal strings are not captured as a path parameter.
@@ -68,6 +68,19 @@ class PatchRegistryRequest(BaseModel):
     handle: Optional[str] = None
     role: Optional[str] = None
     capabilities: Optional[list[str]] = None
+
+
+class OrgUpdateRequest(BaseModel):
+    """Body for PUT /api/agents/{canonical_id}/org.
+
+    ``reports_to`` follows the same clear-with-empty-string convention as
+    ``emoji`` elsewhere in the agent routes: omit the field (None) to leave
+    the manager untouched, pass "" to clear it (make the agent an org-tree
+    root), or pass a canonical_id to set/change it.
+    """
+    role: Optional[str] = None
+    title: Optional[str] = None
+    reports_to: Optional[str] = None
 
 
 # Scopes an operator may grant when minting an internal agent. Mirrors the
@@ -214,7 +227,7 @@ async def register_agent(
 ):
     """Register an agent and issue a signed identity token.
 
-    The minted token's user_id is the authenticated caller's id — not
+    The minted token's user_id is the authenticated caller's id - not
     a value from the request body, so identity cannot be spoofed.
     """
     store = _get_store(request)
@@ -451,7 +464,7 @@ async def list_inactive_entries(
 
     Response: {"inactive": [{canonical_id, status}, ...]}
 
-    Admin only — covers pending/suspended/rejected/revoked.
+    Admin only - covers pending/suspended/rejected/revoked.
     The bus polls this to reject any canonical_id present.
     """
     if not user.is_admin:
@@ -529,7 +542,7 @@ async def get_registry_entry(
     """Fetch a single registry entry by canonical_id.
 
     Returns 404 for unknown entries and for entries the caller does not own
-    (existence-hiding — avoids disclosing whether an id exists to non-owners).
+    (existence-hiding - avoids disclosing whether an id exists to non-owners).
     """
     store = _get_store(request)
     record = await store.get(canonical_id)
@@ -691,3 +704,60 @@ async def reactivate_agent(
 ):
     """Reactivate a suspended agent (suspended → active). Admin only."""
     return await _transition(request, canonical_id, "reactivate", "active", user)
+
+
+# ---------------------------------------------------------------------------
+# Org model (#161): reporting lines, roles/titles, org tree
+#
+# Registered here (not routes/agents.py) so this file remains the single
+# owner of the registry's read/write surface. Both routes live under
+# /api/agents/... but this router is included before the generic
+# /api/agents/{name} route in routes/__init__.py, so /api/agents/org is not
+# shadowed (same reasoning as /api/agents/registry/*).
+# ---------------------------------------------------------------------------
+
+@router.get("/api/agents/org")
+async def get_org_chart(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Return the full reporting forest (org chart). Admin only - the tree
+    spans every agent's manager regardless of owner, which is an operator/
+    admin concern (mirrors the admin-only registry feeds above)."""
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+    store = _get_store(request)
+    return {"tree": await store.get_org_tree()}
+
+
+@router.put("/api/agents/{canonical_id}/org")
+async def update_org_fields(
+    request: Request,
+    canonical_id: str,
+    body: OrgUpdateRequest,
+    user: CurrentUser = Depends(current_user),
+):
+    """Set role/title and/or reporting line on a registry entry.
+
+    Only the owning user or an admin may update an entry (mirrors PATCH
+    /api/agents/registry/{canonical_id}). ``reports_to`` is validated via
+    ``set_reporting`` - 400 on a nonexistent manager, self-report, or a
+    reporting cycle.
+    """
+    store = _get_store(request)
+    record = await store.get(canonical_id)
+    if record is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    require_owner_or_admin(user, record["user_id"])
+
+    if body.role is not None or body.title is not None:
+        await store.set_role_title(canonical_id, role=body.role, title=body.title)
+
+    if body.reports_to is not None:
+        manager_id = body.reports_to or None  # "" clears the manager
+        try:
+            await store.set_reporting(canonical_id, manager_id)
+        except (ValueError, KeyError) as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+
+    return await store.get(canonical_id)

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -251,6 +251,7 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
     await _apply_app_grant(request, updated, body.value)
     await _apply_execution_grant(request, updated, body.value)
+    await _apply_delegation_grant(request, updated, body.value)
     await _route_answer_to_agent(updated, body.value)
     return updated
 
@@ -289,6 +290,53 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> Non
     await _route_answer_to_agent(
         decision,
         "you may retry the action now" if approved else "your action was denied",
+    )
+
+
+async def _apply_delegation_grant(request: Request, decision: dict, value) -> None:
+    """Side effect for a delegation-gate Decision (#161 gated delegation): the
+    decision's metadata carries {kind: "delegation_gate", from_agent, to_agent,
+    task_id, task_title, note}. Approving it writes a short-lived delegate
+    grant (so a future delegation by the same agent doesn't re-ask until the
+    grant expires) AND completes THIS delegation (assign the task + notify
+    to_agent); denying just routes the answer. Mirrors
+    ``_apply_execution_grant``: the answer is already persisted, so a
+    grant-store or delegation-completion hiccup must not fail the answer."""
+    meta = decision.get("metadata") or {}
+    if meta.get("kind") != "delegation_gate":
+        return
+    policies = getattr(request.app.state, "execution_policies", None)
+    from_agent = meta.get("from_agent")
+    to_agent = meta.get("to_agent")
+    if policies is None or not from_agent or not to_agent:
+        return
+    approved = value == "approve"
+    if approved:
+        try:
+            await policies.add_grant(from_agent, "delegate", decision.get("id"))
+        except Exception:
+            logger.warning(
+                "delegate grant write failed for agent %s (decision %s)",
+                from_agent, decision.get("id"), exc_info=True,
+            )
+        try:
+            from tinyagentos.routes.delegation import complete_delegation
+            await complete_delegation(
+                request,
+                from_agent=from_agent,
+                to_agent=to_agent,
+                task_id=meta.get("task_id"),
+                task_title=meta.get("task_title"),
+                project_id=decision.get("project_id"),
+                note=meta.get("note") or "",
+            )
+        except Exception:
+            logger.warning(
+                "delegation completion failed for decision %s", decision.get("id"), exc_info=True,
+            )
+    await _route_answer_to_agent(
+        decision,
+        "delegation approved - the task has been assigned" if approved else "delegation denied",
     )
 
 

--- a/tinyagentos/routes/delegation.py
+++ b/tinyagentos/routes/delegation.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+"""Gated agent-to-agent delegation (#161, option A: org metadata + gated
+delegation, no approval rerouting).
+
+``POST /api/agents/{from_agent}/delegate`` lets one agent hand a task to
+another. The reporting line on the agent registry (see
+``agent_registry_store.set_reporting``) is org metadata only here - it does
+NOT change who approves a delegation. Every delegation is gated by the same
+governance layer as ``routes/skill_exec.py``'s tool-execution gate: the
+``delegate`` action class defaults to ``require_approval`` (see
+``governance/action_classes.SENSITIVE_ACTION_CLASSES``), so an ungranted
+delegation queues a blocking Decision instead of running immediately.
+
+The gate/decision-creation flow below mirrors
+``routes.skill_exec._check_execution_policy`` closely but is not a direct
+call into it - that function is keyed on a ``skill_id`` classified via
+``governance.action_classes.classify``, whereas delegation is not a skill
+call. Keeping a small, self-contained mirror here avoids reshaping the
+well-tested skill-exec gate for a caller it was never designed around.
+"""
+
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.agent_db import find_agent
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+ACTION_CLASS = "delegate"
+
+
+def _is_admin_or_local_token(request: Request) -> bool:
+    """True if the caller is an admin session or presented the host's local
+    token. Mirrors ``routes.skill_exec._is_admin_or_local_token`` - delegation
+    is an agent action, gated the same way skill execution is."""
+    if getattr(request.state, "is_admin", False):
+        return True
+    return getattr(request.state, "via", None) == "local_token"
+
+
+async def _resolve_agent_name(request: Request, ref: str) -> str | None:
+    """Resolve *ref* to the config agent slug (the identity used everywhere
+    else for policy grants, task assignee_id, A2A membership, board audit).
+
+    Accepts either the slug itself or a registry canonical_id: a canonical_id
+    is looked up in the agent registry and its display_name/handle matched
+    back to a config agent. Returns None if *ref* does not resolve.
+    """
+    if not ref:
+        return None
+    config = request.app.state.config
+    agent = find_agent(config, ref)
+    if agent is not None:
+        return agent["name"]
+
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is None or getattr(registry, "_db", None) is None:
+        # Not wired/initialised in this deployment -- fall back to "not
+        # found via registry" rather than raising, since the common case
+        # (a plain config-agent slug) never needs the registry at all.
+        return None
+    record = await registry.get(ref)
+    if record is None:
+        return None
+    for candidate in (record.get("display_name"), (record.get("handle") or "").lstrip("@")):
+        if candidate:
+            agent = find_agent(config, candidate)
+            if agent is not None:
+                return agent["name"]
+    return None
+
+
+class DelegateRequest(BaseModel):
+    to_agent: str
+    task_id: str | None = None
+    task_title: str | None = None
+    # Required only when creating a brand-new task from task_title (an
+    # existing task_id already carries its project). Not part of the
+    # original design note's body shape, but tasks cannot exist outside a
+    # project in this codebase - see projects/task_store.py.
+    project_id: str | None = None
+    note: str = ""
+
+
+async def _check_delegation_policy(
+    request: Request,
+    *,
+    from_agent: str,
+    to_agent: str,
+    task_id: str | None,
+    task_title: str | None,
+    project_id: str | None,
+    note: str,
+) -> JSONResponse | None:
+    """Agent governance gate for delegation. Returns a JSONResponse to
+    short-circuit the call (deny / pending-approval), or None to let the
+    caller proceed with the delegation."""
+    # Mirrors routes.skill_exec._check_execution_policy: governance applies
+    # only to AGENT callers (local-token). An admin HUMAN session is the
+    # approval authority themselves, so self-gating their own delegation is
+    # noise -- it never substitutes for the _is_admin_or_local_token check in
+    # delegate_task, which already keeps out plain non-admin sessions.
+    if (
+        getattr(request.state, "via", None) == "session"
+        and getattr(request.state, "is_admin", False)
+    ):
+        return None
+
+    policies = getattr(request.app.state, "execution_policies", None)
+    if policies is None:
+        # Not wired in this deployment; fail open rather than break
+        # delegation over an additive, not-yet-present store.
+        return None
+
+    effect = await policies.effective_effect(from_agent, ACTION_CLASS)
+    if effect == "allow":
+        return None
+
+    if effect == "deny":
+        board_audit = getattr(request.app.state, "board_audit", None)
+        if board_audit is not None:
+            try:
+                await board_audit.record(
+                    task_id=f"agent:{from_agent}",
+                    event="delegation_policy_deny",
+                    actor=from_agent,
+                    detail={"to_agent": to_agent, "action_class": ACTION_CLASS},
+                )
+            except Exception:
+                logger.warning(
+                    "board_audit record failed for delegation deny by %s", from_agent, exc_info=True
+                )
+        receipt_store = getattr(request.app.state, "receipt_store", None)
+        if receipt_store is not None:
+            try:
+                await receipt_store.record(
+                    from_agent, tool_name="delegate", stop_reason="policy_deny"
+                )
+            except Exception:
+                logger.warning(
+                    "receipt capture failed for delegation deny by %s", from_agent, exc_info=True
+                )
+        return JSONResponse(
+            {"error": "forbidden_by_policy", "action_class": ACTION_CLASS},
+            status_code=403,
+        )
+
+    # effect == "require_approval"
+    if await policies.has_live_grant(from_agent, ACTION_CLASS):
+        return None
+
+    decision_store = getattr(request.app.state, "decision_store", None)
+    if decision_store is None:
+        # The action needs approval but there is no inbox to raise it in; fail
+        # loud rather than returning a fake pending_approval the caller cannot
+        # poll.
+        return JSONResponse(
+            {"error": "approval required but no decision store is available"},
+            status_code=503,
+        )
+    try:
+        target = f'"{task_title}"' if task_title else (task_id or "")
+        decision = await decision_store.create(
+            from_agent=from_agent,
+            question=f"Agent {from_agent} wants to delegate {target} to {to_agent}".strip(),
+            type="approve_deny",
+            priority="blocking",
+            project_id=project_id,
+            metadata={
+                "kind": "delegation_gate",
+                "from_agent": from_agent,
+                "to_agent": to_agent,
+                "task_id": task_id,
+                "task_title": task_title,
+                "note": note,
+            },
+        )
+    except Exception:
+        logger.warning(
+            "decision create failed for delegation gate (%s -> %s)",
+            from_agent, to_agent, exc_info=True,
+        )
+        return JSONResponse(
+            {"error": "failed to create the delegation approval request"},
+            status_code=503,
+        )
+
+    return JSONResponse(
+        {"status": "pending_approval", "decision_id": decision["id"], "action_class": ACTION_CLASS},
+        status_code=202,
+    )
+
+
+async def _notify_delegate(
+    request: Request, *, from_agent: str, to_agent: str, task: dict, note: str
+) -> None:
+    """Best-effort: post a mention in the project's A2A channel so to_agent
+    sees the handoff. Never raises - the delegation has already completed
+    (task assigned) by the time this is called."""
+    try:
+        from tinyagentos.projects.a2a import ensure_a2a_channel
+
+        channel = await ensure_a2a_channel(
+            request.app.state.chat_channels,
+            request.app.state.project_store,
+            task["project_id"],
+            config=getattr(request.app.state, "config", None),
+        )
+        content = f'@{to_agent} {from_agent} delegated "{task["title"]}" to you.'
+        if note:
+            content += f" Note: {note}"
+        msg_store = request.app.state.chat_messages
+        await msg_store.send_message(
+            channel_id=channel["id"],
+            author_id=from_agent,
+            author_type="agent",
+            content=content,
+        )
+        await request.app.state.chat_channels.update_last_message_at(channel["id"])
+    except Exception:
+        logger.warning(
+            "delegation notify failed (%s -> %s, task %s)",
+            from_agent, to_agent, task.get("id"), exc_info=True,
+        )
+
+
+async def complete_delegation(
+    request: Request,
+    *,
+    from_agent: str,
+    to_agent: str,
+    task_id: str | None,
+    task_title: str | None,
+    project_id: str | None,
+    note: str,
+) -> dict:
+    """Assign the task to to_agent (creating it from task_title if no task_id
+    was given) and notify to_agent. Called both from the direct-allow path in
+    ``delegate_task`` below and from the approved-decision path in
+    ``routes.decisions._apply_delegation_grant``.
+
+    Raises ``ValueError`` on a bad task reference - the caller maps that to a
+    4xx in the direct path; the approval path logs it (the answer is already
+    persisted by then).
+    """
+    task_store = request.app.state.project_task_store
+    if task_id:
+        task = await task_store.get_task(task_id)
+        if task is None:
+            raise ValueError(f"task '{task_id}' not found")
+        await task_store.update_task(task_id, assignee_id=to_agent)
+        task = await task_store.get_task(task_id)
+    else:
+        if not task_title:
+            raise ValueError("task_id or task_title is required")
+        if not project_id:
+            raise ValueError("project_id is required to create a new task")
+        task = await task_store.create_task(
+            project_id=project_id, title=task_title, created_by=from_agent, assignee_id=to_agent,
+        )
+
+    await _notify_delegate(request, from_agent=from_agent, to_agent=to_agent, task=task, note=note)
+    return {"status": "delegated", "task_id": task["id"], "to_agent": to_agent}
+
+
+@router.post("/api/agents/{from_agent}/delegate")
+async def delegate_task(request: Request, from_agent: str, body: DelegateRequest):
+    """Delegate a task from from_agent to to_agent, gated by the delegate
+    action class (conservative default: require_approval).
+
+    On require_approval with no live grant, returns 202 pending_approval and
+    queues a blocking Decision; approving it (routes/decisions.py) grants the
+    action and completes the delegation.
+    """
+    if not _is_admin_or_local_token(request):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    from_name = await _resolve_agent_name(request, from_agent)
+    if from_name is None:
+        return JSONResponse({"error": f"agent '{from_agent}' not found"}, status_code=404)
+    to_name = await _resolve_agent_name(request, body.to_agent)
+    if to_name is None:
+        return JSONResponse({"error": f"agent '{body.to_agent}' not found"}, status_code=404)
+
+    if not body.task_id and not body.task_title:
+        return JSONResponse({"error": "task_id or task_title is required"}, status_code=400)
+
+    project_id = body.project_id
+    if body.task_id:
+        task_store = request.app.state.project_task_store
+        existing_task = await task_store.get_task(body.task_id)
+        if existing_task is None:
+            return JSONResponse({"error": f"task '{body.task_id}' not found"}, status_code=404)
+        project_id = existing_task["project_id"]
+    elif not project_id:
+        return JSONResponse(
+            {"error": "project_id is required when delegating a new task_title"},
+            status_code=400,
+        )
+
+    gate_response = await _check_delegation_policy(
+        request,
+        from_agent=from_name,
+        to_agent=to_name,
+        task_id=body.task_id,
+        task_title=body.task_title,
+        project_id=project_id,
+        note=body.note or "",
+    )
+    if gate_response is not None:
+        return gate_response
+
+    try:
+        return await complete_delegation(
+            request,
+            from_agent=from_name,
+            to_agent=to_name,
+            task_id=body.task_id,
+            task_title=body.task_title,
+            project_id=project_id,
+            note=body.note or "",
+        )
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)

--- a/uv.lock
+++ b/uv.lock
@@ -471,59 +471,59 @@ wheels = [
 
 [[package]]
 name = "croniter"
-version = "6.2.2"
+version = "6.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/35/96ad0a71eb0b27ab4476a7ed23facd0713d82da9c911edc8af7f34a62d6a/croniter-6.2.3.tar.gz", hash = "sha256:fb129986ef7e2c44e3f4c9f503da83ad914d2afa48f40a43ee3dca4b5c41d476", size = 166174, upload-time = "2026-07-02T14:34:22.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/dd/6466498a8b69754cffbd7237ce4c66446ca5ffcf53fb397d437666f056d2/croniter-6.2.3-py3-none-any.whl", hash = "sha256:137a97001b4d52fb71c10b750e303db79e6e42d40fff8ff77126102176c9f786", size = 46446, upload-time = "2026-07-02T14:34:20.889Z" },
 ]
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "48.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/45/870e7f4bef50e5f53b9f51d4428aee5290eedf58ba443f16b1ebb7ab8e66/cryptography-48.0.1.tar.gz", hash = "sha256:266f4ee051abb2f725b74ef8072b521ce1feacf685a3364fa6a6b45548db791a", size = 832989, upload-time = "2026-06-09T22:32:31.8Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
-    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
-    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bc/ee4137cbbe105652c0ee4252792b78fc8e7afa4b8e61d9d5dc05a7f45731/cryptography-48.0.1-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:3e4a1a3232eef2e6c732827d5722db29a0cc8b27af2a4d865b094cf954be9ca1", size = 8008324, upload-time = "2026-06-09T22:31:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/85/6379d42181bfc713094f081360fc5784d6c816b599d45e7f082502d173ce/cryptography-48.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:32143b24adb918f078134e1e230f1eb8cc04886b92c28b5f0041aaf3e5699225", size = 4696243, upload-time = "2026-06-09T22:32:33.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/87/c85d147b53323c7eb4d850920c8901377323c2a0ff8d79c262d4fee89aa2/cryptography-48.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0d27a5696721ef7a672b8c810f6aded391058e0b9486e63e6d93baf765da691", size = 4713235, upload-time = "2026-06-09T22:31:40.141Z" },
+    { url = "https://files.pythonhosted.org/packages/79/58/67cbf8cf1ee7c54b439ca07bbecf8362c07afc11a3724fea70f745784add/cryptography-48.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb86ce1af36fe65041b6db9a8bb064ee621a7e5fded0f80d475ec243477cd242", size = 4702323, upload-time = "2026-06-09T22:31:42.191Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/24266ac10c47f6cd2a865f4446062b466da1d1f10b27189eac00e61bf0c9/cryptography-48.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b024e784ad6c077ee0147b35ea9cbfc1e34e1fd4c1dcca214c2794d73a12df08", size = 5300085, upload-time = "2026-06-09T22:31:58.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/bb/cc4b78784f97efc8c5874c2a9743708d172be6663024b34a0467885ae0c8/cryptography-48.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3752f2dbc8f07a30aad2932c986cea495b03bb554887828225da104f732852b6", size = 4746137, upload-time = "2026-06-09T22:31:31.01Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/52/0c44de3f5267f8fbe8e835138017522a333436166e406f0db9b9e6e3033f/cryptography-48.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:bd81490cd5801d755cf97bb68ac191f14b708470b1c7cf4580f669b9c9264cd8", size = 4333867, upload-time = "2026-06-09T22:32:28.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/2e/772d7adbfa931537bc401640b7cac9976bff689bda187833e5d63b428e49/cryptography-48.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:66fd0771e7b9c6dcd44cf1120690d2338d16d72795cf40cae2786a39eba65429", size = 4701805, upload-time = "2026-06-09T22:31:38.284Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a3/b06844f303873493c963caf581c04df31c7035e0c1b0f02c4814d319ec80/cryptography-48.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:3fd2ca57062b241c856670b073487d2e86c4637937ca5601e48f97bf8e11fc8f", size = 5258461, upload-time = "2026-06-09T22:31:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/13/8b765e2e12b07c74941caadb9d1c8fdc006c4dfbf2b8f2d610519758954d/cryptography-48.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:0ee6ea481db1ab889cba043ec1eda17bb9c1ea79db6722f779c3667f9f70322f", size = 4745488, upload-time = "2026-06-09T22:32:30.07Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/aa/48972bce55049b32a94f4907eda4d75fa385aad8a39506cc2fc72196ecf0/cryptography-48.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2ceef93cb096aa3c4cc4b5c94ca6131f9196d28c64d6111533402a9b2054d41", size = 4830256, upload-time = "2026-06-09T22:31:43.868Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a2/e5079a032fb85cf6005046ca92bbd78b0c82dad2b5751ab8c311659da06f/cryptography-48.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9bd3f92d76217892b15df84ca256c2c113d386fdda7a7d8691aeeced976507c6", size = 4979117, upload-time = "2026-06-09T22:31:05.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a0/8f50cae9c74e718ed769d63ed5c74bd0ea830c9550a74629cebd1b9c7bc7/cryptography-48.0.1-cp311-abi3-win32.whl", hash = "sha256:b9a32b876490d66c8bcc9963ef220199569748434ab01a9d6aaeabf88e7f5158", size = 3304154, upload-time = "2026-06-09T22:32:16.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/69/0572c77dbace6fef72f33755bd52ea399c71367250d366237f8691826b9e/cryptography-48.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:39489bfca54c7a1f6b297efcd8bc608ab92d16c4ca631b0cad4da46724588b24", size = 3817138, upload-time = "2026-06-09T22:32:00.388Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6c/00fa2a95997164c8b2072ce327c23d4ab20809ccc323ea5fab91e53a4bba/cryptography-48.0.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:4fdc69f8e4316bcf0c8c8ec1f26f285d12e8142d88d96c876a59a03be3f6ae67", size = 7987408, upload-time = "2026-06-09T22:32:20.777Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d9/45f309a7e4e5f3f8f121d6d3be9e94024a7726ec598d6e08ae04edb2f04d/cryptography-48.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48fe40804d4caa2288f24e70ca8c64c42dd826da0ad7e4f1b41b2128d679e6c8", size = 4690196, upload-time = "2026-06-09T22:31:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9f/a1bc8bcc798811b8527eb374bbccf30a3f3e806829d967118222bf1125eb/cryptography-48.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86be3b1b0b6bf09482fb50a979c508d2950ed95f5621ec77f4e385962006b83a", size = 4696782, upload-time = "2026-06-09T22:31:45.615Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c2/81a4fb4e4373c500bb526bc337ac5719dd31dd15b970b84a238168c6aa08/cryptography-48.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4ab0a343c807bbcd90c971cd1ecf072937cd01847a9e002bef88fb47ac6be577", size = 4696618, upload-time = "2026-06-09T22:31:11.564Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/0b/aa68b221dde92d09cb29a024ede17550ee21e77a404e59fc093c82bb51e1/cryptography-48.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9621de99d2da096006b629979efd8ae7eb2d8b822488d0c89ee4000c306c59b1", size = 5289970, upload-time = "2026-06-09T22:31:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/78/13/fba657f958d2af66ea959a4ba01212632089249d34af1ae48054136344d7/cryptography-48.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:88c852a0ae366e262e5a1744b685e6a433dc8788dd2a277e418bf4904203609d", size = 4731873, upload-time = "2026-06-09T22:31:22.253Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4c/9a964756d24a26b3e34dfcb16f961b89838786e6700b635b0d1e3adff4b6/cryptography-48.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:43c5835e2cb98c8733d86f57d6fc879b613f5c3478607281c3e36daffc6dd8a6", size = 4330804, upload-time = "2026-06-09T22:31:36.56Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0f/a10f3a6eb12950a10e3a874070283aa2dd5875b2bfd15fad8a3e17b3f13e/cryptography-48.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:fe0180af5bf9236518a087e35bf2d9a347d5f5f51e63c579d683ddff424e3d46", size = 4696217, upload-time = "2026-06-09T22:31:13.351Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6f/5cd12f951165ea73ef85266775d97e4c763b2474ccfd816dd69d3a18d6f8/cryptography-48.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:b7a2d1a937a738a881737cec135a38bb61470589b17515b9f73f571d0ae10401", size = 5245252, upload-time = "2026-06-09T22:32:02.193Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/8aaa12e4516ec4464033ab79b6f3b592bd5a92102467c4ace8a0d970203f/cryptography-48.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:b74ca3b8e5ecdd833bf6a002ca41b4793bb27fb8f1c06ffaf2643c9e9140e31b", size = 4731388, upload-time = "2026-06-09T22:32:04.019Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/50027ea4dca85ec1f40688f3c24fb32ccacd520583c9592c3cc95628e6fb/cryptography-48.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2c37f2461406063b417837f5f3daab668652acd82423efcd7f0a9f04be972de1", size = 4824186, upload-time = "2026-06-09T22:32:18.707Z" },
+    { url = "https://files.pythonhosted.org/packages/52/41/04cb5eb17085ade6f50cc611fb657df6a0f5885350de8764ece89c050197/cryptography-48.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:86fe77abb1bd87afb251d4d02ada7ecf53a32cee9b67d976abb2e45a13297475", size = 4964539, upload-time = "2026-06-09T22:31:18.793Z" },
+    { url = "https://files.pythonhosted.org/packages/36/bf/ed70785c496e89d7e73b7cda2d21f2447fd6d4e821714b8d04ff217fed92/cryptography-48.0.1-cp39-abi3-win32.whl", hash = "sha256:6b2c0c3e6ccf3ade7750f836ef3ee36eea250cc467d45c256895573ac08cc6f1", size = 3282307, upload-time = "2026-06-09T22:30:53.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/ff/371ea7d252656ee1eb6d83eeeef3d1d0c6baf1d6497687d081ea03814670/cryptography-48.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:9a49ca6c81417f6a5edb50375a60cccdd70fa0a91a5211829dbea74eba94d2ac", size = 3793408, upload-time = "2026-06-09T22:32:15.191Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d3/eb4e394e587341fdad09a09101fa76478ead3a78b0ad63e55c22f0d75c02/cryptography-48.0.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:08a597acce1ff37f347400087776599e2348a3a8bc53b44120e463cd274efe4a", size = 3951747, upload-time = "2026-06-09T22:31:23.871Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/3f43451b4f858bfceaaaffc649e6e787e8d4fb332a1d443af39ab02cc8f1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:735824ec41b7f74a7c45fb1591349333e4c696cb6c044e5f46356e560143e4cd", size = 4641226, upload-time = "2026-06-09T22:31:02.532Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/855584c2c23b09e4ce2d3b9c30e983e679cd60b068c513c6bbdb91e11782/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:92a46e1d638daa264ba2971c0b0489c9409787943efae4d60ffda3d091ef832c", size = 4668958, upload-time = "2026-06-09T22:32:06.213Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3b/d35750e41d803d1e516fd6d6011f065424924da7af1748cef4cc9cb3ede1/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:7e234ac052af99f2700826a5c29ea99d9c1b1f80341cde62d11c8154dc8e0bd9", size = 4640793, upload-time = "2026-06-09T22:32:26.331Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/aa/cdb7181fe865285e87e96825aaab239400f1de0c3bfba9bd9769b79f1a92/cryptography-48.0.1-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:33842cf0888951cef5bc7ac724ab844a42044c1727b967b7f8997289a0464f92", size = 4668505, upload-time = "2026-06-09T22:31:27.534Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8c/ce3823c06c2804f194f9e64f0d67fa3f4094a39f2bb1a990cd03603af8fc/cryptography-48.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6184ca7b174f28d7c703f1290d4b297217c45355f77a98f67e9b7f14549ac54a", size = 3742204, upload-time = "2026-06-09T22:31:34.773Z" },
 ]
 
 [[package]]
@@ -582,6 +582,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
+name = "expression"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/c7/bb061623b5815566bda69f5e9d156e38a97ebb383b8db3d2dedb26415466/expression-5.6.0.tar.gz", hash = "sha256:454f6fe138347194a43c7f878d958efe9b84b9cc770e462010c7a52e18058065", size = 59147, upload-time = "2025-02-19T09:37:37.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/a2/656b8bebe495117342a8676ccabf52b3885ce11a856c8dfe1fbbdc250d2d/expression-5.6.0-py3-none-any.whl", hash = "sha256:f5c62e38186c9287e088dee9cf3939b0bbde21cb4c59571872154a53d33dd7c0", size = 69673, upload-time = "2025-02-19T09:37:35.476Z" },
 ]
 
 [[package]]
@@ -1220,7 +1232,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.90.0"
+version = "1.91.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1236,9 +1248,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/c6/45b74e44f6605f91cffb2d6ad5463bc743f5636c66a2892c834d90b708e7/litellm-1.90.0.tar.gz", hash = "sha256:55f2be4adfc350ae2931bf369aebf1229aa54ea8ceaa1c13ee65a07724572dae", size = 14815671, upload-time = "2026-06-27T03:12:47.81Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/1e/90cfeada42170986a290feebaca0a90923b3c310cddeb0f8690abd239ad4/litellm-1.91.0.tar.gz", hash = "sha256:4fd469fe7356ba8fcc86f4efdf332e3426b760962ab12331fdaf1a01aeec065f", size = 14872290, upload-time = "2026-07-04T19:18:28.466Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/f7/0864ca487526ed478b857c704244255c7be4e13ed4dde7aeec13f679c904/litellm-1.90.0-py3-none-any.whl", hash = "sha256:3a0fec8405606e34f501544fb9cfe4261fe073bef340d3ca9a60d3fb31c639ee", size = 16607104, upload-time = "2026-06-27T03:12:44.493Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/15/81fc2d162513803fe08b359c2e2a98f7a33195034fb94b005e263e272c6b/litellm-1.91.0-py3-none-any.whl", hash = "sha256:c3eb52dd2c6a5779e9efd67350f3640f9055d9c05d4b572fc1dd01a217e562ad", size = 16669331, upload-time = "2026-07-04T19:18:25.203Z" },
 ]
 
 [package.optional-dependencies]
@@ -1249,6 +1261,7 @@ proxy = [
     { name = "backoff" },
     { name = "boto3" },
     { name = "cryptography" },
+    { name = "expression" },
     { name = "fastapi" },
     { name = "fastapi-sso" },
     { name = "granian" },
@@ -1276,11 +1289,11 @@ proxy = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.43"
+version = "0.1.44"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/6f/4975b020898c5eacf8818c24e2db7c037b0eecf33656634cb8c80d72322e/litellm_enterprise-0.1.43.tar.gz", hash = "sha256:73efe65ad130bd8dcbd221eb42de5ee4f29e86450fd264b617f109c2b93053db", size = 71001, upload-time = "2026-06-21T01:24:33.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/24/cff90fd913861cc6569cd6374c7a2da53de84ffb1ee421045ae1698e3467/litellm_enterprise-0.1.44.tar.gz", hash = "sha256:0712c743810192c3bb16f5163dd25a42eff73f99a85fb056f7756a48e73e7b8b", size = 70982, upload-time = "2026-06-26T17:01:24.162Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/a8/b3094699deb738cb4518347a8ac02de00158d0cf657716882953b4e76cea/litellm_enterprise-0.1.43-py3-none-any.whl", hash = "sha256:081e8824960bb1f259c44b4b7993cc582828e44e69c57e93ff7521a0936aac1a", size = 138240, upload-time = "2026-06-21T01:24:31.914Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/a511aba9243879ccbf877381a68020c63bfc928e439788aec88dd3b7ee63/litellm_enterprise-0.1.44-py3-none-any.whl", hash = "sha256:5821cf9a313650edf1fb26a628d70e49b213507e556a95ee811112366edbbdbb", size = 138240, upload-time = "2026-06-26T17:01:23.198Z" },
 ]
 
 [[package]]
@@ -3059,14 +3072,14 @@ worker = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "argon2-cffi", specifier = ">=23.1.0" },
-    { name = "croniter", specifier = ">=3.0.3" },
+    { name = "croniter", specifier = ">=6.2.3" },
     { name = "diff-match-patch", specifier = ">=20230430" },
     { name = "fastapi", specifier = ">=0.115.0,<0.137" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "libtorrent", marker = "extra == 'torrent'", specifier = ">=2.0.9" },
-    { name = "litellm", extras = ["proxy"], marker = "extra == 'proxy'", specifier = ">=1.90.0" },
+    { name = "litellm", extras = ["proxy"], marker = "extra == 'proxy'", specifier = ">=1.91.0" },
     { name = "lxml", specifier = ">=5.0.0" },
     { name = "matrix-nio", specifier = ">=0.21.0" },
     { name = "pillow", specifier = ">=10.0" },
@@ -3087,7 +3100,7 @@ requires-dist = [
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "sqlcipher3", specifier = ">=0.6.2" },
     { name = "taosmd", specifier = "==0.4.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.49.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.50.0" },
     { name = "websockets", specifier = ">=12.0" },
     { name = "websockets", marker = "extra == 'dev'", specifier = ">=12.0" },
     { name = "zeroconf", specifier = ">=0.150.0" },
@@ -3238,15 +3251,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.49.0"
+version = "0.50.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/41/06cce5dbb9f77591512957710ac709e60b12e6216a2f2d0d607fd49706e8/uvicorn-0.50.0.tar.gz", hash = "sha256:0c92e1bc2259cb7faa4fcef774a5966588f2e88542744550b66799fba10b76f1", size = 93257, upload-time = "2026-07-04T05:03:26.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3a/eb70620ca2bf8213603d5c731460687c49fee38b0072f0b4a637781f0a53/uvicorn-0.50.0-py3-none-any.whl", hash = "sha256:05f0eb19edf38208f79f43df8a63081b48df31b0cd1e5997be957a4dc97d1b19", size = 72716, upload-time = "2026-07-04T05:03:24.848Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Extends the routines engine (#159) with a global heartbeat tick that gives idle running agents a nudge to pull their own queue, instead of only reacting to routine-created tasks.

- **Global tick, house style**: `agent_heartbeat_loop(app_state)` in `tinyagentos/agent_heartbeat.py` is a plain `while True` + `asyncio.sleep(60)` loop, registered exactly like `routine_tick_loop` via `_create_supervised_task(..., app.state._background_tasks)` right next to it in `app.py`'s lifespan. No new start/stop lifecycle; it rides the existing bounded `cancel_and_wait` shutdown path.
- **"Act" = notify, not drive**: waking an agent means enqueueing a system message onto its bridge session (`bridge_sessions.enqueue_user_message`) plus posting to the project's a2a channel (`ensure_a2a_channel` + `chat_messages.send_message`) - the exact mechanism `routine_runner._wake_and_announce` already uses. This never drives an ACP/LLM turn directly and never deploys or execs a non-running agent; agents with `status != "running"` are skipped outright.
- **Opt-in**: gated behind `config.server["agent_heartbeat_enabled"]` (default `False`), re-read from `app_state.config` every tick so it can be toggled via the existing `PUT /api/config` without a restart.
- **Reuse, not reinvention**: the ready-task/claim semantics already in `ProjectTaskStore` are reused as-is. The only new query is `list_ready_tasks_for_assignee(assignee_id, limit=5)`, the per-assignee counterpart to the existing project-scoped `list_ready_tasks`, built on the same `ready_tasks` view. Relational context comes straight from `get_task_context` + `format_why` (#158), unchanged.
- Each agent's handling is wrapped in its own try/except so one bad agent never breaks the tick, and an in-memory `{agent_id: (task_id, last_wake_ts)}` debounce on `app.state` prevents re-waking the same still-pending task inside a 300s cooldown.

**assignee_id identifier**: confirmed via `beads_bridge._resolve_assignee` (which resolves an `@name` to "the agent's hex member_id" before it's stored) and the routine wake test covering a native member's hex config id, that `project_tasks.assignee_id` is the agent's canonical config `id`, not its `name`. The heartbeat loop queries `list_ready_tasks_for_assignee` with each running agent's `id`.

**Follow-ups (explicitly out of scope here)**: a per-agent schedule store, forcing an LLM/ACP turn instead of a best-effort notify, and waking offline/non-running agents (e.g. via deploy) are all left for later work - this PR only wakes agents that are already running.

## Test plan

- [x] `python3 -m pytest tests/test_agent_heartbeat.py tests/test_project_task_store.py -q` - 61 passed
- [x] `python3 -m pytest tests/projects/ tests/test_task_store.py tests/test_project_task_store.py tests/test_agent_heartbeat.py -q` - 385 passed (no regressions in adjacent routine/task-store suites)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gated agent-to-agent task delegation via an API, including approval-required flows and task creation from title when needed.
  * Added agent organization tools: an admin org chart plus endpoints to set role/title and reporting relationships.
  * Added an opt-in background “agent heartbeat” loop to wake running agents when eligible work is ready.
* **Bug Fixes**
  * Expanded governance coverage for the new delegation action and improved sensitive/approval handling.
  * Improved ready-task selection used by delegation and heartbeat (assignee filtering, eligibility, ordering).
* **Tests**
  * Added extensive coverage for delegation, org updates, heartbeat behavior, migrations, and store queries.
* **Chores**
  * Updated a few dependency version constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

----
## Summary by Gitar

- **Agent heartbeat loop:**
  - Implemented `agent_heartbeat_loop` in `tinyagentos/agent_heartbeat.py` to periodically wake idle running agents with ready tasks.
  - Added `list_ready_tasks_for_assignee` in `ProjectTaskStore` to efficiently query pending tasks for specific agents.
- **Gated agent delegation:**
  - Added `POST /api/agents/{from_agent}/delegate` to support task handoffs, requiring governance approval by default.
  - Integrated `complete_delegation` flow into the `decision_store` approval loop in `routes/decisions.py`.
- **Org model and registry:**
  - Extended agent registry with `title` and `reports_to` fields, including schema migration and org tree visualization via `GET /api/agents/org`.
  - Added cycle-detection and self-report guards to `set_reporting` in `AgentRegistryStore`.
- **Governance:**
  - Classified `delegate` as a sensitive action class, defaulting to `require_approval` in `governance/action_classes.py`.


<sub>This will update automatically on new commits.</sub>