### PR TITLE
fix(agents): discard + persist stale per-agent key on re-scope failure (supersedes #1686)

### DIFF
--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -365,6 +365,35 @@ async def test_update_agent_model_downloaded_backend_down_returns_actionable_409
     assert "not running" in data["error"]
 
 
+@pytest.mark.asyncio
+async def test_update_agent_model_discards_stale_key_on_re_scope_failure(monkeypatch):
+    """When update_agent_key returns False (e.g. routing-only mode or provider
+    type mismatch), the stale per-agent key must be discarded so the deployer
+    falls back to the master key on the next deploy."""
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {})
+    # routing-only proxy (no database_url) — update_agent_key returns False
+    proxy = _FakeProxy(db=False)
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200))
+    from tinyagentos.routes.agents import update_agent_model, AgentModelUpdate
+    agents = [
+        {
+            "name": "alpha",
+            "model": "llama3",
+            "llm_key": "sk-stale",
+            "permitted_models": ["llama3"],
+        }
+    ]
+    req = _FakeRequest(agents, proxy=proxy)
+    body = AgentModelUpdate(model="qwen3")
+    resp = await update_agent_model(req, "alpha", body)
+    assert resp["status"] == "updated"
+    assert resp["key_rescoped"] is False
+    # The stale key must be discarded
+    assert agents[0].get("llm_key") is None
+
+
 # ---------------------------------------------------------------------------
 # Piece 3 — GET /api/agents/me/models (agent-facing, bearer auth)
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -368,9 +368,19 @@ async def test_update_agent_model_downloaded_backend_down_returns_actionable_409
 @pytest.mark.asyncio
 async def test_update_agent_model_discards_stale_key_on_re_scope_failure(monkeypatch):
     """When update_agent_key returns False (e.g. routing-only mode or provider
-    type mismatch), the stale per-agent key must be discarded so the deployer
-    falls back to the master key on the next deploy."""
-    _patch_save(monkeypatch)
+    type mismatch), the stale per-agent key must be discarded AND that discard
+    must be persisted -- the earlier save runs before the re-scope, so without a
+    second save the stale key survives on disk and the next deploy still uses
+    it."""
+    # Record the persisted llm_key at each save so we can assert the discard was
+    # actually written, not just mutated in memory.
+    saved_keys = []
+    import tinyagentos.routes.agents as mod
+
+    async def _recording_save(config, path, *a, **k):
+        saved_keys.append(config.agents[0].get("llm_key"))
+
+    monkeypatch.setattr(mod, "save_config_locked", _recording_save)
     _patch_resolver(monkeypatch, {})
     # routing-only proxy (no database_url) — update_agent_key returns False
     proxy = _FakeProxy(db=False)
@@ -390,8 +400,11 @@ async def test_update_agent_model_discards_stale_key_on_re_scope_failure(monkeyp
     resp = await update_agent_model(req, "alpha", body)
     assert resp["status"] == "updated"
     assert resp["key_rescoped"] is False
-    # The stale key must be discarded
+    # The stale key must be discarded in memory...
     assert agents[0].get("llm_key") is None
+    # ...and persisted: the final save must have written the None, otherwise the
+    # on-disk config keeps the stale key (the bug this guards against).
+    assert saved_keys and saved_keys[-1] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1135,6 +1135,17 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
             key_rescoped = await proxy.update_agent_key(llm_key, permitted)
         except Exception:
             logger.exception("update_agent_model: re-scoping key for %s failed", name)
+        if not key_rescoped:
+            # Key re-scope failed (e.g. provider type mismatch after model
+            # change).  Discard the stale per-agent key so the deployer
+            # falls back to the master key on the next deploy — a stale
+            # scope would cause LiteLLM to 403 the new model.
+            logger.warning(
+                "update_agent_model: re-scope failed for %s — "
+                "discarding stale per-agent key (will fall back to master key)",
+                name,
+            )
+            agent["llm_key"] = None
 
     framework = agent.get("framework")
     if framework in ("openclaw", "hermes"):

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1146,6 +1146,10 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
                 name,
             )
             agent["llm_key"] = None
+            # Persist the discard: the earlier save_config_locked ran before the
+            # re-scope, so without this the stale key survives on disk and the
+            # next deploy would still use it.
+            await save_config_locked(config, config.config_path)
 
     framework = agent.get("framework")
     if framework in ("openclaw", "hermes"):


### PR DESCRIPTION
Maintainer takeover of #1686 by @hognek (his commit is preserved here), folding the Kilo review before merge.

## The bug Kilo caught
Hogne's change discards the stale per-agent `llm_key` when the LiteLLM re-scope fails (so the deployer falls back to the master key). But `save_config_locked` runs **before** the re-scope, so `agent["llm_key"] = None` only mutated the in-memory dict and was never written. The next deploy reads the config off disk and still finds the stale key, defeating the fix.

## What I added on top of Hogne's commit
- Persist the discard with a `save_config_locked` after `agent["llm_key"] = None`.
- Harden the test: it now records the persisted `llm_key` at each save and asserts the final write was `None`. Verified it **fails without** the persistence line and **passes with** it (the original test only asserted the in-memory dict, so it passed even with the bug).

Full suite green (23 tests). Closes #1686.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When changing an agent’s model, if the agent’s key can’t be re-scoped, the system now clears the outdated per-agent key and saves that update.
  * This prevents future deploys from reusing a stale key and helps the agent fall back to the primary key as expected.
  * Added test coverage for the failed re-scope path to confirm the response and saved configuration stay in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->