### PR TITLE
fix(rknpu): a live rkllama port is not 'installed' unless it is a managed systemd service

### DIFF
--- a/scripts/install-rkllama.sh
+++ b/scripts/install-rkllama.sh
@@ -24,16 +24,29 @@ PROJECT_DIR="${1:-$(pwd)}"
 PORT="${TAOS_RKLLAMA_PORT:-7833}"
 LEGACY_PORT=8080
 
-# 1. Idempotent short-circuit: a live rkllama already satisfies the install.
-#    Require an rkllama/Ollama-shaped /api/tags body (a "models" key), not just
-#    any HTTP 200 -- another local service on these ports must not be mistaken
-#    for an installed rkllama. Mirrors _port_responds_with_rkllama() in the
-#    Python installer.
+# 1. Idempotent short-circuit: a live AND MANAGED rkllama already satisfies the
+#    install. Two conditions, both required:
+#      (a) an rkllama/Ollama-shaped /api/tags body (a "models" key), not just any
+#          HTTP 200 -- another local service on these ports must not be mistaken
+#          for rkllama. Mirrors _port_responds_with_rkllama() in the Python installer.
+#      (b) the rkllama.service systemd unit is enabled. taOS manages backends as
+#          systemd services (boot persistence, the Activity "Restart AI Services"
+#          recovery in routes/system.py, and cluster placement/migration all
+#          depend on it). A hand-started bare process answers (a) but has no unit,
+#          which used to short-circuit the install and leave rkllama permanently
+#          unmanaged (no reboot survival, not systemctl-controllable). If the unit
+#          is missing we fall through to install-rknpu.sh, whose install_systemd_unit
+#          adopts the running instance under systemd (its ExecStartPre reaps the
+#          orphan so the unit can bind the port).
 for p in "$PORT" "$LEGACY_PORT"; do
     body="$(curl -fsS --max-time 2 "http://localhost:${p}/api/tags" 2>/dev/null || true)"
     if printf '%s' "$body" | grep -q '"models"'; then
-        echo "rkllama already running on port ${p} — nothing to install"
-        exit 0
+        if systemctl is-enabled rkllama.service >/dev/null 2>&1; then
+            echo "rkllama already running on port ${p} and managed by systemd — nothing to install"
+            exit 0
+        fi
+        echo "rkllama answers on port ${p} but is not a managed systemd service — running the installer to adopt it under systemd"
+        break
     fi
 done
 

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -121,8 +121,8 @@ async def _do_restart(app_state) -> None:
 
 # AI-stack services a recovery action restarts (issue #1743). These are the
 # local inference backends that can stall independently of the controller:
-# rkllama (NPU model server, installed as a user unit) and qmd (shared model
-# provider, a system unit). The controller itself is deliberately NOT here --
+# rkllama (NPU model server, a system unit per install-rknpu.sh) and qmd (shared
+# model provider, a system unit). The controller itself is deliberately NOT here --
 # bouncing it is the separate /api/system/restart/prepare path.
 AI_STACK_UNITS = ("rkllama.service", "qmd.service")
 


### PR DESCRIPTION
## Why
A deep-dive audit of how local model backends run once installed found the production Pi's rkllama was a **hand-started bare process** (PPID 1, launched from a login session, no systemd unit), so it had **no boot persistence** and the Activity **Restart AI Services** recovery (#1743) could not restart it (`_restart_ai_unit` returns "not installed" with no unit). qmd, by contrast, is a proper managed systemd service, so it survives reboots and is restartable.

## Root cause
The store wrapper `scripts/install-rkllama.sh` short-circuited with `exit 0` the moment any process answered `/api/tags` on 7833/8080 (a `"models"` body) — **before** delegating to `install-rknpu.sh`. So once rkllama was started by hand, the store install treated it as done and `install_systemd_unit()` was never reached: the unit could never be created, permanently.

## Fix
taOS manages backends as systemd services on purpose — boot persistence, the #1743 recovery action, and cluster placement/migration all depend on it. The idempotent short-circuit now requires **both** (a) an rkllama-shaped `/api/tags` body **and** (b) `systemctl is-enabled rkllama.service`. A live-but-unmanaged process falls through to `install-rknpu.sh`, whose `install_systemd_unit()` adopts the running instance under systemd (its `ExecStartPre` pkill reaps the orphan so the unit can bind the port). Also fixes a stale comment in `routes/system.py` (rkllama is a system unit, not a user unit).

## Scope note
This closes the trap so future installs always end managed. Converting the **already-running** Pi instance to the systemd unit is a separate operational step (documented, coordinated with Jay) since it briefly bounces the shared embeddings/rerank backend. A broader cluster-aware backend-service-management design is being written up separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the installer’s behavior when a local rkllama response is present but the service is not enabled, so setup now continues instead of stopping early.
  * Adjusted system restart handling notes to better reflect which AI stack services are included, while still excluding the controller.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->