### PR TITLE
release: promote 1.0.0-beta.36 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.36] - 2026-07-08
+
+### Fixed
+- The RK3588 (RKLLM) install path no longer produces a broken rkllama service after an update. A previous pin bumped the rkllama server to a build that had dropped its startup preload flag, so the service failed to start on existing installs. The pin now points at a server that restores preload and adds a pre-flight context-length check, so a prompt longer than the model context returns a clear error instead of crashing the worker. Reported by @mandresve (#1730, #1732).
+- SearXNG installs now enable the JSON output format by default, so an agent can use the local SearXNG as a search backend without hand-editing its settings (#969).
+- Fixed a chat initialization error where a temporal-dead-zone reference could stop the conversation view from loading (#1720).
+
+### Security
+- Per-app secret files created during install are now written owner-only (0600) and regenerated if a prior write left them empty or malformed, so a session-signing key can no longer be left world-readable on disk (#1734).
+
+### Changed
+- taOS is now dual-licensed as AGPL-3.0-or-later plus a commercial option. The public core is AGPL-3.0, an OSI-approved license, with a separate commercial license available for uses that need different terms (#1721).
+
 ## [1.0.0-beta.35] - 2026-07-07
 
 ### Fixed

--- a/app-catalog/services/searxng/manifest.yaml
+++ b/app-catalog/services/searxng/manifest.yaml
@@ -16,9 +16,25 @@ install:
   image: searxng/searxng:latest
   volumes:
     - config:/etc/searxng
+    - ./settings.yml:/etc/searxng/settings.yml:ro
   # 8080 is the container-internal port; the host port is allocated from the
   # managed pool (30000-40000) by the installer — never bound to 8080 on the host.
   ports: [8080]
+  config_files:
+    - path: settings.yml
+      content: |
+        # SearXNG settings — JSON format is enabled so agents can query
+        # the engine programmatically (?format=json).
+        use_default_settings: true
+
+        search:
+          formats:
+            - html
+            - json
+
+        server:
+          secret_key: "{secret_key}"
+          bind_address: "0.0.0.0"
 
 hardware_tiers:
   arm-npu-16gb: full

--- a/app-catalog/services/searxng/manifest.yaml
+++ b/app-catalog/services/searxng/manifest.yaml
@@ -15,7 +15,6 @@ install:
   method: docker
   image: searxng/searxng:latest
   volumes:
-    - config:/etc/searxng
     - ./settings.yml:/etc/searxng/settings.yml:ro
   # 8080 is the container-internal port; the host port is allocated from the
   # managed pool (30000-40000) by the installer — never bound to 8080 on the host.

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.35",
+      "version": "1.0.0-beta.36",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.35",
+  "version": "1.0.0-beta.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1021,8 +1021,16 @@ export function MessagesApp({
 
   /* ---- typing emitter + slash menu derived state ---- */
   const emitTyping = useTypingEmitter(selectedChannel, "user");
-  const showSlash = input.startsWith("/");
-  const slashQuery = showSlash ? input.slice(1).split(/\s/, 1)[0] || "" : "";
+  // In a DM (2 members: user + 1 agent), a leading "/" opens the agent's
+  // slash menu.  In a group channel (3+ members), the user must prefix
+  // with "@agentname /" so we know which agent's commands to show.
+  const isDm = (currentChannel?.members?.length ?? 0) <= 2;
+  const showSlash = isDm ? input.startsWith("/") : /@\S+\s+\//.test(input);
+  // The agent scoped by "@agentname /" (group only; undefined in DM).
+  const slashAgent = !isDm && showSlash ? input.match(/@(\S+)\s+\//)?.[1] || undefined : undefined;
+  const slashQuery = showSlash
+    ? (isDm ? input.slice(1).split(/\s/, 1)[0] : input.slice(input.indexOf("/") + 1).split(/\s/, 1)[0]) || ""
+    : "";
 
   /* ---- mutex: settings vs thread panel ---- */
   const handleOpenSettings = () => {
@@ -2586,6 +2594,7 @@ export function MessagesApp({
                   commands={slashCommands}
                   queryAfterSlash={slashQuery}
                   members={currentChannel?.members || []}
+                  scopedAgent={slashAgent}
                   onPick={(slug, cmd) => {
                     setInput(`@${slug} /${cmd} `);
                   }}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1019,18 +1019,8 @@ export function MessagesApp({
       ? items.filter((ch) => (unread[ch.id] ?? 0) > 0 || ch.id === selectedChannel)
       : items;
 
-  /* ---- typing emitter + slash menu derived state ---- */
+  /* ---- typing emitter ---- */
   const emitTyping = useTypingEmitter(selectedChannel, "user");
-  // In a DM (2 members: user + 1 agent), a leading "/" opens the agent's
-  // slash menu.  In a group channel (3+ members), the user must prefix
-  // with "@agentname /" so we know which agent's commands to show.
-  const isDm = (currentChannel?.members?.length ?? 0) <= 2;
-  const showSlash = isDm ? input.startsWith("/") : /@\S+\s+\//.test(input);
-  // The agent scoped by "@agentname /" (group only; undefined in DM).
-  const slashAgent = !isDm && showSlash ? input.match(/@(\S+)\s+\//)?.[1] || undefined : undefined;
-  const slashQuery = showSlash
-    ? (isDm ? input.slice(1).split(/\s/, 1)[0] : input.slice(input.indexOf("/") + 1).split(/\s/, 1)[0]) || ""
-    : "";
 
   /* ---- mutex: settings vs thread panel ---- */
   const handleOpenSettings = () => {
@@ -1429,6 +1419,18 @@ export function MessagesApp({
   const allChannels = [...channels, ...archivedChannels];
   const currentChannel = allChannels.find((c) => c.id === selectedChannel);
   const isCurrentArchived = currentChannel?.settings?.archived === true;
+
+  /* ---- slash menu derived state ---- */
+  // In a DM (2 members: user + 1 agent), a leading "/" opens the agent's
+  // slash menu.  In a group channel (3+ members), the user must prefix
+  // with "@agentname /" so we know which agent's commands to show.
+  const isDm = (currentChannel?.members?.length ?? 0) === 2;
+  const showSlash = isDm ? input.startsWith("/") : /^@\S+\s+\//.test(input);
+  // The agent scoped by "@agentname /" (group only; undefined in DM).
+  const slashAgent = !isDm && showSlash ? input.match(/^@(\S+)\s+\//)?.[1] || undefined : undefined;
+  const slashQuery = showSlash
+    ? (isDm ? input.slice(1).split(/\s/, 1)[0] : input.slice(input.indexOf("/") + 1).split(/\s/, 1)[0]) || ""
+    : "";
 
   /* ---- @mention autocomplete: candidates = channel members + "all" ---- */
   const mentionCandidates: string[] = (() => {

--- a/desktop/src/apps/chat/SlashMenu.tsx
+++ b/desktop/src/apps/chat/SlashMenu.tsx
@@ -11,18 +11,24 @@ export function SlashMenu({
   commands,
   queryAfterSlash,
   members,
+  scopedAgent,
   onPick,
   onClose,
 }: {
   commands: SlashCommandsBySlug;
   queryAfterSlash: string;
   members: string[]; // agents in current channel (ordered)
+  /** When set, only commands for this agent are shown (for @agent / in group channels). */
+  scopedAgent?: string;
   onPick: (slug: string, cmd: string) => void;
   onClose: () => void;
 }) {
   const [selected, setSelected] = useState(0);
 
-  const rows = useMemo(() => buildRows(commands, members, queryAfterSlash), [commands, members, queryAfterSlash]);
+  const rows = useMemo(
+    () => buildRows(commands, members, queryAfterSlash, scopedAgent),
+    [commands, members, queryAfterSlash, scopedAgent],
+  );
   const cmdRows = rows.filter((r) => r.kind === "cmd") as Extract<Row, { kind: "cmd" }>[];
 
   useEffect(() => { setSelected(0); }, [queryAfterSlash]);
@@ -88,15 +94,22 @@ function buildRows(
   commands: SlashCommandsBySlug,
   members: string[],
   query: string,
+  scopedAgent?: string,
 ): Row[] {
   const q = query.toLowerCase();
-  const agentMembers = members.filter((m) => m !== "user" && commands[m]);
-  const isDm = agentMembers.length === 1;
+  let agentMembers = members.filter((m) => m !== "user" && commands[m]);
+  // When scopedAgent is set, only show commands for that agent.
+  if (scopedAgent && agentMembers.includes(scopedAgent)) {
+    agentMembers = [scopedAgent];
+  }
+  const isDm = agentMembers.length === 1 && !scopedAgent;
   const rows: Row[] = [];
   for (const slug of agentMembers) {
     const cmds = (commands[slug] || []).filter((c) => matches(slug, c, q));
     if (cmds.length === 0) continue;
-    if (!isDm) rows.push({ kind: "header", slug });
+    // Show agent header when not in a DM, or when scoped (to make it clear
+    // whose commands are shown in an @agent / scenario).
+    if (!isDm || scopedAgent) rows.push({ kind: "header", slug });
     for (const cmd of cmds) rows.push({ kind: "cmd", slug, cmd });
   }
   return rows;

--- a/desktop/src/apps/chat/__tests__/SlashMenu.test.tsx
+++ b/desktop/src/apps/chat/__tests__/SlashMenu.test.tsx
@@ -47,4 +47,15 @@ describe("SlashMenu", () => {
     fireEvent.keyDown(document, { key: "Escape" });
     expect(onClose).toHaveBeenCalled();
   });
+
+  it("scopes to a single agent in a group channel via scopedAgent", () => {
+    render(<SlashMenu commands={commands} queryAfterSlash="" members={["user", "tom", "don"]}
+             scopedAgent="tom" onPick={vi.fn()} onClose={vi.fn()} />);
+    // Only tom's commands are shown, with the header.
+    expect(screen.getByText("@tom")).toBeInTheDocument();
+    expect(screen.getByText("/help")).toBeInTheDocument();
+    expect(screen.getByText("/clear")).toBeInTheDocument();
+    // don's commands are excluded.
+    expect(screen.queryByText("@don")).not.toBeInTheDocument();
+  });
 });

--- a/docs/design/model-torrent-mesh.md
+++ b/docs/design/model-torrent-mesh.md
@@ -1,10 +1,23 @@
 # Model Torrent Mesh
 
-**Status:** Draft — design only. Phase 1 tracked by #47, Phase 2 by #48, Phase 3 by #49.
+**Status:** Partially superseded. taOSnet shipped as a CLOSED, authenticated swarm, which changes several choices below (open opentracker, DHT bootstrap, "Jay's home mirror", and the tinyagentos.com hostnames are all obsolete). The authoritative live server contract is `docs/taosnet.md` (built by the taos.my side). The original open-swarm design is kept below for history; the current architecture is summarised next.
 
-Peer-to-peer model distribution for TinyAgentOS. Every instance that downloads
-a model becomes a seeder, taking load off the central mirror server and making
-the catalog resilient to mirror outages.
+Peer-to-peer model distribution for taOS. Every instance that downloads a model becomes a seeder, taking load off the central mirror and making the catalog resilient to outages.
+
+## Current state (2026-07-08)
+
+taOSnet is a closed, account-authenticated swarm on `taos.my`, not an open BitTorrent network.
+
+- **Gate:** an authenticated taOS account (paid via taOSgo today). No account still works via the HTTP web-seed fallback.
+- **Passkey:** each node fetches an opaque, account-bound passkey (`GET /api/taosnet/passkey`) and injects it into the private tracker announce `https://tracker.taos.my/<passkey>/announce`. BEP-27 private torrents, DHT off. Tracker returns 401 on a bad/rotated passkey (re-fetch).
+- **Index + publish:** `GET /api/taosnet/index` (account-authed, keyed on info_hash), `GET /taosnet/<info_hash>.torrent` (public metadata), `PUT /api/taosnet/index/<info_hash>` (bearer `TAOSNET_PUBLISH_TOKEN`, used by the catalog-publish CLI).
+- **Tracker + seedbox:** in-app tracker on `tracker.taos.my` (chihaya upgrade path). The bootstrap seedbox runs on the VPS backed by a 5TB Google Drive with a local-disk cache for the hot set; NOT a home seedbox.
+- **Web seed (BEP-19):** every torrent lists the HuggingFace `resolve` URL, so "no peers" degrades to today's HTTP download. No new failure mode.
+- **Eligibility:** only license-redistributable weights are seeded (`tinyagentos/taosnet/license_eligibility.py`; Apache/MIT/BSD/CC-BY/OpenRAIL/Gemma/Llama-community true, NC/research/gated false).
+
+Built: Phase-1 hybrid-download client (merged); license classifier (PR #1723); client passkey / web-seed / torrent_url wiring + DHT-off in `torrent_downloader.py` and `tinyagentos/taosnet/torrent_client.py` (PR #1728, Pi-verified against libtorrent 2.0.13); the taos.my server contract (live, `docs/taosnet.md`).
+
+Remaining: DownloadManager passkey fetch via the account-session proxy + clean HTTP fallback for unlinked controllers; the catalog-publish CLI (runs where the weights live, i.e. the seedbox) writing magnets/info_hashes back into the manifests; the seedbox build itself.
 
 ## Goals
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.35"
+version = "1.0.0-beta.36"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: d92668edfb6c73e164c7b74baf835d14bd77365e)
+#     TAOS_RKLLAMA_REF        git ref  (default: 5e38bd250b68b34278845ba23f507514d2fcf474)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-d92668edfb6c73e164c7b74baf835d14bd77365e}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-5e38bd250b68b34278845ba23f507514d2fcf474}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.

--- a/tests/taosnet/test_license_eligibility.py
+++ b/tests/taosnet/test_license_eligibility.py
@@ -1,0 +1,103 @@
+"""Tests for taOSnet redistribution-eligibility classification."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tinyagentos.taosnet.license_eligibility import (
+    classify_manifest,
+    license_allows_redistribution,
+    normalize_license,
+)
+
+# Real licence strings from app-catalog/models that DO permit redistribution.
+REDISTRIBUTABLE = [
+    "Apache-2.0",
+    "MIT",
+    "BSD-3-Clause",
+    "CC-BY-4.0",
+    "OpenRAIL",
+    "OpenRAIL++",
+    "OpenRAIL-M",
+    "openrail++",
+    "OpenRAIL++ (commercial use allowed)",  # trailing note stripped
+    "CreativeML OpenRAIL-M",
+    "Gemma Terms of Use",
+    '"Gemma Terms of Use"',  # quoted in YAML source
+    "Gemma",
+    "Llama 3.1 Community License",
+    "Llama 3.3 Community License",
+]
+
+# Real licence strings that must NOT be redistributed: non-commercial, research,
+# gated, dual-with-restricted-part, or simply unknown-so-conservative.
+NOT_REDISTRIBUTABLE = [
+    "Qwen Research License",
+    "Qwen License (commercial requires agreement)",
+    "Tongyi Qianwen License",
+    "stable-cascade-nc-community (non-commercial)",
+    "sai-nc-community (non-commercial)",
+    "Stability AI Community License",
+    "Playground v2.5 Community License",
+    "NVIDIA Open Model License",
+    "DeepSeek License",
+    "S-Lab License 1.0",
+    "CC-BY-NC-4.0",
+    "CC-BY-NC 4.0 (non-commercial)",
+    "CC BY-NC-SA 4.0",
+    "bria-rmbg-1.4 (non-commercial)",
+    "flux-1-dev-non-commercial-license",
+    "Apache-2.0 / MiniCPM Model License",  # dual: weights are MiniCPM-licensed
+]
+
+
+@pytest.mark.parametrize("lic", REDISTRIBUTABLE)
+def test_redistributable_licenses(lic):
+    assert license_allows_redistribution(lic) is True
+
+
+@pytest.mark.parametrize("lic", NOT_REDISTRIBUTABLE)
+def test_restricted_licenses(lic):
+    assert license_allows_redistribution(lic) is False
+
+
+@pytest.mark.parametrize("lic", [None, "", "   ", "Totally Made Up License 2.0"])
+def test_unknown_or_empty_defaults_to_false(lic):
+    assert license_allows_redistribution(lic) is False
+
+
+def test_case_and_whitespace_insensitive():
+    assert license_allows_redistribution("apache-2.0") is True
+    assert license_allows_redistribution("  APACHE-2.0  ") is True
+    assert license_allows_redistribution("MIT") is True
+
+
+def test_cc_by_is_allowed_but_cc_by_nc_is_not():
+    # The NC marker must not also trip on the permissive CC-BY-4.0.
+    assert license_allows_redistribution("CC-BY-4.0") is True
+    assert license_allows_redistribution("CC-BY-NC-4.0") is False
+
+
+def test_normalize_strips_quotes_and_trailing_note():
+    assert normalize_license('"Gemma Terms of Use"') == "gemma terms of use"
+    assert normalize_license("OpenRAIL++ (commercial use allowed)") == "openrail++"
+
+
+def test_classify_manifest_reads_license_field():
+    assert classify_manifest({"license": "MIT"}) is True
+    assert classify_manifest({"license": "CC-BY-NC-4.0"}) is False
+    assert classify_manifest({}) is False
+
+
+def test_every_catalog_manifest_classifies_without_error():
+    """Every model manifest must classify to a bool. If this fails on a NEW
+    licence string, add it to the allow-list or confirm it should stay False."""
+    catalog = Path(__file__).resolve().parents[2] / "app-catalog" / "models"
+    manifests = list(catalog.glob("*/manifest.yaml")) + list(catalog.glob("*/manifest.yml"))
+    assert manifests, "no model manifests found; wrong path?"
+    for path in manifests:
+        data = yaml.safe_load(path.read_text())
+        result = classify_manifest(data)
+        assert isinstance(result, bool), f"{path.name}: {data.get('license')!r} -> {result!r}"

--- a/tests/taosnet/test_torrent_client.py
+++ b/tests/taosnet/test_torrent_client.py
@@ -1,0 +1,55 @@
+"""Pure-URL tests for taOSnet client wiring (no libtorrent required)."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.taosnet.torrent_client import (
+    announce_url,
+    scrape_url,
+    torrent_metadata_url,
+)
+
+
+def test_announce_url_embeds_passkey_as_path_segment():
+    assert (
+        announce_url("abc123")
+        == "https://tracker.taos.my/abc123/announce"
+    )
+
+
+def test_scrape_url():
+    assert scrape_url("abc123") == "https://tracker.taos.my/abc123/scrape"
+
+
+def test_torrent_metadata_url_keyed_on_info_hash():
+    assert (
+        torrent_metadata_url("deadbeef")
+        == "https://taos.my/taosnet/deadbeef.torrent"
+    )
+
+
+def test_passkey_is_percent_encoded_as_single_segment():
+    # An opaque token must not break path structure even if it contains
+    # slashes or other reserved characters.
+    url = announce_url("a/b?c=d")
+    assert url == "https://tracker.taos.my/a%2Fb%3Fc%3Dd/announce"
+    assert url.count("/announce") == 1
+
+
+def test_custom_bases_and_trailing_slash_handling():
+    assert (
+        announce_url("k", tracker_base="https://tracker.example.com/")
+        == "https://tracker.example.com/k/announce"
+    )
+    assert (
+        torrent_metadata_url("h", torrent_base="https://mirror.example.com/")
+        == "https://mirror.example.com/taosnet/h.torrent"
+    )
+
+
+@pytest.mark.parametrize("bad", [None, "", "   "])
+def test_empty_passkey_or_hash_rejected(bad):
+    with pytest.raises(ValueError):
+        announce_url(bad)
+    with pytest.raises(ValueError):
+        torrent_metadata_url(bad)

--- a/tests/taosnet/test_torrent_downloader_taosnet.py
+++ b/tests/taosnet/test_torrent_downloader_taosnet.py
@@ -1,0 +1,83 @@
+"""libtorrent-backed tests for taOSnet wiring in TorrentDownloader.
+
+These require libtorrent and are skipped where it is not installed (the repo
+treats it as an optional runtime dep, so CI skips these; they run on a host
+with python-libtorrent installed, e.g. the Pi).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tinyagentos.torrent_downloader import TORRENT_AVAILABLE, TorrentDownloader, TorrentError
+
+pytestmark = pytest.mark.skipif(
+    not TORRENT_AVAILABLE, reason="libtorrent not installed"
+)
+
+# A well-formed magnet with a 40-hex info_hash and no tracker (the taOSnet shape:
+# info_hash carried, passkey injected by the client at runtime).
+MAGNET = "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567&dn=test"
+
+
+@pytest.fixture
+def downloader():
+    return TorrentDownloader()
+
+
+def test_session_has_dht_disabled(downloader):
+    import libtorrent as lt
+
+    settings = downloader._session.get_settings()
+    assert settings.get("enable_dht") is False
+
+
+def test_passkey_injected_as_private_tracker(downloader, tmp_path):
+    params = downloader._build_params(MAGNET, tmp_path, passkey="secretpasskey")
+    trackers = [t if isinstance(t, str) else t.url for t in params.trackers]
+    assert trackers == ["https://tracker.taos.my/secretpasskey/announce"]
+
+
+def test_web_seeds_added(downloader, tmp_path):
+    seeds = ["https://huggingface.co/x/resolve/main/model.gguf"]
+    params = downloader._build_params(MAGNET, tmp_path, web_seeds=seeds)
+    assert list(params.url_seeds) == seeds
+
+
+def test_no_passkey_leaves_trackers_empty(downloader, tmp_path):
+    params = downloader._build_params(MAGNET, tmp_path)
+    assert list(params.trackers) == []
+
+
+def test_unsupported_source_rejected(downloader, tmp_path):
+    with pytest.raises(TorrentError):
+        downloader._build_params("ftp://nope/file.torrent", tmp_path)
+
+
+def test_torrent_url_fetch_parses_metadata(downloader, tmp_path, monkeypatch):
+    import libtorrent as lt
+
+    # Build a real .torrent for a small file, then serve its bytes via a
+    # monkeypatched httpx.get so _params_from_torrent_url can parse it.
+    data_file = tmp_path / "weights.bin"
+    data_file.write_bytes(b"taosnet-test-weights" * 1024)
+
+    fs = lt.file_storage()
+    lt.add_files(fs, str(data_file))
+    ct = lt.create_torrent(fs)
+    lt.set_piece_hashes(ct, str(tmp_path))
+    torrent_bytes = lt.bencode(ct.generate())
+    expected_ih = str(lt.torrent_info(lt.bdecode(torrent_bytes)).info_hash())
+
+    class _Resp:
+        content = torrent_bytes
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        "httpx.get", lambda *a, **k: _Resp(), raising=True
+    )
+    params = downloader._params_from_torrent_url("https://taos.my/taosnet/x.torrent")
+    assert str(params.ti.info_hash()) == expected_ih

--- a/tests/test_framework_slash_commands.py
+++ b/tests/test_framework_slash_commands.py
@@ -24,3 +24,39 @@ async def test_slash_commands_endpoint_handles_unknown_framework(client, app):
     assert r.status_code == 200
     body = r.json()
     assert body.get("mystery") == []
+
+
+@pytest.mark.asyncio
+async def test_agent_slash_commands_returns_commands_for_valid_agent(client, app):
+    """New per-agent endpoint: known framework → returns its slash commands."""
+    app.state.config.agents.append({
+        "name": "tom", "framework": "hermes", "host": "localhost", "color": "#fff",
+    })
+    r = await client.get("/api/agents/tom/slash-commands")
+    assert r.status_code == 200
+    body = r.json()
+    assert "tom" in body
+    assert isinstance(body["tom"], list)
+    assert len(body["tom"]) > 0
+    assert body["tom"][0]["name"] in ("help", "clear", "model")
+
+
+@pytest.mark.asyncio
+async def test_agent_slash_commands_handles_unknown_framework(client, app):
+    """Per-agent endpoint: unknown framework → empty command list."""
+    app.state.config.agents.append({
+        "name": "mystery", "framework": "nonexistent-fw", "host": "localhost", "color": "#fff",
+    })
+    r = await client.get("/api/agents/mystery/slash-commands")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("mystery") == []
+
+
+@pytest.mark.asyncio
+async def test_agent_slash_commands_404_for_unknown_agent(client, app):
+    """Per-agent endpoint: non-existent agent → 404."""
+    r = await client.get("/api/agents/no-such-agent/slash-commands")
+    assert r.status_code == 404
+    body = r.json()
+    assert "error" in body

--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -98,6 +98,35 @@ class TestDockerInstaller:
         assert "volumes" not in compose  # no named volumes → no top-level block
         assert host_port is None
 
+    def test_write_config_files_creates_files_with_substitution(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        installer._write_config_files("searxng", {
+            "config_files": [
+                {"path": "settings.yml", "content": 'secret_key: "{secret_key}"'},
+                {"path": "sub/deep.yml", "content": "key: static"},
+            ]
+        })
+        settings_yml = tmp_path / "searxng" / "settings.yml"
+        deep_yml = tmp_path / "searxng" / "sub" / "deep.yml"
+        assert settings_yml.exists()
+        assert deep_yml.exists()
+
+        content = settings_yml.read_text()
+        # {secret_key} must be replaced with a 64-hex-char random string
+        assert "{secret_key}" not in content
+        assert content.startswith('secret_key: "')
+        key_val = content[len('secret_key: "'):-1]  # strip prefix and trailing quote
+        assert len(key_val) == 64
+        assert all(c in "0123456789abcdef" for c in key_val)
+
+        assert deep_yml.read_text() == "key: static"
+
+    def test_write_config_files_noop_when_no_config_files(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        installer._write_config_files("app", {"image": "x:1"})
+        # Should not raise, should not create the app dir
+        assert not (tmp_path / "app").exists()
+
     @pytest.mark.asyncio
     async def test_start_runs_compose_up(self, tmp_path):
         installer = DockerInstaller(apps_dir=tmp_path)

--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -121,6 +121,27 @@ class TestDockerInstaller:
 
         assert deep_yml.read_text() == "key: static"
 
+    def test_secret_key_file_is_owner_only(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        installer._write_config_files("searxng", {
+            "config_files": [{"path": "settings.yml", "content": '{secret_key}'}]
+        })
+        secret_path = tmp_path / "searxng" / ".secret_key"
+        assert secret_path.exists()
+        assert (secret_path.stat().st_mode & 0o777) == 0o600
+
+    def test_empty_or_malformed_persisted_secret_is_regenerated(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        app_dir = tmp_path / "searxng"
+        app_dir.mkdir(parents=True)
+        (app_dir / ".secret_key").write_text("   ")  # empty/whitespace from a prior bad write
+        installer._write_config_files("searxng", {
+            "config_files": [{"path": "settings.yml", "content": 'k: "{secret_key}"'}]
+        })
+        key_val = (app_dir / "settings.yml").read_text().split('"')[1]
+        assert len(key_val) == 64
+        assert all(c in "0123456789abcdef" for c in key_val)
+
     def test_write_config_files_noop_when_no_config_files(self, tmp_path):
         installer = DockerInstaller(apps_dir=tmp_path)
         installer._write_config_files("app", {"image": "x:1"})

--- a/tests/test_installers.py
+++ b/tests/test_installers.py
@@ -115,7 +115,7 @@ class TestDockerInstaller:
         # {secret_key} must be replaced with a 64-hex-char random string
         assert "{secret_key}" not in content
         assert content.startswith('secret_key: "')
-        key_val = content[len('secret_key: "'):-1]  # strip prefix and trailing quote
+        key_val = content.split('"')[1]  # extract the value between quotes
         assert len(key_val) == 64
         assert all(c in "0123456789abcdef" for c in key_val)
 
@@ -126,6 +126,62 @@ class TestDockerInstaller:
         installer._write_config_files("app", {"image": "x:1"})
         # Should not raise, should not create the app dir
         assert not (tmp_path / "app").exists()
+
+    def test_write_config_files_rejects_missing_path(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        with pytest.raises(ValueError, match="missing required key 'path'"):
+            installer._write_config_files("app", {
+                "config_files": [{"content": "x"}]
+            })
+
+    def test_write_config_files_rejects_missing_content(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        with pytest.raises(ValueError, match="missing required key 'content'"):
+            installer._write_config_files("app", {
+                "config_files": [{"path": "f.yml"}]
+            })
+
+    def test_write_config_files_rejects_absolute_path(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        with pytest.raises(ValueError, match="must be relative"):
+            installer._write_config_files("app", {
+                "config_files": [{"path": "/etc/passwd", "content": "x"}]
+            })
+
+    def test_write_config_files_rejects_dotdot_path(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        with pytest.raises(ValueError, match="must not contain '..'"):
+            installer._write_config_files("app", {
+                "config_files": [{"path": "../escape.yml", "content": "x"}]
+            })
+
+    def test_write_config_files_rejects_path_resolving_outside_app_dir(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        # Create a symlink that points outside app_dir
+        app_dir = tmp_path / "app"
+        app_dir.mkdir(parents=True)
+        symlink = app_dir / "escape"
+        symlink.symlink_to(tmp_path / "outside")
+        with pytest.raises(ValueError, match="resolves outside app_dir"):
+            installer._write_config_files("app", {
+                "config_files": [{"path": "escape/target.yml", "content": "x"}]
+            })
+
+    def test_write_config_files_persists_secret_key_across_calls(self, tmp_path):
+        installer = DockerInstaller(apps_dir=tmp_path)
+        config = {
+            "config_files": [
+                {"path": "settings.yml", "content": 'secret_key: "{secret_key}"'},
+            ]
+        }
+        installer._write_config_files("searxng", config)
+        first_key = (tmp_path / "searxng" / "settings.yml").read_text()
+        # Call again — must reuse the persisted secret, not generate a new one
+        installer._write_config_files("searxng", config)
+        second_key = (tmp_path / "searxng" / "settings.yml").read_text()
+        assert first_key == second_key
+        # The .secret_key file must exist
+        assert (tmp_path / "searxng" / ".secret_key").exists()
 
     @pytest.mark.asyncio
     async def test_start_runs_compose_up(self, tmp_path):

--- a/tests/test_routes_framework.py
+++ b/tests/test_routes_framework.py
@@ -304,7 +304,9 @@ class TestSlashCommandsManifest:
         r = await client.get("/api/frameworks/slash-commands")
         assert r.status_code == 200
         data = r.json()
-        assert data["plain"] == []
+        # generic framework now includes /help as a built-in command.
+        assert len(data["plain"]) >= 1
+        assert any(c["name"] == "help" for c in data["plain"])
 
     async def test_command_structure(self, client, app):
         app.state.config.agents = []

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.35"
+__version__ = "1.0.0-beta.36"

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -68,6 +68,9 @@ FRAMEWORKS: dict[str, dict] = {
         "name": "Generic",
         "description": "Fallback adapter — echos messages; use as a starting point",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show Generic adapter help"},
+        ],
     },
     "pocketflow": {
         "id": "pocketflow",
@@ -157,54 +160,81 @@ FRAMEWORKS: dict[str, dict] = {
         "name": "Agent Zero",
         "description": "Proxies messages to the Agent Zero HTTP API (agent0ai/agent-zero)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show Agent Zero help"},
+        ],
     },
     "ironclaw": {
         "id": "ironclaw",
         "name": "IronClaw",
         "description": "OpenClaw-inspired Rust agent focused on privacy and security (nearai/ironclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show IronClaw help"},
+        ],
     },
     "microclaw": {
         "id": "microclaw",
         "name": "MicroClaw",
         "description": "Agentic AI assistant in Rust, inspired by NanoClaw (microclaw/microclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show MicroClaw help"},
+        ],
     },
     "moltis": {
         "id": "moltis",
         "name": "Moltis",
         "description": "Secure persistent personal agent server in Rust (moltis-org/moltis)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show Moltis help"},
+        ],
     },
     "nanoclaw": {
         "id": "nanoclaw",
         "name": "NanoClaw",
         "description": "Lightweight container-based OpenClaw alternative on Anthropic Agents SDK (qwibitai/nanoclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show NanoClaw help"},
+        ],
     },
     "nullclaw": {
         "id": "nullclaw",
         "name": "NullClaw",
         "description": "Fully autonomous AI assistant infrastructure in Zig (nullclaw/nullclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show NullClaw help"},
+        ],
     },
     "picoclaw": {
         "id": "picoclaw",
         "name": "PicoClaw",
         "description": "Tiny, fast, and deployable anywhere — automate the mundane, unleash creativity (sipeed/picoclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show PicoClaw help"},
+        ],
     },
     "shibaclaw": {
         "id": "shibaclaw",
         "name": "ShibaClaw",
         "description": "Self-hosted AI agent with 5-layer prompt injection protection (RikyZ90/ShibaClaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show ShibaClaw help"},
+        ],
     },
     "zeroclaw": {
         "id": "zeroclaw",
         "name": "ZeroClaw",
         "description": "Fast, small, fully autonomous AI personal assistant in Rust (zeroclaw-labs/zeroclaw)",
         "verification_status": "alpha",
+        "slash_commands": [
+            {"name": "help", "description": "Show ZeroClaw help"},
+        ],
     },
 }
 

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -65,14 +65,18 @@ class DockerInstaller(AppInstaller):
                     f"config_files[{i}].path resolves outside app_dir: {path!r}"
                 )
 
-        # Persist secret_key per app so re-installs don't rotate it.
+        # Persist secret_key per app so re-installs don't rotate it. It signs
+        # sessions, so keep it owner-only and regenerate if a prior write left
+        # it empty or malformed.
         secret_key_path = app_dir / ".secret_key"
+        secret_key = ""
         if secret_key_path.exists():
             secret_key = secret_key_path.read_text().strip()
-        else:
+        if len(secret_key) != 64 or not all(c in "0123456789abcdef" for c in secret_key):
             secret_key = secrets.token_hex(32)
             app_dir.mkdir(parents=True, exist_ok=True)
             secret_key_path.write_text(secret_key)
+            secret_key_path.chmod(0o600)
 
         for entry in config_files:
             path = entry["path"]

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import secrets
 import shutil
 from pathlib import Path
 
@@ -17,6 +18,30 @@ class DockerInstaller(AppInstaller):
 
     def _compose_path(self, app_id: str) -> Path:
         return self.apps_dir / app_id / "docker-compose.yaml"
+
+    def _write_config_files(self, app_id: str, install_config: dict) -> None:
+        """Write declarative config files from the manifest to the app directory.
+
+        ``install_config['config_files']`` is a list of ``{path, content}``
+        objects.  Each file is written to ``<app_dir>/<path>``, creating
+        parent directories as needed.  The string ``{secret_key}`` in
+        ``content`` is replaced with a random 64-hex-char secret so that
+        apps like SearXNG can ship a default settings file without a
+        hard-coded key.
+        """
+        config_files = install_config.get("config_files", [])
+        if not config_files:
+            return
+        app_dir = self.apps_dir / app_id
+        secret_key = secrets.token_hex(32)
+        for entry in config_files:
+            path = entry["path"]
+            content = entry["content"]
+            if "{secret_key}" in content:
+                content = content.replace("{secret_key}", secret_key)
+            full_path = app_dir / path
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            full_path.write_text(content)
 
     @staticmethod
     def _is_named_volume(source: str) -> bool:
@@ -96,6 +121,10 @@ class DockerInstaller(AppInstaller):
     async def install(self, app_id: str, install_config: dict, **kwargs) -> dict:
         app_dir = self.apps_dir / app_id
         app_dir.mkdir(parents=True, exist_ok=True)
+
+        # Seed any declarative config files before compose generation so
+        # bind mounts like ./settings.yml resolve against the app dir.
+        self._write_config_files(app_id, install_config)
 
         compose, host_port = self._generate_compose(app_id, install_config)
         compose_path = self._compose_path(app_id)

--- a/tinyagentos/installers/docker_installer.py
+++ b/tinyagentos/installers/docker_installer.py
@@ -27,13 +27,53 @@ class DockerInstaller(AppInstaller):
         parent directories as needed.  The string ``{secret_key}`` in
         ``content`` is replaced with a random 64-hex-char secret so that
         apps like SearXNG can ship a default settings file without a
-        hard-coded key.
+        hard-coded key.  The secret is persisted in ``<app_dir>/.secret_key``
+        so re-installs keep it stable.
         """
         config_files = install_config.get("config_files", [])
         if not config_files:
             return
         app_dir = self.apps_dir / app_id
-        secret_key = secrets.token_hex(32)
+
+        # Validate each entry has required keys before using them.
+        for i, entry in enumerate(config_files):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"config_files[{i}] must be a dict, got {type(entry).__name__}"
+                )
+            if "path" not in entry:
+                raise ValueError(f"config_files[{i}] missing required key 'path'")
+            if "content" not in entry:
+                raise ValueError(f"config_files[{i}] missing required key 'content'")
+
+        # Validate paths: reject '..' components and absolute paths; confirm
+        # the resolved path stays within app_dir (path-traversal protection).
+        resolved_app_dir = app_dir.resolve()
+        for i, entry in enumerate(config_files):
+            path = entry["path"]
+            if path.startswith("/"):
+                raise ValueError(
+                    f"config_files[{i}].path must be relative, got {path!r}"
+                )
+            if ".." in Path(path).parts:
+                raise ValueError(
+                    f"config_files[{i}].path must not contain '..', got {path!r}"
+                )
+            resolved = (app_dir / path).resolve()
+            if not str(resolved).startswith(str(resolved_app_dir) + "/"):
+                raise ValueError(
+                    f"config_files[{i}].path resolves outside app_dir: {path!r}"
+                )
+
+        # Persist secret_key per app so re-installs don't rotate it.
+        secret_key_path = app_dir / ".secret_key"
+        if secret_key_path.exists():
+            secret_key = secret_key_path.read_text().strip()
+        else:
+            secret_key = secrets.token_hex(32)
+            app_dir.mkdir(parents=True, exist_ok=True)
+            secret_key_path.write_text(secret_key)
+
         for entry in config_files:
             path = entry["path"]
             content = entry["content"]

--- a/tinyagentos/routes/framework.py
+++ b/tinyagentos/routes/framework.py
@@ -128,8 +128,8 @@ async def agent_slash_commands(request: Request, slug: str):
     """Return the slash commands for a single agent by slug.
 
     Returns {slug: [{name, description}, ...]} so callers can key
-    by slug without transforming the shape.  Unknown agent or
-    framework → empty command list.
+    by slug without transforming the shape.  Unknown agent →
+    404, unknown framework → empty command list.
     """
     config = getattr(request.app.state, "config", None)
     agents = getattr(config, "agents", []) if config else []

--- a/tinyagentos/routes/framework.py
+++ b/tinyagentos/routes/framework.py
@@ -121,3 +121,23 @@ async def slash_commands_manifest(request: Request):
         cmds = fw.get("slash_commands") or []
         out[slug] = [{"name": c["name"], "description": c.get("description", "")} for c in cmds]
     return JSONResponse(out)
+
+
+@router.get("/api/agents/{slug}/slash-commands")
+async def agent_slash_commands(request: Request, slug: str):
+    """Return the slash commands for a single agent by slug.
+
+    Returns {slug: [{name, description}, ...]} so callers can key
+    by slug without transforming the shape.  Unknown agent or
+    framework → empty command list.
+    """
+    config = getattr(request.app.state, "config", None)
+    agents = getattr(config, "agents", []) if config else []
+    agent = next((a for a in agents if a.get("name") == slug), None)
+    if agent is None:
+        return JSONResponse({"error": "agent not found"}, status_code=404)
+    fw = FRAMEWORKS.get(agent.get("framework") or "", {})
+    cmds = fw.get("slash_commands") or []
+    return JSONResponse({
+        slug: [{"name": c["name"], "description": c.get("description", "")} for c in cmds]
+    })

--- a/tinyagentos/taosnet/__init__.py
+++ b/tinyagentos/taosnet/__init__.py
@@ -1,0 +1,5 @@
+"""taOSnet: peer-to-peer distribution of model weights.
+
+Phase 2 client-side pieces. See docs/design/model-torrent-mesh.md and the
+taos.my-side contract in docs/taosnet.md (built by the website side).
+"""

--- a/tinyagentos/taosnet/license_eligibility.py
+++ b/tinyagentos/taosnet/license_eligibility.py
@@ -1,0 +1,90 @@
+"""Decide whether a model's weights may be redistributed over taOSnet.
+
+taOSnet seeds model weights peer-to-peer. We may only do that for models whose
+licence permits redistribution. This module is the single source of truth for
+that decision; the catalog-publish CLI calls it to set the manifest's
+``license_allows_redistribution`` flag, which the download client
+(``should_use_torrent``) requires before it will touch the swarm.
+
+Policy (conservative by default):
+
+1. If the licence carries any restrictive marker (non-commercial, research-only,
+   commercial-requires-agreement, gated, S-Lab), it is NOT redistributable.
+2. Otherwise, if the licence exactly matches a known-redistributable licence
+   (permissive, plus the RAIL / Gemma / Llama-community family that permit
+   redistribution with their terms attached), it IS redistributable.
+3. Otherwise it is NOT redistributable, and the caller should surface it for a
+   human to review and, if appropriate, add to ``PERMISSIVE_LICENSES``.
+
+Missing a genuinely-redistributable model only costs us an HTTP-only download
+(no harm). Wrongly redistributing a restricted one is a legal problem. So the
+default is always False.
+"""
+from __future__ import annotations
+
+# Substrings (matched against the normalised licence) that force a False result,
+# checked BEFORE the allow-list so a dual or annotated licence cannot slip through.
+_RESTRICTIVE_MARKERS: tuple[str, ...] = (
+    "non-commercial",
+    "noncommercial",
+    "by-nc",        # CC BY-NC / CC-BY-NC-SA
+    "-nc-",         # sai-nc-community, stable-cascade-nc-community
+    "nc-community",
+    "research",     # Qwen Research License
+    "commercial requires",
+    "requires agreement",
+    "s-lab",        # S-Lab License: research/non-commercial only
+    "gated",
+)
+
+# Licences that permit redistribution. Normalised (lower-case, quotes stripped,
+# whitespace collapsed, any trailing "(...)" note removed). Matched exactly, so a
+# dual licence like "Apache-2.0 / MiniCPM Model License" does NOT match "apache-2.0".
+PERMISSIVE_LICENSES: frozenset[str] = frozenset(
+    {
+        # Permissive / public
+        "apache-2.0",
+        "mit",
+        "bsd-3-clause",
+        "cc-by-4.0",
+        # RAIL family: redistribution permitted, use-restrictions ride along
+        "openrail",
+        "openrail++",
+        "openrail-m",
+        "creativeml openrail-m",
+        # Vendor community licences that permit redistribution with their terms
+        "gemma",
+        "gemma terms of use",
+        "llama 3.1 community license",
+        "llama 3.3 community license",
+    }
+)
+
+
+def normalize_license(raw: str) -> str:
+    """Lower-case, strip surrounding quotes, drop a trailing ``(...)`` note, and
+    collapse internal whitespace, so catalog licence strings compare stably."""
+    text = raw.strip().strip('"').strip("'").lower()
+    # Drop a single trailing parenthetical note, e.g. "openrail++ (commercial use allowed)".
+    if text.endswith(")") and "(" in text:
+        text = text[: text.rindex("(")].strip()
+    return " ".join(text.split())
+
+
+def license_allows_redistribution(raw: str | None) -> bool:
+    """True only when the licence is known to permit redistributing the weights.
+
+    Conservative: an unknown, empty, or restrictively-marked licence returns
+    False. See module docstring for the policy.
+    """
+    if not raw or not raw.strip():
+        return False
+    normalized = normalize_license(raw)
+    if any(marker in normalized for marker in _RESTRICTIVE_MARKERS):
+        return False
+    return normalized in PERMISSIVE_LICENSES
+
+
+def classify_manifest(manifest: dict) -> bool:
+    """Convenience wrapper: read ``manifest['license']`` and classify it."""
+    return license_allows_redistribution(manifest.get("license"))

--- a/tinyagentos/taosnet/torrent_client.py
+++ b/tinyagentos/taosnet/torrent_client.py
@@ -1,0 +1,44 @@
+"""Client-side taOSnet wiring for the libtorrent download path.
+
+taOSnet is a closed, authenticated swarm. The shared magnet/.torrent carries
+the info_hash and the HuggingFace web seeds but NOT the tracker passkey; each
+node injects its own account-bound passkey into the tracker announce at
+runtime. The tracker answers 401 on a bad or rotated passkey, so the client
+re-fetches the passkey and re-announces.
+
+This module holds the pure URL construction. The libtorrent-touching wiring
+(setting trackers / url_seeds on add_torrent_params, torrent_url metadata
+fetch) lives in torrent_downloader.py, which imports these helpers.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+DEFAULT_TRACKER_BASE = "https://tracker.taos.my"
+DEFAULT_TORRENT_BASE = "https://taos.my"
+
+
+def announce_url(passkey: str, tracker_base: str = DEFAULT_TRACKER_BASE) -> str:
+    """Private tracker announce URL with the node's passkey as a path segment:
+    ``https://tracker.taos.my/<passkey>/announce``.
+
+    The passkey is opaque and is percent-encoded as a single path segment.
+    """
+    return f"{tracker_base.rstrip('/')}/{_segment(passkey, 'passkey')}/announce"
+
+
+def scrape_url(passkey: str, tracker_base: str = DEFAULT_TRACKER_BASE) -> str:
+    """Private tracker scrape URL, passkey as a path segment."""
+    return f"{tracker_base.rstrip('/')}/{_segment(passkey, 'passkey')}/scrape"
+
+
+def torrent_metadata_url(info_hash: str, torrent_base: str = DEFAULT_TORRENT_BASE) -> str:
+    """Public .torrent metadata URL, keyed on info_hash. This is the
+    web-seed-only fetch path libtorrent uses to get the piece hashes."""
+    return f"{torrent_base.rstrip('/')}/taosnet/{_segment(info_hash, 'info_hash')}.torrent"
+
+
+def _segment(value: str, name: str) -> str:
+    if not value or not value.strip():
+        raise ValueError(f"{name} is required")
+    return quote(value.strip(), safe="")

--- a/tinyagentos/torrent_downloader.py
+++ b/tinyagentos/torrent_downloader.py
@@ -146,7 +146,9 @@ class TorrentDownloader:
         upload_bps = max(0, self.settings.upload_rate_limit_kbps * 1024)
         self._session = lt.session({
             "listen_interfaces": f"0.0.0.0:{listen_port_range[0]}",
-            "enable_dht": True,
+            # taOSnet is a closed, authenticated swarm: no DHT. Private torrents
+            # (BEP-27) also disable it per-torrent, but keep it off session-wide.
+            "enable_dht": False,
             "enable_lsd": True,
             "enable_upnp": True,
             "enable_natpmp": True,
@@ -182,6 +184,50 @@ class TorrentDownloader:
     def get_task(self, task_id: str) -> Optional[TorrentTask]:
         return self._tasks.get(task_id)
 
+    def _params_from_torrent_url(self, url: str):
+        """Fetch a .torrent over HTTP (the public taOSnet metadata path) and
+        build add_torrent_params from it. Used when a manifest supplies a
+        ``torrent_url`` instead of a magnet."""
+        import httpx
+
+        resp = httpx.get(url, timeout=30.0, follow_redirects=True)
+        resp.raise_for_status()
+        ti = lt.torrent_info(lt.bdecode(resp.content))
+        params = lt.add_torrent_params()
+        params.ti = ti
+        return params
+
+    def _build_params(
+        self,
+        magnet_or_torrent: str,
+        save_dir: Path,
+        passkey: Optional[str] = None,
+        web_seeds: Optional[list[str]] = None,
+    ):
+        """Build a configured add_torrent_params from a magnet or torrent_url.
+
+        For taOSnet the shared magnet/.torrent carries the info_hash and web
+        seeds but no tracker; the caller passes this node's ``passkey`` and we
+        inject the private announce URL (BEP-27 private, DHT already off at the
+        session). ``web_seeds`` (BEP-19) are the HTTP fallback the swarm rides.
+        """
+        if magnet_or_torrent.startswith("magnet:"):
+            params = lt.parse_magnet_uri(magnet_or_torrent)
+        elif magnet_or_torrent.startswith(("http://", "https://")):
+            params = self._params_from_torrent_url(magnet_or_torrent)
+        else:
+            raise TorrentError(
+                f"unsupported torrent source: {magnet_or_torrent[:40]!r}"
+            )
+        params.save_path = str(save_dir)
+        if passkey:
+            from tinyagentos.taosnet.torrent_client import announce_url
+
+            params.trackers = [announce_url(passkey)]
+        if web_seeds:
+            params.url_seeds = list(web_seeds)
+        return params
+
     async def download(
         self,
         task_id: str,
@@ -189,8 +235,14 @@ class TorrentDownloader:
         dest: Path,
         expected_sha256: Optional[str] = None,
         progress_cb: Optional[Callable[[TorrentTask], None]] = None,
+        passkey: Optional[str] = None,
+        web_seeds: Optional[list[str]] = None,
     ) -> TorrentTask:
         """Start a torrent download and poll to completion.
+
+        ``passkey`` (opaque, account-bound) is injected into the taOSnet tracker
+        announce; ``web_seeds`` are added as BEP-19 HTTP seeds. Both optional so
+        the method still serves plain public magnets.
 
         Raises :class:`TorrentTimeout` if no peers are found within
         ``peer_timeout_seconds`` — the caller should catch and fall back
@@ -206,10 +258,7 @@ class TorrentDownloader:
         )
         self._tasks[task_id] = task
 
-        params = lt.parse_magnet_uri(magnet_or_torrent) if magnet_or_torrent.startswith("magnet:") else None
-        if params is None:
-            raise TorrentError("torrent_url fetching not yet implemented — use magnet URIs in Phase 1")
-        params.save_path = str(dest.parent)
+        params = self._build_params(magnet_or_torrent, dest.parent, passkey, web_seeds)
         handle = self._session.add_torrent(params)
         self._handles[task_id] = handle
 

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b35"
+version = "1.0.0b36"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotes dev to master for the 1.0.0-beta.36 release.

Ships since beta.35:
- #1733 RK3588 rkllama pin restore + context-overflow pre-flight check (resolves @mandresve #1730, #1732)
- #1724 SearXNG JSON output default (#969)
- #1720 chat temporal-dead-zone init fix
- #1734 per-app secret file 0600 perms + validity guard
- #1721 AGPL-3.0-or-later + commercial dual-license
- #1723/#1728/#1729 taOSnet client plumbing (dormant, web-seed baseline)

Tag v1.0.0-beta.36 on the resulting master SHA after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-agent slash commands, including scoped commands in group chats and a new agent-specific endpoint.
  * Expanded torrent support with tracker, scrape, and metadata URL handling plus web seed support.
  * SearXNG now uses JSON-formatted search output by default.

* **Bug Fixes**
  * Resolved chat initialization loading issues and an RK3588 install/startup problem.
  * Fixed secret file handling to regenerate invalid values and keep them owner-only.
  * Improved slash-command behavior for generic and framework-specific agents.

* **Changed**
  * Updated licensing to dual-license AGPL-3.0-or-later with a commercial option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->