### PR TITLE
fix(governance): delegation + org-model hardening (#1661/#1662 retro, #174)

### DIFF
--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -986,6 +986,21 @@ class TestSetRoleTitle:
         result = await store.set_role_title("no-such-20260101-000000", title="X")
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_empty_string_clears_field(self, store):
+        row = await store.register(framework="openclaw", display_name="A", role="worker")
+        cleared = await store.set_role_title(row["canonical_id"], role="")
+        assert cleared["role"] is None
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_is_treated_as_set_not_clear(self, store):
+        # set_role_title clears only on a truly empty string; the route strips
+        # whitespace-only input to "" before calling, so raw "   " here stays
+        # verbatim (the store does not itself strip).
+        row = await store.register(framework="openclaw", display_name="A", role="worker")
+        updated = await store.set_role_title(row["canonical_id"], role="   ")
+        assert updated["role"] == "   "
+
 
 # ---------------------------------------------------------------------------
 # set_reporting
@@ -1055,6 +1070,37 @@ class TestSetReporting:
         await store.set_reporting(report["canonical_id"], m1["canonical_id"])
         updated = await store.set_reporting(report["canonical_id"], m2["canonical_id"])
         assert updated["reports_to"] == m2["canonical_id"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_edits_cannot_persist_cycle(self, store):
+        """Two concurrent edits (A->B and B->A) must not both pass the cycle
+        guard and then both write. The reporting lock serializes the
+        check-then-write, so exactly one edge survives and no cycle persists."""
+        import asyncio
+
+        a = await store.register(framework="openclaw", display_name="A")
+        b = await store.register(framework="openclaw", display_name="B")
+        aid = a["canonical_id"]
+        bid = b["canonical_id"]
+
+        results = await asyncio.gather(
+            store.set_reporting(aid, bid),
+            store.set_reporting(bid, aid),
+            return_exceptions=True,
+        )
+        # One edit wins; the other either wins the ordering and then the second
+        # is rejected as a cycle, or both individually succeed only if they do
+        # not close a loop. Either way the final state must be acyclic.
+        cycle_errors = [r for r in results if isinstance(r, ValueError)]
+        assert len(cycle_errors) <= 1
+
+        a_final = await store.get(aid)
+        b_final = await store.get(bid)
+        # A reciprocal A->B and B->A pair is exactly the persisted cycle the
+        # lock exists to prevent.
+        assert not (
+            a_final["reports_to"] == bid and b_final["reports_to"] == aid
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes_agent_org.py
+++ b/tests/test_routes_agent_org.py
@@ -109,6 +109,43 @@ class TestUpdateOrgFields:
         assert body["role"] == "engineer"
         assert body["title"] == "Staff Engineer"
 
+    async def test_empty_body_is_400(self, org_client):
+        """An all-None body is a silent no-op write; it must be rejected."""
+        client, _uid = org_client
+        reg = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Worker"},
+        )
+        cid = reg.json()["canonical_id"]
+        resp = await client.put(f"/api/agents/{cid}/org", json={})
+        assert resp.status_code == 400
+
+    async def test_clear_role_with_empty_string(self, org_client):
+        client, _uid = org_client
+        reg = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Worker"},
+        )
+        cid = reg.json()["canonical_id"]
+        await client.put(f"/api/agents/{cid}/org", json={"role": "engineer"})
+
+        resp = await client.put(f"/api/agents/{cid}/org", json={"role": ""})
+        assert resp.status_code == 200
+        assert resp.json()["role"] is None
+
+    async def test_whitespace_only_title_is_cleared(self, org_client):
+        client, _uid = org_client
+        reg = await client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "Worker"},
+        )
+        cid = reg.json()["canonical_id"]
+        await client.put(f"/api/agents/{cid}/org", json={"title": "Staff Engineer"})
+
+        resp = await client.put(f"/api/agents/{cid}/org", json={"title": "   "})
+        assert resp.status_code == 200
+        assert resp.json()["title"] is None
+
     async def test_set_reports_to(self, org_client):
         client, _uid = org_client
         manager = (await client.post(

--- a/tests/test_routes_delegation.py
+++ b/tests/test_routes_delegation.py
@@ -32,14 +32,21 @@ async def _make_project_and_task(app, *, title="Do the thing", created_by="from-
     return project, task
 
 
+# The to-agent's config id is deliberately distinct from its name: task
+# assignee_id is keyed on this hex id everywhere it is read (beads, project
+# members, the heartbeat sweep), so a delegation must write the id, not the
+# slug. Fixtures that omit a distinct id masked that mismatch.
+TO_AGENT_ID = "aid-to-000002"
+
+
 @pytest.fixture(autouse=True)
 def _seed_agents(app):
     """Two config agents so from_agent/to_agent resolve via find_agent."""
     app.state.config.agents.append(
-        {"name": "from-agent", "host": "", "qmd_index": "from-agent", "color": "#111111"}
+        {"name": "from-agent", "id": "aid-from-0001", "host": "", "qmd_index": "from-agent", "color": "#111111"}
     )
     app.state.config.agents.append(
-        {"name": "to-agent", "host": "", "qmd_index": "to-agent", "color": "#222222"}
+        {"name": "to-agent", "id": TO_AGENT_ID, "host": "", "qmd_index": "to-agent", "color": "#222222"}
     )
 
 
@@ -63,6 +70,35 @@ class TestDelegationGateDeny:
 
         unchanged = await app.state.project_task_store.get_task(task["id"])
         assert unchanged["assignee_id"] is None
+
+    async def test_deny_audit_event_is_findable_in_project_feed(self, client, app):
+        """A denied delegation must be recorded against the real project (and
+        the real task when one exists) so it appears in the project activity
+        feed - the old synthetic agent:{from_agent} task_id with a blank
+        project_id left the deny event unfindable everywhere."""
+        await app.state.execution_policies.set_policy("delegate", "deny", agent_name="from-agent")
+        project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 403
+
+        feed = await app.state.board_audit.recent_for_project(project["id"])
+        denies = [e for e in feed if e["event"] == "delegation_policy_deny"]
+        assert len(denies) == 1
+        assert denies[0]["task_id"] == task["id"]
+        assert denies[0]["project_id"] == project["id"]
+        assert denies[0]["detail"]["to_agent"] == "to-agent"
+
+        # It is also reachable from the real task's history.
+        history = await app.state.board_audit.history(task["id"])
+        assert any(e["event"] == "delegation_policy_deny" for e in history)
 
 
 @pytest.mark.asyncio
@@ -119,10 +155,11 @@ class TestDelegationGateRequireApproval:
         body = resp.json()
         assert body["status"] == "delegated"
         assert body["task_id"] == task["id"]
+        # The response keeps the display name; the stored assignee is the id.
         assert body["to_agent"] == "to-agent"
 
         updated = await app.state.project_task_store.get_task(task["id"])
-        assert updated["assignee_id"] == "to-agent"
+        assert updated["assignee_id"] == TO_AGENT_ID
 
     async def test_grant_is_scoped_per_agent(self, client, app):
         """A grant for one agent does not authorize a different agent's delegation."""
@@ -186,7 +223,7 @@ class TestDelegationApprovalFlow:
         assert answer_resp.status_code == 200
 
         completed = await app.state.project_task_store.get_task(task["id"])
-        assert completed["assignee_id"] == "to-agent"
+        assert completed["assignee_id"] == TO_AGENT_ID
 
         # The action class is now granted for from-agent, so a follow-up
         # delegation by the same agent proceeds without another approval.
@@ -241,7 +278,7 @@ class TestDelegationApprovalFlow:
 
         tasks = await app.state.project_task_store.list_tasks(project["id"])
         new_task = next(t for t in tasks if t["title"] == "Brand new task")
-        assert new_task["assignee_id"] == "to-agent"
+        assert new_task["assignee_id"] == TO_AGENT_ID
 
     async def test_approving_routes_exactly_one_honest_message(self, client, app, monkeypatch):
         """Answering a delegation gate must send the asking agent a SINGLE
@@ -342,7 +379,7 @@ class TestDelegationTaskTitleCreatesTask:
 
         tasks = await app.state.project_task_store.list_tasks(project["id"])
         created = next(t for t in tasks if t["title"] == "Write the docs")
-        assert created["assignee_id"] == "to-agent"
+        assert created["assignee_id"] == TO_AGENT_ID
 
     async def test_task_title_without_project_id_is_400(self, client, app):
         await app.state.execution_policies.set_policy("delegate", "allow", agent_name="from-agent")
@@ -355,6 +392,53 @@ class TestDelegationTaskTitleCreatesTask:
         finally:
             await agent_client.aclose()
         assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+class TestDelegationApprovalQuestion:
+    async def test_existing_task_question_uses_title_not_raw_id(self, client, app):
+        """Delegating an existing task with no task_title must show the task's
+        title in the human approval inbox, not the raw task id."""
+        _project, task = await _make_project_and_task(app, title="Ship the release notes")
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "to-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 202
+
+        decision = await app.state.decision_store.get(resp.json()["decision_id"])
+        assert '"Ship the release notes"' in decision["question"]
+        assert task["id"] not in decision["question"]
+
+
+@pytest.mark.asyncio
+class TestDelegationAssigneeIdFallback:
+    async def test_agent_without_config_id_falls_back_to_name(self, client, app):
+        """An older/test agent whose config carries no distinct id (id == name)
+        must still delegate cleanly, storing the name as assignee_id."""
+        app.state.config.agents.append(
+            {"name": "legacy-agent", "host": "", "qmd_index": "legacy-agent", "color": "#333333"}
+        )
+        await app.state.execution_policies.set_policy("delegate", "allow", agent_name="from-agent")
+        _project, task = await _make_project_and_task(app)
+
+        agent_client = _local_token_client(app)
+        try:
+            resp = await agent_client.post(
+                "/api/agents/from-agent/delegate",
+                json={"to_agent": "legacy-agent", "task_id": task["id"]},
+            )
+        finally:
+            await agent_client.aclose()
+        assert resp.status_code == 200
+
+        updated = await app.state.project_task_store.get_task(task["id"])
+        assert updated["assignee_id"] == "legacy-agent"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -328,17 +328,20 @@ class AgentRegistryStore(BaseStore):
 
     SCHEMA = SCHEMA
 
-    # Serializes set_reporting's cycle-check-then-write so two concurrent org
-    # edits (A->B and B->A) can't both pass the cycle guard and then both write
-    # a persisted cycle. The shared aiosqlite connection yields on every await
-    # inside the check, so the read chain and the write must be held together.
-    _reporting_lock: asyncio.Lock
+    def __init__(self, db_path: Path):
+        super().__init__(db_path)
+        # Serializes set_reporting's cycle-check-then-write so two concurrent
+        # org edits (A->B and B->A) can't both pass the cycle guard and then
+        # both write a persisted cycle. The shared aiosqlite connection yields
+        # on every await inside the check, so the read chain and the write must
+        # be held together. Created at construction (not in init()) so it always
+        # exists before any caller, independent of init ordering.
+        self._reporting_lock = asyncio.Lock()
 
     async def init(self) -> None:
         await super().init()
         if self._db is not None:
             self._db.row_factory = aiosqlite.Row
-        self._reporting_lock = asyncio.Lock()
 
     async def _post_init(self) -> None:
         """Idempotently ensure the status column exists and is backfilled."""

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -11,6 +11,7 @@ The public key is exposed via GET /api/agents/registry/pubkey so the A2A bus
 (taOSmd) can verify tokens independently without needing the private key.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -327,10 +328,17 @@ class AgentRegistryStore(BaseStore):
 
     SCHEMA = SCHEMA
 
+    # Serializes set_reporting's cycle-check-then-write so two concurrent org
+    # edits (A->B and B->A) can't both pass the cycle guard and then both write
+    # a persisted cycle. The shared aiosqlite connection yields on every await
+    # inside the check, so the read chain and the write must be held together.
+    _reporting_lock: asyncio.Lock
+
     async def init(self) -> None:
         await super().init()
         if self._db is not None:
             self._db.row_factory = aiosqlite.Row
+        self._reporting_lock = asyncio.Lock()
 
     async def _post_init(self) -> None:
         """Idempotently ensure the status column exists and is backfilled."""
@@ -650,10 +658,34 @@ class AgentRegistryStore(BaseStore):
     ) -> Optional[dict]:
         """Set *role* and/or *title* on *canonical_id* (free-form strings).
 
-        Only the provided (non-None) fields are changed.  Returns the updated
-        record, or None if *canonical_id* does not exist.
+        Only the provided (non-None) fields are changed. A provided empty
+        string clears the field (stores NULL), matching the ""-clears
+        convention used for reports_to. Returns the updated record, or None if
+        *canonical_id* does not exist.
         """
-        return await self.update(canonical_id, role=role, title=title)
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        record = await self.get(canonical_id)
+        if record is None:
+            return None
+
+        cols: list[str] = []
+        vals: list = []
+        if role is not None:
+            cols.append("role = ?")
+            vals.append(role or None)
+        if title is not None:
+            cols.append("title = ?")
+            vals.append(title or None)
+        if not cols:
+            return record
+        vals.append(canonical_id)
+        await self._db.execute(
+            f"UPDATE agent_registry SET {', '.join(cols)} WHERE canonical_id = ?",
+            vals,
+        )
+        await self._db.commit()
+        return await self.get(canonical_id)
 
     async def set_reporting(
         self, canonical_id: str, reports_to: Optional[str]
@@ -673,43 +705,49 @@ class AgentRegistryStore(BaseStore):
         """
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
-        record = await self.get(canonical_id)
-        if record is None:
-            raise KeyError(canonical_id)
 
-        if reports_to is not None:
-            if reports_to == canonical_id:
-                raise ValueError("an agent cannot report to itself")
-            manager = await self.get(reports_to)
-            if manager is None:
-                raise ValueError(f"reports_to manager not found: {reports_to!r}")
+        # Hold the lock across the whole cycle-check-then-write. Every await in
+        # the check yields the shared aiosqlite connection, so without this two
+        # concurrent edits (A->B and B->A) could both pass the guard and then
+        # both write, persisting a cycle.
+        async with self._reporting_lock:
+            record = await self.get(canonical_id)
+            if record is None:
+                raise KeyError(canonical_id)
 
-            # Cycle guard: walk the candidate manager's existing reports_to
-            # chain; if it ever reaches canonical_id, this edge would close a
-            # loop. `seen` guards against looping forever on an already-
-            # corrupt chain independent of the depth cap.
-            seen: set[str] = set()
-            current: Optional[str] = reports_to
-            depth = 0
-            while current is not None and depth < self._MAX_REPORTS_TO_WALK:
-                if current == canonical_id:
-                    raise ValueError(
-                        f"assigning reports_to={reports_to!r} would create "
-                        f"a reporting cycle"
-                    )
-                if current in seen:
-                    break
-                seen.add(current)
-                current_record = await self.get(current)
-                current = current_record.get("reports_to") if current_record else None
-                depth += 1
+            if reports_to is not None:
+                if reports_to == canonical_id:
+                    raise ValueError("an agent cannot report to itself")
+                manager = await self.get(reports_to)
+                if manager is None:
+                    raise ValueError(f"reports_to manager not found: {reports_to!r}")
 
-        await self._db.execute(
-            "UPDATE agent_registry SET reports_to = ? WHERE canonical_id = ?",
-            (reports_to, canonical_id),
-        )
-        await self._db.commit()
-        return await self.get(canonical_id)  # type: ignore[return-value]
+                # Cycle guard: walk the candidate manager's existing reports_to
+                # chain; if it ever reaches canonical_id, this edge would close a
+                # loop. `seen` guards against looping forever on an already-
+                # corrupt chain independent of the depth cap.
+                seen: set[str] = set()
+                current: Optional[str] = reports_to
+                depth = 0
+                while current is not None and depth < self._MAX_REPORTS_TO_WALK:
+                    if current == canonical_id:
+                        raise ValueError(
+                            f"assigning reports_to={reports_to!r} would create "
+                            f"a reporting cycle"
+                        )
+                    if current in seen:
+                        break
+                    seen.add(current)
+                    current_record = await self.get(current)
+                    current = current_record.get("reports_to") if current_record else None
+                    depth += 1
+
+            await self._db.execute(
+                "UPDATE agent_registry SET reports_to = ? WHERE canonical_id = ?",
+                (reports_to, canonical_id),
+            )
+            await self._db.commit()
+            return await self.get(canonical_id)  # type: ignore[return-value]
 
     async def direct_reports(self, canonical_id: str) -> list[dict]:
         """Return the agents whose reports_to is *canonical_id*, oldest first."""

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -750,8 +750,18 @@ async def update_org_fields(
         return JSONResponse({"error": "not found"}, status_code=404)
     require_owner_or_admin(user, record["user_id"])
 
+    if body.role is None and body.title is None and body.reports_to is None:
+        # An all-None body is a no-op write; reject it rather than returning a
+        # misleading 200 that reports success while changing nothing.
+        return JSONResponse({"error": "no fields to update"}, status_code=400)
+
     if body.role is not None or body.title is not None:
-        await store.set_role_title(canonical_id, role=body.role, title=body.title)
+        # Normalize whitespace-only values to "" so set_role_title clears the
+        # field (NULL), matching the reports_to ""-clears convention below;
+        # a None field is left untouched.
+        role = body.role.strip() if body.role is not None else None
+        title = body.title.strip() if body.title is not None else None
+        await store.set_role_title(canonical_id, role=role, title=title)
 
     if body.reports_to is not None:
         manager_id = body.reports_to or None  # "" clears the manager

--- a/tinyagentos/routes/delegation.py
+++ b/tinyagentos/routes/delegation.py
@@ -76,6 +76,25 @@ async def _resolve_agent_name(request: Request, ref: str) -> str | None:
     return None
 
 
+def _resolve_agent_id(request: Request, name: str) -> str:
+    """Resolve a config-agent *name* (slug) to its stable hex id.
+
+    Task assignee_id is keyed on the config hex id everywhere else that reads
+    it - beads (projects/beads_bridge._resolve_assignee -> agent["id"]),
+    project members (member_id), and the heartbeat sweep
+    (agent_heartbeat.list_ready_tasks_for_assignee(agent["id"])). The name is
+    kept only for display/notify text. Falls back to *name* when the agent has
+    no id (older/test agents where id == name) or cannot be found.
+    """
+    config = getattr(request.app.state, "config", None)
+    if config is None:
+        return name
+    agent = find_agent(config, name)
+    if agent is None:
+        return name
+    return agent.get("id") or name
+
+
 class DelegateRequest(BaseModel):
     to_agent: str
     task_id: str | None = None
@@ -97,6 +116,7 @@ async def _check_delegation_policy(
     task_title: str | None,
     project_id: str | None,
     note: str,
+    existing_title: str | None = None,
 ) -> JSONResponse | None:
     """Agent governance gate for delegation. Returns a JSONResponse to
     short-circuit the call (deny / pending-approval), or None to let the
@@ -126,8 +146,15 @@ async def _check_delegation_policy(
         board_audit = getattr(request.app.state, "board_audit", None)
         if board_audit is not None:
             try:
+                # Key the deny on the real task when one exists (so it shows in
+                # that task's history) and always carry the real project_id so
+                # recent_for_project surfaces it in the project feed. Without a
+                # task, record a policy-level event rather than fabricating an
+                # agent:{from_agent} task_id - the old synthetic id plus a blank
+                # project_id left every deny event unfindable in any feed.
                 await board_audit.record(
-                    task_id=f"agent:{from_agent}",
+                    task_id=task_id or f"policy:{ACTION_CLASS}",
+                    project_id=project_id or "",
                     event="delegation_policy_deny",
                     actor=from_agent,
                     detail={"to_agent": to_agent, "action_class": ACTION_CLASS},
@@ -165,7 +192,10 @@ async def _check_delegation_policy(
             status_code=503,
         )
     try:
-        target = f'"{task_title}"' if task_title else (task_id or "")
+        # Prefer a human-readable title in the approval question: the existing
+        # task's fetched title, then a new-task task_title, then the raw id.
+        display_title = existing_title or task_title
+        target = f'"{display_title}"' if display_title else (task_id or "")
         decision = await decision_store.create(
             from_agent=from_agent,
             question=f"Agent {from_agent} wants to delegate {target} to {to_agent}".strip(),
@@ -250,11 +280,15 @@ async def complete_delegation(
     persisted by then).
     """
     task_store = request.app.state.project_task_store
+    # to_agent is the config slug (name); task assignee_id must be the agent's
+    # stable hex id so the heartbeat sweep and id-keyed member lookups can see
+    # the delegated task. The name is still used below for the notify text.
+    assignee_id = _resolve_agent_id(request, to_agent)
     if task_id:
         task = await task_store.get_task(task_id)
         if task is None:
             raise ValueError(f"task '{task_id}' not found")
-        await task_store.update_task(task_id, assignee_id=to_agent)
+        await task_store.update_task(task_id, assignee_id=assignee_id)
         task = await task_store.get_task(task_id)
     else:
         if not task_title:
@@ -262,7 +296,7 @@ async def complete_delegation(
         if not project_id:
             raise ValueError("project_id is required to create a new task")
         task = await task_store.create_task(
-            project_id=project_id, title=task_title, created_by=from_agent, assignee_id=to_agent,
+            project_id=project_id, title=task_title, created_by=from_agent, assignee_id=assignee_id,
         )
 
     await _notify_delegate(request, from_agent=from_agent, to_agent=to_agent, task=task, note=note)
@@ -292,12 +326,14 @@ async def delegate_task(request: Request, from_agent: str, body: DelegateRequest
         return JSONResponse({"error": "task_id or task_title is required"}, status_code=400)
 
     project_id = body.project_id
+    existing_title: str | None = None
     if body.task_id:
         task_store = request.app.state.project_task_store
         existing_task = await task_store.get_task(body.task_id)
         if existing_task is None:
             return JSONResponse({"error": f"task '{body.task_id}' not found"}, status_code=404)
         project_id = existing_task["project_id"]
+        existing_title = existing_task.get("title")
     elif not project_id:
         return JSONResponse(
             {"error": "project_id is required when delegating a new task_title"},
@@ -312,6 +348,7 @@ async def delegate_task(request: Request, from_agent: str, body: DelegateRequest
         task_title=body.task_title,
         project_id=project_id,
         note=body.note or "",
+        existing_title=existing_title,
     )
     if gate_response is not None:
         return gate_response


### PR DESCRIPTION
Retrospective audit fixes for the merged agent org model (#1661) and heartbeat (#1662), all verified against current `dev`. Each fix ships with a test. Relates to #174.

## Fixes

**1. CRITICAL - deny-event audit rows were unfindable.** On a policy `deny`, `delegation.py` recorded the board-audit event with a synthetic `task_id=f"agent:{from_agent}"` and no `project_id` (defaults to `""`). Since `recent_for_project` filters on `project_id`, deny events never appeared in any project feed. Now the deny is keyed on the real `task_id` when a task is present (so it also shows in the task's history) and always carries the real `project_id`; with no task it records a `policy:delegate` event rather than a fabricated agent-as-task id.

**2. WARNING - raw task id leaked to the human approval inbox.** When delegating an existing task with no `task_title`, the blocking Decision question read "wants to delegate `<raw task_id>`". The task's title (already fetched in `delegate_task`) is now threaded into `_check_delegation_policy` and used, falling back to `task_title` then `task_id`.

**3. MEDIUM - assignee identity mismatch (from #1662).** `complete_delegation` wrote `assignee_id=to_agent`, but that is the agent NAME (slug), while beads, project members, and the heartbeat sweep (`list_ready_tasks_for_assignee`) all key on the config HEX id (`config.py` mints `uuid4().hex[:12]`). Delegated tasks were therefore invisible to the heartbeat and id-keyed member lookups. The name is now resolved to the hex id for `assignee_id` (name kept for display/notify), with a graceful fallback when the agent has no distinct id (`id == name`).

**4. WARNING - set_reporting TOCTOU cycle race.** The cycle guard walked the reporting chain via multiple `await self.get(...)` reads and then issued a separate UPDATE with no serialization. On the shared aiosqlite connection the awaits yield, so two concurrent edits (A->B and B->A) could both pass the check then both write, persisting a cycle. The check-then-write is now held under an `asyncio.Lock`.

**5. WARNING - PUT /org empty-body no-op + no "" normalization.** A body of `{}` (all fields None) returned 200 while changing nothing, and `role`/`title` were stored verbatim including whitespace, whereas the codebase convention (applied to `reports_to`) is that `""` clears a nullable field. An all-empty body is now rejected with 400, and empty/whitespace-only `role`/`title` clear the field (NULL).

## Tests

- `tests/test_routes_delegation.py`: fixtures given distinct `id` vs `name` (which masked #3); new tests for the findable deny audit event, the title-not-raw-id approval question, and the `id == name` fallback.
- `tests/test_agent_registry_store.py`: empty-string/whitespace clear for `set_role_title`; concurrent A->B / B->A edits cannot persist a cycle.
- `tests/test_routes_agent_org.py`: empty body 400, clear role via `""`, whitespace-only title cleared.

All affected and adjacent suites pass (`test_routes_delegation`, `test_routes_agent_org`, `test_agent_registry_store`, `test_agent_registry`, `test_board_audit`, `test_routes_decisions`, `test_agent_heartbeat`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating agent org fields now rejects `{}` (HTTP 400) and properly clears `role`/`title` when empty or whitespace is provided, returning `null` in responses.
  * Concurrent reporting-line updates are now protected against persisting circular reporting relationships.
  * Delegation handling now uses stable agent identifiers for task assignment and produces more discoverable denial/audit events; approval prompts use the existing task’s title when available.
* **Tests**
  * Added coverage for role/title clearing and concurrent reporting-cycle prevention, plus updated route/delegation scenarios and audit/approval behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->