### PR TITLE
release: 1.0.0-beta.38 (agent-window resilience + mobile-friendliness)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.38] - 2026-07-08
+
+### Added
+- The Agent conversation window now shows a live activity banner when a response is slow or has stalled. If no output arrives for a while it surfaces a "taking longer than usual" hint, escalating to a "may be stalled" warning with a shortcut to restart the AI services, so a stuck generation no longer looks like a frozen window. Requested by @mandresve (#1741).
+- A "Restart AI Services" action in the Activity tab restarts the local inference backends (rkllama and qmd) without bouncing the controller or your agents, for recovering a stalled model on an edge device without a terminal. It asks for confirmation first and reports the result per service. Requested by @mandresve (#1743).
+
+### Fixed
+- The Agent conversation window now scrolls when a conversation is longer than the visible area, so long responses and logs stay reachable instead of pushing earlier content out of view. Reported by @mandresve (#1742).
+- The Agents view is now readable on a phone. Archived agent rows stack so the agent name is no longer squeezed to a single character, and the header condenses so nothing truncates.
+- Several other app views now reflow correctly on a phone instead of overflowing: the Images studio edit and library panels, the Tasks and Observatory lists, the add-agent dialog, and the Mail reading toolbar.
+
 ## [1.0.0-beta.37] - 2026-07-08
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.37",
+  "version": "1.0.0-beta.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.37",
+      "version": "1.0.0-beta.38",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.37",
+  "version": "1.0.0-beta.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.37"
+__version__ = "1.0.0-beta.38"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b37"
+version = "1.0.0b38"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Cuts beta.38 to ship the agent-window resilience trio and the mobile-friendliness pass now sitting on dev.

Included since beta.37:
- #1748 agent-window scrollbars (#1742) + stall detection (#1741)
- #1749 Restart AI Services recovery action (#1743)
- #1750 folded Kilo findings on the above
- #1751 mobile Agents view (archived rows + header)
- #1752 mobile pass batch 1 (Images/Tasks/Observatory/add-agent dialog/Mail)

Version bumped across pyproject, __init__, desktop package.json + lock, uv.lock (1.0.0b38), CHANGELOG (em-dash-free). Version-lock test green, doc-gate clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an activity banner for Agent conversations to better indicate when responses are slow or stalled.
  * Added a “Restart AI Services” action in the Activity view with confirmation and status feedback.

* **Bug Fixes**
  * Improved automatic scrolling in long Agent conversations.
  * Fixed layout issues on phones and various view/toolbars, including image, task, observatory, agent, and mail screens.

* **Chores**
  * Updated the app version to 1.0.0-beta.38.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->