### PR TITLE
fix: surface divergence message when branch diverged from tracked remote

### DIFF
--- a/tests/test_docs_only_update.py
+++ b/tests/test_docs_only_update.py
@@ -143,6 +143,11 @@ async def test_update_check_hides_docs_only_diff(client, monkeypatch):
         fake_docs_only,
         raising=False,
     )
+    monkeypatch.setattr(
+        "tinyagentos.auto_update.branch_is_diverged",
+        AsyncMock(return_value=False),
+        raising=False,
+    )
 
     r = await client.get("/api/settings/update-check")
     assert r.status_code == 200

--- a/tinyagentos/auto_update.py
+++ b/tinyagentos/auto_update.py
@@ -262,6 +262,22 @@ async def remote_is_strictly_ahead(project_dir: Path, current: str, remote: str)
     return rc == 0
 
 
+async def branch_is_diverged(project_dir: Path, current: str, remote: str) -> bool:
+    """True when *current* and *remote* have diverged.
+
+    Callers must already have confirmed that ``remote_is_strictly_ahead(current, remote)``
+    is False, and that *current* and *remote* are non-empty and different. Under those
+    preconditions, this returns True when *remote* is also not an ancestor of *current*
+    (i.e. neither side is a strict ancestor — truly diverged).
+    """
+    if not current or not remote or current == remote:
+        return False
+    rc, _ = await _run(
+        ["git", "merge-base", "--is-ancestor", remote, current], project_dir
+    )
+    return rc != 0
+
+
 class AutoUpdateService:
     """Background service that periodically checks GitHub for updates.
 
@@ -362,6 +378,16 @@ class AutoUpdateService:
                     # Remember so we don't re-notify next hour.
                     prefs["last_notified_commit"] = new_commit
                     await self._save_prefs(prefs)
+            elif current and new_commit and current != new_commit \
+                    and await branch_is_diverged(self._project_dir, current, new_commit):
+                # Local branch has diverged from the tracked remote — the
+                # user won't see an update notification until they reconcile
+                # (or manually check via Settings, which surfaces a message).
+                logger.debug(
+                    "auto-update: branch diverged from tracked remote "
+                    "(%s vs %s) — no update notification will fire",
+                    current[:7], new_commit[:7],
+                )
 
         # Poll latest framework release metadata for frameworks that publish
         # GitHub releases. Guarded with getattr so it's a no-op before Task 8.1

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -531,7 +531,7 @@ async def check_for_updates(request: Request):
     import asyncio
     import re
     from tinyagentos import __version__
-    from tinyagentos.auto_update import changes_are_docs_only, remote_is_strictly_ahead
+    from tinyagentos.auto_update import changes_are_docs_only, remote_is_strictly_ahead, branch_is_diverged
     project_dir = str(Path(__file__).parent.parent.parent)
 
     # Track the user's selected branch (Updates → Advanced selector), or the
@@ -569,6 +569,21 @@ async def check_for_updates(request: Request):
     if has_updates and await changes_are_docs_only(Path(project_dir), local_sha, remote_sha):
         has_updates = False
 
+    # Detect divergence: when neither side is a strict ancestor of the other,
+    # the local branch has commits not in the remote. Surface an actionable
+    # message so the user knows an update would hard-reset to the remote
+    # (their local work is preserved as a recovery tag).
+    diverged = False
+    diverged_message: str | None = None
+    if not has_updates and local_sha and remote_sha and local_sha != remote_sha \
+            and await branch_is_diverged(project_dir, local_sha, remote_sha):
+        diverged = True
+        diverged_message = (
+            "Your local branch has diverged from the tracked branch. "
+            "An update will preserve your local commits as a recovery tag "
+            "before syncing to the remote."
+        )
+
     async def _log1(ref: str) -> str:
         p = await asyncio.create_subprocess_exec(
             "git", "log", "-1", "--format=%h %s", ref,
@@ -579,12 +594,12 @@ async def check_for_updates(request: Request):
         return out.decode().strip() if out else "unknown"
 
     current = await _log1("HEAD")
-    new_commit = await _log1(f"origin/{branch}") if has_updates else None
+    new_commit = await _log1(f"origin/{branch}") if (has_updates or diverged) else None
 
     # Read the version string from the remote branch HEAD so the UI can show
     # the target version number without requiring a full install first.
     new_version: str | None = None
-    if has_updates:
+    if has_updates or diverged:
         try:
             rc, raw = await _run_capture(
                 ["git", "show", f"origin/{branch}:tinyagentos/__init__.py"],
@@ -599,6 +614,8 @@ async def check_for_updates(request: Request):
 
     return {
         "has_updates": has_updates,
+        "diverged": diverged,
+        "diverged_message": diverged_message,
         "current_version": __version__,
         "new_version": new_version,
         "current_commit": current,


### PR DESCRIPTION
Task: t_b5c4c9b4. Fixes #841. Tests: 27/27 pass.

----
## Summary by Gitar

- **Divergence Handling:**
  - Added logic to detect and surface divergence messages when a branch deviates from its tracked remote.
  - Updated the UI feedback layer to display these messages in `status_reporter.py` and `branch_manager.py`.

<sub>This will update automatically on new commits.</sub>