### PR TITLE
fix(mobile): reflow broken app layouts on phones (mobile pass, batch 1)

### DIFF
--- a/desktop/src/apps/MailApp/MailApp.module.css
+++ b/desktop/src/apps/MailApp/MailApp.module.css
@@ -589,6 +589,15 @@
   padding: 0 16px;
   border-bottom: 1px solid var(--ml-border);
 }
+/* On a phone the full action set (back/reply/reply-all/forward/archive/delete/
+   share/more) overflows one 48px row, so allow it to wrap. */
+@media (max-width: 767px) {
+  .readToolbar {
+    height: auto;
+    flex-wrap: wrap;
+    padding: 6px 12px;
+  }
+}
 .tbtn {
   display: flex;
   align-items: center;

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -251,7 +251,7 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
   return (
     <div className="flex h-full flex-col overflow-hidden bg-shell-bg">
       {/* Header + global steer */}
-      <div className="flex items-center gap-2 border-b border-shell-border px-5 py-4">
+      <div className="flex flex-wrap items-center gap-2 gap-y-2 border-b border-shell-border px-5 py-4">
         <Radar size={18} className="text-accent" />
         <h1 className="text-base font-semibold text-shell-text">Observatory</h1>
         {health && health.total > 0 && (
@@ -318,7 +318,7 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
       )}
 
       {/* Steer: global concurrency cap (volume knob alongside the pause switch) */}
-      <div className="flex items-center gap-3 border-b border-shell-border px-5 py-2.5">
+      <div className="flex flex-wrap items-center gap-3 gap-y-1.5 border-b border-shell-border px-5 py-2.5">
         <span className="text-xs font-medium uppercase tracking-wide text-shell-text-tertiary">
           Concurrency cap
         </span>
@@ -365,7 +365,7 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
               return (
                 <li
                   key={a.handle + (a.holds?.task_id ?? "")}
-                  className="flex items-center gap-3 rounded-xl border border-shell-border bg-shell-surface px-4 py-3"
+                  className="flex flex-wrap items-center gap-3 gap-y-2 rounded-xl border border-shell-border bg-shell-surface px-4 py-3"
                 >
                   <CircleDot
                     size={14}

--- a/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
@@ -103,8 +103,8 @@ export function AddAgentDialog({
   };
 
   return createPortal(
-    <div role="dialog" aria-modal="true" aria-label="Add agent" className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <form onSubmit={onSubmit} className="bg-zinc-900 p-4 rounded shadow w-[26rem] space-y-3">
+    <div role="dialog" aria-modal="true" aria-label="Add agent" className="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+      <form onSubmit={onSubmit} className="bg-zinc-900 p-4 rounded shadow w-full max-w-md space-y-3">
         <h3 className="text-lg font-semibold">Add agent</h3>
 
         <fieldset className="border border-zinc-800 p-2 rounded">

--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -24,6 +24,7 @@ import {
   Switch,
 } from "@/components/ui";
 import { useShortcuts } from "@/hooks/use-shortcut-registry";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useThemeStore } from "@/stores/theme-store";
 import { useDockStore } from "@/stores/dock-store";
 import { ThemesPanel } from "@/apps/SettingsApp/ThemesPanel";
@@ -771,7 +772,9 @@ export function SettingsApp({ windowId: _windowId, section: initialSection }: { 
     return () => { cancelled = true; };
   }, []);
 
-  const isMobile = typeof window !== "undefined" && window.innerWidth < 640;
+  // Reactive + app-standard 768px breakpoint (was a one-shot innerWidth < 640
+  // read that never updated on resize/rotate).
+  const isMobile = useIsMobile();
 
   const visibleSections = isAdmin ? SECTIONS : SECTIONS.filter((s) => !ADMIN_ONLY.has(s.id));
   const effectiveSection: Section =

--- a/desktop/src/apps/SettingsApp/ThemesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/ThemesPanel.tsx
@@ -66,7 +66,7 @@ export function ThemesPanel() {
 
   return (
     <section aria-label="Themes">
-      <div className="flex items-center justify-between mb-5 gap-3">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-5 gap-3">
         <div>
           <h2 className="text-lg font-semibold">Themes</h2>
           <p className="text-sm text-shell-text-tertiary mt-0.5">

--- a/desktop/src/apps/StoreApp/MobileStore.tsx
+++ b/desktop/src/apps/StoreApp/MobileStore.tsx
@@ -84,7 +84,7 @@ function GetButton({
       onClick={handleGet}
       disabled={busy}
       aria-label={failed ? `Retry installing ${app.name}` : `Get ${app.name}`}
-      className={`shrink-0 min-w-[68px] h-7 inline-flex items-center justify-center rounded-full text-[13px] font-bold tracking-wide active:scale-[0.94] transition-transform ${
+      className={`shrink-0 min-w-[68px] h-9 inline-flex items-center justify-center rounded-full text-[13px] font-bold tracking-wide active:scale-[0.94] transition-transform ${
         failed
           ? "bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/40"
           : "bg-shell-surface-active text-shell-text"

--- a/desktop/src/apps/TasksApp.tsx
+++ b/desktop/src/apps/TasksApp.tsx
@@ -366,7 +366,7 @@ export function TasksApp({ windowId: _windowId }: { windowId: string }) {
                             {task.agent_name || "\u2014"}
                           </span>
                         </div>
-                        <div className="flex items-center gap-3 mt-1 text-xs text-shell-text-tertiary">
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1 text-xs text-shell-text-tertiary">
                           <span className="font-mono">{task.schedule}</span>
                           <span className="font-mono truncate max-w-[200px]">{task.command}</span>
                           <span className="tabular-nums">

--- a/desktop/src/apps/images/EditView.tsx
+++ b/desktop/src/apps/images/EditView.tsx
@@ -464,7 +464,7 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
         </div>
 
         {/* options panel */}
-        <div className="flex w-[286px] flex-none flex-col gap-[18px] overflow-auto border-l border-shell-border p-[18px]">
+        <div className="flex w-full md:w-[286px] flex-none flex-col gap-[18px] overflow-auto border-t md:border-t-0 md:border-l border-shell-border p-[18px]">
           <div className="flex items-center gap-2.5 text-[15px] font-bold tracking-[-0.01em]">
             <def.icon size={18} className="text-accent" />
             {def.title}

--- a/desktop/src/apps/images/EditView.tsx
+++ b/desktop/src/apps/images/EditView.tsx
@@ -379,10 +379,10 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
         </span>
       </div>
 
-      <div className="flex min-h-0 flex-1">
-        {/* tool rail */}
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+        {/* tool rail — horizontal scroller on mobile, vertical rail on desktop */}
         <div
-          className="flex w-[78px] flex-none flex-col items-center gap-1 border-r border-shell-border bg-shell-bg-deep py-3"
+          className="flex w-full md:w-[78px] flex-none flex-row md:flex-col items-center gap-1 overflow-x-auto md:overflow-x-visible border-b md:border-b-0 md:border-r border-shell-border bg-shell-bg-deep px-2 py-2 md:px-0 md:py-3"
           role="tablist"
           aria-label="Edit tools"
         >

--- a/desktop/src/apps/images/LibraryView.tsx
+++ b/desktop/src/apps/images/LibraryView.tsx
@@ -82,11 +82,11 @@ export function LibraryView({
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         {/* grid */}
         <div
-          className={`grid flex-1 content-start gap-3.5 overflow-auto p-[22px] ${
-            selected ? "grid-cols-3" : "grid-cols-4"
+          className={`grid flex-1 content-start gap-3.5 overflow-auto p-[22px] grid-cols-2 sm:grid-cols-3 ${
+            selected ? "md:grid-cols-3" : "md:grid-cols-4"
           }`}
         >
           {loading ? (
@@ -137,7 +137,7 @@ export function LibraryView({
 
         {/* detail pane */}
         {selected && (
-          <div className="flex w-[300px] flex-none flex-col gap-4 overflow-auto border-l border-shell-border p-[18px]">
+          <div className="flex w-full md:w-[300px] flex-none flex-col gap-4 overflow-auto border-t md:border-t-0 md:border-l border-shell-border p-[18px]">
             <div className="aspect-square overflow-hidden rounded-2xl border border-shell-border bg-shell-bg-deep">
               {selected.url ? (
                 <img


### PR DESCRIPTION
A general mobile-friendliness pass, following the Agents-view fix (#1751). I audited the apps for the same bug class (fixed horizontal rows/columns that do not reflow, fixed-width panels, non-wrapping toolbars, sub-40px primary tap targets) and fixed the layouts that genuinely break at ~390px.

## Fixed (HIGH: layout actually breaks)
- **images/EditView** — three fixed side-by-side columns (78px tool rail + canvas + 286px options) overflowed a phone before the canvas got any width. Now stacks on mobile; tool rail becomes a horizontal scroller; options panel `w-full md:w-[286px]`.
- **images/LibraryView** — 300px detail pane sat beside the grid with no stacking; grid columns hardcoded. Pane stacks below on mobile; grid steps 2/3/4 across breakpoints.
- **TasksApp** — task metadata (schedule + command + full datetime) was one non-wrapping line competing with 3 action buttons; now wraps.
- **ObservatoryApp** — header, concurrency-cap bar, and fleet rows wrap instead of overflowing/starving the agent handle.
- **ProjectsApp/AddAgentDialog** — fixed `w-[26rem]` form overflowed a phone (scrim had no padding); now `w-full max-w-md` + scrim `p-4`.
- **MailApp reading toolbar** — full action set overflowed one 48px row; wraps under 768px.

## Fixed (correctness + tap target)
- **SettingsApp** — replaced a one-shot `window.innerWidth < 640` read (never updated on resize/rotate, wrong breakpoint) with the reactive `useIsMobile()` hook.
- **SettingsApp/ThemesPanel** — header stacks on mobile so the long assistant button stops colliding with the title.
- **StoreApp/MobileStore** — primary Get/install button 28px → 36px.

## Deferred to batch 2 (documented, not lost)
Remaining sub-40px **secondary** tap targets (Models delete, Secrets/Cluster/MCP/Projects controls) and the advanced LibraryApp rules-table overflow wrapper. These are usable today, just not ideal.

## Verified
tsc clean; images/Store/Settings test suites green (98 tests). Visual check on the Pi at mobile width (both themes) to follow once this + the Agents PR are on dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed responsive layouts across Mail, Observatory, Projects, Settings, Tasks, Images, and Store for smoother wrapping and spacing on smaller screens.
  * Updated the image editor and library views to switch appropriately between mobile and desktop, including grid and pane/rail behavior.
* **Bug Fixes**
  * Prevented narrow-screen overflow in the Mail reading toolbar and task/metadata rows.
  * Improved dialog sizing and increased Store “Get/Retry” button height for better touch usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->