### PR TITLE
fix(agents): guard against non-chat + small-context models for agents (#1740)

### DIFF
--- a/tests/test_agent_model_chat_guard.py
+++ b/tests/test_agent_model_chat_guard.py
@@ -1,0 +1,47 @@
+"""The agent model-assignment guard rejects non-chat (embedding) models.
+
+Assigning an embedding model as an agent's chat model produces undefined,
+looping output instead of a reply (reported in #1740). The guard returns a
+400 for embedding/reranker slugs and passes chat-capable models through.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tinyagentos.routes.agents import _reject_non_chat_model
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "qwen3-embedding-0.6b",
+        "nomic-embed-text",
+        "mxbai-embed-large",
+        "bge-large-en",
+        "arctic-embed-s",
+    ],
+)
+def test_embedding_models_are_rejected(model_id):
+    rejection = _reject_non_chat_model(model_id)
+    assert rejection is not None
+    assert rejection.status_code == 400
+    body = json.loads(rejection.body)
+    assert body["reason"] == "not_chat_capable"
+    assert body["model"] == model_id
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "qwen2.5-1.5b-rkllm",
+        "llama-3.1-8b-instruct",
+        "gpt-4o",
+        "qwen2.5-coder-7b",
+        "",
+    ],
+)
+def test_chat_capable_models_pass(model_id):
+    # None means "allowed"; the empty string is a no-op (validated elsewhere).
+    assert _reject_non_chat_model(model_id) is None

--- a/tests/test_agent_model_chat_guard.py
+++ b/tests/test_agent_model_chat_guard.py
@@ -10,7 +10,10 @@ import json
 
 import pytest
 
-from tinyagentos.routes.agents import _reject_non_chat_model
+from tinyagentos.routes.agents import (
+    _reject_non_chat_model,
+    _small_context_warning,
+)
 
 
 @pytest.mark.parametrize(
@@ -45,3 +48,40 @@ def test_embedding_models_are_rejected(model_id):
 def test_chat_capable_models_pass(model_id):
     # None means "allowed"; the empty string is a no-op (validated elsewhere).
     assert _reject_non_chat_model(model_id) is None
+
+
+class _FakeManifest:
+    def __init__(self, context_window):
+        self.id = "m"
+        self.type = "model"
+        self.context_window = context_window
+
+
+class _FakeRegistry:
+    def __init__(self, manifest):
+        self._manifest = manifest
+
+    def get(self, model_id):
+        return self._manifest
+
+    def list_available(self, type_filter=None):
+        return []
+
+
+def test_small_context_model_warns():
+    warning = _small_context_warning(_FakeRegistry(_FakeManifest(4096)), "qwen2.5-1.5b-rkllm")
+    assert warning is not None
+    assert "4096" in warning
+
+
+def test_adequate_context_model_does_not_warn():
+    assert _small_context_warning(_FakeRegistry(_FakeManifest(32768)), "gemma-4-e4b") is None
+
+
+def test_unknown_model_does_not_warn():
+    # A cloud/aliased model resolves to no local manifest -> no advisory.
+    assert _small_context_warning(_FakeRegistry(None), "gpt-4o") is None
+
+
+def test_missing_registry_does_not_warn():
+    assert _small_context_warning(None, "anything") is None

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -241,6 +241,33 @@ async def agent_set_own_model(request: Request, body: AgentSelfModelUpdate):
     return {"status": "updated", "current": model}
 
 
+def _reject_non_chat_model(model_id: str):
+    """Reject a non-chat model being assigned as an agent's chat model.
+
+    An embedding or reranker model cannot do chat completion, so assigning it
+    as an agent's model produces undefined, looping output instead of a reply
+    (reported by @mandresve in #1740, where a 0.6B embedding model was
+    selectable as an agent model and generated endless "analysis" text).
+    Returns a 400 JSONResponse to hand back, or None when the model is
+    chat-capable and may be assigned.
+    """
+    from tinyagentos.litellm_config import _is_embedding_model
+
+    if model_id and _is_embedding_model(model_id):
+        return JSONResponse(
+            {
+                "error": (
+                    f"'{model_id}' is an embedding model and cannot be used as an "
+                    "agent chat model. Choose a chat-capable model."
+                ),
+                "model": model_id,
+                "reason": "not_chat_capable",
+            },
+            status_code=400,
+        )
+    return None
+
+
 @router.get("/api/agents/{name}/deploy-status")
 async def get_deploy_status(request: Request, name: str):
     """Get the background deploy task status for an agent."""
@@ -436,6 +463,11 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
        We never silently retarget a pinned deploy.
     6. Model not found anywhere in the cluster — 404.
     """
+    # Reject a non-chat model (e.g. embedding) before any side effects (#1740).
+    rejection = _reject_non_chat_model((body.model or "").strip())
+    if rejection is not None:
+        return rejection
+
     # --- Idempotency guard ---
     idempotency_cache = getattr(request.app.state, "idempotency_cache", None)
     idempotency_key = request.headers.get("Idempotency-Key")
@@ -1075,6 +1107,10 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
     if not model_id:
         return JSONResponse({"error": "model must not be empty"}, status_code=400)
 
+    rejection = _reject_non_chat_model(model_id)
+    if rejection is not None:
+        return rejection
+
     # Validate reachability against the live cluster state.
     from tinyagentos.cluster.model_resolver import (
         describe_downloaded_backend_down,
@@ -1195,6 +1231,11 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
 
     if not body.models:
         return JSONResponse({"error": "models must not be empty"}, status_code=400)
+
+    for _requested in body.models:
+        rejection = _reject_non_chat_model((_requested or "").strip())
+        if rejection is not None:
+            return rejection
 
     # Build the final set up front — the current primary must always be a
     # member — so it is validated alongside the requested models. Otherwise an

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -1235,7 +1235,7 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         "location": location.kind,
         "key_rescoped": key_rescoped,
     }
-    warning = _small_context_warning(request.app.state.registry, model_id)
+    warning = _small_context_warning(getattr(request.app.state, "registry", None), model_id)
     if warning:
         result["warning"] = warning
     return result

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -268,6 +268,37 @@ def _reject_non_chat_model(model_id: str):
     return None
 
 
+RECOMMENDED_AGENT_CONTEXT = 8192
+
+
+def _small_context_warning(registry, model_id: str) -> str | None:
+    """Advisory when a model's context window is too small for the agent harness.
+
+    The agent system prompt plus tool definitions are large (order of 10k
+    tokens), so a model with a small context window (e.g. a 4096-token RK
+    model) receives a truncated prompt and can degenerate into looping or
+    off-topic output rather than a coherent reply (#1740). Returns a warning
+    string, or None when the context is adequate or unknown (a cloud or
+    aliased model has no local manifest to read a context window from). This
+    is advisory only and must never block or break an assignment.
+    """
+    try:
+        from tinyagentos.cluster.model_resolver import _find_model_manifest
+
+        manifest = _find_model_manifest(registry, model_id)
+        ctx = int(getattr(manifest, "context_window", 0) or 0) if manifest else 0
+    except Exception:  # noqa: BLE001 - an advisory must never break assignment
+        return None
+    if 0 < ctx < RECOMMENDED_AGENT_CONTEXT:
+        return (
+            f"'{model_id}' has a {ctx}-token context window, smaller than the "
+            f"{RECOMMENDED_AGENT_CONTEXT} tokens recommended for agent use. The "
+            "agent system prompt may be truncated, which can cause looping or "
+            "off-topic output. Consider a model with a larger context window."
+        )
+    return None
+
+
 @router.get("/api/agents/{name}/deploy-status")
 async def get_deploy_status(request: Request, name: str):
     """Get the background deploy task status for an agent."""
@@ -1195,7 +1226,7 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         except Exception:
             logger.exception("model sync: pushing framework config for %s failed", name)
 
-    return {
+    result = {
         "status": "updated",
         "name": name,
         "model": model_id,
@@ -1204,6 +1235,10 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         "location": location.kind,
         "key_rescoped": key_rescoped,
     }
+    warning = _small_context_warning(request.app.state.registry, model_id)
+    if warning:
+        result["warning"] = warning
+    return result
 
 
 @router.get("/api/agents/{name}/permitted-models")


### PR DESCRIPTION
The two backend root causes of #1740 (found by @mandresve: a 0.6B embedding model was selectable as an agent model and produced endless `analysis` output, and the agent harness prompt of 11543 tokens exceeded the model's 4096 context).

## Changes
1. **Reject embedding models as agent chat models.** A shared `_reject_non_chat_model` guard (400, clear message) at the three points a model enters an agent config: `deploy_agent_endpoint`, `update_agent_model`, `set_permitted_models`. `agent_set_own_model` only picks from the already-guarded permitted set. Uses `litellm_config._is_embedding_model`.
2. **Warn on too-small context windows.** `update_agent_model` attaches a non-blocking `warning` when the model's declared context window is below the recommended 8192 (resolved from the model manifest via `_find_model_manifest`; cloud/aliased models have no manifest, so no warning). Advisory only, never blocks.

## Tests
`tests/test_agent_model_chat_guard.py`: embedding slugs rejected, chat-capable allowed; small-context warns, adequate/unknown/no-registry do not.

## Out of scope (follow-ups)
Surfacing the warning + a small-context badge in the model picker UI, and the agent-window liveness/scrollbars/recovery cluster (#1741/#1742/#1743), are frontend and need visual verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent non-chat models from being used in agent deployment, model updates, and permitted-model settings, returning a clear HTTP 400 error with the model and reason.
  * Agent model updates now include a warning when the selected model’s context window is below the recommended threshold, helping avoid low-context runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->