### PR TITLE
feat(taosnet): headless passkey fetch for background model downloads

### DIFF
--- a/tests/taosnet/test_passkey_client.py
+++ b/tests/taosnet/test_passkey_client.py
@@ -1,0 +1,99 @@
+"""Tests for the headless taOSnet passkey fetch.
+
+The passkey fetch must degrade to "web-seed only" (return None) on every
+failure mode so a passkey lookup can never block or crash a model download.
+httpx is mocked via MockTransport so no network is touched.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tinyagentos.taosnet import passkey_client as pk
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_no_token_returns_none_without_calling():
+    # No controller token means the host has not joined a mesh; skip the fetch.
+    assert await pk.fetch_passkey(None) is None
+    assert await pk.fetch_passkey("") is None
+
+
+@pytest.mark.asyncio
+async def test_passkey_returned_and_bearer_sent():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"passkey": "PK-abc123"})
+
+    async with _client(handler) as c:
+        result = await pk.fetch_passkey("tok-xyz", client=c)
+
+    assert result == "PK-abc123"
+    assert seen["auth"] == "Bearer tok-xyz"
+    assert seen["path"] == "/api/taosnet/passkey"
+
+
+@pytest.mark.asyncio
+async def test_null_passkey_returns_none():
+    # Account has no passkey issued yet -> web-seed only.
+    async with _client(lambda r: httpx.Response(200, json={"passkey": None})) as c:
+        assert await pk.fetch_passkey("tok", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_401_returns_none():
+    # Token missing/invalid/revoked (host row gone) -> web-seed only.
+    async with _client(lambda r: httpx.Response(401, json={"detail": "not_authenticated"})) as c:
+        assert await pk.fetch_passkey("tok", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_server_error_returns_none():
+    async with _client(lambda r: httpx.Response(500, text="boom")) as c:
+        assert await pk.fetch_passkey("tok", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_transport_error_returns_none():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    async with _client(handler) as c:
+        assert await pk.fetch_passkey("tok", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_base_override_used():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["host"] = request.url.host
+        return httpx.Response(200, json={"passkey": "x"})
+
+    async with _client(handler) as c:
+        await pk.fetch_passkey("tok", base="https://example.test", client=c)
+
+    assert seen["host"] == "example.test"
+
+
+def test_get_controller_token_from_env(monkeypatch):
+    monkeypatch.delenv("TAOS_CONTROLLER_TOKEN", raising=False)
+    assert pk.get_controller_token() is None
+    monkeypatch.setenv("TAOS_CONTROLLER_TOKEN", "")
+    assert pk.get_controller_token() is None
+    monkeypatch.setenv("TAOS_CONTROLLER_TOKEN", "the-token")
+    assert pk.get_controller_token() == "the-token"
+
+
+def test_taosnet_base_default_and_override(monkeypatch):
+    monkeypatch.delenv("TAOS_TAOSNET_BASE", raising=False)
+    assert pk.taosnet_base() == "https://taos.my"
+    monkeypatch.setenv("TAOS_TAOSNET_BASE", "https://self.hosted/")
+    assert pk.taosnet_base() == "https://self.hosted"

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -415,7 +415,7 @@ class TestDownloadWithFallback:
         fake_progress_task.total_bytes = 999
         fake_progress_task.downloaded_bytes = 999
 
-        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb, passkey=None, web_seeds=None):
             dest.write_bytes(data)
             progress_cb(fake_progress_task)
 
@@ -448,7 +448,7 @@ class TestDownloadWithFallback:
         fake_progress_task.total_bytes = 999
         fake_progress_task.downloaded_bytes = 999
 
-        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb, passkey=None, web_seeds=None):
             # never writes dest, just reports progress as if it finished
             progress_cb(fake_progress_task)
 
@@ -473,7 +473,7 @@ class TestDownloadWithFallback:
 
         fake_torrent = AsyncMock()
 
-        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb, passkey=None, web_seeds=None):
             dest.write_bytes(b"")
 
         fake_torrent.download = mock_download

--- a/tinyagentos/download_manager.py
+++ b/tinyagentos/download_manager.py
@@ -66,6 +66,7 @@ class DownloadManager:
         expected_sha256: str | None = None,
         magnet: str | None = None,
         license_allows_redistribution: bool = False,
+        web_seeds: list[str] | None = None,
     ) -> DownloadTask:
         """Start a model download.
 
@@ -75,6 +76,10 @@ class DownloadManager:
         torrent error the download falls back transparently to HTTP
         using ``url``. The caller sees a single DownloadTask either
         way and never has to branch on transport.
+
+        ``web_seeds`` are the manifest's BEP-19 HTTP seeds (typically the
+        HuggingFace resolve URLs) that the swarm rides as a correctness
+        fallback. They are passed straight through to the torrent path.
         """
         task = DownloadTask(id=download_id, url=url, dest=dest)
         self._tasks[download_id] = task
@@ -84,6 +89,7 @@ class DownloadManager:
                 expected_sha256=expected_sha256,
                 magnet=magnet,
                 license_allows_redistribution=license_allows_redistribution,
+                web_seeds=web_seeds,
             )
         )
         return task
@@ -180,6 +186,7 @@ class DownloadManager:
         expected_sha256: str | None = None,
         magnet: str | None = None,
         license_allows_redistribution: bool = False,
+        web_seeds: list[str] | None = None,
     ) -> None:
         """Hybrid download path: swarm first, HTTP fallback.
 
@@ -195,6 +202,16 @@ class DownloadManager:
             and license_allows_redistribution
             and (torrent := self._get_torrent_downloader()) is not None
         ):
+            # Headless passkey fetch: if this host has joined an account mesh,
+            # the controller token unlocks the private taOSnet tracker. A null
+            # passkey (not joined, no passkey yet, revoked, or offline) leaves
+            # the download on the web-seed baseline. Never raises.
+            from tinyagentos.taosnet.passkey_client import (
+                fetch_passkey,
+                get_controller_token,
+            )
+
+            passkey = await fetch_passkey(get_controller_token())
             task.status = "downloading"
             task.started_at = time.time()
             try:
@@ -208,6 +225,8 @@ class DownloadManager:
                     dest=task.dest,
                     expected_sha256=expected_sha256,
                     progress_cb=_progress,
+                    passkey=passkey,
+                    web_seeds=web_seeds,
                 )
                 # torrent.download() already SHA-verified the file internally
                 # (and raised on mismatch), so re-hashing here would just re-read

--- a/tinyagentos/taosnet/passkey_client.py
+++ b/tinyagentos/taosnet/passkey_client.py
@@ -1,0 +1,91 @@
+"""Headless taOSnet passkey fetch (Phase 2 of the model torrent mesh).
+
+A background model download has no browser session cookie, so it cannot use
+the cookie-authenticated passkey path the desktop uses. Instead the taOS
+controller stores a ``controller_token`` minted at cluster-join (bound to the
+account host row, scoped to ``taosnet:passkey`` only) and presents it as a
+Bearer credential to fetch this account's taOSnet passkey.
+
+Contract (taos.my, see docs and jaylfc/taos-website#83):
+
+- ``GET /api/taosnet/passkey`` with ``Authorization: Bearer <controller_token>``
+- ``200 {"passkey": "<opaque>"}`` when the account has a passkey issued
+- ``200 {"passkey": null}`` when none has been issued yet
+- ``401`` when the token is missing, invalid, or revoked (host row gone)
+
+Fallback rule (mirrors the DownloadManager): a null passkey, a 401, or any
+transport failure all mean "web-seed only" (no taOSnet tracker). A non-null
+passkey enables the private taOSnet tracker alongside the BEP-19 web seeds.
+This module never raises, so a passkey lookup can never block a download.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE = "https://taos.my"
+
+
+def taosnet_base() -> str:
+    """The taos.my base URL for account API calls, overridable in tests and
+    self-hosted setups via ``TAOS_TAOSNET_BASE``."""
+    return os.getenv("TAOS_TAOSNET_BASE", _DEFAULT_BASE).rstrip("/")
+
+
+def get_controller_token() -> Optional[str]:
+    """The controller token persisted when this host joined an account mesh,
+    or None if it has not joined one.
+
+    Read from ``TAOS_CONTROLLER_TOKEN`` for now; this is the seam the
+    cluster-join client writes to (alongside the Headscale key) once that
+    client lands. None means the headless passkey fetch is skipped and the
+    download stays on the web-seed baseline.
+    """
+    return os.getenv("TAOS_CONTROLLER_TOKEN") or None
+
+
+async def fetch_passkey(
+    controller_token: Optional[str],
+    *,
+    base: Optional[str] = None,
+    client: Optional[httpx.AsyncClient] = None,
+    timeout: float = 15.0,
+) -> Optional[str]:
+    """Fetch the account taOSnet passkey using the controller token.
+
+    Returns the passkey string, or None when there is no token, the account
+    has no passkey yet, the token is unauthorized/revoked (401), or any
+    transport error occurs. None always means "fall back to web-seed only".
+    Never raises, so a download is never blocked by a passkey lookup.
+
+    ``client`` lets a caller (or a test) inject an ``httpx.AsyncClient``;
+    otherwise a short-lived one is created for the single request.
+    """
+    if not controller_token:
+        return None
+    url = f"{base or taosnet_base()}/api/taosnet/passkey"
+    headers = {"Authorization": f"Bearer {controller_token}"}
+    try:
+        if client is not None:
+            resp = await client.get(url, headers=headers, timeout=timeout)
+        else:
+            async with httpx.AsyncClient(timeout=timeout) as owned:
+                resp = await owned.get(url, headers=headers)
+        if resp.status_code == 401:
+            logger.info(
+                "taosnet passkey fetch: 401 (token missing/invalid/revoked), "
+                "using web seeds only"
+            )
+            return None
+        resp.raise_for_status()
+        return resp.json().get("passkey") or None
+    except Exception as exc:  # noqa: BLE001 - any failure means web-seed fallback
+        logger.warning(
+            "taosnet passkey fetch failed (%s), using web seeds only", exc
+        )
+        return None


### PR DESCRIPTION
## What
The consumer half of the taOSnet controller-credential flow (taos.my side shipped in jaylfc/taos-website#83, deployed and verified live). A background model download has no browser session cookie, so it presents the cluster-join `controller_token` (scoped `taosnet:passkey`, host-bound) as a Bearer credential to `GET /api/taosnet/passkey` to unlock the private taOSnet tracker.

## Changes
- `tinyagentos/taosnet/passkey_client.py` — `fetch_passkey()` (pure, never raises) plus the `get_controller_token()` storage seam (reads `TAOS_CONTROLLER_TOKEN` for now; the cluster-join client will write the token here once that client lands).
- `download_manager` — fetch the passkey and thread it plus the manifest `web_seeds` into the torrent attempt.

## Fallback rule
Null passkey / 401 / any transport error all degrade to the web-seed baseline, so a passkey lookup never blocks or crashes a download.

## Verification
- Unit tests cover token-present/absent, passkey returned, null passkey, 401, 500, transport error, and base override.
- Server contract verified live against taos.my: bogus/no bearer returns `401 {"detail":"not_authenticated"}`, matching the 401 to None branch.

## Dormancy
Dormant until a host joins an account mesh and a token is present (`get_controller_token()` returns None otherwise), so today's behavior is unchanged (web-seed baseline). The remaining piece to make it live end to end is the cluster-join client that persists `controller_token`, tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for web seed URLs during downloads.
  * Downloading can now automatically try to retrieve a passkey before starting a torrent-based transfer.

* **Bug Fixes**
  * Passkey retrieval now safely falls back when no token is available, the server returns an error, or network issues occur.
  * Improved handling of passkey responses so downloads continue without interruption when a passkey isn’t issued.

* **Tests**
  * Added coverage for passkey fetching, URL selection, token handling, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->