### PR TITLE
release: promote 1.0.0-beta.38 to master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.38] - 2026-07-08
+
+### Added
+- The Agent conversation window now shows a live activity banner when a response is slow or has stalled. If no output arrives for a while it surfaces a "taking longer than usual" hint, escalating to a "may be stalled" warning with a shortcut to restart the AI services, so a stuck generation no longer looks like a frozen window. Requested by @mandresve (#1741).
+- A "Restart AI Services" action in the Activity tab restarts the local inference backends (rkllama and qmd) without bouncing the controller or your agents, for recovering a stalled model on an edge device without a terminal. It asks for confirmation first and reports the result per service. Requested by @mandresve (#1743).
+
+### Fixed
+- The Agent conversation window now scrolls when a conversation is longer than the visible area, so long responses and logs stay reachable instead of pushing earlier content out of view. Reported by @mandresve (#1742).
+- The Agents view is now readable on a phone. Archived agent rows stack so the agent name is no longer squeezed to a single character, and the header condenses so nothing truncates.
+- Several other app views now reflow correctly on a phone instead of overflowing: the Images studio edit and library panels, the Tasks and Observatory lists, the add-agent dialog, and the Mail reading toolbar.
+
 ## [1.0.0-beta.37] - 2026-07-08
 
 ### Fixed

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.37",
+  "version": "1.0.0-beta.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.37",
+      "version": "1.0.0-beta.38",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.37",
+  "version": "1.0.0-beta.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/apps/ActivityApp.aiStack.test.tsx
+++ b/desktop/src/apps/ActivityApp.aiStack.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AiStackRecovery } from "./ActivityApp.aiStack";
+
+describe("AiStackRecovery", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requires confirmation before restarting", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    render(<AiStackRecovery />);
+    fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
+    // The confirm dialog is shown; no request has been made yet.
+    expect(screen.getByText(/restart ai services\?/i)).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts the restart and reports per-service results on confirm", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "ok",
+          restarted: ["rkllama.service", "qmd.service"],
+          failed: [],
+          results: [
+            { unit: "rkllama.service", ok: true, scope: "user" },
+            { unit: "qmd.service", ok: true, scope: "system" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const onRecovered = vi.fn();
+    render(<AiStackRecovery onRecovered={onRecovered} />);
+    fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+
+    await waitFor(() => expect(screen.getByText(/ai services restarted/i)).toBeInTheDocument());
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/system/ai-stack/restart",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(onRecovered).toHaveBeenCalled();
+    expect(screen.getByText("rkllama")).toBeInTheDocument();
+    expect(screen.getByText("qmd")).toBeInTheDocument();
+  });
+
+  it("surfaces a per-service failure detail on partial recovery", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "ok",
+          restarted: ["rkllama.service"],
+          failed: [{ unit: "qmd.service", ok: false, detail: "Interactive authentication required" }],
+          results: [
+            { unit: "rkllama.service", ok: true, scope: "user" },
+            { unit: "qmd.service", ok: false, detail: "Interactive authentication required" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    render(<AiStackRecovery />);
+    fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/interactive authentication required/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows an admin-only message on 403", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "forbidden" }), { status: 403 }),
+    );
+    render(<AiStackRecovery />);
+    fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+    await waitFor(() => expect(screen.getByText(/admin access is required/i)).toBeInTheDocument());
+  });
+});

--- a/desktop/src/apps/ActivityApp.aiStack.test.tsx
+++ b/desktop/src/apps/ActivityApp.aiStack.test.tsx
@@ -53,7 +53,7 @@ describe("AiStackRecovery", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
-          status: "ok",
+          status: "partial",
           restarted: ["rkllama.service"],
           failed: [{ unit: "qmd.service", ok: false, detail: "Interactive authentication required" }],
           results: [
@@ -67,9 +67,13 @@ describe("AiStackRecovery", () => {
     render(<AiStackRecovery />);
     fireEvent.click(screen.getByRole("button", { name: /restart ai services/i }));
     fireEvent.click(screen.getByRole("button", { name: /^restart$/i }));
+    // Partial recovery must not read as full success: amber heading + the
+    // per-service failure detail + the "could not be restarted" note.
     await waitFor(() =>
-      expect(screen.getByText(/interactive authentication required/i)).toBeInTheDocument(),
+      expect(screen.getByText(/some ai services restarted/i)).toBeInTheDocument(),
     );
+    expect(screen.getByText(/interactive authentication required/i)).toBeInTheDocument();
+    expect(screen.getByText(/some services could not be restarted/i)).toBeInTheDocument();
   });
 
   it("shows an admin-only message on 403", async () => {

--- a/desktop/src/apps/ActivityApp.aiStack.tsx
+++ b/desktop/src/apps/ActivityApp.aiStack.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import { Zap, Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui";
+
+// #1743: a recovery action in the Activity tab. On edge devices a local model
+// can stall (endless NPU generation, unresponsive inference) while the
+// controller stays up, and recovery previously meant SSH + `systemctl restart
+// rkllama qmd`. This restarts those backend services from the UI, with a
+// confirmation first since it interrupts any running inference.
+
+interface UnitResult {
+  unit: string;
+  ok?: boolean;
+  scope?: string;
+  detail?: string;
+}
+
+interface RestartResponse {
+  status: string;
+  restarted: string[];
+  failed: UnitResult[];
+  results: UnitResult[];
+}
+
+type Phase = "idle" | "confirm" | "running" | "done" | "error";
+
+const unitLabel = (unit: string) => unit.replace(/\.service$/, "");
+
+export function AiStackRecovery({ onRecovered }: { onRecovered?: () => void }) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [result, setResult] = useState<RestartResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async () => {
+    setPhase("running");
+    setError(null);
+    try {
+      const r = await fetch("/api/system/ai-stack/restart", { method: "POST" });
+      const body = await r.json().catch(() => null);
+      if (r.status === 403) {
+        setError("Admin access is required to restart AI services.");
+        setPhase("error");
+        return;
+      }
+      if (!r.ok || !body) {
+        setError((body && body.error) || "The restart request failed.");
+        setPhase("error");
+        return;
+      }
+      setResult(body as RestartResponse);
+      setPhase("done");
+      onRecovered?.();
+    } catch (e) {
+      setError((e as Error).message || "Network error");
+      setPhase("error");
+    }
+  };
+
+  const close = () => {
+    setPhase("idle");
+    setResult(null);
+    setError(null);
+  };
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setPhase("confirm")}
+        aria-label="Restart AI services"
+        className="gap-1.5 text-shell-text-secondary hover:text-shell-text"
+      >
+        <Zap size={14} aria-hidden="true" />
+        Restart AI Services
+      </Button>
+
+      {phase !== "idle" && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Restart AI services"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+        >
+          <div className="bg-shell-surface border border-white/10 rounded-xl p-6 w-full max-w-md shadow-xl space-y-4">
+            {phase === "confirm" && (
+              <>
+                <h3 className="text-base font-semibold flex items-center gap-2">
+                  <AlertTriangle size={16} className="text-amber-400" aria-hidden="true" />
+                  Restart AI services?
+                </h3>
+                <p className="text-sm text-shell-text-secondary">
+                  This restarts the local inference backends (rkllama and qmd) and interrupts any
+                  running generation. The desktop and your agents stay up.
+                </p>
+                <div className="flex justify-end gap-2">
+                  <Button variant="outline" size="sm" onClick={close}>
+                    Cancel
+                  </Button>
+                  <Button variant="default" size="sm" onClick={run}>
+                    Restart
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {phase === "running" && (
+              <p className="text-sm flex items-center gap-2 text-shell-text-secondary">
+                <Loader2 size={16} className="animate-spin" aria-hidden="true" />
+                Restarting AI services…
+              </p>
+            )}
+
+            {phase === "done" && result && (
+              <>
+                <h3 className="text-base font-semibold flex items-center gap-2">
+                  {result.status === "ok" ? (
+                    <>
+                      <CheckCircle2 size={16} className="text-emerald-400" aria-hidden="true" />
+                      AI services restarted
+                    </>
+                  ) : (
+                    <>
+                      <AlertTriangle size={16} className="text-amber-400" aria-hidden="true" />
+                      Could not restart AI services
+                    </>
+                  )}
+                </h3>
+                <ul className="space-y-1.5 text-sm" aria-label="Restart results">
+                  {result.results.map((r) => (
+                    <li key={r.unit} className="flex items-start justify-between gap-3">
+                      <span className="text-shell-text-secondary">{unitLabel(r.unit)}</span>
+                      {r.ok ? (
+                        <span className="text-[11px] px-1.5 py-0.5 rounded bg-emerald-500/20 text-emerald-300 shrink-0">
+                          restarted
+                        </span>
+                      ) : (
+                        <span className="text-[11px] text-amber-300/90 text-right">
+                          {r.detail ?? "failed"}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+                {result.status !== "ok" && (
+                  <p className="text-xs text-shell-text-tertiary">
+                    Some services could not be restarted automatically — they may need permissions
+                    this device has not granted yet.
+                  </p>
+                )}
+                <div className="flex justify-end">
+                  <Button variant="outline" size="sm" onClick={close}>
+                    Close
+                  </Button>
+                </div>
+              </>
+            )}
+
+            {phase === "error" && (
+              <>
+                <h3 className="text-base font-semibold flex items-center gap-2">
+                  <AlertTriangle size={16} className="text-red-400" aria-hidden="true" />
+                  Restart failed
+                </h3>
+                <p className="text-sm text-shell-text-secondary">{error}</p>
+                <div className="flex justify-end">
+                  <Button variant="outline" size="sm" onClick={close}>
+                    Close
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/desktop/src/apps/ActivityApp.aiStack.tsx
+++ b/desktop/src/apps/ActivityApp.aiStack.tsx
@@ -114,10 +114,15 @@ export function AiStackRecovery({ onRecovered }: { onRecovered?: () => void }) {
             {phase === "done" && result && (
               <>
                 <h3 className="text-base font-semibold flex items-center gap-2">
-                  {result.status === "ok" ? (
+                  {result.failed.length === 0 ? (
                     <>
                       <CheckCircle2 size={16} className="text-emerald-400" aria-hidden="true" />
                       AI services restarted
+                    </>
+                  ) : result.restarted.length > 0 ? (
+                    <>
+                      <AlertTriangle size={16} className="text-amber-400" aria-hidden="true" />
+                      Some AI services restarted
                     </>
                   ) : (
                     <>
@@ -142,9 +147,9 @@ export function AiStackRecovery({ onRecovered }: { onRecovered?: () => void }) {
                     </li>
                   ))}
                 </ul>
-                {result.status !== "ok" && (
+                {result.failed.length > 0 && (
                   <p className="text-xs text-shell-text-tertiary">
-                    Some services could not be restarted automatically — they may need permissions
+                    Some services could not be restarted automatically. They may need permissions
                     this device has not granted yet.
                   </p>
                 )}

--- a/desktop/src/apps/ActivityApp.tsx
+++ b/desktop/src/apps/ActivityApp.tsx
@@ -4,6 +4,7 @@ import {
   Gauge, Layers, RefreshCw, Loader2, Server,
 } from "lucide-react";
 import { Card, CardContent, Button } from "@/components/ui";
+import { AiStackRecovery } from "./ActivityApp.aiStack";
 import type { ClusterWorker } from "@/lib/cluster";
 import { workerStatus, workerHardwareSummary, workerShortIp, normalizeBackendName, STATUS_PILL_CLASS, STATUS_LABEL } from "@/lib/cluster";
 
@@ -337,9 +338,12 @@ export function ActivityApp({ windowId: _windowId }: { windowId: string }) {
             {hardware.ram_mb && ` \u00b7 ${(hardware.ram_mb / 1024).toFixed(0)} GB RAM`}
           </p>
         </div>
-        <Button variant="ghost" size="icon" onClick={fetchData} aria-label="Refresh">
-          <RefreshCw size={14} />
-        </Button>
+        <div className="flex items-center gap-1">
+          <AiStackRecovery onRecovered={fetchData} />
+          <Button variant="ghost" size="icon" onClick={fetchData} aria-label="Refresh">
+            <RefreshCw size={14} />
+          </Button>
+        </div>
       </div>
 
       {/* Grid */}

--- a/desktop/src/apps/AgentsApp.tsx
+++ b/desktop/src/apps/AgentsApp.tsx
@@ -488,24 +488,27 @@ export function AgentsApp({ windowId: _windowId }: { windowId: string }) {
           </span>
         </div>
         <div className="flex items-center gap-2 shrink-0">
+          {/* On mobile the labels are dropped to icon-only so the two actions
+              plus the title fit without truncating "N deployed". */}
           <Button
             onClick={() => setImportWizardOpen(true)}
-            size="sm"
+            size={isMobile ? "icon" : "sm"}
             variant="outline"
+            className={isMobile ? "h-11 w-11" : undefined}
             aria-label="Import an existing agent"
           >
-            <Upload size={14} />
-            Import Agent
+            <Upload size={isMobile ? 18 : 14} />
+            {!isMobile && "Import Agent"}
           </Button>
           <Button
             onClick={() => setWizardOpen(true)}
-            size="sm"
-            className="text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0"
+            size={isMobile ? "icon" : "sm"}
+            className={`text-white shadow-lg hover:shadow-xl hover:-translate-y-0.5 hover:brightness-110 border-0${isMobile ? " h-11 w-11" : ""}`}
             style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
             aria-label="Deploy new agent"
           >
-            <Plus size={14} />
-            Deploy Agent
+            <Plus size={isMobile ? 18 : 14} />
+            {!isMobile && "Deploy Agent"}
           </Button>
         </div>
       </div>

--- a/desktop/src/apps/MailApp/MailApp.module.css
+++ b/desktop/src/apps/MailApp/MailApp.module.css
@@ -589,6 +589,15 @@
   padding: 0 16px;
   border-bottom: 1px solid var(--ml-border);
 }
+/* On a phone the full action set (back/reply/reply-all/forward/archive/delete/
+   share/more) overflows one 48px row, so allow it to wrap. */
+@media (max-width: 767px) {
+  .readToolbar {
+    height: auto;
+    flex-wrap: wrap;
+    padding: 6px 12px;
+  }
+}
 .tbtn {
   display: flex;
   align-items: center;

--- a/desktop/src/apps/MessagesApp.stallWatch.test.ts
+++ b/desktop/src/apps/MessagesApp.stallWatch.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  pickWatchAgent,
+  computeStallInfo,
+  STALL_HINT_MS,
+  STALL_WARN_MS,
+  type StallWatch,
+} from "./MessagesApp.stallWatch";
+
+const AGENTS = ["naira", "atlas"];
+
+describe("pickWatchAgent", () => {
+  it("waits on the agent in a DM", () => {
+    expect(
+      pickWatchAgent({ id: "c1", type: "dm", members: ["user", "naira"] }, "hi", AGENTS),
+    ).toBe("naira");
+  });
+
+  it("returns null for a human-only DM", () => {
+    expect(
+      pickWatchAgent({ id: "c1", type: "dm", members: ["user", "bob"] }, "hi", AGENTS),
+    ).toBeNull();
+  });
+
+  it("waits only on an @mentioned agent in a non-DM channel", () => {
+    const chan = { id: "c2", type: "topic", members: ["user", "naira", "atlas"] };
+    expect(pickWatchAgent(chan, "hey @atlas can you help", AGENTS)).toBe("atlas");
+  });
+
+  it("does not wait in a non-DM channel with no mention", () => {
+    const chan = { id: "c2", type: "topic", members: ["user", "naira"] };
+    expect(pickWatchAgent(chan, "just chatting", AGENTS)).toBeNull();
+  });
+
+  it("ignores a mentioned name that is not a known agent", () => {
+    const chan = { id: "c2", type: "topic", members: ["user", "naira"] };
+    expect(pickWatchAgent(chan, "@bob hello", AGENTS)).toBeNull();
+  });
+
+  it("returns null when there is no channel", () => {
+    expect(pickWatchAgent(undefined, "hi", AGENTS)).toBeNull();
+  });
+});
+
+describe("computeStallInfo", () => {
+  const watch: StallWatch = { channelId: "c1", agent: "naira", lastActivityAt: 0 };
+
+  it("stays silent while activity is recent", () => {
+    expect(computeStallInfo(watch, "c1", STALL_HINT_MS - 1)).toBeNull();
+  });
+
+  it("shows the soft hint after the hint threshold", () => {
+    const info = computeStallInfo(watch, "c1", STALL_HINT_MS + 5_000);
+    expect(info).toEqual({ agent: "naira", seconds: 25, stalled: false });
+  });
+
+  it("escalates to a stalled warning at the warn threshold", () => {
+    const info = computeStallInfo(watch, "c1", STALL_WARN_MS);
+    expect(info?.stalled).toBe(true);
+  });
+
+  it("returns null when the watch is for another channel", () => {
+    expect(computeStallInfo(watch, "c2", STALL_WARN_MS)).toBeNull();
+  });
+
+  it("returns null when there is no watch", () => {
+    expect(computeStallInfo(null, "c1", STALL_WARN_MS)).toBeNull();
+  });
+});

--- a/desktop/src/apps/MessagesApp.stallWatch.ts
+++ b/desktop/src/apps/MessagesApp.stallWatch.ts
@@ -13,6 +13,11 @@ export interface StallWatch {
   channelId: string;
   agent: string;
   lastActivityAt: number;
+  // Id of the agent's in-flight reply message, set when its placeholder frame
+  // arrives. Deltas carry no channel_id, so this is how we scope delta bumps to
+  // the reply we are actually waiting on rather than any concurrent generation
+  // in another open channel.
+  streamId?: string;
 }
 
 export interface StallWatchChannel {

--- a/desktop/src/apps/MessagesApp.stallWatch.ts
+++ b/desktop/src/apps/MessagesApp.stallWatch.ts
@@ -1,0 +1,70 @@
+// Pure logic for the #1741 agent-window stall watchdog, split out of
+// MessagesApp so the escalation thresholds and the "which agent do we wait
+// for" decision can be unit-tested without rendering the full chat component.
+//
+// The chat window streams an agent reply over a WebSocket as a series of
+// deltas. If a generation stalls (endless model loop, broken stream, or a
+// missing completion event) no further frames arrive and the window would
+// otherwise look frozen with no hint. The component arms a watch on send,
+// bumps `lastActivityAt` on every inbound frame, and clears it on completion;
+// these helpers decide when to arm and what banner (if any) to show.
+
+export interface StallWatch {
+  channelId: string;
+  agent: string;
+  lastActivityAt: number;
+}
+
+export interface StallWatchChannel {
+  id: string;
+  type?: string;
+  members?: string[];
+}
+
+/**
+ * Decide which agent a send should wait on, or null if none is expected to
+ * reply. In a DM with an agent we always wait; elsewhere we only wait when an
+ * agent member is @mentioned, so human-only channels never trip the watch.
+ */
+export function pickWatchAgent(
+  channel: StallWatchChannel | undefined,
+  text: string,
+  agentNames: string[],
+): string | null {
+  if (!channel) return null;
+  const agentMembers = (channel.members ?? []).filter(
+    (m) => m !== "user" && agentNames.includes(m),
+  );
+  if (channel.type === "dm") return agentMembers[0] ?? null;
+  return agentMembers.find((m) => text.includes(`@${m}`)) ?? null;
+}
+
+export interface StallInfo {
+  agent: string;
+  seconds: number;
+  stalled: boolean;
+}
+
+// Silent for the first HINT window (healthy responses resolve well before it),
+// a soft "taking longer" hint after, an amber "may be stalled" warning at WARN.
+export const STALL_HINT_MS = 20_000;
+export const STALL_WARN_MS = 75_000;
+
+/**
+ * Derive the stall banner from the current watch, or null if nothing should
+ * show (no watch, watch belongs to another channel, or activity is recent).
+ */
+export function computeStallInfo(
+  watch: StallWatch | null,
+  selectedChannel: string | null,
+  now: number,
+): StallInfo | null {
+  if (!watch || watch.channelId !== selectedChannel) return null;
+  const elapsed = now - watch.lastActivityAt;
+  if (elapsed < STALL_HINT_MS) return null;
+  return {
+    agent: watch.agent,
+    seconds: Math.floor(elapsed / 1000),
+    stalled: elapsed >= STALL_WARN_MS,
+  };
+}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -628,8 +628,12 @@ export function MessagesApp({
           return;
         }
         if (data.type === "thinking") {
-          // #1741: any thinking frame is live activity — keep the watch fresh.
-          setResponseWatch((w) => (w ? { ...w, lastActivityAt: Date.now() } : w));
+          // #1741: a thinking frame from the waited-on agent is live activity.
+          // Scope to that agent so a concurrent generation by another agent
+          // cannot keep a stalled watch fresh.
+          setResponseWatch((w) =>
+            w && data.slug === w.agent ? { ...w, lastActivityAt: Date.now() } : w,
+          );
           if (data.state === "start") {
             setTypingAgents((prev) => {
               const without = prev.filter((a) => a.slug !== data.slug);
@@ -663,12 +667,16 @@ export function MessagesApp({
                 notify(`${data.author_id} in #${chName}`, data.content ?? "", () => setSelectedChannel(data.channel_id));
               }
             }
-            // #1741: an agent's reply frame in the watched channel is activity.
-            if (data.author_id && data.author_id !== "user") {
-              setResponseWatch((w) =>
-                w && w.channelId === data.channel_id ? { ...w, lastActivityAt: Date.now() } : w,
-              );
-            }
+            // #1741: the waited-on agent's reply frame in the watched channel
+            // is activity. Scope to that agent (not any non-user author) so a
+            // message from another speaker in a group channel cannot mask a
+            // real stall, and record the reply id so subsequent deltas (which
+            // carry no channel_id) can be matched to this stream.
+            setResponseWatch((w) =>
+              w && w.channelId === data.channel_id && data.author_id === w.agent
+                ? { ...w, lastActivityAt: Date.now(), streamId: data.id }
+                : w,
+            );
             break;
 
           case "message_delta":
@@ -679,9 +687,14 @@ export function MessagesApp({
                   : m,
               ),
             );
-            // #1741: deltas carry no channel_id, but a delta only flows for an
-            // in-flight generation — bump the watch so streaming never trips it.
-            setResponseWatch((w) => (w ? { ...w, lastActivityAt: Date.now() } : w));
+            // #1741: bump only for the reply we are waiting on (matched by the
+            // stream id captured above), so a concurrent generation in another
+            // open channel cannot keep this watch alive.
+            setResponseWatch((w) =>
+              w && w.streamId && data.message_id === w.streamId
+                ? { ...w, lastActivityAt: Date.now() }
+                : w,
+            );
             break;
 
           case "message_state":
@@ -690,9 +703,13 @@ export function MessagesApp({
                 m.id === data.message_id ? { ...m, state: data.state } : m,
               ),
             );
-            // #1741: a terminal state means the response resolved — stop watching.
+            // #1741: a terminal state on the watched reply means it resolved.
+            // Clear only for our stream (or before any stream id was captured,
+            // as a defensive fallback), not for an unrelated channel's finish.
             if (data.state === "complete" || data.state === "error") {
-              setResponseWatch((w) => (w ? null : w));
+              setResponseWatch((w) =>
+                w && (!w.streamId || data.message_id === w.streamId) ? null : w,
+              );
             }
             break;
 

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -24,6 +24,8 @@ import {
   Search,
   Copy,
   Check,
+  AlertTriangle,
+  Loader2,
 } from "lucide-react";
 import {
   Button,
@@ -77,6 +79,11 @@ import {
   writeLastChannel,
 } from "./MessagesApp.a2aSelection";
 import { bucketAgentChannels } from "./MessagesApp.agentSections";
+import {
+  pickWatchAgent,
+  computeStallInfo,
+  type StallWatch,
+} from "./MessagesApp.stallWatch";
 import { displayAuthor } from "./chat/format-author";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
@@ -430,6 +437,15 @@ export function MessagesApp({
   const [typingHumans, setTypingHumans] = useState<string[]>([]);
   const [typingAgents, setTypingAgents] = useState<AgentTyping[]>([]);
   const [sendError, setSendError] = useState<string | null>(null);
+  // #1741 stall watchdog. The backend streams a reply via WS deltas, but if a
+  // generation stalls (endless model loop, broken stream, or a missing
+  // completion event) no further frames arrive and the window looks frozen with
+  // no hint. We arm a watch when the user sends to an agent and clear it on
+  // completion; `lastActivityAt` is bumped on every inbound frame so the render
+  // can surface an escalating "taking longer / may be stalled" banner once
+  // activity stops. Fast, healthy responses never trip it.
+  const [responseWatch, setResponseWatch] = useState<StallWatch | null>(null);
+  const [, bumpStallClock] = useState(0);
   const [hoveredMessageId, setHoveredMessageId] = useState<string | null>(null);
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([]);
   const [overflowMenu, setOverflowMenu] = useState<{ messageId: string; x: number; y: number } | null>(null);
@@ -612,6 +628,8 @@ export function MessagesApp({
           return;
         }
         if (data.type === "thinking") {
+          // #1741: any thinking frame is live activity — keep the watch fresh.
+          setResponseWatch((w) => (w ? { ...w, lastActivityAt: Date.now() } : w));
           if (data.state === "start") {
             setTypingAgents((prev) => {
               const without = prev.filter((a) => a.slug !== data.slug);
@@ -645,6 +663,12 @@ export function MessagesApp({
                 notify(`${data.author_id} in #${chName}`, data.content ?? "", () => setSelectedChannel(data.channel_id));
               }
             }
+            // #1741: an agent's reply frame in the watched channel is activity.
+            if (data.author_id && data.author_id !== "user") {
+              setResponseWatch((w) =>
+                w && w.channelId === data.channel_id ? { ...w, lastActivityAt: Date.now() } : w,
+              );
+            }
             break;
 
           case "message_delta":
@@ -655,6 +679,9 @@ export function MessagesApp({
                   : m,
               ),
             );
+            // #1741: deltas carry no channel_id, but a delta only flows for an
+            // in-flight generation — bump the watch so streaming never trips it.
+            setResponseWatch((w) => (w ? { ...w, lastActivityAt: Date.now() } : w));
             break;
 
           case "message_state":
@@ -663,6 +690,10 @@ export function MessagesApp({
                 m.id === data.message_id ? { ...m, state: data.state } : m,
               ),
             );
+            // #1741: a terminal state means the response resolved — stop watching.
+            if (data.state === "complete" || data.state === "error") {
+              setResponseWatch((w) => (w ? null : w));
+            }
             break;
 
           case "typing":
@@ -1051,6 +1082,37 @@ export function MessagesApp({
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
+  // #1741: drop any active watch when the user switches channels — a stall
+  // banner from a previous conversation must not bleed into another.
+  useEffect(() => {
+    setResponseWatch(null);
+  }, [selectedChannel]);
+
+  // #1741: while a watch is armed, tick once a second so the render recomputes
+  // elapsed-since-activity and the banner escalates. Only the presence of a
+  // watch (not each bump) gates the interval, so healthy streaming does not
+  // thrash it.
+  useEffect(() => {
+    if (!responseWatch) return;
+    const id = setInterval(() => bumpStallClock((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, [responseWatch !== null]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // #1741: arm the stall watch after a send if this channel has an agent that
+  // is expected to reply — always in a DM with an agent, or when an agent
+  // member is @mentioned elsewhere. Human-only channels never arm it.
+  const armResponseWatch = (text: string) => {
+    if (!currentChannel) return;
+    const agent = pickWatchAgent(
+      currentChannel,
+      text,
+      liveAgents.map((a) => a.name),
+    );
+    if (agent) {
+      setResponseWatch({ channelId: currentChannel.id, agent, lastActivityAt: Date.now() });
+    }
+  };
+
   /* ---- send message ---- */
   const sendMessage = async () => {
     const text = input.trim();
@@ -1093,6 +1155,7 @@ export function MessagesApp({
         setPendingAttachments([]);
         if (inputRef.current) inputRef.current.style.height = "auto";
         autoScrollRef.current = true;
+        armResponseWatch(text);
         return;
       } catch (e) {
         setSendError((e as Error).message || "send failed");
@@ -1163,6 +1226,7 @@ export function MessagesApp({
     setNewDividerAtId(null);
     autoScrollRef.current = true;
     if (inputRef.current) inputRef.current.style.height = "auto";
+    armResponseWatch(text);
   };
 
   /* ---- typing indicator ---- */
@@ -1421,6 +1485,10 @@ export function MessagesApp({
   const allChannels = [...channels, ...archivedChannels];
   const currentChannel = allChannels.find((c) => c.id === selectedChannel);
   const isCurrentArchived = currentChannel?.settings?.archived === true;
+  // #1741: derive the stall banner. Silent for the first 20s of no activity
+  // (healthy responses resolve well before then), a soft "taking longer" hint
+  // after, and an amber "may be stalled" warning with a recovery pointer at 75s.
+  const stallInfo = computeStallInfo(responseWatch, selectedChannel, Date.now());
 
   /* ---- slash menu derived state ---- */
   // In a DM (2 members: user + 1 agent), a leading "/" opens the agent's
@@ -2152,7 +2220,7 @@ export function MessagesApp({
           <div
             ref={messageListRef}
             onScroll={handleScroll}
-            className={`flex-1 overflow-y-auto px-4 py-3 space-y-0.5 select-text message-list-drop-target ${
+            className={`flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-0.5 select-text message-list-drop-target ${
               shellFileDropTarget.isOver
                 ? "ring-2 ring-sky-400/60 ring-inset bg-sky-500/5"
                 : shellFileDropTarget.isValidTarget
@@ -2516,6 +2584,47 @@ export function MessagesApp({
 
           {/* typing footer */}
           <TypingFooter humans={typingHumans} agents={typingAgents} selfId="user" />
+
+          {/* #1741: stall banner — surfaces only when a response is abnormally
+              slow or has gone quiet, so a stalled generation no longer looks
+              like a frozen window. */}
+          {stallInfo && (
+            <div
+              role="status"
+              className={`mx-4 mb-2 px-3 py-2 rounded-lg border text-[12px] flex items-center gap-2 shrink-0 ${
+                stallInfo.stalled
+                  ? "bg-amber-500/10 border-amber-500/25 text-amber-300/90"
+                  : "bg-white/[0.04] border-white/10 text-white/55"
+              }`}
+            >
+              {stallInfo.stalled ? (
+                <AlertTriangle size={13} aria-hidden="true" className="shrink-0" />
+              ) : (
+                <Loader2 size={13} aria-hidden="true" className="shrink-0 animate-spin" />
+              )}
+              {stallInfo.stalled ? (
+                <span className="flex-1">
+                  No response from {stallInfo.agent} for {stallInfo.seconds}s. The model may be
+                  stalled.{" "}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const a = getApp("dashboard");
+                      if (a) openWindow("dashboard", a.defaultSize);
+                    }}
+                    className="underline underline-offset-2 hover:text-amber-200"
+                  >
+                    Open Activity to restart the AI services
+                  </button>
+                  .
+                </span>
+              ) : (
+                <span className="flex-1">
+                  {stallInfo.agent} is taking longer than usual… ({stallInfo.seconds}s)
+                </span>
+              )}
+            </div>
+          )}
 
           {/* archived banner */}
           {isCurrentArchived && (

--- a/desktop/src/apps/ObservatoryApp.tsx
+++ b/desktop/src/apps/ObservatoryApp.tsx
@@ -251,7 +251,7 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
   return (
     <div className="flex h-full flex-col overflow-hidden bg-shell-bg">
       {/* Header + global steer */}
-      <div className="flex items-center gap-2 border-b border-shell-border px-5 py-4">
+      <div className="flex flex-wrap items-center gap-2 gap-y-2 border-b border-shell-border px-5 py-4">
         <Radar size={18} className="text-accent" />
         <h1 className="text-base font-semibold text-shell-text">Observatory</h1>
         {health && health.total > 0 && (
@@ -318,7 +318,7 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
       )}
 
       {/* Steer: global concurrency cap (volume knob alongside the pause switch) */}
-      <div className="flex items-center gap-3 border-b border-shell-border px-5 py-2.5">
+      <div className="flex flex-wrap items-center gap-3 gap-y-1.5 border-b border-shell-border px-5 py-2.5">
         <span className="text-xs font-medium uppercase tracking-wide text-shell-text-tertiary">
           Concurrency cap
         </span>
@@ -365,7 +365,7 @@ export function ObservatoryApp({ windowId: _windowId }: { windowId: string }) {
               return (
                 <li
                   key={a.handle + (a.holds?.task_id ?? "")}
-                  className="flex items-center gap-3 rounded-xl border border-shell-border bg-shell-surface px-4 py-3"
+                  className="flex flex-wrap items-center gap-3 gap-y-2 rounded-xl border border-shell-border bg-shell-surface px-4 py-3"
                 >
                   <CircleDot
                     size={14}

--- a/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/AddAgentDialog.tsx
@@ -103,8 +103,8 @@ export function AddAgentDialog({
   };
 
   return createPortal(
-    <div role="dialog" aria-modal="true" aria-label="Add agent" className="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <form onSubmit={onSubmit} className="bg-zinc-900 p-4 rounded shadow w-[26rem] space-y-3">
+    <div role="dialog" aria-modal="true" aria-label="Add agent" className="fixed inset-0 bg-black/50 flex items-center justify-center p-4">
+      <form onSubmit={onSubmit} className="bg-zinc-900 p-4 rounded shadow w-full max-w-md space-y-3">
         <h3 className="text-lg font-semibold">Add agent</h3>
 
         <fieldset className="border border-zinc-800 p-2 rounded">

--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -24,6 +24,7 @@ import {
   Switch,
 } from "@/components/ui";
 import { useShortcuts } from "@/hooks/use-shortcut-registry";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useThemeStore } from "@/stores/theme-store";
 import { useDockStore } from "@/stores/dock-store";
 import { ThemesPanel } from "@/apps/SettingsApp/ThemesPanel";
@@ -771,7 +772,9 @@ export function SettingsApp({ windowId: _windowId, section: initialSection }: { 
     return () => { cancelled = true; };
   }, []);
 
-  const isMobile = typeof window !== "undefined" && window.innerWidth < 640;
+  // Reactive + app-standard 768px breakpoint (was a one-shot innerWidth < 640
+  // read that never updated on resize/rotate).
+  const isMobile = useIsMobile();
 
   const visibleSections = isAdmin ? SECTIONS : SECTIONS.filter((s) => !ADMIN_ONLY.has(s.id));
   const effectiveSection: Section =

--- a/desktop/src/apps/SettingsApp/ThemesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/ThemesPanel.tsx
@@ -66,7 +66,7 @@ export function ThemesPanel() {
 
   return (
     <section aria-label="Themes">
-      <div className="flex items-center justify-between mb-5 gap-3">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-5 gap-3">
         <div>
           <h2 className="text-lg font-semibold">Themes</h2>
           <p className="text-sm text-shell-text-tertiary mt-0.5">

--- a/desktop/src/apps/StoreApp/MobileStore.tsx
+++ b/desktop/src/apps/StoreApp/MobileStore.tsx
@@ -84,7 +84,7 @@ function GetButton({
       onClick={handleGet}
       disabled={busy}
       aria-label={failed ? `Retry installing ${app.name}` : `Get ${app.name}`}
-      className={`shrink-0 min-w-[68px] h-7 inline-flex items-center justify-center rounded-full text-[13px] font-bold tracking-wide active:scale-[0.94] transition-transform ${
+      className={`shrink-0 min-w-[68px] h-9 inline-flex items-center justify-center rounded-full text-[13px] font-bold tracking-wide active:scale-[0.94] transition-transform ${
         failed
           ? "bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/40"
           : "bg-shell-surface-active text-shell-text"

--- a/desktop/src/apps/TasksApp.tsx
+++ b/desktop/src/apps/TasksApp.tsx
@@ -366,7 +366,7 @@ export function TasksApp({ windowId: _windowId }: { windowId: string }) {
                             {task.agent_name || "\u2014"}
                           </span>
                         </div>
-                        <div className="flex items-center gap-3 mt-1 text-xs text-shell-text-tertiary">
+                        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1 text-xs text-shell-text-tertiary">
                           <span className="font-mono">{task.schedule}</span>
                           <span className="font-mono truncate max-w-[200px]">{task.command}</span>
                           <span className="tabular-nums">

--- a/desktop/src/apps/agents/ArchivedAgents.mobile.test.tsx
+++ b/desktop/src/apps/agents/ArchivedAgents.mobile.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ArchivedAgentRow } from "./ArchivedAgents";
+import type { ArchivedAgent } from "./types";
+
+// Force the mobile branch so we exercise the stacked layout.
+vi.mock("@/hooks/use-is-mobile", () => ({ useIsMobile: () => true }));
+
+const entry: ArchivedAgent = {
+  id: "arch-1",
+  archived_slug: "worker-nemotron",
+  archived_at: "20260628T101500",
+  original: {
+    name: "worker-nemotron",
+    display_name: "worker-nemotron-a12",
+    color: "#ef4444",
+    emoji: "🤖",
+    framework: "hermes",
+    model: "nvidia/nemotron-3",
+  },
+} as ArchivedAgent;
+
+describe("ArchivedAgentRow (mobile)", () => {
+  it("shows the full agent name, model, and archived date without starving the name", () => {
+    render(<ArchivedAgentRow entry={entry} onRestore={vi.fn()} onPurge={vi.fn()} />);
+    // The full name is present (mobile gives it its own line, not one char).
+    expect(screen.getByText("worker-nemotron-a12")).toBeInTheDocument();
+    expect(screen.getByText("nvidia/nemotron-3")).toBeInTheDocument();
+    expect(screen.getByText(/archived/i)).toBeInTheDocument();
+  });
+
+  it("renders restore + delete with 44px mobile tap targets", () => {
+    render(<ArchivedAgentRow entry={entry} onRestore={vi.fn()} onPurge={vi.fn()} />);
+    const restore = screen.getByRole("button", { name: /restore/i });
+    const del = screen.getByRole("button", { name: /permanently delete/i });
+    expect(restore.className).toContain("h-11");
+    expect(restore.className).toContain("w-11");
+    expect(del.className).toContain("h-11");
+    expect(del.className).toContain("w-11");
+  });
+});

--- a/desktop/src/apps/agents/ArchivedAgents.tsx
+++ b/desktop/src/apps/agents/ArchivedAgents.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Trash2, RotateCcw, ChevronRight, Archive } from "lucide-react";
 import { resolveAgentEmoji } from "@/lib/agent-emoji";
 import { Button, Card } from "@/components/ui";
+import { useIsMobile } from "@/hooks/use-is-mobile";
 import { type ArchivedAgent } from "./types";
 
 /* ------------------------------------------------------------------ */
@@ -37,11 +38,68 @@ export function ArchivedAgentRow({
   onRestore: (id: string, name: string) => void;
   onPurge: (id: string, name: string) => void;
 }) {
+  const isMobile = useIsMobile();
   const displayName = entry.original?.display_name || entry.original?.name || entry.archived_slug;
   const color = entry.original?.color || "#6b7280";
   const emoji = resolveAgentEmoji(entry.original?.emoji, entry.original?.framework);
   const model = entry.original?.model;
   const when = relativeTimeFromTs(entry.archived_at);
+
+  const restoreButton = (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={`${isMobile ? "h-11 w-11" : "h-8 w-8"} hover:bg-emerald-500/15 hover:text-emerald-400`}
+      onClick={() => onRestore(entry.id, displayName)}
+      aria-label={`Restore ${displayName}`}
+      title="Restore agent"
+    >
+      <RotateCcw size={isMobile ? 18 : 15} />
+    </Button>
+  );
+  const deleteButton = (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={`${isMobile ? "h-11 w-11" : "h-8 w-8"} hover:bg-red-500/15 hover:text-red-400`}
+      onClick={() => onPurge(entry.id, displayName)}
+      aria-label={`Permanently delete ${displayName}`}
+      title="Delete permanently"
+    >
+      <Trash2 size={isMobile ? 18 : 15} />
+    </Button>
+  );
+
+  // Mobile: stack so the agent name gets the full row width instead of being
+  // starved to one character by the model + date + actions competing on a
+  // single line. Name on its own line; model and archived-date sit below it.
+  if (isMobile) {
+    return (
+      <Card className="flex items-start gap-3 px-3 py-3 opacity-80">
+        <div className="flex items-center gap-2 shrink-0 pt-1">
+          <span
+            className="w-2.5 h-2.5 rounded-full shrink-0"
+            style={{ backgroundColor: color }}
+            aria-hidden
+          />
+          <span className="text-lg leading-none shrink-0" aria-hidden="true">
+            {emoji}
+          </span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="font-medium text-sm truncate">{displayName}</div>
+          {model && (
+            <div className="text-[11px] text-shell-text-tertiary truncate">{model}</div>
+          )}
+          <div className="text-[11px] text-shell-text-tertiary">archived {when}</div>
+        </div>
+        <div className="flex items-center gap-0.5 shrink-0">
+          {restoreButton}
+          {deleteButton}
+        </div>
+      </Card>
+    );
+  }
 
   return (
     <Card className="flex items-center gap-4 px-4 py-3 hover:bg-shell-surface/50 transition-colors opacity-80">
@@ -61,26 +119,8 @@ export function ArchivedAgentRow({
       </div>
       <span className="text-xs text-shell-text-tertiary shrink-0">archived {when}</span>
       <div className="flex items-center gap-1">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 hover:bg-emerald-500/15 hover:text-emerald-400"
-          onClick={() => onRestore(entry.id, displayName)}
-          aria-label={`Restore ${displayName}`}
-          title="Restore agent"
-        >
-          <RotateCcw size={15} />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8 hover:bg-red-500/15 hover:text-red-400"
-          onClick={() => onPurge(entry.id, displayName)}
-          aria-label={`Permanently delete ${displayName}`}
-          title="Delete permanently"
-        >
-          <Trash2 size={15} />
-        </Button>
+        {restoreButton}
+        {deleteButton}
       </div>
     </Card>
   );

--- a/desktop/src/apps/images/EditView.tsx
+++ b/desktop/src/apps/images/EditView.tsx
@@ -379,10 +379,10 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
         </span>
       </div>
 
-      <div className="flex min-h-0 flex-1">
-        {/* tool rail */}
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row">
+        {/* tool rail — horizontal scroller on mobile, vertical rail on desktop */}
         <div
-          className="flex w-[78px] flex-none flex-col items-center gap-1 border-r border-shell-border bg-shell-bg-deep py-3"
+          className="flex w-full md:w-[78px] flex-none flex-row md:flex-col items-center gap-1 overflow-x-auto md:overflow-x-visible border-b md:border-b-0 md:border-r border-shell-border bg-shell-bg-deep px-2 py-2 md:px-0 md:py-3"
           role="tablist"
           aria-label="Edit tools"
         >
@@ -464,7 +464,7 @@ export function EditView({ image, onApplyAdjust, onEdited }: EditViewProps) {
         </div>
 
         {/* options panel */}
-        <div className="flex w-[286px] flex-none flex-col gap-[18px] overflow-auto border-l border-shell-border p-[18px]">
+        <div className="flex w-full md:w-[286px] flex-none flex-col gap-[18px] overflow-auto border-t md:border-t-0 md:border-l border-shell-border p-[18px]">
           <div className="flex items-center gap-2.5 text-[15px] font-bold tracking-[-0.01em]">
             <def.icon size={18} className="text-accent" />
             {def.title}

--- a/desktop/src/apps/images/LibraryView.tsx
+++ b/desktop/src/apps/images/LibraryView.tsx
@@ -82,11 +82,11 @@ export function LibraryView({
         </div>
       </div>
 
-      <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 flex-1 flex-col md:flex-row">
         {/* grid */}
         <div
-          className={`grid flex-1 content-start gap-3.5 overflow-auto p-[22px] ${
-            selected ? "grid-cols-3" : "grid-cols-4"
+          className={`grid flex-1 content-start gap-3.5 overflow-auto p-[22px] grid-cols-2 sm:grid-cols-3 ${
+            selected ? "md:grid-cols-3" : "md:grid-cols-4"
           }`}
         >
           {loading ? (
@@ -137,7 +137,7 @@ export function LibraryView({
 
         {/* detail pane */}
         {selected && (
-          <div className="flex w-[300px] flex-none flex-col gap-4 overflow-auto border-l border-shell-border p-[18px]">
+          <div className="flex w-full md:w-[300px] flex-none flex-col gap-4 overflow-auto border-t md:border-t-0 md:border-l border-shell-border p-[18px]">
             <div className="aspect-square overflow-hidden rounded-2xl border border-shell-border bg-shell-bg-deep">
               {selected.url ? (
                 <img

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.37"
+version = "1.0.0-beta.38"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tests/test_routes_system.py
+++ b/tests/test_routes_system.py
@@ -7,8 +7,10 @@ from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from httpx import ASGITransport, AsyncClient
 
 from tinyagentos.restart_orchestrator import RestartOrchestrator
+from tinyagentos.routes import system as system_routes
 
 
 # ---------------------------------------------------------------------------
@@ -235,3 +237,136 @@ class TestRestartStatus:
         assert resp.status_code == 503
         data = resp.json()
         assert "error" in data
+
+
+class _FakeProc:
+    """Minimal asyncio subprocess stand-in for _restart_ai_unit tests."""
+
+    def __init__(self, returncode: int, stderr: bytes = b""):
+        self.returncode = returncode
+        self._stderr = stderr
+
+    async def communicate(self):
+        return (b"", self._stderr)
+
+
+async def _member_client(app) -> AsyncClient:
+    """Cookie'd client for a non-admin member session (mirrors settings authz)."""
+    auth_mgr = app.state.auth
+    invite_code = auth_mgr.add_user_invite("member", "admin")
+    auth_mgr.complete_invite("member", invite_code, "Test Member", "", "memberpass123456")
+    member = auth_mgr.find_user("member")
+    token = auth_mgr.create_session(user_id=member["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+class TestRestartAiStack:
+    """POST /api/system/ai-stack/restart -- issue #1743 backend recovery."""
+
+    @pytest.mark.asyncio
+    async def test_all_ok(self, client, monkeypatch):
+        monkeypatch.setattr(
+            system_routes,
+            "_restart_ai_unit",
+            AsyncMock(side_effect=[
+                {"unit": "rkllama.service", "ok": True, "scope": "user"},
+                {"unit": "qmd.service", "ok": True, "scope": "system"},
+            ]),
+        )
+        resp = await client.post("/api/system/ai-stack/restart")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["restarted"] == ["rkllama.service", "qmd.service"]
+        assert data["failed"] == []
+
+    @pytest.mark.asyncio
+    async def test_partial_recovery_still_ok(self, client, monkeypatch):
+        monkeypatch.setattr(
+            system_routes,
+            "_restart_ai_unit",
+            AsyncMock(side_effect=[
+                {"unit": "rkllama.service", "ok": True, "scope": "user"},
+                {"unit": "qmd.service", "ok": False, "detail": "not installed"},
+            ]),
+        )
+        data = (await client.post("/api/system/ai-stack/restart")).json()
+        assert data["status"] == "ok"
+        assert data["restarted"] == ["rkllama.service"]
+        assert len(data["failed"]) == 1
+        assert data["failed"][0]["unit"] == "qmd.service"
+
+    @pytest.mark.asyncio
+    async def test_all_fail_reports_failed(self, client, monkeypatch):
+        monkeypatch.setattr(
+            system_routes,
+            "_restart_ai_unit",
+            AsyncMock(side_effect=[
+                {"unit": "rkllama.service", "ok": False, "detail": "auth required"},
+                {"unit": "qmd.service", "ok": False, "detail": "auth required"},
+            ]),
+        )
+        data = (await client.post("/api/system/ai-stack/restart")).json()
+        assert data["status"] == "failed"
+        assert data["restarted"] == []
+        assert len(data["failed"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_admin_rejected_403(self, client, app, monkeypatch):
+        # Guard should reject before any restart is attempted.
+        monkeypatch.setattr(
+            system_routes, "_restart_ai_unit", AsyncMock(return_value={"ok": True})
+        )
+        member_client = await _member_client(app)
+        try:
+            resp = await member_client.post("/api/system/ai-stack/restart")
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403
+
+
+class TestRestartAiUnit:
+    """_restart_ai_unit scope resolution + fail-soft behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_restart_user_scope_ok(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "test")  # force systemd-present path
+        # cat finds the unit in --user scope (rc 0), so restart uses --user.
+        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=0))
+        monkeypatch.setattr(
+            asyncio, "create_subprocess_exec", AsyncMock(return_value=_FakeProc(0))
+        )
+        result = await system_routes._restart_ai_unit("rkllama.service")
+        assert result == {"unit": "rkllama.service", "ok": True, "scope": "user"}
+
+    @pytest.mark.asyncio
+    async def test_restart_failure_captures_stderr(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "test")
+        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=0))
+        monkeypatch.setattr(
+            asyncio,
+            "create_subprocess_exec",
+            AsyncMock(return_value=_FakeProc(1, b"Interactive authentication required")),
+        )
+        result = await system_routes._restart_ai_unit("qmd.service")
+        assert result["ok"] is False
+        assert "Interactive authentication required" in result["detail"]
+
+    @pytest.mark.asyncio
+    async def test_not_installed_when_cat_fails_both_scopes(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "test")
+        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=1))
+        result = await system_routes._restart_ai_unit("rkllama.service")
+        assert result == {"unit": "rkllama.service", "ok": False, "detail": "not installed"}
+
+    @pytest.mark.asyncio
+    async def test_no_systemd_fails_soft(self, monkeypatch):
+        monkeypatch.delenv("INVOCATION_ID", raising=False)
+        monkeypatch.setattr(system_routes.os.path, "exists", lambda p: False)
+        result = await system_routes._restart_ai_unit("qmd.service")
+        assert result["ok"] is False
+        assert "systemd not available" in result["detail"]

--- a/tests/test_routes_system.py
+++ b/tests/test_routes_system.py
@@ -285,7 +285,7 @@ class TestRestartAiStack:
         assert data["failed"] == []
 
     @pytest.mark.asyncio
-    async def test_partial_recovery_still_ok(self, client, monkeypatch):
+    async def test_partial_recovery_reports_partial(self, client, monkeypatch):
         monkeypatch.setattr(
             system_routes,
             "_restart_ai_unit",
@@ -295,7 +295,8 @@ class TestRestartAiStack:
             ]),
         )
         data = (await client.post("/api/system/ai-stack/restart")).json()
-        assert data["status"] == "ok"
+        # A mixed result is "partial" (not "ok"), so the UI can flag it.
+        assert data["status"] == "partial"
         assert data["restarted"] == ["rkllama.service"]
         assert len(data["failed"]) == 1
         assert data["failed"][0]["unit"] == "qmd.service"

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.37"
+__version__ = "1.0.0-beta.38"

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -119,6 +119,106 @@ async def _do_restart(app_state) -> None:
         await _emit_fail(str(exc))
 
 
+# AI-stack services a recovery action restarts (issue #1743). These are the
+# local inference backends that can stall independently of the controller:
+# rkllama (NPU model server, installed as a user unit) and qmd (shared model
+# provider, a system unit). The controller itself is deliberately NOT here --
+# bouncing it is the separate /api/system/restart/prepare path.
+AI_STACK_UNITS = ("rkllama.service", "qmd.service")
+
+
+def _is_admin_or_local_token(request: Request) -> bool:
+    """True if the caller is an admin session or presented the host local token.
+
+    Restarting host services is privileged (it runs ``systemctl restart``), so
+    a plain non-admin user session must never reach it. ``AuthMiddleware`` sets
+    both signals on ``request.state`` (see
+    ``tinyagentos/routes/skill_exec.py::_is_admin_or_local_token`` for the full
+    rationale). The ``system`` router is not gated at the router level, so this
+    handler guards itself.
+    """
+    if getattr(request.state, "is_admin", False):
+        return True
+    return getattr(request.state, "via", None) == "local_token"
+
+
+async def _systemctl_rc(args: list[str]) -> int:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    await proc.wait()
+    return proc.returncode
+
+
+async def _restart_ai_unit(unit: str) -> dict:
+    """Restart one AI-stack systemd unit, resolving user vs system scope.
+
+    Fails soft: a unit that is not installed, or that the service user lacks
+    rights to restart (polkit / interactive auth), is reported rather than
+    raised, so restarting one backend still helps when the other cannot be
+    touched. Scope is resolved with ``systemctl [--user] cat`` (returns 0 iff
+    the unit file exists) so a dead/crashed unit -- exactly what recovery
+    targets -- is still restarted, unlike an is-active probe.
+    """
+    if not (os.environ.get("INVOCATION_ID") or os.path.exists("/run/systemd/system")):
+        return {"unit": unit, "ok": False, "detail": "systemd not available on host"}
+
+    scope_flag: list[str] | None = None
+    for candidate in (["--user"], []):
+        if await _systemctl_rc(["systemctl", *candidate, "cat", unit]) == 0:
+            scope_flag = candidate
+            break
+    if scope_flag is None:
+        return {"unit": unit, "ok": False, "detail": "not installed"}
+
+    scope_name = "user" if scope_flag else "system"
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "systemctl",
+            *scope_flag,
+            "restart",
+            unit,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=45)
+    except asyncio.TimeoutError:
+        return {"unit": unit, "ok": False, "scope": scope_name, "detail": "restart timed out"}
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"unit": unit, "ok": False, "scope": scope_name, "detail": str(exc)[:200]}
+
+    if proc.returncode == 0:
+        return {"unit": unit, "ok": True, "scope": scope_name}
+    detail = (stderr.decode(errors="replace").strip() or f"exit code {proc.returncode}")[:200]
+    return {"unit": unit, "ok": False, "scope": scope_name, "detail": detail}
+
+
+@router.post("/api/system/ai-stack/restart")
+async def restart_ai_stack(request: Request):
+    """Restart the local AI inference stack (rkllama + qmd) -- issue #1743.
+
+    A recovery action for edge devices where a model stalls (endless NPU
+    generation, unresponsive inference) while the controller itself stays up.
+    Restarts the backend services without bouncing the controller or agents.
+    Admin (or host local token) only. Fails soft per service so a partial
+    recovery still reports what was restarted.
+    """
+    if not _is_admin_or_local_token(request):
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    results = [await _restart_ai_unit(unit) for unit in AI_STACK_UNITS]
+    restarted = [r["unit"] for r in results if r.get("ok")]
+    failed = [r for r in results if not r.get("ok")]
+    return {
+        "status": "ok" if restarted else "failed",
+        "restarted": restarted,
+        "failed": failed,
+        "results": results,
+    }
+
+
 @router.post("/api/system/hardware/refresh")
 async def hardware_refresh(request: Request):
     """Re-probe hardware and update the cached profile.

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -165,15 +165,21 @@ async def _restart_ai_unit(unit: str) -> dict:
     if not (os.environ.get("INVOCATION_ID") or os.path.exists("/run/systemd/system")):
         return {"unit": unit, "ok": False, "detail": "systemd not available on host"}
 
+    # Resolve scope. Guarded so a missing/unusable systemctl is reported rather
+    # than raised (keeps the documented "reported, not raised" contract).
     scope_flag: list[str] | None = None
-    for candidate in (["--user"], []):
-        if await _systemctl_rc(["systemctl", *candidate, "cat", unit]) == 0:
-            scope_flag = candidate
-            break
+    try:
+        for candidate in (["--user"], []):
+            if await _systemctl_rc(["systemctl", *candidate, "cat", unit]) == 0:
+                scope_flag = candidate
+                break
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"unit": unit, "ok": False, "detail": f"systemctl unavailable: {str(exc)[:160]}"}
     if scope_flag is None:
         return {"unit": unit, "ok": False, "detail": "not installed"}
 
     scope_name = "user" if scope_flag else "system"
+    proc = None
     try:
         proc = await asyncio.create_subprocess_exec(
             "systemctl",
@@ -185,6 +191,13 @@ async def _restart_ai_unit(unit: str) -> dict:
         )
         _, stderr = await asyncio.wait_for(proc.communicate(), timeout=45)
     except asyncio.TimeoutError:
+        # Kill and reap the child so a hung systemctl is not orphaned.
+        if proc is not None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # pragma: no cover - defensive
+                pass
         return {"unit": unit, "ok": False, "scope": scope_name, "detail": "restart timed out"}
     except Exception as exc:  # pragma: no cover - defensive
         return {"unit": unit, "ok": False, "scope": scope_name, "detail": str(exc)[:200]}
@@ -203,16 +216,17 @@ async def restart_ai_stack(request: Request):
     generation, unresponsive inference) while the controller itself stays up.
     Restarts the backend services without bouncing the controller or agents.
     Admin (or host local token) only. Fails soft per service so a partial
-    recovery still reports what was restarted.
+    recovery still reports what was restarted. The units are restarted
+    concurrently so worst-case latency is one unit's timeout, not their sum.
     """
     if not _is_admin_or_local_token(request):
         return JSONResponse({"error": "forbidden"}, status_code=403)
 
-    results = [await _restart_ai_unit(unit) for unit in AI_STACK_UNITS]
+    results = list(await asyncio.gather(*(_restart_ai_unit(u) for u in AI_STACK_UNITS)))
     restarted = [r["unit"] for r in results if r.get("ok")]
     failed = [r for r in results if not r.get("ok")]
     return {
-        "status": "ok" if restarted else "failed",
+        "status": "ok" if restarted and not failed else "partial" if restarted else "failed",
         "restarted": restarted,
         "failed": failed,
         "results": results,

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b37"
+version = "1.0.0b38"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotes dev to master for the 1.0.0-beta.38 release (agent-window resilience #1741/#1742/#1743 + mobile-friendliness pass). Tag + GitHub release follow on the merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI services restart action in the Activity view, with confirmation and status feedback.
  * Added a live banner when an AI reply is taking longer than usual or appears stalled.

* **Bug Fixes**
  * Improved chat scrolling for longer conversations.
  * Fixed several mobile layout issues across Agents, Images, Tasks, Observatory, Projects, Mail, Settings, Store, and Themes views.
  * Improved archived agents display and tap target usability on phones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->