### PR TITLE
feat(taosnet): license-eligibility classifier

### DIFF
--- a/tests/taosnet/test_license_eligibility.py
+++ b/tests/taosnet/test_license_eligibility.py
@@ -1,0 +1,103 @@
+"""Tests for taOSnet redistribution-eligibility classification."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tinyagentos.taosnet.license_eligibility import (
+    classify_manifest,
+    license_allows_redistribution,
+    normalize_license,
+)
+
+# Real licence strings from app-catalog/models that DO permit redistribution.
+REDISTRIBUTABLE = [
+    "Apache-2.0",
+    "MIT",
+    "BSD-3-Clause",
+    "CC-BY-4.0",
+    "OpenRAIL",
+    "OpenRAIL++",
+    "OpenRAIL-M",
+    "openrail++",
+    "OpenRAIL++ (commercial use allowed)",  # trailing note stripped
+    "CreativeML OpenRAIL-M",
+    "Gemma Terms of Use",
+    '"Gemma Terms of Use"',  # quoted in YAML source
+    "Gemma",
+    "Llama 3.1 Community License",
+    "Llama 3.3 Community License",
+]
+
+# Real licence strings that must NOT be redistributed: non-commercial, research,
+# gated, dual-with-restricted-part, or simply unknown-so-conservative.
+NOT_REDISTRIBUTABLE = [
+    "Qwen Research License",
+    "Qwen License (commercial requires agreement)",
+    "Tongyi Qianwen License",
+    "stable-cascade-nc-community (non-commercial)",
+    "sai-nc-community (non-commercial)",
+    "Stability AI Community License",
+    "Playground v2.5 Community License",
+    "NVIDIA Open Model License",
+    "DeepSeek License",
+    "S-Lab License 1.0",
+    "CC-BY-NC-4.0",
+    "CC-BY-NC 4.0 (non-commercial)",
+    "CC BY-NC-SA 4.0",
+    "bria-rmbg-1.4 (non-commercial)",
+    "flux-1-dev-non-commercial-license",
+    "Apache-2.0 / MiniCPM Model License",  # dual: weights are MiniCPM-licensed
+]
+
+
+@pytest.mark.parametrize("lic", REDISTRIBUTABLE)
+def test_redistributable_licenses(lic):
+    assert license_allows_redistribution(lic) is True
+
+
+@pytest.mark.parametrize("lic", NOT_REDISTRIBUTABLE)
+def test_restricted_licenses(lic):
+    assert license_allows_redistribution(lic) is False
+
+
+@pytest.mark.parametrize("lic", [None, "", "   ", "Totally Made Up License 2.0"])
+def test_unknown_or_empty_defaults_to_false(lic):
+    assert license_allows_redistribution(lic) is False
+
+
+def test_case_and_whitespace_insensitive():
+    assert license_allows_redistribution("apache-2.0") is True
+    assert license_allows_redistribution("  APACHE-2.0  ") is True
+    assert license_allows_redistribution("MIT") is True
+
+
+def test_cc_by_is_allowed_but_cc_by_nc_is_not():
+    # The NC marker must not also trip on the permissive CC-BY-4.0.
+    assert license_allows_redistribution("CC-BY-4.0") is True
+    assert license_allows_redistribution("CC-BY-NC-4.0") is False
+
+
+def test_normalize_strips_quotes_and_trailing_note():
+    assert normalize_license('"Gemma Terms of Use"') == "gemma terms of use"
+    assert normalize_license("OpenRAIL++ (commercial use allowed)") == "openrail++"
+
+
+def test_classify_manifest_reads_license_field():
+    assert classify_manifest({"license": "MIT"}) is True
+    assert classify_manifest({"license": "CC-BY-NC-4.0"}) is False
+    assert classify_manifest({}) is False
+
+
+def test_every_catalog_manifest_classifies_without_error():
+    """Every model manifest must classify to a bool. If this fails on a NEW
+    licence string, add it to the allow-list or confirm it should stay False."""
+    catalog = Path(__file__).resolve().parents[2] / "app-catalog" / "models"
+    manifests = list(catalog.glob("*/manifest.yaml")) + list(catalog.glob("*/manifest.yml"))
+    assert manifests, "no model manifests found; wrong path?"
+    for path in manifests:
+        data = yaml.safe_load(path.read_text())
+        result = classify_manifest(data)
+        assert isinstance(result, bool), f"{path.name}: {data.get('license')!r} -> {result!r}"

--- a/tinyagentos/taosnet/__init__.py
+++ b/tinyagentos/taosnet/__init__.py
@@ -1,0 +1,5 @@
+"""taOSnet: peer-to-peer distribution of model weights.
+
+Phase 2 client-side pieces. See docs/design/model-torrent-mesh.md and the
+taos.my-side contract in docs/taosnet.md (built by the website side).
+"""

--- a/tinyagentos/taosnet/license_eligibility.py
+++ b/tinyagentos/taosnet/license_eligibility.py
@@ -1,0 +1,90 @@
+"""Decide whether a model's weights may be redistributed over taOSnet.
+
+taOSnet seeds model weights peer-to-peer. We may only do that for models whose
+licence permits redistribution. This module is the single source of truth for
+that decision; the catalog-publish CLI calls it to set the manifest's
+``license_allows_redistribution`` flag, which the download client
+(``should_use_torrent``) requires before it will touch the swarm.
+
+Policy (conservative by default):
+
+1. If the licence carries any restrictive marker (non-commercial, research-only,
+   commercial-requires-agreement, gated, S-Lab), it is NOT redistributable.
+2. Otherwise, if the licence exactly matches a known-redistributable licence
+   (permissive, plus the RAIL / Gemma / Llama-community family that permit
+   redistribution with their terms attached), it IS redistributable.
+3. Otherwise it is NOT redistributable, and the caller should surface it for a
+   human to review and, if appropriate, add to ``PERMISSIVE_LICENSES``.
+
+Missing a genuinely-redistributable model only costs us an HTTP-only download
+(no harm). Wrongly redistributing a restricted one is a legal problem. So the
+default is always False.
+"""
+from __future__ import annotations
+
+# Substrings (matched against the normalised licence) that force a False result,
+# checked BEFORE the allow-list so a dual or annotated licence cannot slip through.
+_RESTRICTIVE_MARKERS: tuple[str, ...] = (
+    "non-commercial",
+    "noncommercial",
+    "by-nc",        # CC BY-NC / CC-BY-NC-SA
+    "-nc-",         # sai-nc-community, stable-cascade-nc-community
+    "nc-community",
+    "research",     # Qwen Research License
+    "commercial requires",
+    "requires agreement",
+    "s-lab",        # S-Lab License: research/non-commercial only
+    "gated",
+)
+
+# Licences that permit redistribution. Normalised (lower-case, quotes stripped,
+# whitespace collapsed, any trailing "(...)" note removed). Matched exactly, so a
+# dual licence like "Apache-2.0 / MiniCPM Model License" does NOT match "apache-2.0".
+PERMISSIVE_LICENSES: frozenset[str] = frozenset(
+    {
+        # Permissive / public
+        "apache-2.0",
+        "mit",
+        "bsd-3-clause",
+        "cc-by-4.0",
+        # RAIL family: redistribution permitted, use-restrictions ride along
+        "openrail",
+        "openrail++",
+        "openrail-m",
+        "creativeml openrail-m",
+        # Vendor community licences that permit redistribution with their terms
+        "gemma",
+        "gemma terms of use",
+        "llama 3.1 community license",
+        "llama 3.3 community license",
+    }
+)
+
+
+def normalize_license(raw: str) -> str:
+    """Lower-case, strip surrounding quotes, drop a trailing ``(...)`` note, and
+    collapse internal whitespace, so catalog licence strings compare stably."""
+    text = raw.strip().strip('"').strip("'").lower()
+    # Drop a single trailing parenthetical note, e.g. "openrail++ (commercial use allowed)".
+    if text.endswith(")") and "(" in text:
+        text = text[: text.rindex("(")].strip()
+    return " ".join(text.split())
+
+
+def license_allows_redistribution(raw: str | None) -> bool:
+    """True only when the licence is known to permit redistributing the weights.
+
+    Conservative: an unknown, empty, or restrictively-marked licence returns
+    False. See module docstring for the policy.
+    """
+    if not raw or not raw.strip():
+        return False
+    normalized = normalize_license(raw)
+    if any(marker in normalized for marker in _RESTRICTIVE_MARKERS):
+        return False
+    return normalized in PERMISSIVE_LICENSES
+
+
+def classify_manifest(manifest: dict) -> bool:
+    """Convenience wrapper: read ``manifest['license']`` and classify it."""
+    return license_allows_redistribution(manifest.get("license"))


### PR DESCRIPTION
First self-contained slice of the taOSnet (model torrent mesh) Phase-2 client work. No dependency on the taos.my server endpoints.

`tinyagentos/taosnet/license_eligibility.py`: decides `license_allows_redistribution` for a model manifest. Conservative by default (restrictive markers force False; explicit allow-list for permissive + RAIL + Gemma + Llama-community; unknown -> False for human review). The catalog-publish CLI (next slice) uses this to set the manifest flag that `should_use_torrent` already gates on.

40 tests, incl. an integration test that classifies every current `app-catalog/models` manifest without error (so a new/unknown licence string surfaces for review rather than being silently redistributed).

Part of the taOSnet initiative (design: docs/design/model-torrent-mesh.md; taos.my contract owned by @taOS-website-dev).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated license checks to determine whether model weights can be redistributed.
  * Improved license handling for common formatting variations, including quotes, extra notes, and case/whitespace differences.

* **Tests**
  * Added broad coverage for allowed and restricted license types.
  * Added validation to ensure model manifests return a clear boolean result, including when license information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->