### PR TITLE
fix(install-rknpu): pin rkllama --preload restore + context-overflow fix (#1730, #1732)

### DIFF
--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: d92668edfb6c73e164c7b74baf835d14bd77365e)
+#     TAOS_RKLLAMA_REF        git ref  (default: 02ef2a62ee6520efee5122d315590f46eb79f4dc)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-d92668edfb6c73e164c7b74baf835d14bd77365e}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-02ef2a62ee6520efee5122d315590f46eb79f4dc}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 02ef2a62ee6520efee5122d315590f46eb79f4dc)
+#     TAOS_RKLLAMA_REF        git ref  (default: 5e38bd250b68b34278845ba23f507514d2fcf474)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-02ef2a62ee6520efee5122d315590f46eb79f4dc}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-5e38bd250b68b34278845ba23f507514d2fcf474}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.


### PR DESCRIPTION
Fixes the beta.35 regression #1730 (my #1716 pin bump caused it).

The rkllama pin d92668e dropped `--preload` upstream, but install-rknpu.sh still generates a systemd unit with `--preload qwen3-embedding-0.6b,...`, so `rkllama_server` exits with `unrecognized arguments: --preload` on a fresh beta.35 install, blocking RKLLM, model inference, and the taOS Agent.

Fix: bump the pin to 02ef2a6, which restores the `--preload` startup flag (jaylfc/rkllama#1, merged), so the installer's preload of the embedding/reranker/query-expansion (taOSmd memory) models works again. @mandresve validated the restored flag on RK3588. Keeps the intended preload behavior rather than degrading to lazy-load (cf. #1731).

Ships in the next release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the installer’s default pinned `rkllama` reference used when no custom version is provided.
  * Updated the inline usage guidance to reflect the new default, so the displayed version matches what will be installed.
  * Ensures the “already installed” comparison aligns with the updated default reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->