### PR TITLE
release: promote 1.0.0-beta.37 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.37] - 2026-07-08
+
+### Fixed
+- An embedding model can no longer be assigned as an agent's chat model. Assigning one (for example qwen3-embedding-0.6b) now returns a clear error instead of silently accepting it and producing repeating, off-topic output, because an embedding model cannot do chat completion. Reported by @mandresve (#1740).
+- A local RK3588 (RKLLM) model whose context window is too small for the agent harness now surfaces a non-blocking warning when it is assigned, so an over-small context (for example 4096 tokens) is flagged rather than silently truncating the agent prompt and looping (#1740).
+- The RK3588 (RKLLM) backend now returns a structured context-overflow error when a prompt exceeds the model context, so a client can tell a context overflow apart from invalid input or a server fault instead of getting a bare 400. Reported by @mandresve (#1738).
+
+### Added
+- A `taos recover-password` command for offline recovery of a local account password when the admin is locked out of the web login. It resets the password directly in the auth store (single-user, named multi-user, pending, or legacy) and revokes that account's sessions.
+
 ## [1.0.0-beta.36] - 2026-07-08
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.36",
+  "version": "1.0.0-beta.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.36",
+      "version": "1.0.0-beta.37",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.36",
+  "version": "1.0.0-beta.37",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.36"
+version = "1.0.0-beta.37"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 5e38bd250b68b34278845ba23f507514d2fcf474)
+#     TAOS_RKLLAMA_REF        git ref  (default: 58038c956623e9e18eb39f1ef089f812dd82b6bc)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,7 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-5e38bd250b68b34278845ba23f507514d2fcf474}"
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-58038c956623e9e18eb39f1ef089f812dd82b6bc}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.

--- a/tests/taosnet/test_passkey_client.py
+++ b/tests/taosnet/test_passkey_client.py
@@ -1,0 +1,99 @@
+"""Tests for the headless taOSnet passkey fetch.
+
+The passkey fetch must degrade to "web-seed only" (return None) on every
+failure mode so a passkey lookup can never block or crash a model download.
+httpx is mocked via MockTransport so no network is touched.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from tinyagentos.taosnet import passkey_client as pk
+
+
+def _client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_no_token_returns_none_without_calling():
+    # No controller token means the host has not joined a mesh; skip the fetch.
+    assert await pk.fetch_passkey(None) is None
+    assert await pk.fetch_passkey("") is None
+
+
+@pytest.mark.asyncio
+async def test_passkey_returned_and_bearer_sent():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["auth"] = request.headers.get("authorization")
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"passkey": "PK-abc123"})
+
+    async with _client(handler) as c:
+        result = await pk.fetch_passkey("tok-xyz", client=c)
+
+    assert result == "PK-abc123"
+    assert seen["auth"] == "Bearer tok-xyz"
+    assert seen["path"] == "/api/taosnet/passkey"
+
+
+@pytest.mark.asyncio
+async def test_null_passkey_returns_none():
+    # Account has no passkey issued yet -> web-seed only.
+    async with _client(lambda r: httpx.Response(200, json={"passkey": None})) as c:
+        assert await pk.fetch_passkey("tok", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_401_returns_none():
+    # Token missing/invalid/revoked (host row gone) -> web-seed only.
+    async with _client(lambda r: httpx.Response(401, json={"detail": "not_authenticated"})) as c:
+        assert await pk.fetch_passkey("tok", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_server_error_returns_none():
+    async with _client(lambda r: httpx.Response(500, text="boom")) as c:
+        assert await pk.fetch_passkey("tok", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_transport_error_returns_none():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    async with _client(handler) as c:
+        assert await pk.fetch_passkey("tok", client=c) is None
+
+
+@pytest.mark.asyncio
+async def test_base_override_used():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["host"] = request.url.host
+        return httpx.Response(200, json={"passkey": "x"})
+
+    async with _client(handler) as c:
+        await pk.fetch_passkey("tok", base="https://example.test", client=c)
+
+    assert seen["host"] == "example.test"
+
+
+def test_get_controller_token_from_env(monkeypatch):
+    monkeypatch.delenv("TAOS_CONTROLLER_TOKEN", raising=False)
+    assert pk.get_controller_token() is None
+    monkeypatch.setenv("TAOS_CONTROLLER_TOKEN", "")
+    assert pk.get_controller_token() is None
+    monkeypatch.setenv("TAOS_CONTROLLER_TOKEN", "the-token")
+    assert pk.get_controller_token() == "the-token"
+
+
+def test_taosnet_base_default_and_override(monkeypatch):
+    monkeypatch.delenv("TAOS_TAOSNET_BASE", raising=False)
+    assert pk.taosnet_base() == "https://taos.my"
+    monkeypatch.setenv("TAOS_TAOSNET_BASE", "https://self.hosted/")
+    assert pk.taosnet_base() == "https://self.hosted"

--- a/tests/test_agent_model_chat_guard.py
+++ b/tests/test_agent_model_chat_guard.py
@@ -1,0 +1,87 @@
+"""The agent model-assignment guard rejects non-chat (embedding) models.
+
+Assigning an embedding model as an agent's chat model produces undefined,
+looping output instead of a reply (reported in #1740). The guard returns a
+400 for embedding/reranker slugs and passes chat-capable models through.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tinyagentos.routes.agents import (
+    _reject_non_chat_model,
+    _small_context_warning,
+)
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "qwen3-embedding-0.6b",
+        "nomic-embed-text",
+        "mxbai-embed-large",
+        "bge-large-en",
+        "arctic-embed-s",
+    ],
+)
+def test_embedding_models_are_rejected(model_id):
+    rejection = _reject_non_chat_model(model_id)
+    assert rejection is not None
+    assert rejection.status_code == 400
+    body = json.loads(rejection.body)
+    assert body["reason"] == "not_chat_capable"
+    assert body["model"] == model_id
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "qwen2.5-1.5b-rkllm",
+        "llama-3.1-8b-instruct",
+        "gpt-4o",
+        "qwen2.5-coder-7b",
+        "",
+    ],
+)
+def test_chat_capable_models_pass(model_id):
+    # None means "allowed"; the empty string is a no-op (validated elsewhere).
+    assert _reject_non_chat_model(model_id) is None
+
+
+class _FakeManifest:
+    def __init__(self, context_window):
+        self.id = "m"
+        self.type = "model"
+        self.context_window = context_window
+
+
+class _FakeRegistry:
+    def __init__(self, manifest):
+        self._manifest = manifest
+
+    def get(self, model_id):
+        return self._manifest
+
+    def list_available(self, type_filter=None):
+        return []
+
+
+def test_small_context_model_warns():
+    warning = _small_context_warning(_FakeRegistry(_FakeManifest(4096)), "qwen2.5-1.5b-rkllm")
+    assert warning is not None
+    assert "4096" in warning
+
+
+def test_adequate_context_model_does_not_warn():
+    assert _small_context_warning(_FakeRegistry(_FakeManifest(32768)), "gemma-4-e4b") is None
+
+
+def test_unknown_model_does_not_warn():
+    # A cloud/aliased model resolves to no local manifest -> no advisory.
+    assert _small_context_warning(_FakeRegistry(None), "gpt-4o") is None
+
+
+def test_missing_registry_does_not_warn():
+    assert _small_context_warning(None, "anything") is None

--- a/tests/test_download_manager.py
+++ b/tests/test_download_manager.py
@@ -415,7 +415,7 @@ class TestDownloadWithFallback:
         fake_progress_task.total_bytes = 999
         fake_progress_task.downloaded_bytes = 999
 
-        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb, passkey=None, web_seeds=None):
             dest.write_bytes(data)
             progress_cb(fake_progress_task)
 
@@ -448,7 +448,7 @@ class TestDownloadWithFallback:
         fake_progress_task.total_bytes = 999
         fake_progress_task.downloaded_bytes = 999
 
-        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb, passkey=None, web_seeds=None):
             # never writes dest, just reports progress as if it finished
             progress_cb(fake_progress_task)
 
@@ -473,7 +473,7 @@ class TestDownloadWithFallback:
 
         fake_torrent = AsyncMock()
 
-        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb):
+        async def mock_download(task_id, magnet_or_torrent, dest, expected_sha256, progress_cb, passkey=None, web_seeds=None):
             dest.write_bytes(b"")
 
         fake_torrent.download = mock_download

--- a/tests/test_recover_password.py
+++ b/tests/test_recover_password.py
@@ -1,0 +1,80 @@
+"""Offline local-account recovery (`taos recover-password`).
+
+Verifies AuthManager.recover_password force-sets a verifiable password across
+the store shapes it must handle: a single-user record, a named user in a
+multi-user store, a pending (invite) user, and the legacy password file.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tinyagentos.auth import AuthManager
+
+
+def _write_users(data_dir, users):
+    (data_dir / ".auth_user.json").write_text(json.dumps({"users": users}))
+
+
+def test_single_user_recover(tmp_path):
+    _write_users(tmp_path, [{"id": "u1", "username": "jay", "password_hash": "old"}])
+    am = AuthManager(tmp_path)
+    who = am.recover_password("newpassw0rd")
+    assert who == "jay"
+    ok, rec = am.check_password("newpassw0rd", username="jay")
+    assert ok and rec["username"] == "jay"
+
+
+def test_multi_user_requires_username(tmp_path):
+    _write_users(
+        tmp_path,
+        [
+            {"id": "u1", "username": "jay", "password_hash": "a"},
+            {"id": "u2", "username": "sam", "password_hash": "b"},
+        ],
+    )
+    am = AuthManager(tmp_path)
+    with pytest.raises(ValueError):
+        am.recover_password("newpassw0rd")  # ambiguous without --username
+
+
+def test_multi_user_named(tmp_path):
+    _write_users(
+        tmp_path,
+        [
+            {"id": "u1", "username": "jay", "password_hash": "a"},
+            {"id": "u2", "username": "sam", "password_hash": "b"},
+        ],
+    )
+    am = AuthManager(tmp_path)
+    who = am.recover_password("newpassw0rd", username="sam")
+    assert who == "sam"
+    assert am.check_password("newpassw0rd", username="sam")[0] is True
+    # the other user is untouched
+    assert am.check_password("newpassw0rd", username="jay")[0] is False
+
+
+def test_unknown_username_errors(tmp_path):
+    _write_users(tmp_path, [{"id": "u1", "username": "jay", "password_hash": "a"}])
+    with pytest.raises(ValueError):
+        AuthManager(tmp_path).recover_password("newpassw0rd", username="ghost")
+
+
+def test_pending_user_becomes_active(tmp_path):
+    _write_users(tmp_path, [{"id": "u1", "username": "jay", "pending_invite": "code123"}])
+    am = AuthManager(tmp_path)
+    who = am.recover_password("newpassw0rd")
+    assert who == "jay"
+    stored = json.loads((tmp_path / ".auth_user.json").read_text())["users"][0]
+    assert "pending_invite" not in stored
+    assert am.check_password("newpassw0rd", username="jay")[0] is True
+
+
+def test_legacy_password_store(tmp_path):
+    # No users list -> legacy single-password file.
+    am = AuthManager(tmp_path)
+    who = am.recover_password("newpassw0rd")
+    assert who == "(legacy)"
+    assert (tmp_path / ".auth_password").exists()
+    assert am.check_password("newpassw0rd")[0] is True

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.36"
+__version__ = "1.0.0-beta.37"

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -1622,6 +1622,59 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     return app
 
 
+def _recover_password_cli(argv) -> int:
+    """``taos recover-password`` -- offline reset of a local account password.
+
+    For when the admin is locked out of the web login. Runs directly against
+    the auth store (no server, no token) using the same data directory the
+    controller uses, then revokes that account's sessions. Restart the
+    controller afterwards so open sessions re-authenticate.
+    """
+    import argparse
+    import getpass
+    import os
+    import sys
+
+    from tinyagentos.auth import AuthManager
+
+    parser = argparse.ArgumentParser(
+        prog="taos recover-password",
+        description="Reset a local taOS account password (offline recovery).",
+    )
+    parser.add_argument(
+        "--username", help="Username to reset (default: the only user, single-user mode)."
+    )
+    parser.add_argument(
+        "--password", help="New password (min 8 chars). Omit to be prompted without echo."
+    )
+    parser.add_argument(
+        "--data-dir", help="Data directory (default: TAOS_DATA_DIR env, else <project>/data)."
+    )
+    ns = parser.parse_args(argv)
+
+    override = ns.data_dir or os.environ.get("TAOS_DATA_DIR")
+    data_dir = Path(override) if override else (PROJECT_DIR / "data")
+
+    new_password = ns.password
+    if not new_password:
+        new_password = getpass.getpass("New password: ")
+        if new_password != getpass.getpass("Confirm password: "):
+            print("passwords do not match", file=sys.stderr)
+            return 1
+    if len(new_password) < 8:
+        print("password must be at least 8 characters", file=sys.stderr)
+        return 1
+
+    try:
+        who = AuthManager(data_dir).recover_password(new_password, username=ns.username)
+    except ValueError as exc:
+        print(f"recovery failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Password reset for '{who}' in {data_dir}.")
+    print("Restart the taOS controller so open sessions re-authenticate.")
+    return 0
+
+
 def main():
     import sys
     # `taos rollback [ref]` -- undo the last update (restore branch + version) and
@@ -1631,6 +1684,12 @@ def main():
         import subprocess
         script = PROJECT_DIR / "scripts" / "rollback.sh"
         raise SystemExit(subprocess.call(["bash", str(script), *sys.argv[2:]]))
+
+    # `taos recover-password [--username U] [--password P]` -- offline recovery
+    # of a local account when the admin is locked out of the web login. Resets
+    # the auth store directly (no running server needed).
+    if len(sys.argv) > 1 and sys.argv[1] == "recover-password":
+        raise SystemExit(_recover_password_cli(sys.argv[2:]))
 
     import uvicorn
     config = load_config(PROJECT_DIR / "data" / "config.yaml")

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -422,6 +422,50 @@ class AuthManager:
         self._password_file.parent.mkdir(parents=True, exist_ok=True)
         self._password_file.write_text(hash_password(password))
 
+    def recover_password(self, new_password: str, username: str | None = None) -> str:
+        """Offline recovery: force-set an account's password without the old one.
+
+        For use by the ``recover-password`` CLI when the admin is locked out.
+        Works across every store shape: sets the ``password_hash`` on the
+        matching user record (found by ``username``, or the sole user in
+        single-user mode), or writes the legacy ``.auth_password`` when there
+        is no user record yet. All of that user's existing sessions are
+        revoked so a leaked/forgotten-password session cannot survive the
+        reset. Returns the username reset (or ``"(legacy)"``).
+        """
+        data = self._read_users()
+        users = data.get("users", [])
+        if users:
+            if username:
+                target_idx = next(
+                    (i for i, u in enumerate(users) if u.get("username") == username),
+                    None,
+                )
+                if target_idx is None:
+                    known = ", ".join(u.get("username", "?") for u in users)
+                    raise ValueError(
+                        f"user '{username}' not found (known users: {known})"
+                    )
+            elif len(users) == 1:
+                target_idx = 0
+            else:
+                names = ", ".join(u.get("username", "?") for u in users)
+                raise ValueError(
+                    f"multiple users exist; pass --username (one of: {names})"
+                )
+            user = users[target_idx]
+            user["password_hash"] = hash_password(new_password)
+            user.pop("pending_invite", None)  # a pending user becomes active
+            users[target_idx] = user
+            data["users"] = users
+            self._write_users(data)
+            if user.get("id"):
+                self.revoke_user_sessions(user["id"])
+            return user.get("username", "(unknown)")
+        # No user records: legacy single-password store.
+        self.set_password(new_password)
+        return "(legacy)"
+
     def check_password(self, password: str, username: str | None = None) -> tuple[bool, dict | None]:
         """Verify credentials.
 

--- a/tinyagentos/download_manager.py
+++ b/tinyagentos/download_manager.py
@@ -66,6 +66,7 @@ class DownloadManager:
         expected_sha256: str | None = None,
         magnet: str | None = None,
         license_allows_redistribution: bool = False,
+        web_seeds: list[str] | None = None,
     ) -> DownloadTask:
         """Start a model download.
 
@@ -75,6 +76,10 @@ class DownloadManager:
         torrent error the download falls back transparently to HTTP
         using ``url``. The caller sees a single DownloadTask either
         way and never has to branch on transport.
+
+        ``web_seeds`` are the manifest's BEP-19 HTTP seeds (typically the
+        HuggingFace resolve URLs) that the swarm rides as a correctness
+        fallback. They are passed straight through to the torrent path.
         """
         task = DownloadTask(id=download_id, url=url, dest=dest)
         self._tasks[download_id] = task
@@ -84,6 +89,7 @@ class DownloadManager:
                 expected_sha256=expected_sha256,
                 magnet=magnet,
                 license_allows_redistribution=license_allows_redistribution,
+                web_seeds=web_seeds,
             )
         )
         return task
@@ -180,6 +186,7 @@ class DownloadManager:
         expected_sha256: str | None = None,
         magnet: str | None = None,
         license_allows_redistribution: bool = False,
+        web_seeds: list[str] | None = None,
     ) -> None:
         """Hybrid download path: swarm first, HTTP fallback.
 
@@ -195,6 +202,16 @@ class DownloadManager:
             and license_allows_redistribution
             and (torrent := self._get_torrent_downloader()) is not None
         ):
+            # Headless passkey fetch: if this host has joined an account mesh,
+            # the controller token unlocks the private taOSnet tracker. A null
+            # passkey (not joined, no passkey yet, revoked, or offline) leaves
+            # the download on the web-seed baseline. Never raises.
+            from tinyagentos.taosnet.passkey_client import (
+                fetch_passkey,
+                get_controller_token,
+            )
+
+            passkey = await fetch_passkey(get_controller_token())
             task.status = "downloading"
             task.started_at = time.time()
             try:
@@ -208,6 +225,8 @@ class DownloadManager:
                     dest=task.dest,
                     expected_sha256=expected_sha256,
                     progress_cb=_progress,
+                    passkey=passkey,
+                    web_seeds=web_seeds,
                 )
                 # torrent.download() already SHA-verified the file internally
                 # (and raised on mismatch), so re-hashing here would just re-read

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -241,6 +241,64 @@ async def agent_set_own_model(request: Request, body: AgentSelfModelUpdate):
     return {"status": "updated", "current": model}
 
 
+def _reject_non_chat_model(model_id: str):
+    """Reject a non-chat model being assigned as an agent's chat model.
+
+    An embedding or reranker model cannot do chat completion, so assigning it
+    as an agent's model produces undefined, looping output instead of a reply
+    (reported by @mandresve in #1740, where a 0.6B embedding model was
+    selectable as an agent model and generated endless "analysis" text).
+    Returns a 400 JSONResponse to hand back, or None when the model is
+    chat-capable and may be assigned.
+    """
+    from tinyagentos.litellm_config import _is_embedding_model
+
+    if model_id and _is_embedding_model(model_id):
+        return JSONResponse(
+            {
+                "error": (
+                    f"'{model_id}' is an embedding model and cannot be used as an "
+                    "agent chat model. Choose a chat-capable model."
+                ),
+                "model": model_id,
+                "reason": "not_chat_capable",
+            },
+            status_code=400,
+        )
+    return None
+
+
+RECOMMENDED_AGENT_CONTEXT = 8192
+
+
+def _small_context_warning(registry, model_id: str) -> str | None:
+    """Advisory when a model's context window is too small for the agent harness.
+
+    The agent system prompt plus tool definitions are large (order of 10k
+    tokens), so a model with a small context window (e.g. a 4096-token RK
+    model) receives a truncated prompt and can degenerate into looping or
+    off-topic output rather than a coherent reply (#1740). Returns a warning
+    string, or None when the context is adequate or unknown (a cloud or
+    aliased model has no local manifest to read a context window from). This
+    is advisory only and must never block or break an assignment.
+    """
+    try:
+        from tinyagentos.cluster.model_resolver import _find_model_manifest
+
+        manifest = _find_model_manifest(registry, model_id)
+        ctx = int(getattr(manifest, "context_window", 0) or 0) if manifest else 0
+    except Exception:  # noqa: BLE001 - an advisory must never break assignment
+        return None
+    if 0 < ctx < RECOMMENDED_AGENT_CONTEXT:
+        return (
+            f"'{model_id}' has a {ctx}-token context window, smaller than the "
+            f"{RECOMMENDED_AGENT_CONTEXT} tokens recommended for agent use. The "
+            "agent system prompt may be truncated, which can cause looping or "
+            "off-topic output. Consider a model with a larger context window."
+        )
+    return None
+
+
 @router.get("/api/agents/{name}/deploy-status")
 async def get_deploy_status(request: Request, name: str):
     """Get the background deploy task status for an agent."""
@@ -436,6 +494,11 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
        We never silently retarget a pinned deploy.
     6. Model not found anywhere in the cluster — 404.
     """
+    # Reject a non-chat model (e.g. embedding) before any side effects (#1740).
+    rejection = _reject_non_chat_model((body.model or "").strip())
+    if rejection is not None:
+        return rejection
+
     # --- Idempotency guard ---
     idempotency_cache = getattr(request.app.state, "idempotency_cache", None)
     idempotency_key = request.headers.get("Idempotency-Key")
@@ -1075,6 +1138,10 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
     if not model_id:
         return JSONResponse({"error": "model must not be empty"}, status_code=400)
 
+    rejection = _reject_non_chat_model(model_id)
+    if rejection is not None:
+        return rejection
+
     # Validate reachability against the live cluster state.
     from tinyagentos.cluster.model_resolver import (
         describe_downloaded_backend_down,
@@ -1159,7 +1226,7 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         except Exception:
             logger.exception("model sync: pushing framework config for %s failed", name)
 
-    return {
+    result = {
         "status": "updated",
         "name": name,
         "model": model_id,
@@ -1168,6 +1235,10 @@ async def update_agent_model(request: Request, name: str, body: AgentModelUpdate
         "location": location.kind,
         "key_rescoped": key_rescoped,
     }
+    warning = _small_context_warning(getattr(request.app.state, "registry", None), model_id)
+    if warning:
+        result["warning"] = warning
+    return result
 
 
 @router.get("/api/agents/{name}/permitted-models")
@@ -1195,6 +1266,11 @@ async def set_permitted_models(request: Request, name: str, body: PermittedModel
 
     if not body.models:
         return JSONResponse({"error": "models must not be empty"}, status_code=400)
+
+    for _requested in body.models:
+        rejection = _reject_non_chat_model((_requested or "").strip())
+        if rejection is not None:
+            return rejection
 
     # Build the final set up front — the current primary must always be a
     # member — so it is validated alongside the requested models. Otherwise an

--- a/tinyagentos/taosnet/passkey_client.py
+++ b/tinyagentos/taosnet/passkey_client.py
@@ -1,0 +1,91 @@
+"""Headless taOSnet passkey fetch (Phase 2 of the model torrent mesh).
+
+A background model download has no browser session cookie, so it cannot use
+the cookie-authenticated passkey path the desktop uses. Instead the taOS
+controller stores a ``controller_token`` minted at cluster-join (bound to the
+account host row, scoped to ``taosnet:passkey`` only) and presents it as a
+Bearer credential to fetch this account's taOSnet passkey.
+
+Contract (taos.my, see docs and jaylfc/taos-website#83):
+
+- ``GET /api/taosnet/passkey`` with ``Authorization: Bearer <controller_token>``
+- ``200 {"passkey": "<opaque>"}`` when the account has a passkey issued
+- ``200 {"passkey": null}`` when none has been issued yet
+- ``401`` when the token is missing, invalid, or revoked (host row gone)
+
+Fallback rule (mirrors the DownloadManager): a null passkey, a 401, or any
+transport failure all mean "web-seed only" (no taOSnet tracker). A non-null
+passkey enables the private taOSnet tracker alongside the BEP-19 web seeds.
+This module never raises, so a passkey lookup can never block a download.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE = "https://taos.my"
+
+
+def taosnet_base() -> str:
+    """The taos.my base URL for account API calls, overridable in tests and
+    self-hosted setups via ``TAOS_TAOSNET_BASE``."""
+    return os.getenv("TAOS_TAOSNET_BASE", _DEFAULT_BASE).rstrip("/")
+
+
+def get_controller_token() -> Optional[str]:
+    """The controller token persisted when this host joined an account mesh,
+    or None if it has not joined one.
+
+    Read from ``TAOS_CONTROLLER_TOKEN`` for now; this is the seam the
+    cluster-join client writes to (alongside the Headscale key) once that
+    client lands. None means the headless passkey fetch is skipped and the
+    download stays on the web-seed baseline.
+    """
+    return os.getenv("TAOS_CONTROLLER_TOKEN") or None
+
+
+async def fetch_passkey(
+    controller_token: Optional[str],
+    *,
+    base: Optional[str] = None,
+    client: Optional[httpx.AsyncClient] = None,
+    timeout: float = 15.0,
+) -> Optional[str]:
+    """Fetch the account taOSnet passkey using the controller token.
+
+    Returns the passkey string, or None when there is no token, the account
+    has no passkey yet, the token is unauthorized/revoked (401), or any
+    transport error occurs. None always means "fall back to web-seed only".
+    Never raises, so a download is never blocked by a passkey lookup.
+
+    ``client`` lets a caller (or a test) inject an ``httpx.AsyncClient``;
+    otherwise a short-lived one is created for the single request.
+    """
+    if not controller_token:
+        return None
+    url = f"{base or taosnet_base()}/api/taosnet/passkey"
+    headers = {"Authorization": f"Bearer {controller_token}"}
+    try:
+        if client is not None:
+            resp = await client.get(url, headers=headers, timeout=timeout)
+        else:
+            async with httpx.AsyncClient(timeout=timeout) as owned:
+                resp = await owned.get(url, headers=headers)
+        if resp.status_code == 401:
+            logger.info(
+                "taosnet passkey fetch: 401 (token missing/invalid/revoked), "
+                "using web seeds only"
+            )
+            return None
+        resp.raise_for_status()
+        return resp.json().get("passkey") or None
+    except Exception as exc:  # noqa: BLE001 - any failure means web-seed fallback
+        logger.warning(
+            "taosnet passkey fetch failed (%s), using web seeds only", exc
+        )
+        return None

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b36"
+version = "1.0.0b37"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotes dev to master for 1.0.0-beta.37.

Ships since beta.36:
- #1744 embedding-model-as-agent guard + small-context warning (@mandresve #1740, verified on RK3588)
- #1739 rkllama structured context-overflow error (@mandresve #1738)
- #1745 taos recover-password offline account recovery CLI
- #1737 taosnet passkey client (dormant)

Tag v1.0.0-beta.37 on the resulting master SHA after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline `recover-password` command to reset a local account password and revoke existing sessions.
  * Downloading now better supports torrent fallback behavior, including web seeds and account-based passkey lookup.

* **Bug Fixes**
  * Improved error messages when a non-chat model is selected for chat use.
  * Added a warning for models with very small context windows and clearer context-overflow handling.

* **Tests**
  * Expanded automated coverage for password recovery, model validation, and passkey lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->