### PR TITLE
feat(a2a): authenticated bus send proxy (agents post as themselves, no spoofing)

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -81,6 +81,20 @@ POST <bus>/a2a/send
 - After posting to a specific thread, verify it landed there (read the thread
   back and confirm your message id is present) before assuming it was delivered.
 
+The raw bus above is unauthenticated on the LAN and trusts the `from` field, so
+reaching it means either the owner's account or an SSH hop. A registered agent
+should instead post through the controller's authenticated proxy, which forces
+`from` to the agent's own registry handle (no spoofing) — so it posts as itself,
+not the owner:
+
+```
+POST <controller>/api/a2a/bus/send   (Authorization: Bearer <registry JWT, scope a2a_send>)
+{"thread": "build", "body": "...", "reply_to": <id>?}
+```
+
+An admin session may also call it and set an explicit `from`. On a bus failure
+the proxy returns 502 (the read proxies degrade to an empty 200 instead).
+
 These rules are deliberately lightweight. The goal is not process for its own
 sake; it is to let many hands move quickly on the same codebase without undoing
 each other's work.

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -359,6 +359,40 @@ class TestBusAgentSend:
             )
         assert resp.status_code == 400
 
+    async def test_reply_to_must_be_positive(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "build", "body": "hi", "reply_to": 0},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 400
+
+    async def test_body_is_trimmed_before_forwarding(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        ctx, client = _mock_bus_post({"id": 9, "from": "@bus-reader", "thread": "build"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "build", "body": "  padded  "},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert client.post.call_args.kwargs["json"]["body"] == "padded"
+
+    async def test_admin_from_control_chars_stripped(self, bus_client):
+        ctx, client = _mock_bus_post({"id": 10, "from": "@x", "thread": "general"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            resp = await bus_client.post(
+                "/api/a2a/bus/send",
+                json={"thread": "general", "body": "hi", "from": "@evil\nInjected: x"},
+            )
+        assert resp.status_code == 200
+        # Newline/control chars removed so nothing can be injected downstream.
+        assert "\n" not in client.post.call_args.kwargs["json"]["from"]
+
     async def test_bus_error_surfaces_502(self, bus_client):
         _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
         ctx, _client = _mock_bus_post({}, raise_on_status=True)

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -271,3 +271,102 @@ class TestBusAgentAuth:
             )
         # Falls through middleware to the session gate: API request -> 401.
         assert resp.status_code == 401
+
+
+def _mock_bus_post(json_payload: dict, *, raise_on_status: bool = False):
+    """A mock httpx.AsyncClient whose async ctx yields a client whose
+    .post().json() returns *json_payload*. If *raise_on_status* the mocked
+    response.raise_for_status() raises, simulating a bus error."""
+    mock_resp = MagicMock()
+    if raise_on_status:
+        mock_resp.raise_for_status = MagicMock(side_effect=RuntimeError("bus 500"))
+    else:
+        mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = json_payload
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_ctx, mock_client
+
+
+@pytest.mark.asyncio
+class TestBusAgentSend:
+    """Authenticated write path: agents post as themselves, never spoofing."""
+
+    async def test_agent_send_derives_from_from_registry_handle(self, bus_client):
+        # _make_agent_token registers handle "@bus-reader".
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        ctx, client = _mock_bus_post({"id": 1, "from": "@bus-reader", "thread": "build"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "build", "body": "hi", "from": "@somebody-else"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["from"] == "@bus-reader"
+        # Anti-spoof: the body's "from" is ignored; the bus is called with the
+        # agent's own registry handle.
+        sent = client.post.call_args.kwargs["json"]
+        assert sent["from"] == "@bus-reader"
+        assert sent["thread"] == "build" and sent["body"] == "hi"
+
+    async def test_agent_without_send_scope_forbidden(self, bus_client):
+        # Only a2a_receive -> cannot send.
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_receive",))
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "build", "body": "hi"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 403
+
+    async def test_no_auth_rejected(self, bus_client):
+        # No Bearer header at all: the auth middleware rejects the API request
+        # with 401 before it reaches the route (no credentials presented). The
+        # route's own 403 covers a *valid* token that lacks the a2a_send grant.
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "build", "body": "hi"},
+            )
+        assert resp.status_code == 401
+
+    async def test_admin_may_send_with_explicit_from(self, bus_client):
+        ctx, client = _mock_bus_post({"id": 2, "from": "@operator", "thread": "general"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            resp = await bus_client.post(
+                "/api/a2a/bus/send",
+                json={"thread": "general", "body": "ops note", "from": "@release-bot"},
+            )
+        assert resp.status_code == 200
+        # Admin's explicit from is honored.
+        assert client.post.call_args.kwargs["json"]["from"] == "@release-bot"
+
+    async def test_missing_thread_or_body_400(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "  ", "body": "hi"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 400
+
+    async def test_bus_error_surfaces_502(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        ctx, _client = _mock_bus_post({}, raise_on_status=True)
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "build", "body": "hi"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 502

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -23,10 +23,16 @@ _A2A_BUS_READ_PATHS = frozenset({
     "/api/a2a/bus/channels",
     "/api/a2a/bus/messages",
 })
+# Authenticated A2A bus WRITE path: an agent may POST here with its own registry
+# JWT (scope a2a_send, verified by the route, which forces the bus `from` to the
+# agent's own handle so it posts as itself instead of the owner's account).
+_A2A_BUS_WRITE_PATHS = frozenset({
+    "/api/a2a/bus/send",
+})
 # Every path that accepts a registry JWT in place of the admin session.  The
 # passthrough is allowlisted to exactly these paths -- a registry JWT must never
 # authenticate an arbitrary route (no skeleton key).
-_AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS
+_AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE_PATHS
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -156,7 +156,11 @@ async def _resolve_send_identity(request: Request, body_from: str | None) -> str
       Bearer header returns None and is rejected here as 403 (fail closed).
     """
     if getattr(request.state, "is_admin", False):
-        return (body_from or "").strip() or "@operator"
+        # Admin may post as an explicit handle, but keep it a single clean token
+        # so it cannot inject newlines/control chars into the bus record or logs.
+        handle = (body_from or "").strip()
+        handle = "".join(c for c in handle if c.isprintable())[:64].strip()
+        return handle or "@operator"
 
     caller = await check_agent_scope(request, "a2a_send")
     if caller is None:
@@ -186,10 +190,15 @@ async def bus_send(request: Request, body: BusSendBody):
     from_handle = await _resolve_send_identity(request, body.from_)
 
     thread = body.thread.strip()
-    if not thread or not body.body.strip():
+    text = body.body.strip()
+    if not thread or not text:
         return JSONResponse({"error": "thread and body required"}, status_code=400)
+    if body.reply_to is not None and body.reply_to <= 0:
+        return JSONResponse(
+            {"error": "reply_to must be a positive message id"}, status_code=400
+        )
 
-    payload: dict = {"from": from_handle, "thread": thread, "body": body.body}
+    payload: dict = {"from": from_handle, "thread": thread, "body": text}
     if body.reply_to is not None:
         payload["reply_to"] = body.reply_to
 

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -6,15 +6,21 @@ with the controller (default http://127.0.0.1:7900). It is where cross-product
 agents (@taOS, @taOSmd, @hermes) coordinate. This is DISTINCT from taOS's own
 internal per-project a2a channels (tinyagentos/projects/a2a.py).
 
-These endpoints are a thin READ-ONLY proxy: the Messages app can list bus
-channels and read messages, but there is no send/post path here. The bus is
-unauthenticated on the LAN; the URL is resolved from ``TAOS_A2A_BUS_URL``.
+These endpoints proxy the bus: the Messages app can list bus channels and read
+messages (read paths), and a registry-authenticated agent (or an admin) can post
+a message (POST /api/a2a/bus/send). The raw bus is unauthenticated on the LAN and
+trusts its ``from`` field, so the send proxy is the authenticated write path --
+an agent posts as its OWN registry handle (scope ``a2a_send``), never able to
+spoof another identity or borrow the owner's account. The URL is resolved from
+``TAOS_A2A_BUS_URL``.
 
 Bus API (verified live):
-  GET {bus}/a2a/channels
-      -> {"channels":[{"channel","members","message_count","created_ts","last_ts"}, ...]}
-  GET {bus}/a2a/messages?thread={channel}&limit={n}
-      -> {"messages":[{"id","ts","from","body","thread","reply_to"}, ...]}
+  GET  {bus}/a2a/channels
+       -> {"channels":[{"channel","members","message_count","created_ts","last_ts"}, ...]}
+  GET  {bus}/a2a/messages?thread={channel}&limit={n}
+       -> {"messages":[{"id","ts","from","body","thread","reply_to"}, ...]}
+  POST {bus}/a2a/send  {"from","thread","body","reply_to"?}
+       -> {"id","from","thread","reply_to"}
 """
 from __future__ import annotations
 
@@ -24,6 +30,7 @@ import os
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 
 from tinyagentos.agent_token_auth import check_agent_scope
 
@@ -118,3 +125,82 @@ async def bus_messages(request: Request, channel: str = "", limit: int = 100):
 
     messages = data.get("messages", []) if isinstance(data, dict) else []
     return {"messages": messages, "available": True}
+
+
+class BusSendBody(BaseModel):
+    """A message to post to a coordination-bus thread.
+
+    ``from_`` (JSON key ``from``) is honored ONLY for admin callers, so an
+    operator can post as any handle. For an agent-token caller it is ignored and
+    the ``from`` is derived from the agent's own registry handle -- one agent can
+    never post as another.
+    """
+
+    thread: str
+    body: str
+    reply_to: int | None = None
+    from_: str | None = Field(default=None, alias="from")
+
+    model_config = {"populate_by_name": True}
+
+
+async def _resolve_send_identity(request: Request, body_from: str | None) -> str:
+    """Return the bus ``from`` handle authorized for this send, or raise.
+
+    - Admin (session cookie or local token): may set an explicit ``from``
+      (operator posts as any handle); defaults to ``@operator`` when omitted.
+    - Otherwise the caller must present a registry JWT holding an active
+      ``a2a_send`` grant. The ``from`` is DERIVED from that agent's registry
+      handle; a client-supplied ``from`` is ignored, so an agent cannot spoof
+      another agent's identity. ``check_agent_scope`` raises 401/403; a missing
+      Bearer header returns None and is rejected here as 403 (fail closed).
+    """
+    if getattr(request.state, "is_admin", False):
+        return (body_from or "").strip() or "@operator"
+
+    caller = await check_agent_scope(request, "a2a_send")
+    if caller is None:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    registry = getattr(request.app.state, "agent_registry", None)
+    record = await registry.get(caller) if registry is not None else None
+    handle = ((record or {}).get("handle") or "").strip()
+    if not handle:
+        # An active a2a_send grant with no bus handle cannot be safely attributed.
+        raise HTTPException(status_code=403, detail="agent has no bus handle")
+    return handle
+
+
+@router.post("/api/a2a/bus/send")
+async def bus_send(request: Request, body: BusSendBody):
+    """Post a message to a coordination-bus thread as the authenticated identity.
+
+    Authorized senders: an admin session / host local token (may set ``from``),
+    or an active agent registry JWT holding the ``a2a_send`` scope (``from`` is
+    forced to the agent's own handle). This is the authenticated write path so
+    agents post as themselves instead of sharing the owner's account.
+
+    Unlike the read endpoints, a bus failure surfaces as 502: a caller must know
+    when its message did not land.
+    """
+    from_handle = await _resolve_send_identity(request, body.from_)
+
+    thread = body.thread.strip()
+    if not thread or not body.body.strip():
+        return JSONResponse({"error": "thread and body required"}, status_code=400)
+
+    payload: dict = {"from": from_handle, "thread": thread, "body": body.body}
+    if body.reply_to is not None:
+        payload["reply_to"] = body.reply_to
+
+    bus = _bus_url()
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(f"{bus}/a2a/send", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("A2A bus send failed (%s): %s", bus, exc)
+        raise HTTPException(status_code=502, detail="a2a bus unavailable")
+
+    return {"ok": True, "from": from_handle, "message": data}

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -193,7 +193,10 @@ async def bus_send(request: Request, body: BusSendBody):
     text = body.body.strip()
     if not thread or not text:
         return JSONResponse({"error": "thread and body required"}, status_code=400)
-    if body.reply_to is not None and body.reply_to <= 0:
+    # reply_to is a bus message id (a SQLite rowid): must be a positive integer
+    # within the signed-64-bit id space. The bus owns id existence; the proxy
+    # only rejects values that could never be a real id.
+    if body.reply_to is not None and not (0 < body.reply_to <= 2**63 - 1):
         return JSONResponse(
             {"error": "reply_to must be a positive message id"}, status_code=400
         )


### PR DESCRIPTION
Unblocks @taOS-website-dev thread 995: it was riding the owner account to post on the A2A bus because there was no authenticated send path.

## Problem
The controller `/api/a2a/bus/*` proxy is **read-only**. The only way to *send* is the raw `:7900` bus, which is **unauthenticated on the LAN and trusts the `from` field**. So a non-owner agent must borrow the owner session / SSH to post, and any LAN caller can spoof any identity.

## Change
New `POST /api/a2a/bus/send`, reusing the existing registry-JWT infra (`check_agent_scope`, the `a2a_send` scope already minted by `taosctl agents`):
- **Senders:** an admin session / host local token (may set an explicit `from`), or an agent registry JWT holding the **`a2a_send`** grant.
- **Anti-spoof:** for an agent caller the bus `from` is **derived from that agent's own registry `handle`** — a client-supplied `from` is ignored, so one agent cannot post as another.
- **Write semantics:** returns **502** on bus failure (a send must know it did not land), unlike the read proxies which degrade to an empty 200.
- **Middleware:** allowlisted as its own write-path set (`_A2A_BUS_WRITE_PATHS`), preserving the no-skeleton-key guard.

## Tests
7 new cases in `test_a2a_bus_agent_auth.py::TestBusAgentSend`: from-derivation + anti-spoof, scope required (403), no-auth (401 at middleware), admin explicit-`from`, validation (400), bus-error (502). Full bus suites green (31 passed). `test_auth_middleware.py` green (24). doc-gate clean.

## Docs
`docs/agent-coordination.md` documents the authenticated-send path alongside the raw bus; module docstring updated to reflect the new write path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for sending messages to the A2A coordination bus.
  * Authorized agents can send messages using their registered identity; administrators can provide an explicit sender.
  * Added validation for message threads and content, optional reply references, and clear responses for successful or failed delivery.
  * Unauthorized requests and agents without sending permission are rejected.

* **Documentation**
  * Clarified authentication requirements, identity protections, request examples, and error behavior for A2A bus messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->