### PR TITLE
fix(config): heal stale rkllama provider port :8080 -> :7833 (#1697)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -355,3 +355,27 @@ class TestLitellmPortPin:
         assert config.server["litellm_port"] == 5000
         # File must not be rewritten when no pin was applied.
         assert p.stat().st_mtime == original_mtime
+
+
+def test_load_config_migrates_legacy_rkllama_port(tmp_path):
+    """An install seeded before the taOS default moved to :7833 keeps a stale
+    localhost:8080 rkllama provider; load_config heals it to :7833 (#1697)."""
+    import yaml
+    from tinyagentos.config import load_config
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({
+        "backends": [
+            {"name": "rkllama", "type": "rkllama", "url": "http://localhost:8080"},
+            {"name": "custom-rk", "type": "rkllama", "url": "http://10.0.0.5:8080"},
+            {"name": "ollama", "type": "ollama", "url": "http://localhost:8080"},
+        ]
+    }))
+    cfg = load_config(cfg_path)
+    by_name = {b["name"]: b["url"] for b in cfg.backends}
+    # auto-seeded localhost rkllama -> healed to 7833
+    assert by_name["rkllama"] == "http://localhost:7833"
+    # deliberate custom host -> untouched
+    assert by_name["custom-rk"] == "http://10.0.0.5:8080"
+    # non-rkllama backend on 8080 -> untouched
+    assert by_name["ollama"] == "http://localhost:8080"

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -72,6 +72,31 @@ class AppConfig:
             d["archive"] = self.archive
         return d
 
+# rkllama's taOS default port moved from the upstream 8080 to 7833. Installs
+# seeded before that switch kept a stale ``localhost:8080`` provider URL, so the
+# Providers page and live model discovery point at a dead port (#1697). We heal
+# only the auto-seeded localhost default, never a deliberately-set custom host.
+_LEGACY_RKLLAMA_URLS = frozenset(
+    {"http://localhost:8080", "http://127.0.0.1:8080"}
+)
+
+
+def _migrate_legacy_rkllama_port(backends: list[dict]) -> None:
+    """Rewrite a stale ``rkllama`` provider URL from the legacy :8080 to :7833
+    in place (#1697). Idempotent and targeted: only the auto-seeded localhost
+    default is touched."""
+    for b in backends:
+        if b.get("type") != "rkllama":
+            continue
+        url = (b.get("url") or "").rstrip("/")
+        if url in _LEGACY_RKLLAMA_URLS:
+            b["url"] = url.replace(":8080", ":7833")
+            log.info(
+                "migrating rkllama provider %r from legacy :8080 to :7833 (#1697)",
+                b.get("name"),
+            )
+
+
 def load_config(path: Path) -> AppConfig:
     if not path.exists():
         # Fresh install: build defaults with litellm_port explicitly recorded
@@ -109,9 +134,11 @@ def load_config(path: Path) -> AppConfig:
             "new installs use %d, see #795",
             _LITELLM_PORT_LEGACY, _LITELLM_PORT_NEW,
         )
+    backends = data.get("backends", [])
+    _migrate_legacy_rkllama_port(backends)
     cfg = AppConfig(
         server=server,
-        backends=data.get("backends", []),
+        backends=backends,
         qmd=data.get("qmd", DEFAULT_CONFIG["qmd"].copy()),
         agents=agents,
         metrics=data.get("metrics", DEFAULT_CONFIG["metrics"].copy()),


### PR DESCRIPTION
## The bug
@mandresve (#1697): the local RKLLM provider is configured with `http://localhost:8080`, but rkllama runs on `7833`. Changing it manually makes Test succeed. Every rkllama provider shows **Error** and live model discovery fails because taOS polls a dead port.

## Root cause
rkllama's taOS default port moved from the upstream `8080` to `7833`. The service manifest already declares `7833`, but an install **seeded before that switch** (mandresve updated from beta.26) kept the old `localhost:8080` URL in its `config.json`, and a controller update doesn't migrate it. Same class as #1548: an update doesn't heal existing install state.

## Fix
`load_config` now rewrites a stale `rkllama` provider URL from the legacy `:8080` to `:7833`. Targeted and idempotent: only the auto-seeded `localhost`/`127.0.0.1` default is touched, never a deliberately-set custom host, and non-rkllama backends are left alone. Test covers all three cases. 27 config tests pass.

Closes #1697.