### PR TITLE
fix: remove --preload argument from systemd ExecStart

### DIFF
--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -618,9 +618,11 @@ install_systemd_unit() {
     local exec_start
     # This ExecStart line is copy-of-truth from the live orange pi:
     #   rkllama_server --processor rk3588 --port 8080 \
-    #     --models /home/jay/rkllama/models \
-    #     --preload qwen3-embedding-0.6b,qwen3-reranker-0.6b,qmd-query-expansion
-    exec_start="$RKLLAMA_VENV/bin/python $RKLLAMA_VENV/bin/rkllama_server --processor $SOC --port $RKLLAMA_PORT --models $RKLLAMA_MODELS --preload qwen3-embedding-0.6b,qwen3-reranker-0.6b,qmd-query-expansion"
+    #     --models /home/jay/rkllama/models
+    # Note: --preload was removed because the current rkllama server
+    # no longer supports it. Models load lazily on first inference
+    # request (see scripts/systemd/rkllama.service for rationale).
+    exec_start="$RKLLAMA_VENV/bin/python $RKLLAMA_VENV/bin/rkllama_server --processor $SOC --port $RKLLAMA_PORT --models $RKLLAMA_MODELS"
 
     log "installing $unit"
     sudo tee "$unit" >/dev/null <<EOF
@@ -679,9 +681,9 @@ verify_models() {
         fi
     done
     if (( missing )); then
-        die "one or more preloaded models are missing — see list above"
+        die "one or more required models are missing — see list above"
     fi
-    log "all three preloaded models are present"
+    log "all three required models are present"
 }
 
 # -------- (8) summary + idempotency check --------------------------------
@@ -719,7 +721,7 @@ print_summary() {
     rkllama dir:   $RKLLAMA_DIR
     rkllama ref:   ${RKLLAMA_REF:0:12}
     models dir:    $RKLLAMA_MODELS
-    preloaded:     qwen3-embedding-0.6b, qwen3-reranker-0.6b, qmd-query-expansion
+    preloaded:     qwen3-embedding-0.6b, qwen3-reranker-0.6b, qmd-query-expansion (lazy-load mode)
     HTTP endpoint: http://localhost:$RKLLAMA_PORT
     systemd unit:  /etc/systemd/system/rkllama.service
 


### PR DESCRIPTION
## Summary

Removes the unsupported `--preload` argument from the `ExecStart` line in `install-rknpu.sh`. This fixes a regression where the generated `rkllama.service` fails to start because the current `rkllama_server` no longer recognizes the `--preload` flag.

## Changes

- Removed `--preload qwen3-embedding-0.6b,qwen3-reranker-0.6b,qmd-query-expansion` from the `ExecStart` command in `install_systemd_unit()`
- Updated comments to explain why `--preload` was removed
- Changed log messages from "preloaded models" to "required models" for accuracy
- Added lazy-load mode note to the summary output

## Rationale

The `scripts/systemd/rkllama.service` file already documents why `--preload` was intentionally removed:
1. Frees NPU memory budget when chat models aren't in use
2. Each loaded model can use all 3 RK3588 NPU cores

Models now load lazily on first inference request, which is the correct behavior for the current rkllama version.

## Testing

- Verified the generated systemd unit no longer contains `--preload`
- The fix matches the behavior already documented in `scripts/systemd/rkllama.service`

Closes #1730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The service now starts in lazy-load mode, loading models on first use instead of at startup.
* **Bug Fixes**
  * Updated verification messaging to more clearly report missing required models.
  * Improved the final status summary to explicitly indicate lazy-load mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->