### PR TITLE
fix(cluster): authenticate + harden GPU lease endpoints (#1680 retro)

### DIFF
--- a/tests/test_leases.py
+++ b/tests/test_leases.py
@@ -42,6 +42,15 @@ async def _heartbeat(client, key, name, **fields):
     return resp
 
 
+def _auth(app) -> dict:
+    """Authorization header carrying the app's local token.
+
+    The lease endpoints require a trusted principal (admin session, local
+    token, or worker HMAC); the local token is the simplest in tests and
+    stands in for a same-host controller-side caller (dispatcher/agent)."""
+    return {"Authorization": f"Bearer {app.state.auth.get_local_token()}"}
+
+
 @pytest.mark.asyncio
 async def test_claim_lease_success(client, app):
     """Claiming a lease on an online worker with enough VRAM returns 200."""
@@ -54,7 +63,7 @@ async def test_claim_lease_success(client, app):
     # Send a heartbeat with free VRAM
     await _heartbeat(client, key, "gpu-node", free_vram_mb=6000, used_vram_mb=2000)
 
-    resp = await client.post("/api/cluster/leases/claim", json={
+    resp = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "caller": "skald-dispatcher",
         "ttl_seconds": 30,
@@ -76,7 +85,7 @@ async def test_claim_lease_insufficient_vram(client, app):
     key = await _register_worker(client, app, "gpu-node", "http://10.0.0.1:9000", capabilities=["llm-chat"])
     await _heartbeat(client, key, "gpu-node", free_vram_mb=1000, used_vram_mb=7000)
 
-    resp = await client.post("/api/cluster/leases/claim", json={
+    resp = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "required_vram_mb": 8000,
     })
@@ -91,7 +100,7 @@ async def test_claim_lease_already_leased(client, app):
     await _heartbeat(client, key, "gpu-node", free_vram_mb=8000, used_vram_mb=0)
 
     # First claim succeeds
-    resp1 = await client.post("/api/cluster/leases/claim", json={
+    resp1 = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "caller": "skald-dispatcher",
         "ttl_seconds": 30,
@@ -100,7 +109,7 @@ async def test_claim_lease_already_leased(client, app):
     lease_id = resp1.json()["lease_id"]
 
     # Second claim on same resource fails
-    resp2 = await client.post("/api/cluster/leases/claim", json={
+    resp2 = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "caller": "a2a-agent:extract",
     })
@@ -118,7 +127,7 @@ async def test_claim_lease_unknown_vram_is_granted(client, app):
     await _register_worker(client, app, "cpu-node", "http://10.0.0.2:9000", capabilities=["llm-chat"])
     # No heartbeat with free_vram_mb ever sent -- it stays at its default (None).
 
-    resp = await client.post("/api/cluster/leases/claim", json={
+    resp = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "cpu-node:gpu-cuda-0",
         "required_vram_mb": 4000,
     })
@@ -127,13 +136,13 @@ async def test_claim_lease_unknown_vram_is_granted(client, app):
 
 
 @pytest.mark.asyncio
-async def test_claim_lease_worker_offline(client):
+async def test_claim_lease_worker_offline(client, app):
     """Claiming against an offline worker returns 409."""
     # Worker registered but no heartbeat ever sent — marked offline after
     # monitor_loop sweep.  The monitor_loop hasn't run in this test
     # context (no app startup), so the worker is technically "online" from
     # registration.  To test offline, claim against a nonexistent worker.
-    resp = await client.post("/api/cluster/leases/claim", json={
+    resp = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "ghost:gpu-cuda-0",
         "required_vram_mb": 4000,
     })
@@ -142,9 +151,9 @@ async def test_claim_lease_worker_offline(client):
 
 
 @pytest.mark.asyncio
-async def test_claim_lease_malformed_resource_id(client):
+async def test_claim_lease_malformed_resource_id(client, app):
     """A resource_id without a colon returns 409."""
-    resp = await client.post("/api/cluster/leases/claim", json={
+    resp = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "bogus",
     })
     assert resp.status_code == 409
@@ -156,29 +165,29 @@ async def test_release_lease_idempotent(client, app):
     key = await _register_worker(client, app, "gpu-node", "http://10.0.0.1:9000", capabilities=["llm-chat"])
     await _heartbeat(client, key, "gpu-node", free_vram_mb=8000)
 
-    claim = await client.post("/api/cluster/leases/claim", json={
+    claim = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
     })
     lease_id = claim.json()["lease_id"]
 
     # First release
-    resp1 = await client.post("/api/cluster/leases/release", json={
+    resp1 = await client.post("/api/cluster/leases/release", headers=_auth(app), json={
         "lease_id": lease_id,
     })
     assert resp1.status_code == 200
     assert resp1.json()["status"] == "released"
 
     # Second release (idempotent)
-    resp2 = await client.post("/api/cluster/leases/release", json={
+    resp2 = await client.post("/api/cluster/leases/release", headers=_auth(app), json={
         "lease_id": lease_id,
     })
     assert resp2.status_code == 200
 
 
 @pytest.mark.asyncio
-async def test_release_lease_unknown(client):
+async def test_release_lease_unknown(client, app):
     """Releasing an unknown lease_id is still 200 (idempotent)."""
-    resp = await client.post("/api/cluster/leases/release", json={
+    resp = await client.post("/api/cluster/leases/release", headers=_auth(app), json={
         "lease_id": "l_doesnotexist",
     })
     assert resp.status_code == 200
@@ -190,14 +199,14 @@ async def test_renew_lease_success(client, app):
     key = await _register_worker(client, app, "gpu-node", "http://10.0.0.1:9000", capabilities=["llm-chat"])
     await _heartbeat(client, key, "gpu-node", free_vram_mb=8000)
 
-    claim = await client.post("/api/cluster/leases/claim", json={
+    claim = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "ttl_seconds": 10,
     })
     lease_id = claim.json()["lease_id"]
     original_expiry = claim.json()["expires_at"]
 
-    resp = await client.post("/api/cluster/leases/renew", json={
+    resp = await client.post("/api/cluster/leases/renew", headers=_auth(app), json={
         "lease_id": lease_id,
         "ttl_seconds": 60,
     })
@@ -213,7 +222,7 @@ async def test_renew_lease_expired(client, app):
     key = await _register_worker(client, app, "gpu-node", "http://10.0.0.1:9000", capabilities=["llm-chat"])
     await _heartbeat(client, key, "gpu-node", free_vram_mb=8000)
 
-    claim = await client.post("/api/cluster/leases/claim", json={
+    claim = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "ttl_seconds": 0.001,  # effectively instant
     })
@@ -222,7 +231,7 @@ async def test_renew_lease_expired(client, app):
     # Wait a moment for it to expire
     time.sleep(0.1)
 
-    resp = await client.post("/api/cluster/leases/renew", json={
+    resp = await client.post("/api/cluster/leases/renew", headers=_auth(app), json={
         "lease_id": lease_id,
         "ttl_seconds": 30,
     })
@@ -237,19 +246,19 @@ async def test_list_leases(client, app):
     await _heartbeat(client, key, "gpu-node", free_vram_mb=8000)
 
     # No leases yet
-    resp = await client.get("/api/cluster/leases")
+    resp = await client.get("/api/cluster/leases", headers=_auth(app))
     assert resp.status_code == 200
     assert resp.json()["count"] == 0
 
     # Claim one
-    claim = await client.post("/api/cluster/leases/claim", json={
+    claim = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "caller": "test",
         "ttl_seconds": 30,
     })
     assert claim.status_code == 200
 
-    resp = await client.get("/api/cluster/leases")
+    resp = await client.get("/api/cluster/leases", headers=_auth(app))
     assert resp.status_code == 200
     assert resp.json()["count"] == 1
     lease = resp.json()["leases"][0]
@@ -265,7 +274,7 @@ async def test_expired_lease_returns_409_on_claim(client, app):
     await _heartbeat(client, key, "gpu-node", free_vram_mb=8000)
 
     # Claim with very short TTL
-    await client.post("/api/cluster/leases/claim", json={
+    await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "ttl_seconds": 0.001,
     })
@@ -273,12 +282,60 @@ async def test_expired_lease_returns_409_on_claim(client, app):
     time.sleep(0.1)
 
     # The lease is now expired; a new claim succeeds
-    resp = await client.post("/api/cluster/leases/claim", json={
+    resp = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
         "resource_id": "gpu-node:gpu-cuda-0",
         "caller": "second-caller",
     })
     assert resp.status_code == 200
     assert resp.json()["status"] == "claimed"
+
+
+@pytest.mark.asyncio
+async def test_lease_endpoints_require_auth(client, app):
+    """Unauthenticated callers are rejected on every lease endpoint.
+
+    Without this gate any LAN process could list and release every lease,
+    re-enabling the concurrent-GPU-load the lease system prevents.
+    """
+    # Drop the default admin session so the requests are genuinely anonymous.
+    client.cookies.clear()
+    rejected = {401, 403}
+    claim = await client.post("/api/cluster/leases/claim", json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+    })
+    assert claim.status_code in rejected
+    release = await client.post("/api/cluster/leases/release", json={
+        "lease_id": "l_whatever",
+    })
+    assert release.status_code in rejected
+    renew = await client.post("/api/cluster/leases/renew", json={
+        "lease_id": "l_whatever",
+    })
+    assert renew.status_code in rejected
+    listing = await client.get("/api/cluster/leases")
+    assert listing.status_code in rejected
+
+
+@pytest.mark.asyncio
+async def test_claim_rejects_nonpositive_ttl(client, app):
+    """A zero/negative ttl is rejected (422) rather than minting a lease that
+    is already expired and grants no exclusivity."""
+    resp = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "ttl_seconds": 0,
+    })
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_claim_rejects_negative_vram(client, app):
+    """A negative required_vram_mb is rejected (422) rather than silently
+    bypassing the VRAM guard."""
+    resp = await client.post("/api/cluster/leases/claim", headers=_auth(app), json={
+        "resource_id": "gpu-node:gpu-cuda-0",
+        "required_vram_mb": -1,
+    })
+    assert resp.status_code == 422
 
 
 # ── ClusterManager unit tests ──────────────────────────────────────────

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -318,12 +318,16 @@ class ClusterManager:
         ``_lease_lock`` so two concurrent claims for the same resource
         cannot both succeed.
         """
-        worker = self._worker_for_resource(resource_id)
-        if worker is None:
-            logger.debug("claim_lease: worker not found or offline for %s", resource_id)
-            return None
-
         async with self._lease_lock:
+            # Resolve the worker and re-check its status inside the lock: the
+            # monitor loop marks workers offline and sweeps their leases under
+            # this same lock, so a lookup before the lock could admit a lease
+            # against a worker that went offline while we waited (TOCTOU).
+            worker = self._worker_for_resource(resource_id)
+            if worker is None:
+                logger.debug("claim_lease: worker not found or offline for %s", resource_id)
+                return None
+
             existing = self.find_existing_lease(resource_id)
             if existing is not None:
                 logger.debug(
@@ -343,7 +347,7 @@ class ClusterManager:
                 )
                 return None
 
-            lease_id = f"l_{secrets.token_hex(4)}"
+            lease_id = f"l_{secrets.token_hex(16)}"
             lease = GpuLease(
                 lease_id=lease_id,
                 resource_id=resource_id,

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -7,7 +7,7 @@ from dataclasses import asdict
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
@@ -1004,11 +1004,17 @@ async def promote_archived_models(request: Request):
 # ── GPU lease coordination (taOS #893) ───────────────────────────────────
 
 
+# Lease TTLs are short-lived reservations; cap at a day so a bad caller
+# can't pin a GPU indefinitely, and require a positive value so a zero/negative
+# TTL can't mint a lease that is already expired (and thus grants no exclusion).
+_LEASE_TTL_MAX = 86_400
+
+
 class LeaseClaimRequest(BaseModel):
     resource_id: str
-    ttl_seconds: float = 30
+    ttl_seconds: float = Field(default=30, gt=0, le=_LEASE_TTL_MAX)
     caller: str = ""
-    required_vram_mb: int = 0
+    required_vram_mb: int = Field(default=0, ge=0)
 
 
 class LeaseReleaseRequest(BaseModel):
@@ -1017,7 +1023,36 @@ class LeaseReleaseRequest(BaseModel):
 
 class LeaseRenewRequest(BaseModel):
     lease_id: str
-    ttl_seconds: float = 30
+    ttl_seconds: float = Field(default=30, gt=0, le=_LEASE_TTL_MAX)
+
+
+async def _require_lease_access(request: Request) -> JSONResponse | None:
+    """Gate the lease coordination endpoints.
+
+    Leases are a controller-internal coordination surface (claimed by
+    controller-side dispatchers, A2A agents, or paired workers), so restrict
+    them to trusted principals: an admin session, a valid local token
+    (same-host trust), or a signed worker HMAC. Returns an error response to
+    return to the client if denied, or ``None`` when access is allowed.
+
+    Without this gate the endpoints are reachable unauthenticated, so any LAN
+    process could list every lease id and release them, re-enabling the
+    concurrent-GPU-load the lease system exists to prevent.
+    """
+    ok, _ = _require_admin(request)
+    if ok:
+        return None
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        presented = auth_header[7:].strip()
+        if presented and request.app.state.auth.validate_local_token(presented):
+            return None
+    try:
+        await require_worker_hmac(request)
+        return None
+    except _HMACError:
+        pass
+    return JSONResponse({"error": "forbidden"}, status_code=403)
 
 
 @router.post("/api/cluster/leases/claim")
@@ -1027,6 +1062,9 @@ async def claim_lease(request: Request, body: LeaseClaimRequest):
     Returns 200 with lease details on success, 409 if the resource is
     already leased or the worker has insufficient free VRAM.
     """
+    denied = await _require_lease_access(request)
+    if denied is not None:
+        return denied
     cluster = request.app.state.cluster_manager
     lease = await cluster.claim_lease(
         resource_id=body.resource_id,
@@ -1061,6 +1099,9 @@ async def claim_lease(request: Request, body: LeaseClaimRequest):
 @router.post("/api/cluster/leases/release")
 async def release_lease(request: Request, body: LeaseReleaseRequest):
     """Release a GPU lease by id.  Idempotent."""
+    denied = await _require_lease_access(request)
+    if denied is not None:
+        return denied
     cluster = request.app.state.cluster_manager
     await cluster.release_lease(body.lease_id)
     return {"status": "released", "lease_id": body.lease_id}
@@ -1069,6 +1110,9 @@ async def release_lease(request: Request, body: LeaseReleaseRequest):
 @router.post("/api/cluster/leases/renew")
 async def renew_lease(request: Request, body: LeaseRenewRequest):
     """Extend a lease's TTL.  Returns 409 if the lease is expired."""
+    denied = await _require_lease_access(request)
+    if denied is not None:
+        return denied
     cluster = request.app.state.cluster_manager
     lease = await cluster.renew_lease(body.lease_id, ttl_seconds=body.ttl_seconds)
     if lease is None:
@@ -1086,6 +1130,9 @@ async def renew_lease(request: Request, body: LeaseRenewRequest):
 @router.get("/api/cluster/leases")
 async def list_leases(request: Request):
     """Return active (non-expired) GPU leases."""
+    denied = await _require_lease_access(request)
+    if denied is not None:
+        return denied
     cluster = request.app.state.cluster_manager
     leases = cluster.get_leases()
     return {


### PR DESCRIPTION
## What

Retrospective hardening of the GPU lease coordination API (landed in #1680), from a deep-dive audit of the merged code.

The four lease endpoints (`claim` / `release` / `renew` / `GET leases`) were reachable **unauthenticated**, unlike every sibling cluster route. Any process on the LAN could `GET /api/cluster/leases` to enumerate every lease id and then release them, freeing all reservations and re-enabling the concurrent-GPU-load (OOM / Xid 62) the lease system exists to prevent.

The lease API has **no callers on dev yet** (the GPU arbiter that will consume it is not merged), so this closes the hole before it goes live rather than fixing a live exploit.

## Changes

- **Auth gate** on all four endpoints: a trusted principal is required, accepting an admin session, a valid local token (same-host trust, for controller-side dispatchers/agents), or a signed worker HMAC.
- **Wider lease ids** (`token_hex(4)` -> `token_hex(16)`) so ids cannot collide and free the wrong holder's reservation.
- **Input validation**: reject non-positive `ttl_seconds` (a zero ttl minted a lease that was already expired and granted no exclusivity) and negative `required_vram_mb` (bypassed the capacity guard) at the request boundary.
- **TOCTOU fix**: resolve the worker and re-check its status inside `_lease_lock`, so a claim cannot be admitted against a worker the monitor loop took offline while the claim waited on the lock.

## Tests

- Lease calls now authenticate via the local token.
- New: unauthenticated requests are rejected on every endpoint; zero/negative ttl and negative vram are rejected with 422.
- 31 lease + 78 cluster/pairing/worker-auth tests pass locally.

Follow-up (not in scope here): per-holder ownership binding on release/renew, deferred until the arbiter wires real callers and defines holder semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lease operations now require proper authorization, allowing access only for approved sessions or paired worker requests.
  * Lease requests now enforce a maximum time-to-live of 24 hours.

* **Bug Fixes**
  * Improved lease handling to reduce race conditions when a worker goes offline during lease assignment.
  * Lease identifiers are now harder to guess.
  * Updated lease API behavior and tests to cover authenticated access, validation, and error cases consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->