### PR TITLE
feat(chat): per-agent framework slash commands via @agent / prefix in groups

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1021,8 +1021,16 @@ export function MessagesApp({
 
   /* ---- typing emitter + slash menu derived state ---- */
   const emitTyping = useTypingEmitter(selectedChannel, "user");
-  const showSlash = input.startsWith("/");
-  const slashQuery = showSlash ? input.slice(1).split(/\s/, 1)[0] || "" : "";
+  // In a DM (2 members: user + 1 agent), a leading "/" opens the agent's
+  // slash menu.  In a group channel (3+ members), the user must prefix
+  // with "@agentname /" so we know which agent's commands to show.
+  const isDm = (currentChannel?.members?.length ?? 0) <= 2;
+  const showSlash = isDm ? input.startsWith("/") : /@\S+\s+\//.test(input);
+  // The agent scoped by "@agentname /" (group only; undefined in DM).
+  const slashAgent = !isDm && showSlash ? input.match(/@(\S+)\s+\//)?.[1] || undefined : undefined;
+  const slashQuery = showSlash
+    ? (isDm ? input.slice(1).split(/\s/, 1)[0] : input.slice(input.indexOf("/") + 1).split(/\s/, 1)[0]) || ""
+    : "";
 
   /* ---- mutex: settings vs thread panel ---- */
   const handleOpenSettings = () => {
@@ -2586,6 +2594,7 @@ export function MessagesApp({
                   commands={slashCommands}
                   queryAfterSlash={slashQuery}
                   members={currentChannel?.members || []}
+                  scopedAgent={slashAgent}
                   onPick={(slug, cmd) => {
                     setInput(`@${slug} /${cmd} `);
                   }}

--- a/desktop/src/apps/chat/SlashMenu.tsx
+++ b/desktop/src/apps/chat/SlashMenu.tsx
@@ -11,18 +11,24 @@ export function SlashMenu({
   commands,
   queryAfterSlash,
   members,
+  scopedAgent,
   onPick,
   onClose,
 }: {
   commands: SlashCommandsBySlug;
   queryAfterSlash: string;
   members: string[]; // agents in current channel (ordered)
+  /** When set, only commands for this agent are shown (for @agent / in group channels). */
+  scopedAgent?: string;
   onPick: (slug: string, cmd: string) => void;
   onClose: () => void;
 }) {
   const [selected, setSelected] = useState(0);
 
-  const rows = useMemo(() => buildRows(commands, members, queryAfterSlash), [commands, members, queryAfterSlash]);
+  const rows = useMemo(
+    () => buildRows(commands, members, queryAfterSlash, scopedAgent),
+    [commands, members, queryAfterSlash, scopedAgent],
+  );
   const cmdRows = rows.filter((r) => r.kind === "cmd") as Extract<Row, { kind: "cmd" }>[];
 
   useEffect(() => { setSelected(0); }, [queryAfterSlash]);
@@ -88,15 +94,22 @@ function buildRows(
   commands: SlashCommandsBySlug,
   members: string[],
   query: string,
+  scopedAgent?: string,
 ): Row[] {
   const q = query.toLowerCase();
-  const agentMembers = members.filter((m) => m !== "user" && commands[m]);
-  const isDm = agentMembers.length === 1;
+  let agentMembers = members.filter((m) => m !== "user" && commands[m]);
+  // When scopedAgent is set, only show commands for that agent.
+  if (scopedAgent && agentMembers.includes(scopedAgent)) {
+    agentMembers = [scopedAgent];
+  }
+  const isDm = agentMembers.length === 1 && !scopedAgent;
   const rows: Row[] = [];
   for (const slug of agentMembers) {
     const cmds = (commands[slug] || []).filter((c) => matches(slug, c, q));
     if (cmds.length === 0) continue;
-    if (!isDm) rows.push({ kind: "header", slug });
+    // Show agent header when not in a DM, or when scoped (to make it clear
+    // whose commands are shown in an @agent / scenario).
+    if (!isDm || scopedAgent) rows.push({ kind: "header", slug });
     for (const cmd of cmds) rows.push({ kind: "cmd", slug, cmd });
   }
   return rows;

--- a/desktop/src/apps/chat/__tests__/SlashMenu.test.tsx
+++ b/desktop/src/apps/chat/__tests__/SlashMenu.test.tsx
@@ -47,4 +47,15 @@ describe("SlashMenu", () => {
     fireEvent.keyDown(document, { key: "Escape" });
     expect(onClose).toHaveBeenCalled();
   });
+
+  it("scopes to a single agent in a group channel via scopedAgent", () => {
+    render(<SlashMenu commands={commands} queryAfterSlash="" members={["user", "tom", "don"]}
+             scopedAgent="tom" onPick={vi.fn()} onClose={vi.fn()} />);
+    // Only tom's commands are shown, with the header.
+    expect(screen.getByText("@tom")).toBeInTheDocument();
+    expect(screen.getByText("/help")).toBeInTheDocument();
+    expect(screen.getByText("/clear")).toBeInTheDocument();
+    // don's commands are excluded.
+    expect(screen.queryByText("@don")).not.toBeInTheDocument();
+  });
 });

--- a/tests/test_framework_slash_commands.py
+++ b/tests/test_framework_slash_commands.py
@@ -24,3 +24,39 @@ async def test_slash_commands_endpoint_handles_unknown_framework(client, app):
     assert r.status_code == 200
     body = r.json()
     assert body.get("mystery") == []
+
+
+@pytest.mark.asyncio
+async def test_agent_slash_commands_returns_commands_for_valid_agent(client, app):
+    """New per-agent endpoint: known framework → returns its slash commands."""
+    app.state.config.agents.append({
+        "name": "tom", "framework": "hermes", "host": "localhost", "color": "#fff",
+    })
+    r = await client.get("/api/agents/tom/slash-commands")
+    assert r.status_code == 200
+    body = r.json()
+    assert "tom" in body
+    assert isinstance(body["tom"], list)
+    assert len(body["tom"]) > 0
+    assert body["tom"][0]["name"] in ("help", "clear", "model")
+
+
+@pytest.mark.asyncio
+async def test_agent_slash_commands_handles_unknown_framework(client, app):
+    """Per-agent endpoint: unknown framework → empty command list."""
+    app.state.config.agents.append({
+        "name": "mystery", "framework": "nonexistent-fw", "host": "localhost", "color": "#fff",
+    })
+    r = await client.get("/api/agents/mystery/slash-commands")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("mystery") == []
+
+
+@pytest.mark.asyncio
+async def test_agent_slash_commands_404_for_unknown_agent(client, app):
+    """Per-agent endpoint: non-existent agent → 404."""
+    r = await client.get("/api/agents/no-such-agent/slash-commands")
+    assert r.status_code == 404
+    body = r.json()
+    assert "error" in body

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -68,6 +68,9 @@ FRAMEWORKS: dict[str, dict] = {
         "name": "Generic",
         "description": "Fallback adapter — echos messages; use as a starting point",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show Generic adapter help"},
+        ],
     },
     "pocketflow": {
         "id": "pocketflow",
@@ -157,54 +160,81 @@ FRAMEWORKS: dict[str, dict] = {
         "name": "Agent Zero",
         "description": "Proxies messages to the Agent Zero HTTP API (agent0ai/agent-zero)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show Agent Zero help"},
+        ],
     },
     "ironclaw": {
         "id": "ironclaw",
         "name": "IronClaw",
         "description": "OpenClaw-inspired Rust agent focused on privacy and security (nearai/ironclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show IronClaw help"},
+        ],
     },
     "microclaw": {
         "id": "microclaw",
         "name": "MicroClaw",
         "description": "Agentic AI assistant in Rust, inspired by NanoClaw (microclaw/microclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show MicroClaw help"},
+        ],
     },
     "moltis": {
         "id": "moltis",
         "name": "Moltis",
         "description": "Secure persistent personal agent server in Rust (moltis-org/moltis)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show Moltis help"},
+        ],
     },
     "nanoclaw": {
         "id": "nanoclaw",
         "name": "NanoClaw",
         "description": "Lightweight container-based OpenClaw alternative on Anthropic Agents SDK (qwibitai/nanoclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show NanoClaw help"},
+        ],
     },
     "nullclaw": {
         "id": "nullclaw",
         "name": "NullClaw",
         "description": "Fully autonomous AI assistant infrastructure in Zig (nullclaw/nullclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show NullClaw help"},
+        ],
     },
     "picoclaw": {
         "id": "picoclaw",
         "name": "PicoClaw",
         "description": "Tiny, fast, and deployable anywhere — automate the mundane, unleash creativity (sipeed/picoclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show PicoClaw help"},
+        ],
     },
     "shibaclaw": {
         "id": "shibaclaw",
         "name": "ShibaClaw",
         "description": "Self-hosted AI agent with 5-layer prompt injection protection (RikyZ90/ShibaClaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show ShibaClaw help"},
+        ],
     },
     "zeroclaw": {
         "id": "zeroclaw",
         "name": "ZeroClaw",
         "description": "Fast, small, fully autonomous AI personal assistant in Rust (zeroclaw-labs/zeroclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show ZeroClaw help"},
+        ],
     },
 }
 

--- a/tinyagentos/routes/framework.py
+++ b/tinyagentos/routes/framework.py
@@ -121,3 +121,23 @@ async def slash_commands_manifest(request: Request):
         cmds = fw.get("slash_commands") or []
         out[slug] = [{"name": c["name"], "description": c.get("description", "")} for c in cmds]
     return JSONResponse(out)
+
+
+@router.get("/api/agents/{slug}/slash-commands")
+async def agent_slash_commands(request: Request, slug: str):
+    """Return the slash commands for a single agent by slug.
+
+    Returns {slug: [{name, description}, ...]} so callers can key
+    by slug without transforming the shape.  Unknown agent or
+    framework → empty command list.
+    """
+    config = getattr(request.app.state, "config", None)
+    agents = getattr(config, "agents", []) if config else []
+    agent = next((a for a in agents if a.get("name") == slug), None)
+    if agent is None:
+        return JSONResponse({"error": "agent not found"}, status_code=404)
+    fw = FRAMEWORKS.get(agent.get("framework") or "", {})
+    cmds = fw.get("slash_commands") or []
+    return JSONResponse({
+        slug: [{"name": c["name"], "description": c.get("description", "")} for c in cmds]
+    })


### PR DESCRIPTION
Task: t_a6cd1609. Fixes #840.

## Summary

### Backend
- Add `slash_commands` to all 10 frameworks that were missing them (generic, agent_zero, ironclaw, microclaw, moltics, nanoclaw, nullclaw, picoclaw, shibaclaw, zeroclaw) — every framework now exposes at least `/help`.
- New endpoint `GET /api/agents/{slug}/slash-commands` returns a single agent's command list, keyed by slug. Returns 404 for unknown agents.

### Frontend
- `SlashMenu`: accepts optional `scopedAgent` prop. When set, only commands for that agent are shown, with the agent header visible (makes it clear whose commands are shown in an `@agent /` scenario).
- `MessagesApp`: in group channels (3+ members), the slash menu now only opens for the `@agentname /` pattern — bare `/` no longer shows all agents' commands, avoiding confusion about which agent a command targets. In DMs, leading `/` still opens the single agent's menu as before.

### Tests
- 51 framework tests pass (frameworks.py + framework_manifest + slash_commands + routes_framework)
- 6 SlashMenu tests pass (including new `scopedAgent` test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent-specific slash commands, including a new endpoint for fetching commands for a single agent.
  * Slash command menus now respect chat context, showing the right agent’s commands in group chats and allowing simple slash commands in direct messages.

* **Bug Fixes**
  * Improved slash-command behavior so command menus open only when the input format matches the current channel type.
  * Command lists now display more clearly when scoped to a specific agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->