### PR TITLE
fix(models): discover models where the rkllama service writes, for existing installs (#1548)

### DIFF
--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -452,3 +452,35 @@ class TestRkllamaServiceModelsDir:
         unit = tmp_path / "rkllama.service"
         unit.write_text("[Service]\nExecStart=/usr/bin/rkllama_server --port 7833\n")
         assert rkllama_service_models_dir(unit) is None
+
+    def test_parses_multiline_backslash_continuation(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        unit = tmp_path / "rkllama.service"
+        unit.write_text(
+            "[Service]\n"
+            "ExecStart=/opt/x/.venv/bin/rkllama_server \\\n"
+            "  --processor rk3588 --port 7833 \\\n"
+            "  --models /opt/taos/data/models/rkllama \\\n"
+            "  --preload a,b\n"
+        )
+        assert rkllama_service_models_dir(unit) == Path("/opt/taos/data/models/rkllama")
+
+    def test_parses_quoted_path_with_spaces(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        unit = tmp_path / "rkllama.service"
+        unit.write_text(
+            "[Service]\nExecStart=/usr/bin/rkllama_server --models '/srv/rk models/dir' --port 7833\n"
+        )
+        assert rkllama_service_models_dir(unit) == Path("/srv/rk models/dir")
+
+    def test_falls_back_to_systemctl_when_no_unit_file(self, tmp_path, monkeypatch):
+        import subprocess as _sp
+        from tinyagentos.installers import rkllama_installer as ri
+
+        class _Res:
+            stdout = "/opt/x/rkllama_server --processor rk3588 --models /var/lib/rkllama/models"
+
+        monkeypatch.setattr(ri.subprocess, "run", lambda *a, **k: _Res())
+        # No file at the given path -> falls back to systemctl show
+        assert ri.rkllama_service_models_dir(tmp_path / "absent.service") == Path("/var/lib/rkllama/models")
+

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -6,6 +6,8 @@ roundtrip to /api/pull is exercised manually on the Pi (see PR description).
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 import pytest
 import respx
@@ -424,3 +426,29 @@ class TestRkllamaServiceManifest:
         script = install.get("script")
         assert script, "rkllama manifest declares no install.script"
         assert (repo / script).is_file(), f"rkllama install script missing: {script}"
+
+
+class TestRkllamaServiceModelsDir:
+    """rkllama_service_models_dir parses the --models path from the installed
+    systemd unit so taOS can scan wherever an existing rkllama writes (#1548)."""
+
+    def test_parses_models_flag(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        unit = tmp_path / "rkllama.service"
+        unit.write_text(
+            "[Service]\n"
+            "ExecStart=/opt/x/.venv/bin/python /opt/x/.venv/bin/rkllama_server "
+            "--processor rk3588 --port 7833 --models /home/jay/rkllama/models "
+            "--preload a,b\n"
+        )
+        assert rkllama_service_models_dir(unit) == Path("/home/jay/rkllama/models")
+
+    def test_none_when_unit_absent(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        assert rkllama_service_models_dir(tmp_path / "nope.service") is None
+
+    def test_none_when_no_models_flag(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        unit = tmp_path / "rkllama.service"
+        unit.write_text("[Service]\nExecStart=/usr/bin/rkllama_server --port 7833\n")
+        assert rkllama_service_models_dir(unit) is None

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -20,6 +20,7 @@ import logging
 import re
 import socket
 import urllib.request
+from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlparse
 
@@ -94,6 +95,37 @@ def default_rkllama_url() -> str:
         )
         return f"http://localhost:{_LEGACY_RKLLAMA_PORT}"
     return f"http://localhost:{_DEFAULT_RKLLAMA_PORT}"
+
+
+_RKLLAMA_UNIT_PATH = Path("/etc/systemd/system/rkllama.service")
+# rkllama_server ... --models <dir> ...  (space or = between flag and value)
+_RKLLAMA_MODELS_ARG_RE = re.compile(r"--models[=\s]+(\S+)")
+
+
+def rkllama_service_models_dir(
+    unit_path: Path = _RKLLAMA_UNIT_PATH,
+) -> Path | None:
+    """Directory the installed rkllama systemd service actually writes models
+    to, parsed from its unit's ``ExecStart --models`` flag.
+
+    Lets taOS discover models wherever an *existing* rkllama install puts them,
+    even one whose service predates the unified-model-store change (#1682) and
+    therefore writes to a directory taOS's own roots don't cover. Updating the
+    controller doesn't regenerate that service, so without this an existing
+    install's downloads stay invisible until a manual reinstall (#1548).
+
+    Returns ``None`` when there is no readable unit or no ``--models`` flag.
+    """
+    try:
+        text = unit_path.read_text()
+    except OSError:
+        return None
+    for line in text.splitlines():
+        if line.strip().startswith("ExecStart"):
+            m = _RKLLAMA_MODELS_ARG_RE.search(line)
+            if m:
+                return Path(m.group(1).strip("'\""))
+    return None
 
 
 _PLAIN_PERCENT_RE = re.compile(r"^\s*(\d{1,3})(?:\.\d+)?\s*%\s*$")

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -144,7 +144,7 @@ def rkllama_service_models_dir(
         return result
     try:
         proc = subprocess.run(
-            ["systemctl", "show", "rkllama", "--property=ExecStart", "--value"],
+            ["systemctl", "show", "rkllama.service", "--property=ExecStart", "--value"],
             capture_output=True, text=True, timeout=5,
         )
     except (OSError, subprocess.SubprocessError):

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -19,6 +19,7 @@ import json
 import logging
 import re
 import socket
+import subprocess
 import urllib.request
 from pathlib import Path
 from typing import Any, Callable
@@ -98,15 +99,30 @@ def default_rkllama_url() -> str:
 
 
 _RKLLAMA_UNIT_PATH = Path("/etc/systemd/system/rkllama.service")
-# rkllama_server ... --models <dir> ...  (space or = between flag and value)
-_RKLLAMA_MODELS_ARG_RE = re.compile(r"--models[=\s]+(\S+)")
+# --models <dir>, tolerating `=` or space and single/double-quoted paths that
+# may contain whitespace (e.g. --models '/path with spaces').
+_RKLLAMA_MODELS_ARG_RE = re.compile(r"--models[=\s]+('[^']*'|\"[^\"]*\"|\S+)")
+
+
+def _extract_models_arg(text: str) -> Path | None:
+    """Pull the ``--models`` value out of an ExecStart command blob. Collapses
+    systemd backslash line-continuations first so a multi-line ExecStart still
+    matches, and strips surrounding quotes."""
+    if not text:
+        return None
+    joined = text.replace("\\\n", " ")
+    m = _RKLLAMA_MODELS_ARG_RE.search(joined)
+    if not m:
+        return None
+    val = m.group(1).strip("'\"")
+    return Path(val) if val else None
 
 
 def rkllama_service_models_dir(
     unit_path: Path = _RKLLAMA_UNIT_PATH,
 ) -> Path | None:
     """Directory the installed rkllama systemd service actually writes models
-    to, parsed from its unit's ``ExecStart --models`` flag.
+    to, parsed from its ``ExecStart --models`` flag.
 
     Lets taOS discover models wherever an *existing* rkllama install puts them,
     even one whose service predates the unified-model-store change (#1682) and
@@ -114,18 +130,26 @@ def rkllama_service_models_dir(
     controller doesn't regenerate that service, so without this an existing
     install's downloads stay invisible until a manual reinstall (#1548).
 
-    Returns ``None`` when there is no readable unit or no ``--models`` flag.
+    Reads the standard unit file first (fast, no subprocess); if that yields
+    nothing (drop-in override, user-level unit, or a non-standard path), falls
+    back to ``systemctl show`` which resolves the effective ExecStart wherever
+    the unit lives. Returns ``None`` when neither source has a ``--models``.
     """
     try:
         text = unit_path.read_text()
     except OSError:
+        text = ""
+    result = _extract_models_arg(text)
+    if result is not None:
+        return result
+    try:
+        proc = subprocess.run(
+            ["systemctl", "show", "rkllama", "--property=ExecStart", "--value"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
         return None
-    for line in text.splitlines():
-        if line.strip().startswith("ExecStart"):
-            m = _RKLLAMA_MODELS_ARG_RE.search(line)
-            if m:
-                return Path(m.group(1).strip("'\""))
-    return None
+    return _extract_models_arg(proc.stdout)
 
 
 _PLAIN_PERCENT_RE = re.compile(r"^\s*(\d{1,3})(?:\.\d+)?\s*%\s*$")

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -84,12 +84,21 @@ def _scan_roots(request: Request) -> list[Path]:
     Legacy ``data/models`` plus the new shared layout root
     (~/models/<backend>/<family>/<id>/...). Both get walked so files
     placed by older installers still surface alongside the new tree.
+
+    Also includes wherever the installed rkllama service actually writes its
+    models (read from its systemd unit), so a model downloaded by an *existing*
+    rkllama install whose service predates the unified tree is still discovered,
+    without needing to regenerate that service (#1548).
     """
     primary = _models_dir(request)
     extra = getattr(request.app.state, "models_root", None)
     roots = [primary]
     if extra is not None and Path(extra) != primary:
         roots.append(Path(extra))
+    from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+    rkllama_dir = rkllama_service_models_dir()
+    if rkllama_dir is not None and rkllama_dir not in roots:
+        roots.append(rkllama_dir)
     return roots
 
 


### PR DESCRIPTION
## The gap
@mandresve updated to beta.33 and #1548 was **still not fixed** for him. Root cause: #1682 changed `install-rknpu.sh` so *new* rkllama installs write into the unified model tree, but his rkllama **systemd service was generated by the old installer** and still writes to its old `--models` directory. **A controller update doesn't regenerate that service**, so his downloaded model lands in a directory taOS never scans, and stays invisible in the Models UI.

## The fix (privilege-free, works for all installs)
Instead of editing his systemd unit on update (needs root, brittle, brick-adjacent), taOS now **reads the rkllama service's own `--models` path** from `/etc/systemd/system/rkllama.service` and adds it to the model scan roots. It looks wherever rkllama actually writes, so an existing install's downloads are discovered with **no reinstall, no privilege, no unit editing**. Degrades gracefully (returns `None`) when there's no readable unit.

- `rkllama_service_models_dir()` parses `ExecStart --models <dir>`.
- `routes/models.py::_scan_roots` includes it.
- Tests cover the parser (present / absent unit / no --models flag).

This complements #1682 (which unifies where *new* installs write) and, with #1697 (provider port heal), closes out mandresve's cluster on existing installs. Part of #1548.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model listings now include models stored by an existing rkllama service, so `/api/models` can discover them automatically.
  * Improved detection of service model paths, including quoted paths, multi-line service commands, and fallback lookup when direct config is unavailable.

* **Tests**
  * Added coverage for service model-path detection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->