### PR TITLE
release: 1.0.0-beta.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.33] - 2026-07-06
+
+### Fixed
+- Downloaded RK3588 (rkllama) models now appear in the Models list. rkllama downloaded and registered models correctly, but wrote them to its own directory that taOS never scanned, so a model that finished downloading never showed up. taOS now points rkllama at the unified model directory it already scans, and migrates any models you have already downloaded into it on upgrade, so nothing needs re-downloading. Reported by @mandresve (#1548).
+- rkllama install failures now surface the real cause (e.g. HuggingFace unreachable) instead of a generic "model not registered", so a failed download is self-diagnosing (#1548).
+- Scheduled backups (and any other scheduled task) actually run now. The scheduler stored the cron expression but had no execution engine, so due tasks never fired (#165).
+
+### Added
+- Cluster GPU-lease coordination: agents claim and release a worker's GPU atomically over the A2A bus, and `/api/cluster/workers` now reports real-time free/used VRAM, so shared-hardware model loads on one node no longer collide. Archived models are promoted automatically when compatible hardware joins the cluster (#893, #333).
+
+### Changed
+- Backends (rkllama and other GPU/NPU model servers) run as the unprivileged `taos` service user with the device-group access they need, rather than root.
+- Non-admin users no longer see system-settings panels, a UX follow-up to the settings-router access gate (#163).
+- The documentation gate no longer trips on test-only files (#171).
+- Cleared seven Dependabot alerts by pinning `lodash-es`, `uuid`, and `nanoid` (#173), and added a safe cleanup policy for stale agent worktrees (#172).
+
 ## [1.0.0-beta.32] - 2026-07-06
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.32",
+  "version": "1.0.0-beta.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.32",
+      "version": "1.0.0-beta.33",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.32",
+  "version": "1.0.0-beta.33",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.32"
+version = "1.0.0-beta.33"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.32"
+__version__ = "1.0.0-beta.33"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b32"
+version = "1.0.0b33"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release train for **1.0.0-beta.33**.

## Highlights
- **#1548 fixed** — downloaded RK3588 (rkllama) models now appear in the Models list. rkllama wrote models to its own dir taOS never scanned; it now writes into the unified taOS model tree (with on-upgrade migration, no re-download), and runs as the `taos` service user with GPU/NPU device-group access. rkllama install failures now surface the real cause.
- **Cluster GPU-lease coordination** (#893) — atomic claim/release over A2A + real-time VRAM in `/api/cluster/workers`; archived models auto-promote when compatible hardware joins (#333).
- **Scheduled tasks execute** (#165) — the scheduler had no execution engine, so backups never ran.
- **Hardening/hygiene** — non-admin users can't see system-settings panels (#163); doc-gate skips test-only files (#171); 7 Dependabot alerts cleared (#173); safe agent-worktree prune policy (#172).

Version bumped across pyproject.toml, tinyagentos/__init__.py, desktop/package.json, desktop/package-lock.json, and uv.lock (normalized `1.0.0b33`). CHANGELOG updated. `test_version_lock_sync` + version endpoint/header tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cluster GPU coordination with real-time VRAM reporting and automatic promotion of compatible archived models.

* **Bug Fixes**
  * Downloaded models now appear correctly in the Models list.
  * Install errors now show the underlying cause.
  * Scheduled tasks and backups now run as expected.

* **Changes**
  * Model backends now run under a more restricted service account.
  * Non-admin users no longer see system settings panels.
  * Documentation-related checks are now less restrictive.

* **Chores**
  * Updated the release version to **1.0.0-beta.33**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->