### PR TITLE
fix(rkllama): surface the pull error on install failure instead of generic 'not registered' (#1548)

### DIFF
--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -42,6 +42,28 @@ class TestRkllamaIsRunning:
         assert rkllama_is_running() is False
 
 
+class TestParsePullError:
+    """The plain-text fallback must recognise real 'Error: ...' lines but not
+    lines that merely begin with those letters (folds Kilo review on #1681)."""
+
+    def test_ndjson_error_shape(self):
+        assert (
+            rkllama_installer._parse_pull_error('{"status":"error","error":"repo not found"}')
+            == "repo not found"
+        )
+
+    def test_plaintext_error_variants_match(self):
+        for line in ("Error: boom", "error something went wrong", "error"):
+            assert rkllama_installer._parse_pull_error(line) is not None
+
+    def test_lines_that_only_start_with_error_letters_do_not_match(self):
+        for line in ("errored gracefully", "error-free run", "Downloading 45%", "45%", ""):
+            assert rkllama_installer._parse_pull_error(line) is None
+
+    def test_success_ndjson_is_not_an_error(self):
+        assert rkllama_installer._parse_pull_error('{"status":"success"}') is None
+
+
 class TestParseHfResolveUrl:
     def test_standard_main_branch(self):
         url = (

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -172,6 +172,39 @@ class TestInstallVerification:
 
     @respx.mock
     @pytest.mark.asyncio
+    async def test_surfaces_pull_error_from_ndjson(self, monkeypatch):
+        # When the download errors AND the model never registers, the failure
+        # must surface the real cause, not the generic "could not confirm" (#1548).
+        monkeypatch.setattr(rkllama_installer.asyncio, "sleep", _no_sleep)
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(
+                200, text='{"status":"error","error":"repository not found"}\n'
+            )
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": []})
+        )
+        res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
+        assert res["success"] is False
+        assert "repository not found" in res["error"]
+        assert "download failed" in res["error"]
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_surfaces_pull_error_from_plaintext(self, monkeypatch):
+        monkeypatch.setattr(rkllama_installer.asyncio, "sleep", _no_sleep)
+        respx.post("http://localhost:7833/api/pull").mock(
+            return_value=httpx.Response(200, text="Downloading foo...\nError: Invalid path\n")
+        )
+        respx.get("http://localhost:7833/api/tags").mock(
+            return_value=httpx.Response(200, json={"models": []})
+        )
+        res = await self._installer().install("rkllama-x", {}, variant=_VARIANT)
+        assert res["success"] is False
+        assert "Invalid path" in res["error"]
+
+    @respx.mock
+    @pytest.mark.asyncio
     async def test_failure_when_tags_unreachable(self, monkeypatch):
         # Previously this path returned a false success. Now an unreachable
         # /api/tags (after retries) is a clean failure.

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -97,9 +97,15 @@ def default_rkllama_url() -> str:
 
 
 _PLAIN_PERCENT_RE = re.compile(r"^\s*(\d{1,3})(?:\.\d+)?\s*%\s*$")
+# "error" at the start of a plain-text line, followed by a colon, whitespace,
+# or end of line -- matches "Error: ...", "error ..." but not "errored" or
+# "error-free", which merely begin with those letters and aren't failures.
+_PLAIN_ERROR_RE = re.compile(r"error(?::|\s|$)", re.IGNORECASE)
 
 
-def _report_pull_progress(line: str, on_progress: Callable[[int, int], None]) -> None:
+def _report_pull_progress(
+    line: str, on_progress: Callable[[int, int], None], data: dict | None = None
+) -> None:
     """Parse one line from rkllama's /api/pull stream and forward
     ``(completed, total)`` to ``on_progress``.
 
@@ -116,11 +122,9 @@ def _report_pull_progress(line: str, on_progress: Callable[[int, int], None]) ->
     blanks) is ignored -- a stray or malformed line must never abort the
     install.
     """
-    try:
-        data = json.loads(line)
-    except (TypeError, ValueError):
-        data = None
-    if isinstance(data, dict):
+    if data is None:
+        data = _line_as_dict(line)
+    if data is not None:
         completed = data.get("completed")
         total = data.get("total")
         if isinstance(completed, (int, float)) and isinstance(total, (int, float)) and total > 0:
@@ -134,21 +138,37 @@ def _report_pull_progress(line: str, on_progress: Callable[[int, int], None]) ->
     on_progress(percent, 100)
 
 
-def _parse_pull_error(line: str) -> str | None:
-    """Return a human error string if a pull-stream line reports a failure, else
-    None. Handles both the ndjson shape (``{"status":"error","error":...}``) and
-    the plain-text ``"Error: ..."`` lines rkllama emits, so a failed download
-    surfaces its real cause instead of a generic "not registered" (#1548)."""
+def _line_as_dict(line: str) -> dict | None:
+    """Best-effort parse of a pull-stream line into a dict, else None. Shared by
+    the progress and error parsers so a single line is JSON-decoded once and
+    both answer from the same result (no risk of the two diverging on edge
+    cases like BOMs or trailing junk)."""
     try:
         data = json.loads(line)
     except (TypeError, ValueError):
-        data = None
-    if isinstance(data, dict):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _parse_pull_error(line: str, data: dict | None = None) -> str | None:
+    """Return a human error string if a pull-stream line reports a failure, else
+    None. Handles both the ndjson shape (``{"status":"error","error":...}``) and
+    the plain-text ``"Error: ..."`` lines rkllama emits, so a failed download
+    surfaces its real cause instead of a generic "not registered" (#1548).
+
+    ``data`` may be a pre-parsed dict for the line (from ``_line_as_dict``) so a
+    line isn't JSON-decoded twice; when omitted it is parsed here."""
+    if data is None:
+        data = _line_as_dict(line)
+    if data is not None:
         if str(data.get("status", "")).lower() == "error":
             return str(data.get("error") or "unknown error")
         return None
     stripped = line.strip()
-    if stripped.lower().startswith("error"):
+    # Match the word "error" (case-insensitive) at the start -- "Error: <msg>",
+    # "error <msg>" -- but not tokens that merely begin with those letters, like
+    # "errored gracefully" or "error-free", which are not failures.
+    if _PLAIN_ERROR_RE.match(stripped):
         return stripped
     return None
 
@@ -238,11 +258,15 @@ class RkllamaInstaller(AppInstaller):
                     async for line in resp.aiter_lines():
                         if line:
                             last_line = line
-                            err = _parse_pull_error(line)
+                            # Parse the line's JSON once and share it with both
+                            # the error and progress parsers so they can't
+                            # disagree on the same line.
+                            parsed = _line_as_dict(line)
+                            err = _parse_pull_error(line, parsed)
                             if err:
                                 pull_error = err
                             if on_progress is not None:
-                                _report_pull_progress(line, on_progress)
+                                _report_pull_progress(line, on_progress, parsed)
                     logger.info(
                         "rkllama install: pull complete for %s (last line: %s)",
                         app_id, last_line[:200],

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -134,6 +134,25 @@ def _report_pull_progress(line: str, on_progress: Callable[[int, int], None]) ->
     on_progress(percent, 100)
 
 
+def _parse_pull_error(line: str) -> str | None:
+    """Return a human error string if a pull-stream line reports a failure, else
+    None. Handles both the ndjson shape (``{"status":"error","error":...}``) and
+    the plain-text ``"Error: ..."`` lines rkllama emits, so a failed download
+    surfaces its real cause instead of a generic "not registered" (#1548)."""
+    try:
+        data = json.loads(line)
+    except (TypeError, ValueError):
+        data = None
+    if isinstance(data, dict):
+        if str(data.get("status", "")).lower() == "error":
+            return str(data.get("error") or "unknown error")
+        return None
+    stripped = line.strip()
+    if stripped.lower().startswith("error"):
+        return stripped
+    return None
+
+
 def parse_hf_resolve_url(url: str) -> tuple[str, str, str]:
     """Return (user, repo, filename) for an HF resolve URL.
 
@@ -199,6 +218,10 @@ class RkllamaInstaller(AppInstaller):
         endpoint = f"{self.rkllama_url}/api/pull"
         logger.info("rkllama install: POST %s body=%r", endpoint, body)
 
+        # Capture any error the download stream reports so a failure surfaces the
+        # real cause (e.g. HuggingFace unreachable, repo not found) rather than a
+        # generic "not registered" (#1548).
+        pull_error: str | None = None
         try:
             async with httpx.AsyncClient(timeout=self.timeout) as client:
                 # /api/pull streams plain-text progress lines (see
@@ -215,6 +238,9 @@ class RkllamaInstaller(AppInstaller):
                     async for line in resp.aiter_lines():
                         if line:
                             last_line = line
+                            err = _parse_pull_error(line)
+                            if err:
+                                pull_error = err
                             if on_progress is not None:
                                 _report_pull_progress(line, on_progress)
                     logger.info(
@@ -267,6 +293,15 @@ class RkllamaInstaller(AppInstaller):
                 await asyncio.sleep(1.0 * (attempt + 1))
 
         if not verified:
+            # If the download itself reported an error, that is the real cause;
+            # surface it instead of the generic "could not confirm" (#1548). A
+            # stray error line that still ended in a registered model does not
+            # reach here (verified is True), so this never masks a real success.
+            if pull_error:
+                return {
+                    "success": False,
+                    "error": f"model download failed on the rkllama backend: {pull_error}",
+                }
             return {
                 "success": False,
                 "error": (


### PR DESCRIPTION
## What

When an rkllama model install fails at the download step, the installer previously fell through to a generic `model not registered` message — hiding the actual cause (HuggingFace unreachable, repo/file not found, disk full, etc.). This is exactly what bit @mandresve in #1548: the download failed on his network, but taOS reported it as a registration problem, so the failure was not self-diagnosing.

## Change

- New `_parse_pull_error(line)` helper: recognises a failure in a pull-stream line in both shapes the fork emits — the ndjson `{"status":"error","error":...}` and the plain-text `Error: ...` lines — and returns the human error string.
- The drain loop records the last reported error into `pull_error` alongside the existing progress reporting.
- When post-download verification fails, if the stream reported an error we surface `model download failed on the rkllama backend: <cause>` instead of the generic message.

## Why it does not mask real successes

The error is only surfaced inside the `if not verified:` path. A stray `Error:` line that still ends in a successfully-registered model reaches `verified = True` and returns success normally, so a real success is never turned into a failure. This is covered by the pre-existing `test_error_and_blank_lines_ignored_not_raised`.

## Tests

- `test_surfaces_pull_error_from_ndjson` — ndjson error line + empty `/api/tags` → `success: False` with the real cause in `error`.
- `test_surfaces_pull_error_from_plaintext` — plain-text `Error: ...` line + empty `/api/tags` → same.
- All 28 installer tests pass.

Closes #1548.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installation failures now surface the actual download/pull error message instead of only a generic confirmation failure.
  * Improved handling for both structured error responses and plain text error output during model downloads.

* **Tests**
  * Added coverage for failed install scenarios to verify the specific error message is returned to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->