### PR TITLE
fix(rkllama): bump pinned ref to main HEAD (fixes /api/chat on Python 3.11 + delivers ndjson) (#1710)

### DIFF
--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 06cf874d8b29767729ec06547cf02fc92acd875c)
+#     TAOS_RKLLAMA_REF        git ref  (default: d92668edfb6c73e164c7b74baf835d14bd77365e)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-06cf874d8b29767729ec06547cf02fc92acd875c}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-d92668edfb6c73e164c7b74baf835d14bd77365e}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.


### PR DESCRIPTION
Bumps `TAOS_RKLLAMA_REF` from `06cf874` to jaylfc/rkllama main HEAD `d92668ed`.

## Why

Reported by mandresve on #1710. The pinned commit predates two fixes on rkllama main:

1. **/api/chat broken on Python < 3.12.** `server_utils.py:350` used a nested same-quoted string inside an f-string (`f"...{int(rkllama.config.get("model", ...))}..."`), which is a SyntaxError on 3.11 and earlier (valid only on 3.12+ per PEP 701). It fails at `ChatEndpointHandler` import, so `/api/chat` 500s before inference and an agent using an rkllama chat model gets no output. main refactored the `int()` out to a `timeout` variable, removing the nested quotes.
2. **/api/pull ndjson progress fix** (rkllama PR #2) merged to main but was never delivered because the installer pin was not bumped.

## Scope note

The bumped range also includes an experimental llama.cpp integration and a lock-removal change on rkllama main; pinning to main HEAD is the maintainer's intended production state.

This is one of two fixes for #1710; the other is PR #1715 (LiteLLM chat-model registration). Both are needed for the agent to produce output on an RKLLM chat model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default version selected during installation for RKLLAMA-based setup, so fresh installs now use a newer checked-out revision when no override is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->