### PR TITLE
fix(weather): allow open-meteo origins in CSP connect-src (#1668)

### DIFF
--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -27,6 +27,16 @@ class TestSecurityHeaders:
         assert "wss:" in csp
 
     @pytest.mark.asyncio
+    async def test_csp_allows_weather_open_meteo_origins(self, client):
+        # Regression for #1668: the built-in Weather app fetches the open-meteo
+        # geocoding + forecast APIs directly, so both origins must be in
+        # connect-src or default-src 'self' silently blocks every city search.
+        resp = await client.get("/api/health")
+        csp = resp.headers.get("content-security-policy", "")
+        assert "https://geocoding-api.open-meteo.com" in csp
+        assert "https://api.open-meteo.com" in csp
+
+    @pytest.mark.asyncio
     async def test_x_frame_options_sameorigin(self, client):
         resp = await client.get("/api/health")
         assert resp.headers.get("x-frame-options", "").upper() == "SAMEORIGIN"

--- a/tinyagentos/middleware/security_headers.py
+++ b/tinyagentos/middleware/security_headers.py
@@ -28,7 +28,11 @@ def _build_csp(frame_src_extra: str = "") -> str:
         f"{frame_src}; "
         # data: lets the canvas (tldraw) load its bundled translation URIs
         # (data:application/json), which are inline data, not a network fetch.
-        "connect-src 'self' ws: wss: data:"
+        # The two open-meteo origins are the geocoding (city search) and
+        # forecast APIs the built-in Weather app fetches directly; without them
+        # default-src 'self' silently blocks every lookup and the app looks dead.
+        "connect-src 'self' ws: wss: data: "
+        "https://geocoding-api.open-meteo.com https://api.open-meteo.com"
     )
 
 


### PR DESCRIPTION
Fixes #1668.

## Root cause
The built-in **Weather** app (`WeatherApp.tsx`, `WeatherWidget.tsx`) fetches the open-meteo **geocoding** (city search) and **forecast** APIs directly from the browser. The global `SecurityHeadersMiddleware` sets `connect-src 'self' ws: wss: data:` on every response, so `default-src 'self'` blocked every request to `open-meteo.com`. `searchLocations` catches the CSP error and returns `[]`, so the search field looks completely dead - no results, no error - exactly as reported.

This is why it reproduces on a fresh desktop install (current CSP enforced) but can appear to work on an installed mobile PWA serving a cached shell from before the CSP was tightened.

## Fix
Add `https://geocoding-api.open-meteo.com` and `https://api.open-meteo.com` to `connect-src`. These are the only two origins the built-in Weather app needs; nothing else is widened.

## Test
`test_csp_allows_weather_open_meteo_origins` asserts both origins are present in the served CSP. Full `tests/test_security_headers.py`: 8 passed.

Takes effect on a controller update (backend middleware header) - no SPA rebuild needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security headers so the app can connect directly to Open-Meteo services without being blocked by the browser.
  * Fixed an issue affecting weather-related requests on the health endpoint.
  * Added a regression test to help prevent Content Security Policy connection issues from returning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->