### PR TITLE
fix(searxng): enable JSON output format via Docker env vars

### DIFF
--- a/app-catalog/services/searxng/manifest.yaml
+++ b/app-catalog/services/searxng/manifest.yaml
@@ -19,6 +19,9 @@ install:
   # 8080 is the container-internal port; the host port is allocated from the
   # managed pool (30000-40000) by the installer — never bound to 8080 on the host.
   ports: [8080]
+  env:
+    SEARXNG_SEARCH__FORMATS__0: "html"
+    SEARXNG_SEARCH__FORMATS__1: "json"
 
 hardware_tiers:
   arm-npu-16gb: full


### PR DESCRIPTION
## Summary

SearXNG defaults to only HTML output format, which prevents agents from querying it programmatically via `?format=json`. This adds two environment variables to the catalog manifest that tell the SearXNG Docker image to include JSON alongside HTML.

## Change

- `app-catalog/services/searxng/manifest.yaml`: `+3` lines
- Add `SEARXNG_SEARCH__FORMATS__0: html` and `SEARXNG_SEARCH__FORMATS__1: json` env vars

## How it works

The SearXNG Docker image reads `SEARXNG_`-prefixed environment variables to override its settings.yml. Setting both format indices ensures `search.formats` becomes `[html, json]` instead of the default `[html]` — no code changes needed; the Docker installer already maps `env:` to `environment:` in the generated compose file.

## Verification

- Manifest validation passes (`test_all_manifests_valid_yaml`)
- Docker installer compose generation tests pass (18/18)
- Service manifest license guard tests pass (16/16)

Fixes #969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded search output options to include both HTML and JSON formats, improving compatibility with different ways of viewing and integrating results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->