### PR TITLE
fix(config): rkllama backend name local-npu -> local-rkllama so installed models reach LiteLLM (#1710)

### DIFF
--- a/data/config.yaml.example
+++ b/data/config.yaml.example
@@ -10,7 +10,7 @@ server:
   browser_proxy_port: 6970
 
 backends:
-  - name: local-npu
+  - name: local-rkllama
     type: rkllama
     url: http://localhost:8080
     priority: 3

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -379,3 +379,31 @@ def test_load_config_migrates_legacy_rkllama_port(tmp_path):
     assert by_name["custom-rk"] == "http://10.0.0.5:8080"
     # non-rkllama backend on 8080 -> untouched
     assert by_name["ollama"] == "http://localhost:8080"
+
+
+def test_load_config_migrates_legacy_rkllama_backend_name(tmp_path):
+    """An install seeded before #1710 names the rkllama backend local-npu,
+    whose service-id (npu) never matches the RKLLM manifests'
+    requires.backends id (rkllama), so installed chat models get no LiteLLM
+    alias. load_config renames it to local-rkllama so the service-id matches."""
+    import yaml
+    from tinyagentos.config import load_config
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({
+        "backends": [
+            {"name": "local-npu", "type": "rkllama", "url": "http://localhost:7833"},
+            {"name": "custom-rk", "type": "rkllama", "url": "http://10.0.0.5:8080"},
+            {"name": "local-npu", "type": "ollama", "url": "http://localhost:11434"},
+        ]
+    }))
+    cfg = load_config(cfg_path)
+    rkllama_names = [b["name"] for b in cfg.backends if b["type"] == "rkllama"]
+    # The auto-seeded rkllama local-npu is renamed to local-rkllama.
+    assert "local-rkllama" in rkllama_names
+    assert "local-npu" not in rkllama_names
+    # A deliberately custom rkllama name is untouched.
+    assert "custom-rk" in rkllama_names
+    # A non-rkllama backend that happens to be named local-npu is untouched.
+    ollama = [b for b in cfg.backends if b["type"] == "ollama"][0]
+    assert ollama["name"] == "local-npu"

--- a/tests/test_llm_proxy.py
+++ b/tests/test_llm_proxy.py
@@ -14,7 +14,7 @@ class TestConfigGeneration:
     def test_generates_config_from_backends(self):
         backends = [
             {"name": "fedora-gpu", "type": "ollama", "url": "http://fedora:11434", "priority": 1},
-            {"name": "local-npu", "type": "rkllama", "url": "http://localhost:8080", "priority": 3},
+            {"name": "local-rkllama", "type": "rkllama", "url": "http://localhost:8080", "priority": 3},
         ]
         config = generate_litellm_config(backends)
         assert "model_list" in config

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -97,6 +97,29 @@ def _migrate_legacy_rkllama_port(backends: list[dict]) -> None:
             )
 
 
+def _migrate_legacy_rkllama_backend_name(backends: list[dict]) -> None:
+    """Rename the auto-seeded rkllama backend ``local-npu`` to ``local-rkllama``
+    in place (#1710).
+
+    LiteLLM registers an installed local chat model only when a backend named
+    ``local-<service-id>`` exists whose service-id matches the
+    ``requires.backends[].id`` the model's manifest declares. Every RKLLM model
+    manifest declares ``id: rkllama``, but the shipped seed named the backend
+    ``local-npu`` (service-id ``npu``), which never matches. The result is that
+    an installed RKLLM chat model gets no LiteLLM alias and an agent selecting
+    it receives no output. Renaming to ``local-rkllama`` makes the service-id
+    ``rkllama`` and restores the match. Idempotent and targeted: only the
+    legacy-named rkllama default is touched, and it collapses the boot-time
+    dedup collision with auto_register's own ``local-rkllama``."""
+    for b in backends:
+        if b.get("type") == "rkllama" and b.get("name") == "local-npu":
+            b["name"] = "local-rkllama"
+            log.info(
+                "migrating rkllama backend name local-npu to local-rkllama so "
+                "installed RKLLM models resolve in LiteLLM (#1710)",
+            )
+
+
 def load_config(path: Path) -> AppConfig:
     if not path.exists():
         # Fresh install: build defaults with litellm_port explicitly recorded
@@ -136,6 +159,7 @@ def load_config(path: Path) -> AppConfig:
         )
     backends = data.get("backends", [])
     _migrate_legacy_rkllama_port(backends)
+    _migrate_legacy_rkllama_backend_name(backends)
     cfg = AppConfig(
         server=server,
         backends=backends,


### PR DESCRIPTION
## What

Fixes the root cause of #1710 ("taOS Agent returns 'the agent backend returned no output'"), reported by mandresve.

## Root cause

LiteLLM registers an installed local chat model only when a backend named `local-<service-id>` exists whose service-id matches the `requires.backends[].id` the model's manifest declares. Every RKLLM model manifest declares `id: rkllama`, but the shipped seed named the rkllama backend **`local-npu`**. `_local_backend_models_from_registry` derives the service-id from the `local-` name suffix, so `local-npu` yields service-id `npu`, which never matches `rkllama`. Result: an installed RKLLM chat model gets **no LiteLLM alias**. The agent (via OpenCode) then calls `litellm/<model-id>`, LiteLLM has no such model, and the completion returns zero parts, surfacing as "the agent backend returned no output."

The model is installed and in the registry, and the manifest is correct. It is purely a backend-name mismatch. mandresve independently traced the failing hop to LiteLLM not exposing his chat model, which matches exactly.

## Fix (registry-first, design intact)

- Rename the seeded backend `local-npu` -> `local-rkllama` in `data/config.yaml.example` (fresh installs), so the service-id is `rkllama`.
- Add `_migrate_legacy_rkllama_backend_name` in `config.py` `load_config` to heal existing installs in place, mirroring the #1697 port migration. It also collapses the boot-time dedup collision with `auto_register`'s own `local-rkllama`.
- No discovery-based change: chat models continue to flow through the installed-model registry, which is the only supported source.

## Verification

- Confirmed on a live Pi install that its config carries the `local-npu` name (the exact mismatch).
- Tests: added a migration test (`local-npu` rkllama renamed, custom names + non-rkllama `local-npu` untouched); updated the `test_llm_proxy` fixture. 163 config/llm_proxy/litellm_config tests pass locally.

## Follow-up (out of scope)

The rkllama service manifest's `hardware_tiers` floor (16GB) can strand sub-16GB NPU boards from the auto-registered `local-rkllama`; lowering it to match the models it serves is a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy RKLLM backend configurations are now automatically normalized to the current backend name when loading saved settings.
  * Generated configuration output now shows the updated backend name, keeping backend lists consistent.
  * Existing custom backend names are preserved, and unrelated backends are not changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->