### PR TITLE
fix(docker-installer): 0600 perms + validity guard on the persisted app secret

### DIFF
--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -121,6 +121,27 @@ class TestDockerInstaller:
 
         assert deep_yml.read_text() == "key: static"
 
+    def test_secret_key_file_is_owner_only(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        installer._write_config_files("searxng", {
+            "config_files": [{"path": "settings.yml", "content": '{secret_key}'}]
+        })
+        secret_path = tmp_path / "searxng" / ".secret_key"
+        assert secret_path.exists()
+        assert (secret_path.stat().st_mode & 0o777) == 0o600
+
+    def test_empty_or_malformed_persisted_secret_is_regenerated(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        app_dir = tmp_path / "searxng"
+        app_dir.mkdir(parents=True)
+        (app_dir / ".secret_key").write_text("   ")  # empty/whitespace from a prior bad write
+        installer._write_config_files("searxng", {
+            "config_files": [{"path": "settings.yml", "content": 'k: "{secret_key}"'}]
+        })
+        key_val = (app_dir / "settings.yml").read_text().split('"')[1]
+        assert len(key_val) == 64
+        assert all(c in "0123456789abcdef" for c in key_val)
+
     def test_write_config_files_noop_when_no_config_files(self, tmp_path):
         installer = DockerInstaller(apps_dir=tmp_path)
         installer._write_config_files("app", {"image": "x:1"})

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -65,14 +65,18 @@ class DockerInstaller(AppInstaller):
                     f"config_files[{i}].path resolves outside app_dir: {path!r}"
                 )
 
-        # Persist secret_key per app so re-installs don't rotate it.
+        # Persist secret_key per app so re-installs don't rotate it. It signs
+        # sessions, so keep it owner-only and regenerate if a prior write left
+        # it empty or malformed.
         secret_key_path = app_dir / ".secret_key"
+        secret_key = ""
         if secret_key_path.exists():
             secret_key = secret_key_path.read_text().strip()
-        else:
+        if len(secret_key) != 64 or not all(c in "0123456789abcdef" for c in secret_key):
             secret_key = secrets.token_hex(32)
             app_dir.mkdir(parents=True, exist_ok=True)
             secret_key_path.write_text(secret_key)
+            secret_key_path.chmod(0o600)
 
         for entry in config_files:
             path = entry["path"]


### PR DESCRIPTION
Fold on #1724. The per-app `.secret_key` (used by searxng and any config-files app) signs sessions, so: (1) chmod it 0600 (was default 0644, world-readable), a valid CodeRabbit finding; (2) regenerate if a prior write left it empty/malformed so we never substitute a blank secret_key into the mounted settings.yml. +2 tests.