### PR TITLE
fix(agents): make the mobile Agents view readable (archived rows + header)

### DIFF
--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -488,24 +488,27 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           </span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          {/* On mobile the labels are dropped to icon-only so the two actions
+              plus the title fit without truncating "N deployed". */}
           <Button
             onClick={() => setImportWizardOpen(true)}
-            size="sm"
+            size={isMobile ? "icon" : "sm"}
             variant="outline"
+            className={isMobile ? "h-10 w-10" : undefined}
             aria-label="Import an existing agent"
           >
-            <Upload size={14} />
-            Import Agent
+            <Upload size={isMobile ? 18 : 14} />
+            {!isMobile && "Import Agent"}
           </Button>
           <Button
             onClick={() => setWizardOpen(true)}
-            size="sm"
-            className="text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0"
+            size={isMobile ? "icon" : "sm"}
+            className={`text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0${isMobile ? " h-10 w-10" : ""}`}
             style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
             aria-label="Deploy new agent"
           >
-            <Plus size={14} />
-            Deploy Agent
+            <Plus size={isMobile ? 18 : 14} />
+            {!isMobile && "Deploy Agent"}
           </Button>
         </div>
       </div>

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -494,7 +494,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
             onClick={() => setImportWizardOpen(true)}
             size={isMobile ? "icon" : "sm"}
             variant="outline"
-            className={isMobile ? "h-10 w-10" : undefined}
+            className={isMobile ? "h-11 w-11" : undefined}
             aria-label="Import an existing agent"
           >
             <Upload size={isMobile ? 18 : 14} />
@@ -503,7 +503,7 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           <Button
             onClick={() => setWizardOpen(true)}
             size={isMobile ? "icon" : "sm"}
-            className={`text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0${isMobile ? " h-10 w-10" : ""}`}
+            className={`text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0${isMobile ? " h-11 w-11" : ""}`}
             style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
             aria-label="Deploy new agent"
           >

--- a/desktop/src/apps/agents/ArchivedAgents.mobile.test.tsx
+++ b/desktop/src/apps/agents/ArchivedAgents.mobile.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ArchivedAgentRow } from "./ArchivedAgents";
+import type { ArchivedAgent } from "./types";
+
+// Force the mobile branch so we exercise the stacked layout.
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: () => true }));
+
+const entry: ArchivedAgent = {
+  id: "arch-1",
+  archived_slug: "worker-nemotron",
+  archived_at: "20260628T101500",
+  original: {
+    name: "worker-nemotron",
+    display_name: "worker-nemotron-a12",
+    color: "#ef4444",
+    emoji: "🤖",
+    framework: "hermes",
+    model: "nvidia/nemotron-3",
+  },
+} as ArchivedAgent;
+
+describe("ArchivedAgentRow (mobile)", () => {
+  it("shows the full agent name, model, and archived date without starving the name", () => {
+    render(<ArchivedAgentRow entry={entry} onRestore={vi.fn()} onPurge={vi.fn()} />);
+    // The full name is present (mobile gives it its own line, not one char).
+    expect(screen.getByText("worker-nemotron-a12")).toBeInTheDocument();
+    expect(screen.getByText("nvidia/nemotron-3")).toBeInTheDocument();
+    expect(screen.getByText(/archived/i)).toBeInTheDocument();
+  });
+
+  it("renders restore + delete with 44px mobile tap targets", () => {
+    render(<ArchivedAgentRow entry={entry} onRestore={vi.fn()} onPurge={vi.fn()} />);
+    const restore = screen.getByRole("button", { name: /restore/i });
+    const del = screen.getByRole("button", { name: /permanently delete/i });
+    expect(restore.className).toContain("h-11");
+    expect(restore.className).toContain("w-11");
+    expect(del.className).toContain("h-11");
+    expect(del.className).toContain("w-11");
+  });
+});

--- a/desktop/src/apps/agents/ArchivedAgents.tsx
+++ b/desktop/src/apps/agents/ArchivedAgents.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Trash2, RotateCcw, ChevronRight, Archive } from "lucide-react";
 import { resolveAgentEmoji } from "@/lib/agent-emoji";
 import { Button, Card } from "@/components/ui";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { type ArchivedAgent } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -37,11 +38,68 @@ export function ArchivedAgentRow({
   onRestore: (id: string, name: string) => void;
   onPurge: (id: string, name: string) => void;
 }) {
+  const isMobile = useIsMobile();
   const displayName = entry.original?.display_name || entry.original?.name || entry.archived_slug;
   const color = entry.original?.color || "#6b7280";
   const emoji = resolveAgentEmoji(entry.original?.emoji, entry.original?.framework);
   const model = entry.original?.model;
   const when = relativeTimeFromTs(entry.archived_at);
+
+  const restoreButton = (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={`${isMobile ? "h-11 w-11" : "h-8 w-8"} hover:bg-emerald-500/15 hover:text-emerald-400`}
+      onClick={() => onRestore(entry.id, displayName)}
+      aria-label={`Restore ${displayName}`}
+      title="Restore agent"
+    >
+      <RotateCcw size={isMobile ? 18 : 15} />
+    </Button>
+  );
+  const deleteButton = (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={`${isMobile ? "h-11 w-11" : "h-8 w-8"} hover:bg-red-500/15 hover:text-red-400`}
+      onClick={() => onPurge(entry.id, displayName)}
+      aria-label={`Permanently delete ${displayName}`}
+      title="Delete permanently"
+    >
+      <Trash2 size={isMobile ? 18 : 15} />
+    </Button>
+  );
+
+  // Mobile: stack so the agent name gets the full row width instead of being
+  // starved to one character by the model + date + actions competing on a
+  // single line. Name on its own line; model and archived-date sit below it.
+  if (isMobile) {
+    return (
+      <Card className="flex items-start gap-3 px-3 py-3 opacity-80">
+        <div className="flex items-center gap-2 shrink-0 pt-1">
+          <span
+            className="w-2.5 h-2.5 rounded-full shrink-0"
+            style={{ backgroundColor: color }}
+            aria-hidden
+          />
+          <span className="text-lg leading-none shrink-0" aria-hidden="true">
+            {emoji}
+          </span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="font-medium text-sm truncate">{displayName}</div>
+          {model && (
+            <div className="text-[11px] text-shell-text-tertiary truncate">{model}</div>
+          )}
+          <div className="text-[11px] text-shell-text-tertiary">archived {when}</div>
+        </div>
+        <div className="flex items-center gap-0.5 shrink-0">
+          {restoreButton}
+          {deleteButton}
+        </div>
+      </Card>
+    );
+  }
 
   return (
     <Card className="flex items-center gap-4 px-4 py-3 hover:bg-shell-surface/50 transition-colors opacity-80">
@@ -61,26 +119,8 @@ export function ArchivedAgentRow({
       </div>
       <span className="text-xs text-shell-text-tertiary shrink-0">archived {when}</span>
       <div className="flex items-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 hover:bg-emerald-500/15 hover:text-emerald-400"
-          onClick={() => onRestore(entry.id, displayName)}
-          aria-label={`Restore ${displayName}`}
-          title="Restore agent"
-        >
-          <RotateCcw size={15} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 hover:bg-red-500/15 hover:text-red-400"
-          onClick={() => onPurge(entry.id, displayName)}
-          aria-label={`Permanently delete ${displayName}`}
-          title="Delete permanently"
-        >
-          <Trash2 size={15} />
-        </Button>
+        {restoreButton}
+        {deleteButton}
       </div>
     </Card>
   );


### PR DESCRIPTION
Reported from mobile: the Agents view is not mobile-friendly. Agent names in the Archived list collapse to a single character ("t...", "wkr...").

## Root cause
`agents/ArchivedAgents.tsx` had **no mobile branch** (unlike the live `AgentRow`, which does). Each archived row crammed status dot + emoji + name + model + "archived DD/MM/YYYY" + restore + delete onto one `flex items-center` line. With the name and model as two `truncate` siblings competing against the fixed-width date and two icon buttons, the flexbox shrank the name to its minimum on a narrow screen.

## Changes
- **Archived rows (mobile):** stacked layout. The agent name gets its own full-width line; model and archived-date sit below it (muted); restore/delete become 44px tap targets. Desktop one-line layout unchanged.
- **Header (mobile):** the Import/Deploy buttons drop their text labels to icon-only (44px, keeping aria-labels), so title + both actions fit and "N deployed" no longer truncates.
- Left as-is (already responsive): the **Registry** and **Base Images** panels use `flex-wrap` + `min-w-0`, and the **live agent card** already has a mobile branch.

## Tests
New `ArchivedAgents.mobile` unit test (mocks `useIsMobile`): full name + model + date present, restore/delete carry the 44px classes. tsc clean.

## Verification
Visual check on the Pi at mobile width (both themes, with real archived agents) is still to do once this lands on dev; I will screenshot-verify then and follow up if anything in the wizards/detail flow needs the same treatment.