### PR TITLE
feat(activity): recover/restart the local AI stack (#1743)

### DIFF
--- a/desktop/src/apps/ActivityApp.aiStack.test.tsx
+++ b/desktop/src/apps/ActivityApp.aiStack.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AiStackRecovery } from "./ActivityApp.aiStack";
+
+describe("AiStackRecovery", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requires confirmation before restarting", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    render(<AiStackRecovery />);
+    fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
+    // The confirm dialog is shown; no request has been made yet.
+    expect(screen.getByText(/restart ai services\?/i)).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts the restart and reports per-service results on confirm", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "ok",
+          restarted: ["rkllama.service", "qmd.service"],
+          failed: [],
+          results: [
+            { unit: "rkllama.service", ok: true, scope: "user" },
+            { unit: "qmd.service", ok: true, scope: "system" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const onRecovered = vi.fn();
+    render(<AiStackRecovery onRecovered={onRecovered} />);
+    fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+
+    await waitFor(() => expect(screen.getByText(/ai services restarted/i)).toBeInTheDocument());
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/system/ai-stack/restart",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(onRecovered).toHaveBeenCalled();
+    expect(screen.getByText("rkllama")).toBeInTheDocument();
+    expect(screen.getByText("qmd")).toBeInTheDocument();
+  });
+
+  it("surfaces a per-service failure detail on partial recovery", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "ok",
+          restarted: ["rkllama.service"],
+          failed: [{ unit: "qmd.service", ok: false, detail: "Interactive authentication required" }],
+          results: [
+            { unit: "rkllama.service", ok: true, scope: "user" },
+            { unit: "qmd.service", ok: false, detail: "Interactive authentication required" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    render(<AiStackRecovery />);
+    fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/interactive authentication required/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows an admin-only message on 403", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "forbidden" }), { status: 403 }),
+    );
+    render(<AiStackRecovery />);
+    fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+    await waitFor(() => expect(screen.getByText(/admin access is required/i)).toBeInTheDocument());
+  });
+});

--- a/desktop/src/apps/ActivityApp.aiStack.tsx
+++ b/desktop/src/apps/ActivityApp.aiStack.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import { Zap, Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui";
+
+// #1743: a recovery action in the Activity tab. On edge devices a local model
+// can stall (endless NPU generation, unresponsive inference) while the
+// controller stays up, and recovery previously meant SSH + `systemctl restart
+// rkllama qmd`. This restarts those backend services from the UI, with a
+// confirmation first since it interrupts any running inference.
+
+interface UnitResult {
+  unit: string;
+  ok?: boolean;
+  scope?: string;
+  detail?: string;
+}
+
+interface RestartResponse {
+  status: string;
+  restarted: string[];
+  failed: UnitResult[];
+  results: UnitResult[];
+}
+
+type Phase = "idle" | "confirm" | "running" | "done" | "error";
+
+const unitLabel = (unit: string) => unit.replace(/\.service$/, "");
+
+export function AiStackRecovery({ onRecovered }: { onRecovered?: () => void }) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [result, setResult] = useState<RestartResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async () => {
+    setPhase("running");
+    setError(null);
+    try {
+      const r = await fetch("/api/system/ai-stack/restart", { method: "POST" });
+      const body = await r.json().catch(() => null);
+      if (r.status === 403) {
+        setError("Admin access is required to restart AI services.");
+        setPhase("error");
+        return;
+      }
+      if (!r.ok || !body) {
+        setError((body && body.error) || "The restart request failed.");
+        setPhase("error");
+        return;
+      }
+      setResult(body as RestartResponse);
+      setPhase("done");
+      onRecovered?.();
+    } catch (e) {
+      setError((e as Error).message || "Network error");
+      setPhase("error");
+    }
+  };
+
+  const close = () => {
+    setPhase("idle");
+    setResult(null);
+    setError(null);
+  };
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setPhase("confirm")}
+        aria-label="Restart AI services"
+        className="gap-1.5 text-shell-text-secondary hover:text-shell-text"
+      >
+        <Zap size={14} aria-hidden="true" />
+        Restart AI Services
+      </Button>
+
+      {phase !== "idle" && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Restart AI services"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+        >
+          <div className="bg-shell-surface border border-white/10 rounded-xl p-6 w-full max-w-md shadow-xl space-y-4">
+            {phase === "confirm" && (
+              <>
+                <h3 className="text-base font-semibold flex items-center gap-2">
+                  <AlertTriangle size={16} className="text-amber-400" aria-hidden="true" />
+                  Restart AI services?
+                </h3>
+                <p className="text-sm text-shell-text-secondary">
+                  This restarts the local inference backends (rkllama and qmd) and interrupts any
+                  running generation. The desktop and your agents stay up.
+                </p>
+                <div className="flex justify-end gap-2">
+                  <Button variant="outline" size="sm" onClick={close}>
+                    Cancel
+                  </Button>
+                  <Button variant="default" size="sm" onClick={run}>
+                    Restart
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {phase === "running" && (
+              <p className="text-sm flex items-center gap-2 text-shell-text-secondary">
+                <Loader2 size={16} className="animate-spin" aria-hidden="true" />
+                Restarting AI services…
+              </p>
+            )}
+
+            {phase === "done" && result && (
+              <>
+                <h3 className="text-base font-semibold flex items-center gap-2">
+                  {result.status === "ok" ? (
+                    <>
+                      <CheckCircle2 size={16} className="text-emerald-400" aria-hidden="true" />
+                      AI services restarted
+                    </>
+                  ) : (
+                    <>
+                      <AlertTriangle size={16} className="text-amber-400" aria-hidden="true" />
+                      Could not restart AI services
+                    </>
+                  )}
+                </h3>
+                <ul className="space-y-1.5 text-sm" aria-label="Restart results">
+                  {result.results.map((r) => (
+                    <li key={r.unit} className="flex items-start justify-between gap-3">
+                      <span className="text-shell-text-secondary">{unitLabel(r.unit)}</span>
+                      {r.ok ? (
+                        <span className="text-[11px] px-1.5 py-0.5 rounded bg-emerald-500/20 text-emerald-300 shrink-0">
+                          restarted
+                        </span>
+                      ) : (
+                        <span className="text-[11px] text-amber-300/90 text-right">
+                          {r.detail ?? "failed"}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+                {result.status !== "ok" && (
+                  <p className="text-xs text-shell-text-tertiary">
+                    Some services could not be restarted automatically — they may need permissions
+                    this device has not granted yet.
+                  </p>
+                )}
+                <div className="flex justify-end">
+                  <Button variant="outline" size="sm" onClick={close}>
+                    Close
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {phase === "error" && (
+              <>
+                <h3 className="text-base font-semibold flex items-center gap-2">
+                  <AlertTriangle size={16} className="text-red-400" aria-hidden="true" />
+                  Restart failed
+                </h3>
+                <p className="text-sm text-shell-text-secondary">{error}</p>
+                <div className="flex justify-end">
+                  <Button variant="outline" size="sm" onClick={close}>
+                    Close
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/desktop/src/apps/ActivityApp.tsx
+++ b/desktop/src/apps/ActivityApp.tsx
@@ -4,6 +4,7 @@ import {
   Gauge, Layers, RefreshCw, Loader2, Server,
 } from "lucide-react";
 import { Card, CardContent, Button } from "@/components/ui";
+import { AiStackRecovery } from "./ActivityApp.aiStack";
 import type { ClusterWorker } from "@/lib/cluster";
 import { workerStatus, workerHardwareSummary, workerShortIp, normalizeBackendName, STATUS_PILL_CLASS, STATUS_LABEL } from "@/lib/cluster";
 
@@ -337,9 +338,12 @@ export function ActivityApp({ windowId: _windowId }: { windowId: string }) {
             {hardware.ram_mb && ` \u00b7 ${(hardware.ram_mb / 1024).toFixed(0)} GB RAM`}
           </p>
         </div>
-        <Button variant="ghost" size="icon" onClick={fetchData} aria-label="Refresh">
-          <RefreshCw size={14} />
-        </Button>
+        <div className="flex items-center gap-1">
+          <AiStackRecovery onRecovered={fetchData} />
+          <Button variant="ghost" size="icon" onClick={fetchData} aria-label="Refresh">
+            <RefreshCw size={14} />
+          </Button>
+        </div>
       </div>
 
       {/* Grid */}

--- a/tests/test_routes_system.py
+++ b/tests/test_routes_system.py
@@ -7,8 +7,10 @@ from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.restart_orchestrator import RestartOrchestrator
+from tinyagentos.routes import system as system_routes
 
 
 # ---------------------------------------------------------------------------
@@ -235,3 +237,136 @@ class TestRestartStatus:
         assert resp.status_code == 503
         data = resp.json()
         assert "error" in data
+
+
+class _FakeProc:
+    """Minimal asyncio subprocess stand-in for _restart_ai_unit tests."""
+
+    def __init__(self, returncode: int, stderr: bytes = b""):
+        self.returncode = returncode
+        self._stderr = stderr
+
+    async def communicate(self):
+        return (b"", self._stderr)
+
+
+async def _member_client(app) -> AsyncClient:
+    """Cookie'd client for a non-admin member session (mirrors settings authz)."""
+    auth_mgr = app.state.auth
+    invite_code = auth_mgr.add_user_invite("member", "admin")
+    auth_mgr.complete_invite("member", invite_code, "Test Member", "", "memberpass123456")
+    member = auth_mgr.find_user("member")
+    token = auth_mgr.create_session(user_id=member["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+class TestRestartAiStack:
+    """POST /api/system/ai-stack/restart -- issue #1743 backend recovery."""
+
+    @pytest.mark.asyncio
+    async def test_all_ok(self, client, monkeypatch):
+        monkeypatch.setattr(
+            system_routes,
+            "_restart_ai_unit",
+            AsyncMock(side_effect=[
+                {"unit": "rkllama.service", "ok": True, "scope": "user"},
+                {"unit": "qmd.service", "ok": True, "scope": "system"},
+            ]),
+        )
+        resp = await client.post("/api/system/ai-stack/restart")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["restarted"] == ["rkllama.service", "qmd.service"]
+        assert data["failed"] == []
+
+    @pytest.mark.asyncio
+    async def test_partial_recovery_still_ok(self, client, monkeypatch):
+        monkeypatch.setattr(
+            system_routes,
+            "_restart_ai_unit",
+            AsyncMock(side_effect=[
+                {"unit": "rkllama.service", "ok": True, "scope": "user"},
+                {"unit": "qmd.service", "ok": False, "detail": "not installed"},
+            ]),
+        )
+        data = (await client.post("/api/system/ai-stack/restart")).json()
+        assert data["status"] == "ok"
+        assert data["restarted"] == ["rkllama.service"]
+        assert len(data["failed"]) == 1
+        assert data["failed"][0]["unit"] == "qmd.service"
+
+    @pytest.mark.asyncio
+    async def test_all_fail_reports_failed(self, client, monkeypatch):
+        monkeypatch.setattr(
+            system_routes,
+            "_restart_ai_unit",
+            AsyncMock(side_effect=[
+                {"unit": "rkllama.service", "ok": False, "detail": "auth required"},
+                {"unit": "qmd.service", "ok": False, "detail": "auth required"},
+            ]),
+        )
+        data = (await client.post("/api/system/ai-stack/restart")).json()
+        assert data["status"] == "failed"
+        assert data["restarted"] == []
+        assert len(data["failed"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_admin_rejected_403(self, client, app, monkeypatch):
+        # Guard should reject before any restart is attempted.
+        monkeypatch.setattr(
+            system_routes, "_restart_ai_unit", AsyncMock(return_value={"ok": True})
+        )
+        member_client = await _member_client(app)
+        try:
+            resp = await member_client.post("/api/system/ai-stack/restart")
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403
+
+
+class TestRestartAiUnit:
+    """_restart_ai_unit scope resolution + fail-soft behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_restart_user_scope_ok(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "test")  # force systemd-present path
+        # cat finds the unit in --user scope (rc 0), so restart uses --user.
+        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=0))
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", AsyncMock(return_value=_FakeProc(0))
+        )
+        result = await system_routes._restart_ai_unit("rkllama.service")
+        assert result == {"unit": "rkllama.service", "ok": True, "scope": "user"}
+
+    @pytest.mark.asyncio
+    async def test_restart_failure_captures_stderr(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "test")
+        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=0))
+        monkeypatch.setattr(
+            asyncio,
+            "create_subprocess_exec",
+            AsyncMock(return_value=_FakeProc(1, b"Interactive authentication required")),
+        )
+        result = await system_routes._restart_ai_unit("qmd.service")
+        assert result["ok"] is False
+        assert "Interactive authentication required" in result["detail"]
+
+    @pytest.mark.asyncio
+    async def test_not_installed_when_cat_fails_both_scopes(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "test")
+        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=1))
+        result = await system_routes._restart_ai_unit("rkllama.service")
+        assert result == {"unit": "rkllama.service", "ok": False, "detail": "not installed"}
+
+    @pytest.mark.asyncio
+    async def test_no_systemd_fails_soft(self, monkeypatch):
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setattr(system_routes.os.path, "exists", lambda p: False)
+        result = await system_routes._restart_ai_unit("qmd.service")
+        assert result["ok"] is False
+        assert "systemd not available" in result["detail"]

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -119,6 +119,106 @@ async def _do_restart(app_state) -> None:
         await _emit_fail(str(exc))
 
 
+# AI-stack services a recovery action restarts (issue #1743). These are the
+# local inference backends that can stall independently of the controller:
+# rkllama (NPU model server, installed as a user unit) and qmd (shared model
+# provider, a system unit). The controller itself is deliberately NOT here --
+# bouncing it is the separate /api/system/restart/prepare path.
+AI_STACK_UNITS = ("rkllama.service", "qmd.service")
+
+
+def _is_admin_or_local_token(request: Request) -> bool:
+    """True if the caller is an admin session or presented the host local token.
+
+    Restarting host services is privileged (it runs ``systemctl restart``), so
+    a plain non-admin user session must never reach it. ``AuthMiddleware`` sets
+    both signals on ``request.state`` (see
+    ``tinyagentos/routes/skill_exec.py::_is_admin_or_local_token`` for the full
+    rationale). The ``system`` router is not gated at the router level, so this
+    handler guards itself.
+    """
+    if getattr(request.state, "is_admin", False):
+        return True
+    return getattr(request.state, "via", None) == "local_token"
+
+
+async def _systemctl_rc(args: list[str]) -> int:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    await proc.wait()
+    return proc.returncode
+
+
+async def _restart_ai_unit(unit: str) -> dict:
+    """Restart one AI-stack systemd unit, resolving user vs system scope.
+
+    Fails soft: a unit that is not installed, or that the service user lacks
+    rights to restart (polkit / interactive auth), is reported rather than
+    raised, so restarting one backend still helps when the other cannot be
+    touched. Scope is resolved with ``systemctl [--user] cat`` (returns 0 iff
+    the unit file exists) so a dead/crashed unit -- exactly what recovery
+    targets -- is still restarted, unlike an is-active probe.
+    """
+    if not (os.environ.get("INVOCATION_ID") or os.path.exists("/run/systemd/system")):
+        return {"unit": unit, "ok": False, "detail": "systemd not available on host"}
+
+    scope_flag: list[str] | None = None
+    for candidate in (["--user"], []):
+        if await _systemctl_rc(["systemctl", *candidate, "cat", unit]) == 0:
+            scope_flag = candidate
+            break
+    if scope_flag is None:
+        return {"unit": unit, "ok": False, "detail": "not installed"}
+
+    scope_name = "user" if scope_flag else "system"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "systemctl",
+            *scope_flag,
+            "restart",
+            unit,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=45)
+    except asyncio.TimeoutError:
+        return {"unit": unit, "ok": False, "scope": scope_name, "detail": "restart timed out"}
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"unit": unit, "ok": False, "scope": scope_name, "detail": str(exc)[:200]}
+
+    if proc.returncode == 0:
+        return {"unit": unit, "ok": True, "scope": scope_name}
+    detail = (stderr.decode(errors="replace").strip() or f"exit code {proc.returncode}")[:200]
+    return {"unit": unit, "ok": False, "scope": scope_name, "detail": detail}
+
+
+@router.post("/api/system/ai-stack/restart")
+async def restart_ai_stack(request: Request):
+    """Restart the local AI inference stack (rkllama + qmd) -- issue #1743.
+
+    A recovery action for edge devices where a model stalls (endless NPU
+    generation, unresponsive inference) while the controller itself stays up.
+    Restarts the backend services without bouncing the controller or agents.
+    Admin (or host local token) only. Fails soft per service so a partial
+    recovery still reports what was restarted.
+    """
+    if not _is_admin_or_local_token(request):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    results = [await _restart_ai_unit(unit) for unit in AI_STACK_UNITS]
+    restarted = [r["unit"] for r in results if r.get("ok")]
+    failed = [r for r in results if not r.get("ok")]
+    return {
+        "status": "ok" if restarted else "failed",
+        "restarted": restarted,
+        "failed": failed,
+        "results": results,
+    }
+
+
 @router.post("/api/system/hardware/refresh")
 async def hardware_refresh(request: Request):
     """Re-probe hardware and update the cached profile.


### PR DESCRIPTION
@mandresve's third agent-window resilience request: a recovery action for when a local model stalls but the controller stays up. Today that means SSH + `sudo systemctl restart rkllama qmd`, which the reporter noted many users cannot do (no terminal on the device).

## Backend — `POST /api/system/ai-stack/restart`
Restarts the local inference backends (**rkllama**, **qmd**) without bouncing the controller or agents (that is the separate `/api/system/restart/prepare` path).
- Resolves each unit's user-vs-system systemd scope with `systemctl [--user] cat` (returns 0 iff the unit file exists), so a **dead/crashed** unit — exactly what recovery targets — is still restarted, unlike an is-active probe.
- **Fails soft per service:** a unit that is not installed, or that the service user lacks rights to restart (polkit / interactive auth), is reported rather than raised, so restarting one backend still helps when the other cannot be touched.
- **Admin-gated.** The `system` router is not gated at the router level, so the handler guards itself with the same admin-or-local-token check used for skill execution and the settings router (it runs `systemctl`, i.e. privileged).

## Frontend — Activity header
A **Restart AI Services** control opens a confirmation (it interrupts any running inference; the desktop and agents stay up), fires the restart, shows per-service results, and refreshes the Activity + loaded-models view on success. The stall banner from #1741 links here.

## Tests
- Backend: endpoint aggregation (all-ok / partial / all-fail), 403 gate for a non-admin session, and `_restart_ai_unit` scope resolution + fail-soft (user scope ok, stderr captured on failure, not-installed, no-systemd).
- Frontend: confirm-before-restart (no request until confirmed), per-service result rendering, partial-failure detail, 403 message.

## Deploy note / follow-up
Whether the restart *succeeds* depends on the service user's rights to run `systemctl restart` on these units. On hosts where rkllama/qmd are system units and taOS runs as a non-root service user, a polkit rule or sudoers entry is needed — I will verify the actual behaviour on the Pi and, if needed, add that grant to the installer as a follow-up. The endpoint already degrades gracefully and reports the permission error per service until then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Activity screen control to restart AI services directly from the UI.
  * Included a confirmation step, progress state, and a results view showing which services restarted successfully.

* **Bug Fixes**
  * Added clearer error handling for restart failures, including partial recovery details and access-denied messaging for restricted users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->