### PR TITLE
release: 1.0.0-beta.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.37] - 2026-07-08
+
+### Fixed
+- An embedding model can no longer be assigned as an agent's chat model. Assigning one (for example qwen3-embedding-0.6b) now returns a clear error instead of silently accepting it and producing repeating, off-topic output, because an embedding model cannot do chat completion. Reported by @mandresve (#1740).
+- A local RK3588 (RKLLM) model whose context window is too small for the agent harness now surfaces a non-blocking warning when it is assigned, so an over-small context (for example 4096 tokens) is flagged rather than silently truncating the agent prompt and looping (#1740).
+- The RK3588 (RKLLM) backend now returns a structured context-overflow error when a prompt exceeds the model context, so a client can tell a context overflow apart from invalid input or a server fault instead of getting a bare 400. Reported by @mandresve (#1738).
+
+### Added
+- A `taos recover-password` command for offline recovery of a local account password when the admin is locked out of the web login. It resets the password directly in the auth store (single-user, named multi-user, pending, or legacy) and revokes that account's sessions.
+
 ## [1.0.0-beta.36] - 2026-07-08
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.36",
+  "version": "1.0.0-beta.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.36",
+      "version": "1.0.0-beta.37",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.36",
+  "version": "1.0.0-beta.37",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.36"
+__version__ = "1.0.0-beta.37"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b36"
+version = "1.0.0b37"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release train for 1.0.0-beta.37. Bumps pyproject, __init__, desktop package + lock, uv.lock (1.0.0b37), and CHANGELOG.

Ships since beta.36:
- #1744: embedding-model-as-agent guard + small-context warning (resolves @mandresve #1740), verified on RK3588
- #1739: rkllama structured context-overflow error (@mandresve #1738)
- #1745: taos recover-password offline account recovery CLI
- #1737: taosnet passkey client (dormant, web-seed baseline)

Once green, promote dev to master and tag v1.0.0-beta.37.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline password recovery command for local accounts, with session revocation after reset.

* **Bug Fixes**
  * Improved handling when an incompatible model is chosen for chat.
  * Added clearer warnings and errors for context window limits on supported hardware.

* **Chores**
  * Updated the release version to 1.0.0-beta.37 across project files.
  * Added the latest release notes entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->