### PR TITLE
fix(models): parse rkllama plain-text pull progress so RK3588 downloads leave 0% (#1648)

### DIFF
--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -226,8 +226,14 @@ async def _no_sleep(*_a, **_k):
 
 
 class TestInstallProgress:
-    """install() must forward /api/pull's ndjson progress lines to an
-    optional on_progress callback, and never let a malformed line raise.
+    """install() must forward /api/pull's progress lines to an optional
+    on_progress callback, and never let a malformed line raise.
+
+    The jaylfc/rkllama fork actually installed on taOS streams plain-text
+    lines (a "Downloading ... (N MB)..." banner followed by repeated bare
+    "NN%" lines), not Ollama-style JSON -- that's the real cause of #1648
+    (downloads stuck at 0%). The parser stays tolerant of a hypothetical
+    future JSON-emitting build too.
     """
 
     def _installer(self):
@@ -235,7 +241,60 @@ class TestInstallProgress:
 
     @respx.mock
     @pytest.mark.asyncio
-    async def test_progress_lines_forwarded_to_callback(self):
+    async def test_plain_text_percent_lines_forwarded_to_callback(self):
+        # Real shape of the fork's /api/pull stream: a banner line, then
+        # repeated bare-percent lines with no JSON at all.
+        pull_body = (
+            "Downloading foo (3500.00 MB)...\n"
+            "0%\n"
+            "13%\n"
+            "47%\n"
+            "100%\n"
+        )
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text=pull_body)
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": [{"name": "rkllama-x"}]})
+        )
+        calls = []
+        res = await self._installer().install(
+            "rkllama-x", {}, variant=_VARIANT, on_progress=lambda c, t: calls.append((c, t))
+        )
+        assert res["success"] is True
+        assert calls == [(0, 100), (13, 100), (47, 100), (100, 100)]
+        # Percent-of-100 reporting means the task's percent goes 0 -> 100.
+        assert calls[0][0] == 0
+        assert calls[-1] == (100, 100)
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_error_and_blank_lines_ignored_not_raised(self):
+        pull_body = (
+            "Downloading foo (100.00 MB)...\n"
+            "\n"
+            "Error: boom\n"
+            "50%\n"
+        )
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text=pull_body)
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": [{"name": "rkllama-x"}]})
+        )
+        calls = []
+        res = await self._installer().install(
+            "rkllama-x", {}, variant=_VARIANT, on_progress=lambda c, t: calls.append((c, t))
+        )
+        assert res["success"] is True
+        # Only the "50%" line produces a callback; the banner, blank line,
+        # and "Error: ..." line must never be mistaken for progress.
+        assert calls == [(50, 100)]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_json_completed_total_lines_still_supported(self):
+        # A hypothetical future Ollama-compatible build should still work.
         pull_body = (
             '{"status":"downloading","completed":1000,"total":10000}\n'
             '{"status":"downloading","completed":5000,"total":10000}\n'
@@ -257,9 +316,8 @@ class TestInstallProgress:
 
     @respx.mock
     @pytest.mark.asyncio
-    async def test_malformed_lines_ignored_not_raised(self):
+    async def test_malformed_json_lines_ignored_not_raised(self):
         pull_body = (
-            "not json at all\n"
             '{"status":"downloading"}\n'
             '{"status":"downloading","completed":"oops","total":10000}\n'
             '{"status":"downloading","completed":250,"total":1000}\n'
@@ -282,9 +340,7 @@ class TestInstallProgress:
     async def test_no_callback_still_works(self):
         # Default on_progress=None must not change existing behaviour.
         respx.post("http://localhost:7833/api/pull").mock(
-            return_value=httpx.Response(
-                200, text='{"status":"downloading","completed":1,"total":2}\n'
-            )
+            return_value=httpx.Response(200, text="50%\n")
         )
         respx.get("http://localhost:7833/api/tags").mock(
             return_value=httpx.Response(200, json={"models": [{"name": "rkllama-x"}]})

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -96,26 +96,42 @@ def default_rkllama_url() -> str:
     return f"http://localhost:{_DEFAULT_RKLLAMA_PORT}"
 
 
+_PLAIN_PERCENT_RE = re.compile(r"^\s*(\d{1,3})(?:\.\d+)?\s*%\s*$")
+
+
 def _report_pull_progress(line: str, on_progress: Callable[[int, int], None]) -> None:
-    """Parse one ndjson line from rkllama's /api/pull stream and forward
+    """Parse one line from rkllama's /api/pull stream and forward
     ``(completed, total)`` to ``on_progress``.
 
-    rkllama's pull endpoint is Ollama-style ndjson, e.g.
-    ``{"status":"downloading","completed":1234,"total":56789}``. Lines
-    without both numeric fields (status-only messages, blank keepalives) are
-    silently ignored -- a stray or malformed line must never abort the
+    The jaylfc/rkllama fork actually installed on taOS does NOT stream
+    Ollama-style ndjson. ``generate_progress()`` yields plain-text lines
+    like ``"Downloading <repo> (<size> MB)...\n"`` followed by repeated
+    bare-percent lines like ``"45%\n"``, and ``"Error: <msg>\n"`` on
+    failure -- there are no ``completed``/``total`` JSON fields at all.
+
+    We stay tolerant of both shapes: if a line happens to be JSON with
+    numeric ``completed``/``total`` (e.g. a future Ollama-compatible
+    build), use those directly; otherwise look for a bare percent and
+    report it as completed-of-100. Any other line (banners, "Error: ...",
+    blanks) is ignored -- a stray or malformed line must never abort the
     install.
     """
     try:
         data = json.loads(line)
     except (TypeError, ValueError):
+        data = None
+    if isinstance(data, dict):
+        completed = data.get("completed")
+        total = data.get("total")
+        if isinstance(completed, (int, float)) and isinstance(total, (int, float)) and total > 0:
+            on_progress(int(completed), int(total))
         return
-    if not isinstance(data, dict):
+
+    m = _PLAIN_PERCENT_RE.match(line)
+    if not m:
         return
-    completed = data.get("completed")
-    total = data.get("total")
-    if isinstance(completed, (int, float)) and isinstance(total, (int, float)) and total > 0:
-        on_progress(int(completed), int(total))
+    percent = max(0, min(100, int(m.group(1))))
+    on_progress(percent, 100)
 
 
 def parse_hf_resolve_url(url: str) -> tuple[str, str, str]:
@@ -185,8 +201,9 @@ class RkllamaInstaller(AppInstaller):
 
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
-                # /api/pull streams ndjson progress; we drain the stream until
-                # close. Any non-2xx status is an install failure.
+                # /api/pull streams plain-text progress lines (see
+                # _report_pull_progress); we drain the stream until close.
+                # Any non-2xx status is an install failure.
                 async with client.stream("POST", endpoint, json=body) as resp:
                     if resp.status_code >= 400:
                         text = (await resp.aread()).decode("utf-8", errors="replace")


### PR DESCRIPTION
## Summary

The jaylfc/rkllama fork taOS installs streams `/api/pull` progress as plain text, not Ollama-style JSON. `generate_progress()` yields lines like `"Downloading foo (3500.00 MB)...\n"`, then repeated bare `"45%\n"` lines, and `"Error: <msg>\n"` on failure. There are no `completed`/`total` JSON fields.

The prior fix (#1658) assumed an ndjson stream with numeric `completed`/`total` fields. Every plain-text `"45%"` line fails `json.loads` and was silently dropped, so `on_progress` was never called and the download task stayed at 0% for the whole pull. That's the real cause of #1648.

`_report_pull_progress` now:
1. Tries `json.loads` first; if it's a dict with numeric `completed`/`total`, uses those directly (keeps the door open for a future Ollama-compatible build).
2. Otherwise matches a bare percent line (`"NN%"`) and reports it as `(percent, 100)`, which the download task turns into the correct 0-100 percent.
3. Ignores anything else (banners, `"Error: ..."`, blanks) without raising.

## Test plan

- [x] `python3 -m pytest tests/test_rkllama_installer.py -q` - 26 passed
- [x] `python3 -m pytest tests/test_download_manager.py tests/test_routes_models.py -q` - 69 passed
- [x] New test feeds the fork's real plain-text sequence (`"Downloading foo (3500.00 MB)..."`, `"0%"`, `"13%"`, `"47%"`, `"100%"`) and asserts `on_progress` advances to `(100, 100)`
- [x] New test asserts an `"Error: boom"` line and a blank line do not call `on_progress` and do not raise
- [x] Existing JSON `{completed,total}` path kept and re-verified so a future Ollama-compatible fork still works
- [ ] Not verified on real RK3588 hardware (mock-only; matches the fork's documented streaming format)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation progress reporting to handle both percentage-style updates and structured progress data.
  * Ignored blank lines, banners, and error messages so they no longer interfere with progress updates.
  * Kept support for malformed progress lines without interrupting the install flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->