### PR TITLE
release: promote dev to master (1.0.0-beta.32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,9 +129,15 @@ jobs:
       # order-dependent are quarantined in vite.config.ts (test.exclude, tagged
       # #114); un-exclude each as its owning work lands.
       - name: Run desktop tests (vitest)
+        env:
+          # Headroom for the jsdom suite so a worker is not OOM-killed on the
+          # 2-core runner (the fork children also get this via poolOptions in
+          # vite.config.ts). One automatic retry absorbs a rare transient
+          # worker death so a flake never blocks a release.
+          NODE_OPTIONS: --max-old-space-size=4096
         run: |
           cd desktop
-          npx vitest run
+          npx vitest run || (echo "vitest failed once, retrying..." && npx vitest run)
 
       # On master, publish the freshly-built SPA as a prebuilt bundle so the
       # installer can download it instead of running the memory-heavy vite build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.32] - 2026-07-06
+
+### Fixed
+- Weather app location search works again. The app looks up cities and forecasts from the open-meteo API, but the Content-Security-Policy only allowed same-origin connections, so the browser silently blocked every lookup and the search field did nothing. The two open-meteo origins are now allowed. Reported by @mandresve (#1668).
+- Desktop wallpaper no longer resets on login for anyone using a theme that declares a default wallpaper. Your explicitly chosen wallpaper is now authoritative on restore and is not overridden by the theme's default. Reported by @mandresve (#1603).
+
+### Added
+- Groundwork for the native iOS and watchOS client: a per-user device registry with revocable per-device scoped tokens, device management endpoints, a device-token auth path, and an APNs push sender (inactive until configured). No user-facing app yet; this is the server foundation the mobile app will build on (#1671).
+
+### Changed
+- Governance: answering a gated Decision no longer sends the asking agent a duplicate message, and delegation and retry replies now state honestly whether the action actually completed (#174).
+
 ## [1.0.0-beta.31] - 2026-07-06
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.31",
+      "version": "1.0.0-beta.32",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.31",
+  "version": "1.0.0-beta.32",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/stores/__tests__/restore-theme.test.ts
+++ b/desktop/src/stores/__tests__/restore-theme.test.ts
@@ -99,21 +99,28 @@ describe("restoreActiveTheme does not clobber the persisted wallpaper", () => {
     expect(useThemeStore.getState().wallpaperId).toBe("ocean");
   });
 
-  it("still applies the theme's declared defaultWallpaperId on restore", async () => {
+  it("does NOT override the user's persisted wallpaper with the theme's default (#1603)", async () => {
+    // The user actively picked Ocean while on Indigo. On boot,
+    // useSessionPersistence restores that persisted pick; restoreActiveTheme
+    // must not stomp it back to Indigo's declared default (neural-live).
     vi.spyOn(globalThis, "fetch").mockImplementation((input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
       if (url.includes("/api/preferences/themes")) {
         return Promise.resolve(new Response(JSON.stringify({ active_theme_id: "indigo" })));
       }
-      // Provide an Indigo-like theme that declares neural-live.
+      // Provide an Indigo-like theme that declares neural-live as its default.
       return Promise.resolve(
         new Response(JSON.stringify([{ theme_id: "indigo", config: { tokens: {}, defaultWallpaperId: "neural-live" } }])),
       );
     });
+    // Stand in for useSessionPersistence having restored the user's pick.
+    useThemeStore.getState().setWallpaper("ocean");
+    expect(useThemeStore.getState().wallpaperId).toBe("ocean");
 
     await restoreActiveTheme();
 
     expect(useThemeStore.getState().activeThemeId).toBe("indigo");
-    expect(useThemeStore.getState().wallpaperId).toBe("neural-live");
+    // The user's explicit pick wins over the theme's declared default.
+    expect(useThemeStore.getState().wallpaperId).toBe("ocean");
   });
 });

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -402,36 +402,28 @@ export function setWallpaperForActiveTheme(value: string) {
   useThemeStore.setState({ wallpaperByTheme: { ...wallpaperByTheme, [activeThemeId]: value } });
 }
 
-// Apply the right wallpaper to the live desktop when switching to a theme.
+// Apply the right wallpaper to the live desktop when the user actively SWITCHES
+// to a theme (keepTheme). This is symmetric: switching away from a theme that
+// set its own wallpaper (e.g. Indigo -> neural-live) back to Dark/Light must not
+// leave neural-live stuck. Resolution order:
+//   1. a wallpaper the user explicitly picked for the target theme, else
+//   2. the target theme's declared defaultWallpaperId, else
+//   3. the global default wallpaper (never the previous theme's).
 //
-// This runs in two contexts with different correctness needs:
-//
-//   * Live switch (keepTheme): the user is actively changing themes, so it is
-//     safe and desirable to be symmetric -- switching away from a theme that
-//     set its own wallpaper (e.g. Indigo -> neural-live) back to Dark/Light
-//     must not leave neural-live stuck. Resolution order:
-//       1. a wallpaper the user explicitly picked for the target theme, else
-//       2. the target theme's declared defaultWallpaperId, else
-//       3. the global default wallpaper (never the previous theme's).
-//
-//   * Restore (restoreActiveTheme, on boot): the user's chosen wallpaper is
-//     persisted separately (PUT /api/desktop/settings) and restored by
-//     useSessionPersistence. The per-theme memory (wallpaperIdByTheme) is
-//     in-memory only and empty at boot, so a global-default fallback would race
-//     that restore and reset a custom wallpaper back to graphite. On restore we
-//     therefore only act on a positive reason -- the target theme's declared
-//     defaultWallpaperId -- and never force the global default, leaving the
-//     persisted wallpaper untouched.
-function applyThemeDefaultWallpaper(themeId: string, cfg: ThemeConfig, opts?: { restore?: boolean }) {
+// On BOOT/restore this is deliberately NOT called. The user's chosen wallpaper
+// is persisted separately (PUT /api/desktop/settings) and restored by
+// useSessionPersistence, and that persisted choice is authoritative. A theme's
+// declared default is applied (and thus persisted) when the user switches to
+// the theme, so it already survives restore through that persisted value.
+// Re-applying the theme default on boot would override a wallpaper the user
+// later picked while on the theme, which is exactly the "wallpaper always
+// resets" report in #1603 -- so the user's persisted pick now wins.
+function applyThemeDefaultWallpaper(themeId: string, cfg: ThemeConfig) {
   const state = useThemeStore.getState();
-  // Explicit user choice for this theme always wins.
+  // Explicit user choice for this theme always wins, else the theme's declared
+  // default, else the global default (never the previous theme's wallpaper).
   const remembered = state.wallpaperIdByTheme[themeId];
-  // On restore there is no in-memory memory to trust and the global default
-  // must never override the separately-persisted wallpaper, so the theme's own
-  // declared default is the only positive reason to change anything.
-  const target = opts?.restore
-    ? cfg.defaultWallpaperId
-    : (remembered ?? cfg.defaultWallpaperId ?? DEFAULT_WP.id);
+  const target = remembered ?? cfg.defaultWallpaperId ?? DEFAULT_WP.id;
   if (!target) return; // no positive reason to change the wallpaper
   if (target === state.wallpaperId) return; // already showing it
   const wp = WALLPAPERS.find((w) => w.id === target);
@@ -492,7 +484,9 @@ export async function restoreActiveTheme(): Promise<void> {
         ...(cfg.wallpaper ? { [themeId]: cfg.wallpaper } : {}),
       },
     });
-    applyThemeDefaultWallpaper(themeId, cfg, { restore: true });
+    // Do NOT apply the theme's default wallpaper here: useSessionPersistence
+    // restores the user's persisted wallpaper, which is authoritative (#1603).
+    // The theme default was already persisted when the theme was selected.
   } catch {
     // best-effort: ignore
   }

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -9,6 +9,19 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
+    // The jsdom suite (2600+ tests) OOM-killed a worker intermittently on the
+    // 2-core CI runner, failing the whole run with no assertion. Bound the fork
+    // pool and give each worker a large heap so GC has room; a single flaky
+    // test also retries rather than failing the gate.
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks: 2,
+        minForks: 1,
+        execArgv: ["--max-old-space-size=4096"],
+      },
+    },
+    retry: 1,
     // *.spec.ts is reserved for Playwright e2e specs; vitest uses *.test.ts
     exclude: [
       "**/node_modules/**",

--- a/desktop/vitest.setup.ts
+++ b/desktop/vitest.setup.ts
@@ -58,3 +58,29 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
     }),
   });
 }
+
+// JSDOM does not implement HTMLCanvasElement.getContext (it logs a noisy "Not
+// implemented" line and returns null). Components that touch a canvas (charts,
+// game/wallpaper previews) would otherwise crash or spam the log. Return a
+// minimal no-op 2D context so those tests render without a native canvas dep.
+if (typeof HTMLCanvasElement !== "undefined") {
+  const noop = () => {};
+  const stub2d = () =>
+    new Proxy(
+      {
+        canvas: null as unknown,
+        measureText: () => ({ width: 0 }),
+        getImageData: () => ({ data: new Uint8ClampedArray(0), width: 0, height: 0 }),
+        createImageData: () => ({ data: new Uint8ClampedArray(0), width: 0, height: 0 }),
+        createLinearGradient: () => ({ addColorStop: noop }),
+        createRadialGradient: () => ({ addColorStop: noop }),
+        createPattern: () => null,
+      },
+      // Any unknown drawing method (fillRect, arc, beginPath, ...) is a no-op.
+      { get: (target, prop) => (prop in target ? (target as Record<string, unknown>)[prop as string] : noop) },
+    );
+  HTMLCanvasElement.prototype.getContext = function (type: string) {
+    return type === "2d" ? (stub2d() as unknown as CanvasRenderingContext2D) : null;
+  } as HTMLCanvasElement["getContext"];
+  HTMLCanvasElement.prototype.toDataURL = () => "data:image/png;base64,";
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.31"
+version = "1.0.0-beta.32"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -372,6 +372,10 @@ async def client(app, tmp_data_dir):
     if client_log_store._db is not None:
         await client_log_store.close()
     await client_log_store.init()
+    device_store = app.state.device_store
+    if device_store._db is not None:
+        await device_store.close()
+    await device_store.init()
     # BrowserApp v2 stores
     from tinyagentos.routes.desktop_browser.store import BrowserStore, BrowserCookieStore
     _browser_store = BrowserStore(tmp_data_dir / "browser.sqlite3")

--- a/tests/push/test_apns.py
+++ b/tests/push/test_apns.py
@@ -1,0 +1,78 @@
+import json
+import httpx
+import pytest
+
+from tinyagentos.push.apns import (
+    NullApnsSender,
+    HttpApnsSender,
+    build_apns_payload,
+    build_apns_jwt,
+    apns_sender_from_env,
+)
+
+
+def test_build_payload_alert_and_silent():
+    alert = build_apns_payload(title="Hi", body="there", data={"k": "v"})
+    assert alert["aps"]["alert"] == {"title": "Hi", "body": "there"}
+    assert alert["k"] == "v"
+
+    silent = build_apns_payload(title="", body="", content_available=True)
+    assert silent["aps"]["content-available"] == 1
+
+
+@pytest.mark.asyncio
+async def test_null_sender_returns_false():
+    assert await NullApnsSender().send("tok", {"aps": {}}) is False
+
+
+def test_apns_sender_from_env_defaults_to_null(monkeypatch):
+    for var in ("TAOS_APNS_KEY_ID", "TAOS_APNS_TEAM_ID", "TAOS_APNS_BUNDLE_ID", "TAOS_APNS_KEY_PATH"):
+        monkeypatch.delenv(var, raising=False)
+    assert isinstance(apns_sender_from_env(), NullApnsSender)
+
+
+def test_build_jwt_is_three_segments():
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    tok = build_apns_jwt(key_pem=pem, key_id="KID", team_id="TID", now=1_700_000_000)
+    assert tok.count(".") == 2
+
+
+@pytest.mark.asyncio
+async def test_http_sender_posts_and_reads_status():
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+    seen = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen["url"] = str(req.url)
+        seen["auth"] = req.headers.get("authorization")
+        seen["topic"] = req.headers.get("apns-topic")
+        return httpx.Response(200)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    sender = HttpApnsSender(
+        key_pem=pem, key_id="KID", team_id="TID", bundle_id="com.taos.app",
+        host="api.push.apple.com", client=client,
+    )
+    ok = await sender.send("devtoken", build_apns_payload(title="Hi", body="yo"))
+    assert ok is True
+    assert seen["url"].endswith("/3/device/devtoken")
+    assert seen["auth"].startswith("bearer ")
+    assert seen["topic"] == "com.taos.app"
+    await client.aclose()

--- a/tests/routes/test_devices.py
+++ b/tests/routes/test_devices.py
@@ -1,0 +1,49 @@
+import pytest
+
+
+@pytest.mark.asyncio
+class TestDeviceRoutes:
+    async def test_register_returns_scoped_token_and_scopes_to_session_user(self, client):
+        resp = await client.post(
+            "/api/devices/register",
+            json={"platform": "ios", "display_name": "iPhone", "user_id": "attacker"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["platform"] == "ios"
+        assert body["scoped_token"].startswith("taosdev_")
+        # Body user_id is ignored; the session user owns the device.
+        assert body["user_id"] != "attacker"
+
+    async def test_list_hides_scoped_token(self, client):
+        await client.post("/api/devices/register", json={"platform": "ios"})
+        resp = await client.get("/api/devices")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert "scoped_token" not in items[0]
+
+    async def test_update_push_token(self, client):
+        reg = (await client.post("/api/devices/register", json={"platform": "ios"})).json()
+        resp = await client.patch(
+            f"/api/devices/{reg['device_id']}/push-token", json={"push_token": "abc123"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["push_token"] == "abc123"
+        assert "scoped_token" not in resp.json()
+
+    async def test_revoke_then_absent_from_list(self, client):
+        reg = (await client.post("/api/devices/register", json={"platform": "ios"})).json()
+        resp = await client.delete(f"/api/devices/{reg['device_id']}")
+        assert resp.status_code == 200 and resp.json()["revoked"] is True
+        assert (await client.get("/api/devices")).json()["items"] == []
+
+    async def test_cannot_touch_another_users_device(self, client, app):
+        # Register a device owned by a different user directly in the store.
+        other = await app.state.device_store.register(user_id="someone-else", platform="ios")
+        assert (await client.delete(f"/api/devices/{other['device_id']}")).status_code == 404
+        assert (
+            await client.patch(
+                f"/api/devices/{other['device_id']}/push-token", json={"push_token": "x"}
+            )
+        ).status_code == 404

--- a/tests/test_device_auth.py
+++ b/tests/test_device_auth.py
@@ -1,0 +1,58 @@
+import pytest
+import pytest_asyncio
+from types import SimpleNamespace
+from fastapi import HTTPException
+
+from tinyagentos.device_store import DeviceStore
+from tinyagentos.device_auth import extract_bearer, require_device
+
+
+def _request(app, auth_header=None):
+    headers = {}
+    if auth_header is not None:
+        headers["authorization"] = auth_header
+    # Minimal stand-in for a Starlette request: .headers.get + .app.state.
+    return SimpleNamespace(
+        headers=SimpleNamespace(get=lambda k, d=None: headers.get(k.lower(), d)),
+        app=SimpleNamespace(state=app.state),
+    )
+
+
+class _AppState:
+    def __init__(self, store):
+        self.state = SimpleNamespace(device_store=store)
+
+
+@pytest_asyncio.fixture
+async def app_with_store(tmp_path):
+    store = DeviceStore(tmp_path / "devices.db")
+    await store.init()
+    yield _AppState(store)
+    await store.close()
+
+
+def test_extract_bearer():
+    assert extract_bearer(_request(_AppState(None), "Bearer abc")) == "abc"
+    assert extract_bearer(_request(_AppState(None), "Basic abc")) is None
+    assert extract_bearer(_request(_AppState(None))) is None
+
+
+@pytest.mark.asyncio
+async def test_require_device_resolves_valid_token(app_with_store):
+    dev = await app_with_store.state.device_store.register(user_id="u1", platform="ios")
+    req = _request(app_with_store, f"Bearer {dev['scoped_token']}")
+    resolved = await require_device(req)
+    assert resolved["device_id"] == dev["device_id"]
+
+
+@pytest.mark.asyncio
+async def test_require_device_rejects_missing_and_revoked(app_with_store):
+    with pytest.raises(HTTPException) as ei:
+        await require_device(_request(app_with_store))
+    assert ei.value.status_code == 401
+
+    dev = await app_with_store.state.device_store.register(user_id="u1", platform="ios")
+    await app_with_store.state.device_store.revoke(dev["device_id"])
+    with pytest.raises(HTTPException) as ei2:
+        await require_device(_request(app_with_store, f"Bearer {dev['scoped_token']}"))
+    assert ei2.value.status_code == 401

--- a/tests/test_device_store.py
+++ b/tests/test_device_store.py
@@ -1,0 +1,56 @@
+import pytest
+import pytest_asyncio
+from tinyagentos.device_store import DeviceStore, DEVICE_TOKEN_PREFIX
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = DeviceStore(tmp_path / "devices.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_register_mints_scoped_token_and_persists(store):
+    dev = await store.register(user_id="u1", platform="ios", display_name="iPhone")
+    assert dev["device_id"]
+    assert dev["user_id"] == "u1"
+    assert dev["platform"] == "ios"
+    assert dev["display_name"] == "iPhone"
+    assert dev["scoped_token"].startswith(DEVICE_TOKEN_PREFIX)
+    assert dev["revoked"] == 0
+    assert int(dev["registered_at"]) > 0
+
+    fetched = await store.get(dev["device_id"])
+    assert fetched["scoped_token"] == dev["scoped_token"]
+
+
+@pytest.mark.asyncio
+async def test_get_by_token_resolves_then_stops_after_revoke(store):
+    dev = await store.register(user_id="u1", platform="ios")
+    assert (await store.get_by_token(dev["scoped_token"]))["device_id"] == dev["device_id"]
+    assert await store.get_by_token("taosdev_nope") is None
+
+    assert await store.revoke(dev["device_id"]) is True
+    assert await store.get_by_token(dev["scoped_token"]) is None
+
+
+@pytest.mark.asyncio
+async def test_list_for_user_scopes_and_hides_token(store):
+    a = await store.register(user_id="u1", platform="ios")
+    await store.register(user_id="u2", platform="ios")
+    revoked = await store.register(user_id="u1", platform="watchos")
+    await store.revoke(revoked["device_id"])
+
+    rows = await store.list_for_user("u1")
+    assert [r["device_id"] for r in rows] == [a["device_id"]]
+    assert "scoped_token" not in rows[0]
+
+
+@pytest.mark.asyncio
+async def test_update_push_token(store):
+    dev = await store.register(user_id="u1", platform="ios", push_token="old")
+    updated = await store.update_push_token(dev["device_id"], "new")
+    assert updated["push_token"] == "new"
+    assert (await store.get(dev["device_id"]))["push_token"] == "new"

--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -314,6 +314,9 @@ class TestDelegationApprovalFlow:
         # The task must NOT have been assigned.
         still_open = await app.state.project_task_store.get_task(task["id"])
         assert still_open["assignee_id"] is None
+        # And the delegate grant must NOT leak: a failed completion cannot leave
+        # behind a grant that would let a later delegation skip approval.
+        assert not await app.state.execution_policies.has_live_grant("from-agent", "delegate")
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -243,6 +243,78 @@ class TestDelegationApprovalFlow:
         new_task = next(t for t in tasks if t["title"] == "Brand new task")
         assert new_task["assignee_id"] == "to-agent"
 
+    async def test_approving_routes_exactly_one_honest_message(self, client, app, monkeypatch):
+        """Answering a delegation gate must send the asking agent a SINGLE
+        reply: the delegation handler owns the message, so the generic
+        answer-router must not also fire (the old code sent two)."""
+        from tinyagentos.routes import decisions as decisions_mod
+
+        calls: list[str] = []
+
+        async def _capture(decision, value):
+            calls.append(str(value))
+
+        monkeypatch.setattr(decisions_mod, "_route_answer_to_agent", _capture)
+
+        _project, task = await _make_project_and_task(app)
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "approve"}
+        )
+        assert answer_resp.status_code == 200
+        assert len(calls) == 1
+        assert calls[0] == "delegation approved - the task has been assigned"
+
+    async def test_failed_completion_reports_retry_not_success(self, client, app, monkeypatch):
+        """If assigning the task fails after approval, the agent must be told
+        the truth (retry), never that the task was assigned."""
+        from tinyagentos.routes import decisions as decisions_mod
+
+        calls: list[str] = []
+
+        async def _capture(decision, value):
+            calls.append(str(value))
+
+        monkeypatch.setattr(decisions_mod, "_route_answer_to_agent", _capture)
+
+        async def _boom(*args, **kwargs):
+            raise RuntimeError("assign failed")
+
+        # _apply_delegation_grant imports complete_delegation from this module
+        # at call time, so patching it here intercepts the assignment.
+        import tinyagentos.routes.delegation as delegation_mod
+        monkeypatch.setattr(delegation_mod, "complete_delegation", _boom)
+
+        _project, task = await _make_project_and_task(app)
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        decision_id = resp.json()["decision_id"]
+
+        answer_resp = await client.post(
+            f"/api/decisions/{decision_id}/answer", json={"value": "approve"}
+        )
+        assert answer_resp.status_code == 200
+        assert len(calls) == 1
+        assert "please retry" in calls[0]
+        # The task must NOT have been assigned.
+        still_open = await app.state.project_task_store.get_task(task["id"])
+        assert still_open["assignee_id"] is None
+
 
 @pytest.mark.asyncio
 class TestDelegationTaskTitleCreatesTask:

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -27,6 +27,16 @@ class TestSecurityHeaders:
         assert "wss:" in csp
 
     @pytest.mark.asyncio
+    async def test_csp_allows_weather_open_meteo_origins(self, client):
+        # Regression for #1668: the built-in Weather app fetches the open-meteo
+        # geocoding + forecast APIs directly, so both origins must be in
+        # connect-src or default-src 'self' silently blocks every city search.
+        resp = await client.get("/api/health")
+        csp = resp.headers.get("content-security-policy", "")
+        assert "https://geocoding-api.open-meteo.com" in csp
+        assert "https://api.open-meteo.com" in csp
+
+    @pytest.mark.asyncio
     async def test_x_frame_options_sameorigin(self, client):
         resp = await client.get("/api/health")
         assert resp.headers.get("x-frame-options", "").upper() == "SAMEORIGIN"

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.31"
+__version__ = "1.0.0-beta.32"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -397,6 +397,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     chat_hub = ChatHub()
     canvas_store = CanvasStore(data_dir / "canvas.db")
     desktop_settings = DesktopSettingsStore(data_dir / "desktop.db")
+    from tinyagentos.device_store import DeviceStore
+    device_store = DeviceStore(data_dir / "devices.db")
     user_memory = UserMemoryStore(data_dir / "user_memory.db")
     user_personas = UserPersonaStore(data_dir / "user_personas.db")
     installed_apps = InstalledAppsStore(data_dir / "installed_apps.db")
@@ -518,6 +520,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         projects_root.mkdir(parents=True, exist_ok=True)
         await canvas_store.init()
         await desktop_settings.init()
+        await device_store.init()
         await user_memory.init()
         await installed_apps.init()
         await feedback_store.init()
@@ -835,6 +838,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.agent_chat_router = AgentChatRouter(app.state)
         app.state.canvas_store = canvas_store
         app.state.desktop_settings = desktop_settings
+        app.state.device_store = device_store
         app.state.user_memory = user_memory
         app.state.user_personas = user_personas
         app.state.installed_apps = installed_apps
@@ -1339,6 +1343,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await install_registry_store.close()
         await user_memory.close()
         await desktop_settings.close()
+        await device_store.close()
         await canvas_store.close()
         try:
             bb = getattr(app.state, "beads_bridge", None)
@@ -1520,6 +1525,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.typing = None
     app.state.canvas_store = canvas_store
     app.state.desktop_settings = desktop_settings
+    app.state.device_store = device_store
     app.state.user_memory = user_memory
     app.state.user_personas = user_personas
     app.state.installed_apps = installed_apps

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -399,6 +399,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     desktop_settings = DesktopSettingsStore(data_dir / "desktop.db")
     from tinyagentos.device_store import DeviceStore
     device_store = DeviceStore(data_dir / "devices.db")
+    from tinyagentos.push.apns import apns_sender_from_env
+    apns_sender = apns_sender_from_env()
     user_memory = UserMemoryStore(data_dir / "user_memory.db")
     user_personas = UserPersonaStore(data_dir / "user_personas.db")
     installed_apps = InstalledAppsStore(data_dir / "installed_apps.db")
@@ -839,6 +841,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.canvas_store = canvas_store
         app.state.desktop_settings = desktop_settings
         app.state.device_store = device_store
+        app.state.apns_sender = apns_sender
         app.state.user_memory = user_memory
         app.state.user_personas = user_personas
         app.state.installed_apps = installed_apps
@@ -1526,6 +1529,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.canvas_store = canvas_store
     app.state.desktop_settings = desktop_settings
     app.state.device_store = device_store
+    app.state.apns_sender = apns_sender
     app.state.user_memory = user_memory
     app.state.user_personas = user_personas
     app.state.installed_apps = installed_apps

--- a/tinyagentos/device_auth.py
+++ b/tinyagentos/device_auth.py
@@ -1,20 +1,31 @@
 from __future__ import annotations
 
+import time
+
 from fastapi import HTTPException, Request
+
+# Only refresh last_seen at most once a minute per device so authenticating on
+# every request does not turn auth into a per-request DB write (write
+# amplification / a DoS-on-the-DB surface).
+_TOUCH_INTERVAL_S = 60
 
 
 def extract_bearer(request) -> str | None:
     header = request.headers.get("authorization")
-    if not header or not header.startswith("Bearer "):
+    if not header:
         return None
-    token = header[len("Bearer "):].strip()
+    scheme, _, token = header.partition(" ")
+    # RFC 6750: the auth scheme name is case-insensitive.
+    if scheme.lower() != "bearer":
+        return None
+    token = token.strip()
     return token or None
 
 
 async def require_device(request: Request) -> dict:
     """FastAPI dependency: authenticate the caller as a registered device by
     its scoped token. 401 if the header is missing or the token is unknown or
-    revoked. Touches last_seen on success."""
+    revoked. Refreshes last_seen (debounced) on success."""
     token = extract_bearer(request)
     if not token:
         raise HTTPException(status_code=401, detail="device token required")
@@ -22,5 +33,6 @@ async def require_device(request: Request) -> dict:
     device = await store.get_by_token(token)
     if device is None:
         raise HTTPException(status_code=401, detail="invalid device token")
-    await store.touch(device["device_id"])
+    if time.time() - device["last_seen"] > _TOUCH_INTERVAL_S:
+        await store.touch(device["device_id"])
     return device

--- a/tinyagentos/device_auth.py
+++ b/tinyagentos/device_auth.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+
+def extract_bearer(request) -> str | None:
+    header = request.headers.get("authorization")
+    if not header or not header.startswith("Bearer "):
+        return None
+    token = header[len("Bearer "):].strip()
+    return token or None
+
+
+async def require_device(request: Request) -> dict:
+    """FastAPI dependency: authenticate the caller as a registered device by
+    its scoped token. 401 if the header is missing or the token is unknown or
+    revoked. Touches last_seen on success."""
+    token = extract_bearer(request)
+    if not token:
+        raise HTTPException(status_code=401, detail="device token required")
+    store = request.app.state.device_store
+    device = await store.get_by_token(token)
+    if device is None:
+        raise HTTPException(status_code=401, detail="invalid device token")
+    await store.touch(device["device_id"])
+    return device

--- a/tinyagentos/device_store.py
+++ b/tinyagentos/device_store.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import secrets
+import uuid
+
+from tinyagentos.base_store import BaseStore
+
+DEVICE_TOKEN_PREFIX = "taosdev_"
+
+# Columns returned to internal callers (includes the secret scoped_token).
+_FULL_COLS = (
+    "device_id, user_id, platform, push_token, scoped_token, "
+    "display_name, registered_at, last_seen, revoked"
+)
+# Columns safe to return to the owning user (no scoped_token).
+_SAFE_COLS = (
+    "device_id, user_id, platform, push_token, "
+    "display_name, registered_at, last_seen, revoked"
+)
+
+
+def _row(cols: str, values) -> dict:
+    return dict(zip(cols.split(", "), values))
+
+
+class DeviceStore(BaseStore):
+    SCHEMA = """
+    CREATE TABLE IF NOT EXISTS devices (
+        device_id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL,
+        platform TEXT NOT NULL,
+        push_token TEXT NOT NULL DEFAULT '',
+        scoped_token TEXT NOT NULL UNIQUE,
+        display_name TEXT NOT NULL DEFAULT '',
+        registered_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+        last_seen INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+        revoked INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_devices_user ON devices(user_id);
+    CREATE INDEX IF NOT EXISTS idx_devices_token ON devices(scoped_token);
+    """
+
+    async def register(
+        self, *, user_id: str, platform: str, push_token: str = "", display_name: str = ""
+    ) -> dict:
+        assert self._db is not None
+        device_id = uuid.uuid4().hex
+        scoped_token = DEVICE_TOKEN_PREFIX + secrets.token_urlsafe(32)
+        await self._db.execute(
+            "INSERT INTO devices (device_id, user_id, platform, push_token, "
+            "scoped_token, display_name) VALUES (?, ?, ?, ?, ?, ?)",
+            (device_id, user_id, platform, push_token, scoped_token, display_name),
+        )
+        await self._db.commit()
+        got = await self.get(device_id)
+        assert got is not None
+        return got
+
+    async def get(self, device_id: str) -> dict | None:
+        assert self._db is not None
+        cur = await self._db.execute(
+            f"SELECT {_FULL_COLS} FROM devices WHERE device_id = ?", (device_id,)
+        )
+        row = await cur.fetchone()
+        return _row(_FULL_COLS, row) if row else None
+
+    async def get_by_token(self, scoped_token: str) -> dict | None:
+        assert self._db is not None
+        cur = await self._db.execute(
+            f"SELECT {_FULL_COLS} FROM devices WHERE scoped_token = ? AND revoked = 0",
+            (scoped_token,),
+        )
+        row = await cur.fetchone()
+        return _row(_FULL_COLS, row) if row else None
+
+    async def list_for_user(self, user_id: str) -> list[dict]:
+        assert self._db is not None
+        cur = await self._db.execute(
+            f"SELECT {_SAFE_COLS} FROM devices WHERE user_id = ? AND revoked = 0 "
+            "ORDER BY registered_at DESC, device_id DESC",
+            (user_id,),
+        )
+        return [_row(_SAFE_COLS, r) for r in await cur.fetchall()]
+
+    async def update_push_token(self, device_id: str, push_token: str) -> dict | None:
+        assert self._db is not None
+        await self._db.execute(
+            "UPDATE devices SET push_token = ? WHERE device_id = ?",
+            (push_token, device_id),
+        )
+        await self._db.commit()
+        return await self.get(device_id)
+
+    async def touch(self, device_id: str) -> None:
+        assert self._db is not None
+        await self._db.execute(
+            "UPDATE devices SET last_seen = strftime('%s','now') WHERE device_id = ?",
+            (device_id,),
+        )
+        await self._db.commit()
+
+    async def revoke(self, device_id: str) -> bool:
+        assert self._db is not None
+        cur = await self._db.execute(
+            "UPDATE devices SET revoked = 1 WHERE device_id = ? AND revoked = 0",
+            (device_id,),
+        )
+        await self._db.commit()
+        return cur.rowcount > 0

--- a/tinyagentos/middleware/security_headers.py
+++ b/tinyagentos/middleware/security_headers.py
@@ -28,7 +28,11 @@ def _build_csp(frame_src_extra: str = "") -> str:
         f"{frame_src}; "
         # data: lets the canvas (tldraw) load its bundled translation URIs
         # (data:application/json), which are inline data, not a network fetch.
-        "connect-src 'self' ws: wss: data:"
+        # The two open-meteo origins are the geocoding (city search) and
+        # forecast APIs the built-in Weather app fetches directly; without them
+        # default-src 'self' silently blocks every lookup and the app looks dead.
+        "connect-src 'self' ws: wss: data: "
+        "https://geocoding-api.open-meteo.com https://api.open-meteo.com"
     )
 
 

--- a/tinyagentos/push/apns.py
+++ b/tinyagentos/push/apns.py
@@ -101,10 +101,28 @@ def apns_sender_from_env() -> ApnsSender:
     team_id = os.environ.get("TAOS_APNS_TEAM_ID")
     bundle_id = os.environ.get("TAOS_APNS_BUNDLE_ID")
     key_path = os.environ.get("TAOS_APNS_KEY_PATH")
+    # Default to Apple's production gateway; TAOS_APNS_SANDBOX routes dev/TestFlight
+    # builds to the sandbox gateway (a token minted for one is rejected by the other).
+    host = (
+        "api.sandbox.push.apple.com"
+        if os.environ.get("TAOS_APNS_SANDBOX", "").lower() in ("1", "true", "yes")
+        else "api.push.apple.com"
+    )
     if key_id and team_id and bundle_id and key_path and os.path.isfile(key_path):
+        # The .p8 signing key is a long-lived credential; warn (do not fail) if it
+        # is group/world accessible so the operator can tighten it to 600.
+        try:
+            if os.stat(key_path).st_mode & 0o077:
+                logger.warning(
+                    "APNs signing key %s is group/world accessible; tighten to 600",
+                    key_path,
+                )
+        except OSError:
+            pass
         with open(key_path) as fh:
             key_pem = fh.read()
         return HttpApnsSender(
-            key_pem=key_pem, key_id=key_id, team_id=team_id, bundle_id=bundle_id
+            key_pem=key_pem, key_id=key_id, team_id=team_id,
+            bundle_id=bundle_id, host=host,
         )
     return NullApnsSender()

--- a/tinyagentos/push/apns.py
+++ b/tinyagentos/push/apns.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from typing import Protocol
+
+import httpx
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, utils as asym_utils
+
+logger = logging.getLogger(__name__)
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+class ApnsSender(Protocol):
+    async def send(self, push_token: str, payload: dict, *, topic: str | None = None) -> bool:
+        ...
+
+
+class NullApnsSender:
+    """Used when APNs is unconfigured: logs the intent and reports failure so
+    callers treat the device as unreachable rather than assuming delivery."""
+
+    async def send(self, push_token: str, payload: dict, *, topic: str | None = None) -> bool:
+        logger.info("APNs not configured; dropping push to %s", push_token[:8])
+        return False
+
+
+def build_apns_payload(
+    *, title: str, body: str, data: dict | None = None, content_available: bool = False
+) -> dict:
+    aps: dict = {}
+    if title or body:
+        aps["alert"] = {"title": title, "body": body}
+    if content_available:
+        aps["content-available"] = 1
+    payload = {"aps": aps}
+    if data:
+        payload.update(data)
+    return payload
+
+
+def build_apns_jwt(*, key_pem: str, key_id: str, team_id: str, now: int) -> str:
+    header = {"alg": "ES256", "kid": key_id}
+    claims = {"iss": team_id, "iat": now}
+    signing_input = (
+        _b64url(json.dumps(header, separators=(",", ":")).encode())
+        + "."
+        + _b64url(json.dumps(claims, separators=(",", ":")).encode())
+    )
+    key = serialization.load_pem_private_key(key_pem.encode(), password=None)
+    der_sig = key.sign(signing_input.encode(), ec.ECDSA(hashes.SHA256()))
+    r, s = asym_utils.decode_dss_signature(der_sig)
+    raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    return signing_input + "." + _b64url(raw_sig)
+
+
+class HttpApnsSender:
+    def __init__(
+        self, *, key_pem: str, key_id: str, team_id: str, bundle_id: str,
+        host: str = "api.push.apple.com", client: httpx.AsyncClient | None = None,
+    ):
+        self._key_pem = key_pem
+        self._key_id = key_id
+        self._team_id = team_id
+        self._bundle_id = bundle_id
+        self._host = host
+        self._client = client or httpx.AsyncClient(http2=True)
+
+    async def send(self, push_token: str, payload: dict, *, topic: str | None = None) -> bool:
+        jwt = build_apns_jwt(
+            key_pem=self._key_pem, key_id=self._key_id,
+            team_id=self._team_id, now=int(time.time()),
+        )
+        try:
+            resp = await self._client.post(
+                f"https://{self._host}/3/device/{push_token}",
+                headers={
+                    "authorization": f"bearer {jwt}",
+                    "apns-topic": topic or self._bundle_id,
+                    "apns-push-type": "background" if payload.get("aps", {}).get(
+                        "content-available"
+                    ) else "alert",
+                },
+                content=json.dumps(payload),
+            )
+        except httpx.HTTPError:
+            logger.warning("APNs send failed for %s", push_token[:8], exc_info=True)
+            return False
+        return resp.status_code == 200
+
+
+def apns_sender_from_env() -> ApnsSender:
+    key_id = os.environ.get("TAOS_APNS_KEY_ID")
+    team_id = os.environ.get("TAOS_APNS_TEAM_ID")
+    bundle_id = os.environ.get("TAOS_APNS_BUNDLE_ID")
+    key_path = os.environ.get("TAOS_APNS_KEY_PATH")
+    if key_id and team_id and bundle_id and key_path and os.path.isfile(key_path):
+        with open(key_path) as fh:
+            key_pem = fh.read()
+        return HttpApnsSender(
+            key_pem=key_pem, key_id=key_id, team_id=team_id, bundle_id=bundle_id
+        )
+    return NullApnsSender()

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -64,6 +64,9 @@ def register_all_routers(app):
     from tinyagentos.routes.decisions import router as decisions_router
     app.include_router(decisions_router)
 
+    from tinyagentos.routes.devices import router as devices_router
+    app.include_router(devices_router)
+
     from tinyagentos.routes.observatory import router as observatory_router
     app.include_router(observatory_router)
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -249,14 +249,19 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
     updated = await store.answer(decision_id, body.value, answered_by)
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
-    await _apply_app_grant(request, updated, body.value)
-    await _apply_execution_grant(request, updated, body.value)
-    await _apply_delegation_grant(request, updated, body.value)
-    await _route_answer_to_agent(updated, body.value)
+    # Each kind-specific handler runs its side effect and returns True if it
+    # already routed a reply to the asking agent (a more informative,
+    # kind-specific message). Only route the generic answer when none did, so
+    # a gated decision does not send the agent two messages.
+    routed_app = await _apply_app_grant(request, updated, body.value)
+    routed_exec = await _apply_execution_grant(request, updated, body.value)
+    routed_deleg = await _apply_delegation_grant(request, updated, body.value)
+    if not (routed_app or routed_exec or routed_deleg):
+        await _route_answer_to_agent(updated, body.value)
     return updated
 
 
-async def _apply_execution_grant(request: Request, decision: dict, value) -> None:
+async def _apply_execution_grant(request: Request, decision: dict, value) -> bool:
     """Side effect for an execution-gate Decision (agent governance #160 slice
     1): the decision's metadata carries {kind: "execution_gate", agent_name,
     action_class, tool}. Approving it writes a short-lived execution grant so
@@ -266,12 +271,12 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> Non
     store hiccup must not fail the answer."""
     meta = decision.get("metadata") or {}
     if meta.get("kind") != "execution_gate":
-        return
+        return False
     policies = getattr(request.app.state, "execution_policies", None)
     agent_name = meta.get("agent_name")
     action_class = meta.get("action_class")
     if policies is None or not agent_name or not action_class:
-        return
+        return False
     approved = value == "approve"
     try:
         if approved:
@@ -291,9 +296,10 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> Non
         decision,
         "you may retry the action now" if approved else "your action was denied",
     )
+    return True
 
 
-async def _apply_delegation_grant(request: Request, decision: dict, value) -> None:
+async def _apply_delegation_grant(request: Request, decision: dict, value) -> bool:
     """Side effect for a delegation-gate Decision (#161 gated delegation): the
     decision's metadata carries {kind: "delegation_gate", from_agent, to_agent,
     task_id, task_title, note}. Approving it writes a short-lived delegate
@@ -304,13 +310,14 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> No
     grant-store or delegation-completion hiccup must not fail the answer."""
     meta = decision.get("metadata") or {}
     if meta.get("kind") != "delegation_gate":
-        return
+        return False
     policies = getattr(request.app.state, "execution_policies", None)
     from_agent = meta.get("from_agent")
     to_agent = meta.get("to_agent")
     if policies is None or not from_agent or not to_agent:
-        return
+        return False
     approved = value == "approve"
+    completed = False
     if approved:
         try:
             await policies.add_grant(from_agent, "delegate", decision.get("id"))
@@ -330,31 +337,39 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> No
                 project_id=decision.get("project_id"),
                 note=meta.get("note") or "",
             )
+            completed = True
         except Exception:
             logger.warning(
                 "delegation completion failed for decision %s", decision.get("id"), exc_info=True,
             )
-    await _route_answer_to_agent(
-        decision,
-        "delegation approved - the task has been assigned" if approved else "delegation denied",
-    )
+    # Tell the agent the truth: only claim the task was assigned when the
+    # completion actually succeeded, so a failed assign is not reported as done.
+    if not approved:
+        reply = "delegation denied"
+    elif completed:
+        reply = "delegation approved - the task has been assigned"
+    else:
+        reply = "delegation approved, but assigning the task failed - please retry"
+    await _route_answer_to_agent(decision, reply)
+    return True
 
 
-async def _apply_app_grant(request: Request, decision: dict, value) -> None:
+async def _apply_app_grant(request: Request, decision: dict, value) -> bool:
     """Side effect for an app-grant consent Decision: write the per-capability
     grant decisions to the app_grants ledger. The decision's metadata carries
     {kind: "app_grant", app_id, capabilities}; for the multi_select consent card
     the answer is the list of granted capability values, so the rest are denied.
     Best-effort: the answer is already persisted, so a grant-store hiccup must
-    not fail the answer."""
+    not fail the answer. Returns False: app grants do not route an agent reply,
+    so the caller sends the generic answer."""
     meta = decision.get("metadata") or {}
     if meta.get("kind") != "app_grant":
-        return
+        return False
     grants = getattr(request.app.state, "app_grants", None)
     app_id = meta.get("app_id")
     caps = meta.get("capabilities") or []
     if grants is None or not app_id:
-        return
+        return False
     user_id = decision.get("user_id") or ""
     granted = set(value if isinstance(value, list) else [value])
     try:
@@ -372,3 +387,4 @@ async def _apply_app_grant(request: Request, decision: dict, value) -> None:
             "app_grant ledger write failed for app %s (decision %s)",
             app_id, decision.get("id"), exc_info=True,
         )
+    return False

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -278,9 +278,11 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> boo
     if policies is None or not agent_name or not action_class:
         return False
     approved = value == "approve"
+    granted = False
     try:
         if approved:
             await policies.add_grant(agent_name, action_class, decision.get("id"))
+            granted = True
     except Exception:
         # Best-effort: the answer is already persisted, so a grant-store write
         # must not fail the request. Log it rather than swallow silently so a
@@ -290,12 +292,16 @@ async def _apply_execution_grant(request: Request, decision: dict, value) -> boo
             agent_name, decision.get("id"), exc_info=True,
         )
     # decision["from_agent"] is already agent_name (set when the gate created
-    # this decision in skill_exec.py); reuse the existing answer-routing path
-    # with a retry-specific message instead of the generic answer text.
-    await _route_answer_to_agent(
-        decision,
-        "you may retry the action now" if approved else "your action was denied",
-    )
+    # this decision in skill_exec.py); reuse the existing answer-routing path.
+    # Only tell the agent it may retry when the grant actually persisted -- if
+    # the write failed, the gate will re-prompt on retry, so say so honestly.
+    if not approved:
+        reply = "your action was denied"
+    elif granted:
+        reply = "you may retry the action now"
+    else:
+        reply = "your action was approved, but saving the grant failed - please retry"
+    await _route_answer_to_agent(decision, reply)
     return True
 
 
@@ -320,13 +326,6 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
     completed = False
     if approved:
         try:
-            await policies.add_grant(from_agent, "delegate", decision.get("id"))
-        except Exception:
-            logger.warning(
-                "delegate grant write failed for agent %s (decision %s)",
-                from_agent, decision.get("id"), exc_info=True,
-            )
-        try:
             from tinyagentos.routes.delegation import complete_delegation
             await complete_delegation(
                 request,
@@ -342,6 +341,18 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
             logger.warning(
                 "delegation completion failed for decision %s", decision.get("id"), exc_info=True,
             )
+        # Grant the delegate capability only once THIS delegation actually
+        # completed. Writing it before completion leaked a grant on failure: a
+        # later delegation by the same agent would then skip approval while the
+        # original assignment had silently never happened.
+        if completed:
+            try:
+                await policies.add_grant(from_agent, "delegate", decision.get("id"))
+            except Exception:
+                logger.warning(
+                    "delegate grant write failed for agent %s (decision %s)",
+                    from_agent, decision.get("id"), exc_info=True,
+                )
     # Tell the agent the truth: only claim the task was assigned when the
     # completion actually succeeded, so a failed assign is not reported as done.
     if not approved:

--- a/tinyagentos/routes/devices.py
+++ b/tinyagentos/routes/devices.py
@@ -3,17 +3,24 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from tinyagentos.auth_context import CurrentUser, current_user
 
 router = APIRouter()
 
+# Cap devices per user so a compromised or looping client cannot issue unbounded
+# scoped tokens (token-issuance + storage exhaustion). A push token is at most a
+# few hundred bytes; the bound is generous but keeps a single value finite.
+_MAX_DEVICES_PER_USER = 50
+_MAX_PUSH_TOKEN = 4096
+_MAX_DISPLAY_NAME = 200
+
 
 class RegisterIn(BaseModel):
     platform: str
-    display_name: str = ""
-    push_token: str = ""
+    display_name: str = Field(default="", max_length=_MAX_DISPLAY_NAME)
+    push_token: str = Field(default="", max_length=_MAX_PUSH_TOKEN)
 
     @field_validator("platform")
     @classmethod
@@ -24,7 +31,7 @@ class RegisterIn(BaseModel):
 
 
 class PushTokenIn(BaseModel):
-    push_token: str
+    push_token: str = Field(max_length=_MAX_PUSH_TOKEN)
 
 
 @router.post("/api/devices/register")
@@ -32,6 +39,11 @@ async def register_device(
     body: RegisterIn, request: Request, user: CurrentUser = Depends(current_user)
 ):
     store = request.app.state.device_store
+    if len(await store.list_for_user(user.user_id)) >= _MAX_DEVICES_PER_USER:
+        return JSONResponse(
+            {"error": f"device limit reached ({_MAX_DEVICES_PER_USER})"},
+            status_code=429,
+        )
     device = await store.register(
         user_id=user.user_id,
         platform=body.platform,

--- a/tinyagentos/routes/devices.py
+++ b/tinyagentos/routes/devices.py
@@ -1,0 +1,84 @@
+# tinyagentos/routes/devices.py
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, field_validator
+
+from tinyagentos.auth_context import CurrentUser, current_user
+
+router = APIRouter()
+
+
+class RegisterIn(BaseModel):
+    platform: str
+    display_name: str = ""
+    push_token: str = ""
+
+    @field_validator("platform")
+    @classmethod
+    def platform_supported(cls, v: str) -> str:
+        if v not in ("ios", "watchos"):
+            raise ValueError("platform must be 'ios' or 'watchos'")
+        return v
+
+
+class PushTokenIn(BaseModel):
+    push_token: str
+
+
+@router.post("/api/devices/register")
+async def register_device(
+    body: RegisterIn, request: Request, user: CurrentUser = Depends(current_user)
+):
+    store = request.app.state.device_store
+    device = await store.register(
+        user_id=user.user_id,
+        platform=body.platform,
+        push_token=body.push_token,
+        display_name=body.display_name,
+    )
+    return device  # includes scoped_token, the only time it is returned
+
+
+@router.get("/api/devices")
+async def list_devices(request: Request, user: CurrentUser = Depends(current_user)):
+    store = request.app.state.device_store
+    return {"items": await store.list_for_user(user.user_id)}
+
+
+async def _owned_or_404(store, device_id: str, user: CurrentUser):
+    # Devices are strictly personal: each holds a per-device scoped token and
+    # its owner's sensor grants. Unlike system Decisions, there is NO admin
+    # bypass here, so even an admin session manages only its own devices through
+    # these self-service routes (a compromised admin cannot hijack a user's
+    # device or its grants). Admin device management, if ever needed, is a
+    # separate surface.
+    device = await store.get(device_id)
+    if device is None or device["revoked"] or device["user_id"] != user.user_id:
+        return None
+    return device
+
+
+@router.patch("/api/devices/{device_id}/push-token")
+async def update_push_token(
+    device_id: str, body: PushTokenIn, request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = request.app.state.device_store
+    if await _owned_or_404(store, device_id, user) is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    updated = await store.update_push_token(device_id, body.push_token)
+    updated.pop("scoped_token", None)
+    return updated
+
+
+@router.delete("/api/devices/{device_id}")
+async def revoke_device(
+    device_id: str, request: Request, user: CurrentUser = Depends(current_user)
+):
+    store = request.app.state.device_store
+    if await _owned_or_404(store, device_id, user) is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.revoke(device_id)
+    return {"revoked": True}

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b31"
+version = "1.0.0b32"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotion of dev to master for the **v1.0.0-beta.32** release.

Batches since beta.31:
- #1668 Weather location search (open-meteo CSP)
- #1603 desktop wallpaper persistence on login
- #1671 native Apple client server foundation (device registry + scoped tokens + APNs)
- #174 governance decision-routing dedup + honest messages
- #1666 desktop vitest CI stabilization

Tag + release will be cut on the resulting master SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device self-service support: register devices, view your devices, update push tokens, and revoke devices.
  * Added push notification support for Apple devices, including APNs delivery when configured.
  * Expanded support for native mobile device management and onboarding.

* **Bug Fixes**
  * Restored weather location search by allowing required API connections in security settings.
  * Prevented theme restoration from overwriting a user’s saved wallpaper choice.
  * Improved decision and delegation replies to avoid duplicate or misleading messages.

* **Chores**
  * Updated release version to **1.0.0-beta.32**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->