### PR TITLE
fix(scheduler): execute due scheduled tasks incl. auto-backup (#165)

### DIFF
--- a/tests/scheduler/test_task_runner.py
+++ b/tests/scheduler/test_task_runner.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.scheduler import TaskScheduler
+from tinyagentos.scheduler.task_runner import run_due_once
+
+
+@pytest_asyncio.fixture
+async def scheduler(tmp_path):
+    s = TaskScheduler(tmp_path / "scheduler.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+def app_state(scheduler, tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "dummy.txt").write_text("hello")
+    return SimpleNamespace(scheduler=scheduler, data_dir=data_dir)
+
+
+@pytest.mark.asyncio
+class TestClaimRunAtomicity:
+    async def test_only_one_claim_wins(self, scheduler):
+        task_id = await scheduler.add_task("auto-backup", "* * * * *", "create_backup")
+        results = [
+            await scheduler.claim_run(task_id, None, 1000, 2000),
+            await scheduler.claim_run(task_id, None, 1000, 2000),
+        ]
+        assert results.count(True) == 1
+        assert results.count(False) == 1
+
+
+@pytest.mark.asyncio
+class TestRunDueOnce:
+    async def test_due_backup_runs_and_advances_last_run(self, scheduler, app_state):
+        task_id = await scheduler.add_task("auto-backup", "* * * * *", "create_backup")
+        await scheduler._db.execute(
+            "UPDATE scheduled_tasks SET last_run = 0 WHERE id = ?", (task_id,)
+        )
+        await scheduler._db.commit()
+
+        now = time.time() + 10 * 365 * 24 * 3600  # far future: always past-due
+        dispatched = await run_due_once(app_state, now)
+
+        assert dispatched == 1
+        backups_root = app_state.data_dir / "data-backups"
+        auto_backups = list(backups_root.glob("auto-*"))
+        assert len(auto_backups) == 1
+        assert (auto_backups[0] / "dummy.txt").exists()
+
+        task = await scheduler.get_task(task_id)
+        assert task["last_run"] == int(now)
+
+    async def test_not_due_task_does_not_run(self, scheduler, app_state):
+        await scheduler.add_task("yearly", "0 0 1 1 *", "create_backup")
+
+        now = time.time()
+        dispatched = await run_due_once(app_state, now)
+
+        assert dispatched == 0
+        backups_root = app_state.data_dir / "data-backups"
+        assert not backups_root.exists()
+
+    async def test_unknown_command_is_never_executed(self, scheduler, app_state):
+        """SECURITY: an arbitrary command string (e.g. a preset like
+        `curl http://evil`) must never be shell-executed. run_due_once must
+        not raise and must dispatch nothing for it."""
+        await scheduler.add_task("suspicious", "* * * * *", "curl http://evil")
+
+        now = time.time() + 10 * 365 * 24 * 3600  # far future: always past-due
+        dispatched = await run_due_once(app_state, now)
+
+        assert dispatched == 0
+        backups_root = app_state.data_dir / "data-backups"
+        assert not backups_root.exists()

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1197,6 +1197,12 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         from tinyagentos.projects.routine_runner import routine_tick_loop
         _create_supervised_task(routine_tick_loop(app.state), app.state._background_tasks)
 
+        # Scheduled tasks executor: sweeps due TaskScheduler entries every 60s
+        # and dispatches each via an allow-listed handler (v1: create_backup
+        # only). Always runs; cheap no-op unless a task is due.
+        from tinyagentos.scheduler.task_runner import scheduled_task_tick_loop
+        _create_supervised_task(scheduled_task_tick_loop(app.state), app.state._background_tasks)
+
         # Agent heartbeat: every 60s, wakes each idle running agent with its
         # next ready task (opt-in via config.server["agent_heartbeat_enabled"],
         # default off). Same supervised-loop pattern as routine_tick_loop above.

--- a/tinyagentos/data_snapshot.py
+++ b/tinyagentos/data_snapshot.py
@@ -46,8 +46,8 @@ def _harden_perms(root: Path) -> None:
                 pass
 
 
-def snapshot_data_dir(data_dir: Path) -> Optional[Path]:
-    """Copy data_dir into data-backups/pre-switch-<ts>/, skipping _EXCLUDE.
+def snapshot_data_dir(data_dir: Path, prefix: str = "pre-switch") -> Optional[Path]:
+    """Copy data_dir into data-backups/{prefix}-<ts>/, skipping _EXCLUDE.
 
     Returns the backup path, or None if data_dir doesn't exist. Best-effort:
     per-entry copy failures are logged, not raised.
@@ -62,7 +62,7 @@ def snapshot_data_dir(data_dir: Path) -> Optional[Path]:
     ts = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
     backups_root = data_dir / "data-backups"
     backups_root.mkdir(parents=True, exist_ok=True)
-    dest = backups_root / f"pre-switch-{ts}"
+    dest = backups_root / f"{prefix}-{ts}"
     dest.mkdir(parents=True, exist_ok=True)
     for d in (backups_root, dest):
         try:

--- a/tinyagentos/scheduler/task_runner.py
+++ b/tinyagentos/scheduler/task_runner.py
@@ -1,0 +1,110 @@
+"""Scheduled task executor: cron tick loop for TaskScheduler entries.
+
+Mirrors tinyagentos/projects/routine_runner.py's routine_tick_loop: a plain
+`while True` + try/except-per-iteration + sleep, registered in
+app.state._background_tasks so the existing bounded `cancel_and_wait`
+shutdown path cancels it alongside every other loop.
+
+SECURITY: the `command` field on a scheduled task is an arbitrary string (UI
+presets include things like `curl ...` and `qmd embed`). It is NEVER
+shell-executed. Dispatch is limited to a hardcoded allow-list of internal
+handlers (`_SAFE_COMMANDS`) keyed by exact command string. Any command not in
+the allow-list is logged at debug level and skipped.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import time
+
+from croniter import croniter
+
+from tinyagentos.data_snapshot import snapshot_data_dir
+
+logger = logging.getLogger(__name__)
+
+TICK_INTERVAL = 60  # seconds between due-task sweeps
+
+_AUTO_BACKUP_KEEP = 7  # how many auto-* snapshots to retain
+
+
+async def _run_backup(app_state) -> None:
+    """Snapshot the data dir with the "auto" prefix, then prune old auto
+    snapshots down to the most recent _AUTO_BACKUP_KEEP."""
+    data_dir = app_state.data_dir
+    backup_path = snapshot_data_dir(data_dir, prefix="auto")
+    logger.info("scheduled backup: created %s", backup_path)
+
+    backups_root = data_dir / "data-backups"
+    auto_backups = sorted(
+        (p for p in backups_root.glob("auto-*") if p.is_dir()),
+        key=lambda p: p.name,
+        reverse=True,
+    )
+    for stale in auto_backups[_AUTO_BACKUP_KEEP:]:
+        try:
+            shutil.rmtree(stale)
+        except OSError as exc:
+            logger.warning("scheduled backup: failed to prune %s: %s", stale, exc)
+
+
+# Hardcoded allow-list: only these exact command strings are ever dispatched.
+# Anything else is logged and skipped; stored command strings are never
+# shell-executed.
+_SAFE_COMMANDS = {
+    "create_backup": _run_backup,
+}
+
+
+async def run_due_once(app_state, now: float) -> int:
+    """Sweep enabled scheduled tasks once and fire each one that is due.
+
+    Returns the number of commands actually dispatched. Failure-isolated per
+    task: one bad task is logged and skipped, never aborting the sweep.
+    """
+    scheduler = app_state.scheduler
+    dispatched = 0
+    for task in await scheduler.list_enabled():
+        try:
+            schedule = task["schedule"]
+            if not croniter.is_valid(schedule):
+                continue
+            base = task["last_run"] if task["last_run"] else task["created_at"]
+            due_at = croniter(schedule, base).get_next(float)
+            if due_at > now:
+                continue
+            next_run = int(croniter(schedule, now).get_next(float))
+            claimed = await scheduler.claim_run(
+                task["id"], task["last_run"], int(now), next_run
+            )
+            if not claimed:
+                # Another tick already fired this due instant.
+                continue
+            handler = _SAFE_COMMANDS.get(task["command"])
+            if handler is None:
+                logger.debug(
+                    "scheduled task %s: unhandled command %r, skipping",
+                    task["id"], task["command"],
+                )
+                continue
+            await handler(app_state)
+            dispatched += 1
+        except Exception:
+            logger.exception(
+                "scheduled task tick: fire failed for task %s", task.get("id")
+            )
+    return dispatched
+
+
+async def scheduled_task_tick_loop(app_state) -> None:
+    """Sweep due scheduled tasks every TICK_INTERVAL seconds and dispatch
+    each one via the allow-listed handler for its command."""
+    while True:
+        try:
+            await run_due_once(app_state, time.time())
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("scheduled task tick: sweep crashed")
+        await asyncio.sleep(TICK_INTERVAL)

--- a/tinyagentos/scheduler/task_scheduler.py
+++ b/tinyagentos/scheduler/task_scheduler.py
@@ -104,6 +104,25 @@ class TaskScheduler(BaseStore):
         await self._db.commit()
         return cursor.rowcount > 0
 
+    async def list_enabled(self) -> list[dict]:
+        sql = "SELECT id, name, schedule, command, last_run, created_at FROM scheduled_tasks WHERE enabled = 1"
+        async with self._db.execute(sql) as cursor:
+            return [{"id": r[0], "name": r[1], "schedule": r[2], "command": r[3],
+                     "last_run": r[4], "created_at": r[5]} for r in await cursor.fetchall()]
+
+    async def claim_run(self, task_id: int, prev_last_run, run_ts: int, next_run: int) -> bool:
+        """Atomically advance last_run/next_run, guarded on the previous
+        last_run still matching, so two concurrent ticks racing on the same
+        due instant cannot both fire it (the loser's UPDATE matches zero rows)."""
+        cursor = await self._db.execute(
+            "UPDATE scheduled_tasks SET last_run = ?, next_run = ? "
+            "WHERE id = ? AND enabled = 1 "
+            "AND ((last_run IS NULL AND ? IS NULL) OR last_run = ?)",
+            (run_ts, next_run, task_id, prev_last_run, prev_last_run),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
     async def get_presets(self) -> list[dict]:
         async with self._db.execute("SELECT id, name, description, tasks FROM task_presets ORDER BY name") as cursor:
             return [{"id": r[0], "name": r[1], "description": r[2], "tasks": json.loads(r[3])} for r in await cursor.fetchall()]


### PR DESCRIPTION
## Bug
`TaskScheduler` persists scheduled tasks (cron `schedule`, `command`, `last_run`/`next_run`), and `PUT /api/settings/backup-schedule` stores an `auto-backup` task - but nothing ever executed them. Scheduled backups (and the other presets) silently never ran.

## Fix
A tick-loop execution engine mirroring the working `routine_tick_loop`:
- **`scheduled_task_tick_loop`** sweeps enabled tasks every 60s, computes due-ness via croniter (base = `last_run` or `created_at`), and dispatches due ones. Wired into the lifespan as a supervised background task next to the routines runner.
- **Atomic claim** (`TaskScheduler.claim_run`, guarded UPDATE on the prior `last_run`) so a concurrent/restarted tick cannot double-fire the same due instant.
- **`create_backup`** handler creates a `data-backups/auto-<ts>` snapshot (reusing the symlink-safe, owner-only `snapshot_data_dir`, now with a `prefix` param) and prunes to the newest 7.

## Security (the load-bearing property)
The `command` field is an arbitrary string (presets include `curl ...`, `qmd embed`). The engine dispatches **only** via a hardcoded allow-list (`_SAFE_COMMANDS = {"create_backup": ...}`); any other command is logged and skipped. There is no `subprocess`/`os.system`/`eval` path - stored command strings are never shell-executed. A dedicated test asserts `curl http://evil` is skipped, not run.

## Tests
`tests/scheduler/test_task_runner.py`: claim_run atomicity, due backup runs + advances last_run, not-due is a no-op, and the security test. Full scheduler suite green; app constructs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic scheduled task execution in the app, so due tasks can run in the background without manual intervention.
  * Added support for scheduled backups with a new backup prefix format and automatic cleanup of older auto-generated backups.

* **Bug Fixes**
  * Improved task execution reliability so only one runner can claim and process a task at a time.
  * Restricted scheduled commands to approved actions, preventing unknown commands from running and avoiding unintended side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->