### PR TITLE
feat(catalog): managed-backend-service manifest contract + CI lint (Phase 1.1)

### DIFF
--- a/.github/workflows/doc-gate.yml
+++ b/.github/workflows/doc-gate.yml
@@ -35,3 +35,8 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: python scripts/check_doc_gate.py diff-gate --base "origin/$BASE_REF"
+
+      - name: Managed backend manifest lint
+        run: |
+          python -m pip install --quiet pyyaml
+          python scripts/check_manifests.py managed-lint

--- a/app-catalog/services/rkllama/manifest.yaml
+++ b/app-catalog/services/rkllama/manifest.yaml
@@ -31,6 +31,13 @@ lifecycle:
   backend_type: rkllama
   default_url: http://localhost:7833
   auto_manage: true
+  # Managed as a systemd service (see scripts/install-rknpu.sh install_systemd_unit).
+  # taOS manages the unit per node: start/stop/restart default to `systemctl <verb> <unit>`.
+  unit: rkllama.service
+  scope: system
+  health:
+    url: "http://localhost:7833/api/tags"
+    expect: '"models"'
   keep_alive_minutes: 0
   start_cmd: "systemctl start rkllama"
   stop_cmd: "systemctl stop rkllama"

--- a/scripts/check_manifests.py
+++ b/scripts/check_manifests.py
@@ -34,34 +34,56 @@ GRANDFATHER: dict[str, str] = {}
 VALID_SCOPES = {"system", "user"}
 
 
-def _load(path: Path) -> dict | None:
-    try:
-        data = yaml.safe_load(path.read_text())
-    except yaml.YAMLError:
-        return None
-    return data if isinstance(data, dict) else None
-
-
 def lint_managed(root: Path) -> list[str]:
-    """Return a list of human-readable errors for the managed-service contract."""
+    """Return a list of human-readable errors for the managed-service contract.
+
+    ``lifecycle.health.expect`` is a literal substring matched against the
+    backend's health-endpoint response body (a 200 body must contain it).
+    """
     errors: list[str] = []
     services_dir = root / "services"
     for manifest in sorted(services_dir.glob("*/manifest.yaml")):
-        data = _load(manifest)
-        if data is None:
+        sid_dir = manifest.parent.name
+        # An unparseable or non-mapping manifest is an error, not a silent skip
+        # (silently skipping gave a false "clean").
+        try:
+            data = yaml.safe_load(manifest.read_text())
+        except yaml.YAMLError as exc:
+            first = str(exc).splitlines()[0] if str(exc) else "parse error"
+            errors.append(f"{sid_dir}: manifest.yaml is not valid YAML ({first[:120]})")
             continue
-        sid = str(data.get("id") or manifest.parent.name)
+        if not isinstance(data, dict):
+            errors.append(f"{sid_dir}: manifest.yaml top-level is not a mapping")
+            continue
+
+        sid = str(data.get("id") or sid_dir)
         lifecycle = data.get("lifecycle")
         if not isinstance(lifecycle, dict):
             continue
-        if lifecycle.get("auto_manage") is not True:
-            continue  # not claiming to be a managed service
+
+        auto_manage = lifecycle.get("auto_manage")
+        if not auto_manage:
+            continue  # None / False / 0 / "" -> not claiming to be managed
+
         if sid in GRANDFATHER:
             continue
 
+        # Truthy but not a real bool (e.g. quoted "true", 1) would otherwise slip
+        # past an identity check and bypass the contract -- flag it, and still
+        # enforce the rest since it is clearly meant to be managed.
+        if auto_manage is not True:
+            errors.append(
+                f"{sid}: lifecycle.auto_manage must be a boolean true, got {auto_manage!r}"
+            )
+
         missing: list[str] = []
-        if not lifecycle.get("unit"):
+        unit = lifecycle.get("unit")
+        if not unit:
             missing.append("lifecycle.unit")
+        elif not str(unit).endswith(".service"):
+            errors.append(
+                f"{sid}: lifecycle.unit '{unit}' should be a systemd unit name ending in .service"
+            )
 
         scope = lifecycle.get("scope")
         if not scope:
@@ -77,8 +99,14 @@ def lint_managed(root: Path) -> list[str]:
         else:
             if not health.get("url"):
                 missing.append("lifecycle.health.url")
-            if not health.get("expect"):
+            expect = health.get("expect")
+            if not expect:
                 missing.append("lifecycle.health.expect")
+            elif not isinstance(expect, str):
+                errors.append(
+                    f"{sid}: lifecycle.health.expect must be a string (a substring "
+                    f"matched against the health response body), got {type(expect).__name__}"
+                )
 
         if missing:
             errors.append(

--- a/scripts/check_manifests.py
+++ b/scripts/check_manifests.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Catalog manifest lints that run in CI (separate from audit-manifests.py,
+which is a one-off migration checker and is not wired into CI).
+
+Currently implements the managed-backend-service contract lint (Phase 1 of the
+cluster-aware backend service management design,
+docs/design/cluster-backend-service-management.md):
+
+    A service manifest whose ``lifecycle.auto_manage`` is true MUST declare
+    ``lifecycle.unit`` (systemd unit name), ``lifecycle.scope`` ("system" or
+    "user"), and ``lifecycle.health`` with ``url`` + ``expect``. This is what
+    lets taOS treat the backend as a managed systemd service uniformly across
+    cluster nodes (boot persistence, the Activity "Restart AI Services"
+    recovery, and placement/migration all depend on it). Without the lint a
+    backend can ship claiming auto_manage while giving taOS no unit to manage,
+    which is how the production rkllama ended up a hand-started orphan.
+
+Usage:
+    python scripts/check_manifests.py managed-lint [--root app-catalog]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# Services that declare auto_manage but are legitimately not yet a systemd unit
+# on the host (or are managed by a non-manifest installer). Empty today; add an
+# id here with a one-line reason only as a deliberate, temporary exception.
+GRANDFATHER: dict[str, str] = {}
+
+VALID_SCOPES = {"system", "user"}
+
+
+def _load(path: Path) -> dict | None:
+    try:
+        data = yaml.safe_load(path.read_text())
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def lint_managed(root: Path) -> list[str]:
+    """Return a list of human-readable errors for the managed-service contract."""
+    errors: list[str] = []
+    services_dir = root / "services"
+    for manifest in sorted(services_dir.glob("*/manifest.yaml")):
+        data = _load(manifest)
+        if data is None:
+            continue
+        sid = str(data.get("id") or manifest.parent.name)
+        lifecycle = data.get("lifecycle")
+        if not isinstance(lifecycle, dict):
+            continue
+        if lifecycle.get("auto_manage") is not True:
+            continue  # not claiming to be a managed service
+        if sid in GRANDFATHER:
+            continue
+
+        missing: list[str] = []
+        if not lifecycle.get("unit"):
+            missing.append("lifecycle.unit")
+
+        scope = lifecycle.get("scope")
+        if not scope:
+            missing.append("lifecycle.scope")
+        elif scope not in VALID_SCOPES:
+            errors.append(
+                f"{sid}: lifecycle.scope is '{scope}', must be one of {sorted(VALID_SCOPES)}"
+            )
+
+        health = lifecycle.get("health")
+        if not isinstance(health, dict):
+            missing.append("lifecycle.health")
+        else:
+            if not health.get("url"):
+                missing.append("lifecycle.health.url")
+            if not health.get("expect"):
+                missing.append("lifecycle.health.expect")
+
+        if missing:
+            errors.append(
+                f"{sid}: lifecycle.auto_manage is true but is missing "
+                f"{', '.join(missing)} (managed backends must declare their "
+                f"systemd unit + health so taOS can manage them per node)"
+            )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["managed-lint"])
+    parser.add_argument("--root", default="app-catalog", help="catalog root dir")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    errors = lint_managed(root)
+    if errors:
+        print("MANIFEST-LINT FAIL (managed-service contract):", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    print("manifest managed-lint: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_manifests.py
+++ b/tests/test_check_manifests.py
@@ -1,0 +1,100 @@
+"""Tests for the managed-service manifest contract lint
+(scripts/check_manifests.py)."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_manifests",
+    Path(__file__).resolve().parent.parent / "scripts" / "check_manifests.py",
+)
+check_manifests = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(check_manifests)  # type: ignore[union-attr]
+
+
+def _write(root: Path, sid: str, manifest: dict) -> None:
+    d = root / "services" / sid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "manifest.yaml").write_text(yaml.safe_dump(manifest))
+
+
+def _managed_ok(sid: str = "rkllama") -> dict:
+    return {
+        "id": sid,
+        "type": "service",
+        "category": "llm-runtime",
+        "lifecycle": {
+            "backend_type": "rkllama",
+            "auto_manage": True,
+            "unit": f"{sid}.service",
+            "scope": "system",
+            "health": {"url": "http://localhost:7833/api/tags", "expect": '"models"'},
+        },
+    }
+
+
+def test_valid_managed_manifest_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "rkllama", _managed_ok())
+    assert check_manifests.lint_managed(tmp_path) == []
+
+
+def test_auto_manage_without_unit_fails(tmp_path: Path) -> None:
+    m = _managed_ok()
+    del m["lifecycle"]["unit"]
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert len(errors) == 1
+    assert "lifecycle.unit" in errors[0]
+
+
+def test_auto_manage_without_health_fails(tmp_path: Path) -> None:
+    m = _managed_ok()
+    del m["lifecycle"]["health"]
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert "lifecycle.health" in errors[0]
+
+
+def test_invalid_scope_fails(tmp_path: Path) -> None:
+    m = _managed_ok()
+    m["lifecycle"]["scope"] = "root"
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("scope is 'root'" in e for e in errors)
+
+
+def test_non_managed_service_is_ignored(tmp_path: Path) -> None:
+    # auto_manage false -> not claiming managed, no unit/health required
+    m = {
+        "id": "rk-llama-cpp",
+        "type": "service",
+        "category": "llm-runtime",
+        "lifecycle": {"backend_type": "openai-compatible", "auto_manage": False},
+    }
+    _write(tmp_path, "rk-llama-cpp", m)
+    assert check_manifests.lint_managed(tmp_path) == []
+
+
+def test_service_without_lifecycle_is_ignored(tmp_path: Path) -> None:
+    _write(tmp_path, "ollama", {"id": "ollama", "type": "service"})
+    assert check_manifests.lint_managed(tmp_path) == []
+
+
+def test_grandfathered_service_is_skipped(tmp_path: Path, monkeypatch) -> None:
+    m = _managed_ok("legacy-backend")
+    del m["lifecycle"]["unit"]  # would normally fail
+    _write(tmp_path, "legacy-backend", m)
+    monkeypatch.setattr(
+        check_manifests, "GRANDFATHER", {"legacy-backend": "pre-systemd, tracked in #NNNN"}
+    )
+    assert check_manifests.lint_managed(tmp_path) == []
+
+
+def test_real_catalog_is_clean() -> None:
+    """The shipped app-catalog must pass the managed-service lint."""
+    root = Path(__file__).resolve().parent.parent / "app-catalog"
+    errors = check_manifests.lint_managed(root)
+    assert errors == [], "real catalog failed managed-lint:\n" + "\n".join(errors)

--- a/tests/test_check_manifests.py
+++ b/tests/test_check_manifests.py
@@ -93,6 +93,39 @@ def test_grandfathered_service_is_skipped(tmp_path: Path, monkeypatch) -> None:
     assert check_manifests.lint_managed(tmp_path) == []
 
 
+def test_non_bool_auto_manage_is_flagged_and_enforced(tmp_path: Path) -> None:
+    # A quoted "true" must not slip past the identity check.
+    m = _managed_ok()
+    m["lifecycle"]["auto_manage"] = "true"
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("must be a boolean true" in e for e in errors)
+
+
+def test_unparseable_yaml_is_an_error(tmp_path: Path) -> None:
+    d = tmp_path / "services" / "broken"
+    d.mkdir(parents=True)
+    (d / "manifest.yaml").write_text("id: broken\nlifecycle: {: bad")
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("not valid YAML" in e for e in errors)
+
+
+def test_unit_without_service_suffix_is_flagged(tmp_path: Path) -> None:
+    m = _managed_ok()
+    m["lifecycle"]["unit"] = "rkllama"  # missing .service
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("ending in .service" in e for e in errors)
+
+
+def test_non_string_expect_is_flagged(tmp_path: Path) -> None:
+    m = _managed_ok()
+    m["lifecycle"]["health"]["expect"] = ["models"]
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("expect must be a string" in e for e in errors)
+
+
 def test_real_catalog_is_clean() -> None:
     """The shipped app-catalog must pass the managed-service lint."""
     root = Path(__file__).resolve().parent.parent / "app-catalog"


### PR DESCRIPTION
First unit of the [cluster-aware backend service management design](../blob/dev/docs/design/cluster-backend-service-management.md). Establishes the contract that makes 'install a backend' mean 'a managed systemd service', enforced in CI so it can't drift again (the gap that let the production rkllama become a hand-started orphan).

## What
- **Contract:** a service manifest with `lifecycle.auto_manage: true` MUST declare `lifecycle.unit` (systemd unit), `lifecycle.scope` (`system`|`user`), and `lifecycle.health` (`url` + `expect`). Extends the existing `lifecycle` block rather than inventing a new one.
- **Lint:** `scripts/check_manifests.py managed-lint`, wired into `.github/workflows/doc-gate.yml`. (The existing `audit-manifests.py` is a one-off migration checker and is not in CI.)
- **Normalized rkllama** (the only `auto_manage: true` manifest today) to declare `rkllama.service` / `system` / `/api/tags` health. `auto_manage: false` backends are grandfathered (empty explicit allowlist) until a later slice flips them on with real fields.

## Tests
8 lint tests (valid / missing-unit / missing-health / bad-scope / non-managed / no-lifecycle / grandfathered / **real catalog is clean**). doc-gate clean.

## Next (same design, separate PRs)
Unit 2: node-local backend service manager in the worker agent (ensure/self-heal/start/stop/restart/health). Unit 3: #1743 rewire onto it. Unit 4: Cluster app Backend Services UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated linting for managed service manifests in pull request checks.
  * Added manifest metadata for a managed service, including service scope and health verification.

* **Tests**
  * Added coverage for valid and invalid managed-service manifest configurations.
  * Confirmed non-managed and grandfathered services are skipped.
  * Verified the published catalog passes the new manifest checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->