### PR TITLE
fix(agents): discard stale per-agent key on re-scope failure, fall back to master

### DIFF
--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -365,6 +365,35 @@ async def test_update_agent_model_downloaded_backend_down_returns_actionable_409
     assert "not running" in data["error"]
 
 
+@pytest.mark.asyncio
+async def test_update_agent_model_discards_stale_key_on_re_scope_failure(monkeypatch):
+    """When update_agent_key returns False (e.g. routing-only mode or provider
+    type mismatch), the stale per-agent key must be discarded so the deployer
+    falls back to the master key on the next deploy."""
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {})
+    # routing-only proxy (no database_url) — update_agent_key returns False
+    proxy = _FakeProxy(db=False)
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200))
+    from tinyagentos.routes.agents import update_agent_model, AgentModelUpdate
+    agents = [
+        {
+            "name": "alpha",
+            "model": "llama3",
+            "llm_key": "sk-stale",
+            "permitted_models": ["llama3"],
+        }
+    ]
+    req = _FakeRequest(agents, proxy=proxy)
+    body = AgentModelUpdate(model="qwen3")
+    resp = await update_agent_model(req, "alpha", body)
+    assert resp["status"] == "updated"
+    assert resp["key_rescoped"] is False
+    # The stale key must be discarded
+    assert agents[0].get("llm_key") is None
+
+
 # ---------------------------------------------------------------------------
 # Piece 3 — GET /api/agents/me/models (agent-facing, bearer auth)
 # ---------------------------------------------------------------------------

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1135,6 +1135,17 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
             key_rescoped = await proxy.update_agent_key(llm_key, permitted)
         except Exception:
             logger.exception("update_agent_model: re-scoping key for %s failed", name)
+        if not key_rescoped:
+            # Key re-scope failed (e.g. provider type mismatch after model
+            # change).  Discard the stale per-agent key so the deployer
+            # falls back to the master key on the next deploy — a stale
+            # scope would cause LiteLLM to 403 the new model.
+            logger.warning(
+                "update_agent_model: re-scope failed for %s — "
+                "discarding stale per-agent key (will fall back to master key)",
+                name,
+            )
+            agent["llm_key"] = None
 
     framework = agent.get("framework")
     if framework in ("openclaw", "hermes"):


### PR DESCRIPTION
Task: t_fc93d300. Fixes #825.

## Problem

When an agent's model changes and `update_agent_key` returns False (e.g. provider type mismatch, routing-only mode), the stale per-agent LiteLLM key persists on the agent record. LiteLLM prefers the stale per-agent key over the master key, causing 403s on requests for the new model.

## Fix

In `update_agent_model`, when `update_agent_key` returns False, set `agent["llm_key"] = None`. This signals the deployer to fall back to the master key on the next deploy cycle.

## Changes

- **routes/agents.py** (+11): Discard stale key when re-scope fails
- **tests/test_agent_permitted_models.py** (+29): Test verifying stale key is set to None on failure

## Test results

- `tests/test_agent_permitted_models.py`: 23/23 pass (including new test)
- `tests/test_update_agent_key.py`: 4/4 pass
- Full suite running in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model updates so agents no longer keep an outdated key when key re-scoping fails.
  * Model changes still complete successfully, and agents now fall back to the shared key if needed.
  * Added coverage for this edge case to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->