### PR TITLE
release: 1.0.0-beta.31 (agent org model + delegation, heartbeat loop, rkllama progress fix, crypto bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.31] - 2026-07-06
+
+### Fixed
+- Model downloads on RK3588 (rkllama backend) really do show progress now. The earlier fix assumed the rkllama pull stream was JSON, but it streams plain-text percentage lines; taOS now parses those (and still handles the JSON form), so the bar advances instead of sitting at 0%. Reported by @mandresve (#1648).
+
+### Added
+- Agent org model: agents can carry a role and title and a reporting line (who reports to whom), viewable as an org tree, with cycle-safe validation. Agents can delegate a task to another agent through the existing governance gate, so a delegation is allowed, denied, or sent to the Decisions inbox for approval like any other gated action (#161).
+- Agent heartbeat loop (opt-in, off by default): when enabled, taOS periodically wakes each idle running agent with its next ready task and that task's goal context, so agents pull and act on their queue on a schedule. Enable it with the `agent_heartbeat_enabled` setting (#164).
+
+### Security
+- Bumped cryptography to 48.0.1 to clear a high-severity OpenSSL advisory in the bundled wheels; the new version keeps wheels for every supported platform (including Intel Mac and 32-bit Windows), so no platform loses coverage (#1653).
+
 ## [1.0.0-beta.30] - 2026-07-05
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.30",
+  "version": "1.0.0-beta.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.30",
+      "version": "1.0.0-beta.31",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.30",
+  "version": "1.0.0-beta.31",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.30"
+version = "1.0.0-beta.31"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.30"
+__version__ = "1.0.0-beta.31"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b30"
+version = "1.0.0b31"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts 1.0.0-beta.31.

- feat(governance): agent org model - roles/titles/reporting lines + gated delegation (#161)
- feat(agents): opt-in heartbeat loop - wake idle running agents with ready tasks (#164)
- fix(models): parse rkllama plain-text pull progress so RK3588 downloads leave 0% (#1648)
- security: cryptography bumped to 48.0.1, clears the OpenSSL advisory, all platform wheels retained (#1653)

Note: dev was reconciled with master first (the heartbeat #1662 had merged to master by mistake; merged master into dev so dev is a superset before release). Versions bumped across pyproject.toml, __init__.py, package.json, package-lock.json, uv.lock (1.0.0b31), CHANGELOG. test_version_lock_sync green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agent organization view with role/title hierarchy and reporting lines.
  * Added an optional agent heartbeat loop to keep idle agents moving with the next task and goal context.

* **Bug Fixes**
  * Improved model download progress so percentage updates display correctly during RK3588 downloads.

* **Security**
  * Updated bundled cryptography components to address an OpenSSL advisory.

* **Chores**
  * Bumped the app version to `1.0.0-beta.31`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->