### PR TITLE
fix(desktop): user's wallpaper pick wins over theme default on login (#1603)

### DIFF
--- a/desktop/src/stores/__tests__/restore-theme.test.ts
+++ b/desktop/src/stores/__tests__/restore-theme.test.ts
@@ -99,21 +99,28 @@ describe("restoreActiveTheme does not clobber the persisted wallpaper", () => {
     expect(useThemeStore.getState().wallpaperId).toBe("ocean");
   });
 
-  it("still applies the theme's declared defaultWallpaperId on restore", async () => {
+  it("does NOT override the user's persisted wallpaper with the theme's default (#1603)", async () => {
+    // The user actively picked Ocean while on Indigo. On boot,
+    // useSessionPersistence restores that persisted pick; restoreActiveTheme
+    // must not stomp it back to Indigo's declared default (neural-live).
     vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.includes("/api/preferences/themes")) {
         return Promise.resolve(new Response(JSON.stringify({ active_theme_id: "indigo" })));
       }
-      // Provide an Indigo-like theme that declares neural-live.
+      // Provide an Indigo-like theme that declares neural-live as its default.
       return Promise.resolve(
         new Response(JSON.stringify([{ theme_id: "indigo", config: { tokens: {}, defaultWallpaperId: "neural-live" } }])),
       );
     });
+    // Stand in for useSessionPersistence having restored the user's pick.
+    useThemeStore.getState().setWallpaper("ocean");
+    expect(useThemeStore.getState().wallpaperId).toBe("ocean");
 
     await restoreActiveTheme();
 
     expect(useThemeStore.getState().activeThemeId).toBe("indigo");
-    expect(useThemeStore.getState().wallpaperId).toBe("neural-live");
+    // The user's explicit pick wins over the theme's declared default.
+    expect(useThemeStore.getState().wallpaperId).toBe("ocean");
   });
 });

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -402,36 +402,28 @@ export function setWallpaperForActiveTheme(value: string) {
   useThemeStore.setState({ wallpaperByTheme: { ...wallpaperByTheme, [activeThemeId]: value } });
 }
 
-// Apply the right wallpaper to the live desktop when switching to a theme.
+// Apply the right wallpaper to the live desktop when the user actively SWITCHES
+// to a theme (keepTheme). This is symmetric: switching away from a theme that
+// set its own wallpaper (e.g. Indigo -> neural-live) back to Dark/Light must not
+// leave neural-live stuck. Resolution order:
+//   1. a wallpaper the user explicitly picked for the target theme, else
+//   2. the target theme's declared defaultWallpaperId, else
+//   3. the global default wallpaper (never the previous theme's).
 //
-// This runs in two contexts with different correctness needs:
-//
-//   * Live switch (keepTheme): the user is actively changing themes, so it is
-//     safe and desirable to be symmetric -- switching away from a theme that
-//     set its own wallpaper (e.g. Indigo -> neural-live) back to Dark/Light
-//     must not leave neural-live stuck. Resolution order:
-//       1. a wallpaper the user explicitly picked for the target theme, else
-//       2. the target theme's declared defaultWallpaperId, else
-//       3. the global default wallpaper (never the previous theme's).
-//
-//   * Restore (restoreActiveTheme, on boot): the user's chosen wallpaper is
-//     persisted separately (PUT /api/desktop/settings) and restored by
-//     useSessionPersistence. The per-theme memory (wallpaperIdByTheme) is
-//     in-memory only and empty at boot, so a global-default fallback would race
-//     that restore and reset a custom wallpaper back to graphite. On restore we
-//     therefore only act on a positive reason -- the target theme's declared
-//     defaultWallpaperId -- and never force the global default, leaving the
-//     persisted wallpaper untouched.
-function applyThemeDefaultWallpaper(themeId: string, cfg: ThemeConfig, opts?: { restore?: boolean }) {
+// On BOOT/restore this is deliberately NOT called. The user's chosen wallpaper
+// is persisted separately (PUT /api/desktop/settings) and restored by
+// useSessionPersistence, and that persisted choice is authoritative. A theme's
+// declared default is applied (and thus persisted) when the user switches to
+// the theme, so it already survives restore through that persisted value.
+// Re-applying the theme default on boot would override a wallpaper the user
+// later picked while on the theme, which is exactly the "wallpaper always
+// resets" report in #1603 -- so the user's persisted pick now wins.
+function applyThemeDefaultWallpaper(themeId: string, cfg: ThemeConfig) {
   const state = useThemeStore.getState();
-  // Explicit user choice for this theme always wins.
+  // Explicit user choice for this theme always wins, else the theme's declared
+  // default, else the global default (never the previous theme's wallpaper).
   const remembered = state.wallpaperIdByTheme[themeId];
-  // On restore there is no in-memory memory to trust and the global default
-  // must never override the separately-persisted wallpaper, so the theme's own
-  // declared default is the only positive reason to change anything.
-  const target = opts?.restore
-    ? cfg.defaultWallpaperId
-    : (remembered ?? cfg.defaultWallpaperId ?? DEFAULT_WP.id);
+  const target = remembered ?? cfg.defaultWallpaperId ?? DEFAULT_WP.id;
   if (!target) return; // no positive reason to change the wallpaper
   if (target === state.wallpaperId) return; // already showing it
   const wp = WALLPAPERS.find((w) => w.id === target);
@@ -492,7 +484,9 @@ export async function restoreActiveTheme(): Promise<void> {
         ...(cfg.wallpaper ? { [themeId]: cfg.wallpaper } : {}),
       },
     });
-    applyThemeDefaultWallpaper(themeId, cfg, { restore: true });
+    // Do NOT apply the theme's default wallpaper here: useSessionPersistence
+    // restores the user's persisted wallpaper, which is authoritative (#1603).
+    // The theme default was already persisted when the theme was selected.
   } catch {
     // best-effort: ignore
   }


### PR DESCRIPTION
Addresses the wallpaper half of #1603.

## Root cause
The desktop-settings persistence race that caused resets was already fixed (beta.24). The remaining "wallpaper always resets" symptom comes from a second restore path: `restoreActiveTheme` called `applyThemeDefaultWallpaper(..., { restore: true })` on every boot, which re-applied the **active theme's declared default wallpaper** over the user's own pick. The user's chosen wallpaper is persisted separately (`PUT /api/desktop/settings`) and restored by `useSessionPersistence`, so for anyone on a non-default theme that declares a wallpaper, their pick was stomped on every login.

## Fix
Stop applying the theme default on restore. The persisted wallpaper is authoritative, and a theme's default is already persisted when the theme is selected (so it still survives restore through that persisted value). Removed the now-dead `restore` branch of `applyThemeDefaultWallpaper` and its `opts` param.

This is a deliberate product decision (jaylfc): a user's explicit wallpaper choice should win over a theme's default. The previously-passing test that asserted the old override is updated to assert the pick wins.

## Test
`restore-theme.test.ts`: user's persisted "ocean" survives restore of an Indigo theme declaring "neural-live". Theme-store suites: 20 passed.

Takes effect after an SPA rebuild (frontend change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring a theme now keeps your previously saved wallpaper instead of replacing it with the theme’s default.
  * Theme restoration still updates the active theme correctly, while respecting your personal wallpaper choice after startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->