### PR TITLE
release: 1.0.0-beta.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.32] - 2026-07-06
+
+### Fixed
+- Weather app location search works again. The app looks up cities and forecasts from the open-meteo API, but the Content-Security-Policy only allowed same-origin connections, so the browser silently blocked every lookup and the search field did nothing. The two open-meteo origins are now allowed. Reported by @mandresve (#1668).
+- Desktop wallpaper no longer resets on login for anyone using a theme that declares a default wallpaper. Your explicitly chosen wallpaper is now authoritative on restore and is not overridden by the theme's default. Reported by @mandresve (#1603).
+
+### Added
+- Groundwork for the native iOS and watchOS client: a per-user device registry with revocable per-device scoped tokens, device management endpoints, a device-token auth path, and an APNs push sender (inactive until configured). No user-facing app yet; this is the server foundation the mobile app will build on (#1671).
+
+### Changed
+- Governance: answering a gated Decision no longer sends the asking agent a duplicate message, and delegation and retry replies now state honestly whether the action actually completed (#174).
+
 ## [1.0.0-beta.31] - 2026-07-06
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.31",
+      "version": "1.0.0-beta.32",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.31"
+version = "1.0.0-beta.32"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.31"
+__version__ = "1.0.0-beta.32"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b31"
+version = "1.0.0b32"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump for the beta.32 release train. Batches what has landed on dev since beta.31:

- **#1668** Weather app location search fixed (open-meteo allowed in CSP)
- **#1603** desktop wallpaper no longer resets on login for themed-default users
- **#1671** native Apple client server foundation (device registry + scoped tokens + APNs sender; no user-facing app yet)
- **#174** governance: dedupe decision-answer routing + honest delegation/exec messages
- **#1666** desktop vitest CI stabilization (internal)

Related fork release: jaylfc/rkllama /api/pull now emits real Ollama ndjson + reliable model registration (#175), which closes out the model-install completion chain for RK3588 users on reinstall.

Version bumped in pyproject.toml, tinyagentos/__init__.py, desktop/package.json, desktop/package-lock.json (x2), uv.lock (1.0.0b32), CHANGELOG. test_version_lock_sync green.