### PR TITLE
fix(rkllama): land models in the unified taOS tree so the Models UI sees them (#1548)

### DIFF
--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -585,7 +585,17 @@ migrate_legacy_models() {
 }
 
 pull_models() {
-    run_as_user mkdir -p "$RKLLAMA_MODELS"
+    # The unified root (TAOS_MODELS_ROOT / <project>/data/models) may live under
+    # a tree the service user can't write (e.g. a project dir owned by someone
+    # else -> EACCES). If creating it as $TARGET_USER fails, fall back to the
+    # always-safe per-install path under $TARGET_HOME so the install still
+    # succeeds. RKLLAMA_MODELS is global, so install_systemd_unit (called after
+    # pull_models) picks up the fallback too.
+    if ! run_as_user mkdir -p "$RKLLAMA_MODELS" 2>/dev/null; then
+        warn "cannot create $RKLLAMA_MODELS as $TARGET_USER; falling back to $LEGACY_RKLLAMA_MODELS"
+        RKLLAMA_MODELS="$LEGACY_RKLLAMA_MODELS"
+        run_as_user mkdir -p "$RKLLAMA_MODELS"
+    fi
     migrate_legacy_models
 
     fetch_model "qwen3-embedding-0.6b" "$EMBEDDING_LOCAL_NAME" "$EMBEDDING_URL" \

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -216,9 +216,45 @@ TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
 [[ -d "$TARGET_HOME" ]] || die "cannot resolve home directory for user $TARGET_USER"
 TARGET_GROUP="$(id -gn "$TARGET_USER")"
 
+# The unit runs rkllama as $TARGET_USER (see install_systemd_unit), not root.
+# On RK3588 the NPU/GPU is reached through the render/video group-owned DRI
+# nodes (/dev/dri/renderD12x, /dev/mpp_service, mode 660), so the service user
+# must be in those groups or model load fails with a device-permission error.
+# Best-effort (like install-server.sh's incus/docker group setup): warn, don't
+# die, if a group is absent on this board.
+for _grp in render video; do
+    if getent group "$_grp" >/dev/null 2>&1; then
+        if ! id -nG "$TARGET_USER" | tr ' ' '\n' | grep -qx "$_grp"; then
+            sudo usermod -aG "$_grp" "$TARGET_USER" \
+                && log "added '$TARGET_USER' to the '$_grp' group (NPU/GPU device access)" \
+                || warn "could not add '$TARGET_USER' to '$_grp' — rkllama may fail to reach the NPU"
+        fi
+    else
+        warn "group '$_grp' not found — if rkllama can't reach the NPU, create it and re-run"
+    fi
+done
+
 RKLLAMA_DIR="${TAOS_RKLLAMA_DIR:-$TARGET_HOME/rkllama}"
 RKLLAMA_VENV="$RKLLAMA_DIR/rkllama-env"
-RKLLAMA_MODELS="$RKLLAMA_DIR/models"
+
+# Models land in the unified taOS model tree so every backend shares one
+# location and the Models UI — which scans <data_dir>/models recursively and
+# recognises .rkllm — sees rkllama pulls. Previously rkllama wrote to its own
+# ~/rkllama/models, which taOS never scanned, so a downloaded model never
+# appeared in the UI (#1548). Resolution order:
+#   1. TAOS_MODELS_ROOT env (taOS may export it),
+#   2. <project_dir>/data/models derived from arg 1 (taOS's script installer
+#      passes the project root; data_dir defaults to <project>/data),
+#   3. legacy $RKLLAMA_DIR/models for standalone runs with neither available.
+LEGACY_RKLLAMA_MODELS="$RKLLAMA_DIR/models"
+TAOS_PROJECT_DIR="${1:-}"
+if [[ -n "${TAOS_MODELS_ROOT:-}" ]]; then
+    RKLLAMA_MODELS="${TAOS_MODELS_ROOT%/}/rkllama"
+elif [[ -n "$TAOS_PROJECT_DIR" && -d "$TAOS_PROJECT_DIR/data" ]]; then
+    RKLLAMA_MODELS="${TAOS_PROJECT_DIR%/}/data/models/rkllama"
+else
+    RKLLAMA_MODELS="$LEGACY_RKLLAMA_MODELS"
+fi
 
 # run_as_user <cmd...> — run a command as the unprivileged target user
 run_as_user() {
@@ -526,8 +562,31 @@ TEMPERATURE=$temperature
 EOF
 }
 
+# One-time move of models from the legacy per-install ~/rkllama/models tree
+# into the unified taOS tree, so an upgrade doesn't strand already-downloaded
+# weights (and force a re-download). Idempotent: only moves model dirs that
+# aren't already present at the destination, and is a no-op when the legacy
+# and unified paths are the same or the legacy tree is absent/empty.
+migrate_legacy_models() {
+    [[ "$LEGACY_RKLLAMA_MODELS" == "$RKLLAMA_MODELS" ]] && return 0
+    [[ -d "$LEGACY_RKLLAMA_MODELS" ]] || return 0
+    local moved=0 entry name
+    for entry in "$LEGACY_RKLLAMA_MODELS"/*/; do
+        [[ -d "$entry" ]] || continue
+        name="$(basename "$entry")"
+        if [[ -e "$RKLLAMA_MODELS/$name" ]]; then
+            continue  # already migrated / present — leave the legacy copy for the user to clean up
+        fi
+        run_as_user mv "$entry" "$RKLLAMA_MODELS/$name"
+        moved=$((moved + 1))
+    done
+    [[ "$moved" -gt 0 ]] && log "migrated $moved model(s) from $LEGACY_RKLLAMA_MODELS -> $RKLLAMA_MODELS"
+    return 0
+}
+
 pull_models() {
     run_as_user mkdir -p "$RKLLAMA_MODELS"
+    migrate_legacy_models
 
     fetch_model "qwen3-embedding-0.6b" "$EMBEDDING_LOCAL_NAME" "$EMBEDDING_URL" \
         "$EMBEDDING_HF_TOKENIZER" \

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1707,6 +1707,18 @@ ensure_taos_user() {
     else
         warn "'docker' group not found — skipping (install Docker first, then re-run to add 'taos' to the group)"
     fi
+
+    # GPU/NPU device access. Backends (rkllama, image-gen, hardware video
+    # encode) run as 'taos', not root, and reach the accelerator through the
+    # render/video group-owned DRI/mpp device nodes (mode 660). Without these
+    # groups an NPU/GPU model load fails with a device-permission error.
+    for _dev_grp in render video; do
+        if getent group "$_dev_grp" >/dev/null 2>&1; then
+            $sudo_cmd usermod -aG "$_dev_grp" taos >/dev/null 2>&1 \
+                && log "added 'taos' to the '$_dev_grp' group (GPU/NPU device access)" \
+                || warn "could not add 'taos' to '$_dev_grp' — GPU/NPU backends may fail"
+        fi
+    done
 }
 
 # --- data dir ownership + permissions ------------------------------------

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1713,7 +1713,11 @@ ensure_taos_user() {
     # render/video group-owned DRI/mpp device nodes (mode 660). Without these
     # groups an NPU/GPU model load fails with a device-permission error.
     for _dev_grp in render video; do
-        if getent group "$_dev_grp" >/dev/null 2>&1; then
+        if ! getent group "$_dev_grp" >/dev/null 2>&1; then
+            warn "group '$_dev_grp' not found — if a GPU/NPU backend can't reach the device, create it and re-run"
+        elif id -nG taos 2>/dev/null | tr ' ' '\n' | grep -qx "$_dev_grp"; then
+            log "'taos' already in the '$_dev_grp' group"
+        else
             $sudo_cmd usermod -aG "$_dev_grp" taos >/dev/null 2>&1 \
                 && log "added 'taos' to the '$_dev_grp' group (GPU/NPU device access)" \
                 || warn "could not add 'taos' to '$_dev_grp' — GPU/NPU backends may fail"

--- a/tests/test_install_rknpu_health_gate.sh
+++ b/tests/test_install_rknpu_health_gate.sh
@@ -58,4 +58,68 @@ if ! grep -q "systemctl enable --now rkllama.service" "$NPU_SCRIPT"; then
   exit 1
 fi
 
+echo "test: rkllama models land in the unified taOS tree (#1548)"
+# The service must point rkllama at \$RKLLAMA_MODELS, and that path must be
+# resolved from the unified root (TAOS_MODELS_ROOT / <project>/data/models),
+# not the old per-install ~/rkllama/models, so the Models UI scan sees pulls.
+if ! grep -q -- "--models \$RKLLAMA_MODELS" "$NPU_SCRIPT"; then
+  echo "FAIL: rkllama.service ExecStart no longer uses --models \$RKLLAMA_MODELS"
+  exit 1
+fi
+if ! grep -q 'TAOS_MODELS_ROOT' "$NPU_SCRIPT"; then
+  echo "FAIL: install-rknpu.sh no longer honours TAOS_MODELS_ROOT for the unified model tree"
+  exit 1
+fi
+if ! grep -q 'data/models/rkllama' "$NPU_SCRIPT"; then
+  echo "FAIL: install-rknpu.sh no longer derives the unified <project>/data/models/rkllama path"
+  exit 1
+fi
+
+echo "test: migrate_legacy_models moves legacy models, is idempotent, and never re-downloads"
+MIG_FN="$(sed -n '/^migrate_legacy_models() {/,/^}/p' "$NPU_SCRIPT")"
+if [ -z "$MIG_FN" ]; then
+  echo "FAIL: could not extract migrate_legacy_models() from $NPU_SCRIPT"
+  exit 1
+fi
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mig_out="$(
+  (
+    log() { :; }
+    run_as_user() { "$@"; }  # tests run as the invoking user
+    LEGACY_RKLLAMA_MODELS="$TMP/legacy"
+    RKLLAMA_MODELS="$TMP/unified"
+    mkdir -p "$LEGACY_RKLLAMA_MODELS/gemma3-270m" "$RKLLAMA_MODELS"
+    echo weights > "$LEGACY_RKLLAMA_MODELS/gemma3-270m/model.rkllm"
+    # Pre-existing model at destination must NOT be clobbered by a legacy copy.
+    mkdir -p "$RKLLAMA_MODELS/qwen3-1.7b" "$LEGACY_RKLLAMA_MODELS/qwen3-1.7b"
+    echo keep > "$RKLLAMA_MODELS/qwen3-1.7b/model.rkllm"
+    echo stale > "$LEGACY_RKLLAMA_MODELS/qwen3-1.7b/model.rkllm"
+    eval "$MIG_FN"
+    migrate_legacy_models
+    migrate_legacy_models  # second run must be a clean no-op
+    [ -f "$RKLLAMA_MODELS/gemma3-270m/model.rkllm" ] || { echo "MISSING_MIGRATED"; exit 1; }
+    [ ! -d "$LEGACY_RKLLAMA_MODELS/gemma3-270m" ] || { echo "LEGACY_NOT_MOVED"; exit 1; }
+    [ "$(cat "$RKLLAMA_MODELS/qwen3-1.7b/model.rkllm")" = "keep" ] || { echo "CLOBBERED_EXISTING"; exit 1; }
+    echo OK
+  ) 2>&1
+)" && mrc=0 || mrc=$?
+if [ "$mrc" -ne 0 ] || ! grep -q '^OK$' <<<"$mig_out"; then
+  echo "FAIL: migrate_legacy_models misbehaved: $mig_out"
+  exit 1
+fi
+echo "PASS: migrate_legacy_models moves new models, keeps existing, idempotent"
+
+echo "test: service user is granted render+video groups for NPU/GPU access"
+# The unit runs rkllama as \$TARGET_USER (not root), so on RK3588 that user
+# must be in render+video to reach the DRI/mpp device nodes.
+if ! grep -q 'User=\$TARGET_USER' "$NPU_SCRIPT"; then
+  echo "FAIL: rkllama.service no longer runs as \$TARGET_USER (would run as root)"
+  exit 1
+fi
+if ! grep -qE 'for _grp in render video' "$NPU_SCRIPT"; then
+  echo "FAIL: install-rknpu.sh no longer grants the service user render+video groups"
+  exit 1
+fi
+
 echo "all tests passed"


### PR DESCRIPTION
## The bug (root-caused on the Pi)

@mandresve reported (#1548) that a model downloads to completion but never appears in the Models list. Reproduced on identical RK3588 hardware: the current `jaylfc/rkllama` fork downloads and **registers correctly** — the `.rkllm` shows in rkllama's own `/api/tags`. The gap is purely *where* rkllama writes vs *where* taOS looks:

- rkllama's systemd unit runs `--models ~/rkllama/models`.
- taOS's Models UI lists downloaded models by disk-scanning its own roots (`data/models` + `models_root()`), which recurse and recognise `.rkllm`.
- `~/rkllama/models` is **neither** taOS root, so the model is downloaded-but-invisible.

## The fix

Point rkllama at the **unified taOS model tree** (`data_dir/models/rkllama`), which taOS already scans recursively:

- **Path resolution** in `install-rknpu.sh`: `TAOS_MODELS_ROOT` → else `<project_dir>/data/models` (taOS passes the project root as arg 1; `data_dir` defaults to `<project>/data`) → else the legacy per-install dir for standalone runs. Because taOS invokes the installer as `taos` and `~taos` resolves to the install dir, the whole rkllama tree + models land under taos ownership with no cross-user perms.
- **Run backends as `taos`:** the unit already runs as `$TARGET_USER` (= `taos` via taOS). On RK3588 the NPU/GPU is reached through the `render`/`video` group-owned DRI/mpp nodes (there is no `/dev/rknpu`), so this grants the service user those groups — in both `install-rknpu.sh` (for the NPU service user) and `install-server.sh` (for the `taos` user generally, so every GPU/NPU backend can run as taos). **Verified on the Pi:** after `usermod -aG render,video taos`, the `taos` user can read/write and `open()` the DRI render node.
- **Migration:** existing `~/rkllama/models` is moved into the unified tree on upgrade — idempotent, non-clobbering, no re-download.

## Why data_dir/models

It is the persistent data dir taOS already uses (survives `git pull` updates) and is `taos`-owned, so with all backends running as `taos` it needs no permission loosening.

## Tests

Extended `tests/test_install_rknpu_health_gate.sh`: unified-root resolution + `--models $RKLLAMA_MODELS`, the `render`/`video` grant + `User=$TARGET_USER`, and a behavioural `migrate_legacy_models` test (moves new, keeps existing, idempotent). All pass.

## Scope

This is the rkllama slice. A follow-up collapses taOS's own two roots (`data/models` vs `models_root()`) into one and migrates any legacy llama.cpp models.

Part of #1548.