### PR TITLE
feat(cli): taos recover-password for offline local account recovery

### DIFF
--- a/tests/test_recover_password.py
+++ b/tests/test_recover_password.py
@@ -1,0 +1,80 @@
+"""Offline local-account recovery (`taos recover-password`).
+
+Verifies AuthManager.recover_password force-sets a verifiable password across
+the store shapes it must handle: a single-user record, a named user in a
+multi-user store, a pending (invite) user, and the legacy password file.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tinyagentos.auth import AuthManager
+
+
+def _write_users(data_dir, users):
+    (data_dir / ".auth_user.json").write_text(json.dumps({"users": users}))
+
+
+def test_single_user_recover(tmp_path):
+    _write_users(tmp_path, [{"id": "u1", "username": "jay", "password_hash": "old"}])
+    am = AuthManager(tmp_path)
+    who = am.recover_password("newpassw0rd")
+    assert who == "jay"
+    ok, rec = am.check_password("newpassw0rd", username="jay")
+    assert ok and rec["username"] == "jay"
+
+
+def test_multi_user_requires_username(tmp_path):
+    _write_users(
+        tmp_path,
+        [
+            {"id": "u1", "username": "jay", "password_hash": "a"},
+            {"id": "u2", "username": "sam", "password_hash": "b"},
+        ],
+    )
+    am = AuthManager(tmp_path)
+    with pytest.raises(ValueError):
+        am.recover_password("newpassw0rd")  # ambiguous without --username
+
+
+def test_multi_user_named(tmp_path):
+    _write_users(
+        tmp_path,
+        [
+            {"id": "u1", "username": "jay", "password_hash": "a"},
+            {"id": "u2", "username": "sam", "password_hash": "b"},
+        ],
+    )
+    am = AuthManager(tmp_path)
+    who = am.recover_password("newpassw0rd", username="sam")
+    assert who == "sam"
+    assert am.check_password("newpassw0rd", username="sam")[0] is True
+    # the other user is untouched
+    assert am.check_password("newpassw0rd", username="jay")[0] is False
+
+
+def test_unknown_username_errors(tmp_path):
+    _write_users(tmp_path, [{"id": "u1", "username": "jay", "password_hash": "a"}])
+    with pytest.raises(ValueError):
+        AuthManager(tmp_path).recover_password("newpassw0rd", username="ghost")
+
+
+def test_pending_user_becomes_active(tmp_path):
+    _write_users(tmp_path, [{"id": "u1", "username": "jay", "pending_invite": "code123"}])
+    am = AuthManager(tmp_path)
+    who = am.recover_password("newpassw0rd")
+    assert who == "jay"
+    stored = json.loads((tmp_path / ".auth_user.json").read_text())["users"][0]
+    assert "pending_invite" not in stored
+    assert am.check_password("newpassw0rd", username="jay")[0] is True
+
+
+def test_legacy_password_store(tmp_path):
+    # No users list -> legacy single-password file.
+    am = AuthManager(tmp_path)
+    who = am.recover_password("newpassw0rd")
+    assert who == "(legacy)"
+    assert (tmp_path / ".auth_password").exists()
+    assert am.check_password("newpassw0rd")[0] is True

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1622,6 +1622,59 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     return app
 
 
+def _recover_password_cli(argv) -> int:
+    """``taos recover-password`` -- offline reset of a local account password.
+
+    For when the admin is locked out of the web login. Runs directly against
+    the auth store (no server, no token) using the same data directory the
+    controller uses, then revokes that account's sessions. Restart the
+    controller afterwards so open sessions re-authenticate.
+    """
+    import argparse
+    import getpass
+    import os
+    import sys
+
+    from tinyagentos.auth import AuthManager
+
+    parser = argparse.ArgumentParser(
+        prog="taos recover-password",
+        description="Reset a local taOS account password (offline recovery).",
+    )
+    parser.add_argument(
+        "--username", help="Username to reset (default: the only user, single-user mode)."
+    )
+    parser.add_argument(
+        "--password", help="New password (min 8 chars). Omit to be prompted without echo."
+    )
+    parser.add_argument(
+        "--data-dir", help="Data directory (default: TAOS_DATA_DIR env, else <project>/data)."
+    )
+    ns = parser.parse_args(argv)
+
+    override = ns.data_dir or os.environ.get("TAOS_DATA_DIR")
+    data_dir = Path(override) if override else (PROJECT_DIR / "data")
+
+    new_password = ns.password
+    if not new_password:
+        new_password = getpass.getpass("New password: ")
+        if new_password != getpass.getpass("Confirm password: "):
+            print("passwords do not match", file=sys.stderr)
+            return 1
+    if len(new_password) < 8:
+        print("password must be at least 8 characters", file=sys.stderr)
+        return 1
+
+    try:
+        who = AuthManager(data_dir).recover_password(new_password, username=ns.username)
+    except ValueError as exc:
+        print(f"recovery failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Password reset for '{who}' in {data_dir}.")
+    print("Restart the taOS controller so open sessions re-authenticate.")
+    return 0
+
+
 def main():
     import sys
     # `taos rollback [ref]` -- undo the last update (restore branch + version) and
@@ -1631,6 +1684,12 @@ def main():
         import subprocess
         script = PROJECT_DIR / "scripts" / "rollback.sh"
         raise SystemExit(subprocess.call(["bash", str(script), *sys.argv[2:]]))
+
+    # `taos recover-password [--username U] [--password P]` -- offline recovery
+    # of a local account when the admin is locked out of the web login. Resets
+    # the auth store directly (no running server needed).
+    if len(sys.argv) > 1 and sys.argv[1] == "recover-password":
+        raise SystemExit(_recover_password_cli(sys.argv[2:]))
 
     import uvicorn
     config = load_config(PROJECT_DIR / "data" / "config.yaml")

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -422,6 +422,50 @@ class AuthManager:
         self._password_file.parent.mkdir(parents=True, exist_ok=True)
         self._password_file.write_text(hash_password(password))
 
+    def recover_password(self, new_password: str, username: str | None = None) -> str:
+        """Offline recovery: force-set an account's password without the old one.
+
+        For use by the ``recover-password`` CLI when the admin is locked out.
+        Works across every store shape: sets the ``password_hash`` on the
+        matching user record (found by ``username``, or the sole user in
+        single-user mode), or writes the legacy ``.auth_password`` when there
+        is no user record yet. All of that user's existing sessions are
+        revoked so a leaked/forgotten-password session cannot survive the
+        reset. Returns the username reset (or ``"(legacy)"``).
+        """
+        data = self._read_users()
+        users = data.get("users", [])
+        if users:
+            if username:
+                target_idx = next(
+                    (i for i, u in enumerate(users) if u.get("username") == username),
+                    None,
+                )
+                if target_idx is None:
+                    known = ", ".join(u.get("username", "?") for u in users)
+                    raise ValueError(
+                        f"user '{username}' not found (known users: {known})"
+                    )
+            elif len(users) == 1:
+                target_idx = 0
+            else:
+                names = ", ".join(u.get("username", "?") for u in users)
+                raise ValueError(
+                    f"multiple users exist; pass --username (one of: {names})"
+                )
+            user = users[target_idx]
+            user["password_hash"] = hash_password(new_password)
+            user.pop("pending_invite", None)  # a pending user becomes active
+            users[target_idx] = user
+            data["users"] = users
+            self._write_users(data)
+            if user.get("id"):
+                self.revoke_user_sessions(user["id"])
+            return user.get("username", "(unknown)")
+        # No user records: legacy single-password store.
+        self.set_password(new_password)
+        return "(legacy)"
+
     def check_password(self, password: str, username: str | None = None) -> tuple[bool, dict | None]:
         """Verify credentials.
 


### PR DESCRIPTION
## Why
There was no way to recover a local taOS admin account when the web-login password is lost or unknown, short of editing `.auth_user.json` by hand as the service user. This adds a first-class offline recovery command.

## What
`taos recover-password [--username U] [--password P] [--data-dir D]`
- Resolves the data directory exactly as the server does (TAOS_DATA_DIR env, else `<project>/data`), so it always targets the store the controller reads.
- New `AuthManager.recover_password(new_password, username=None)` force-sets the argon2 hash and revokes that account's sessions. Handles single-user, a named user in multi-user, a pending (invite) user, and the legacy `.auth_password` store.
- Wired into the `taos` console-script entry next to `taos rollback` (offline, no server or token needed). Prompts for the password without echo when `--password` is omitted.

## Tests
`tests/test_recover_password.py`: single-user, multi-user-needs-username, named multi-user (others untouched), unknown username, pending->active, legacy store.

## Note
This is the recovery *tool*. Separately, I hit a case on the Pi where a correctly-reset password (verified via a fresh AuthManager) was still rejected by the running controller's /login; that looks like a distinct issue in the live login path worth its own investigation, tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline password recovery command for local accounts.
  * Password can be entered interactively or provided on the command line, with basic validation for minimum length.

* **Bug Fixes**
  * Supports recovering passwords for specific users in multi-user setups.
  * Preserves other accounts during recovery and clears any pending invite state.
  * Works with legacy account storage when newer user records are not present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->