### PR TITLE
fix(searxng): enable JSON output format via settings.yml bind mount, not env vars

### DIFF
--- a/app-catalog/services/searxng/manifest.yaml
+++ b/app-catalog/services/searxng/manifest.yaml
@@ -16,9 +16,25 @@ install:
   image: searxng/searxng:latest
   volumes:
     - config:/etc/searxng
+    - ./settings.yml:/etc/searxng/settings.yml:ro
   # 8080 is the container-internal port; the host port is allocated from the
   # managed pool (30000-40000) by the installer — never bound to 8080 on the host.
   ports: [8080]
+  config_files:
+    - path: settings.yml
+      content: |
+        # SearXNG settings — JSON format is enabled so agents can query
+        # the engine programmatically (?format=json).
+        use_default_settings: true
+
+        search:
+          formats:
+            - html
+            - json
+
+        server:
+          secret_key: "{secret_key}"
+          bind_address: "0.0.0.0"
 
 hardware_tiers:
   arm-npu-16gb: full

--- a/app-catalog/services/searxng/manifest.yaml
+++ b/app-catalog/services/searxng/manifest.yaml
@@ -15,7 +15,6 @@ install:
   method: docker
   image: searxng/searxng:latest
   volumes:
-    - config:/etc/searxng
     - ./settings.yml:/etc/searxng/settings.yml:ro
   # 8080 is the container-internal port; the host port is allocated from the
   # managed pool (30000-40000) by the installer — never bound to 8080 on the host.

--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -98,6 +98,35 @@ class TestDockerInstaller:
         assert "volumes" not in compose  # no named volumes → no top-level block
         assert host_port is None
 
+    def test_write_config_files_creates_files_with_substitution(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        installer._write_config_files("searxng", {
+            "config_files": [
+                {"path": "settings.yml", "content": 'secret_key: "{secret_key}"'},
+                {"path": "sub/deep.yml", "content": "key: static"},
+            ]
+        })
+        settings_yml = tmp_path / "searxng" / "settings.yml"
+        deep_yml = tmp_path / "searxng" / "sub" / "deep.yml"
+        assert settings_yml.exists()
+        assert deep_yml.exists()
+
+        content = settings_yml.read_text()
+        # {secret_key} must be replaced with a 64-hex-char random string
+        assert "{secret_key}" not in content
+        assert content.startswith('secret_key: "')
+        key_val = content[len('secret_key: "'):-1]  # strip prefix and trailing quote
+        assert len(key_val) == 64
+        assert all(c in "0123456789abcdef" for c in key_val)
+
+        assert deep_yml.read_text() == "key: static"
+
+    def test_write_config_files_noop_when_no_config_files(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        installer._write_config_files("app", {"image": "x:1"})
+        # Should not raise, should not create the app dir
+        assert not (tmp_path / "app").exists()
+
     @pytest.mark.asyncio
     async def test_start_runs_compose_up(self, tmp_path):
         installer = DockerInstaller(apps_dir=tmp_path)

--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -115,7 +115,7 @@ class TestDockerInstaller:
         # {secret_key} must be replaced with a 64-hex-char random string
         assert "{secret_key}" not in content
         assert content.startswith('secret_key: "')
-        key_val = content[len('secret_key: "'):-1]  # strip prefix and trailing quote
+        key_val = content.split('"')[1]  # extract the value between quotes
         assert len(key_val) == 64
         assert all(c in "0123456789abcdef" for c in key_val)
 
@@ -126,6 +126,62 @@ class TestDockerInstaller:
         installer._write_config_files("app", {"image": "x:1"})
         # Should not raise, should not create the app dir
         assert not (tmp_path / "app").exists()
+
+    def test_write_config_files_rejects_missing_path(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        with pytest.raises(ValueError, match="missing required key 'path'"):
+            installer._write_config_files("app", {
+                "config_files": [{"content": "x"}]
+            })
+
+    def test_write_config_files_rejects_missing_content(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        with pytest.raises(ValueError, match="missing required key 'content'"):
+            installer._write_config_files("app", {
+                "config_files": [{"path": "f.yml"}]
+            })
+
+    def test_write_config_files_rejects_absolute_path(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        with pytest.raises(ValueError, match="must be relative"):
+            installer._write_config_files("app", {
+                "config_files": [{"path": "/etc/passwd", "content": "x"}]
+            })
+
+    def test_write_config_files_rejects_dotdot_path(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        with pytest.raises(ValueError, match="must not contain '..'"):
+            installer._write_config_files("app", {
+                "config_files": [{"path": "../escape.yml", "content": "x"}]
+            })
+
+    def test_write_config_files_rejects_path_resolving_outside_app_dir(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        # Create a symlink that points outside app_dir
+        app_dir = tmp_path / "app"
+        app_dir.mkdir(parents=True)
+        symlink = app_dir / "escape"
+        symlink.symlink_to(tmp_path / "outside")
+        with pytest.raises(ValueError, match="resolves outside app_dir"):
+            installer._write_config_files("app", {
+                "config_files": [{"path": "escape/target.yml", "content": "x"}]
+            })
+
+    def test_write_config_files_persists_secret_key_across_calls(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        config = {
+            "config_files": [
+                {"path": "settings.yml", "content": 'secret_key: "{secret_key}"'},
+            ]
+        }
+        installer._write_config_files("searxng", config)
+        first_key = (tmp_path / "searxng" / "settings.yml").read_text()
+        # Call again — must reuse the persisted secret, not generate a new one
+        installer._write_config_files("searxng", config)
+        second_key = (tmp_path / "searxng" / "settings.yml").read_text()
+        assert first_key == second_key
+        # The .secret_key file must exist
+        assert (tmp_path / "searxng" / ".secret_key").exists()
 
     @pytest.mark.asyncio
     async def test_start_runs_compose_up(self, tmp_path):

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 import shutil
 from pathlib import Path
 
@@ -17,6 +18,30 @@ class DockerInstaller(AppInstaller):
 
     def _compose_path(self, app_id: str) -> Path:
         return self.apps_dir / app_id / "docker-compose.yaml"
+
+    def _write_config_files(self, app_id: str, install_config: dict) -> None:
+        """Write declarative config files from the manifest to the app directory.
+
+        ``install_config['config_files']`` is a list of ``{path, content}``
+        objects.  Each file is written to ``<app_dir>/<path>``, creating
+        parent directories as needed.  The string ``{secret_key}`` in
+        ``content`` is replaced with a random 64-hex-char secret so that
+        apps like SearXNG can ship a default settings file without a
+        hard-coded key.
+        """
+        config_files = install_config.get("config_files", [])
+        if not config_files:
+            return
+        app_dir = self.apps_dir / app_id
+        secret_key = secrets.token_hex(32)
+        for entry in config_files:
+            path = entry["path"]
+            content = entry["content"]
+            if "{secret_key}" in content:
+                content = content.replace("{secret_key}", secret_key)
+            full_path = app_dir / path
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
 
     @staticmethod
     def _is_named_volume(source: str) -> bool:
@@ -96,6 +121,10 @@ class DockerInstaller(AppInstaller):
     async def install(self, app_id: str, install_config: dict, **kwargs) -> dict:
         app_dir = self.apps_dir / app_id
         app_dir.mkdir(parents=True, exist_ok=True)
+
+        # Seed any declarative config files before compose generation so
+        # bind mounts like ./settings.yml resolve against the app dir.
+        self._write_config_files(app_id, install_config)
 
         compose, host_port = self._generate_compose(app_id, install_config)
         compose_path = self._compose_path(app_id)

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -27,13 +27,53 @@ class DockerInstaller(AppInstaller):
         parent directories as needed.  The string ``{secret_key}`` in
         ``content`` is replaced with a random 64-hex-char secret so that
         apps like SearXNG can ship a default settings file without a
-        hard-coded key.
+        hard-coded key.  The secret is persisted in ``<app_dir>/.secret_key``
+        so re-installs keep it stable.
         """
         config_files = install_config.get("config_files", [])
         if not config_files:
             return
         app_dir = self.apps_dir / app_id
-        secret_key = secrets.token_hex(32)
+
+        # Validate each entry has required keys before using them.
+        for i, entry in enumerate(config_files):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"config_files[{i}] must be a dict, got {type(entry).__name__}"
+                )
+            if "path" not in entry:
+                raise ValueError(f"config_files[{i}] missing required key 'path'")
+            if "content" not in entry:
+                raise ValueError(f"config_files[{i}] missing required key 'content'")
+
+        # Validate paths: reject '..' components and absolute paths; confirm
+        # the resolved path stays within app_dir (path-traversal protection).
+        resolved_app_dir = app_dir.resolve()
+        for i, entry in enumerate(config_files):
+            path = entry["path"]
+            if path.startswith("/"):
+                raise ValueError(
+                    f"config_files[{i}].path must be relative, got {path!r}"
+                )
+            if ".." in Path(path).parts:
+                raise ValueError(
+                    f"config_files[{i}].path must not contain '..', got {path!r}"
+                )
+            resolved = (app_dir / path).resolve()
+            if not str(resolved).startswith(str(resolved_app_dir) + "/"):
+                raise ValueError(
+                    f"config_files[{i}].path resolves outside app_dir: {path!r}"
+                )
+
+        # Persist secret_key per app so re-installs don't rotate it.
+        secret_key_path = app_dir / ".secret_key"
+        if secret_key_path.exists():
+            secret_key = secret_key_path.read_text().strip()
+        else:
+            secret_key = secrets.token_hex(32)
+            app_dir.mkdir(parents=True, exist_ok=True)
+            secret_key_path.write_text(secret_key)
+
         for entry in config_files:
             path = entry["path"]
             content = entry["content"]


### PR DESCRIPTION
Fixes #969.

SearXNG only reads SEARXNG_SETTINGS_PATH and SEARXNG_DISABLE_ETC_SETTINGS — there is no generic SEARXNG_* nested override (the __ pattern is Home Assistant, not SearXNG). The previous env-var approach did nothing.

## What this does

1. **Adds `config_files` support to `DockerInstaller`** — a declarative way for manifests to seed config files into the app directory before compose generation. Supports `{secret_key}` templating for per-install random secrets.

2. **Seeds a real `settings.yml`** with:
   - `use_default_settings: true`
   - `search.formats: [html, json]` — JSON format enabled for agent queries
   - `server.secret_key` — per-install generated (64-hex-char random)

3. **Bind-mounts `./settings.yml:/etc/searxng/settings.yml:ro`** — overrides the default settings.yml inside the named config volume.

4. **Removes the non-functional `SEARXNG_SEARCH__FORMATS__*` env vars** from the old approach.

## Upgrade handling

Existing installs get the fix automatically: re-running the install flow writes the settings.yml and adds the bind mount to compose. The named volume's default settings.yml is overridden by the bind mount.

## Tests

- 53/53 pass: `pytest tests/test_installers.py tests/routes/test_store_install_v2.py tests/test_routes_store.py`
- 2 new tests: `test_write_config_files_creates_files_with_substitution`, `test_write_config_files_noop_when_no_config_files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for app-specific configuration files during installation.
  * Configuration can now include a generated secret placeholder and default settings.
  * Docker-based installs now write config files before deployment so local file mounts work reliably.

* **Bug Fixes**
  * Improved handling of configuration file paths to prevent invalid or unsafe locations.
  * Kept the generated secret consistent across reinstalls for stable configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->