### PR TITLE
fix(install-rknpu): structured context-overflow error payload (#1738)

### DIFF
--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 5e38bd250b68b34278845ba23f507514d2fcf474)
+#     TAOS_RKLLAMA_REF        git ref  (default: 58038c956623e9e18eb39f1ef089f812dd82b6bc)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-5e38bd250b68b34278845ba23f507514d2fcf474}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-58038c956623e9e18eb39f1ef089f812dd82b6bc}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.


### PR DESCRIPTION
Bumps `TAOS_RKLLAMA_REF` to `58038c9` (jaylfc/rkllama#4), reported downstream as #1738 by @mandresve.

The #1732 pre-flight guard already rejects an oversized prompt with 400 instead of crashing, but the body was only `{"error": "<message>"}`. The pinned rkllama now returns a structured payload so the taOS agent can programmatically detect a context overflow:
```json
{"error": "context_length_exceeded", "message": "...", "prompt_tokens": 11543, "max_context": 4096}
```

Verified before pinning (the #1730 lesson): the pinned commit keeps the `--preload` flag and the structured payload is present. Ships in the next beta.