### PR TITLE
feat(cluster): GPU lease claim/release API for shared coordination (#893)

### DIFF
--- a/docs/design/a2a-gpu-lease-proposal.md
+++ b/docs/design/a2a-gpu-lease-proposal.md
@@ -1,0 +1,326 @@
+# RFC: Shared-GPU Lease Coordination on the TAOS Controller (#893)
+
+**Author:** Hogne (Skald platform, taOS fork)  
+**Date:** 2026-07-06  
+**Status:** Draft — seeking jaylfc buy-in before prototyping  
+**Target:** taOS controller endpoints + Skald TaosDispatcher integration
+
+---
+
+## Problem
+
+Skald's `TaosDispatcher._trigger_load()` calls `POST /api/system/load-model` on the
+Skald server — a heavyweight operation that kills running processes, waits for VRAM
+to drain, and starts a new backend process. The dispatcher fires this *before checking
+whether the target worker has enough free VRAM*.
+
+taOS now surfaces real-time VRAM per worker (`free_vram_mb` / `used_vram_mb` on
+`/api/cluster/workers`, shipped in #894), but that data is a **snapshot**, not a
+**reservation**. Two concurrent requests can both see "8 GiB free", both fire
+load-model, and one loses the race — the loser's load fails or (worse) OOM-kills
+the winner.
+
+The gap: **no coordination primitive on the controller** that lets an external
+caller (Skald, any A2A agent, future tool servers) atomically *reserve* GPU capacity
+before committing to a load.
+
+## Proposal: Lease API on `/api/cluster`
+
+Add two endpoints to the taOS controller:
+
+### `POST /api/cluster/leases/claim`
+
+**Request body:**
+
+```json
+{
+  "resource_id": "worker-name:gpu-cuda-0",
+  "ttl_seconds": 30,
+  "caller": "skald-dispatcher"
+}
+```
+
+`resource_id` follows the convention `{worker_name}:{resource_name}`. The `worker_name`
+portion is the registered worker name; the `resource_name` portion is the stable resource
+identifier (e.g. `gpu-cuda-0` for a single-GPU host, `gpu-cuda-0` / `gpu-cuda-1` for
+multi-GPU). The caller provides whatever label is meaningful.
+
+`ttl_seconds`: maximum lease duration. If the caller doesn't release or renew within
+this window, the lease expires and the reservation is freed. Typical value: 30s for
+a model-load check, 120s for the load itself.
+
+**Pre-claim check:** The controller checks the target worker's current `free_vram_mb`
+(from the most recent heartbeat) against the VRAM the caller says it needs. If
+`free_vram_mb < required_vram_mb`, the claim is refused with 409 Conflict.
+
+**Response (200):**
+
+```json
+{
+  "status": "claimed",
+  "lease_id": "l_a1b2c3d4",
+  "resource_id": "hognehermes:gpu-cuda-0",
+  "expires_at": 1783350000.0,
+  "ttl_seconds": 30,
+  "free_vram_mb": 6144,
+  "used_vram_mb": 2048
+}
+```
+
+**Response (409):**
+
+```json
+{
+  "error": "resource already leased",
+  "lease_id": "l_xxxxxxx",
+  "holder": "skald-dispatcher",
+  "expires_at": 1783349975.0
+}
+```
+
+### `POST /api/cluster/leases/release`
+
+```json
+{
+  "lease_id": "l_a1b2c3d4"
+}
+```
+
+**Response (200):**
+
+```json
+{
+  "status": "released",
+  "lease_id": "l_a1b2c3d4"
+}
+```
+
+Idempotent — releasing an already-expired or unknown lease returns 200 (no error).
+
+### `POST /api/cluster/leases/renew`
+
+```json
+{
+  "lease_id": "l_a1b2c3d4",
+  "ttl_seconds": 30
+}
+```
+
+For long-running model loads (120s swap + health poll), the caller can heartbeat the
+lease to extend it. Returns 409 if the lease has expired.
+
+## Modelling
+
+Leases live in the controller's in-memory `ClusterManager` alongside the worker
+registry — no external store needed, no Persistence. A lease is a lightweight struct:
+
+```python
+@dataclass
+class GpuLease:
+    lease_id: str
+    resource_id: str        # "worker-name:gpu-cuda-0"
+    caller: str             # "skald-dispatcher"
+    holder: str             # remote IP or caller label
+    expires_at: float       # monotonic timestamp
+    required_vram_mb: int   # how much VRAM the caller requested
+```
+
+The controller cleanup task (`_monitor_loop`) sweeps expired leases on its existing
+5-second tick — same loop that marks workers offline.
+
+### Why in-memory and not Postgres?
+
+- Short-lived (30–120s), ephemeral data with no durability requirement.
+- Controller restart already resets the entire cluster view — leases lost in a
+  restart are harmless because the workers reconnect and re-advertise fresh VRAM
+  anyway.
+- Avoids adding a new table and cleanup logic for something that is never queried
+  historically.
+
+### Why on the controller, not on the worker?
+
+The controller is the single source of truth for the cluster view. Workers might be
+behind NAT (no inbound reachability for claim/release). The controller aggregates
+VRAM data from heartbeats and is already the coordination point for worker
+registration.
+
+## Skald Integration
+
+### What changes in TaosDispatcher
+
+Current code in `_route_taos()` (taos.py:128–228):
+
+1. Fetches workers from `GET /api/cluster/workers`
+2. Separates candidates into "already loaded" and "available but not loaded"
+3. Sorts by load + total VRAM
+4. If an available-candidate is picked, fires `_trigger_load()` without any lease
+
+Proposed change:
+
+1. Fetch workers (unchanged)
+2. Separate loaded / available candidates (unchanged)
+3. Sort by load + **free VRAM** (not total VRAM — taOS #894 makes this possible)
+4. Before picking an available-candidate, attempt to `POST /api/cluster/leases/claim`
+   for the candidate worker with the model's VRAM requirement
+5. Only if the claim succeeds, proceed to `_trigger_load()`
+6. Store the `lease_id` alongside the load trigger so the scheduler can release it
+   when the model is healthy (or on error)
+
+```python
+# Pseudocode for TaosDispatcher._route_taos:
+if not loaded_candidates and available_candidates and requested_model:
+    best = available_candidates[0]  # after VRAM-aware sort
+    worker_name = best["name"]
+    resource_id = f"{worker_name}:gpu-cuda-0"
+    required_vram = _lookup_vram(requested_model)  # from gpu_models.yaml
+    lease = await self._claim_lease(resource_id, required_vram_mb=required_vram)
+
+    if lease:
+        ok = self._trigger_load(requested_model, resource_id)
+        if ok:
+            self._pending_lease = lease["lease_id"]
+        else:
+            self._release_lease(lease["lease_id"])
+    else:
+        # Try next candidate, or fall back
+        ...
+```
+
+### What changes in Skald's `load_model` endpoint
+
+Currently `POST /api/system/load-model` does an **in-process** `ModelSwapper.ensure_software()`.
+The swap happens synchronously inside the HTTP handler, blocking up to 120s.
+
+The lease-aware flow:
+
+1. Skald server receives the request, reads `lease_id` from the body
+2. Skald spawns the swap in a *background worker* (following the pattern already
+   in `model_swapper_worker.py`)
+3. The endpoint returns 202 Accepted immediately with the lease_id
+4. The background worker polls `POST /api/cluster/leases/renew` to keep the lease
+   alive during the swap
+5. On swap complete: the worker releases the lease
+6. On swap fail: the worker releases the lease, and the scheduler retries
+
+The dispatcher / scheduler polls the model gate (as today) to detect when the model
+is healthy; the lease just prevents another caller from also triggering a load.
+
+## API Surface Summary
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/cluster/leases/claim` | Reserve GPU capacity for TTL seconds |
+| POST | `/api/cluster/leases/release` | Free a reservation |
+| POST | `/api/cluster/leases/renew`  | Extend lease TTL |
+| GET  | `/api/cluster/leases`       | List active leases (diagnostics) |
+
+All endpoints are **unauthenticated** (same as the rest of the cluster API — the
+controller is on a LAN-only port). If auth is added to the cluster API later,
+leases inherit the same guard.
+
+## Edge Cases
+
+### Lease holder crashes
+The TTL handles this. After `ttl_seconds`, the lease expires in the monitor loop
+and the resource is freed. The crashed caller's model-load might still be running,
+but that's a local problem on the Skald side (swapper detects stale locks already).
+
+### Two callers race for the same resource
+The `claim` endpoint is a synchronous in-memory operation under the asyncio lock
+on the controller — no two claims for the same resource_id can succeed.
+
+### Worker goes offline with active lease
+When a worker is marked offline in `_monitor_loop` (30s no heartbeat), all leases
+for that worker's resources are released. The next heartbeat from a stale lease
+holder gets a 404, and it releases its local state.
+
+### Caller asks for more VRAM than the model actually needs
+The pre-claim check uses the `required_vram_mb` from the request body. The caller
+(Skald) should look this up from `gpu_models.yaml`'s `vram_required_gb` field.
+
+### VRAM snaphot is stale (last heartbeat was 5s ago)
+In the worst case: heartbeat at T+0 reports 8 GiB free, model load starts at T+5
+consuming 6 GiB, Skald claims at T+5.5 — the claim succeeds based on stale data,
+but the worker's actual free VRAM is now 2 GiB.
+
+**Mitigation:** The lease is advisory, not a hard guarantee. The real check is the
+Skald model swapper's `ensure_software()` which probes actual GPU state on the
+worker before launching. The lease prevents the *blind double-fire* problem; it
+doesn't replace the worker-side GPU probe.
+
+If this becomes a meaningful gap in practice, the controller can validate at
+claim time by comparing `required_vram_mb + worker_used_vram_mb` against the
+hardware's `total_vram_mb` rather than relying solely on `free_vram_mb` from the
+last heartbeat. But `free_vram_mb` is good enough for the 80% case.
+
+### Multiple GPU resources on one worker
+`resource_id = "worker-name:gpu-cuda-0"` vs `"worker-name:gpu-cuda-1"` allows
+per-GPU leases. The free/used VRAM fields on WorkerInfo are per-worker (first GPU
+only today — `gpu_vram_snapshot()` probes GPU 0). Multi-GPU workers would need the
+heartbeat to report per-GPU VRAM before per-GPU leases work correctly; until then,
+a single `gpu-cuda-0` resource_id represents the worker's GPU capacity.
+
+## Implementation Plan (prototype on fork)
+
+### Phase 1: Controller lease API (taOS fork)
+
+1. Add `GpuLease` dataclass to `worker_protocol.py`
+2. Add lease registry (`_leases: dict[str, GpuLease]`) to `ClusterManager`
+3. Add `claim_lease()`, `release_lease()`, `renew_lease()` methods
+4. Add lease expiry sweep to `_monitor_loop()`
+5. Add routes in `routes/cluster.py`:
+   - `POST /api/cluster/leases/claim`
+   - `POST /api/cluster/leases/release`
+   - `POST /api/cluster/leases/renew`
+   - `GET /api/cluster/leases`
+6. Tests (unit + integration)
+
+### Phase 2: TaosDispatcher integration (Skald fork)
+
+1. Add `_claim_lease()` / `_release_lease()` HTTP helpers to `TaosDispatcher`
+2. Modify `_route_taos()` to sort by free VRAM (uses the #894 data already available)
+3. Add lease claim/release around `_trigger_load()` calls
+4. Store `_pending_lease` so the scheduler can release on task completion
+5. Pass `lease_id` through to `/api/system/load-model` for background renew
+
+### Phase 3: Background swap with lease renewal (Skald fork)
+
+1. Refactor `/api/system/load-model` to spawn background swap + return 202
+2. Background worker renews lease every 10s during swap
+3. Release lease on completion/failure
+
+## Alternatives Considered
+
+### A: Do nothing — rely on the swapper's existing in-process lock
+The Skald model swapper already has `swap_in_progress` in settings. This works for
+a single Skald instance but does nothing when two different callers (e.g., Skald
++ a separate A2A agent) both try to use the GPU. The lease API is cheap to add
+and unlocks multi-tenant GPU sharing.
+
+### B: Put the lease logic entirely in Skald (Postgres settings)
+Leases in the Skald DB only work if every GPU consumer talks to Skald. The point of
+the taOS controller is to be the **infrastructure coordination hub** — putting the
+lease there makes it available to any A2A agent on the LAN, not just Skald.
+
+### C: Full distributed lock (etcd/consul/Redis)
+Massive overkill. One controller, one LAN, sub-second lease TTL — in-memory on the
+controller is all we need.
+
+## Questions for jaylfc
+
+1. **`resource_id` convention:** Does `{worker_name}:{resource_name}` work as a
+   naming scheme? It mirrors the `resource_pool` convention in Skald but open to
+   alternatives.
+
+2. **VRAM pre-check vs. advisory:** Should the controller enforce VRAM at claim
+   time (return 409 if `free_vram_mb < required_vram_mb`) or purely advisory?
+   I lean toward enforcing — it prevents the most common failure mode.
+
+3. **Auth boundary:** The cluster API is currently unauthenticated (LAN-only).
+   Leases inherit this. Should lease endpoints require any caller identification
+   beyond the `caller` field?
+
+4. **Per-GPU VRAM in heartbeats:** For multi-GPU workers, the heartbeat currently
+   reports only GPU 0. Extending `gpu_vram_snapshot()` to return an array of
+   per-GPU dicts is a natural follow-on but out of scope for this RFC.
+

--- a/tests/test_cluster_worker_protocol.py
+++ b/tests/test_cluster_worker_protocol.py
@@ -120,3 +120,82 @@ class TestKvQuantUnion:
         mgr.heartbeat("w1", kv_cache_quant_support=["fp16", "turboquant-k3v2"])
         result = mgr.kv_quant_union()
         assert "turboquant-k3v2" in result
+
+
+# ---------------------------------------------------------------------------
+# WorkerInfo VRAM fields (taOS #894 slice)
+# ---------------------------------------------------------------------------
+
+class TestWorkerInfoVramDefaults:
+    def test_default_vram_is_zero(self):
+        w = WorkerInfo(name="w", url="http://localhost:9000")
+        assert w.free_vram_mb == 0
+        assert w.used_vram_mb == 0
+
+    def test_vram_stored_and_serialised(self):
+        w = WorkerInfo(
+            name="w",
+            url="http://localhost:9000",
+            free_vram_mb=8192,
+            used_vram_mb=4096,
+        )
+        assert w.free_vram_mb == 8192
+        assert w.used_vram_mb == 4096
+        d = asdict(w)
+        assert d["free_vram_mb"] == 8192
+        assert d["used_vram_mb"] == 4096
+
+    def test_vram_roundtrip(self):
+        w = WorkerInfo(
+            name="w",
+            url="http://localhost:9000",
+            free_vram_mb=12288,
+            used_vram_mb=2048,
+        )
+        d = asdict(w)
+        w2 = WorkerInfo(**{k: v for k, v in d.items() if not isinstance(v, bytes)})
+        assert w2.free_vram_mb == 12288
+        assert w2.used_vram_mb == 2048
+
+
+# ---------------------------------------------------------------------------
+# ClusterManager heartbeat VRAM storage (taOS #894 slice)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestHeartbeatVram:
+    async def _register(self, mgr: ClusterManager, name: str) -> WorkerInfo:
+        w = WorkerInfo(name=name, url=f"http://localhost:900{name[-1]}")
+        await mgr.register_worker(w)
+        return w
+
+    async def test_heartbeat_stores_vram(self):
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        mgr.heartbeat("w1", free_vram_mb=8192, used_vram_mb=4096)
+        w = mgr.get_worker("w1")
+        assert w.free_vram_mb == 8192
+        assert w.used_vram_mb == 4096
+
+    async def test_heartbeat_omitting_vram_preserves_prior(self):
+        """Legacy heartbeat without VRAM fields leaves stored values unchanged."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        mgr.heartbeat("w1", free_vram_mb=12288, used_vram_mb=4096)
+        # Sparse heartbeat — only load + models, no VRAM fields
+        mgr.heartbeat("w1", load=0.5, models=["phi3"])
+        w = mgr.get_worker("w1")
+        assert w.free_vram_mb == 12288
+        assert w.used_vram_mb == 4096
+        assert w.load == 0.5
+        assert w.models == ["phi3"]
+
+    async def test_vram_zero_is_stored(self):
+        """Explicit zero is stored (distinct from 'not sent' which preserves prior)."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        mgr.heartbeat("w1", free_vram_mb=8192, used_vram_mb=4096)
+        mgr.heartbeat("w1", free_vram_mb=0, used_vram_mb=0)
+        w = mgr.get_worker("w1")
+        assert w.free_vram_mb == 0
+        assert w.used_vram_mb == 0

--- a/tests/test_leases.py
+++ b/tests/test_leases.py
@@ -1,0 +1,440 @@
+"""Tests for GPU lease API (taOS #893)."""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tinyagentos.cluster.manager import ClusterManager
+from tinyagentos.cluster.worker_protocol import GpuLease, WorkerInfo
+
+
+@pytest.mark.asyncio
+async def test_claim_lease_success(client):
+    """Claiming a lease on an online worker with enough VRAM returns 200."""
+    # Register a worker with free VRAM
+    await client.post("/api/cluster/workers", json={
+        "name": "gpu-node",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["llm-chat"],
+        "hardware": {"gpu": {"model": "GTX 1080", "vram_mb": 8192}},
+    })
+    # Send a heartbeat with free VRAM
+    await client.post("/api/cluster/heartbeat", json={
+        "name": "gpu-node",
+        "free_vram_mb": 6000,
+        "used_vram_mb": 2000,
+    })
+
+    resp = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "caller": "skald-dispatcher",
+        "ttl_seconds": 30,
+        "required_vram_mb": 4000,
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "claimed"
+    assert data["lease_id"].startswith("l_")
+    assert data["resource_id"] == "gpu-node:gpu-cuda-0"
+    assert data["ttl_seconds"] == 30
+    assert data["required_vram_mb"] == 4000
+    assert "expires_at" in data
+
+
+@pytest.mark.asyncio
+async def test_claim_lease_insufficient_vram(client):
+    """Claiming with required_vram_mb > free_vram_mb returns 409."""
+    await client.post("/api/cluster/workers", json={
+        "name": "gpu-node",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["llm-chat"],
+    })
+    await client.post("/api/cluster/heartbeat", json={
+        "name": "gpu-node",
+        "free_vram_mb": 1000,
+        "used_vram_mb": 7000,
+    })
+
+    resp = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "required_vram_mb": 8000,
+    })
+    assert resp.status_code == 409
+    assert "unavailable" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_claim_lease_already_leased(client):
+    """A second claim on the same resource returns 409 with the existing lease info."""
+    await client.post("/api/cluster/workers", json={
+        "name": "gpu-node",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["llm-chat"],
+    })
+    await client.post("/api/cluster/heartbeat", json={
+        "name": "gpu-node",
+        "free_vram_mb": 8000,
+        "used_vram_mb": 0,
+    })
+
+    # First claim succeeds
+    resp1 = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "caller": "skald-dispatcher",
+        "ttl_seconds": 30,
+    })
+    assert resp1.status_code == 200
+    lease_id = resp1.json()["lease_id"]
+
+    # Second claim on same resource fails
+    resp2 = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "caller": "a2a-agent:extract",
+    })
+    assert resp2.status_code == 409
+    err = resp2.json()
+    assert err["error"] == "resource already leased"
+    assert err["lease_id"] == lease_id
+    assert err["holder"] == "skald-dispatcher"
+
+
+@pytest.mark.asyncio
+async def test_claim_lease_worker_offline(client):
+    """Claiming against an offline worker returns 409."""
+    # Worker registered but no heartbeat ever sent — marked offline after
+    # monitor_loop sweep.  The monitor_loop hasn't run in this test
+    # context (no app startup), so the worker is technically "online" from
+    # registration.  To test offline, claim against a nonexistent worker.
+    resp = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "ghost:gpu-cuda-0",
+        "required_vram_mb": 4000,
+    })
+    assert resp.status_code == 409
+    assert "unavailable" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_claim_lease_malformed_resource_id(client):
+    """A resource_id without a colon returns 409."""
+    resp = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "bogus",
+    })
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_release_lease_idempotent(client):
+    """Releasing a lease returns 200; releasing again is also 200."""
+    await client.post("/api/cluster/workers", json={
+        "name": "gpu-node",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["llm-chat"],
+    })
+    await client.post("/api/cluster/heartbeat", json={
+        "name": "gpu-node",
+        "free_vram_mb": 8000,
+    })
+
+    claim = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+    })
+    lease_id = claim.json()["lease_id"]
+
+    # First release
+    resp1 = await client.post("/api/cluster/leases/release", json={
+        "lease_id": lease_id,
+    })
+    assert resp1.status_code == 200
+    assert resp1.json()["status"] == "released"
+
+    # Second release (idempotent)
+    resp2 = await client.post("/api/cluster/leases/release", json={
+        "lease_id": lease_id,
+    })
+    assert resp2.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_release_lease_unknown(client):
+    """Releasing an unknown lease_id is still 200 (idempotent)."""
+    resp = await client.post("/api/cluster/leases/release", json={
+        "lease_id": "l_doesnotexist",
+    })
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_renew_lease_success(client):
+    """Renewing an active lease extends its TTL."""
+    await client.post("/api/cluster/workers", json={
+        "name": "gpu-node",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["llm-chat"],
+    })
+    await client.post("/api/cluster/heartbeat", json={
+        "name": "gpu-node",
+        "free_vram_mb": 8000,
+    })
+
+    claim = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "ttl_seconds": 10,
+    })
+    lease_id = claim.json()["lease_id"]
+    original_expiry = claim.json()["expires_at"]
+
+    resp = await client.post("/api/cluster/leases/renew", json={
+        "lease_id": lease_id,
+        "ttl_seconds": 60,
+    })
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "renewed"
+    assert resp.json()["lease_id"] == lease_id
+    assert resp.json()["expires_at"] > original_expiry
+
+
+@pytest.mark.asyncio
+async def test_renew_lease_expired(client):
+    """Renewing an expired lease returns 409."""
+    await client.post("/api/cluster/workers", json={
+        "name": "gpu-node",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["llm-chat"],
+    })
+    await client.post("/api/cluster/heartbeat", json={
+        "name": "gpu-node",
+        "free_vram_mb": 8000,
+    })
+
+    claim = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "ttl_seconds": 0.001,  # effectively instant
+    })
+    lease_id = claim.json()["lease_id"]
+
+    # Wait a moment for it to expire
+    time.sleep(0.1)
+
+    resp = await client.post("/api/cluster/leases/renew", json={
+        "lease_id": lease_id,
+        "ttl_seconds": 30,
+    })
+    assert resp.status_code == 409
+    assert "expired" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_list_leases(client):
+    """GET /leases returns active leases only."""
+    await client.post("/api/cluster/workers", json={
+        "name": "gpu-node",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["llm-chat"],
+    })
+    await client.post("/api/cluster/heartbeat", json={
+        "name": "gpu-node",
+        "free_vram_mb": 8000,
+    })
+
+    # No leases yet
+    resp = await client.get("/api/cluster/leases")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 0
+
+    # Claim one
+    claim = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "caller": "test",
+        "ttl_seconds": 30,
+    })
+    assert claim.status_code == 200
+
+    resp = await client.get("/api/cluster/leases")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+    lease = resp.json()["leases"][0]
+    assert lease["caller"] == "test"
+    assert lease["resource_id"] == "gpu-node:gpu-cuda-0"
+    assert "lease_id" in lease
+
+
+@pytest.mark.asyncio
+async def test_expired_lease_returns_409_on_claim(client):
+    """After a lease expires, a new claim on the same resource succeeds."""
+    await client.post("/api/cluster/workers", json={
+        "name": "gpu-node",
+        "url": "http://10.0.0.1:9000",
+        "capabilities": ["llm-chat"],
+    })
+    await client.post("/api/cluster/heartbeat", json={
+        "name": "gpu-node",
+        "free_vram_mb": 8000,
+    })
+
+    # Claim with very short TTL
+    await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "ttl_seconds": 0.001,
+    })
+
+    time.sleep(0.1)
+
+    # The lease is now expired; a new claim succeeds
+    resp = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "caller": "second-caller",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "claimed"
+
+
+# ── ClusterManager unit tests ──────────────────────────────────────────
+
+
+def _worker(name, free_vram=0):
+    w = WorkerInfo(
+        name=name,
+        url=f"http://{name}:9000",
+        capabilities=["llm-chat"],
+        free_vram_mb=free_vram,
+    )
+    w.status = "online"
+    w.last_heartbeat = time.time()
+    return w
+
+
+class TestClusterManagerLeases:
+    def test_claim_success(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=6000)
+
+        lease = mgr.claim_lease(
+            "gpu-node:gpu-cuda-0",
+            caller="test",
+            ttl_seconds=30,
+            required_vram_mb=4000,
+        )
+        assert lease is not None
+        assert lease.lease_id.startswith("l_")
+        assert lease.resource_id == "gpu-node:gpu-cuda-0"
+        assert lease.caller == "test"
+        assert lease.required_vram_mb == 4000
+
+    def test_claim_fails_insufficient_vram(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=1000)
+
+        lease = mgr.claim_lease(
+            "gpu-node:gpu-cuda-0",
+            required_vram_mb=8000,
+        )
+        assert lease is None
+
+    def test_claim_fails_already_leased(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=8000)
+
+        first = mgr.claim_lease("gpu-node:gpu-cuda-0", caller="first")
+        assert first is not None
+
+        second = mgr.claim_lease("gpu-node:gpu-cuda-0", caller="second")
+        assert second is None
+
+    def test_claim_fails_worker_offline(self):
+        mgr = ClusterManager()
+        w = _worker("gpu-node", free_vram=8000)
+        w.status = "offline"
+        mgr._workers["gpu-node"] = w
+
+        lease = mgr.claim_lease("gpu-node:gpu-cuda-0")
+        assert lease is None
+
+    def test_claim_fails_missing_worker(self):
+        mgr = ClusterManager()
+        lease = mgr.claim_lease("nonexistent:gpu-cuda-0")
+        assert lease is None
+
+    def test_release_idempotent(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=8000)
+
+        lease = mgr.claim_lease("gpu-node:gpu-cuda-0")
+        assert lease is not None
+
+        # Releasing works
+        assert mgr.release_lease(lease.lease_id) is True
+
+        # Releasing again (idempotent)
+        assert mgr.release_lease(lease.lease_id) is True
+
+    def test_release_unknown(self):
+        mgr = ClusterManager()
+        assert mgr.release_lease("l_nonexistent") is True
+
+    def test_renew_active(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=8000)
+
+        lease = mgr.claim_lease("gpu-node:gpu-cuda-0", ttl_seconds=10)
+        original_expiry = lease.expires_at
+
+        renewed = mgr.renew_lease(lease.lease_id, ttl_seconds=60)
+        assert renewed is not None
+        assert renewed.expires_at > original_expiry
+
+    def test_renew_expired(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=8000)
+
+        lease = mgr.claim_lease("gpu-node:gpu-cuda-0", ttl_seconds=0.001)
+        time.sleep(0.1)
+
+        renewed = mgr.renew_lease(lease.lease_id, ttl_seconds=30)
+        assert renewed is None
+
+    def test_renew_unknown(self):
+        mgr = ClusterManager()
+        assert mgr.renew_lease("l_nonexistent") is None
+
+    def test_get_leases_active_only(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=8000)
+
+        mgr.claim_lease("gpu-node:gpu-cuda-0", ttl_seconds=30)
+        assert len(mgr.get_leases()) == 1
+
+        # Add an expired lease manually
+        mgr._leases["l_expired"] = GpuLease(
+            lease_id="l_expired",
+            resource_id="gpu-node:gpu-cuda-0",
+            expires_at=0,
+        )
+        # get_leases only returns active (non-expired)
+        assert len(mgr.get_leases()) == 1
+
+    def test_sweep_removes_expired(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=8000)
+
+        # Claim with instant TTL
+        lease = mgr.claim_lease("gpu-node:gpu-cuda-0", ttl_seconds=0.001)
+        time.sleep(0.1)
+
+        # Before sweep, expired lease still in dict
+        assert lease.lease_id in mgr._leases
+
+        mgr._sweep_expired_leases()
+        assert lease.lease_id not in mgr._leases
+        assert len(mgr.get_leases()) == 0
+
+    def test_claim_after_release_succeeds(self):
+        mgr = ClusterManager()
+        mgr._workers["gpu-node"] = _worker("gpu-node", free_vram=8000)
+
+        first = mgr.claim_lease("gpu-node:gpu-cuda-0", caller="first")
+        mgr.release_lease(first.lease_id)
+
+        second = mgr.claim_lease("gpu-node:gpu-cuda-0", caller="second")
+        assert second is not None
+        assert second.caller == "second"

--- a/tests/test_model_archive.py
+++ b/tests/test_model_archive.py
@@ -1,0 +1,383 @@
+"""Tests for the model archive promotion engine."""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tinyagentos.cluster.model_archive import (
+    _archive_root,
+    _active_models_root,
+    _worker_can_run,
+    find_promotable,
+    list_archived_models,
+    promote_model,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_worker_hw(
+    ram_mb: int = 8192,
+    gpu_type: str = "nvidia",
+    gpu_cuda: bool = True,
+    vram_mb: int = 8192,
+    arch: str = "x86_64",
+) -> dict:
+    return {
+        "ram_mb": ram_mb,
+        "gpu": {
+            "type": gpu_type,
+            "cuda": gpu_cuda,
+            "vram_mb": vram_mb,
+        },
+        "cpu": {"arch": arch},
+        "npu": {"type": "none"},
+    }
+
+
+def _write_archive_manifest(
+    archive_dir: Path,
+    model_id: str,
+    requirements: dict | None = None,
+    files: list[str] | None = None,
+    backend: str = "llama-cpp",
+    family: str = "qwen3",
+) -> dict:
+    """Write a manifest AND create a dummy model-files dir so
+    :func:`promote_model` has something to move.
+    """
+    manifest = {
+        "model_id": model_id,
+        "backend": backend,
+        "family": family,
+        "files": files or [f"{model_id}-Q4_K_M.gguf"],
+        "requirements": requirements or {},
+        "archived_at": 1700000000.0,
+    }
+    manifest_path = archive_dir / f"{model_id}.json"
+    manifest_path.write_text(json.dumps(manifest))
+    # Create the accompanying model files directory
+    files_dir = archive_dir / model_id
+    files_dir.mkdir(parents=True, exist_ok=True)
+    (files_dir / f"{model_id}-Q4_K_M.gguf").write_text("fake-model-data")
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# _worker_can_run
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerCanRun:
+    def test_empty_requirements(self):
+        assert _worker_can_run(_make_worker_hw(), {}) is True
+
+    def test_vram_met(self):
+        assert _worker_can_run(
+            _make_worker_hw(vram_mb=8192),
+            {"min_vram_mb": 4096},
+        ) is True
+
+    def test_vram_not_met(self):
+        assert _worker_can_run(
+            _make_worker_hw(vram_mb=4096),
+            {"min_vram_mb": 8192},
+        ) is False
+
+    def test_ram_met(self):
+        assert _worker_can_run(
+            _make_worker_hw(ram_mb=16384),
+            {"min_ram_mb": 8192},
+        ) is True
+
+    def test_ram_not_met(self):
+        assert _worker_can_run(
+            _make_worker_hw(ram_mb=4096),
+            {"min_ram_mb": 8192},
+        ) is False
+
+    def test_gpu_type_nvidia_match(self):
+        assert _worker_can_run(
+            _make_worker_hw(gpu_type="nvidia"),
+            {"gpu_type": "nvidia"},
+        ) is True
+
+    def test_gpu_type_nvidia_mismatch(self):
+        assert _worker_can_run(
+            _make_worker_hw(gpu_type="amd"),
+            {"gpu_type": "nvidia"},
+        ) is False
+
+    def test_gpu_accel_cuda_match(self):
+        assert _worker_can_run(
+            _make_worker_hw(gpu_type="nvidia", gpu_cuda=True),
+            {"gpu_accel": "cuda"},
+        ) is True
+
+    def test_gpu_accel_cuda_mismatch(self):
+        assert _worker_can_run(
+            _make_worker_hw(gpu_type="nvidia", gpu_cuda=False),
+            {"gpu_accel": "cuda"},
+        ) is False
+
+    def test_arch_match(self):
+        assert _worker_can_run(
+            _make_worker_hw(arch="x86_64"),
+            {"arch": "x86_64"},
+        ) is True
+
+    def test_arch_mismatch(self):
+        assert _worker_can_run(
+            _make_worker_hw(arch="aarch64"),
+            {"arch": "x86_64"},
+        ) is False
+
+    def test_apple_silicon_unified_memory(self):
+        worker_hw = {
+            "ram_mb": 16384,
+            "gpu": {"type": "apple", "vulkan": True, "vram_mb": 16384},
+            "cpu": {"arch": "aarch64"},
+            "npu": {"type": "none"},
+        }
+        assert _worker_can_run(worker_hw, {"min_vram_mb": 8192}) is True
+
+    def test_all_requirements_met(self):
+        worker = _make_worker_hw(vram_mb=12288, ram_mb=16384, gpu_type="nvidia", gpu_cuda=True)
+        reqs = {
+            "min_vram_mb": 8192,
+            "min_ram_mb": 8192,
+            "gpu_type": "nvidia",
+            "gpu_accel": "cuda",
+            "arch": "x86_64",
+        }
+        assert _worker_can_run(worker, reqs) is True
+
+    def test_one_requirement_fails_whole_thing_fails(self):
+        worker = _make_worker_hw(vram_mb=4096, ram_mb=16384, gpu_type="nvidia", gpu_cuda=True)
+        reqs = {
+            "min_vram_mb": 8192,
+            "min_ram_mb": 8192,
+            "gpu_type": "nvidia",
+            "gpu_accel": "cuda",
+        }
+        assert _worker_can_run(worker, reqs) is False
+
+
+# ---------------------------------------------------------------------------
+# list_archived_models
+# ---------------------------------------------------------------------------
+
+
+class TestListArchivedModels:
+    def test_empty_dir(self, tmp_path: Path):
+        assert list_archived_models(tmp_path) == []
+
+    def test_nonexistent_dir(self, tmp_path: Path):
+        assert list_archived_models(tmp_path / "nonexistent") == []
+
+    def test_single_manifest(self, tmp_path: Path):
+        _write_archive_manifest(tmp_path, "qwen3.5-4b")
+        result = list_archived_models(tmp_path)
+        assert len(result) == 1
+        assert result[0]["model_id"] == "qwen3.5-4b"
+        assert "manifest_path" in result[0]
+
+    def test_skips_corrupt_manifest(self, tmp_path: Path):
+        (tmp_path / "bad.json").write_text("not json")
+        _write_archive_manifest(tmp_path, "gemma-4-e2b")
+        result = list_archived_models(tmp_path)
+        assert len(result) == 1
+        assert result[0]["model_id"] == "gemma-4-e2b"
+
+    def test_multiple_manifests_sorted(self, tmp_path: Path):
+        _write_archive_manifest(tmp_path, "llama3-8b")
+        _write_archive_manifest(tmp_path, "gemma-4-e2b")
+        _write_archive_manifest(tmp_path, "qwen3.5-4b")
+        result = list_archived_models(tmp_path)
+        ids = [m["model_id"] for m in result]
+        # Sorted alphabetically by filename
+        assert ids == sorted(ids)
+
+
+# ---------------------------------------------------------------------------
+# find_promotable
+# ---------------------------------------------------------------------------
+
+
+class TestFindPromotable:
+    def test_no_archive(self, tmp_path: Path):
+        worker = _make_worker_hw()
+        assert find_promotable(worker, "test-worker", tmp_path) == []
+
+    def test_no_compatible(self, tmp_path: Path):
+        # Archive a model requiring 16GB VRAM; worker has 8GB
+        _write_archive_manifest(
+            tmp_path, "big-model",
+            requirements={"min_vram_mb": 16384},
+        )
+        worker = _make_worker_hw(vram_mb=8192)
+        assert find_promotable(worker, "test-worker", tmp_path) == []
+
+    def test_compatible_found(self, tmp_path: Path):
+        _write_archive_manifest(
+            tmp_path, "qwen3.5-4b",
+            requirements={"min_vram_mb": 4096, "gpu_accel": "cuda"},
+        )
+        worker = _make_worker_hw(vram_mb=8192)
+        result = find_promotable(worker, "test-worker", tmp_path)
+        assert len(result) == 1
+        assert result[0]["model_id"] == "qwen3.5-4b"
+        assert result[0]["worker_name"] == "test-worker"
+
+    def test_mixed_compatible_and_incompatible(self, tmp_path: Path):
+        _write_archive_manifest(
+            tmp_path, "qwen3.5-4b",
+            requirements={"min_vram_mb": 4096},
+        )
+        _write_archive_manifest(
+            tmp_path, "big-model",
+            requirements={"min_vram_mb": 32768},
+        )
+        worker = _make_worker_hw(vram_mb=8192)
+        result = find_promotable(worker, "test-worker", tmp_path)
+        assert len(result) == 1
+        assert result[0]["model_id"] == "qwen3.5-4b"
+
+    def test_no_requirements_always_promotable(self, tmp_path: Path):
+        _write_archive_manifest(tmp_path, "no-reqs-model", requirements={})
+        worker = _make_worker_hw(vram_mb=128)  # very weak
+        result = find_promotable(worker, "test-worker", tmp_path)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# promote_model
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteModel:
+    def test_promote_moves_files_and_removes_manifest(self, tmp_path: Path, monkeypatch):
+        archive_dir = tmp_path / "archive"
+        active_dir = tmp_path / "active"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        active_dir.mkdir(parents=True, exist_ok=True)
+
+        # Override paths for test isolation
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_archive._archive_root",
+            lambda: archive_dir,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_archive._active_models_root",
+            lambda: active_dir,
+        )
+
+        _write_archive_manifest(
+            archive_dir, "qwen3.5-4b",
+            requirements={"min_vram_mb": 4096},
+            backend="llama-cpp",
+            family="qwen3.5",
+        )
+        models = list_archived_models(archive_dir)
+        assert len(models) == 1
+
+        ok = promote_model(models[0])
+        assert ok is True
+
+        # Manifest removed
+        assert not (archive_dir / "qwen3.5-4b.json").exists()
+        # Files dir moved
+        assert not (archive_dir / "qwen3.5-4b").is_dir()
+        target = active_dir / "llama-cpp" / "qwen3.5" / "qwen3.5-4b"
+        assert target.is_dir()
+        assert (target / "qwen3.5-4b-Q4_K_M.gguf").read_text() == "fake-model-data"
+
+    def test_promote_skips_when_target_exists(self, tmp_path: Path, monkeypatch):
+        archive_dir = tmp_path / "archive"
+        active_dir = tmp_path / "active"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        active_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_archive._archive_root",
+            lambda: archive_dir,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_archive._active_models_root",
+            lambda: active_dir,
+        )
+
+        _write_archive_manifest(
+            archive_dir, "qwen3.5-4b",
+            backend="llama-cpp",
+            family="qwen3.5",
+        )
+        # Pre-create target dir
+        target_dir = active_dir / "llama-cpp" / "qwen3.5" / "qwen3.5-4b"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        (target_dir / "existing.gguf").write_text("preexisting")
+
+        models = list_archived_models(archive_dir)
+        ok = promote_model(models[0])
+        assert ok is True
+        # Manifest removed, but existing target untouched
+        assert not (archive_dir / "qwen3.5-4b.json").exists()
+        assert (target_dir / "existing.gguf").read_text() == "preexisting"
+
+    def test_promote_fails_without_files_dir(self, tmp_path: Path, monkeypatch):
+        archive_dir = tmp_path / "archive"
+        active_dir = tmp_path / "active"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        active_dir.mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_archive._archive_root",
+            lambda: archive_dir,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.cluster.model_archive._active_models_root",
+            lambda: active_dir,
+        )
+
+        # Create manifest without files dir
+        manifest = {
+            "model_id": "orphan-model",
+            "backend": "llama-cpp",
+            "family": "orphan",
+            "files": ["orphan.gguf"],
+            "requirements": {},
+            "archived_at": 1700000000.0,
+        }
+        (archive_dir / "orphan-model.json").write_text(json.dumps(manifest))
+        # No files dir — don't create it
+
+        models = list_archived_models(archive_dir)
+        assert len(models) == 1
+        ok = promote_model(models[0])
+        assert ok is False
+        # Manifest remains
+        assert (archive_dir / "orphan-model.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Archive root env var override
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveRootOverride:
+    def test_env_var_override(self, tmp_path: Path, monkeypatch):
+        custom = tmp_path / "custom-archive"
+        monkeypatch.setenv("TAOS_ARCHIVE_ROOT", str(custom))
+        assert _archive_root() == custom
+
+    def test_default_is_home_taos(self, monkeypatch):
+        monkeypatch.delenv("TAOS_ARCHIVE_ROOT", raising=False)
+        root = _archive_root()
+        assert root.name == "models"
+        assert "taos" in str(root)
+        assert "archive" in str(root)

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -93,6 +93,23 @@ class ClusterManager:
                     level="info",
                 )
 
+        # Promote any archived models this worker can now run
+        try:
+            from tinyagentos.cluster.model_archive import (
+                promote_compatible_models,
+            )
+
+            await promote_compatible_models(
+                worker_hardware=info.hardware,
+                worker_name=info.name,
+                notifications=self._notifications,
+            )
+        except Exception:
+            logger.exception(
+                "model_archive: promotion scan failed for worker '%s'",
+                info.name,
+            )
+
     def kv_quant_union(self) -> list[str]:
         """Return the set-union of KV cache quant types across all online workers.
 

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -165,6 +165,8 @@ class ClusterManager:
         kv_cache_quant_k_support: list[str] | None = None,
         kv_cache_quant_v_support: list[str] | None = None,
         kv_cache_quant_boundary_layer_protect: bool | None = None,
+        free_vram_mb: int | None = None,
+        used_vram_mb: int | None = None,
     ) -> bool:
         """Accept a worker heartbeat.
 
@@ -203,6 +205,10 @@ class ClusterManager:
             worker.kv_cache_quant_v_support = list(kv_cache_quant_v_support)
         if kv_cache_quant_boundary_layer_protect is not None:
             worker.kv_cache_quant_boundary_layer_protect = bool(kv_cache_quant_boundary_layer_protect)
+        if free_vram_mb is not None:
+            worker.free_vram_mb = int(free_vram_mb)
+        if used_vram_mb is not None:
+            worker.used_vram_mb = int(used_vram_mb)
         # Fire worker.online notification when a previously-offline worker recovers.
         # heartbeat() is sync, so schedule the async emit as a background task.
         if self._notifications and prev_status in ("offline", "stale"):

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 import asyncio
 import logging
+import secrets
 import time
-from tinyagentos.cluster.worker_protocol import WorkerInfo
+from tinyagentos.cluster.worker_protocol import GpuLease, WorkerInfo
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ def _format_hw(hw) -> str:
 class ClusterManager:
     def __init__(self, notifications=None, capabilities=None):
         self._workers: dict[str, WorkerInfo] = {}
+        self._leases: dict[str, GpuLease] = {}
         self._monitor_task: asyncio.Task | None = None
         self._notifications = notifications  # NotificationStore, optional
         self._capabilities = capabilities    # CapabilityChecker, optional
@@ -245,6 +247,123 @@ class ClusterManager:
                 return w
         return None
 
+    # ── Lease management ───────────────────────────────────────────────
+
+    def _parse_resource_id(self, resource_id: str) -> tuple[str, str] | None:
+        """Split ``"worker-name:gpu-cuda-0"`` into (worker_name, resource_name)."""
+        if ":" not in resource_id:
+            return None
+        worker, rest = resource_id.split(":", 1)
+        return worker, rest
+
+    def _worker_for_resource(self, resource_id: str) -> WorkerInfo | None:
+        """Return the WorkerInfo for a resource_id, or None."""
+        parsed = self._parse_resource_id(resource_id)
+        if parsed is None:
+            return None
+        worker_name, _ = parsed
+        worker = self._workers.get(worker_name)
+        if worker is None or worker.status != "online":
+            return None
+        return worker
+
+    def _find_existing_lease(self, resource_id: str) -> GpuLease | None:
+        """Return the active (non-expired) lease for a resource, if any."""
+        now = time.time()
+        for lease in self._leases.values():
+            if lease.resource_id == resource_id and lease.expires_at > now:
+                return lease
+        return None
+
+    def claim_lease(
+        self,
+        resource_id: str,
+        caller: str = "",
+        ttl_seconds: float = 30,
+        required_vram_mb: int = 0,
+    ) -> GpuLease | None:
+        """Attempt to claim a GPU lease on ``resource_id``.
+
+        Fails if:
+        - The resource_id is malformed.
+        - The target worker is not online.
+        - Another active lease already exists for this resource.
+        - ``required_vram_mb > worker.free_vram_mb`` (when
+          ``required_vram_mb > 0``).
+        """
+        worker = self._worker_for_resource(resource_id)
+        if worker is None:
+            logger.debug("claim_lease: worker not found or offline for %s", resource_id)
+            return None
+
+        existing = self._find_existing_lease(resource_id)
+        if existing is not None:
+            logger.debug(
+                "claim_lease: resource %s already leased by %r (expires in %.0fs)",
+                resource_id, existing.caller, existing.expires_at - time.time(),
+            )
+            return None
+
+        if required_vram_mb > 0 and required_vram_mb > worker.free_vram_mb:
+            logger.debug(
+                "claim_lease: %s needs %d MiB VRAM but %s has %d MiB free",
+                caller, required_vram_mb, worker.name, worker.free_vram_mb,
+            )
+            return None
+
+        lease_id = f"l_{secrets.token_hex(4)}"
+        lease = GpuLease(
+            lease_id=lease_id,
+            resource_id=resource_id,
+            caller=caller,
+            expires_at=time.time() + ttl_seconds,
+            required_vram_mb=required_vram_mb,
+        )
+        self._leases[lease_id] = lease
+        logger.info(
+            "Lease claimed: %s on %s by %r (ttl=%.0fs, vram=%d MiB)",
+            lease_id, resource_id, caller, ttl_seconds, required_vram_mb,
+        )
+        return lease
+
+    def release_lease(self, lease_id: str) -> bool:
+        """Release a lease by id.  Idempotent — returns True even if the
+        lease was already expired or never existed."""
+        lease = self._leases.pop(lease_id, None)
+        if lease is not None:
+            logger.info("Lease released: %s on %s", lease_id, lease.resource_id)
+        return True  # idempotent
+
+    def renew_lease(self, lease_id: str, ttl_seconds: float = 30) -> GpuLease | None:
+        """Extend a lease's TTL.  Returns the lease, or None if expired/unknown."""
+        lease = self._leases.get(lease_id)
+        if lease is None:
+            return None
+        now = time.time()
+        if lease.expires_at <= now:
+            self._leases.pop(lease_id, None)
+            return None
+        lease.expires_at = now + ttl_seconds
+        return lease
+
+    def get_leases(self) -> list[GpuLease]:
+        """Return a snapshot of active (non-expired) leases."""
+        now = time.time()
+        return [lease for lease in self._leases.values() if lease.expires_at > now]
+
+    def _sweep_expired_leases(self):
+        """Remove leases whose TTL has elapsed.  Called from _monitor_loop."""
+        now = time.time()
+        expired = [
+            lid for lid, lease in self._leases.items()
+            if lease.expires_at <= now
+        ]
+        for lid in expired:
+            lease = self._leases.pop(lid)
+            logger.debug("Lease expired: %s on %s", lid, lease.resource_id)
+
+    # ── Capability routing ─────────────────────────────────────────────
+
     def get_workers_for_capability(self, capability: str) -> list[WorkerInfo]:
         """Get online workers that support a capability, sorted by priority (lowest load first)."""
         eligible = [
@@ -333,7 +452,8 @@ class ClusterManager:
         }
 
     async def _monitor_loop(self):
-        """Monitor worker heartbeats, mark stale workers as offline."""
+        """Monitor worker heartbeats, mark stale workers as offline, and
+        sweep expired GPU leases."""
         while True:
             now = time.time()
             for worker in self._workers.values():
@@ -347,4 +467,13 @@ class ClusterManager:
                             f"No heartbeat for {HEARTBEAT_TIMEOUT}s. Capabilities may be reduced.",
                             level="warning",
                         )
+                    # Release any active leases for this worker's resources
+                    offline_lids = [
+                        lid for lid, lease in self._leases.items()
+                        if lease.resource_id.startswith(worker.name + ":")
+                    ]
+                    for lid in offline_lids:
+                        self._leases.pop(lid, None)
+                        logger.debug("Lease %s released — worker %s went offline", lid, worker.name)
+            self._sweep_expired_leases()
             await asyncio.sleep(5)

--- a/tinyagentos/cluster/model_archive.py
+++ b/tinyagentos/cluster/model_archive.py
@@ -1,0 +1,257 @@
+"""Archived model store and promotion engine.
+
+When a model is downloaded and no current worker can run it
+(PR #325 force=True "Archive anyway"), it lands in
+
+    ~/taos/archive/models/<model_id>.json  + files under
+    ~/taos/archive/models/<model_id>/
+
+This module scans that directory on worker join and promotes
+any model that the new worker can now run — moving it into the
+active models tree via :func:`~tinyagentos.installers.model_paths.models_root`.
+
+Consumed by:
+- :meth:`~tinyagentos.cluster.manager.ClusterManager.register_worker`
+  (automatic promotion on worker join)
+- ``GET /api/cluster/promote-archived`` (manual trigger)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _archive_root() -> Path:
+    """Root directory for archived models. Override with TAOS_ARCHIVE_ROOT env."""
+    override = os.environ.get("TAOS_ARCHIVE_ROOT")
+    return Path(override) if override else Path.home() / "taos" / "archive" / "models"
+
+
+def _active_models_root() -> Path:
+    """The active models tree — same as all backend installers write into."""
+    from tinyagentos.installers.model_paths import models_root
+    return models_root()
+
+
+def list_archived_models(archive_dir: Path | None = None) -> list[dict]:
+    """Scan the archive directory and return every archived model's manifest.
+
+    Each manifest is a JSON file ``<model_id>.json`` in the archive root.
+    Returns a list of dicts with keys: ``model_id``, ``files``,
+    ``requirements``, ``archived_at``, ``backend``, ``manifest_path``.
+    """
+    root = archive_dir or _archive_root()
+    if not root.is_dir():
+        return []
+    models: list[dict] = []
+    for manifest_path in sorted(root.glob("*.json")):
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            logger.warning("model_archive: skipping unreadable manifest %s", manifest_path)
+            continue
+        data["manifest_path"] = str(manifest_path)
+        models.append(data)
+    return models
+
+
+def _worker_can_run(worker_hardware: dict, requirements: dict) -> bool:
+    """True if the worker's hardware meets the model's minimum requirements.
+
+    Checks: VRAM, RAM, GPU type (cuda/rocm/vulkan/apple/npu), architecture.
+
+    Requirements shape (all keys optional; missing means no constraint)::
+
+        {
+            "min_vram_mb": 8192,
+            "min_ram_mb": 4096,
+            "gpu_type": "nvidia",       # or "amd" / "apple" / ""
+            "gpu_accel": "cuda",        # or "rocm" / "vulkan" / "mlx" / ""
+            "npu_type": "rknpu",        # or ""
+            "arch": "x86_64"            # or "aarch64" / ""
+        }
+    """
+    if not requirements:
+        return True  # No requirements = runs anywhere
+
+    hw_gpu = worker_hardware.get("gpu") or {}
+    hw_npu = worker_hardware.get("npu") or {}
+    hw_cpu_raw = worker_hardware.get("cpu") or {}
+    hw_cpu: dict = hw_cpu_raw if isinstance(hw_cpu_raw, dict) else {}
+    hw_ram = worker_hardware.get("ram_mb", 0)
+
+    # VRAM check
+    min_vram = requirements.get("min_vram_mb")
+    if min_vram:
+        worker_vram = hw_gpu.get("vram_mb", 0) or 0
+        # Apple Silicon unified memory counts
+        if hw_gpu.get("type") == "apple":
+            worker_vram = max(worker_vram, hw_ram)
+        if worker_vram < min_vram:
+            return False
+
+    # RAM check
+    min_ram = requirements.get("min_ram_mb")
+    if min_ram and hw_ram < min_ram:
+        return False
+
+    # GPU type / accelerator check
+    req_gpu_type = requirements.get("gpu_type")
+    req_gpu_accel = requirements.get("gpu_accel")
+    worker_gpu_type = hw_gpu.get("type", "none") or "none"
+
+    if req_gpu_type:
+        if req_gpu_type == "nvidia" and worker_gpu_type != "nvidia":
+            return False
+        if req_gpu_type == "amd" and worker_gpu_type != "amd":
+            return False
+        if req_gpu_type == "apple" and worker_gpu_type != "apple":
+            return False
+
+    if req_gpu_accel:
+        if req_gpu_accel == "cuda" and not hw_gpu.get("cuda"):
+            return False
+        if req_gpu_accel == "rocm" and not hw_gpu.get("rocm"):
+            return False
+        if req_gpu_accel == "vulkan" and not hw_gpu.get("vulkan"):
+            return False
+
+    # NPU check
+    req_npu = requirements.get("npu_type")
+    if req_npu:
+        worker_npu_type = hw_npu.get("type", "none") or "none"
+        if worker_npu_type != req_npu and worker_npu_type not in (req_npu,):
+            return False
+
+    # Architecture check
+    req_arch = requirements.get("arch")
+    if req_arch:
+        worker_arch = hw_cpu.get("arch", "")
+        if worker_arch and worker_arch != req_arch:
+            return False
+
+    return True
+
+
+def find_promotable(
+    worker_hardware: dict,
+    worker_name: str,
+    archive_dir: Path | None = None,
+) -> list[dict]:
+    """Return archived models that *this* worker can now run.
+
+    Each entry is the model manifest dict with an extra ``worker_name`` key.
+    Does NOT move files — call :func:`promote_model` for each.
+    """
+    promotable: list[dict] = []
+    for model in list_archived_models(archive_dir):
+        reqs = model.get("requirements") or {}
+        if _worker_can_run(worker_hardware, reqs):
+            model["worker_name"] = worker_name
+            promotable.append(model)
+    return promotable
+
+
+def promote_model(model: dict) -> bool:
+    """Move one archived model into the active models tree.
+
+    Args:
+        model: A manifest dict from :func:`list_archived_models`.
+
+    Returns True on success, False if the move fails (model stays archived).
+    """
+    model_id = model.get("model_id", "")
+    manifest_path_str = model.get("manifest_path", "")
+    if not model_id or not manifest_path_str:
+        logger.warning("model_archive: cannot promote — missing model_id or manifest_path")
+        return False
+
+    manifest_path = Path(manifest_path_str)
+    archive_root_path = manifest_path.parent
+    model_files_dir = archive_root_path / model_id
+
+    # Resolve target directory in the active models tree.
+    # Use the backend from the manifest if present; otherwise guess.
+    backend = model.get("backend", "uncategorised")
+    # Build a target path: ~/models/<backend>/<family>/<model_id>/
+    # The family is derived from the model_id's first token or from the manifest.
+    family = model.get("family", model_id.split("-", 1)[0] if "-" in model_id else model_id)
+    target_dir = _active_models_root() / backend / family / model_id
+
+    if not model_files_dir.is_dir():
+        logger.warning(
+            "model_archive: model files directory %s not found — "
+            "promotion requires both the manifest and the files dir",
+            model_files_dir,
+        )
+        return False
+
+    try:
+        target_dir.parent.mkdir(parents=True, exist_ok=True)
+        # If target already exists, don't overwrite — but still remove
+        # the archive manifest so we don't keep trying.
+        if target_dir.exists():
+            logger.info(
+                "model_archive: target %s already exists; removing archive entry, skipping move",
+                target_dir,
+            )
+            manifest_path.unlink(missing_ok=True)
+            # Clean up empty model files dir if possible
+            if model_files_dir.is_dir():
+                try:
+                    model_files_dir.rmdir()
+                except OSError:
+                    pass
+            return True
+
+        shutil.move(str(model_files_dir), str(target_dir))
+        # Remove the archive manifest after successful move
+        manifest_path.unlink(missing_ok=True)
+        logger.info("model_archive: promoted %s -> %s", model_id, target_dir)
+        return True
+    except (OSError, shutil.Error) as exc:
+        logger.error("model_archive: failed to promote %s: %s", model_id, exc)
+        return False
+
+
+async def promote_compatible_models(
+    worker_hardware: dict,
+    worker_name: str,
+    archive_dir: Path | None = None,
+    notifications=None,
+) -> list[str]:
+    """Scan archive, promote every model compatible with this worker.
+
+    Called by :meth:`ClusterManager.register_worker` when a new worker joins.
+    Sends a notification for each promoted model.
+
+    Returns the list of promoted model IDs.
+    """
+    promotable = find_promotable(worker_hardware, worker_name, archive_dir)
+    promoted: list[str] = []
+    for model in promotable:
+        model_id = model.get("model_id", "?")
+        if promote_model(model):
+            promoted.append(model_id)
+            if notifications:
+                await notifications.emit_event(
+                    "model.promoted",
+                    f"Archived model '{model_id}' promoted",
+                    f"Worker '{worker_name}' can now run '{model_id}'. "
+                    f"Moved from archive to active models.",
+                    level="info",
+                )
+    if promoted:
+        logger.info(
+            "model_archive: worker '%s' promoted %d model(s): %s",
+            worker_name, len(promoted), ", ".join(promoted),
+        )
+    return promoted

--- a/tinyagentos/cluster/worker_capacity.py
+++ b/tinyagentos/cluster/worker_capacity.py
@@ -96,3 +96,24 @@ def capacity_snapshot(
         "storage_used_bytes": used,
         "bytes_deduped_total": read_bees_deduped_total(bees_status_path),
     }
+
+
+def gpu_vram_snapshot() -> dict | None:
+    """Return real-time free/used VRAM for the first GPU, or None.
+
+    Dispatches to the appropriate probe based on what's available on
+    this worker (nvidia-smi, etc). Returns a dict with ``free_vram_mb``
+    and ``used_vram_mb`` integers, or ``None`` when no GPU probe is
+    available or the probe fails.
+
+    Called from the worker heartbeat loop alongside capacity_snapshot().
+    Best-effort: a missing nvidia-smi or a probe timeout is not an error.
+    """
+    from tinyagentos.system_stats import read_nvidia_vram
+
+    pair = read_nvidia_vram()
+    if pair is None:
+        return None
+    used_mb, total_mb = pair
+    free_mb = max(0, total_mb - used_mb)
+    return {"free_vram_mb": free_mb, "used_vram_mb": used_mb}

--- a/tinyagentos/cluster/worker_protocol.py
+++ b/tinyagentos/cluster/worker_protocol.py
@@ -58,3 +58,9 @@ class WorkerInfo:
     worker_lxc_image_version: str | None = None  # Ubuntu image version, e.g. "ubuntu/24.04/amd64"
     degraded: bool = False
     degraded_reason: str | None = None
+    # Real-time GPU VRAM reported on every heartbeat (free/used in MiB).
+    # Default 0 means unreported / no GPU; consumers (Skald's TaosDispatcher)
+    # use these to sort candidates by actual availability instead of total
+    # capacity. Worker reports them; controller stores them; API surfaces them.
+    free_vram_mb: int = 0
+    used_vram_mb: int = 0

--- a/tinyagentos/cluster/worker_protocol.py
+++ b/tinyagentos/cluster/worker_protocol.py
@@ -64,3 +64,31 @@ class WorkerInfo:
     # capacity. Worker reports them; controller stores them; API surfaces them.
     free_vram_mb: int = 0
     used_vram_mb: int = 0
+
+
+@dataclass
+class GpuLease:
+    """A time-limited reservation of GPU capacity on a cluster worker.
+
+    Created by ``POST /api/cluster/leases/claim`` and tracked in the
+    controller's in-memory ``ClusterManager._leases`` dict.  Expired
+    leases are swept by the same monitor loop that marks workers
+    offline.
+
+    Attributes:
+        lease_id: Short unique id (``l_<8 hex>``).
+        resource_id: ``{worker_name}:{resource_name}``, e.g.
+            ``"hognehermes:gpu-cuda-0"``.
+        caller: Human-readable label for the lease holder
+            (``"skald-dispatcher"``, ``"a2a-agent:extract"``).
+        expires_at: monotonic timestamp after which the lease is
+            considered stale and automatically freed.
+        required_vram_mb: How many MiB of VRAM the caller declared it
+            needs.  Used by the pre-claim check to refuse a claim when
+            the worker's ``free_vram_mb`` is too low.
+    """
+    lease_id: str
+    resource_id: str
+    caller: str = ""
+    expires_at: float = 0.0
+    required_vram_mb: int = 0

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -656,3 +656,57 @@ async def worker_remote_command(request: Request, name: str, body: WorkerRemoteR
             return resp.json()
     except Exception as exc:
         return JSONResponse({"error": str(exc)}, status_code=502)
+
+
+@router.get("/api/cluster/promote-archived")
+async def promote_archived_models(request: Request):
+    """Manual trigger: scan all online workers and promote any archived
+    models that are now compatible with cluster hardware.
+
+    Called by the user from the Cluster page or admin CLI. Safe to call
+    repeatedly — already-promoted models are skipped.
+    """
+    cluster = request.app.state.cluster_manager
+    notifications = getattr(request.app.state, "notifications", None)
+
+    workers = cluster.get_workers()
+    online = [w for w in workers if w.status == "online"]
+
+    from tinyagentos.cluster.model_archive import (
+        find_promotable,
+        promote_model,
+    )
+
+    promoted_by_worker: dict[str, list[str]] = {}
+    total = 0
+
+    for w in online:
+        promotable = find_promotable(
+            worker_hardware=w.hardware,
+            worker_name=w.name,
+        )
+        for model in promotable:
+            model_id = model.get("model_id", "?")
+            if promote_model(model):
+                promoted_by_worker.setdefault(w.name, []).append(model_id)
+                total += 1
+                if notifications:
+                    try:
+                        await notifications.emit_event(
+                            "model.promoted",
+                            f"Archived model '{model_id}' promoted",
+                            f"Worker '{w.name}' can now run '{model_id}'. "
+                            f"Moved from archive to active models.",
+                            level="info",
+                        )
+                    except Exception:
+                        logger.exception(
+                            "notification emit failed for model promotion %s",
+                            model_id,
+                        )
+
+    return {
+        "promoted": total,
+        "by_worker": promoted_by_worker,
+        "workers_scanned": len(online),
+    }

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -718,3 +718,105 @@ async def promote_archived_models(request: Request):
         "by_worker": promoted_by_worker,
         "workers_scanned": len(online),
     }
+
+
+# ── GPU lease coordination (taOS #893) ───────────────────────────────────
+
+
+class LeaseClaimRequest(BaseModel):
+    resource_id: str
+    ttl_seconds: float = 30
+    caller: str = ""
+    required_vram_mb: int = 0
+
+
+class LeaseReleaseRequest(BaseModel):
+    lease_id: str
+
+
+class LeaseRenewRequest(BaseModel):
+    lease_id: str
+    ttl_seconds: float = 30
+
+
+@router.post("/api/cluster/leases/claim")
+async def claim_lease(request: Request, body: LeaseClaimRequest):
+    """Claim a GPU lease on a cluster resource.
+
+    Returns 200 with lease details on success, 409 if the resource is
+    already leased or the worker has insufficient free VRAM.
+    """
+    cluster = request.app.state.cluster_manager
+    lease = cluster.claim_lease(
+        resource_id=body.resource_id,
+        caller=body.caller,
+        ttl_seconds=body.ttl_seconds,
+        required_vram_mb=body.required_vram_mb,
+    )
+    if lease is None:
+        # Check why it failed — already leased or insufficient VRAM?
+        existing = cluster._find_existing_lease(body.resource_id)
+        if existing is not None:
+            return JSONResponse({
+                "error": "resource already leased",
+                "lease_id": existing.lease_id,
+                "holder": existing.caller,
+                "expires_at": existing.expires_at,
+            }, status_code=409)
+        return JSONResponse({
+            "error": "resource unavailable — check worker status and VRAM",
+        }, status_code=409)
+
+    return {
+        "status": "claimed",
+        "lease_id": lease.lease_id,
+        "resource_id": lease.resource_id,
+        "expires_at": lease.expires_at,
+        "ttl_seconds": int(body.ttl_seconds),
+        "required_vram_mb": lease.required_vram_mb,
+    }
+
+
+@router.post("/api/cluster/leases/release")
+async def release_lease(request: Request, body: LeaseReleaseRequest):
+    """Release a GPU lease by id.  Idempotent."""
+    cluster = request.app.state.cluster_manager
+    cluster.release_lease(body.lease_id)
+    return {"status": "released", "lease_id": body.lease_id}
+
+
+@router.post("/api/cluster/leases/renew")
+async def renew_lease(request: Request, body: LeaseRenewRequest):
+    """Extend a lease's TTL.  Returns 409 if the lease is expired."""
+    cluster = request.app.state.cluster_manager
+    lease = cluster.renew_lease(body.lease_id, ttl_seconds=body.ttl_seconds)
+    if lease is None:
+        return JSONResponse({
+            "error": "lease not found or expired",
+            "lease_id": body.lease_id,
+        }, status_code=409)
+    return {
+        "status": "renewed",
+        "lease_id": lease.lease_id,
+        "expires_at": lease.expires_at,
+    }
+
+
+@router.get("/api/cluster/leases")
+async def list_leases(request: Request):
+    """Return active (non-expired) GPU leases."""
+    cluster = request.app.state.cluster_manager
+    leases = cluster.get_leases()
+    return {
+        "leases": [
+            {
+                "lease_id": lease.lease_id,
+                "resource_id": lease.resource_id,
+                "caller": lease.caller,
+                "expires_at": lease.expires_at,
+                "required_vram_mb": lease.required_vram_mb,
+            }
+            for lease in leases
+        ],
+        "count": len(leases),
+    }

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -66,6 +66,12 @@ class HeartbeatBody(BaseModel):
     storage_cap_bytes: int | None = None
     storage_used_bytes: int | None = None
     bytes_deduped_total: int | None = None
+    # Real-time GPU VRAM reported by the worker on every heartbeat.
+    # Optional so legacy workers that don't send them leave stored values
+    # unchanged. Consumers (e.g. Skald's TaosDispatcher) use these to
+    # rank candidates by actual free memory, not total capacity.
+    free_vram_mb: int | None = None
+    used_vram_mb: int | None = None
 
 
 class RouteRequest(BaseModel):
@@ -232,6 +238,8 @@ async def worker_heartbeat(request: Request, body: HeartbeatBody):
         kv_cache_quant_k_support=body.kv_cache_quant_k_support,
         kv_cache_quant_v_support=body.kv_cache_quant_v_support,
         kv_cache_quant_boundary_layer_protect=body.kv_cache_quant_boundary_layer_protect,
+        free_vram_mb=body.free_vram_mb,
+        used_vram_mb=body.used_vram_mb,
     )
     if not ok:
         return JSONResponse({"error": "Worker not registered"}, status_code=404)

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -393,7 +393,7 @@ class WorkerAgent:
         the 404 case (controller restarted and forgot about us) and
         trigger a re-registration.
         """
-        from tinyagentos.cluster.worker_capacity import capacity_snapshot
+        from tinyagentos.cluster.worker_capacity import capacity_snapshot, gpu_vram_snapshot
 
         try:
             load = psutil.cpu_percent() / 100.0
@@ -401,6 +401,7 @@ class WorkerAgent:
             caps = self.detect_capabilities(backends)
             kv_quant = self.detect_kv_quant_support(backends)
             snap = capacity_snapshot()
+            vram = gpu_vram_snapshot()
             async with httpx.AsyncClient(timeout=5) as client:
                 resp = await client.post(
                     f"{self.controller_url}/api/cluster/heartbeat",
@@ -416,6 +417,8 @@ class WorkerAgent:
                         "storage_cap_bytes": snap["storage_cap_bytes"],
                         "storage_used_bytes": snap["storage_used_bytes"],
                         "bytes_deduped_total": snap["bytes_deduped_total"],
+                        "free_vram_mb": vram["free_vram_mb"] if vram else 0,
+                        "used_vram_mb": vram["used_vram_mb"] if vram else 0,
                     },
                 )
                 return resp.status_code


### PR DESCRIPTION
Prototype: GPU lease claim/release API on taOS controller. See docs/design/a2a-gpu-lease-proposal.md for full RFC.

----
## Summary by Gitar

- **Cluster API:**
  - Added `/api/cluster/leases/claim`, `/release`, `/renew`, and `/list` to enable GPU capacity reservations.
  - Added `GpuLease` tracking to `ClusterManager` with automatic expiry via `_monitor_loop`.
- **Worker heartbeats:**
  - Extended heartbeat protocol to include real-time `free_vram_mb` and `used_vram_mb`.
  - Added `gpu_vram_snapshot` probe for workers to report VRAM usage via `nvidia-smi`.
- **Model management:**
  - Implemented `model_archive` to support promoting archived models when hardware requirements are met.
  - Added `GET /api/cluster/promote-archived` for manual compatibility-based model promotion.
- **Testing:**
  - Added `tests/test_leases.py` for lease lifecycle and `tests/test_model_archive.py` for promotion logic.

<sub>This will update automatically on new commits.</sub>