### PR TITLE
fix(messages): add hover copy button + select-text to agent message bubbles

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -22,6 +22,8 @@ import {
   RotateCcw,
   MessagesSquare,
   Search,
+  Copy,
+  Check,
 } from "lucide-react";
 import {
   Button,
@@ -2313,8 +2315,15 @@ export function MessagesApp({
                       onCancel={() => setEditingMessageId(null)}
                     />
                   ) : (
-                    <div className={`${isMobile ? "text-[14px]" : "text-[15px]"} leading-[1.46] whitespace-pre-wrap break-words ${isDeadAgent ? "text-shell-text-secondary" : "text-shell-text"}`}>
-                      {renderContent(msg.content)}
+                    <div className="relative">
+                      {msg.content && msg.state !== "streaming" && msg.state !== "pending" && (
+                        <CopyButton
+                          content={msg.content}
+                          className="absolute -top-1 right-0 p-1 rounded opacity-0 group-hover:opacity-100 focus:opacity-100 bg-shell-surface border border-white/10 text-shell-text-secondary hover:text-shell-text transition-opacity select-none z-10"
+                        />
+                      )}
+                      <div className={`${isMobile ? "text-[14px]" : "text-[15px]"} leading-[1.46] whitespace-pre-wrap break-words select-text ${isDeadAgent ? "text-shell-text-secondary" : "text-shell-text"}`}>
+                        {renderContent(msg.content)}
                       {msg.state === "pending" && (
                         <span className="ml-1 text-shell-text-tertiary">...</span>
                       )}
@@ -2328,6 +2337,7 @@ export function MessagesApp({
                       {msg.state === "error" && (
                         <span className="ml-1 text-red-400 text-[11px]">(error)</span>
                       )}
+                    </div>
                     </div>
                   )}
                   {msg.metadata?.pin_requested && msg.author_type === "agent" && (
@@ -3103,5 +3113,35 @@ export function MessagesApp({
         )
       )}
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  CopyButton — hover copy affordance for message bubbles             */
+/*  Matches the CodeBlock + TaosAssistantPanel copy-button pattern.    */
+/* ------------------------------------------------------------------ */
+
+function CopyButton({ content, className }: { content: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!content) return;
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy message"}
+      className={className}
+    >
+      {copied ? <Check size={10} /> : <Copy size={10} />}
+    </button>
   );
 }

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -2316,7 +2316,7 @@ export function MessagesApp({
                     />
                   ) : (
                     <div className="relative">
-                      {msg.content && msg.state !== "streaming" && msg.state !== "pending" && (
+                      {msg.content && msg.author_type === "agent" && msg.state !== "streaming" && msg.state !== "pending" && (
                         <CopyButton
                           content={msg.content}
                           className="absolute -top-1 right-0 p-1 rounded opacity-0 group-hover:opacity-100 focus:opacity-100 bg-shell-surface border border-white/10 text-shell-text-secondary hover:text-shell-text transition-opacity select-none z-10"
@@ -3123,25 +3123,46 @@ export function MessagesApp({
 
 function CopyButton({ content, className }: { content: string; className?: string }) {
   const [copied, setCopied] = useState(false);
+  const [clipError, setClipError] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /* Clear any pending timers on unmount so we never setState on a dead component. */
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+    };
+  }, []);
 
   const handleCopy = async () => {
     if (!content) return;
     try {
       await navigator.clipboard.writeText(content);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      setClipError(false);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 1500);
     } catch {
-      // ignore
+      setClipError(true);
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+      errorTimerRef.current = setTimeout(() => setClipError(false), 2500);
     }
   };
 
   return (
     <button
       onClick={handleCopy}
-      aria-label={copied ? "Copied" : "Copy message"}
+      aria-label={copied ? "Copied" : clipError ? "Copy failed — check clipboard permissions" : "Copy message"}
       className={className}
     >
-      {copied ? <Check size={10} /> : <Copy size={10} />}
+      {copied ? (
+        <Check size={10} />
+      ) : clipError ? (
+        <X size={10} className="text-red-400" />
+      ) : (
+        <Copy size={10} />
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary

Adds a hover copy button to message bubbles in taOS MessagesApp, matching the CodeBlock and TaosAssistantPanel pattern. Also adds explicit `select-text` to the message content area for reliable text selection.

Fixes #835 — "Make agent text copy/paste-able in every app and chat surface."

## Changes

- Add `Copy` and `Check` icon imports to MessagesApp
- Add `CopyButton` component (reusable hover copy affordance)
- Copy button renders on each message bubble, visible on hover at top-right
- Only shows when content exists and not in streaming/pending state
- Add explicit `select-text` Tailwind class to message content div
- Desktop SPA build passes cleanly

## Affected surfaces

- MessagesApp (main chat surface) — now has hover copy button + select-text
- TaosAssistantPanel — already had hover copy button + select-text (no changes needed)
- AgentMessagesPanel — already had select-text (no changes needed)
- CodeBlock — already had hover copy button + select-text (no changes needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-click copying for message bubbles, with a copy button that appears on hover or focus for eligible messages.
  * Improved message text selection so rendered content can be selected and copied more easily.
  * Added clear success and failure feedback after copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->