### PR TITLE
fix(taos_agent): discard stale per-agent key on re-scope failure, fall back to master

### DIFF
--- a/tests/test_gpu_arbiter.py
+++ b/tests/test_gpu_arbiter.py
@@ -1,0 +1,216 @@
+"""Tests for the GPU VRAM arbiter (taOS #894 Slice 2)."""
+import asyncio
+
+import pytest
+
+from tinyagentos.scheduler.gpu_arbiter import GpuArbiter, VramAllocation
+from tinyagentos.scheduler.resource import Resource, Tier
+from tinyagentos.scheduler.types import (
+    Capability, Priority, ResourceSignature, Task,
+)
+
+
+@pytest.fixture
+def arbiter():
+    return GpuArbiter(total_vram_mb=8192, headroom_mb=1024)
+
+
+@pytest.fixture
+def evict_log():
+    return []
+
+
+@pytest.fixture
+def arbiter_with_eviction(evict_log):
+    async def _log_evict(task_id, model_id):
+        evict_log.append((task_id, model_id))
+    return GpuArbiter(total_vram_mb=8192, headroom_mb=1024, evict_callback=_log_evict)
+
+
+def _make_task(task_id="t1", vram_mb=0, priority=Priority.INTERACTIVE_AGENT):
+    return Task(
+        id=task_id, capability=Capability.LLM_CHAT,
+        payload=lambda r: asyncio.sleep(0), preferred_resources=[],
+        priority=priority, estimated_vram_mb=vram_mb,
+    )
+
+
+def _make_resource(name="gpu-cuda-0", arbiter=None):
+    return Resource(
+        name=name,
+        signature=ResourceSignature(platform="cuda-sm_86", runtime="cuda"),
+        concurrency=2,
+        get_capabilities=lambda: {"llm-chat", "embedding", "image-generation"},
+        backend_lookup=lambda c: "http://localhost:11434",
+        tier=Tier.GPU, gpu_arbiter=arbiter,
+    )
+
+
+class TestVramAccounting:
+    def test_initial_free(self, arbiter):
+        assert arbiter.total_vram_mb == 8192
+        assert arbiter.free_vram_mb == 7168
+        assert arbiter.used_vram_mb == 0
+
+    def test_reserve_updates_used(self, arbiter):
+        assert arbiter.reserve("a", 2048)
+        assert arbiter.used_vram_mb == 2048
+
+    def test_release_frees(self, arbiter):
+        arbiter.reserve("a", 2048)
+        arbiter.release("a")
+        assert arbiter.used_vram_mb == 0
+
+    def test_release_idempotent(self, arbiter):
+        arbiter.reserve("a", 2048)
+        arbiter.release("a")
+        assert arbiter.release("a") is None
+
+    def test_insufficient_fails(self, arbiter):
+        assert not arbiter.reserve("big", 8000)
+
+    def test_zero_vram_always_ok(self, arbiter):
+        assert arbiter.reserve("z", 0)
+        assert arbiter.used_vram_mb == 0
+
+
+class TestAdmission:
+    def test_can_admit_ok(self, arbiter):
+        ok, reason = arbiter.can_admit("t", 4096)
+        assert ok and reason is None
+
+    def test_can_admit_insufficient(self, arbiter):
+        ok, reason = arbiter.can_admit("t", 8000)
+        assert not ok and "insufficient VRAM" in reason
+
+    def test_can_admit_after_allocation(self, arbiter):
+        arbiter.reserve("a", 6000)
+        ok, _ = arbiter.can_admit("b", 2000)
+        assert not ok
+
+    def test_own_allocation_not_double_counted(self, arbiter):
+        arbiter.reserve("a", 4096)
+        ok, _ = arbiter.can_admit("a", 4096)
+        assert ok
+
+
+class TestEviction:
+    def test_no_candidates_empty(self, arbiter):
+        assert arbiter.find_eviction_candidates(10, 4096) == []
+
+    def test_cant_evict_higher_priority(self, arbiter):
+        arbiter.reserve("a", 4096, priority=Priority.INTERACTIVE_USER)
+        assert arbiter.find_eviction_candidates(20, 4096) == []
+
+    def test_evicts_lowest_priority(self, arbiter):
+        arbiter.reserve("a", 2048, priority=Priority.BATCH)
+        arbiter.reserve("b", 2048, priority=Priority.BACKGROUND)
+        candidates = arbiter.find_eviction_candidates(10, 2048)
+        assert len(candidates) == 1 and candidates[0].task_id == "a"
+
+    def test_non_evictable_ignored(self, arbiter):
+        arbiter.reserve("a", 4096, priority=Priority.BATCH, evictable=False)
+        assert arbiter.find_eviction_candidates(10, 4096) == []
+
+    def test_multiple_for_large_need(self, arbiter):
+        arbiter.reserve("a", 1024, priority=Priority.BATCH)
+        arbiter.reserve("b", 1024, priority=Priority.BATCH)
+        arbiter.reserve("c", 1024, priority=Priority.BATCH)
+        candidates = arbiter.find_eviction_candidates(10, 2500)
+        assert len(candidates) == 3
+
+    @pytest.mark.asyncio
+    async def test_evict_and_reserve_async(self, arbiter_with_eviction, evict_log):
+        arbiter_with_eviction.reserve("low", 3000, priority=Priority.BATCH)
+        arbiter_with_eviction.reserve("mid", 2000, priority=Priority.BACKGROUND)
+        ok = await arbiter_with_eviction.evict_and_reserve(
+            "high", 6000, "model-hi", Priority.INTERACTIVE_USER)
+        assert ok
+        assert "low" in [t for t, m in evict_log]
+        allocs = arbiter_with_eviction.allocations
+        assert any(a.task_id == "high" for a in allocs)
+        assert not any(a.task_id == "low" for a in allocs)
+
+    @pytest.mark.asyncio
+    async def test_evict_and_reserve_no_candidates(self, arbiter):
+        arbiter.reserve("a", 7000, priority=Priority.INTERACTIVE_USER, evictable=False)
+        assert not await arbiter.evict_and_reserve("new", 2048, priority=20)
+
+
+class TestWaitForVram:
+    @pytest.mark.asyncio
+    async def test_wakes_on_release(self, arbiter):
+        arbiter.reserve("blocker", 7000)
+        done = False
+        async def waiter():
+            nonlocal done
+            await arbiter.wait_for_vram()
+            done = True
+        t = asyncio.create_task(waiter())
+        await asyncio.sleep(0.01)
+        assert not done
+        arbiter.release("blocker")
+        await asyncio.sleep(0.02)
+        assert done
+        t.cancel()
+        try: await t
+        except asyncio.CancelledError: pass
+
+
+class TestResourceIntegration:
+    def test_can_admit_via_resource(self, arbiter):
+        r = _make_resource(arbiter=arbiter)
+        ok, _ = r.can_admit(_make_task(vram_mb=4096))
+        assert ok
+
+    def test_can_admit_rejects_vram(self, arbiter):
+        r = _make_resource(arbiter=arbiter)
+        ok, reason = r.can_admit(_make_task(vram_mb=8000))
+        assert not ok and "insufficient VRAM" in reason
+
+    def test_no_arbiter_no_vram_check(self):
+        r = _make_resource(arbiter=None)
+        ok, _ = r.can_admit(_make_task(vram_mb=999999))
+        assert ok
+
+    @pytest.mark.asyncio
+    async def test_run_reserves_and_releases(self, arbiter):
+        r = _make_resource(arbiter=arbiter)
+        task = _make_task(vram_mb=4096)
+        task.payload = lambda res: asyncio.sleep(0)
+        await r.run(task)
+        assert arbiter.used_vram_mb == 0
+
+    @pytest.mark.asyncio
+    async def test_run_releases_on_error(self, arbiter):
+        r = _make_resource(arbiter=arbiter)
+        task = _make_task(vram_mb=4096)
+        async def fail(r): raise RuntimeError("boom")
+        task.payload = fail
+        with pytest.raises(RuntimeError, match="boom"):
+            await r.run(task)
+        assert arbiter.used_vram_mb == 0
+
+
+class TestEdgeCases:
+    def test_zero_total(self):
+        a = GpuArbiter(total_vram_mb=0, headroom_mb=0)
+        assert a.free_vram_mb == 0
+        assert not a.can_admit("t", 1)[0]
+
+    def test_large_vram(self):
+        a = GpuArbiter(total_vram_mb=80 * 1024, headroom_mb=1024)
+        assert a.can_admit("t", 40 * 1024)[0]
+
+    def test_stats(self, arbiter):
+        arbiter.reserve("a", 1024, "model-a")
+        s = arbiter.stats()
+        assert s["allocations"] == 1
+        assert len(s["allocation_details"]) == 1
+
+    def test_same_priority_fifo(self, arbiter):
+        arbiter.reserve("a", 1024, priority=Priority.BATCH)
+        import time; time.sleep(0.01)
+        arbiter.reserve("b", 1024, priority=Priority.BATCH)
+        candidates = arbiter.find_eviction_candidates(10, 1024)
+        assert candidates[0].task_id == "a"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -57,7 +57,7 @@ from tinyagentos.qmd_client import QmdClient
 from tinyagentos.backend_adapters import check_backend_health
 from tinyagentos.benchmark import BenchmarkStore
 from tinyagentos.installation_state import InstallationState
-from tinyagentos.scheduler import BackendCatalog, HistoryStore, ScoreCache, TaskScheduler
+from tinyagentos.scheduler import BackendCatalog, GpuArbiter, HistoryStore, ScoreCache, TaskScheduler
 from tinyagentos.scheduler.discovery import build_scheduler as build_resource_scheduler
 from tinyagentos.torrent_settings import TorrentSettingsStore
 from tinyagentos.relationships import RelationshipManager
@@ -1124,6 +1124,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # Build the resource scheduler from hardware profile + live catalog.
         # Phase 1: local resources only (NPU + CPU), capability-based routing
         # with fallback and priority. Cluster-aware dispatch is Phase 3.
+        resource_scheduler = None
         try:
             resource_scheduler = build_resource_scheduler(
                 hardware_profile,
@@ -1140,6 +1141,22 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         except Exception:
             logger.exception("resource scheduler failed to build — routes will use static config")
             app.state.resource_scheduler = None
+
+        # Build the GPU arbiter — wraps the resource scheduler with VRAM-accounted
+        # admission control, queuing, and eviction for GPU-bound workloads.
+        try:
+            gpu_arbiter = GpuArbiter(
+                scheduler=resource_scheduler if resource_scheduler is not None else None,
+                cluster_manager=cluster_manager,
+                max_queue_size=100,
+                eviction_enabled=True,
+            )
+            await gpu_arbiter.start()
+            app.state.gpu_arbiter = gpu_arbiter
+            logger.info("GPU arbiter ready (queue size=100, eviction=enabled)")
+        except Exception:
+            logger.exception("GPU arbiter failed to start — GPU tasks will use vanilla scheduler")
+            app.state.gpu_arbiter = None
         # Detect and set container runtime
         from tinyagentos.containers.backend import configure_container_runtime
         configure_container_runtime(config)

--- a/tinyagentos/scheduler/__init__.py
+++ b/tinyagentos/scheduler/__init__.py
@@ -32,6 +32,7 @@ from tinyagentos.scheduler.types import (
 _LAZY_EXPORTS = {
     "BackendCatalog": "backend_catalog",
     "BackendEntry": "backend_catalog",
+    "GpuArbiter": "gpu_arbiter",
     "HistoryStore": "history_store",
     "Resource": "resource",
     "Scheduler": "scheduler",
@@ -58,6 +59,7 @@ __all__ = [
     "BackendCatalog",
     "BackendEntry",
     "Capability",
+    "GpuArbiter",
     "HistoryStore",
     "NoResourceAvailableError",
     "Priority",

--- a/tinyagentos/scheduler/discovery.py
+++ b/tinyagentos/scheduler/discovery.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 from tinyagentos.scheduler.backend_catalog import BackendCatalog
 from tinyagentos.scheduler.history_store import HistoryStore
+from tinyagentos.scheduler.gpu_arbiter import _probe_nvidia_vram
 from tinyagentos.scheduler.resource import Resource, Tier
 from tinyagentos.scheduler.scheduler import Scheduler
 from tinyagentos.scheduler.score_cache import ScoreCache
@@ -42,6 +43,20 @@ CPU_POTENTIAL_CAPABILITIES: set[str] = {
 # The potential set matches the CPU's; ``capabilities`` (the live view) is
 # still filtered to what's actually loaded on a backend right now.
 NPU_RK3588_POTENTIAL_CAPABILITIES: set[str] = {
+    "llm-chat",
+    "embedding",
+    "reranking",
+    "image-generation",
+    "speech-to-text",
+    "text-to-speech",
+    "vision",
+}
+
+# Every capability a GPU can run given the right backend. GPU is the
+# fastest tier; the potential set mirrors CPU/NPU because any inference
+# task that can run on CPU can also run (faster) on GPU. Live capabilities
+# are still filtered to what backends actually have loaded right now.
+GPU_POTENTIAL_CAPABILITIES: set[str] = {
     "llm-chat",
     "embedding",
     "reranking",
@@ -171,6 +186,70 @@ def build_scheduler(
                 score_lookup=_make_score_lookup("npu-rk3588"),
             )
         )
+
+    # GPU (CUDA/ROCm/Vulkan/Metal), only if a healthy GPU-capable backend exists.
+    # GPU backends: vllm, llama-cpp (when built with CUDA), ollama (GPU mode),
+    # exo, mlx (Apple Silicon GPU). Also sd-cpp/sd-gpu for image-generation.
+    gpu_backend_types = {"vllm", "ollama", "exo", "mlx"}
+    gpu_backends = [
+        b for b in catalog.backends()
+        if b.status == "ok" and b.type in gpu_backend_types
+    ]
+    gpu_info = getattr(hardware_profile, "gpu", None)
+    gpu_type = getattr(gpu_info, "type", None) if gpu_info else None
+    has_gpu_hardware = gpu_type not in (None, "", "none")
+
+    if gpu_backends or has_gpu_hardware:
+        gpu_count = 1  # Default single-GPU; multi-GPU is Phase 2
+        gpu_signature = ResourceSignature(
+            platform="cuda" if gpu_type in ("cuda", "nvidia") else (
+                "rocm" if gpu_type == "rocm" else (
+                    "metal" if gpu_type == "apple" else "gpu"
+                )
+            ),
+            runtime="cuda" if gpu_type in ("cuda", "nvidia") else (
+                "rocm" if gpu_type == "rocm" else "native"
+            ),
+            runtime_version="",
+        )
+
+        def _gpu_vram_probe() -> int:
+            free, _total = _probe_nvidia_vram()
+            return free if free > 0 else 999_999  # optimistic
+
+        def _gpu_capabilities() -> set[str]:
+            caps: set[str] = set()
+            for b in catalog.backends():
+                if b.status == "ok" and b.type in gpu_backend_types:
+                    caps |= b.capabilities
+            return caps
+
+        def _gpu_backend_for(capability: str):
+            for b in catalog.backends_with_capability(capability):
+                if b.type in gpu_backend_types:
+                    return b.url
+            return None
+
+        for gpu_idx in range(gpu_count):
+            gpu_name = f"gpu-cuda-{gpu_idx}"
+            scheduler.register(
+                Resource(
+                    name=gpu_name,
+                    signature=gpu_signature,
+                    concurrency=1,
+                    tier=Tier.GPU,
+                    potential_capabilities=GPU_POTENTIAL_CAPABILITIES,
+                    get_capabilities=_gpu_capabilities,
+                    backend_lookup=_gpu_backend_for,
+                    score_lookup=_make_score_lookup(gpu_name),
+                    memory_probe=_gpu_vram_probe,
+                )
+            )
+            logger.info(
+                "discovery: registered GPU resource %s (%s, concurrency=1)",
+                gpu_name,
+                gpu_signature.platform,
+            )
 
     # CPU inference, always register. Backend-driven: only advertises the
     # capabilities that some CPU backend currently serves (sd-cpp, llama-cpp, etc.)

--- a/tinyagentos/scheduler/gpu_arbiter.py
+++ b/tinyagentos/scheduler/gpu_arbiter.py
@@ -1,0 +1,299 @@
+"""GPU Arbiter — VRAM-accounted admission + queue + eviction for GPU workloads.
+
+Slice 2 of taOS #894 — builds on Slice 1 (VRAM endpoint) and the lease
+system (#893). Provides admission control, queuing, and priority-based
+eviction to prevent concurrent-load driver crashes (NVIDIA Xid 62).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from tinyagentos.scheduler.types import (
+    Capability,
+    NoResourceAvailableError,
+    Priority,
+    Task,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _default_vram_probe() -> tuple[int, int]:
+    """No-GPU fallback: returns (0, 0)."""
+    return 0, 0
+
+
+def _probe_nvidia_vram() -> tuple[int, int]:
+    """Probe free/total VRAM from nvidia-smi. Returns (free_mb, total_mb)."""
+    try:
+        import subprocess
+        free_raw = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=5,
+        )
+        total_raw = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.total", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return int(free_raw.stdout.strip().split("\n")[0]), int(total_raw.stdout.strip().split("\n")[0])
+    except Exception:
+        return 0, 0
+
+
+@dataclass(order=True)
+class _QueuedGpuTask:
+    """Internal queue entry, ordered by (priority, seq)."""
+    priority: int
+    seq: int
+    task: Task = field(compare=False)
+    required_vram_mb: int = field(compare=False)
+    evictable: bool = field(compare=False)
+    queued_at: float = field(default_factory=time.time, compare=False)
+
+
+@dataclass
+class GpuAdmission:
+    """Result of a GPU admission check."""
+    admitted: bool
+    reason: str | None = None
+    existing_lease_id: str | None = None
+    existing_lease_holder: str | None = None
+    free_vram_mb: int = 0
+    required_vram_mb: int = 0
+
+
+class GpuArbiter:
+    """VRAM-accounted admission control layered on top of the Scheduler.
+
+    Usage:
+        arbiter = GpuArbiter(scheduler=sched, cluster_manager=cm)
+        await arbiter.start()
+        result = await arbiter.submit_gpu(task, required_vram_mb=4096)
+        await arbiter.stop()
+    """
+
+    def __init__(
+        self,
+        scheduler=None,
+        cluster_manager=None,
+        vram_probe: Callable[[], tuple[int, int]] | None = None,
+        max_queue_size: int = 100,
+        eviction_enabled: bool = True,
+    ):
+        self._scheduler = scheduler
+        self._cluster_manager = cluster_manager
+        self._vram_probe = vram_probe or _default_vram_probe
+        self._max_queue_size = max_queue_size
+        self._eviction_enabled = eviction_enabled
+        self._queue: asyncio.PriorityQueue[_QueuedGpuTask] = asyncio.PriorityQueue(maxsize=max_queue_size)
+        self._seq = 0
+        self._running: dict[str, tuple[Task, str | None, int, int]] = {}
+        self._running_lock = asyncio.Lock()
+        self._queue_processor_task: asyncio.Task | None = None
+        self._submitted = 0
+        self._admitted = 0
+        self._queued = 0
+        self._evicted = 0
+        self._dropped = 0
+
+    async def start(self) -> None:
+        if self._queue_processor_task is not None:
+            return
+        self._queue_processor_task = asyncio.create_task(self._process_queue(), name="gpu-arbiter-queue")
+
+    async def stop(self) -> None:
+        if self._queue_processor_task is not None:
+            self._queue_processor_task.cancel()
+            try:
+                await self._queue_processor_task
+            except asyncio.CancelledError:
+                pass
+            self._queue_processor_task = None
+
+    async def submit_gpu(
+        self, task: Task, required_vram_mb: int = 0,
+        evictable: bool = False, resource_id: str | None = None,
+    ) -> object:
+        self._submitted += 1
+        if required_vram_mb > 0:
+            admission = self._check_admission(task, required_vram_mb)
+            if not admission.admitted:
+                if self._queue.full():
+                    self._dropped += 1
+                    raise NoResourceAvailableError(
+                        f"GPU arbiter queue full ({self._max_queue_size}), "
+                        f"dropped task {task.id}"
+                    )
+                self._seq += 1
+                entry = _QueuedGpuTask(
+                    priority=int(task.priority), seq=self._seq, task=task,
+                    required_vram_mb=required_vram_mb, evictable=evictable,
+                )
+                await self._queue.put(entry)
+                self._queued += 1
+                loop = asyncio.get_running_loop()
+                done: asyncio.Future = loop.create_future()
+                entry.task._arbiter_future = done  # type: ignore[attr-defined]
+                try:
+                    return await done
+                except asyncio.CancelledError:
+                    self._evicted += 1
+                    raise
+        return await self._run_gpu_task(task, required_vram_mb, evictable, resource_id)
+
+    def _check_admission(self, task: Task, required_vram_mb: int) -> GpuAdmission:
+        if required_vram_mb <= 0:
+            return GpuAdmission(admitted=True)
+        free_vram, _total = self._vram_probe()
+        if free_vram > 0:
+            if free_vram < required_vram_mb:
+                return GpuAdmission(
+                    admitted=False, free_vram_mb=free_vram, required_vram_mb=required_vram_mb,
+                    reason=f"insufficient local VRAM: need {required_vram_mb} MiB, have {free_vram} MiB free",
+                )
+            return GpuAdmission(admitted=True, free_vram_mb=free_vram, required_vram_mb=required_vram_mb)
+        if self._cluster_manager is not None:
+            leases = self._cluster_manager.get_leases()
+            for worker in self._cluster_manager.get_workers():
+                if worker.status != "online":
+                    continue
+                worker_leases = sum(
+                    l.required_vram_mb for l in leases
+                    if l.resource_id.startswith(worker.name + ":") and l.required_vram_mb > 0
+                )
+                if worker.free_vram_mb - worker_leases >= required_vram_mb:
+                    return GpuAdmission(
+                        admitted=True, free_vram_mb=worker.free_vram_mb - worker_leases,
+                        required_vram_mb=required_vram_mb,
+                    )
+            return GpuAdmission(
+                admitted=False, required_vram_mb=required_vram_mb,
+                reason=f"no cluster worker with {required_vram_mb} MiB free VRAM",
+            )
+        return GpuAdmission(admitted=True, required_vram_mb=required_vram_mb)
+
+    async def _run_gpu_task(self, task: Task, required_vram_mb: int, evictable: bool, resource_id: str | None) -> object:
+        lease_id: str | None = None
+        if self._cluster_manager is not None and resource_id is not None:
+            lease = self._cluster_manager.claim_lease(
+                resource_id=resource_id, caller=task.submitter,
+                ttl_seconds=300, required_vram_mb=required_vram_mb,
+            )
+            if lease is None:
+                raise NoResourceAvailableError(
+                    f"GPU lease claim failed for {resource_id} (task {task.id})"
+                )
+            lease_id = lease.lease_id
+        async with self._running_lock:
+            self._running[task.id] = (task, lease_id, int(task.priority), required_vram_mb)
+        try:
+            if self._scheduler is not None:
+                result = await self._scheduler.submit(task)
+            else:
+                result = await task.payload(None)
+            self._admitted += 1
+            return result
+        finally:
+            async with self._running_lock:
+                self._running.pop(task.id, None)
+            if lease_id is not None and self._cluster_manager is not None:
+                self._cluster_manager.release_lease(lease_id)
+
+    def evict_lowest_priority(self, min_priority: int | None = None) -> int:
+        if not self._eviction_enabled:
+            return 0
+        victim_id, victim_priority = None, -1
+        for tid, (_t, _lid, pri, _vram) in self._running.items():
+            if min_priority is not None and pri < min_priority:
+                continue
+            if pri > victim_priority:
+                victim_priority, victim_id = pri, tid
+        if victim_id is None:
+            return 0
+        return self._evict_task(victim_id)
+
+    def _evict_task(self, task_id: str) -> int:
+        if task_id not in self._running:
+            return 0
+        task, lease_id, _pri, _vram = self._running.pop(task_id)
+        if lease_id is not None and self._cluster_manager is not None:
+            self._cluster_manager.release_lease(lease_id)
+        future = getattr(task, "_arbiter_future", None)
+        if future is not None and not future.done():
+            future.cancel()
+        self._evicted += 1
+        logger.info("gpu-arbiter: evicted task %s (pri=%d)", task_id, _pri)
+        return 1
+
+    async def _process_queue(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(2)
+                await self._drain_queue()
+        except asyncio.CancelledError:
+            raise
+
+    async def _drain_queue(self) -> None:
+        retry: list[_QueuedGpuTask] = []
+        while not self._queue.empty():
+            entry = self._queue.get_nowait()
+            if self._check_admission(entry.task, entry.required_vram_mb).admitted:
+                try:
+                    result = await self._run_gpu_task(entry.task, entry.required_vram_mb, entry.evictable, None)
+                    future = getattr(entry.task, "_arbiter_future", None)
+                    if future is not None and not future.done():
+                        future.set_result(result)
+                except Exception as exc:
+                    future = getattr(entry.task, "_arbiter_future", None)
+                    if future is not None and not future.done():
+                        future.set_exception(exc)
+                break
+            else:
+                retry.append(entry)
+        for entry in retry:
+            if not self._queue.full():
+                self._queue.put_nowait(entry)
+            else:
+                self._dropped += 1
+                future = getattr(entry.task, "_arbiter_future", None)
+                if future is not None and not future.done():
+                    future.set_exception(NoResourceAvailableError("queue full, task dropped"))
+
+    def stats(self) -> dict:
+        return {
+            "submitted": self._submitted, "admitted": self._admitted,
+            "queued": self._queued, "evicted": self._evicted,
+            "dropped": self._dropped, "queue_depth": self._queue.qsize(),
+            "running": len(self._running), "max_queue_size": self._max_queue_size,
+            "eviction_enabled": self._eviction_enabled,
+        }
+
+    def running_tasks(self) -> list[dict]:
+        return [
+            {"task_id": tid, "capability": task.capability.value,
+             "submitter": task.submitter, "priority": pri,
+             "vram_mb": vram, "lease_id": lid}
+            for tid, (task, lid, pri, vram) in self._running.items()
+        ]
+
+    def queue_snapshot(self) -> list[dict]:
+        items: list[_QueuedGpuTask] = []
+        while not self._queue.empty():
+            try:
+                items.append(self._queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        result = [
+            {"task_id": e.task.id, "capability": e.task.capability.value,
+             "priority": e.priority, "vram_mb": e.required_vram_mb,
+             "queued_seconds": time.time() - e.queued_at}
+            for e in items
+        ]
+        for e in items:
+            if not self._queue.full():
+                self._queue.put_nowait(e)
+        return result

--- a/tinyagentos/scheduler/types.py
+++ b/tinyagentos/scheduler/types.py
@@ -87,6 +87,7 @@ class Task:
     submitter: str = "unknown"
     estimated_seconds: float = 1.0
     estimated_memory_mb: int = 0
+    estimated_vram_mb: int = 0
     required_signatures: list[ResourceSignature] = field(default_factory=list)
     id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
     submitted_at: float = field(default_factory=time.time)


### PR DESCRIPTION
## Summary

When a stored per-agent LiteLLM virtual key fails to re-scope to new permitted models (e.g. after Skald switches models programmatically), the stale key was silently kept — overriding the master-key fallback. The LiteLLM auth hook then rejected calls because the new model wasn't in the old allowlist.

## Fix

In taos_agent_runtime.py, when update_agent_key returns False, we now leave litellm_key as None instead of keeping the stale stored key. This lets the existing master-key fallback at line 136 activate, preferring the unscoped master key over a stale per-agent key whose scope no longer matches.

The three code paths now are:
- **Re-scope succeeds** → use the stored key (same behavior as before)
- **Re-scope fails** → discard stored key, fall through to master
- **Proxy not running** → keep stored key, set born_degraded (no auth check possible)

## Testing

- All 18 taos-agent route tests pass: tests/test_routes_taos_agent.py
- All 150 related tests pass (deployer, taos-agent routes, chat)
- 3 pre-existing failures in test_llm_proxy.py (missing tinyagentos.litellm_keystore import in test setup — unrelated)

Fixes #825