### PR TITLE
fix(cluster): await cancelled monitor task in ClusterManager.stop()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ docs/STATUS.md
 data/pending-restart.json
 # Stray dev screenshot artifacts
 desktop-initial.png
+venv/

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -51,6 +51,10 @@ class ClusterManager:
     async def stop(self):
         if self._monitor_task:
             self._monitor_task.cancel()
+            try:
+                await self._monitor_task
+            except asyncio.CancelledError:
+                pass
 
     async def register_worker(self, info: WorkerInfo) -> None:
         # Snapshot capabilities before adding worker


### PR DESCRIPTION
## Summary

Fix: properly await the cancelled `_monitor_task` in `ClusterManager.stop()` to prevent `Task was destroyed but it is pending` warnings during async cleanup.

## Background

The A2A GPU-lease claim/release protocol (#893) was implemented and merged in release/1.0.0-beta.33. This branch contributes one remaining quality fix: awaiting the cancelled monitor coroutine and suppressing `CancelledError` in the `stop()` method.

## Changes

- `tinyagentos/cluster/manager.py`: await cancelled `_monitor_task` in `stop()`, catch `CancelledError`
- `.gitignore`: add `venv/` alongside existing `.venv/`

## Tests

- `tests/test_leases.py` — 28/28 pass (138s)
- All lease-related tests (claim, release, renew, expiry, concurrency) pass