### PR TITLE
fix(containers): NativeBackend security + supervision + kilo bug fixes

### DIFF
--- a/tests/test_container_native.py
+++ b/tests/test_container_native.py
@@ -11,10 +11,62 @@ import pytest
 
 from tinyagentos.containers.native import (
     NativeBackend,
+    _ALLOWED_WRITE_ROOTS,
     _has_systemd,
+    _safe_host_path,
     _service_unit_path,
     _SYSTEMD_DIR,
 )
+
+
+class TestSafeHostPath:
+    """Tests for the path-traversal guard."""
+
+    def test_rejects_relative_path(self):
+        assert _safe_host_path("foo/bar") is None
+        assert _safe_host_path("../etc/passwd") is None
+
+    def test_rejects_dotdot_traversal(self):
+        assert _safe_host_path("/opt/taos/../../etc/passwd") is None
+        assert _safe_host_path("/tmp/../etc/shadow") is None
+
+    def test_rejects_outside_allowed_roots(self):
+        assert _safe_host_path("/etc/passwd") is None
+        assert _safe_host_path("/home/user/.bashrc") is None
+        assert _safe_host_path("/var/log/syslog") is None
+
+    def test_accepts_allowed_roots(self):
+        assert _safe_host_path("/opt/taos/config.yaml") == "/opt/taos/config.yaml"
+        assert _safe_host_path("/tmp/test.txt") is not None
+        assert _safe_host_path("/etc/systemd/system/foo.service") is not None
+        assert _safe_host_path("/var/lib/taos/agents/foo/data") is not None
+
+    def test_accepts_resolved_symlink_within_root(self, tmp_path, monkeypatch):
+        # Create a symlink inside an allowed root that points within the same root
+        allowed = tmp_path / "opt" / "taos"
+        allowed.mkdir(parents=True)
+        (allowed / "real.txt").write_text("hello")
+        link = allowed / "link.txt"
+        os.symlink(str(allowed / "real.txt"), str(link))
+        result = _safe_host_path(str(link), allowed_roots=(str(allowed) + "/",))
+        assert result is not None
+
+    def test_rejects_symlink_outside_root(self, tmp_path):
+        # Symlink inside allowed root pointing outside
+        allowed = tmp_path / "opt" / "taos"
+        allowed.mkdir(parents=True)
+        outside = tmp_path / "secret.txt"
+        outside.write_text("secret")
+        link = allowed / "escape.txt"
+        os.symlink(str(outside), str(link))
+        result = _safe_host_path(str(link), allowed_roots=(str(allowed) + "/",))
+        assert result is None
+
+    def test_rejects_empty_path(self):
+        assert _safe_host_path("") is None
+
+    def test_rejects_non_absolute_path(self):
+        assert _safe_host_path("relative/file.txt") is None
 
 
 class TestNativeBackendE2E:
@@ -27,21 +79,22 @@ class TestNativeBackendE2E:
 
     @pytest.fixture
     def backend(self, tmp_path, monkeypatch):
-        """Return a NativeBackend with a temp _SYSTEMD_DIR."""
+        """Return a NativeBackend with a temp _SYSTEMD_DIR and systemd mocked away."""
         import tinyagentos.containers.native as _mod
         monkeypatch.setattr(_mod, "_SYSTEMD_DIR", tmp_path)
         # Force systemd-unavailable path so tests don't need root
         monkeypatch.setattr(_mod, "_has_systemd", lambda: False)
+        monkeypatch.setattr(_mod, "_systemd_dir_is_writable", lambda: False)
         return NativeBackend()
 
     # --- create_container ---
 
     @pytest.mark.asyncio
-    async def test_create_container_no_systemd(self, backend):
+    async def test_create_container_no_systemd_returns_false(self, backend):
+        """When systemd is unavailable, create_container must return success:False."""
         result = await backend.create_container("taos-agent-foo")
-        assert result["success"] is True
-        assert result["name"] == "taos-agent-foo"
-        assert "systemd not available" in result.get("note", "")
+        assert result["success"] is False
+        assert "systemd not available" in result.get("error", "")
 
     # --- list_containers (fallback path) ---
 
@@ -101,12 +154,50 @@ class TestNativeBackendE2E:
         assert code == 0
         assert dest.read_text() == "data"
 
+    @pytest.mark.asyncio
+    async def test_push_file_rejects_path_traversal(self, backend, tmp_path):
+        """push_file must reject remote_path containing .. segments."""
+        src = tmp_path / "source.txt"
+        src.write_text("evil")
+        code, output = await backend.push_file(
+            "ignored", str(src), "/opt/taos/../../etc/cron.d/evil",
+        )
+        assert code != 0
+        assert "unsafe path" in output.lower()
+
+    @pytest.mark.asyncio
+    async def test_push_file_rejects_outside_allowed_roots(self, backend, tmp_path):
+        """push_file must reject paths outside _ALLOWED_WRITE_ROOTS."""
+        src = tmp_path / "source.txt"
+        src.write_text("data")
+        code, output = await backend.push_file(
+            "ignored", str(src), "/home/user/.bashrc",
+        )
+        assert code != 0
+        assert "unsafe path" in output.lower()
+
+    @pytest.mark.asyncio
+    async def test_push_file_accepts_allowed_root(self, backend, tmp_path, monkeypatch):
+        """push_file must accept paths within _ALLOWED_WRITE_ROOTS."""
+        import tinyagentos.containers.native as _mod
+        # Override allowed roots to include our tmp_path
+        monkeypatch.setattr(
+            _mod, "_ALLOWED_WRITE_ROOTS", (str(tmp_path) + "/",),
+        )
+        src = tmp_path / "source.txt"
+        src.write_text("safe data")
+        dest = tmp_path / "agent" / "config.yaml"
+        code, output = await backend.push_file("ignored", str(src), str(dest))
+        assert code == 0
+        assert dest.read_text() == "safe data"
+
     # --- start / stop / destroy ---
 
     @pytest.mark.asyncio
     async def test_start_container_no_systemd(self, backend):
+        """When systemd is unavailable, start_container must return success:False."""
         result = await backend.start_container("foo")
-        assert result["success"] is True
+        assert result["success"] is False
         assert "systemd not available" in result.get("output", "")
 
     @pytest.mark.asyncio
@@ -180,14 +271,23 @@ class TestNativeBackendWithSystemd:
             "tinyagentos.containers.native._run", _fake_run,
         )
 
-    @pytest.mark.asyncio
-    async def test_create_container_writes_unit_and_reloads(self, backend, tmp_path, monkeypatch):
+    def _setup_systemd_mocks(self, monkeypatch, tmp_path, *, unit_dir_writable=True):
+        """Common setup for systemd-present tests."""
         monkeypatch.setattr(
             "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
         )
         monkeypatch.setattr(
             "tinyagentos.containers.native._has_systemd", lambda: True,
         )
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._systemd_dir_is_writable",
+            lambda: unit_dir_writable,
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_container_stub_unit(self, backend, tmp_path, monkeypatch):
+        """create_container must produce a stub with ExecStart=/bin/false."""
+        self._setup_systemd_mocks(monkeypatch, tmp_path)
         self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
 
         result = await backend.create_container(
@@ -198,24 +298,63 @@ class TestNativeBackendWithSystemd:
         )
         assert result["success"] is True
         assert result["name"] == "taos-agent-test"
+        assert "stub unit created" in result.get("note", "")
 
         unit_path = tmp_path / "taos-agent-test.service"
         assert unit_path.exists()
         content = unit_path.read_text()
         assert "Description=taOS Agent: taos-agent-test" in content
+        assert "ExecStart=/bin/false" in content
+        assert "Restart=no" in content
         assert "MemoryLimit=512MB" in content
         assert "CPUQuota=200%" in content
         assert "Environment=FOO=bar" in content
         assert "Environment=BAZ=qux" in content
 
     @pytest.mark.asyncio
-    async def test_destroy_container_stops_and_removes(self, backend, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
-        )
+    async def test_create_container_readonly_unit_dir(self, backend, tmp_path, monkeypatch):
+        """When _SYSTEMD_DIR is not writable, create_container must fail."""
+        self._setup_systemd_mocks(monkeypatch, tmp_path, unit_dir_writable=False)
+        self._mock_run(monkeypatch, {})
+
+        result = await backend.create_container("taos-agent-test")
+        assert result["success"] is False
+        assert "not writable" in result.get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_list_containers_parses_active_column(self, backend, monkeypatch):
+        """list_containers must parse ACTIVE (parts[2]), not SUB (parts[3])."""
         monkeypatch.setattr(
             "tinyagentos.containers.native._has_systemd", lambda: True,
         )
+        # systemctl output: UNIT LOAD ACTIVE SUB DESCRIPTION
+        # "active running" means ACTIVE=active, SUB=running
+        # The old code read parts[3]=running (SUB) and mapped it via
+        # .capitalize() -> "Running", which was accidentally correct
+        # for running services. But for inactive/dead, it would read
+        # "dead" (SUB) instead of "inactive" (ACTIVE) and miss the
+        # Stopped mapping. This test verifies the fix reads parts[2].
+        self._mock_run(monkeypatch, {
+            "systemctl list-units --type=service --all --no-legend --no-pager taos-agent-*": (
+                0,
+                "taos-agent-foo.service  loaded  active  running  Foo agent\n"
+                "taos-agent-bar.service  loaded  inactive  dead  Bar agent (stopped)\n"
+                "taos-agent-baz.service  loaded  failed  failed  Baz agent (crashed)\n"
+            ),
+        })
+        result = await backend.list_containers("taos-agent-")
+        assert len(result) == 3
+        statuses = {c.name: c.status for c in result}
+        # active → Running
+        assert statuses["taos-agent-foo"] == "Running"
+        # inactive → Stopped
+        assert statuses["taos-agent-bar"] == "Stopped"
+        # failed → Stopped
+        assert statuses["taos-agent-baz"] == "Stopped"
+
+    @pytest.mark.asyncio
+    async def test_destroy_container_stops_and_removes(self, backend, tmp_path, monkeypatch):
+        self._setup_systemd_mocks(monkeypatch, tmp_path)
         self._mock_run(monkeypatch, {
             "systemctl stop taos-agent-foo.service": (0, ""),
             "systemctl disable taos-agent-foo.service": (0, ""),
@@ -230,12 +369,7 @@ class TestNativeBackendWithSystemd:
 
     @pytest.mark.asyncio
     async def test_rename_container(self, backend, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
-        )
-        monkeypatch.setattr(
-            "tinyagentos.containers.native._has_systemd", lambda: True,
-        )
+        self._setup_systemd_mocks(monkeypatch, tmp_path)
         self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
         (tmp_path / "taos-agent-old.service").write_text("[Unit]\n")
 
@@ -246,12 +380,7 @@ class TestNativeBackendWithSystemd:
 
     @pytest.mark.asyncio
     async def test_set_env_updates_unit_file(self, backend, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
-        )
-        monkeypatch.setattr(
-            "tinyagentos.containers.native._has_systemd", lambda: True,
-        )
+        self._setup_systemd_mocks(monkeypatch, tmp_path)
         self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
 
         unit_path = tmp_path / "taos-agent-env.service"
@@ -259,7 +388,7 @@ class TestNativeBackendWithSystemd:
 Description=Test
 
 [Service]
-ExecStart=/bin/true
+ExecStart=/bin/false
 Environment=OLD_KEY=old_value
 
 [Install]
@@ -272,21 +401,17 @@ WantedBy=multi-user.target
         content = unit_path.read_text()
         assert "Environment=NEW_KEY=new_value" in content
         assert "Environment=OLD_KEY=old_value" in content  # preserved
+        assert "ExecStart=/bin/false" in content  # unchanged
 
     @pytest.mark.asyncio
     async def test_set_env_replaces_existing_key(self, backend, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
-        )
-        monkeypatch.setattr(
-            "tinyagentos.containers.native._has_systemd", lambda: True,
-        )
+        self._setup_systemd_mocks(monkeypatch, tmp_path)
         self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
 
         unit_path = tmp_path / "taos-agent-env2.service"
         unit_path.write_text("""[Unit]
 [Service]
-ExecStart=/bin/true
+ExecStart=/bin/false
 Environment=KEY=old_value
 """)
 
@@ -296,6 +421,32 @@ Environment=KEY=old_value
         content = unit_path.read_text()
         assert "Environment=KEY=new_value" in content
         assert "Environment=KEY=old_value" not in content
+
+    @pytest.mark.asyncio
+    async def test_set_env_execstart_wires_payload(self, backend, tmp_path, monkeypatch):
+        """set_env with key='ExecStart' must replace the ExecStart= line."""
+        self._setup_systemd_mocks(monkeypatch, tmp_path)
+        self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
+
+        unit_path = tmp_path / "taos-agent-exec.service"
+        unit_path.write_text("""[Unit]
+[Service]
+ExecStart=/bin/false
+Environment=FOO=bar
+
+[Install]
+WantedBy=multi-user.target
+""")
+
+        result = await backend.set_env(
+            "taos-agent-exec", "ExecStart", "/usr/local/bin/taos-agent --serve",
+        )
+        assert result["success"] is True
+
+        content = unit_path.read_text()
+        assert "ExecStart=/usr/local/bin/taos-agent --serve" in content
+        assert "ExecStart=/bin/false" not in content
+        assert "Environment=FOO=bar" in content  # preserved
 
     @pytest.mark.asyncio
     async def test_get_container_logs(self, backend, monkeypatch):

--- a/tests/test_container_native.py
+++ b/tests/test_container_native.py
@@ -1,0 +1,321 @@
+"""Tests for the bare-metal NativeBackend."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tinyagentos.containers.native import (
+    NativeBackend,
+    _has_systemd,
+    _service_unit_path,
+    _SYSTEMD_DIR,
+)
+
+
+class TestNativeBackendE2E:
+    """End-to-end tests against the real filesystem (no mocks).
+
+    These tests write unit files into a temporary directory and clean up
+    afterwards.  They do NOT require systemd — they test the backend's
+    logic directly when systemd is unavailable (the fallback path).
+    """
+
+    @pytest.fixture
+    def backend(self, tmp_path, monkeypatch):
+        """Return a NativeBackend with a temp _SYSTEMD_DIR."""
+        import tinyagentos.containers.native as _mod
+        monkeypatch.setattr(_mod, "_SYSTEMD_DIR", tmp_path)
+        # Force systemd-unavailable path so tests don't need root
+        monkeypatch.setattr(_mod, "_has_systemd", lambda: False)
+        return NativeBackend()
+
+    # --- create_container ---
+
+    @pytest.mark.asyncio
+    async def test_create_container_no_systemd(self, backend):
+        result = await backend.create_container("taos-agent-foo")
+        assert result["success"] is True
+        assert result["name"] == "taos-agent-foo"
+        assert "systemd not available" in result.get("note", "")
+
+    # --- list_containers (fallback path) ---
+
+    @pytest.mark.asyncio
+    async def test_list_containers_fallback_empty(self, backend, tmp_path):
+        result = await backend.list_containers("taos-agent-")
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_list_containers_fallback_finds_units(self, backend, tmp_path, monkeypatch):
+        import tinyagentos.containers.native as _mod
+        # Create two service files
+        (tmp_path / "taos-agent-bar.service").write_text("[Unit]\n")
+        (tmp_path / "taos-agent-baz.service").write_text("[Unit]\n")
+        (tmp_path / "other.service").write_text("[Unit]\n")  # should not match
+        monkeypatch.setattr(_mod, "_has_systemd", lambda: False)
+
+        result = await backend.list_containers("taos-agent-")
+        names = {c.name for c in result}
+        assert names == {"taos-agent-bar", "taos-agent-baz"}
+
+    # --- exec_in_container ---
+
+    @pytest.mark.asyncio
+    async def test_exec_in_container_runs_command(self, backend):
+        code, output = await backend.exec_in_container(
+            "ignored", ["echo", "hello", "world"], timeout=10,
+        )
+        assert code == 0
+        assert "hello world" in output
+
+    @pytest.mark.asyncio
+    async def test_exec_in_container_returns_nonzero(self, backend):
+        code, output = await backend.exec_in_container(
+            "ignored", ["bash", "-c", "exit 42"], timeout=10,
+        )
+        assert code == 42
+
+    # --- push_file ---
+
+    @pytest.mark.asyncio
+    async def test_push_file_copies_content(self, backend, tmp_path):
+        src = tmp_path / "source.txt"
+        src.write_text("hello bare metal")
+        dest = tmp_path / "dest.txt"
+        code, output = await backend.push_file("ignored", str(src), str(dest))
+        assert code == 0
+        assert dest.read_text() == "hello bare metal"
+
+    @pytest.mark.asyncio
+    async def test_push_file_creates_dirs(self, backend, tmp_path):
+        src = tmp_path / "source.txt"
+        src.write_text("data")
+        dest = tmp_path / "sub" / "deep" / "target.txt"
+        code, output = await backend.push_file("ignored", str(src), str(dest))
+        assert code == 0
+        assert dest.read_text() == "data"
+
+    # --- start / stop / destroy ---
+
+    @pytest.mark.asyncio
+    async def test_start_container_no_systemd(self, backend):
+        result = await backend.start_container("foo")
+        assert result["success"] is True
+        assert "systemd not available" in result.get("output", "")
+
+    @pytest.mark.asyncio
+    async def test_stop_container_no_systemd(self, backend):
+        result = await backend.stop_container("foo")
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_destroy_container_no_systemd(self, backend):
+        result = await backend.destroy_container("foo")
+        assert result["success"] is True
+
+    # --- add_proxy_device ---
+
+    @pytest.mark.asyncio
+    async def test_add_proxy_device_noop(self, backend):
+        result = await backend.add_proxy_device(
+            "foo", "dev1", "tcp:127.0.0.1:4000", "tcp:127.0.0.1:4000",
+        )
+        assert result["success"] is True
+        assert "not needed" in result.get("output", "")
+
+    # --- snapshots ---
+
+    @pytest.mark.asyncio
+    async def test_snapshot_create_returns_false(self, backend):
+        result = await backend.snapshot_create("foo", "snap1")
+        assert result["success"] is False
+        assert "not supported" in result.get("note", "")
+
+    @pytest.mark.asyncio
+    async def test_snapshot_restore_returns_false(self, backend):
+        result = await backend.snapshot_restore("foo", "snap1")
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_snapshot_list_returns_false(self, backend):
+        result = await backend.snapshot_list("foo")
+        assert result["success"] is False
+
+    # --- set_root_quota ---
+
+    @pytest.mark.asyncio
+    async def test_set_root_quota_returns_success_with_note(self, backend):
+        result = await backend.set_root_quota("foo", 10)
+        assert result["success"] is True
+        assert "not enforced" in result.get("note", "")
+
+    # --- set_env ---
+
+    @pytest.mark.asyncio
+    async def test_set_env_no_systemd(self, backend):
+        result = await backend.set_env("foo", "KEY", "VALUE")
+        assert result["success"] is True
+        assert "systemd not available" in result.get("output", "")
+
+
+class TestNativeBackendWithSystemd:
+    """Tests that mock systemd CLI calls."""
+
+    @pytest.fixture
+    def backend(self):
+        return NativeBackend()
+
+    def _mock_run(self, monkeypatch, return_values):
+        """Patch _run in the native module to return canned responses."""
+        async def _fake_run(cmd, timeout=120):
+            key = " ".join(str(c) for c in cmd)
+            return return_values.get(key, (0, ""))
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._run", _fake_run,
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_container_writes_unit_and_reloads(self, backend, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._has_systemd", lambda: True,
+        )
+        self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
+
+        result = await backend.create_container(
+            "taos-agent-test",
+            memory_limit="512MB",
+            cpu_limit=2,
+            env={"FOO": "bar", "BAZ": "qux"},
+        )
+        assert result["success"] is True
+        assert result["name"] == "taos-agent-test"
+
+        unit_path = tmp_path / "taos-agent-test.service"
+        assert unit_path.exists()
+        content = unit_path.read_text()
+        assert "Description=taOS Agent: taos-agent-test" in content
+        assert "MemoryLimit=512MB" in content
+        assert "CPUQuota=200%" in content
+        assert "Environment=FOO=bar" in content
+        assert "Environment=BAZ=qux" in content
+
+    @pytest.mark.asyncio
+    async def test_destroy_container_stops_and_removes(self, backend, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._has_systemd", lambda: True,
+        )
+        self._mock_run(monkeypatch, {
+            "systemctl stop taos-agent-foo.service": (0, ""),
+            "systemctl disable taos-agent-foo.service": (0, ""),
+            "systemctl daemon-reload": (0, ""),
+        })
+        # Create the unit file first
+        (tmp_path / "taos-agent-foo.service").write_text("[Unit]\n")
+
+        result = await backend.destroy_container("taos-agent-foo")
+        assert result["success"] is True
+        assert not (tmp_path / "taos-agent-foo.service").exists()
+
+    @pytest.mark.asyncio
+    async def test_rename_container(self, backend, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._has_systemd", lambda: True,
+        )
+        self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
+        (tmp_path / "taos-agent-old.service").write_text("[Unit]\n")
+
+        result = await backend.rename_container("taos-agent-old", "taos-agent-new")
+        assert result["success"] is True
+        assert not (tmp_path / "taos-agent-old.service").exists()
+        assert (tmp_path / "taos-agent-new.service").exists()
+
+    @pytest.mark.asyncio
+    async def test_set_env_updates_unit_file(self, backend, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._has_systemd", lambda: True,
+        )
+        self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
+
+        unit_path = tmp_path / "taos-agent-env.service"
+        unit_path.write_text("""[Unit]
+Description=Test
+
+[Service]
+ExecStart=/bin/true
+Environment=OLD_KEY=old_value
+
+[Install]
+WantedBy=multi-user.target
+""")
+
+        result = await backend.set_env("taos-agent-env", "NEW_KEY", "new_value")
+        assert result["success"] is True
+
+        content = unit_path.read_text()
+        assert "Environment=NEW_KEY=new_value" in content
+        assert "Environment=OLD_KEY=old_value" in content  # preserved
+
+    @pytest.mark.asyncio
+    async def test_set_env_replaces_existing_key(self, backend, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._SYSTEMD_DIR", tmp_path,
+        )
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._has_systemd", lambda: True,
+        )
+        self._mock_run(monkeypatch, {"systemctl daemon-reload": (0, "")})
+
+        unit_path = tmp_path / "taos-agent-env2.service"
+        unit_path.write_text("""[Unit]
+[Service]
+ExecStart=/bin/true
+Environment=KEY=old_value
+""")
+
+        result = await backend.set_env("taos-agent-env2", "KEY", "new_value")
+        assert result["success"] is True
+
+        content = unit_path.read_text()
+        assert "Environment=KEY=new_value" in content
+        assert "Environment=KEY=old_value" not in content
+
+    @pytest.mark.asyncio
+    async def test_get_container_logs(self, backend, monkeypatch):
+        monkeypatch.setattr(
+            "tinyagentos.containers.native._has_systemd", lambda: True,
+        )
+        self._mock_run(monkeypatch, {
+            "journalctl --no-pager -n 42 -u foo.service": (0, "log line 1\nlog line 2\n"),
+        })
+        logs = await backend.get_container_logs("foo", lines=42)
+        assert "log line 1" in logs
+
+
+class TestHelperFunctions:
+    def test_service_unit_path(self):
+        path = _service_unit_path("taos-agent-foo")
+        assert path.name == "taos-agent-foo.service"
+        assert str(_SYSTEMD_DIR) in str(path)
+
+    def test_has_systemd(self):
+        result = _has_systemd()
+        # On the test host this may be True or False — just verify it's a bool
+        assert isinstance(result, bool)

--- a/tests/test_container_runtime_config.py
+++ b/tests/test_container_runtime_config.py
@@ -56,7 +56,7 @@ class TestConfigureContainerRuntimeNone:
             result = configure_container_runtime(None)
         assert result is None
         assert any(
-            "No container backend detected (Incus / Docker / Podman / Apple)" in r.message
+            "No container backend detected (Incus / Docker / Podman / Apple / Native)" in r.message
             for r in caplog.records
         )
 
@@ -90,3 +90,21 @@ class TestConfigureContainerRuntimeConfigOverride:
             result = configure_container_runtime(None)
         mock_detect.assert_called_once()
         assert result == "lxc"
+
+
+class TestConfigureContainerRuntimeNative:
+    def test_config_native_sets_native_backend(self):
+        config = MagicMock()
+        config.container_runtime = "native"
+        with patch("tinyagentos.containers.backend.detect_runtime") as mock_detect:
+            result = configure_container_runtime(config)
+        mock_detect.assert_not_called()
+        assert result == "native"
+        from tinyagentos.containers.native import NativeBackend
+        assert isinstance(_be._active_backend, NativeBackend)
+
+    def test_native_not_auto_detected(self):
+        """detect_runtime() never returns 'native' — it's config-only."""
+        from tinyagentos.containers.backend import detect_runtime
+        result = detect_runtime()
+        assert result != "native"

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -14,6 +14,7 @@ import time
 from .backend import ContainerInfo, _parse_memory, detect_runtime, get_backend, set_backend
 from .lxc import LXCBackend
 from .docker import DockerBackend
+from .native import NativeBackend
 
 logger = logging.getLogger(__name__)
 

--- a/tinyagentos/containers/backend.py
+++ b/tinyagentos/containers/backend.py
@@ -295,9 +295,13 @@ def configure_container_runtime(config: object = None) -> str | None:
     operator to pin a specific runtime.  When ``"auto"``, ``detect_runtime()``
     is called to probe the host.
 
-    Returns the runtime name (``"apple"``, ``"lxc"``, ``"docker"``, or
-    ``"podman"``), or ``None`` (after logging a warning) if no runtime is
-    available.
+    ``"native"`` selects the bare-metal backend.  It is never auto-detected
+    (every host is bare-metal-capable, so auto-detect would shadow LXC/Docker).
+    Set ``container_runtime: native`` explicitly in taOS config to use it.
+
+    Returns the runtime name (``"apple"``, ``"lxc"``, ``"docker"``,
+    ``"podman"``, ``"native"``), or ``None`` (after logging a warning) if no
+    runtime is available.
     """
     from tinyagentos.containers.lxc import LXCBackend
     from tinyagentos.containers.docker import DockerBackend
@@ -315,8 +319,12 @@ def configure_container_runtime(config: object = None) -> str | None:
     if runtime in ("docker", "podman"):
         set_backend(DockerBackend(binary=runtime))
         return runtime
+    if runtime == "native":
+        from tinyagentos.containers.native import NativeBackend
+        set_backend(NativeBackend())
+        return runtime
     logger.warning(
-        "No container backend detected (Incus / Docker / Podman / Apple). "
+        "No container backend detected (Incus / Docker / Podman / Apple / Native). "
         "Cluster features and worker containers will be disabled. "
         "Install one (e.g. 'sudo apt install incus' on Ubuntu/Debian, "
         "'sudo dnf install incus' on Fedora) and restart taOS."

--- a/tinyagentos/containers/lxc.py
+++ b/tinyagentos/containers/lxc.py
@@ -59,7 +59,10 @@ class _IncusPtyHandle(PtyHandle):
             self._proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             self._proc.kill()
-            self._proc.wait(timeout=2)
+            try:
+                self._proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
 
 
 def _open_incus_pty(container: str, shell_cmd: str) -> _IncusPtyHandle:

--- a/tinyagentos/containers/lxc.py
+++ b/tinyagentos/containers/lxc.py
@@ -40,6 +40,13 @@ class _IncusPtyHandle(PtyHandle):
         fcntl.ioctl(self._master_fd, termios.TIOCSWINSZ, winsize)
 
     def close(self) -> None:
+        """Close the PTY and terminate the subprocess.
+
+        Sends SIGTERM, closes the master fd, then waits for the process
+        with a short timeout.  The wait is fire-and-forget — callers in
+        async contexts should wrap this in ``asyncio.to_thread`` if they
+        need to avoid blocking the event loop.
+        """
         try:
             self._proc.send_signal(signal.SIGTERM)
         except ProcessLookupError:
@@ -48,7 +55,11 @@ class _IncusPtyHandle(PtyHandle):
             os.close(self._master_fd)
         except OSError:
             pass
-        self._proc.wait(timeout=5)
+        try:
+            self._proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait(timeout=2)
 
 
 def _open_incus_pty(container: str, shell_cmd: str) -> _IncusPtyHandle:

--- a/tinyagentos/containers/native.py
+++ b/tinyagentos/containers/native.py
@@ -48,6 +48,24 @@ _ALLOWED_WRITE_ROOTS: tuple[str, ...] = (
 )
 
 
+def _validate_env_value(key: str, value: str) -> str | None:
+    """Return an error message if *value* is unsafe for systemd unit files.
+
+    Newlines in env values can inject arbitrary systemd directives
+    into the unit file (e.g. ``ExecStart=/bin/bash\\nRestart=always``
+    exploiting naive line-by-line construction).  This validator rejects
+    any value containing ``\\n`` or ``\\r``.
+
+    Returns ``None`` when the value is safe to write.
+    """
+    if "\n" in value or "\r" in value:
+        return (
+            f"env value for {key!r} must not contain newlines or "
+            f"carriage returns (potential systemd directive injection)"
+        )
+    return None
+
+
 def _safe_host_path(remote_path: str, *, allowed_roots: tuple[str, ...] = _ALLOWED_WRITE_ROOTS) -> str | None:
     """Return the resolved real path if *remote_path* is safe, or None.
 
@@ -125,7 +143,10 @@ class _NativePtyHandle(PtyHandle):
             self._proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             self._proc.kill()
-            self._proc.wait(timeout=2)
+            try:
+                self._proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
 
 
 async def _run(cmd: list[str], timeout: int = 120) -> tuple[int, str]:
@@ -326,9 +347,13 @@ class NativeBackend(ContainerBackend):
             }
 
         unit_path = _service_unit_path(name)
-        # Build environment lines
+        # Build environment lines — reject newlines in values (they can
+        # inject arbitrary systemd directives into the unit file).
         env_lines = ""
         for key, value in (env or {}).items():
+            err = _validate_env_value(key, value)
+            if err is not None:
+                return {"success": False, "name": name, "error": err}
             env_lines += f"Environment={key}={value}\n"
 
         memory_limit_line = ""
@@ -589,6 +614,12 @@ WantedBy=multi-user.target
         unit_path = _service_unit_path(name)
         if not unit_path.exists():
             return {"success": False, "output": f"unit {name}.service not found"}
+
+        # Reject newlines in env values — they can inject arbitrary
+        # systemd directives into the unit file.
+        err = _validate_env_value(key, value)
+        if err is not None:
+            return {"success": False, "output": err}
 
         try:
             content = unit_path.read_text()

--- a/tinyagentos/containers/native.py
+++ b/tinyagentos/containers/native.py
@@ -1,0 +1,478 @@
+"""Native (bare-metal) container backend.
+
+Runs agent workloads directly on the host without container overhead.
+Useful on constrained nodes where container runtimes (Docker, Incus)
+are too heavy, such as CPU-only Qwen3-Embedding-8B deployments.
+
+Selected when ``container_runtime`` is explicitly set to ``"native"``
+in the taOS config.  Not auto-detected — bare metal is always available
+on a Linux host, so detecting it unconditionally would shadow LXC/Docker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import pty
+import select
+import shlex
+import shutil
+import signal
+import subprocess
+from pathlib import Path
+
+from .backend import ContainerBackend, ContainerInfo, PtyHandle, _parse_memory
+
+logger = logging.getLogger(__name__)
+
+_SYSTEMD_DIR = Path("/etc/systemd/system")
+
+
+class _NativePtyHandle(PtyHandle):
+    """PtyHandle backed by a subprocess on the native host."""
+
+    def __init__(self, proc: subprocess.Popen, master_fd: int) -> None:
+        self._proc = proc
+        self._master_fd = master_fd
+
+    def read(self, size: int = 4096) -> bytes:
+        ready, _, _ = select.select([self._master_fd], [], [], 0.1)
+        if ready:
+            return os.read(self._master_fd, size)
+        return b""
+
+    def write(self, data: bytes) -> None:
+        os.write(self._master_fd, data)
+
+    def resize(self, rows: int, cols: int) -> None:
+        import fcntl
+        import struct
+        import termios
+        winsize = struct.pack("HHHH", rows, cols, 0, 0)
+        fcntl.ioctl(self._master_fd, termios.TIOCSWINSZ, winsize)
+
+    def close(self) -> None:
+        try:
+            self._proc.send_signal(signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            os.close(self._master_fd)
+        except OSError:
+            pass
+        self._proc.wait(timeout=5)
+
+
+async def _run(cmd: list[str], timeout: int = 120) -> tuple[int, str]:
+    """Run a command on the host and return (returncode, output)."""
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    return proc.returncode or 0, stdout.decode() if stdout else ""
+
+
+def _service_unit_path(name: str) -> Path:
+    """Return the systemd service unit path for a container name."""
+    return _SYSTEMD_DIR / f"{name}.service"
+
+
+def _has_systemd() -> bool:
+    """Return True if systemd is available on this host."""
+    return shutil.which("systemctl") is not None
+
+
+class NativeBackend(ContainerBackend):
+    """Container backend that runs workloads directly on the bare-metal host.
+
+    Each "container" is a systemd service unit named after the container
+    (e.g. ``taos-agent-foo.service``).  Commands run directly on the host
+    via subprocess — no container isolation.  This is intended for
+    single-purpose constrained nodes where every cycle counts.
+
+    When systemd is not available (container-in-container, CI), falls back
+    to a simple subprocess-pid tracking approach for ``list_containers``
+    and treats ``start/stop/destroy`` as no-ops with a warning.
+    """
+
+    # ------------------------------------------------------------------
+    # list_containers
+    # ------------------------------------------------------------------
+
+    async def list_containers(self, prefix: str = "taos-agent-") -> list[ContainerInfo]:
+        """List systemd services whose name starts with *prefix*."""
+        if not _has_systemd():
+            return await self._list_containers_fallback(prefix)
+        code, output = await _run(
+            ["systemctl", "list-units", "--type=service", "--all",
+             "--no-legend", "--no-pager", f"{prefix}*"],
+            timeout=15,
+        )
+        if code != 0:
+            logger.warning("systemctl list-units failed: %s", output)
+            return []
+        results: list[ContainerInfo] = []
+        for line in output.splitlines():
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            unit = parts[0]
+            # strip .service suffix to get container name
+            name = unit[:-len(".service")] if unit.endswith(".service") else unit
+            if not name.startswith(prefix):
+                continue
+            status = parts[3]  # ACTIVE: active, inactive, failed, etc.
+            # Map systemd states to container-ish statuses
+            if status == "active":
+                mapped = "Running"
+            elif status == "inactive":
+                mapped = "Stopped"
+            elif status == "failed":
+                mapped = "Stopped"
+            else:
+                mapped = status.capitalize()
+            results.append(ContainerInfo(
+                name=name,
+                status=mapped,
+                ip="127.0.0.1",   # bare metal — always reachable at localhost
+                memory_mb=0,
+                cpu_cores=0,
+            ))
+        return results
+
+    async def _list_containers_fallback(
+        self, prefix: str = "taos-agent-",
+    ) -> list[ContainerInfo]:
+        """Fallback when systemd is unavailable: probe /etc/systemd/system."""
+        results: list[ContainerInfo] = []
+        if not _SYSTEMD_DIR.exists():
+            return results
+        for unit_file in sorted(_SYSTEMD_DIR.glob(f"{prefix}*.service")):
+            name = unit_file.stem  # strip .service
+            if not name.startswith(prefix):
+                continue
+            results.append(ContainerInfo(
+                name=name,
+                status="Stopped",
+                ip="127.0.0.1",
+                memory_mb=0,
+                cpu_cores=0,
+            ))
+        return results
+
+    # ------------------------------------------------------------------
+    # set_root_quota
+    # ------------------------------------------------------------------
+
+    async def set_root_quota(self, name: str, size_gib: int) -> dict:
+        """Disk quotas are not enforced on bare metal.
+
+        Returns success=True with an advisory note so callers don't block."""
+        return {
+            "success": True,
+            "note": "disk quota not enforced on bare metal; OS-managed filesystem",
+        }
+
+    # ------------------------------------------------------------------
+    # create_container
+    # ------------------------------------------------------------------
+
+    async def create_container(
+        self,
+        name: str,
+        image: str = "images:debian/bookworm",
+        memory_limit: str | None = None,
+        cpu_limit: int | None = None,
+        mounts: list[tuple[str, str]] | None = None,
+        env: dict[str, str] | None = None,
+        host_uid: int | None = None,
+        root_size_gib: int | None = None,
+    ) -> dict:
+        """Create a systemd service unit for the agent.
+
+        The created unit is a stub — the deployer is expected to follow
+        up with ``push_file`` and ``exec_in_container`` to install the
+        agent payload and start it.  The ``image`` parameter is ignored
+        on bare metal (the host *is* the image).
+
+        Returns ``{"success": True, "name": name}`` on success.
+        """
+        if not _has_systemd():
+            return {
+                "success": True,
+                "name": name,
+                "note": "systemd not available; bare-metal agent runs directly",
+            }
+
+        unit_path = _service_unit_path(name)
+        # Build environment lines
+        env_lines = ""
+        for key, value in (env or {}).items():
+            env_lines += f"Environment={key}={value}\n"
+
+        memory_limit_line = ""
+        if memory_limit is not None:
+            memory_limit_line = f"MemoryLimit={memory_limit}\n"
+
+        cpu_limit_line = ""
+        if cpu_limit is not None:
+            cpu_limit_line = f"CPUQuota={cpu_limit * 100}%\n"
+
+        unit_content = f"""[Unit]
+Description=taOS Agent: {name}
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/bin/true
+Restart=no
+{memory_limit_line}{cpu_limit_line}{env_lines}
+[Install]
+WantedBy=multi-user.target
+"""
+
+        try:
+            _SYSTEMD_DIR.mkdir(parents=True, exist_ok=True)
+            unit_path.write_text(unit_content)
+            code, output = await _run(["systemctl", "daemon-reload"], timeout=15)
+            if code != 0:
+                logger.warning("daemon-reload failed: %s", output)
+                # Not fatal — the unit is still on disk.
+        except OSError as exc:
+            logger.error("Failed to write unit file %s: %s", unit_path, exc)
+            return {"success": False, "error": str(exc)}
+
+        logger.info("bare-metal: created systemd unit %s", name)
+        return {"success": True, "name": name}
+
+    # ------------------------------------------------------------------
+    # exec_in_container
+    # ------------------------------------------------------------------
+
+    async def exec_in_container(
+        self, name: str, cmd: list[str], timeout: int = 300
+    ) -> tuple[int, str]:
+        """Execute a command directly on the host.
+
+        The *name* parameter is ignored — all commands run on the bare
+        host with no isolation.
+        """
+        return await _run(cmd, timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # push_file
+    # ------------------------------------------------------------------
+
+    async def push_file(
+        self, name: str, local_path: str, remote_path: str
+    ) -> tuple[int, str]:
+        """Copy a file to the host filesystem.
+
+        The *name* parameter is ignored — files are copied directly.
+        ``remote_path`` is an absolute host path.
+        """
+        try:
+            remote_dir = os.path.dirname(remote_path)
+            if remote_dir:
+                os.makedirs(remote_dir, exist_ok=True)
+            shutil.copy2(local_path, remote_path)
+            return 0, ""
+        except OSError as exc:
+            return 1, str(exc)
+
+    # ------------------------------------------------------------------
+    # start / stop / restart / destroy
+    # ------------------------------------------------------------------
+
+    async def start_container(self, name: str) -> dict:
+        """Start the systemd service for *name*."""
+        if not _has_systemd():
+            return {"success": True, "output": "systemd not available; service not started"}
+        unit_path = _service_unit_path(name)
+        if not unit_path.exists():
+            return {"success": False, "output": f"unit {name}.service not found"}
+        code, output = await _run(["systemctl", "start", f"{name}.service"], timeout=30)
+        return {"success": code == 0, "output": output}
+
+    async def stop_container(self, name: str, force: bool = False) -> dict:
+        """Stop the systemd service for *name*."""
+        if not _has_systemd():
+            return {"success": True, "output": "systemd not available"}
+        cmd = ["systemctl", "stop", f"{name}.service"]
+        if force:
+            cmd.insert(1, "--force")
+        code, output = await _run(cmd, timeout=30)
+        return {"success": code == 0, "output": output}
+
+    async def restart_container(self, name: str) -> dict:
+        """Restart the systemd service for *name*."""
+        if not _has_systemd():
+            return {"success": True, "output": "systemd not available"}
+        code, output = await _run(
+            ["systemctl", "restart", f"{name}.service"], timeout=30,
+        )
+        return {"success": code == 0, "output": output}
+
+    async def destroy_container(self, name: str) -> dict:
+        """Stop and delete the systemd unit for *name*."""
+        if not _has_systemd():
+            return {"success": True, "output": "systemd not available"}
+        unit_path = _service_unit_path(name)
+        # Stop first
+        await _run(["systemctl", "stop", f"{name}.service"], timeout=30)
+        # Disable
+        await _run(["systemctl", "disable", f"{name}.service"], timeout=30)
+        # Remove unit file
+        try:
+            unit_path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("Failed to remove unit %s: %s", unit_path, exc)
+        await _run(["systemctl", "daemon-reload"], timeout=15)
+        return {"success": True, "output": f"destroyed {name}"}
+
+    # ------------------------------------------------------------------
+    # get_container_logs
+    # ------------------------------------------------------------------
+
+    async def get_container_logs(self, name: str, lines: int = 100) -> str:
+        """Get recent journalctl logs for the service."""
+        if not _has_systemd():
+            return "systemd not available; no logs"
+        code, output = await _run(
+            ["journalctl", "--no-pager", "-n", str(lines),
+             "-u", f"{name}.service"],
+            timeout=30,
+        )
+        return output if code == 0 else f"Error getting logs: {output}"
+
+    # ------------------------------------------------------------------
+    # rename_container
+    # ------------------------------------------------------------------
+
+    async def rename_container(self, old_name: str, new_name: str) -> dict:
+        """Rename the systemd service unit file."""
+        if not _has_systemd():
+            return {"success": True, "output": "systemd not available"}
+        old_path = _service_unit_path(old_name)
+        new_path = _service_unit_path(new_name)
+        if not old_path.exists():
+            return {"success": False, "output": f"unit {old_name}.service not found"}
+        try:
+            old_path.rename(new_path)
+            await _run(["systemctl", "daemon-reload"], timeout=15)
+            return {"success": True, "output": f"renamed {old_name} -> {new_name}"}
+        except OSError as exc:
+            return {"success": False, "output": str(exc)}
+
+    # ------------------------------------------------------------------
+    # add_proxy_device
+    # ------------------------------------------------------------------
+
+    async def add_proxy_device(
+        self, name: str, device_name: str, listen: str, connect: str,
+        bind_mode: str | None = None,
+    ) -> dict:
+        """No-op on bare metal — everything is localhost already."""
+        return {"success": True, "output": "proxy devices not needed on bare metal"}
+
+    # ------------------------------------------------------------------
+    # snapshots
+    # ------------------------------------------------------------------
+
+    async def snapshot_create(self, name: str, snapshot_name: str) -> dict:
+        """Snapshots not supported on bare metal."""
+        return {
+            "success": False,
+            "output": "",
+            "note": "snapshots not supported on bare metal; use host-level backup tools",
+        }
+
+    async def snapshot_restore(self, name: str, snapshot_name: str) -> dict:
+        """Snapshots not supported on bare metal."""
+        return {
+            "success": False,
+            "output": "",
+            "note": "snapshots not supported on bare metal",
+        }
+
+    async def snapshot_list(self, name: str) -> dict:
+        """Snapshots not supported on bare metal."""
+        return {"success": False, "snapshots": [], "output": "not supported on bare metal"}
+
+    # ------------------------------------------------------------------
+    # spawn_pty
+    # ------------------------------------------------------------------
+
+    def spawn_pty(self, name: str, cmd: list[str] | None = None) -> PtyHandle:
+        """Open an interactive PTY directly on the host.
+
+        *name* is ignored — the PTY runs on the bare host.
+        """
+        master_fd, slave_fd = pty.openpty()
+        shell_cmd = "exec bash -l" if cmd is None else " ".join(shlex.quote(c) for c in cmd)
+        proc = subprocess.Popen(
+            ["bash", "-lc", shell_cmd],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        return _NativePtyHandle(proc, master_fd)
+
+    # ------------------------------------------------------------------
+    # set_env
+    # ------------------------------------------------------------------
+
+    async def set_env(self, name: str, key: str, value: str) -> dict:
+        """Update an Environment= line in the systemd service unit.
+
+        Systemd does not support hot-reload of environment variables on a
+        running service — the service must be restarted to pick up the
+        change.  The unit file is updated in-place and daemon-reloaded.
+        """
+        if not _has_systemd():
+            return {
+                "success": True,
+                "output": "systemd not available; env not persisted",
+            }
+        unit_path = _service_unit_path(name)
+        if not unit_path.exists():
+            return {"success": False, "output": f"unit {name}.service not found"}
+
+        try:
+            content = unit_path.read_text()
+        except OSError as exc:
+            return {"success": False, "output": str(exc)}
+
+        # Replace existing Environment= line for this key, or add new one
+        env_line = f"Environment={key}={value}"
+        old_prefix = f"Environment={key}="
+        if old_prefix in content:
+            # Replace the existing line
+            lines = content.splitlines()
+            new_lines = []
+            for line in lines:
+                if line.strip().startswith(old_prefix):
+                    new_lines.append(env_line)
+                else:
+                    new_lines.append(line)
+            content = "\n".join(new_lines) + "\n"
+        else:
+            # Insert before [Install] or at end
+            if "\n[Install]" in content:
+                content = content.replace("\n[Install]", f"\n{env_line}\n[Install]")
+            else:
+                content = content.rstrip("\n") + f"\n{env_line}\n"
+
+        try:
+            unit_path.write_text(content)
+            await _run(["systemctl", "daemon-reload"], timeout=15)
+        except OSError as exc:
+            return {"success": False, "output": str(exc)}
+
+        return {"success": True, "output": f"set {key}={value} in {name}.service"}

--- a/tinyagentos/containers/native.py
+++ b/tinyagentos/containers/native.py
@@ -28,6 +28,59 @@ logger = logging.getLogger(__name__)
 
 _SYSTEMD_DIR = Path("/etc/systemd/system")
 
+# ---------------------------------------------------------------------------
+# SECURITY: the "name" parameter on exec / push_file / spawn_pty is
+# DECORATIVE on the native backend — it does NOT provide container-style
+# isolation.  All commands run directly on the bare host, and push_file
+# writes to arbitrary host paths unless guarded by _safe_host_path.
+# Callers MUST treat name as an opaque identifier, not a security boundary.
+# ---------------------------------------------------------------------------
+
+# Directories that push_file is allowed to write into on the host.
+# Any remote_path that resolves outside these roots is rejected.
+# This set MUST be kept minimal — add entries only when a concrete
+# deployment path genuinely needs them.
+_ALLOWED_WRITE_ROOTS: tuple[str, ...] = (
+    "/opt/taos/",
+    "/etc/systemd/system/",
+    "/var/lib/taos/",
+    "/tmp/",
+)
+
+
+def _safe_host_path(remote_path: str, *, allowed_roots: tuple[str, ...] = _ALLOWED_WRITE_ROOTS) -> str | None:
+    """Return the resolved real path if *remote_path* is safe, or None.
+
+    Rejects:
+    - Paths containing ``..`` segments (path traversal).
+    - Paths that, when resolved, fall outside every directory in
+      *allowed_roots*.
+    - Symlinks that escape the allowed roots (realpath is checked after
+      resolution).
+
+    Returns the resolved absolute path on success, or ``None`` when the
+    path is unsafe.
+    """
+    if not remote_path or not remote_path.startswith("/"):
+        return None
+
+    # Block literal ".." components — simple, hard to bypass, and
+    # catches the common case before we touch the filesystem.
+    parts = remote_path.split("/")
+    if ".." in parts:
+        return None
+
+    # Resolve symlinks + collapse any indirect traversal.
+    try:
+        resolved = os.path.realpath(remote_path)
+    except (OSError, ValueError):
+        return None
+
+    for root in allowed_roots:
+        if resolved == root or resolved.startswith(root.rstrip("/") + "/"):
+            return resolved
+    return None
+
 
 class _NativePtyHandle(PtyHandle):
     """PtyHandle backed by a subprocess on the native host."""
@@ -53,6 +106,13 @@ class _NativePtyHandle(PtyHandle):
         fcntl.ioctl(self._master_fd, termios.TIOCSWINSZ, winsize)
 
     def close(self) -> None:
+        """Close the PTY and terminate the subprocess.
+
+        Sends SIGTERM, closes the master fd, then waits for the process
+        with a short timeout.  The wait is fire-and-forget — callers in
+        async contexts should wrap this in ``asyncio.to_thread`` if they
+        need to avoid blocking the event loop.
+        """
         try:
             self._proc.send_signal(signal.SIGTERM)
         except ProcessLookupError:
@@ -61,7 +121,11 @@ class _NativePtyHandle(PtyHandle):
             os.close(self._master_fd)
         except OSError:
             pass
-        self._proc.wait(timeout=5)
+        try:
+            self._proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._proc.kill()
+            self._proc.wait(timeout=2)
 
 
 async def _run(cmd: list[str], timeout: int = 120) -> tuple[int, str]:
@@ -85,6 +149,22 @@ def _has_systemd() -> bool:
     return shutil.which("systemctl") is not None
 
 
+def _systemd_dir_is_writable() -> bool:
+    """Return True if the systemd unit directory exists and is writable.
+
+    Called once at backend init time so a read-only /etc/systemd/system
+    (common in containers) is caught early rather than failing mid-deploy.
+    """
+    try:
+        _SYSTEMD_DIR.mkdir(parents=True, exist_ok=True)
+        test = _SYSTEMD_DIR / ".taos-native-write-test"
+        test.touch()
+        test.unlink()
+        return True
+    except (OSError, PermissionError):
+        return False
+
+
 class NativeBackend(ContainerBackend):
     """Container backend that runs workloads directly on the bare-metal host.
 
@@ -96,14 +176,32 @@ class NativeBackend(ContainerBackend):
     When systemd is not available (container-in-container, CI), falls back
     to a simple subprocess-pid tracking approach for ``list_containers``
     and treats ``start/stop/destroy`` as no-ops with a warning.
+
+    .. SECURITY::
+
+       The ``name`` parameter on ``exec_in_container``, ``push_file``,
+       and ``spawn_pty`` is DECORATIVE — it does NOT provide the
+       container-style name-is-the-boundary guarantee that LXC and Docker
+       backends offer.  Commands run directly on the host, and
+       ``push_file`` is gated by :data:`_ALLOWED_WRITE_ROOTS` rather
+       than a container rootfs.
     """
+
+    def __init__(self) -> None:
+        pass  # writability is checked lazily at create_container time
 
     # ------------------------------------------------------------------
     # list_containers
     # ------------------------------------------------------------------
 
     async def list_containers(self, prefix: str = "taos-agent-") -> list[ContainerInfo]:
-        """List systemd services whose name starts with *prefix*."""
+        """List systemd services whose name starts with *prefix*.
+
+        Parses the ACTIVE column of ``systemctl list-units`` (index 2),
+        not the SUB column (index 3), so states like "active",
+        "inactive", and "failed" are correctly detected instead of
+        misreading sub-states like "running" / "dead" / "exited".
+        """
         if not _has_systemd():
             return await self._list_containers_fallback(prefix)
         code, output = await _run(
@@ -124,7 +222,7 @@ class NativeBackend(ContainerBackend):
             name = unit[:-len(".service")] if unit.endswith(".service") else unit
             if not name.startswith(prefix):
                 continue
-            status = parts[3]  # ACTIVE: active, inactive, failed, etc.
+            status = parts[2]  # ACTIVE column: active, inactive, failed, etc.
             # Map systemd states to container-ish statuses
             if status == "active":
                 mapped = "Running"
@@ -193,18 +291,38 @@ class NativeBackend(ContainerBackend):
     ) -> dict:
         """Create a systemd service unit for the agent.
 
-        The created unit is a stub — the deployer is expected to follow
-        up with ``push_file`` and ``exec_in_container`` to install the
-        agent payload and start it.  The ``image`` parameter is ignored
-        on bare metal (the host *is* the image).
+        The created unit is a STUB — its ``ExecStart`` is a placeholder
+        (``/bin/false``) so a bare ``start_container`` will fail rather
+        than silently report success with nothing running.  The deployer
+        is expected to follow up with ``push_file`` and
+        ``exec_in_container`` to install the agent payload, then call
+        ``set_env`` to update ``ExecStart`` before starting.
 
-        Returns ``{"success": True, "name": name}`` on success.
+        The ``image`` parameter is ignored on bare metal (the host *is*
+        the image).
+
+        Returns ``{"success": False, "name": name, "note": ...}`` when
+        the unit directory is not writable or systemd is unavailable —
+        the caller must not proceed assuming a working service.
         """
         if not _has_systemd():
             return {
-                "success": True,
+                "success": False,
                 "name": name,
-                "note": "systemd not available; bare-metal agent runs directly",
+                "error": (
+                    "systemd not available on this host. "
+                    "bare-metal backend requires systemd to manage agent services."
+                ),
+            }
+
+        if not _systemd_dir_is_writable():
+            return {
+                "success": False,
+                "name": name,
+                "error": (
+                    f"{_SYSTEMD_DIR} is not writable. "
+                    "bare-metal backend needs write access to the systemd unit directory."
+                ),
             }
 
         unit_path = _service_unit_path(name)
@@ -221,6 +339,11 @@ class NativeBackend(ContainerBackend):
         if cpu_limit is not None:
             cpu_limit_line = f"CPUQuota={cpu_limit * 100}%\n"
 
+        # ExecStart is a sentinel: /bin/false exits 1 immediately so a
+        # bare start_container call fails instead of silently succeeding
+        # with nothing running.  The deployer MUST update ExecStart to a
+        # real payload (via set_env or direct unit-file edit) before
+        # starting the agent.
         unit_content = f"""[Unit]
 Description=taOS Agent: {name}
 After=network-online.target
@@ -228,7 +351,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/bin/true
+ExecStart=/bin/false
 Restart=no
 {memory_limit_line}{cpu_limit_line}{env_lines}
 [Install]
@@ -246,8 +369,16 @@ WantedBy=multi-user.target
             logger.error("Failed to write unit file %s: %s", unit_path, exc)
             return {"success": False, "error": str(exc)}
 
-        logger.info("bare-metal: created systemd unit %s", name)
-        return {"success": True, "name": name}
+        logger.info("bare-metal: created systemd unit %s (stub — update ExecStart before starting)", name)
+        return {
+            "success": True,
+            "name": name,
+            "note": (
+                "stub unit created with ExecStart=/bin/false. "
+                "update ExecStart (via set_env or direct edit) to a real agent "
+                "payload before calling start_container."
+            ),
+        }
 
     # ------------------------------------------------------------------
     # exec_in_container
@@ -259,7 +390,7 @@ WantedBy=multi-user.target
         """Execute a command directly on the host.
 
         The *name* parameter is ignored — all commands run on the bare
-        host with no isolation.
+        host with no isolation.  See the class-level SECURITY note.
         """
         return await _run(cmd, timeout=timeout)
 
@@ -273,13 +404,22 @@ WantedBy=multi-user.target
         """Copy a file to the host filesystem.
 
         The *name* parameter is ignored — files are copied directly.
-        ``remote_path`` is an absolute host path.
+        ``remote_path`` MUST resolve within :data:`_ALLOWED_WRITE_ROOTS`
+        or the call is rejected with an error.  See the class-level
+        SECURITY note.
         """
+        safe = _safe_host_path(remote_path)
+        if safe is None:
+            return 1, (
+                f"push_file rejected unsafe path {remote_path!r}. "
+                f"remote_path must be an absolute path within one of: "
+                f"{', '.join(_ALLOWED_WRITE_ROOTS)}"
+            )
         try:
-            remote_dir = os.path.dirname(remote_path)
+            remote_dir = os.path.dirname(safe)
             if remote_dir:
                 os.makedirs(remote_dir, exist_ok=True)
-            shutil.copy2(local_path, remote_path)
+            shutil.copy2(local_path, safe)
             return 0, ""
         except OSError as exc:
             return 1, str(exc)
@@ -291,7 +431,7 @@ WantedBy=multi-user.target
     async def start_container(self, name: str) -> dict:
         """Start the systemd service for *name*."""
         if not _has_systemd():
-            return {"success": True, "output": "systemd not available; service not started"}
+            return {"success": False, "output": "systemd not available; service not started"}
         unit_path = _service_unit_path(name)
         if not unit_path.exists():
             return {"success": False, "output": f"unit {name}.service not found"}
@@ -411,6 +551,7 @@ WantedBy=multi-user.target
         """Open an interactive PTY directly on the host.
 
         *name* is ignored — the PTY runs on the bare host.
+        See the class-level SECURITY note.
         """
         master_fd, slave_fd = pty.openpty()
         shell_cmd = "exec bash -l" if cmd is None else " ".join(shlex.quote(c) for c in cmd)
@@ -434,6 +575,11 @@ WantedBy=multi-user.target
         Systemd does not support hot-reload of environment variables on a
         running service — the service must be restarted to pick up the
         change.  The unit file is updated in-place and daemon-reloaded.
+
+        Special handling for ``ExecStart``: when *key* is ``ExecStart``,
+        the ``ExecStart=`` line in the ``[Service]`` section is replaced
+        rather than treated as an ``Environment=`` entry.  This lets the
+        deployer wire the stub unit to a real agent payload after install.
         """
         if not _has_systemd():
             return {
@@ -449,25 +595,40 @@ WantedBy=multi-user.target
         except OSError as exc:
             return {"success": False, "output": str(exc)}
 
-        # Replace existing Environment= line for this key, or add new one
-        env_line = f"Environment={key}={value}"
-        old_prefix = f"Environment={key}="
-        if old_prefix in content:
-            # Replace the existing line
+        is_exec_start = key == "ExecStart"
+
+        if is_exec_start:
+            # Replace the ExecStart= line in [Service] section.
+            old_prefix = "ExecStart="
             lines = content.splitlines()
             new_lines = []
             for line in lines:
-                if line.strip().startswith(old_prefix):
-                    new_lines.append(env_line)
+                stripped = line.strip()
+                if stripped.startswith(old_prefix):
+                    new_lines.append(f"ExecStart={value}")
                 else:
                     new_lines.append(line)
             content = "\n".join(new_lines) + "\n"
         else:
-            # Insert before [Install] or at end
-            if "\n[Install]" in content:
-                content = content.replace("\n[Install]", f"\n{env_line}\n[Install]")
+            # Environment variable path
+            env_line = f"Environment={key}={value}"
+            old_prefix = f"Environment={key}="
+            if old_prefix in content:
+                # Replace the existing line
+                lines = content.splitlines()
+                new_lines = []
+                for line in lines:
+                    if line.strip().startswith(old_prefix):
+                        new_lines.append(env_line)
+                    else:
+                        new_lines.append(line)
+                content = "\n".join(new_lines) + "\n"
             else:
-                content = content.rstrip("\n") + f"\n{env_line}\n"
+                # Insert before [Install] or at end
+                if "\n[Install]" in content:
+                    content = content.replace("\n[Install]", f"\n{env_line}\n[Install]")
+                else:
+                    content = content.rstrip("\n") + f"\n{env_line}\n"
 
         try:
             unit_path.write_text(content)

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -503,7 +503,7 @@ async def set_container_runtime(request: Request):
     """Set the container runtime preference."""
     body = await request.json()
     runtime = body.get("runtime", "auto")
-    if runtime not in ("auto", "apple", "lxc", "docker", "podman"):
+    if runtime not in ("auto", "apple", "lxc", "docker", "podman", "native"):
         return JSONResponse({"error": f"Invalid runtime: {runtime}"}, status_code=400)
     config = request.app.state.config
     config.container_runtime = runtime
@@ -522,6 +522,9 @@ async def set_container_runtime(request: Request):
         set_backend(LXCBackend())
     elif effective in ("docker", "podman"):
         set_backend(DockerBackend(binary=effective))
+    elif effective == "native":
+        from tinyagentos.containers.native import NativeBackend
+        set_backend(NativeBackend())
     return {"status": "updated", "runtime": effective}
 
 


### PR DESCRIPTION
Task: t_f310e934. Fixes #1691.

Five fixes on the NativeBackend before it becomes selectable:

**SECURITY (3 items):**
- `push_file` now passes `remote_path` through `_safe_host_path()`, rejecting `..` traversal and writes outside `_ALLOWED_WRITE_ROOTS` (opt/taos/, /etc/systemd/system/, /var/lib/taos/, /tmp/). Symlink escapes are caught via `realpath`.
- `create_container` checks `_systemd_dir_is_writable()` upfront (lazily, at create time) and fails early if the unit directory is read-only.
- Class-level `.. SECURITY::` docstring noting that `name` is DECORATIVE — no container boundary on exec/push/spawn_pty.

**Supervision:**
- Unit stub changed from `ExecStart=/bin/true` + `Restart=no` (silent NO-OP) to `ExecStart=/bin/false` + `Restart=no`. A bare `start_container` now fails rather than returning success with nothing running.
- `create_container` returns a "stub unit created" note telling the caller to update ExecStart before starting.
- `set_env(key="ExecStart", value=...)` now replaces the ExecStart line so the deployer can wire the real agent payload after install.

**Kilo bugs:**
- `list_containers`: reads ACTIVE column (`parts[2]`) instead of SUB (`parts[3]`), correctly mapping "inactive"/"failed" to Stopped.
- `_NativePtyHandle.close()` and `_IncusPtyHandle.close()`: guard `proc.wait(timeout=5)` with `TimeoutExpired` → kill + re-wait; added docstring noting async callers should use `asyncio.to_thread`.

Tests: 57/57 pass (38 native + 19 runtime-config/PTY).
SCOPE: does NOT mark #892 fixed — #892 is a cluster-worker capability contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **native** container runtime option for running workloads directly on the host.
  * The runtime settings UI/API now recognizes and can switch to the native backend.

* **Bug Fixes**
  * Improved container path handling to better prevent unsafe file access.
  * Updated runtime detection messaging to include the native option.
  * Refined container lifecycle behavior and log handling for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->