### PR TITLE
release: 1.0.0-beta.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.36] - 2026-07-08
+
+### Fixed
+- The RK3588 (RKLLM) install path no longer produces a broken rkllama service after an update. A previous pin bumped the rkllama server to a build that had dropped its startup preload flag, so the service failed to start on existing installs. The pin now points at a server that restores preload and adds a pre-flight context-length check, so a prompt longer than the model context returns a clear error instead of crashing the worker. Reported by @mandresve (#1730, #1732).
+- SearXNG installs now enable the JSON output format by default, so an agent can use the local SearXNG as a search backend without hand-editing its settings (#969).
+- Fixed a chat initialization error where a temporal-dead-zone reference could stop the conversation view from loading (#1720).
+
+### Security
+- Per-app secret files created during install are now written owner-only (0600) and regenerated if a prior write left them empty or malformed, so a session-signing key can no longer be left world-readable on disk (#1734).
+
+### Changed
+- taOS is now dual-licensed as AGPL-3.0-or-later plus a commercial option. The public core is AGPL-3.0, an OSI-approved license, with a separate commercial license available for uses that need different terms (#1721).
+
 ## [1.0.0-beta.35] - 2026-07-07
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.35",
+      "version": "1.0.0-beta.36",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.36"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.35"
+__version__ = "1.0.0-beta.36"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b35"
+version = "1.0.0b36"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release train for 1.0.0-beta.36. Bumps pyproject, __init__, desktop package + lock, uv.lock (1.0.0b36), and CHANGELOG.

Ships the fixes merged to dev since beta.35:
- #1733: RK3588 rkllama pin restore + context-overflow pre-flight check, resolving @mandresve #1730 and #1732
- #1724: SearXNG JSON output default (#969)
- #1720: chat temporal-dead-zone init fix
- #1734: per-app secret file 0600 perms + validity guard
- #1721: AGPL-3.0-or-later + commercial dual-license
- #1723/#1728/#1729: taOSnet client plumbing (dormant, web-seed baseline only)

Once green, promote dev to master and tag v1.0.0-beta.36.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could leave the chat view stuck during startup.
  * Corrected an install-path problem that could break service behavior after updates.
  * Enabled JSON output by default for search results.

* **Security**
  * Improved protection for generated secret files by keeping them owner-only and regenerating invalid or empty values.

* **Chores**
  * Updated the app version to **1.0.0-beta.36**.
  * Updated licensing to a dual-license model with an additional commercial option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->