### PR TITLE
release: promote 1.0.0-beta.34 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.34] - 2026-07-07
+
+### Fixed
+- Downloaded RK3588 (rkllama) models now appear after a normal update, with no reinstall. rkllama's background service kept saving models to its old location even after the controller updated, and taOS did not look there. taOS now reads where the rkllama service actually writes (from its systemd unit) and scans that directory, so an existing install's downloaded models show up in the Models list. Reported by @mandresve (#1548).
+- The local RKLLM provider no longer shows Error because of a stale port. Installs seeded before the taOS default port moved to 7833 kept a localhost:8080 provider URL, so the Providers page and model discovery polled a dead port. That URL is now healed to 7833 on load. Reported by @mandresve (#1697).
+- The taOS Agent chat no longer reports "runtime unavailable" when opencode was installed by the operator under their own home. The controller runs as an unprivileged service user that could not see an opencode installed in a different user's home, so it now also checks a TAOS_OPENCODE_BIN override and trusted system locations. Reported by @mandresve (#1616).
+- When an agent's model change cannot re-scope its per-agent key, the stale key is discarded and that discard is now persisted, so the next deploy correctly falls back to the master key instead of reusing a key scoped to the old model (#1686).
+
+### Security
+- opencode discovery only probes trusted locations (system paths, the service user's own home) and an explicit operator override, never arbitrary users' home directories, so a non-privileged user cannot plant a binary the service would run (#1616).
+
 ## [1.0.0-beta.33] - 2026-07-06
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.33",
+  "version": "1.0.0-beta.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.33",
+      "version": "1.0.0-beta.34",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.33",
+  "version": "1.0.0-beta.34",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.33"
+version = "1.0.0-beta.34"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -365,6 +365,35 @@ async def test_update_agent_model_downloaded_backend_down_returns_actionable_409
     assert "not running" in data["error"]
 
 
+@pytest.mark.asyncio
+async def test_update_agent_model_discards_stale_key_on_re_scope_failure(monkeypatch):
+    """When update_agent_key returns False (e.g. routing-only mode or provider
+    type mismatch), the stale per-agent key must be discarded so the deployer
+    falls back to the master key on the next deploy."""
+    _patch_save(monkeypatch)
+    _patch_resolver(monkeypatch, {})
+    # routing-only proxy (no database_url) — update_agent_key returns False
+    proxy = _FakeProxy(db=False)
+    import tinyagentos.llm_proxy as M
+    monkeypatch.setattr(M.httpx, "AsyncClient", lambda **k: _Client(200))
+    from tinyagentos.routes.agents import update_agent_model, AgentModelUpdate
+    agents = [
+        {
+            "name": "alpha",
+            "model": "llama3",
+            "llm_key": "sk-stale",
+            "permitted_models": ["llama3"],
+        }
+    ]
+    req = _FakeRequest(agents, proxy=proxy)
+    body = AgentModelUpdate(model="qwen3")
+    resp = await update_agent_model(req, "alpha", body)
+    assert resp["status"] == "updated"
+    assert resp["key_rescoped"] is False
+    # The stale key must be discarded
+    assert agents[0].get("llm_key") is None
+
+
 # ---------------------------------------------------------------------------
 # Piece 3 — GET /api/agents/me/models (agent-facing, bearer auth)
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_permitted_models.py
+++ b/tests/test_agent_permitted_models.py
@@ -368,9 +368,19 @@ async def test_update_agent_model_downloaded_backend_down_returns_actionable_409
 @pytest.mark.asyncio
 async def test_update_agent_model_discards_stale_key_on_re_scope_failure(monkeypatch):
     """When update_agent_key returns False (e.g. routing-only mode or provider
-    type mismatch), the stale per-agent key must be discarded so the deployer
-    falls back to the master key on the next deploy."""
-    _patch_save(monkeypatch)
+    type mismatch), the stale per-agent key must be discarded AND that discard
+    must be persisted -- the earlier save runs before the re-scope, so without a
+    second save the stale key survives on disk and the next deploy still uses
+    it."""
+    # Record the persisted llm_key at each save so we can assert the discard was
+    # actually written, not just mutated in memory.
+    saved_keys = []
+    import tinyagentos.routes.agents as mod
+
+    async def _recording_save(config, path, *a, **k):
+        saved_keys.append(config.agents[0].get("llm_key"))
+
+    monkeypatch.setattr(mod, "save_config_locked", _recording_save)
     _patch_resolver(monkeypatch, {})
     # routing-only proxy (no database_url) — update_agent_key returns False
     proxy = _FakeProxy(db=False)
@@ -390,8 +400,11 @@ async def test_update_agent_model_discards_stale_key_on_re_scope_failure(monkeyp
     resp = await update_agent_model(req, "alpha", body)
     assert resp["status"] == "updated"
     assert resp["key_rescoped"] is False
-    # The stale key must be discarded
+    # The stale key must be discarded in memory...
     assert agents[0].get("llm_key") is None
+    # ...and persisted: the final save must have written the None, otherwise the
+    # on-disk config keeps the stale key (the bug this guards against).
+    assert saved_keys and saved_keys[-1] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -355,3 +355,27 @@ class TestLitellmPortPin:
         assert config.server["litellm_port"] == 5000
         # File must not be rewritten when no pin was applied.
         assert p.stat().st_mtime == original_mtime
+
+
+def test_load_config_migrates_legacy_rkllama_port(tmp_path):
+    """An install seeded before the taOS default moved to :7833 keeps a stale
+    localhost:8080 rkllama provider; load_config heals it to :7833 (#1697)."""
+    import yaml
+    from tinyagentos.config import load_config
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({
+        "backends": [
+            {"name": "rkllama", "type": "rkllama", "url": "http://localhost:8080"},
+            {"name": "custom-rk", "type": "rkllama", "url": "http://10.0.0.5:8080"},
+            {"name": "ollama", "type": "ollama", "url": "http://localhost:8080"},
+        ]
+    }))
+    cfg = load_config(cfg_path)
+    by_name = {b["name"]: b["url"] for b in cfg.backends}
+    # auto-seeded localhost rkllama -> healed to 7833
+    assert by_name["rkllama"] == "http://localhost:7833"
+    # deliberate custom host -> untouched
+    assert by_name["custom-rk"] == "http://10.0.0.5:8080"
+    # non-rkllama backend on 8080 -> untouched
+    assert by_name["ollama"] == "http://localhost:8080"

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -290,9 +291,12 @@ class TestResolveOpencodeBinary:
     def test_does_not_probe_arbitrary_user_homes(self, monkeypatch):
         """Security: the candidate list must not glob /home/*, since running a binary
         from a non-privileged user's home is a privilege-escalation vector on a
-        multi-user box (#1616 security review)."""
+        multi-user box (#1616 security review). The service user's own home
+        (e.g. /opt/taos) is fine; only *arbitrary* /home/* is banned, so pin
+        home outside /home to isolate it from the CI runner's /home/runner."""
         from tinyagentos import opencode_runtime as ocr
 
+        monkeypatch.setattr(ocr.Path, "home", classmethod(lambda cls: Path("/opt/taos")))
         for candidate in ocr._opencode_candidate_paths():
             assert not str(candidate).startswith("/home/"), (
                 f"must not probe arbitrary user home: {candidate}"

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -268,25 +268,35 @@ class TestResolveOpencodeBinary:
 
         assert ocr.resolve_opencode_binary() == str(binary)
 
-    def test_finds_binary_installed_under_another_user_home(self, tmp_path, monkeypatch):
-        """#1616: opencode installed by the operator lands in *their* home, not
-        the taos service user's. The service must still find it via the extra
-        candidate locations."""
+    def test_finds_first_executable_candidate(self, tmp_path, monkeypatch):
+        """resolve_opencode_binary walks the trusted candidate list and returns
+        the first existing executable, skipping earlier non-existent ones (e.g.
+        the service user's own home has none, but a system path does)."""
         from tinyagentos import opencode_runtime as ocr
 
-        operator_bin = tmp_path / "home" / "operator" / ".opencode" / "bin" / "opencode"
-        operator_bin.parent.mkdir(parents=True)
-        operator_bin.write_text("#!/bin/sh\n")
-        operator_bin.chmod(0o755)
+        system_bin = tmp_path / "usr" / "local" / "bin" / "opencode"
+        system_bin.parent.mkdir(parents=True)
+        system_bin.write_text("#!/bin/sh\n")
+        system_bin.chmod(0o755)
 
         monkeypatch.delenv("TAOS_OPENCODE_BIN", raising=False)
         monkeypatch.setattr(ocr.shutil, "which", lambda name: None)
-        # taos service user's own home has no opencode; the operator's does.
         monkeypatch.setattr(
             ocr, "_opencode_candidate_paths",
-            lambda: [tmp_path / "taos-home" / ".opencode" / "bin" / "opencode", operator_bin],
+            lambda: [tmp_path / "taos-home" / ".opencode" / "bin" / "opencode", system_bin],
         )
-        assert ocr.resolve_opencode_binary() == str(operator_bin)
+        assert ocr.resolve_opencode_binary() == str(system_bin)
+
+    def test_does_not_probe_arbitrary_user_homes(self, monkeypatch):
+        """Security: the candidate list must not glob /home/* — running a binary
+        from a non-privileged user's home is a privilege-escalation vector on a
+        multi-user box (#1616 security review)."""
+        from tinyagentos import opencode_runtime as ocr
+
+        for candidate in ocr._opencode_candidate_paths():
+            assert not str(candidate).startswith("/home/"), (
+                f"must not probe arbitrary user home: {candidate}"
+            )
 
     def test_returns_none_when_not_installed_anywhere(self, tmp_path, monkeypatch):
         from tinyagentos import opencode_runtime as ocr

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -236,8 +236,21 @@ class TestResolveOpencodeBinary:
     def test_prefers_path_lookup(self, monkeypatch):
         from tinyagentos import opencode_runtime as ocr
 
+        monkeypatch.delenv("TAOS_OPENCODE_BIN", raising=False)
         monkeypatch.setattr(ocr.shutil, "which", lambda name: "/usr/local/bin/opencode")
         assert ocr.resolve_opencode_binary() == "/usr/local/bin/opencode"
+
+    def test_env_override_wins(self, tmp_path, monkeypatch):
+        """TAOS_OPENCODE_BIN is the explicit operator override and beats PATH."""
+        from tinyagentos import opencode_runtime as ocr
+
+        binary = tmp_path / "my-opencode"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        monkeypatch.setenv("TAOS_OPENCODE_BIN", str(binary))
+        # Even with a PATH hit, the override wins.
+        monkeypatch.setattr(ocr.shutil, "which", lambda name: "/usr/local/bin/opencode")
+        assert ocr.resolve_opencode_binary() == str(binary)
 
     def test_falls_back_to_installer_default_location(self, tmp_path, monkeypatch):
         from tinyagentos import opencode_runtime as ocr
@@ -249,16 +262,40 @@ class TestResolveOpencodeBinary:
         binary.write_text("#!/bin/sh\n")
         binary.chmod(0o755)
 
+        monkeypatch.delenv("TAOS_OPENCODE_BIN", raising=False)
         monkeypatch.setattr(ocr.shutil, "which", lambda name: None)
         monkeypatch.setattr(ocr.Path, "home", classmethod(lambda cls: fake_home))
 
         assert ocr.resolve_opencode_binary() == str(binary)
 
+    def test_finds_binary_installed_under_another_user_home(self, tmp_path, monkeypatch):
+        """#1616: opencode installed by the operator lands in *their* home, not
+        the taos service user's. The service must still find it via the extra
+        candidate locations."""
+        from tinyagentos import opencode_runtime as ocr
+
+        operator_bin = tmp_path / "home" / "operator" / ".opencode" / "bin" / "opencode"
+        operator_bin.parent.mkdir(parents=True)
+        operator_bin.write_text("#!/bin/sh\n")
+        operator_bin.chmod(0o755)
+
+        monkeypatch.delenv("TAOS_OPENCODE_BIN", raising=False)
+        monkeypatch.setattr(ocr.shutil, "which", lambda name: None)
+        # taos service user's own home has no opencode; the operator's does.
+        monkeypatch.setattr(
+            ocr, "_opencode_candidate_paths",
+            lambda: [tmp_path / "taos-home" / ".opencode" / "bin" / "opencode", operator_bin],
+        )
+        assert ocr.resolve_opencode_binary() == str(operator_bin)
+
     def test_returns_none_when_not_installed_anywhere(self, tmp_path, monkeypatch):
         from tinyagentos import opencode_runtime as ocr
 
+        monkeypatch.delenv("TAOS_OPENCODE_BIN", raising=False)
         monkeypatch.setattr(ocr.shutil, "which", lambda name: None)
-        monkeypatch.setattr(ocr.Path, "home", classmethod(lambda cls: tmp_path / "no-home"))
+        # Neutralise the host filesystem so a real opencode on the CI runner
+        # doesn't leak into this "nothing installed" case.
+        monkeypatch.setattr(ocr, "_opencode_candidate_paths", lambda: [])
 
         assert ocr.resolve_opencode_binary() is None
 

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -288,7 +288,7 @@ class TestResolveOpencodeBinary:
         assert ocr.resolve_opencode_binary() == str(system_bin)
 
     def test_does_not_probe_arbitrary_user_homes(self, monkeypatch):
-        """Security: the candidate list must not glob /home/* — running a binary
+        """Security: the candidate list must not glob /home/*, since running a binary
         from a non-privileged user's home is a privilege-escalation vector on a
         multi-user box (#1616 security review)."""
         from tinyagentos import opencode_runtime as ocr

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -452,3 +452,35 @@ class TestRkllamaServiceModelsDir:
         unit = tmp_path / "rkllama.service"
         unit.write_text("[Service]\nExecStart=/usr/bin/rkllama_server --port 7833\n")
         assert rkllama_service_models_dir(unit) is None
+
+    def test_parses_multiline_backslash_continuation(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        unit = tmp_path / "rkllama.service"
+        unit.write_text(
+            "[Service]\n"
+            "ExecStart=/opt/x/.venv/bin/rkllama_server \\\n"
+            "  --processor rk3588 --port 7833 \\\n"
+            "  --models /opt/taos/data/models/rkllama \\\n"
+            "  --preload a,b\n"
+        )
+        assert rkllama_service_models_dir(unit) == Path("/opt/taos/data/models/rkllama")
+
+    def test_parses_quoted_path_with_spaces(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        unit = tmp_path / "rkllama.service"
+        unit.write_text(
+            "[Service]\nExecStart=/usr/bin/rkllama_server --models '/srv/rk models/dir' --port 7833\n"
+        )
+        assert rkllama_service_models_dir(unit) == Path("/srv/rk models/dir")
+
+    def test_falls_back_to_systemctl_when_no_unit_file(self, tmp_path, monkeypatch):
+        import subprocess as _sp
+        from tinyagentos.installers import rkllama_installer as ri
+
+        class _Res:
+            stdout = "/opt/x/rkllama_server --processor rk3588 --models /var/lib/rkllama/models"
+
+        monkeypatch.setattr(ri.subprocess, "run", lambda *a, **k: _Res())
+        # No file at the given path -> falls back to systemctl show
+        assert ri.rkllama_service_models_dir(tmp_path / "absent.service") == Path("/var/lib/rkllama/models")
+

--- a/tests/test_rkllama_installer.py
+++ b/tests/test_rkllama_installer.py
@@ -6,6 +6,8 @@ roundtrip to /api/pull is exercised manually on the Pi (see PR description).
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 import pytest
 import respx
@@ -424,3 +426,29 @@ class TestRkllamaServiceManifest:
         script = install.get("script")
         assert script, "rkllama manifest declares no install.script"
         assert (repo / script).is_file(), f"rkllama install script missing: {script}"
+
+
+class TestRkllamaServiceModelsDir:
+    """rkllama_service_models_dir parses the --models path from the installed
+    systemd unit so taOS can scan wherever an existing rkllama writes (#1548)."""
+
+    def test_parses_models_flag(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        unit = tmp_path / "rkllama.service"
+        unit.write_text(
+            "[Service]\n"
+            "ExecStart=/opt/x/.venv/bin/python /opt/x/.venv/bin/rkllama_server "
+            "--processor rk3588 --port 7833 --models /home/jay/rkllama/models "
+            "--preload a,b\n"
+        )
+        assert rkllama_service_models_dir(unit) == Path("/home/jay/rkllama/models")
+
+    def test_none_when_unit_absent(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        assert rkllama_service_models_dir(tmp_path / "nope.service") is None
+
+    def test_none_when_no_models_flag(self, tmp_path):
+        from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+        unit = tmp_path / "rkllama.service"
+        unit.write_text("[Service]\nExecStart=/usr/bin/rkllama_server --port 7833\n")
+        assert rkllama_service_models_dir(unit) is None

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.33"
+__version__ = "1.0.0-beta.34"

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -72,6 +72,31 @@ class AppConfig:
             d["archive"] = self.archive
         return d
 
+# rkllama's taOS default port moved from the upstream 8080 to 7833. Installs
+# seeded before that switch kept a stale ``localhost:8080`` provider URL, so the
+# Providers page and live model discovery point at a dead port (#1697). We heal
+# only the auto-seeded localhost default, never a deliberately-set custom host.
+_LEGACY_RKLLAMA_URLS = frozenset(
+    {"http://localhost:8080", "http://127.0.0.1:8080"}
+)
+
+
+def _migrate_legacy_rkllama_port(backends: list[dict]) -> None:
+    """Rewrite a stale ``rkllama`` provider URL from the legacy :8080 to :7833
+    in place (#1697). Idempotent and targeted: only the auto-seeded localhost
+    default is touched."""
+    for b in backends:
+        if b.get("type") != "rkllama":
+            continue
+        url = (b.get("url") or "").rstrip("/")
+        if url in _LEGACY_RKLLAMA_URLS:
+            b["url"] = url.replace(":8080", ":7833")
+            log.info(
+                "migrating rkllama provider %r from legacy :8080 to :7833 (#1697)",
+                b.get("name"),
+            )
+
+
 def load_config(path: Path) -> AppConfig:
     if not path.exists():
         # Fresh install: build defaults with litellm_port explicitly recorded
@@ -109,9 +134,11 @@ def load_config(path: Path) -> AppConfig:
             "new installs use %d, see #795",
             _LITELLM_PORT_LEGACY, _LITELLM_PORT_NEW,
         )
+    backends = data.get("backends", [])
+    _migrate_legacy_rkllama_port(backends)
     cfg = AppConfig(
         server=server,
-        backends=data.get("backends", []),
+        backends=backends,
         qmd=data.get("qmd", DEFAULT_CONFIG["qmd"].copy()),
         agents=agents,
         metrics=data.get("metrics", DEFAULT_CONFIG["metrics"].copy()),

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -20,6 +20,7 @@ import logging
 import re
 import socket
 import urllib.request
+from pathlib import Path
 from typing import Any, Callable
 from urllib.parse import urlparse
 
@@ -94,6 +95,37 @@ def default_rkllama_url() -> str:
         )
         return f"http://localhost:{_LEGACY_RKLLAMA_PORT}"
     return f"http://localhost:{_DEFAULT_RKLLAMA_PORT}"
+
+
+_RKLLAMA_UNIT_PATH = Path("/etc/systemd/system/rkllama.service")
+# rkllama_server ... --models <dir> ...  (space or = between flag and value)
+_RKLLAMA_MODELS_ARG_RE = re.compile(r"--models[=\s]+(\S+)")
+
+
+def rkllama_service_models_dir(
+    unit_path: Path = _RKLLAMA_UNIT_PATH,
+) -> Path | None:
+    """Directory the installed rkllama systemd service actually writes models
+    to, parsed from its unit's ``ExecStart --models`` flag.
+
+    Lets taOS discover models wherever an *existing* rkllama install puts them,
+    even one whose service predates the unified-model-store change (#1682) and
+    therefore writes to a directory taOS's own roots don't cover. Updating the
+    controller doesn't regenerate that service, so without this an existing
+    install's downloads stay invisible until a manual reinstall (#1548).
+
+    Returns ``None`` when there is no readable unit or no ``--models`` flag.
+    """
+    try:
+        text = unit_path.read_text()
+    except OSError:
+        return None
+    for line in text.splitlines():
+        if line.strip().startswith("ExecStart"):
+            m = _RKLLAMA_MODELS_ARG_RE.search(line)
+            if m:
+                return Path(m.group(1).strip("'\""))
+    return None
 
 
 _PLAIN_PERCENT_RE = re.compile(r"^\s*(\d{1,3})(?:\.\d+)?\s*%\s*$")

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -144,7 +144,7 @@ def rkllama_service_models_dir(
         return result
     try:
         proc = subprocess.run(
-            ["systemctl", "show", "rkllama", "--property=ExecStart", "--value"],
+            ["systemctl", "show", "rkllama.service", "--property=ExecStart", "--value"],
             capture_output=True, text=True, timeout=5,
         )
     except (OSError, subprocess.SubprocessError):

--- a/tinyagentos/installers/rkllama_installer.py
+++ b/tinyagentos/installers/rkllama_installer.py
@@ -19,6 +19,7 @@ import json
 import logging
 import re
 import socket
+import subprocess
 import urllib.request
 from pathlib import Path
 from typing import Any, Callable
@@ -98,15 +99,30 @@ def default_rkllama_url() -> str:
 
 
 _RKLLAMA_UNIT_PATH = Path("/etc/systemd/system/rkllama.service")
-# rkllama_server ... --models <dir> ...  (space or = between flag and value)
-_RKLLAMA_MODELS_ARG_RE = re.compile(r"--models[=\s]+(\S+)")
+# --models <dir>, tolerating `=` or space and single/double-quoted paths that
+# may contain whitespace (e.g. --models '/path with spaces').
+_RKLLAMA_MODELS_ARG_RE = re.compile(r"--models[=\s]+('[^']*'|\"[^\"]*\"|\S+)")
+
+
+def _extract_models_arg(text: str) -> Path | None:
+    """Pull the ``--models`` value out of an ExecStart command blob. Collapses
+    systemd backslash line-continuations first so a multi-line ExecStart still
+    matches, and strips surrounding quotes."""
+    if not text:
+        return None
+    joined = text.replace("\\\n", " ")
+    m = _RKLLAMA_MODELS_ARG_RE.search(joined)
+    if not m:
+        return None
+    val = m.group(1).strip("'\"")
+    return Path(val) if val else None
 
 
 def rkllama_service_models_dir(
     unit_path: Path = _RKLLAMA_UNIT_PATH,
 ) -> Path | None:
     """Directory the installed rkllama systemd service actually writes models
-    to, parsed from its unit's ``ExecStart --models`` flag.
+    to, parsed from its ``ExecStart --models`` flag.
 
     Lets taOS discover models wherever an *existing* rkllama install puts them,
     even one whose service predates the unified-model-store change (#1682) and
@@ -114,18 +130,26 @@ def rkllama_service_models_dir(
     controller doesn't regenerate that service, so without this an existing
     install's downloads stay invisible until a manual reinstall (#1548).
 
-    Returns ``None`` when there is no readable unit or no ``--models`` flag.
+    Reads the standard unit file first (fast, no subprocess); if that yields
+    nothing (drop-in override, user-level unit, or a non-standard path), falls
+    back to ``systemctl show`` which resolves the effective ExecStart wherever
+    the unit lives. Returns ``None`` when neither source has a ``--models``.
     """
     try:
         text = unit_path.read_text()
     except OSError:
+        text = ""
+    result = _extract_models_arg(text)
+    if result is not None:
+        return result
+    try:
+        proc = subprocess.run(
+            ["systemctl", "show", "rkllama", "--property=ExecStart", "--value"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
         return None
-    for line in text.splitlines():
-        if line.strip().startswith("ExecStart"):
-            m = _RKLLAMA_MODELS_ARG_RE.search(line)
-            if m:
-                return Path(m.group(1).strip("'\""))
-    return None
+    return _extract_models_arg(proc.stdout)
 
 
 _PLAIN_PERCENT_RE = re.compile(r"^\s*(\d{1,3})(?:\.\d+)?\s*%\s*$")

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -54,34 +54,37 @@ _OPENCODE_SYSTEM_PATHS = (
 def _opencode_candidate_paths() -> list[Path]:
     """Ordered candidate binary locations to probe after PATH lookup.
 
-    Covers the #1616 case: opencode's official installer drops the binary in
-    the *invoking* user's ``~/.opencode/bin``, but the ``taos`` service user's
-    own home is the install dir, not the human operator's home, so an opencode
-    "installed system-wide" (as the operator or root) was invisible. We now also
-    look at standard system paths and every real user's installer location.
+    Only **trusted** locations: root-controlled system paths, root's own home,
+    and the ``taos`` service user's own home. We deliberately do NOT probe
+    arbitrary users' ``~/.opencode/bin`` — taOS is multi-user, and executing a
+    binary from a non-privileged user's home would let that user plant a
+    malicious ``opencode`` and escalate to the service account. An operator who
+    installed opencode into their own home points at it explicitly via the
+    ``TAOS_OPENCODE_BIN`` env override, or installs it to ``/usr/local/bin``.
 
     Broken out from :func:`resolve_opencode_binary` so tests can neutralise the
     host filesystem.
     """
     candidates: list[Path] = [Path.home() / ".opencode" / "bin" / "opencode"]
     candidates += [Path(p) for p in _OPENCODE_SYSTEM_PATHS]
-    # The installer's per-user location for whoever actually ran it (root or a
-    # human operator), which the service user's own home never covers.
+    # root's own home is writable only by root, so a binary there is trusted.
     candidates.append(Path("/root/.opencode/bin/opencode"))
-    candidates += sorted(Path("/home").glob("*/.opencode/bin/opencode"))
     return candidates
 
 
 def resolve_opencode_binary() -> str | None:
     """Locate the opencode binary, working around the PATH gap above.
 
-    Checks, in order:
+    Checks, in order (trusted locations only):
       1. ``TAOS_OPENCODE_BIN`` env var -- explicit operator override.
       2. ``shutil.which("opencode")`` -- covers PATH already containing it.
       3. The service user's own ``~/.opencode/bin/opencode``.
-      4. Standard system paths + every real user's ``~/.opencode/bin`` (the
-         installer's per-user location), so opencode installed by the operator
-         under their own home is still found by the ``taos`` service (#1616).
+      4. Root-controlled locations: standard system paths + ``/root/.opencode``.
+
+    An operator who installed opencode under their own (non-root) home sets
+    ``TAOS_OPENCODE_BIN`` or installs to ``/usr/local/bin`` -- we don't probe
+    arbitrary user homes, since running a binary from a non-privileged user's
+    home on a multi-user box is a privilege-escalation vector (#1616).
 
     Returns the resolved path, or ``None`` if opencode isn't installed
     anywhere we know to look.

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -90,8 +90,13 @@ def resolve_opencode_binary() -> str | None:
     anywhere we know to look.
     """
     override = os.environ.get("TAOS_OPENCODE_BIN")
-    if override and _is_executable(Path(override)):
-        return override
+    if override:
+        if _is_executable(Path(override)):
+            return override
+        logger.warning(
+            "TAOS_OPENCODE_BIN=%s is not an executable file; ignoring it and "
+            "falling back to PATH and standard locations.", override,
+        )
     found = shutil.which("opencode")
     if found:
         return found

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -56,7 +56,7 @@ def _opencode_candidate_paths() -> list[Path]:
 
     Only **trusted** locations: root-controlled system paths, root's own home,
     and the ``taos`` service user's own home. We deliberately do NOT probe
-    arbitrary users' ``~/.opencode/bin`` — taOS is multi-user, and executing a
+    arbitrary users' ``~/.opencode/bin``: taOS is multi-user, and executing a
     binary from a non-privileged user's home would let that user plant a
     malicious ``opencode`` and escalate to the service account. An operator who
     installed opencode into their own home points at it explicitly via the

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -40,24 +40,61 @@ class OpenCodeBinaryNotFoundError(RuntimeError):
     """
 
 
+# Standard system-wide install locations to probe beyond PATH. The controller
+# runs as the unprivileged ``taos`` service user (a non-login systemd service),
+# so it neither sources shell rc PATH exports nor shares a home with whoever
+# ran opencode's installer.
+_OPENCODE_SYSTEM_PATHS = (
+    "/usr/local/bin/opencode",
+    "/usr/bin/opencode",
+    "/opt/opencode/bin/opencode",
+)
+
+
+def _opencode_candidate_paths() -> list[Path]:
+    """Ordered candidate binary locations to probe after PATH lookup.
+
+    Covers the #1616 case: opencode's official installer drops the binary in
+    the *invoking* user's ``~/.opencode/bin``, but the ``taos`` service user's
+    own home is the install dir, not the human operator's home, so an opencode
+    "installed system-wide" (as the operator or root) was invisible. We now also
+    look at standard system paths and every real user's installer location.
+
+    Broken out from :func:`resolve_opencode_binary` so tests can neutralise the
+    host filesystem.
+    """
+    candidates: list[Path] = [Path.home() / ".opencode" / "bin" / "opencode"]
+    candidates += [Path(p) for p in _OPENCODE_SYSTEM_PATHS]
+    # The installer's per-user location for whoever actually ran it (root or a
+    # human operator), which the service user's own home never covers.
+    candidates.append(Path("/root/.opencode/bin/opencode"))
+    candidates += sorted(Path("/home").glob("*/.opencode/bin/opencode"))
+    return candidates
+
+
 def resolve_opencode_binary() -> str | None:
     """Locate the opencode binary, working around the PATH gap above.
 
     Checks, in order:
-      1. ``shutil.which("opencode")`` -- covers PATH already containing it.
-      2. ``~/.opencode/bin/opencode`` -- the official installer's fixed
-         location, which a non-login process (e.g. a systemd service) never
-         picks up via PATH alone.
+      1. ``TAOS_OPENCODE_BIN`` env var -- explicit operator override.
+      2. ``shutil.which("opencode")`` -- covers PATH already containing it.
+      3. The service user's own ``~/.opencode/bin/opencode``.
+      4. Standard system paths + every real user's ``~/.opencode/bin`` (the
+         installer's per-user location), so opencode installed by the operator
+         under their own home is still found by the ``taos`` service (#1616).
 
     Returns the resolved path, or ``None`` if opencode isn't installed
     anywhere we know to look.
     """
+    override = os.environ.get("TAOS_OPENCODE_BIN")
+    if override and Path(override).is_file() and os.access(override, os.X_OK):
+        return override
     found = shutil.which("opencode")
     if found:
         return found
-    candidate = Path.home() / ".opencode" / "bin" / "opencode"
-    if candidate.is_file() and os.access(candidate, os.X_OK):
-        return str(candidate)
+    for candidate in _opencode_candidate_paths():
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
     return None
 
 

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -90,15 +90,26 @@ def resolve_opencode_binary() -> str | None:
     anywhere we know to look.
     """
     override = os.environ.get("TAOS_OPENCODE_BIN")
-    if override and Path(override).is_file() and os.access(override, os.X_OK):
+    if override and _is_executable(Path(override)):
         return override
     found = shutil.which("opencode")
     if found:
         return found
     for candidate in _opencode_candidate_paths():
-        if candidate.is_file() and os.access(candidate, os.X_OK):
+        if _is_executable(candidate):
             return str(candidate)
     return None
+
+
+def _is_executable(path: Path) -> bool:
+    """True if ``path`` is an existing executable file. Swallows OSError so an
+    inaccessible candidate (e.g. ``/root/.opencode/...`` when not running as
+    root -- ``is_file()`` raises PermissionError there) is treated as absent
+    rather than aborting resolution."""
+    try:
+        return path.is_file() and os.access(path, os.X_OK)
+    except OSError:
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1135,6 +1135,17 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
             key_rescoped = await proxy.update_agent_key(llm_key, permitted)
         except Exception:
             logger.exception("update_agent_model: re-scoping key for %s failed", name)
+        if not key_rescoped:
+            # Key re-scope failed (e.g. provider type mismatch after model
+            # change).  Discard the stale per-agent key so the deployer
+            # falls back to the master key on the next deploy — a stale
+            # scope would cause LiteLLM to 403 the new model.
+            logger.warning(
+                "update_agent_model: re-scope failed for %s — "
+                "discarding stale per-agent key (will fall back to master key)",
+                name,
+            )
+            agent["llm_key"] = None
 
     framework = agent.get("framework")
     if framework in ("openclaw", "hermes"):

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1146,6 +1146,10 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
                 name,
             )
             agent["llm_key"] = None
+            # Persist the discard: the earlier save_config_locked ran before the
+            # re-scope, so without this the stale key survives on disk and the
+            # next deploy would still use it.
+            await save_config_locked(config, config.config_path)
 
     framework = agent.get("framework")
     if framework in ("openclaw", "hermes"):

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -84,12 +84,21 @@ def _scan_roots(request: Request) -> list[Path]:
     Legacy ``data/models`` plus the new shared layout root
     (~/models/<backend>/<family>/<id>/...). Both get walked so files
     placed by older installers still surface alongside the new tree.
+
+    Also includes wherever the installed rkllama service actually writes its
+    models (read from its systemd unit), so a model downloaded by an *existing*
+    rkllama install whose service predates the unified tree is still discovered,
+    without needing to regenerate that service (#1548).
     """
     primary = _models_dir(request)
     extra = getattr(request.app.state, "models_root", None)
     roots = [primary]
     if extra is not None and Path(extra) != primary:
         roots.append(Path(extra))
+    from tinyagentos.installers.rkllama_installer import rkllama_service_models_dir
+    rkllama_dir = rkllama_service_models_dir()
+    if rkllama_dir is not None and rkllama_dir not in roots:
+        roots.append(rkllama_dir)
     return roots
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b33"
+version = "1.0.0b34"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promote dev to master for the **1.0.0-beta.34** release (rkllama model discovery + provider port heal for existing installs, opencode discovery, agent key persist).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model scans now include models already installed by an existing service, so more models appear automatically.

* **Bug Fixes**
  * Fixed several issues with model and runtime detection, including stale local ports, missing runtime warnings, and discovery of downloaded models.
  * Improved handling when an agent’s key can’t be re-scoped, so outdated credentials are no longer kept.

* **Security**
  * Tightened binary discovery to check only trusted locations, reducing the risk of unwanted executables being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->