### PR TITLE
fix(agent-window,activity): fold Kilo findings from #1748/#1749

### DIFF
--- a/desktop/src/apps/ActivityApp.aiStack.test.tsx
+++ b/desktop/src/apps/ActivityApp.aiStack.test.tsx
@@ -53,7 +53,7 @@ describe("AiStackRecovery", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
-          status: "ok",
+          status: "partial",
           restarted: ["rkllama.service"],
           failed: [{ unit: "qmd.service", ok: false, detail: "Interactive authentication required" }],
           results: [
@@ -67,9 +67,13 @@ describe("AiStackRecovery", () => {
     render(<AiStackRecovery />);
     fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
     fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+    // Partial recovery must not read as full success: amber heading + the
+    // per-service failure detail + the "could not be restarted" note.
     await waitFor(() =>
-      expect(screen.getByText(/interactive authentication required/i)).toBeInTheDocument(),
+      expect(screen.getByText(/some ai services restarted/i)).toBeInTheDocument(),
     );
+    expect(screen.getByText(/interactive authentication required/i)).toBeInTheDocument();
+    expect(screen.getByText(/some services could not be restarted/i)).toBeInTheDocument();
   });
 
   it("shows an admin-only message on 403", async () => {

--- a/desktop/src/apps/ActivityApp.aiStack.tsx
+++ b/desktop/src/apps/ActivityApp.aiStack.tsx
@@ -114,10 +114,15 @@ export function AiStackRecovery({ onRecovered }: { onRecovered?: () => void }) {
             {phase === "done" && result && (
               <>
                 <h3 className="text-base font-semibold flex items-center gap-2">
-                  {result.status === "ok" ? (
+                  {result.failed.length === 0 ? (
                     <>
                       <CheckCircle2 size={16} className="text-emerald-400" aria-hidden="true" />
                       AI services restarted
+                    </>
+                  ) : result.restarted.length > 0 ? (
+                    <>
+                      <AlertTriangle size={16} className="text-amber-400" aria-hidden="true" />
+                      Some AI services restarted
                     </>
                   ) : (
                     <>
@@ -142,9 +147,9 @@ export function AiStackRecovery({ onRecovered }: { onRecovered?: () => void }) {
                     </li>
                   ))}
                 </ul>
-                {result.status !== "ok" && (
+                {result.failed.length > 0 && (
                   <p className="text-xs text-shell-text-tertiary">
-                    Some services could not be restarted automatically — they may need permissions
+                    Some services could not be restarted automatically. They may need permissions
                     this device has not granted yet.
                   </p>
                 )}

--- a/desktop/src/apps/MessagesApp.stallWatch.ts
+++ b/desktop/src/apps/MessagesApp.stallWatch.ts
@@ -13,6 +13,11 @@ export interface StallWatch {
   channelId: string;
   agent: string;
   lastActivityAt: number;
+  // Id of the agent's in-flight reply message, set when its placeholder frame
+  // arrives. Deltas carry no channel_id, so this is how we scope delta bumps to
+  // the reply we are actually waiting on rather than any concurrent generation
+  // in another open channel.
+  streamId?: string;
 }
 
 export interface StallWatchChannel {

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -628,8 +628,12 @@ export function MessagesApp({
           return;
         }
         if (data.type === "thinking") {
-          // #1741: any thinking frame is live activity — keep the watch fresh.
-          setResponseWatch((w) => (w ? { ...w, lastActivityAt: Date.now() } : w));
+          // #1741: a thinking frame from the waited-on agent is live activity.
+          // Scope to that agent so a concurrent generation by another agent
+          // cannot keep a stalled watch fresh.
+          setResponseWatch((w) =>
+            w && data.slug === w.agent ? { ...w, lastActivityAt: Date.now() } : w,
+          );
           if (data.state === "start") {
             setTypingAgents((prev) => {
               const without = prev.filter((a) => a.slug !== data.slug);
@@ -663,12 +667,16 @@ export function MessagesApp({
                 notify(`${data.author_id} in #${chName}`, data.content ?? "", () => setSelectedChannel(data.channel_id));
               }
             }
-            // #1741: an agent's reply frame in the watched channel is activity.
-            if (data.author_id && data.author_id !== "user") {
-              setResponseWatch((w) =>
-                w && w.channelId === data.channel_id ? { ...w, lastActivityAt: Date.now() } : w,
-              );
-            }
+            // #1741: the waited-on agent's reply frame in the watched channel
+            // is activity. Scope to that agent (not any non-user author) so a
+            // message from another speaker in a group channel cannot mask a
+            // real stall, and record the reply id so subsequent deltas (which
+            // carry no channel_id) can be matched to this stream.
+            setResponseWatch((w) =>
+              w && w.channelId === data.channel_id && data.author_id === w.agent
+                ? { ...w, lastActivityAt: Date.now(), streamId: data.id }
+                : w,
+            );
             break;
 
           case "message_delta":
@@ -679,9 +687,14 @@ export function MessagesApp({
                   : m,
               ),
             );
-            // #1741: deltas carry no channel_id, but a delta only flows for an
-            // in-flight generation — bump the watch so streaming never trips it.
-            setResponseWatch((w) => (w ? { ...w, lastActivityAt: Date.now() } : w));
+            // #1741: bump only for the reply we are waiting on (matched by the
+            // stream id captured above), so a concurrent generation in another
+            // open channel cannot keep this watch alive.
+            setResponseWatch((w) =>
+              w && w.streamId && data.message_id === w.streamId
+                ? { ...w, lastActivityAt: Date.now() }
+                : w,
+            );
             break;
 
           case "message_state":
@@ -690,9 +703,13 @@ export function MessagesApp({
                 m.id === data.message_id ? { ...m, state: data.state } : m,
               ),
             );
-            // #1741: a terminal state means the response resolved — stop watching.
+            // #1741: a terminal state on the watched reply means it resolved.
+            // Clear only for our stream (or before any stream id was captured,
+            // as a defensive fallback), not for an unrelated channel's finish.
             if (data.state === "complete" || data.state === "error") {
-              setResponseWatch((w) => (w ? null : w));
+              setResponseWatch((w) =>
+                w && (!w.streamId || data.message_id === w.streamId) ? null : w,
+              );
             }
             break;
 

--- a/tests/test_routes_system.py
+++ b/tests/test_routes_system.py
@@ -285,7 +285,7 @@ class TestRestartAiStack:
         assert data["failed"] == []
 
     @pytest.mark.asyncio
-    async def test_partial_recovery_still_ok(self, client, monkeypatch):
+    async def test_partial_recovery_reports_partial(self, client, monkeypatch):
         monkeypatch.setattr(
             system_routes,
             "_restart_ai_unit",
@@ -295,7 +295,8 @@ class TestRestartAiStack:
             ]),
         )
         data = (await client.post("/api/system/ai-stack/restart")).json()
-        assert data["status"] == "ok"
+        # A mixed result is "partial" (not "ok"), so the UI can flag it.
+        assert data["status"] == "partial"
         assert data["restarted"] == ["rkllama.service"]
         assert len(data["failed"]) == 1
         assert data["failed"][0]["unit"] == "qmd.service"

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -165,15 +165,21 @@ async def _restart_ai_unit(unit: str) -> dict:
     if not (os.environ.get("INVOCATION_ID") or os.path.exists("/run/systemd/system")):
         return {"unit": unit, "ok": False, "detail": "systemd not available on host"}
 
+    # Resolve scope. Guarded so a missing/unusable systemctl is reported rather
+    # than raised (keeps the documented "reported, not raised" contract).
     scope_flag: list[str] | None = None
-    for candidate in (["--user"], []):
-        if await _systemctl_rc(["systemctl", *candidate, "cat", unit]) == 0:
-            scope_flag = candidate
-            break
+    try:
+        for candidate in (["--user"], []):
+            if await _systemctl_rc(["systemctl", *candidate, "cat", unit]) == 0:
+                scope_flag = candidate
+                break
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"unit": unit, "ok": False, "detail": f"systemctl unavailable: {str(exc)[:160]}"}
     if scope_flag is None:
         return {"unit": unit, "ok": False, "detail": "not installed"}
 
     scope_name = "user" if scope_flag else "system"
+    proc = None
     try:
         proc = await asyncio.create_subprocess_exec(
             "systemctl",
@@ -185,6 +191,13 @@ async def _restart_ai_unit(unit: str) -> dict:
         )
         _, stderr = await asyncio.wait_for(proc.communicate(), timeout=45)
     except asyncio.TimeoutError:
+        # Kill and reap the child so a hung systemctl is not orphaned.
+        if proc is not None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # pragma: no cover - defensive
+                pass
         return {"unit": unit, "ok": False, "scope": scope_name, "detail": "restart timed out"}
     except Exception as exc:  # pragma: no cover - defensive
         return {"unit": unit, "ok": False, "scope": scope_name, "detail": str(exc)[:200]}
@@ -203,16 +216,17 @@ async def restart_ai_stack(request: Request):
     generation, unresponsive inference) while the controller itself stays up.
     Restarts the backend services without bouncing the controller or agents.
     Admin (or host local token) only. Fails soft per service so a partial
-    recovery still reports what was restarted.
+    recovery still reports what was restarted. The units are restarted
+    concurrently so worst-case latency is one unit's timeout, not their sum.
     """
     if not _is_admin_or_local_token(request):
         return JSONResponse({"error": "forbidden"}, status_code=403)
 
-    results = [await _restart_ai_unit(unit) for unit in AI_STACK_UNITS]
+    results = list(await asyncio.gather(*(_restart_ai_unit(u) for u in AI_STACK_UNITS)))
     restarted = [r["unit"] for r in results if r.get("ok")]
     failed = [r for r in results if not r.get("ok")]
     return {
-        "status": "ok" if restarted else "failed",
+        "status": "ok" if restarted and not failed else "partial" if restarted else "failed",
         "restarted": restarted,
         "failed": failed,
         "results": results,


### PR DESCRIPTION
Folds the Kilo review findings on the two agent-window PRs (which auto-merged on green required checks before Kilo posted). All are real; fixed forward.

## Stall watch (#1741 / #1748)
- **WARNING (false-negative stall):** the watch was refreshed by *any* non-user author in the channel, so in a group/topic channel a message from another speaker kept it fresh and a genuinely stalled agent never tripped the banner. Every bump is now scoped to the waited-on agent.
- **Concurrency (suggestions):** the reply `message` frame now records its id as a stream id; `message_delta` bumps only when `message_id` matches it (deltas carry no `channel_id`, so a concurrent generation in another open channel can no longer keep the timer alive); `thinking` bumps only for `w.agent`; the terminal-state clear matches the stream.

## AI-stack recovery (#1743 / #1749)
- **WARNING x2 (partial read as success):** the endpoint returned `status: "ok"` whenever *any* unit restarted, so a partial recovery showed a green "restarted" heading and hid the failure note. Backend now returns a distinct `partial` status (`ok` only when nothing failed); the UI keys its heading and note off `failed.length` (green only when none failed, amber "Some AI services restarted" on partial).
- **Suggestions:** the `systemctl cat` scope probe is now inside the fail-soft guard (an unusable systemctl is reported, not a 500); the child process is killed and reaped on restart timeout instead of being orphaned; the two units restart concurrently via `asyncio.gather` so worst-case latency is one timeout, not their sum.

## Tests
Backend 20/20 (partial now asserts `partial`); frontend stallWatch + aiStack green (partial asserts amber heading + failure detail + note). tsc clean.