### PR TITLE
fix(governance): dedupe decision-answer routing + honest delegation message (#174)

### DIFF
--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -314,6 +314,9 @@ class TestDelegationApprovalFlow:
         # The task must NOT have been assigned.
         still_open = await app.state.project_task_store.get_task(task["id"])
         assert still_open["assignee_id"] is None
+        # And the delegate grant must NOT leak: a failed completion cannot leave
+        # behind a grant that would let a later delegation skip approval.
+        assert not await app.state.execution_policies.has_live_grant("from-agent", "delegate")
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -243,6 +243,78 @@ class TestDelegationApprovalFlow:
         new_task = next(t for t in tasks if t["title"] == "Brand new task")
         assert new_task["assignee_id"] == "to-agent"
 
+    async def test_approving_routes_exactly_one_honest_message(self, client, app, monkeypatch):
+        """Answering a delegation gate must send the asking agent a SINGLE
+        reply: the delegation handler owns the message, so the generic
+        answer-router must not also fire (the old code sent two)."""
+        from tinyagentos.routes import decisions as decisions_mod
+
+        calls: list[str] = []
+
+        async def _capture(decision, value):
+            calls.append(str(value))
+
+        monkeypatch.setattr(decisions_mod, "_route_answer_to_agent", _capture)
+
+        _project, task = await _make_project_and_task(app)
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "approve"}
+        )
+        assert answer_resp.status_code == 200
+        assert len(calls) == 1
+        assert calls[0] == "delegation approved - the task has been assigned"
+
+    async def test_failed_completion_reports_retry_not_success(self, client, app, monkeypatch):
+        """If assigning the task fails after approval, the agent must be told
+        the truth (retry), never that the task was assigned."""
+        from tinyagentos.routes import decisions as decisions_mod
+
+        calls: list[str] = []
+
+        async def _capture(decision, value):
+            calls.append(str(value))
+
+        monkeypatch.setattr(decisions_mod, "_route_answer_to_agent", _capture)
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("assign failed")
+
+        # _apply_delegation_grant imports complete_delegation from this module
+        # at call time, so patching it here intercepts the assignment.
+        import tinyagentos.routes.delegation as delegation_mod
+        monkeypatch.setattr(delegation_mod, "complete_delegation", _boom)
+
+        _project, task = await _make_project_and_task(app)
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "approve"}
+        )
+        assert answer_resp.status_code == 200
+        assert len(calls) == 1
+        assert "please retry" in calls[0]
+        # The task must NOT have been assigned.
+        still_open = await app.state.project_task_store.get_task(task["id"])
+        assert still_open["assignee_id"] is None
+
 
 @pytest.mark.asyncio
 class TestDelegationTaskTitleCreatesTask:

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -249,14 +249,19 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
     updated = await store.answer(decision_id, body.value, answered_by)
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
-    await _apply_app_grant(request, updated, body.value)
-    await _apply_execution_grant(request, updated, body.value)
-    await _apply_delegation_grant(request, updated, body.value)
-    await _route_answer_to_agent(updated, body.value)
+    # Each kind-specific handler runs its side effect and returns True if it
+    # already routed a reply to the asking agent (a more informative,
+    # kind-specific message). Only route the generic answer when none did, so
+    # a gated decision does not send the agent two messages.
+    routed_app = await _apply_app_grant(request, updated, body.value)
+    routed_exec = await _apply_execution_grant(request, updated, body.value)
+    routed_deleg = await _apply_delegation_grant(request, updated, body.value)
+    if not (routed_app or routed_exec or routed_deleg):
+        await _route_answer_to_agent(updated, body.value)
     return updated
 
 
-async def _apply_execution_grant(request: Request, decision: dict, value) -> None:
+async def _apply_execution_grant(request: Request, decision: dict, value) -> bool:
     """Side effect for an execution-gate Decision (agent governance #160 slice
     1): the decision's metadata carries {kind: "execution_gate", agent_name,
     action_class, tool}. Approving it writes a short-lived execution grant so
@@ -266,12 +271,12 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> Non
     store hiccup must not fail the answer."""
     meta = decision.get("metadata") or {}
     if meta.get("kind") != "execution_gate":
-        return
+        return False
     policies = getattr(request.app.state, "execution_policies", None)
     agent_name = meta.get("agent_name")
     action_class = meta.get("action_class")
     if policies is None or not agent_name or not action_class:
-        return
+        return False
     approved = value == "approve"
     try:
         if approved:
@@ -291,9 +296,10 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> Non
         decision,
         "you may retry the action now" if approved else "your action was denied",
     )
+    return True
 
 
-async def _apply_delegation_grant(request: Request, decision: dict, value) -> None:
+async def _apply_delegation_grant(request: Request, decision: dict, value) -> bool:
     """Side effect for a delegation-gate Decision (#161 gated delegation): the
     decision's metadata carries {kind: "delegation_gate", from_agent, to_agent,
     task_id, task_title, note}. Approving it writes a short-lived delegate
@@ -304,13 +310,14 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> No
     grant-store or delegation-completion hiccup must not fail the answer."""
     meta = decision.get("metadata") or {}
     if meta.get("kind") != "delegation_gate":
-        return
+        return False
     policies = getattr(request.app.state, "execution_policies", None)
     from_agent = meta.get("from_agent")
     to_agent = meta.get("to_agent")
     if policies is None or not from_agent or not to_agent:
-        return
+        return False
     approved = value == "approve"
+    completed = False
     if approved:
         try:
             await policies.add_grant(from_agent, "delegate", decision.get("id"))
@@ -330,31 +337,39 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> No
                 project_id=decision.get("project_id"),
                 note=meta.get("note") or "",
             )
+            completed = True
         except Exception:
             logger.warning(
                 "delegation completion failed for decision %s", decision.get("id"), exc_info=True,
             )
-    await _route_answer_to_agent(
-        decision,
-        "delegation approved - the task has been assigned" if approved else "delegation denied",
-    )
+    # Tell the agent the truth: only claim the task was assigned when the
+    # completion actually succeeded, so a failed assign is not reported as done.
+    if not approved:
+        reply = "delegation denied"
+    elif completed:
+        reply = "delegation approved - the task has been assigned"
+    else:
+        reply = "delegation approved, but assigning the task failed - please retry"
+    await _route_answer_to_agent(decision, reply)
+    return True
 
 
-async def _apply_app_grant(request: Request, decision: dict, value) -> None:
+async def _apply_app_grant(request: Request, decision: dict, value) -> bool:
     """Side effect for an app-grant consent Decision: write the per-capability
     grant decisions to the app_grants ledger. The decision's metadata carries
     {kind: "app_grant", app_id, capabilities}; for the multi_select consent card
     the answer is the list of granted capability values, so the rest are denied.
     Best-effort: the answer is already persisted, so a grant-store hiccup must
-    not fail the answer."""
+    not fail the answer. Returns False: app grants do not route an agent reply,
+    so the caller sends the generic answer."""
     meta = decision.get("metadata") or {}
     if meta.get("kind") != "app_grant":
-        return
+        return False
     grants = getattr(request.app.state, "app_grants", None)
     app_id = meta.get("app_id")
     caps = meta.get("capabilities") or []
     if grants is None or not app_id:
-        return
+        return False
     user_id = decision.get("user_id") or ""
     granted = set(value if isinstance(value, list) else [value])
     try:
@@ -372,3 +387,4 @@ async def _apply_app_grant(request: Request, decision: dict, value) -> None:
             "app_grant ledger write failed for app %s (decision %s)",
             app_id, decision.get("id"), exc_info=True,
         )
+    return False

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -278,9 +278,11 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> boo
     if policies is None or not agent_name or not action_class:
         return False
     approved = value == "approve"
+    granted = False
     try:
         if approved:
             await policies.add_grant(agent_name, action_class, decision.get("id"))
+            granted = True
     except Exception:
         # Best-effort: the answer is already persisted, so a grant-store write
         # must not fail the request. Log it rather than swallow silently so a
@@ -290,12 +292,16 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> boo
             agent_name, decision.get("id"), exc_info=True,
         )
     # decision["from_agent"] is already agent_name (set when the gate created
-    # this decision in skill_exec.py); reuse the existing answer-routing path
-    # with a retry-specific message instead of the generic answer text.
-    await _route_answer_to_agent(
-        decision,
-        "you may retry the action now" if approved else "your action was denied",
-    )
+    # this decision in skill_exec.py); reuse the existing answer-routing path.
+    # Only tell the agent it may retry when the grant actually persisted -- if
+    # the write failed, the gate will re-prompt on retry, so say so honestly.
+    if not approved:
+        reply = "your action was denied"
+    elif granted:
+        reply = "you may retry the action now"
+    else:
+        reply = "your action was approved, but saving the grant failed - please retry"
+    await _route_answer_to_agent(decision, reply)
     return True
 
 
@@ -320,13 +326,6 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
     completed = False
     if approved:
         try:
-            await policies.add_grant(from_agent, "delegate", decision.get("id"))
-        except Exception:
-            logger.warning(
-                "delegate grant write failed for agent %s (decision %s)",
-                from_agent, decision.get("id"), exc_info=True,
-            )
-        try:
             from tinyagentos.routes.delegation import complete_delegation
             await complete_delegation(
                 request,
@@ -342,6 +341,18 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
             logger.warning(
                 "delegation completion failed for decision %s", decision.get("id"), exc_info=True,
             )
+        # Grant the delegate capability only once THIS delegation actually
+        # completed. Writing it before completion leaked a grant on failure: a
+        # later delegation by the same agent would then skip approval while the
+        # original assignment had silently never happened.
+        if completed:
+            try:
+                await policies.add_grant(from_agent, "delegate", decision.get("id"))
+            except Exception:
+                logger.warning(
+                    "delegate grant write failed for agent %s (decision %s)",
+                    from_agent, decision.get("id"), exc_info=True,
+                )
     # Tell the agent the truth: only claim the task was assigned when the
     # completion actually succeeded, so a failed assign is not reported as done.
     if not approved:


### PR DESCRIPTION
Folds the Kilo review nits on the #161 org model.

## What
- `answer_decision` was routing a generic answer to the asking agent **and** each grant handler (execution, delegation) was routing its own → the agent received two messages for a single gated decision. Now all three `_apply_*_grant` handlers return whether they routed, and the caller sends the generic reply only when none did.
- The delegation reply is now honest: it only claims the task was assigned when `complete_delegation` actually succeeded. A failed assignment tells the agent to retry rather than falsely reporting success.

## Tests
- `test_approving_routes_exactly_one_honest_message` — a delegation gate answer routes exactly one reply.
- `test_failed_completion_reports_retry_not_success` — a failed assign reports retry and leaves the task unassigned.
- Full `test_routes_delegation.py` + `test_routes_decisions.py`: 38 passed.

Closes #174.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegation gate decisions now deliver more specific approval status to the requesting agent, including whether the task was assigned.

* **Bug Fixes**
  * Prevented duplicate outbound agent messages by ensuring only the most relevant decision response is routed.
  * Improved delegation failure handling so the requesting agent is instructed to retry when assignment doesn’t complete.

* **Tests**
  * Added/expanded coverage for delegation approval routing and retry-on-failure scenarios to guard against regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->