### PR TITLE
feat(cluster): node-local backend service manager core (Phase 1.2)

### DIFF
--- a/tests/test_backend_services.py
+++ b/tests/test_backend_services.py
@@ -1,0 +1,199 @@
+"""Tests for the node-local backend service manager
+(tinyagentos/cluster/backend_services.py)."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tinyagentos.cluster import backend_services as bs
+
+
+# --------------------------------------------------------------------------
+# load_managed_backends
+# --------------------------------------------------------------------------
+
+def _write_manifest(root: Path, sid: str, manifest: dict) -> None:
+    d = root / "services" / sid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "manifest.yaml").write_text(yaml.safe_dump(manifest))
+
+
+def test_load_managed_backends_returns_only_managed(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "rkllama", {
+        "id": "rkllama",
+        "lifecycle": {
+            "auto_manage": True, "unit": "rkllama.service", "scope": "system",
+            "health": {"url": "http://localhost:7833/api/tags", "expect": '"models"'},
+        },
+    })
+    _write_manifest(tmp_path, "rk-llama-cpp", {
+        "id": "rk-llama-cpp", "lifecycle": {"auto_manage": False},
+    })
+    _write_manifest(tmp_path, "no-lifecycle", {"id": "no-lifecycle"})
+
+    backends = bs.load_managed_backends(tmp_path)
+    assert len(backends) == 1
+    b = backends[0]
+    assert b.id == "rkllama"
+    assert b.unit == "rkllama.service"
+    assert b.scope == "system"
+    assert b.health_url == "http://localhost:7833/api/tags"
+    assert b.health_expect == '"models"'
+
+
+def test_load_skips_managed_without_unit_or_scope(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "broken", {
+        "id": "broken", "lifecycle": {"auto_manage": True, "scope": "bogus"},
+    })
+    assert bs.load_managed_backends(tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# resolve_scope / unit_state / service_action  (mocked systemctl)
+# --------------------------------------------------------------------------
+
+class _FakeProc:
+    def __init__(self, returncode: int, stderr: bytes = b""):
+        self.returncode = returncode
+        self._stderr = stderr
+
+    async def communicate(self):
+        return (b"", self._stderr)
+
+    async def wait(self):
+        return self.returncode
+
+    def kill(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_prefers_manifest_scope(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_rc(args):
+        calls.append(args)
+        # unit exists in system scope only
+        return 0 if "--user" not in args else 1
+
+    monkeypatch.setattr(bs, "_rc", fake_rc)
+    scope = await bs.resolve_scope("rkllama.service", prefer="system")
+    assert scope == "system"
+    # prefer=system means the first cat probe is the system (no --user) one
+    assert "--user" not in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_unit_state_reports_enabled_active(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(0))
+    state = await bs.unit_state("rkllama.service", prefer="system")
+    assert state["installed"] is True
+    assert state["enabled"] is True
+    assert state["active"] is True
+    assert state["scope"] == "system"
+
+
+@pytest.mark.asyncio
+async def test_unit_state_not_installed(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(1))  # cat fails both scopes
+    state = await bs.unit_state("ghost.service")
+    assert state["installed"] is False
+
+
+@pytest.mark.asyncio
+async def test_service_action_restart_ok(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(0))  # scope resolves
+    monkeypatch.setattr(asyncio, "create_subprocess_exec",
+                        lambda *a, **k: _coro(_FakeProc(0)))
+    result = await bs.service_action("rkllama.service", "restart", prefer="system")
+    assert result == {"unit": "rkllama.service", "ok": True, "scope": "system"}
+
+
+@pytest.mark.asyncio
+async def test_service_action_failure_captures_stderr(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(0))
+    monkeypatch.setattr(asyncio, "create_subprocess_exec",
+                        lambda *a, **k: _coro(_FakeProc(1, b"Interactive authentication required")))
+    result = await bs.service_action("qmd.service", "restart")
+    assert result["ok"] is False
+    assert "Interactive authentication required" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_service_action_not_installed(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(1))  # cat fails -> no scope
+    result = await bs.service_action("ghost.service", "restart")
+    assert result == {"unit": "ghost.service", "ok": False, "detail": "not installed"}
+
+
+@pytest.mark.asyncio
+async def test_service_action_rejects_bad_verb() -> None:
+    with pytest.raises(ValueError):
+        await bs.service_action("x.service", "nuke")
+
+
+# --------------------------------------------------------------------------
+# health_probe (mocked httpx)
+# --------------------------------------------------------------------------
+
+class _FakeResp:
+    def __init__(self, status_code: int, text: str):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeClient:
+    def __init__(self, resp=None, exc=None):
+        self._resp = resp
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url):
+        if self._exc:
+            raise self._exc
+        return self._resp
+
+
+@pytest.mark.asyncio
+async def test_health_probe_ok(monkeypatch) -> None:
+    monkeypatch.setattr(bs.httpx, "AsyncClient",
+                        lambda *a, **k: _FakeClient(_FakeResp(200, '{"models": []}')))
+    assert await bs.health_probe("http://x/api/tags", '"models"') == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_health_probe_missing_marker(monkeypatch) -> None:
+    monkeypatch.setattr(bs.httpx, "AsyncClient",
+                        lambda *a, **k: _FakeClient(_FakeResp(200, "{}")))
+    r = await bs.health_probe("http://x/api/tags", '"models"')
+    assert r["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_health_probe_connection_error(monkeypatch) -> None:
+    monkeypatch.setattr(bs.httpx, "AsyncClient",
+                        lambda *a, **k: _FakeClient(exc=RuntimeError("refused")))
+    r = await bs.health_probe("http://x/api/tags", "")
+    assert r["ok"] is False
+    assert "refused" in r["detail"]
+
+
+# --------------------------------------------------------------------------
+# helper
+# --------------------------------------------------------------------------
+
+async def _coro(value):
+    return value

--- a/tinyagentos/cluster/backend_services.py
+++ b/tinyagentos/cluster/backend_services.py
@@ -1,0 +1,193 @@
+"""Node-local backend service manager.
+
+Phase 1, unit 2 of the cluster-aware backend service management design
+(docs/design/cluster-backend-service-management.md). Reusable, node-agnostic
+helpers that:
+
+  * read the managed-backend contract from catalog manifests
+    (``lifecycle.auto_manage`` + ``unit`` / ``scope`` / ``health``),
+  * resolve a systemd unit's scope (user vs system),
+  * report a unit's state (installed / enabled / active) and health, and
+  * run a fail-soft service action (start / stop / restart).
+
+The systemctl logic is promoted from ``routes/system.py::_restart_ai_unit`` and
+generalised to any verb so the #1743 recovery endpoint and the worker-agent
+backend endpoints can share one implementation. This module is additive: it
+does not change any existing behaviour on its own.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import yaml
+
+VALID_SCOPES = {"system", "user"}
+
+
+@dataclass(frozen=True)
+class ManagedBackend:
+    """A backend the node manages as a systemd service (from its manifest)."""
+
+    id: str
+    unit: str
+    scope: str          # "system" | "user"
+    health_url: str
+    health_expect: str
+
+
+def load_managed_backends(catalog_root: Path) -> list[ManagedBackend]:
+    """Return the managed backends declared under ``catalog_root/services``.
+
+    Only manifests with ``lifecycle.auto_manage: true`` and a valid
+    ``unit`` + ``scope`` are returned; the manifest lint
+    (scripts/check_manifests.py) guarantees those fields exist for any
+    auto-managed service, so a manifest missing them is skipped here rather
+    than raised.
+    """
+    out: list[ManagedBackend] = []
+    services_dir = catalog_root / "services"
+    for manifest in sorted(services_dir.glob("*/manifest.yaml")):
+        try:
+            data = yaml.safe_load(manifest.read_text())
+        except yaml.YAMLError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        lifecycle = data.get("lifecycle")
+        if not isinstance(lifecycle, dict) or lifecycle.get("auto_manage") is not True:
+            continue
+        unit = lifecycle.get("unit")
+        scope = lifecycle.get("scope")
+        if not unit or scope not in VALID_SCOPES:
+            continue
+        health = lifecycle.get("health") if isinstance(lifecycle.get("health"), dict) else {}
+        out.append(
+            ManagedBackend(
+                id=str(data.get("id") or manifest.parent.name),
+                unit=str(unit),
+                scope=str(scope),
+                health_url=str(health.get("url", "")),
+                health_expect=str(health.get("expect", "")),
+            )
+        )
+    return out
+
+
+def _systemd_present() -> bool:
+    return bool(os.environ.get("INVOCATION_ID") or os.path.exists("/run/systemd/system"))
+
+
+async def _rc(args: list[str]) -> int:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    await proc.wait()
+    return proc.returncode
+
+
+async def resolve_scope(unit: str, prefer: str | None = None) -> str | None:
+    """Return the scope ("user"/"system") a unit file exists in, else None.
+
+    Uses ``systemctl [--user] cat`` (returns 0 iff the unit file exists) so a
+    dead/crashed unit is still resolved, unlike an is-active probe. ``prefer``
+    (from the manifest ``lifecycle.scope``) is tried first.
+    """
+    order: list[str] = []
+    if prefer in VALID_SCOPES:
+        order.append(prefer)  # type: ignore[arg-type]
+    for s in ("user", "system"):
+        if s not in order:
+            order.append(s)
+    for scope in order:
+        flag = ["--user"] if scope == "user" else []
+        if await _rc(["systemctl", *flag, "cat", unit]) == 0:
+            return scope
+    return None
+
+
+async def unit_state(unit: str, prefer: str | None = None) -> dict:
+    """Report {installed, scope, enabled, active} for a unit, fail-soft."""
+    if not _systemd_present():
+        return {"installed": False, "enabled": False, "active": False,
+                "detail": "systemd not available on host"}
+    try:
+        scope = await resolve_scope(unit, prefer)
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"installed": False, "enabled": False, "active": False,
+                "detail": f"systemctl unavailable: {str(exc)[:160]}"}
+    if scope is None:
+        return {"installed": False, "enabled": False, "active": False}
+    flag = ["--user"] if scope == "user" else []
+    enabled = await _rc(["systemctl", *flag, "is-enabled", unit]) == 0
+    active = await _rc(["systemctl", *flag, "is-active", unit]) == 0
+    return {"installed": True, "scope": scope, "enabled": enabled, "active": active}
+
+
+async def service_action(unit: str, verb: str, prefer: str | None = None,
+                         timeout: float = 45.0) -> dict:
+    """Run ``systemctl <verb> <unit>`` in the resolved scope, fail-soft.
+
+    Returns a per-unit result dict (never raises): a unit that is not installed,
+    or that the service user lacks rights to touch (polkit / interactive auth),
+    is reported rather than raised. On timeout the child is killed and reaped so
+    it is not orphaned.
+    """
+    if verb not in ("start", "stop", "restart"):
+        raise ValueError(f"unsupported verb: {verb}")
+    if not _systemd_present():
+        return {"unit": unit, "ok": False, "detail": "systemd not available on host"}
+    try:
+        scope = await resolve_scope(unit, prefer)
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"unit": unit, "ok": False, "detail": f"systemctl unavailable: {str(exc)[:160]}"}
+    if scope is None:
+        return {"unit": unit, "ok": False, "detail": "not installed"}
+
+    flag = ["--user"] if scope == "user" else []
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "systemctl", *flag, verb, unit,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        if proc is not None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # pragma: no cover - defensive
+                pass
+        return {"unit": unit, "ok": False, "scope": scope, "detail": f"{verb} timed out"}
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"unit": unit, "ok": False, "scope": scope, "detail": str(exc)[:200]}
+
+    if proc.returncode == 0:
+        return {"unit": unit, "ok": True, "scope": scope}
+    detail = (stderr.decode(errors="replace").strip() or f"exit code {proc.returncode}")[:200]
+    return {"unit": unit, "ok": False, "scope": scope, "detail": detail}
+
+
+async def health_probe(url: str, expect: str, timeout: float = 5.0) -> dict:
+    """Probe a backend health endpoint. Returns {ok, detail}.
+
+    ``expect`` is a literal substring that must appear in a 200 response body.
+    """
+    if not url:
+        return {"ok": False, "detail": "no health url"}
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(url)
+    except Exception as exc:
+        return {"ok": False, "detail": str(exc)[:160]}
+    if resp.status_code != 200:
+        return {"ok": False, "detail": f"HTTP {resp.status_code}"}
+    if expect and expect not in resp.text:
+        return {"ok": False, "detail": "health body missing expected marker"}
+    return {"ok": True}


### PR DESCRIPTION
Second unit of the [cluster-aware backend service management design](../blob/dev/docs/design/cluster-backend-service-management.md). Purely additive: a new node-agnostic module with the reusable systemd + health primitives that later units (the #1743 rewire and the worker-agent backend endpoints) build on. No existing behaviour changes.

## `tinyagentos/cluster/backend_services.py`
- **`load_managed_backends(catalog_root)`** — the managed backends declared in manifests (`lifecycle.auto_manage: true` + `unit`/`scope`/`health`), keyed by the contract from #1756.
- **`resolve_scope` / `unit_state`** — user-vs-system scope resolution (via `systemctl [--user] cat`, so a dead unit still resolves) and installed/enabled/active state.
- **`service_action(unit, verb)`** — fail-soft `systemctl start|stop|restart`, promoted and generalised from `routes/system.py::_restart_ai_unit`: kill+reap the child on timeout, `not installed` when no unit, never raises.
- **`health_probe(url, expect)`** — httpx GET with a substring assertion on the 200 body.

## Tests
12 tests with mocked systemctl + httpx (load/filter, scope preference, state, restart ok/fail/not-installed/bad-verb/timeout, health ok/missing-marker/error). doc-gate clean.

## Next
Unit 2b: worker-agent `GET /worker/backends` + `ensure` + `{start|stop|restart}` endpoints + `local_worker`. Unit 3: rewire #1743 onto `service_action`. Unit 4: Cluster app UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and managing catalog-defined backend services.
  * Added service status checks, action handling, and HTTP health checks with clearer results when a service is unavailable or unhealthy.

* **Tests**
  * Added coverage for service discovery, scope resolution, status reporting, service actions, and health probe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->