### PR TITLE
feat(agent-window): scrollbars + stall detection (#1741, #1742)

### DIFF
--- a/desktop/src/apps/MessagesApp.stallWatch.test.ts
+++ b/desktop/src/apps/MessagesApp.stallWatch.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  pickWatchAgent,
+  computeStallInfo,
+  STALL_HINT_MS,
+  STALL_WARN_MS,
+  type StallWatch,
+} from "./MessagesApp.stallWatch";
+
+const AGENTS = ["naira", "atlas"];
+
+describe("pickWatchAgent", () => {
+  it("waits on the agent in a DM", () => {
+    expect(
+      pickWatchAgent({ id: "c1", type: "dm", members: ["user", "naira"] }, "hi", AGENTS),
+    ).toBe("naira");
+  });
+
+  it("returns null for a human-only DM", () => {
+    expect(
+      pickWatchAgent({ id: "c1", type: "dm", members: ["user", "bob"] }, "hi", AGENTS),
+    ).toBeNull();
+  });
+
+  it("waits only on an @mentioned agent in a non-DM channel", () => {
+    const chan = { id: "c2", type: "topic", members: ["user", "naira", "atlas"] };
+    expect(pickWatchAgent(chan, "hey @atlas can you help", AGENTS)).toBe("atlas");
+  });
+
+  it("does not wait in a non-DM channel with no mention", () => {
+    const chan = { id: "c2", type: "topic", members: ["user", "naira"] };
+    expect(pickWatchAgent(chan, "just chatting", AGENTS)).toBeNull();
+  });
+
+  it("ignores a mentioned name that is not a known agent", () => {
+    const chan = { id: "c2", type: "topic", members: ["user", "naira"] };
+    expect(pickWatchAgent(chan, "@bob hello", AGENTS)).toBeNull();
+  });
+
+  it("returns null when there is no channel", () => {
+    expect(pickWatchAgent(undefined, "hi", AGENTS)).toBeNull();
+  });
+});
+
+describe("computeStallInfo", () => {
+  const watch: StallWatch = { channelId: "c1", agent: "naira", lastActivityAt: 0 };
+
+  it("stays silent while activity is recent", () => {
+    expect(computeStallInfo(watch, "c1", STALL_HINT_MS - 1)).toBeNull();
+  });
+
+  it("shows the soft hint after the hint threshold", () => {
+    const info = computeStallInfo(watch, "c1", STALL_HINT_MS + 5_000);
+    expect(info).toEqual({ agent: "naira", seconds: 25, stalled: false });
+  });
+
+  it("escalates to a stalled warning at the warn threshold", () => {
+    const info = computeStallInfo(watch, "c1", STALL_WARN_MS);
+    expect(info?.stalled).toBe(true);
+  });
+
+  it("returns null when the watch is for another channel", () => {
+    expect(computeStallInfo(watch, "c2", STALL_WARN_MS)).toBeNull();
+  });
+
+  it("returns null when there is no watch", () => {
+    expect(computeStallInfo(null, "c1", STALL_WARN_MS)).toBeNull();
+  });
+});

--- a/desktop/src/apps/MessagesApp.stallWatch.ts
+++ b/desktop/src/apps/MessagesApp.stallWatch.ts
@@ -1,0 +1,70 @@
+// Pure logic for the #1741 agent-window stall watchdog, split out of
+// MessagesApp so the escalation thresholds and the "which agent do we wait
+// for" decision can be unit-tested without rendering the full chat component.
+//
+// The chat window streams an agent reply over a WebSocket as a series of
+// deltas. If a generation stalls (endless model loop, broken stream, or a
+// missing completion event) no further frames arrive and the window would
+// otherwise look frozen with no hint. The component arms a watch on send,
+// bumps `lastActivityAt` on every inbound frame, and clears it on completion;
+// these helpers decide when to arm and what banner (if any) to show.
+
+export interface StallWatch {
+  channelId: string;
+  agent: string;
+  lastActivityAt: number;
+}
+
+export interface StallWatchChannel {
+  id: string;
+  type?: string;
+  members?: string[];
+}
+
+/**
+ * Decide which agent a send should wait on, or null if none is expected to
+ * reply. In a DM with an agent we always wait; elsewhere we only wait when an
+ * agent member is @mentioned, so human-only channels never trip the watch.
+ */
+export function pickWatchAgent(
+  channel: StallWatchChannel | undefined,
+  text: string,
+  agentNames: string[],
+): string | null {
+  if (!channel) return null;
+  const agentMembers = (channel.members ?? []).filter(
+    (m) => m !== "user" && agentNames.includes(m),
+  );
+  if (channel.type === "dm") return agentMembers[0] ?? null;
+  return agentMembers.find((m) => text.includes(`@${m}`)) ?? null;
+}
+
+export interface StallInfo {
+  agent: string;
+  seconds: number;
+  stalled: boolean;
+}
+
+// Silent for the first HINT window (healthy responses resolve well before it),
+// a soft "taking longer" hint after, an amber "may be stalled" warning at WARN.
+export const STALL_HINT_MS = 20_000;
+export const STALL_WARN_MS = 75_000;
+
+/**
+ * Derive the stall banner from the current watch, or null if nothing should
+ * show (no watch, watch belongs to another channel, or activity is recent).
+ */
+export function computeStallInfo(
+  watch: StallWatch | null,
+  selectedChannel: string | null,
+  now: number,
+): StallInfo | null {
+  if (!watch || watch.channelId !== selectedChannel) return null;
+  const elapsed = now - watch.lastActivityAt;
+  if (elapsed < STALL_HINT_MS) return null;
+  return {
+    agent: watch.agent,
+    seconds: Math.floor(elapsed / 1000),
+    stalled: elapsed >= STALL_WARN_MS,
+  };
+}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -24,6 +24,8 @@ import {
   Search,
   Copy,
   Check,
+  AlertTriangle,
+  Loader2,
 } from "lucide-react";
 import {
   Button,
@@ -77,6 +79,11 @@ import {
   writeLastChannel,
 } from "./MessagesApp.a2aSelection";
 import { bucketAgentChannels } from "./MessagesApp.agentSections";
+import {
+  pickWatchAgent,
+  computeStallInfo,
+  type StallWatch,
+} from "./MessagesApp.stallWatch";
 import { displayAuthor } from "./chat/format-author";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
@@ -430,6 +437,15 @@ export function MessagesApp({
   const [typingHumans, setTypingHumans] = useState<string[]>([]);
   const [typingAgents, setTypingAgents] = useState<AgentTyping[]>([]);
   const [sendError, setSendError] = useState<string | null>(null);
+  // #1741 stall watchdog. The backend streams a reply via WS deltas, but if a
+  // generation stalls (endless model loop, broken stream, or a missing
+  // completion event) no further frames arrive and the window looks frozen with
+  // no hint. We arm a watch when the user sends to an agent and clear it on
+  // completion; `lastActivityAt` is bumped on every inbound frame so the render
+  // can surface an escalating "taking longer / may be stalled" banner once
+  // activity stops. Fast, healthy responses never trip it.
+  const [responseWatch, setResponseWatch] = useState<StallWatch | null>(null);
+  const [, bumpStallClock] = useState(0);
   const [hoveredMessageId, setHoveredMessageId] = useState<string | null>(null);
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [overflowMenu, setOverflowMenu] = useState<{ messageId: string; x: number; y: number } | null>(null);
@@ -612,6 +628,8 @@ export function MessagesApp({
           return;
         }
         if (data.type === "thinking") {
+          // #1741: any thinking frame is live activity — keep the watch fresh.
+          setResponseWatch((w) => (w ? { ...w, lastActivityAt: Date.now() } : w));
           if (data.state === "start") {
             setTypingAgents((prev) => {
               const without = prev.filter((a) => a.slug !== data.slug);
@@ -645,6 +663,12 @@ export function MessagesApp({
                 notify(`${data.author_id} in #${chName}`, data.content ?? "", () => setSelectedChannel(data.channel_id));
               }
             }
+            // #1741: an agent's reply frame in the watched channel is activity.
+            if (data.author_id && data.author_id !== "user") {
+              setResponseWatch((w) =>
+                w && w.channelId === data.channel_id ? { ...w, lastActivityAt: Date.now() } : w,
+              );
+            }
             break;
 
           case "message_delta":
@@ -655,6 +679,9 @@ export function MessagesApp({
                   : m,
               ),
             );
+            // #1741: deltas carry no channel_id, but a delta only flows for an
+            // in-flight generation — bump the watch so streaming never trips it.
+            setResponseWatch((w) => (w ? { ...w, lastActivityAt: Date.now() } : w));
             break;
 
           case "message_state":
@@ -663,6 +690,10 @@ export function MessagesApp({
                 m.id === data.message_id ? { ...m, state: data.state } : m,
               ),
             );
+            // #1741: a terminal state means the response resolved — stop watching.
+            if (data.state === "complete" || data.state === "error") {
+              setResponseWatch((w) => (w ? null : w));
+            }
             break;
 
           case "typing":
@@ -1051,6 +1082,37 @@ export function MessagesApp({
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // #1741: drop any active watch when the user switches channels — a stall
+  // banner from a previous conversation must not bleed into another.
+  useEffect(() => {
+    setResponseWatch(null);
+  }, [selectedChannel]);
+
+  // #1741: while a watch is armed, tick once a second so the render recomputes
+  // elapsed-since-activity and the banner escalates. Only the presence of a
+  // watch (not each bump) gates the interval, so healthy streaming does not
+  // thrash it.
+  useEffect(() => {
+    if (!responseWatch) return;
+    const id = setInterval(() => bumpStallClock((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [responseWatch !== null]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // #1741: arm the stall watch after a send if this channel has an agent that
+  // is expected to reply — always in a DM with an agent, or when an agent
+  // member is @mentioned elsewhere. Human-only channels never arm it.
+  const armResponseWatch = (text: string) => {
+    if (!currentChannel) return;
+    const agent = pickWatchAgent(
+      currentChannel,
+      text,
+      liveAgents.map((a) => a.name),
+    );
+    if (agent) {
+      setResponseWatch({ channelId: currentChannel.id, agent, lastActivityAt: Date.now() });
+    }
+  };
+
   /* ---- send message ---- */
   const sendMessage = async () => {
     const text = input.trim();
@@ -1093,6 +1155,7 @@ export function MessagesApp({
         setPendingAttachments([]);
         if (inputRef.current) inputRef.current.style.height = "auto";
         autoScrollRef.current = true;
+        armResponseWatch(text);
         return;
       } catch (e) {
         setSendError((e as Error).message || "send failed");
@@ -1163,6 +1226,7 @@ export function MessagesApp({
     setNewDividerAtId(null);
     autoScrollRef.current = true;
     if (inputRef.current) inputRef.current.style.height = "auto";
+    armResponseWatch(text);
   };
 
   /* ---- typing indicator ---- */
@@ -1421,6 +1485,10 @@ export function MessagesApp({
   const allChannels = [...channels, ...archivedChannels];
   const currentChannel = allChannels.find((c) => c.id === selectedChannel);
   const isCurrentArchived = currentChannel?.settings?.archived === true;
+  // #1741: derive the stall banner. Silent for the first 20s of no activity
+  // (healthy responses resolve well before then), a soft "taking longer" hint
+  // after, and an amber "may be stalled" warning with a recovery pointer at 75s.
+  const stallInfo = computeStallInfo(responseWatch, selectedChannel, Date.now());
 
   /* ---- slash menu derived state ---- */
   // In a DM (2 members: user + 1 agent), a leading "/" opens the agent's
@@ -2152,7 +2220,7 @@ export function MessagesApp({
           <div
             ref={messageListRef}
             onScroll={handleScroll}
-            className={`flex-1 overflow-y-auto px-4 py-3 space-y-0.5 select-text message-list-drop-target ${
+            className={`flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-0.5 select-text message-list-drop-target ${
               shellFileDropTarget.isOver
                 ? "ring-2 ring-sky-400/60 ring-inset bg-sky-500/5"
                 : shellFileDropTarget.isValidTarget
@@ -2516,6 +2584,47 @@ export function MessagesApp({
 
           {/* typing footer */}
           <TypingFooter humans={typingHumans} agents={typingAgents} selfId="user" />
+
+          {/* #1741: stall banner — surfaces only when a response is abnormally
+              slow or has gone quiet, so a stalled generation no longer looks
+              like a frozen window. */}
+          {stallInfo && (
+            <div
+              role="status"
+              className={`mx-4 mb-2 px-3 py-2 rounded-lg border text-[12px] flex items-center gap-2 shrink-0 ${
+                stallInfo.stalled
+                  ? "bg-amber-500/10 border-amber-500/25 text-amber-300/90"
+                  : "bg-white/[0.04] border-white/10 text-white/55"
+              }`}
+            >
+              {stallInfo.stalled ? (
+                <AlertTriangle size={13} aria-hidden="true" className="shrink-0" />
+              ) : (
+                <Loader2 size={13} aria-hidden="true" className="shrink-0 animate-spin" />
+              )}
+              {stallInfo.stalled ? (
+                <span className="flex-1">
+                  No response from {stallInfo.agent} for {stallInfo.seconds}s. The model may be
+                  stalled.{" "}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const a = getApp("dashboard");
+                      if (a) openWindow("dashboard", a.defaultSize);
+                    }}
+                    className="underline underline-offset-2 hover:text-amber-200"
+                  >
+                    Open Activity to restart the AI services
+                  </button>
+                  .
+                </span>
+              ) : (
+                <span className="flex-1">
+                  {stallInfo.agent} is taking longer than usual… ({stallInfo.seconds}s)
+                </span>
+              )}
+            </div>
+          )}
 
           {/* archived banner */}
           {isCurrentArchived && (


### PR DESCRIPTION
Two of @mandresve's agent-window resilience requests, both frontend-only.

## #1742 — scrollbars in the Agent conversation window
The message list used `flex-1 overflow-y-auto` with no `min-h-0`. In a flex column a `flex-1` child defaults to `min-height:auto`, so it grew to fit its content instead of clamping, and the scrollbar never appeared. Long responses/logs pushed earlier content out of reach. Fix: add `min-h-0` so the list clamps and scrolls.

## #1741 — real-time feedback during long/stalled generations
The reply already streams over the WebSocket as deltas, so the frozen symptom is the gap when **no** frames arrive (endless model loop, broken stream, or a missing completion event) — the window just sat there with no hint.

Added a client-side stall watchdog:
- armed on send to an agent (always in a DM with an agent; elsewhere only when an agent is @mentioned, so human channels never trip it),
- `lastActivityAt` bumped on every inbound frame (message / delta / thinking), cleared on a terminal `message_state`,
- an escalating banner: silent for 20s (healthy replies resolve well before then), a soft "taking longer than usual" hint after, and an amber "may be stalled" warning at 75s with a button to open the Activity app.

The recover/restart action the warning points to is #1743 (separate PR, backend + admin gate).

## Tests
Escalation thresholds and the wait-for-agent decision are pure functions in `MessagesApp.stallWatch.ts`, unit-tested (11 cases). Full suite green (2613).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a stall warning banner in Messages for slow or stalled agent replies, with an elapsed-time indicator and a quick way to open activity.
  * Improved reply detection so the app can better tell when a response is expected in direct messages and channel mentions.

* **Bug Fixes**
  * Prevented stall warnings from carrying over when switching conversations.
  * Cleared stalled-response tracking once an agent message finishes or errors out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->