### PR TITLE
release: 1.0.0-beta.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.35] - 2026-07-07
+
+### Fixed
+- The taOS Agent now returns output when it runs on a local RK3588 (RKLLM) model. Two gaps combined to make the agent report "the agent backend returned no output": the local rkllama backend was registered under a name that did not match the RKLLM model manifests, so the model was never exposed to the LiteLLM proxy the agent calls, and the pinned rkllama server had a Python version incompatibility that made its chat endpoint fail before inference. The backend name now matches on load (existing installs self-heal on update, no reinstall) and the rkllama pin is bumped to the fixed server. Reported by @mandresve (#1710).
+- Agent message bubbles are now selectable and show a copy button on hover, so an agent's reply can be copied without dragging across the whole conversation (#835).
+- The desktop top bar now shows a badge when an update is available, and clicking it opens the Updates pane in Settings (#855).
+- taOS now surfaces a clear message when your local branch has diverged from its tracked remote, instead of a confusing update-check state (#841).
+
+### Security
+- Cluster GPU-lease endpoints now require admin authentication and validate their inputs, so a non-privileged LAN client cannot claim, release, or probe another node's GPU leases (#1675 follow-up).
+- The bare-metal worker backend runs under process supervision with hardened handling, and container environment values now reject embedded newlines (#1691).
+- Agent delegation and the org model were hardened against a stale-permission carry-over and a reporting-lock race (#174, #1661, #1662).
+
 ## [1.0.0-beta.34] - 2026-07-07
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.34",
+  "version": "1.0.0-beta.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.34",
+      "version": "1.0.0-beta.35",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.34",
+  "version": "1.0.0-beta.35",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.34"
+version = "1.0.0-beta.35"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.34"
+__version__ = "1.0.0-beta.35"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b34"
+version = "1.0.0b35"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release train for 1.0.0-beta.35. Version bump across pyproject / __init__ / desktop package(-lock) / uv.lock + CHANGELOG.

Highlights (all already merged to dev):
- Fix #1710: taOS Agent returns output on local RKLLM models (backend-name registry match #1715 + rkllama /api/chat pin bump #1716). Reported by @mandresve.
- #835 copy button + selectable agent messages; #855 update-available top-bar badge; #841 branch-divergence message.
- Security: cluster GPU-lease endpoint auth + input validation; NativeBackend supervision + container env newline rejection; delegation/org-model hardening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local agent output for RK3588/RKLLM setups.
  * Message bubbles are now selectable and support hover-to-copy.
  * The Settings update badge now behaves more consistently in the desktop top bar.
  * Better guidance is shown when a local branch has diverged from its remote.

* **Security**
  * Strengthened authentication and input validation for GPU lease actions.
  * Added protections around worker supervision, environment values, and permission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->