### PR TITLE
refactor(system): derive #1743 restart targets from managed-backend contract (Phase 1.3)

### DIFF
--- a/tests/test_routes_system.py
+++ b/tests/test_routes_system.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -239,17 +238,6 @@ class TestRestartStatus:
         assert "error" in data
 
 
-class _FakeProc:
-    """Minimal asyncio subprocess stand-in for _restart_ai_unit tests."""
-
-    def __init__(self, returncode: int, stderr: bytes = b""):
-        self.returncode = returncode
-        self._stderr = stderr
-
-    async def communicate(self):
-        return (b"", self._stderr)
-
-
 async def _member_client(app) -> AsyncClient:
     """Cookie'd client for a non-admin member session (mirrors settings authz)."""
     auth_mgr = app.state.auth
@@ -265,15 +253,23 @@ async def _member_client(app) -> AsyncClient:
 
 
 class TestRestartAiStack:
-    """POST /api/system/ai-stack/restart -- issue #1743 backend recovery."""
+    """POST /api/system/ai-stack/restart -- issue #1743 backend recovery.
+
+    The endpoint derives its target set via ``_managed_ai_units`` (tested
+    separately below) and restarts each via ``backend_services.service_action``;
+    these tests stub both to exercise the aggregation/status logic.
+    """
 
     @pytest.mark.asyncio
     async def test_all_ok(self, client, monkeypatch):
         monkeypatch.setattr(
-            system_routes,
-            "_restart_ai_unit",
+            system_routes, "_managed_ai_units",
+            AsyncMock(return_value=[("rkllama.service", "system"), ("qmd.service", "system")]),
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "service_action",
             AsyncMock(side_effect=[
-                {"unit": "rkllama.service", "ok": True, "scope": "user"},
+                {"unit": "rkllama.service", "ok": True, "scope": "system"},
                 {"unit": "qmd.service", "ok": True, "scope": "system"},
             ]),
         )
@@ -287,10 +283,13 @@ class TestRestartAiStack:
     @pytest.mark.asyncio
     async def test_partial_recovery_reports_partial(self, client, monkeypatch):
         monkeypatch.setattr(
-            system_routes,
-            "_restart_ai_unit",
+            system_routes, "_managed_ai_units",
+            AsyncMock(return_value=[("rkllama.service", "system"), ("qmd.service", "system")]),
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "service_action",
             AsyncMock(side_effect=[
-                {"unit": "rkllama.service", "ok": True, "scope": "user"},
+                {"unit": "rkllama.service", "ok": True, "scope": "system"},
                 {"unit": "qmd.service", "ok": False, "detail": "not installed"},
             ]),
         )
@@ -304,8 +303,11 @@ class TestRestartAiStack:
     @pytest.mark.asyncio
     async def test_all_fail_reports_failed(self, client, monkeypatch):
         monkeypatch.setattr(
-            system_routes,
-            "_restart_ai_unit",
+            system_routes, "_managed_ai_units",
+            AsyncMock(return_value=[("rkllama.service", "system"), ("qmd.service", "system")]),
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "service_action",
             AsyncMock(side_effect=[
                 {"unit": "rkllama.service", "ok": False, "detail": "auth required"},
                 {"unit": "qmd.service", "ok": False, "detail": "auth required"},
@@ -317,57 +319,92 @@ class TestRestartAiStack:
         assert len(data["failed"]) == 2
 
     @pytest.mark.asyncio
+    async def test_noop_when_no_managed_backends_installed(self, client, monkeypatch):
+        # No managed backend installed on this node (e.g. non-systemd dev host):
+        # report noop rather than a misleading "failed", and never call restart.
+        monkeypatch.setattr(
+            system_routes, "_managed_ai_units", AsyncMock(return_value=[]),
+        )
+        action = AsyncMock()
+        monkeypatch.setattr(system_routes.backend_services, "service_action", action)
+        data = (await client.post("/api/system/ai-stack/restart")).json()
+        assert data["status"] == "noop"
+        assert data["restarted"] == [] and data["failed"] == []
+        action.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_non_admin_rejected_403(self, client, app, monkeypatch):
         # Guard should reject before any restart is attempted.
-        monkeypatch.setattr(
-            system_routes, "_restart_ai_unit", AsyncMock(return_value={"ok": True})
-        )
+        units = AsyncMock(return_value=[("qmd.service", "system")])
+        monkeypatch.setattr(system_routes, "_managed_ai_units", units)
         member_client = await _member_client(app)
         try:
             resp = await member_client.post("/api/system/ai-stack/restart")
         finally:
             await member_client.aclose()
         assert resp.status_code == 403
+        units.assert_not_called()
 
 
-class TestRestartAiUnit:
-    """_restart_ai_unit scope resolution + fail-soft behaviour."""
+class TestManagedAiUnits:
+    """_managed_ai_units: derive core + manifest units, filter to installed."""
+
+    def _request(self, tmp_path):
+        req = MagicMock()
+        req.app.state.registry.catalog_dir = tmp_path
+        return req
 
     @pytest.mark.asyncio
-    async def test_restart_user_scope_ok(self, monkeypatch):
-        monkeypatch.setenv("INVOCATION_ID", "test")  # force systemd-present path
-        # cat finds the unit in --user scope (rc 0), so restart uses --user.
-        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=0))
-        monkeypatch.setattr(
-            asyncio, "create_subprocess_exec", AsyncMock(return_value=_FakeProc(0))
+    async def test_unions_core_and_manifest_when_installed(self, tmp_path, monkeypatch):
+        from tinyagentos.cluster.backend_services import ManagedBackend
+
+        rk = ManagedBackend(
+            id="rkllama", unit="rkllama.service", scope="system",
+            health_url="http://localhost:7833/api/tags", health_expect='"models"',
         )
-        result = await system_routes._restart_ai_unit("rkllama.service")
-        assert result == {"unit": "rkllama.service", "ok": True, "scope": "user"}
-
-    @pytest.mark.asyncio
-    async def test_restart_failure_captures_stderr(self, monkeypatch):
-        monkeypatch.setenv("INVOCATION_ID", "test")
-        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=0))
         monkeypatch.setattr(
-            asyncio,
-            "create_subprocess_exec",
-            AsyncMock(return_value=_FakeProc(1, b"Interactive authentication required")),
+            system_routes.backend_services, "load_managed_backends", lambda root: [rk]
         )
-        result = await system_routes._restart_ai_unit("qmd.service")
-        assert result["ok"] is False
-        assert "Interactive authentication required" in result["detail"]
+        monkeypatch.setattr(
+            system_routes.backend_services, "unit_state",
+            AsyncMock(return_value={"installed": True}),
+        )
+        units = await system_routes._managed_ai_units(self._request(tmp_path))
+        # qmd (core, no manifest) + rkllama (from manifest), both installed.
+        assert set(u for u, _ in units) == {"qmd.service", "rkllama.service"}
 
     @pytest.mark.asyncio
-    async def test_not_installed_when_cat_fails_both_scopes(self, monkeypatch):
-        monkeypatch.setenv("INVOCATION_ID", "test")
-        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=1))
-        result = await system_routes._restart_ai_unit("rkllama.service")
-        assert result == {"unit": "rkllama.service", "ok": False, "detail": "not installed"}
+    async def test_skips_units_not_installed_on_node(self, tmp_path, monkeypatch):
+        from tinyagentos.cluster.backend_services import ManagedBackend
+
+        rk = ManagedBackend(
+            id="rkllama", unit="rkllama.service", scope="system",
+            health_url="", health_expect="",
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "load_managed_backends", lambda root: [rk]
+        )
+
+        async def fake_state(unit, prefer=None):
+            # rkllama has migrated to another node; only qmd is installed here.
+            return {"installed": unit == "qmd.service"}
+
+        monkeypatch.setattr(system_routes.backend_services, "unit_state", fake_state)
+        units = await system_routes._managed_ai_units(self._request(tmp_path))
+        assert [u for u, _ in units] == ["qmd.service"]
 
     @pytest.mark.asyncio
-    async def test_no_systemd_fails_soft(self, monkeypatch):
-        monkeypatch.delenv("INVOCATION_ID", raising=False)
-        monkeypatch.setattr(system_routes.os.path, "exists", lambda p: False)
-        result = await system_routes._restart_ai_unit("qmd.service")
-        assert result["ok"] is False
-        assert "systemd not available" in result["detail"]
+    async def test_catalog_load_failure_still_yields_core(self, tmp_path, monkeypatch):
+        # A broken catalog must not drop qmd from recovery.
+        def boom(root):
+            raise RuntimeError("catalog unreadable")
+
+        monkeypatch.setattr(
+            system_routes.backend_services, "load_managed_backends", boom
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "unit_state",
+            AsyncMock(return_value={"installed": True}),
+        )
+        units = await system_routes._managed_ai_units(self._request(tmp_path))
+        assert [u for u, _ in units] == ["qmd.service"]

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -5,10 +5,12 @@ import logging
 import os
 import sys
 from dataclasses import asdict
+from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from tinyagentos.cluster import backend_services
 from tinyagentos.restart_orchestrator import write_pending_restart, read_pending_restart
 
 logger = logging.getLogger(__name__)
@@ -119,12 +121,52 @@ async def _do_restart(app_state) -> None:
         await _emit_fail(str(exc))
 
 
-# AI-stack services a recovery action restarts (issue #1743). These are the
-# local inference backends that can stall independently of the controller:
-# rkllama (NPU model server, a system unit per install-rknpu.sh) and qmd (shared
-# model provider, a system unit). The controller itself is deliberately NOT here --
-# bouncing it is the separate /api/system/restart/prepare path.
-AI_STACK_UNITS = ("rkllama.service", "qmd.service")
+# Core AI backends taOS manages as systemd services that have NO store manifest
+# (installed by install-server.sh, not via the store): qmd, the shared model
+# provider. Store-installed managed backends (rkllama and any future NPU/GPU
+# runtime) are discovered from their catalog manifests instead
+# (lifecycle.auto_manage), so new managed backends join #1743 recovery
+# automatically without editing this list. The controller itself is deliberately
+# NOT here -- bouncing it is the separate /api/system/restart/prepare path.
+# Value is the preferred systemctl scope for scope resolution.
+CORE_MANAGED_UNITS: dict[str, str] = {"qmd.service": "system"}
+
+
+def _catalog_root(request: Request) -> Path:
+    """Locate the app-catalog root the same way the app wires the registry."""
+    registry = getattr(request.app.state, "registry", None)
+    catalog_dir = getattr(registry, "catalog_dir", None)
+    if catalog_dir is not None:
+        return Path(catalog_dir)
+    return Path(__file__).resolve().parent.parent.parent / "app-catalog"
+
+
+async def _managed_ai_units(request: Request) -> list[tuple[str, str | None]]:
+    """Return (unit, prefer_scope) for every managed AI backend installed here.
+
+    The target set for #1743 recovery is the core-managed units (no store
+    manifest) unioned with the store-declared managed backends
+    (lifecycle.auto_manage in their catalog manifest), then narrowed to units
+    whose systemd file actually exists on THIS node. A backend that has migrated
+    to another cluster node is skipped rather than reported as a spurious
+    failure, and a newly installed managed backend is picked up with no code
+    change. Membership is resolved with ``systemctl cat`` (via
+    ``backend_services.unit_state``) so a dead/crashed unit -- exactly what
+    recovery targets -- still counts as installed.
+    """
+    prefer: dict[str, str | None] = dict(CORE_MANAGED_UNITS)
+    try:
+        for mb in backend_services.load_managed_backends(_catalog_root(request)):
+            prefer.setdefault(mb.unit, mb.scope)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("failed to load managed backends from catalog")
+
+    async def _installed(unit: str, scope: str | None):
+        state = await backend_services.unit_state(unit, scope)
+        return (unit, scope) if state.get("installed") else None
+
+    checks = await asyncio.gather(*(_installed(u, s) for u, s in prefer.items()))
+    return [c for c in checks if c is not None]
 
 
 def _is_admin_or_local_token(request: Request) -> bool:
@@ -142,87 +184,37 @@ def _is_admin_or_local_token(request: Request) -> bool:
     return getattr(request.state, "via", None) == "local_token"
 
 
-async def _systemctl_rc(args: list[str]) -> int:
-    proc = await asyncio.create_subprocess_exec(
-        *args,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    await proc.wait()
-    return proc.returncode
-
-
-async def _restart_ai_unit(unit: str) -> dict:
-    """Restart one AI-stack systemd unit, resolving user vs system scope.
-
-    Fails soft: a unit that is not installed, or that the service user lacks
-    rights to restart (polkit / interactive auth), is reported rather than
-    raised, so restarting one backend still helps when the other cannot be
-    touched. Scope is resolved with ``systemctl [--user] cat`` (returns 0 iff
-    the unit file exists) so a dead/crashed unit -- exactly what recovery
-    targets -- is still restarted, unlike an is-active probe.
-    """
-    if not (os.environ.get("INVOCATION_ID") or os.path.exists("/run/systemd/system")):
-        return {"unit": unit, "ok": False, "detail": "systemd not available on host"}
-
-    # Resolve scope. Guarded so a missing/unusable systemctl is reported rather
-    # than raised (keeps the documented "reported, not raised" contract).
-    scope_flag: list[str] | None = None
-    try:
-        for candidate in (["--user"], []):
-            if await _systemctl_rc(["systemctl", *candidate, "cat", unit]) == 0:
-                scope_flag = candidate
-                break
-    except Exception as exc:  # pragma: no cover - defensive
-        return {"unit": unit, "ok": False, "detail": f"systemctl unavailable: {str(exc)[:160]}"}
-    if scope_flag is None:
-        return {"unit": unit, "ok": False, "detail": "not installed"}
-
-    scope_name = "user" if scope_flag else "system"
-    proc = None
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "systemctl",
-            *scope_flag,
-            "restart",
-            unit,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=45)
-    except asyncio.TimeoutError:
-        # Kill and reap the child so a hung systemctl is not orphaned.
-        if proc is not None:
-            try:
-                proc.kill()
-                await proc.wait()
-            except Exception:  # pragma: no cover - defensive
-                pass
-        return {"unit": unit, "ok": False, "scope": scope_name, "detail": "restart timed out"}
-    except Exception as exc:  # pragma: no cover - defensive
-        return {"unit": unit, "ok": False, "scope": scope_name, "detail": str(exc)[:200]}
-
-    if proc.returncode == 0:
-        return {"unit": unit, "ok": True, "scope": scope_name}
-    detail = (stderr.decode(errors="replace").strip() or f"exit code {proc.returncode}")[:200]
-    return {"unit": unit, "ok": False, "scope": scope_name, "detail": detail}
-
-
 @router.post("/api/system/ai-stack/restart")
 async def restart_ai_stack(request: Request):
-    """Restart the local AI inference stack (rkllama + qmd) -- issue #1743.
+    """Restart the local AI inference stack -- issue #1743.
 
     A recovery action for edge devices where a model stalls (endless NPU
     generation, unresponsive inference) while the controller itself stays up.
-    Restarts the backend services without bouncing the controller or agents.
-    Admin (or host local token) only. Fails soft per service so a partial
-    recovery still reports what was restarted. The units are restarted
+    Restarts the managed backend services without bouncing the controller or
+    agents. The target set is derived from the managed-backend contract (core
+    units plus store manifests) and narrowed to backends actually installed on
+    this node, so it stays correct as backends are added or migrated across
+    cluster nodes. Admin (or host local token) only. Fails soft per service so a
+    partial recovery still reports what was restarted. Units are restarted
     concurrently so worst-case latency is one unit's timeout, not their sum.
     """
     if not _is_admin_or_local_token(request):
         return JSONResponse({"error": "forbidden"}, status_code=403)
 
-    results = list(await asyncio.gather(*(_restart_ai_unit(u) for u in AI_STACK_UNITS)))
+    targets = await _managed_ai_units(request)
+    if not targets:
+        return {
+            "status": "noop",
+            "restarted": [],
+            "failed": [],
+            "results": [],
+            "detail": "no managed AI backends installed on this node",
+        }
+
+    results = list(await asyncio.gather(
+        *(backend_services.service_action(unit, "restart", prefer)
+          for unit, prefer in targets)
+    ))
     restarted = [r["unit"] for r in results if r.get("ok")]
     failed = [r for r in results if not r.get("ok")]
     return {


### PR DESCRIPTION
## What

Phase 1, Unit 3 of the cluster-aware backend service management design (`docs/design/cluster-backend-service-management.md`): rewire the #1743 AI-stack recovery endpoint (`POST /api/system/ai-stack/restart`) onto the node-local backend service manager (`cluster/backend_services.py`, #1758), replacing the hardcoded `AI_STACK_UNITS` literal and the duplicated `_restart_ai_unit` / `_systemctl_rc` helpers.

## Target derivation (the design decision)

The restart set is now derived per node instead of hardcoded:

- **Core-managed units** with no store manifest, `CORE_MANAGED_UNITS = {"qmd.service": "system"}` (qmd is core-installed by `install-server.sh`, not a store app), **unioned with**
- **Store-declared managed backends** discovered from catalog manifests (`lifecycle.auto_manage`, e.g. rkllama), **then narrowed** to units whose systemd file actually exists on this node.

A backend that has migrated to another cluster node is skipped rather than reported as a spurious failure, and a newly installed managed backend joins recovery with no code change. Membership uses `systemctl cat` (via `unit_state`) so a dead/crashed unit still counts as installed.

## Behaviour changes

- A node with no managed backend installed now returns `status: "noop"` instead of a misleading `"failed"`.
- A broken/unreadable catalog still yields the core units, so qmd never drops out of recovery.
- Endpoint path, method, admin/local-token gate, and success/partial/failed response shape are unchanged.

## Tests

- `_restart_ai_unit` / `_systemctl_rc` scope-resolution + kill-reap logic already moved to `backend_services` in #1758 and is tested in `test_backend_services.py`; those direct tests are removed here (no longer this module's code).
- `TestRestartAiStack` now stubs the derivation + `service_action` and covers ok / partial / failed / noop / 403.
- New `TestManagedAiUnits` covers the core+manifest union, the installed-on-this-node filter, and the broken-catalog-still-yields-core path.

Local: 32 passed (`test_routes_system.py` + `test_backend_services.py`), `compileall` clean, doc-gate invariants + managed-lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI stack restarts now include all managed backend services installed on the device, not just a fixed set of components.
  * The restart response now reports per-service results and an overall status: success, partial success, failure, or no action needed.

* **Bug Fixes**
  * Access is now enforced before any restart work begins, preventing unauthorized members from triggering system restarts.
  * Restart handling now skips services that are not installed on the current node, reducing failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->