### PR TITLE
feat(taosnet): client passkey + web-seed + torrent_url wiring, DHT off

### DIFF
--- a/tests/taosnet/test_torrent_client.py
+++ b/tests/taosnet/test_torrent_client.py
@@ -1,0 +1,55 @@
+"""Pure-URL tests for taOSnet client wiring (no libtorrent required)."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.taosnet.torrent_client import (
+    announce_url,
+    scrape_url,
+    torrent_metadata_url,
+)
+
+
+def test_announce_url_embeds_passkey_as_path_segment():
+    assert (
+        announce_url("abc123")
+        == "https://tracker.taos.my/abc123/announce"
+    )
+
+
+def test_scrape_url():
+    assert scrape_url("abc123") == "https://tracker.taos.my/abc123/scrape"
+
+
+def test_torrent_metadata_url_keyed_on_info_hash():
+    assert (
+        torrent_metadata_url("deadbeef")
+        == "https://taos.my/taosnet/deadbeef.torrent"
+    )
+
+
+def test_passkey_is_percent_encoded_as_single_segment():
+    # An opaque token must not break path structure even if it contains
+    # slashes or other reserved characters.
+    url = announce_url("a/b?c=d")
+    assert url == "https://tracker.taos.my/a%2Fb%3Fc%3Dd/announce"
+    assert url.count("/announce") == 1
+
+
+def test_custom_bases_and_trailing_slash_handling():
+    assert (
+        announce_url("k", tracker_base="https://tracker.example.com/")
+        == "https://tracker.example.com/k/announce"
+    )
+    assert (
+        torrent_metadata_url("h", torrent_base="https://mirror.example.com/")
+        == "https://mirror.example.com/taosnet/h.torrent"
+    )
+
+
+@pytest.mark.parametrize("bad", [None, "", "   "])
+def test_empty_passkey_or_hash_rejected(bad):
+    with pytest.raises(ValueError):
+        announce_url(bad)
+    with pytest.raises(ValueError):
+        torrent_metadata_url(bad)

--- a/tests/taosnet/test_torrent_downloader_taosnet.py
+++ b/tests/taosnet/test_torrent_downloader_taosnet.py
@@ -1,0 +1,83 @@
+"""libtorrent-backed tests for taOSnet wiring in TorrentDownloader.
+
+These require libtorrent and are skipped where it is not installed (the repo
+treats it as an optional runtime dep, so CI skips these; they run on a host
+with python-libtorrent installed, e.g. the Pi).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tinyagentos.torrent_downloader import TORRENT_AVAILABLE, TorrentDownloader, TorrentError
+
+pytestmark = pytest.mark.skipif(
+    not TORRENT_AVAILABLE, reason="libtorrent not installed"
+)
+
+# A well-formed magnet with a 40-hex info_hash and no tracker (the taOSnet shape:
+# info_hash carried, passkey injected by the client at runtime).
+MAGNET = "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=test"
+
+
+@pytest.fixture
+def downloader():
+    return TorrentDownloader()
+
+
+def test_session_has_dht_disabled(downloader):
+    import libtorrent as lt
+
+    settings = downloader._session.get_settings()
+    assert settings.get("enable_dht") is False
+
+
+def test_passkey_injected_as_private_tracker(downloader, tmp_path):
+    params = downloader._build_params(MAGNET, tmp_path, passkey="secretpasskey")
+    trackers = [t if isinstance(t, str) else t.url for t in params.trackers]
+    assert trackers == ["https://tracker.taos.my/secretpasskey/announce"]
+
+
+def test_web_seeds_added(downloader, tmp_path):
+    seeds = ["https://huggingface.co/x/resolve/main/model.gguf"]
+    params = downloader._build_params(MAGNET, tmp_path, web_seeds=seeds)
+    assert list(params.url_seeds) == seeds
+
+
+def test_no_passkey_leaves_trackers_empty(downloader, tmp_path):
+    params = downloader._build_params(MAGNET, tmp_path)
+    assert list(params.trackers) == []
+
+
+def test_unsupported_source_rejected(downloader, tmp_path):
+    with pytest.raises(TorrentError):
+        downloader._build_params("ftp://nope/file.torrent", tmp_path)
+
+
+def test_torrent_url_fetch_parses_metadata(downloader, tmp_path, monkeypatch):
+    import libtorrent as lt
+
+    # Build a real .torrent for a small file, then serve its bytes via a
+    # monkeypatched httpx.get so _params_from_torrent_url can parse it.
+    data_file = tmp_path / "weights.bin"
+    data_file.write_bytes(b"taosnet-test-weights" * 1024)
+
+    fs = lt.file_storage()
+    lt.add_files(fs, str(data_file))
+    ct = lt.create_torrent(fs)
+    lt.set_piece_hashes(ct, str(tmp_path))
+    torrent_bytes = lt.bencode(ct.generate())
+    expected_ih = str(lt.torrent_info(lt.bdecode(torrent_bytes)).info_hash())
+
+    class _Resp:
+        content = torrent_bytes
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        "httpx.get", lambda *a, **k: _Resp(), raising=True
+    )
+    params = downloader._params_from_torrent_url("https://taos.my/taosnet/x.torrent")
+    assert str(params.ti.info_hash()) == expected_ih

--- a/tinyagentos/taosnet/torrent_client.py
+++ b/tinyagentos/taosnet/torrent_client.py
@@ -1,0 +1,44 @@
+"""Client-side taOSnet wiring for the libtorrent download path.
+
+taOSnet is a closed, authenticated swarm. The shared magnet/.torrent carries
+the info_hash and the HuggingFace web seeds but NOT the tracker passkey; each
+node injects its own account-bound passkey into the tracker announce at
+runtime. The tracker answers 401 on a bad or rotated passkey, so the client
+re-fetches the passkey and re-announces.
+
+This module holds the pure URL construction. The libtorrent-touching wiring
+(setting trackers / url_seeds on add_torrent_params, torrent_url metadata
+fetch) lives in torrent_downloader.py, which imports these helpers.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+DEFAULT_TRACKER_BASE = "https://tracker.taos.my"
+DEFAULT_TORRENT_BASE = "https://taos.my"
+
+
+def announce_url(passkey: str, tracker_base: str = DEFAULT_TRACKER_BASE) -> str:
+    """Private tracker announce URL with the node's passkey as a path segment:
+    ``https://tracker.taos.my/<passkey>/announce``.
+
+    The passkey is opaque and is percent-encoded as a single path segment.
+    """
+    return f"{tracker_base.rstrip('/')}/{_segment(passkey, 'passkey')}/announce"
+
+
+def scrape_url(passkey: str, tracker_base: str = DEFAULT_TRACKER_BASE) -> str:
+    """Private tracker scrape URL, passkey as a path segment."""
+    return f"{tracker_base.rstrip('/')}/{_segment(passkey, 'passkey')}/scrape"
+
+
+def torrent_metadata_url(info_hash: str, torrent_base: str = DEFAULT_TORRENT_BASE) -> str:
+    """Public .torrent metadata URL, keyed on info_hash. This is the
+    web-seed-only fetch path libtorrent uses to get the piece hashes."""
+    return f"{torrent_base.rstrip('/')}/taosnet/{_segment(info_hash, 'info_hash')}.torrent"
+
+
+def _segment(value: str, name: str) -> str:
+    if not value or not value.strip():
+        raise ValueError(f"{name} is required")
+    return quote(value.strip(), safe="")

--- a/tinyagentos/torrent_downloader.py
+++ b/tinyagentos/torrent_downloader.py
@@ -146,7 +146,9 @@ class TorrentDownloader:
         upload_bps = max(0, self.settings.upload_rate_limit_kbps * 1024)
         self._session = lt.session({
             "listen_interfaces": f"0.0.0.0:{listen_port_range[0]}",
-            "enable_dht": True,
+            # taOSnet is a closed, authenticated swarm: no DHT. Private torrents
+            # (BEP-27) also disable it per-torrent, but keep it off session-wide.
+            "enable_dht": False,
             "enable_lsd": True,
             "enable_upnp": True,
             "enable_natpmp": True,
@@ -182,6 +184,50 @@ class TorrentDownloader:
     def get_task(self, task_id: str) -> Optional[TorrentTask]:
         return self._tasks.get(task_id)
 
+    def _params_from_torrent_url(self, url: str):
+        """Fetch a .torrent over HTTP (the public taOSnet metadata path) and
+        build add_torrent_params from it. Used when a manifest supplies a
+        ``torrent_url`` instead of a magnet."""
+        import httpx
+
+        resp = httpx.get(url, timeout=30.0, follow_redirects=True)
+        resp.raise_for_status()
+        ti = lt.torrent_info(lt.bdecode(resp.content))
+        params = lt.add_torrent_params()
+        params.ti = ti
+        return params
+
+    def _build_params(
+        self,
+        magnet_or_torrent: str,
+        save_dir: Path,
+        passkey: Optional[str] = None,
+        web_seeds: Optional[list[str]] = None,
+    ):
+        """Build a configured add_torrent_params from a magnet or torrent_url.
+
+        For taOSnet the shared magnet/.torrent carries the info_hash and web
+        seeds but no tracker; the caller passes this node's ``passkey`` and we
+        inject the private announce URL (BEP-27 private, DHT already off at the
+        session). ``web_seeds`` (BEP-19) are the HTTP fallback the swarm rides.
+        """
+        if magnet_or_torrent.startswith("magnet:"):
+            params = lt.parse_magnet_uri(magnet_or_torrent)
+        elif magnet_or_torrent.startswith(("http://", "https://")):
+            params = self._params_from_torrent_url(magnet_or_torrent)
+        else:
+            raise TorrentError(
+                f"unsupported torrent source: {magnet_or_torrent[:40]!r}"
+            )
+        params.save_path = str(save_dir)
+        if passkey:
+            from tinyagentos.taosnet.torrent_client import announce_url
+
+            params.trackers = [announce_url(passkey)]
+        if web_seeds:
+            params.url_seeds = list(web_seeds)
+        return params
+
     async def download(
         self,
         task_id: str,
@@ -189,8 +235,14 @@ class TorrentDownloader:
         dest: Path,
         expected_sha256: Optional[str] = None,
         progress_cb: Optional[Callable[[TorrentTask], None]] = None,
+        passkey: Optional[str] = None,
+        web_seeds: Optional[list[str]] = None,
     ) -> TorrentTask:
         """Start a torrent download and poll to completion.
+
+        ``passkey`` (opaque, account-bound) is injected into the taOSnet tracker
+        announce; ``web_seeds`` are added as BEP-19 HTTP seeds. Both optional so
+        the method still serves plain public magnets.
 
         Raises :class:`TorrentTimeout` if no peers are found within
         ``peer_timeout_seconds`` — the caller should catch and fall back
@@ -206,10 +258,7 @@ class TorrentDownloader:
         )
         self._tasks[task_id] = task
 
-        params = lt.parse_magnet_uri(magnet_or_torrent) if magnet_or_torrent.startswith("magnet:") else None
-        if params is None:
-            raise TorrentError("torrent_url fetching not yet implemented — use magnet URIs in Phase 1")
-        params.save_path = str(dest.parent)
+        params = self._build_params(magnet_or_torrent, dest.parent, passkey, web_seeds)
         handle = self._session.add_torrent(params)
         self._handles[task_id] = handle
 


### PR DESCRIPTION
Next taOSnet client slice, built against the now-live taos.my contract (docs/taosnet.md).

**torrent_downloader.py**: `download()` gains optional `passkey` + `web_seeds`; a new `_build_params` injects the account-bound passkey into the private tracker announce (`https://tracker.taos.my/<passkey>/announce`), adds BEP-19 web seeds, and implements `torrent_url` metadata fetch (was a NotImplemented raise). DHT is now disabled session-wide (taOSnet is a closed, authenticated mesh; private torrents disable it per-torrent too). Existing callers unaffected (new args are optional + trailing).

**taosnet/torrent_client.py** (new): pure announce/scrape/metadata URL builders (passkey percent-encoded as a single path segment).

**Boundary**: passkey *acquisition* (GET /api/taosnet/passkey) and 401 re-announce stay with the DownloadManager (it has the account session); this slice is the passkey-agnostic wiring it will call. That integration lands next.

**Tests**: 8 pure URL tests (CI) + 6 libtorrent tests that skip where libtorrent is absent (so CI stays green) and were **verified on the Pi against real libtorrent 2.0.13 (14/14 pass)** in an isolated venv, not the production install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for downloading from direct `.torrent` URLs, not just magnet links.
  * Added optional private tracker passkeys and web seed sources during downloads.

* **Bug Fixes**
  * Improved handling of tracker URLs so passkeys are safely encoded.
  * Added validation for invalid or empty torrent parameters.
  * Disabled DHT for torrent sessions to better align with private tracker downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->