### PR TITLE
feat(taosgo): persist per-host mesh service credentials at cluster-join (Slice 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data/.setup_complete
 data/.auth_password
 data/.auth_sessions
 data/.auth_local_token
+data/mesh_credentials.json
 data/agents.json
 data/images/
 data/videos/

--- a/docs/design/game-studio-asset-generation.md
+++ b/docs/design/game-studio-asset-generation.md
@@ -1,0 +1,89 @@
+# Game Studio offline asset-generation stack (design spec)
+
+Status: DRAFT for Jay review (#55). Game Studio already works as an LLM-authored
+three.js maker; this adds offline generation of the game's ART + AUDIO assets so a
+generated game is not limited to code-drawn primitives. Author: taOS-dev.
+
+## Why this exists
+
+Game Studio v1 is functional: an agent authors a three.js game (HTML + JS file
+set) from a prompt, the game previews sandboxed, packages as `.taosapp`, and shares
+to the store. Today the visuals are whatever the model can draw with three.js
+primitives + procedural code, and audio is absent or web-synth. #55 adds real
+asset generation - textures/sprites, sound effects + music, and (stretch) 3D
+meshes - all offline, tier-aware, reusing the backends taOS already ships. This
+mirrors the Images Studio pattern: the app calls tier-aware backends, degrading
+gracefully on low-end hardware.
+
+## Asset types, in ascending difficulty
+
+1. **Textures / sprites / skyboxes (2D images).** Highest value, lowest new cost:
+   reuse the EXISTING image-generation backend (SD on the RTX 3060 per the image
+   stack; RK image-gen on the NPU as the arms-length low tier). A game asks for
+   "a mossy stone texture, tileable" or "a pixel-art spaceship sprite sheet"; the
+   backend returns a PNG the game references. Tileable/seamless + transparent-bg
+   (sprite) are prompt/pipeline options, not new models.
+2. **Audio - SFX + music.** SFX (jump, hit, coin) and short loops. Reuse MusicGen
+   for music loops (already in the stack, license-gated CC-BY-NC per the licensing
+   work) and a small text-to-SFX path (e.g. a lightweight audio model or a curated
+   procedural/sample fallback). Output: ogg/mp3 the game loads.
+3. **3D meshes (stretch, gated).** The hard one: text/image-to-3D (TripoSR,
+   Shap-E, InstantMesh, or image-to-mesh). Heavy, GPU-bound, quality is rough, and
+   glTF export + three.js loading add complexity. Ship LAST, tier-gated to the
+   discrete-GPU tier only, behind a clear "experimental" flag. Many good three.js
+   games never need generated meshes (primitives + textures go far).
+
+## Design (tier-aware, backend-reusing)
+
+- **Backend contract.** One controller route surface, `routes/game_assets.py`,
+  with `POST /api/games/{id}/assets/texture`, `.../assets/audio`, and (later)
+  `.../assets/mesh`. Each resolves the tier-appropriate backend the same way the
+  Images Studio edit backends do (hardware tier -> concrete backend), writes the
+  asset into the game's file set (so it packages + previews with the game), and
+  returns the asset path. No new per-asset infra: textures go through the existing
+  image backend, audio through MusicGen + the SFX path.
+- **Frontend.** Game Studio's Editor gains an "Assets" panel: generate a
+  texture/sprite/audio from a prompt, preview it, and insert a reference into the
+  current file (the authoring agent already manages the file set, so an inserted
+  asset is just another file + a code reference the agent or user wires up).
+  Tier-gated UI: unavailable backends show a clear "needs a GPU worker" state
+  rather than a broken button (matches the Images Studio + reduce-effects
+  precedent).
+- **License + provenance.** Reuse the existing license-accept gate (MusicGen /
+  FLUX weights are CC-BY-NC; SD/Apache-clean is the default). A game that bundles
+  generated assets records their provenance in the package, consistent with the
+  app-security-analyzer + provenance work.
+- **Offline-first.** Everything runs on the local/worker GPU; no cloud. On a
+  GPU-less host (Pi core alone) textures fall back to the NPU RK backend or a
+  curated built-in pack; 3D is simply unavailable.
+
+## Slice plan (spec -> build -> harden, per Jay)
+
+- **Slice 1 - textures/sprites** (build first; highest value/lowest cost). Route +
+  tier-aware image-backend call + Editor Assets panel (texture/sprite) + tests.
+  Live-verify a generated texture appears in a previewed game on the 3060 tier.
+- **Slice 2 - audio (SFX + music).** MusicGen loop + SFX path + Assets-panel audio
+  tab + license gate + tests.
+- **Slice 3 - 3D meshes (experimental, gated).** Text/image-to-3D on the
+  discrete-GPU tier only, glTF export, three.js loader wiring, behind an
+  experimental flag. Only if Slices 1-2 land clean.
+- **Harden (last, per your ordering):** test coverage across the asset routes +
+  panel, and screenshot-verify a real generated game with generated assets on the
+  Pi.
+
+## Open questions for Jay
+
+1. **SFX model choice** for Slice 2: a dedicated text-to-SFX model vs a
+   curated-sample + light-synth fallback. MusicGen covers music loops already;
+   SFX is the gap. Recommend starting with the fallback + MusicGen and adding a
+   model only if quality demands it.
+2. **3D scope (Slice 3):** ship it experimental on the 3060 tier, or defer 3D
+   entirely for now and stop at textures + audio? (Textures + audio deliver most
+   of the value; 3D is heavy and rough.)
+3. Confirm the target build/verify hardware: the RTX 3060 (Fedora worker) for the
+   GPU tiers, RK NPU (Pi) for the low tier - consistent with the existing image
+   stack.
+
+## Non-goals (v1)
+
+Animation/rigging, video, voice/TTS dialogue, and any cloud generation.

--- a/docs/design/taosgo-mesh-join-foundation.md
+++ b/docs/design/taosgo-mesh-join-foundation.md
@@ -1,0 +1,170 @@
+# taOSgo mesh-join foundation (design spec)
+
+Status: DRAFT for Jay review. Unblocks Web Studio publish (#167) and, more
+broadly, off-LAN remote access (taOSgo). Author: taOS-dev.
+
+## Why this exists
+
+Web Studio v1 is a complete static-site builder (generate -> edit -> preview ->
+install/export). Its one missing feature, publish to `<label>.<handle>.taos.my`,
+is blocked, and so is off-LAN remote access to the desktop. The block is not a
+small wiring gap: the taOS **controller has no mesh-join code at all**. There is
+no `tailscale up`, no preauth-key consumption, no Headscale connection, and no
+persistence of the per-host service credentials taos.my hands back at join time.
+
+taos.my's side is DONE and deployed: the cluster-join ready payload emits a
+`headscale_preauth_key`, a `controller_token` (scope `taosnet:passkey`), and a
+`sites_token` (scope `sites:publish`) -- each single-scope and host-bound -- and
+the routing endpoints (`/api/relay/authorize-site`, `/api/sites/*`) are live and
+fail-closed. What is missing is entirely on the taOS controller side.
+
+## Current state (verified in code)
+
+- `routes/account_proxy.py` is a thin cookie-passthrough proxy: it forwards the
+  browser's join request / approve / deny / poll to taos.my `/api/cluster/join/*`.
+  The **ready payload lands in the browser**, not on the controller.
+- `taosnet/passkey_client.py::get_controller_token()` is a READER seam: it reads
+  `TAOS_CONTROLLER_TOKEN` from the env and its own docstring says it is "the seam
+  the cluster-join client writes to once that client lands." That writer does not
+  exist.
+- No code anywhere consumes the `headscale_preauth_key` or brings up a tailnet
+  interface. The Pi's current LAN clustering uses a different, non-Headscale path.
+
+So three things are missing, in dependency order: (1) a server-side way to obtain
++ persist the ready-payload credentials; (2) an actual headless mesh-join; (3)
+the publish caller + a server for the published static site.
+
+## Design
+
+### Unit 1 - credential store + persistence (the `get_controller_token` writer)
+
+A small host-local credential store, `taosnet/mesh_credentials.py`, persisting the
+ready-payload service credentials to a single file under the data dir
+(`<data_dir>/mesh/credentials.json`, mode 0600, dir 0700). Fields:
+`{account_id, host_id, tailnet_name, controller_token, sites_token, joined_at}`.
+The preauth key is consumed immediately by Unit 2 and NOT persisted (it is
+single-use). Public API:
+
+- `save_mesh_credentials(payload: dict) -> None` (atomic write; validates the
+  expected keys; refuses to widen scope silently)
+- `get_controller_token() -> str | None` and `get_sites_token() -> str | None`
+  (replace the env-var placeholder in `passkey_client.py`; keep the env var as a
+  dev override that wins if set, so existing tests + local dev keep working)
+- `get_host_id() -> str | None`, `clear()` (on leave/unjoin)
+
+**How the controller obtains the payload - two options:**
+
+- **(A) Poll-intercept (recommended).** `cluster_join_poll` in `account_proxy.py`
+  already forwards the poll and receives the ready payload on its way to the
+  browser. When the forwarded response is a `ready` with the credentials, extract
+  and `save_mesh_credentials(...)` server-side *before* returning to the browser,
+  and strip the raw `controller_token`/`sites_token` from the browser-facing body
+  (the browser only needs join status + whatever the UI shows; the service tokens
+  must not sit in browser JS). Minimal new surface, reuses the existing proxy, and
+  keeps the credentials server-side by construction.
+- (B) Explicit `POST /api/account/cluster/join/finalize` the browser calls after
+  approval, which makes the controller do its own authenticated poll + persist.
+  More moving parts, another endpoint to auth. Rejected unless (A) proves awkward.
+
+Decision: **A.** Note the one subtlety to verify at build time: confirm the poll
+response shape so the intercept keys off `ready` state correctly and never
+double-consumes a single-use preauth key (idempotent: if credentials already
+persisted for this host_id, skip re-save).
+
+### Unit 2 - headless Headscale mesh-join (the open infra decision)
+
+This is the real fork and the reason this is a spec, not a straight build. The
+controller must bring up a tailnet interface using the one-shot
+`headscale_preauth_key` against the account's Headscale control server
+(`hs.taos.my`). Options, with tradeoffs:
+
+- **(2a) System `tailscale` + `tailscaled`.** `tailscale up --login-server
+  https://hs.taos.my --authkey <preauth> --hostname <handle-host>`. Simplest and
+  most robust (real kernel networking, standard tooling), but adds a system
+  dependency + a privileged daemon, and the install/upgrade path must ship it per
+  platform (Pi/Debian, Fedora, macOS). Best for a device that IS the always-on
+  host.
+- **(2b) `tsnet` (userspace Tailscale, in-process).** taOS embeds a userspace
+  tailnet in the controller process (Go `tsnet`, or a Python binding / sidecar).
+  No system daemon, no root, self-contained. But taOS is Python; this means a Go
+  sidecar or a userspace-WireGuard lib, and userspace perf/reliability is lower.
+  The website side already anticipates a `tsnet` menubar app for clients (bus
+  discussion), so there is precedent for tsnet on the CLIENT; the QUESTION is
+  whether the always-on HOST should also be userspace or system.
+- (2c) Reuse whatever the streamed-browser / Neko work uses for its tailnet, if
+  it already brings up a tailnet on the Pi. To verify at build time.
+
+**Recommendation: 2a (system tailscale) for the always-on host**, because the
+published site + remote desktop need a stable, performant, boot-persistent mesh
+membership, and the host is a managed device where installing a package + service
+is acceptable (it already manages systemd units per the backend-service work).
+Keep 2b (tsnet) for the light clients. But this is Jay's call - it defines a new
+per-platform install dependency, so it belongs in the installer story. If 2a: the
+join sequence is `mesh_up(preauth, hostname)` -> shell out to `tailscale up`
+(fail-soft, structured error), then record membership; on reboot, tailscaled
+rejoins automatically and Unit 1's persisted credentials remain valid.
+
+Health/observability: a `mesh_status()` that reports `{joined, tailnet_name,
+node_ip}` for the Account pane and the routing (the published_sites `host_id` maps
+to this node in taos.my's hosts table).
+
+### Unit 3 - publish caller + static-site server
+
+Once Units 1+2 land, publishing a Web Studio site is:
+
+1. **Serve the static export.** The controller serves the site's already-built
+   static bundle (the same `/api/web/sites/{id}/package` / preview content) on a
+   dedicated internal port bound to the tailnet interface (not the LAN). A tiny
+   static file server per published site, or one server keyed by label. Static
+   only in v1 (matches Web Studio's stated scope); "dynamic + keep-running"
+   containers are a later phase.
+2. **Register the route.** `POST hs.taos.my.../api/sites/publish` with
+   `Authorization: Bearer <sites_token>` and `{label, port, host_id}` -- handle is
+   derived server-side from the token (the anti-spoof we already reviewed in #94).
+   The label is validated client-side against the same reserved rules, but taos.my
+   re-validates.
+3. **Web Studio UI.** ShareView gains a "Publish to <handle>.taos.my" action
+   (alongside install/export): pick a label, POST, show the resulting FQDN + a
+   copy link, and an "unpublish". Gated on the host having joined a mesh
+   (`mesh_status().joined`) with a clear "connect your taOS account first" empty
+   state otherwise.
+
+The ops half (wildcard `*.taos.my` DNS-01 cert + the front proxy that calls
+`/api/relay/authorize-site`) is already flagged for Jay/@hermes and is
+independent of this controller work.
+
+## Slice plan (each independently shippable + testable)
+
+- **Slice 1 - credential store + poll-intercept persistence.** `mesh_credentials.py`
+  + `save/get` API, `get_controller_token`/`get_sites_token` backed by it, the
+  `cluster_join_poll` intercept that persists server-side and strips tokens from
+  the browser body. Tests: persistence round-trip, 0600 perms, idempotent
+  re-poll, browser body has no raw tokens, env-var dev override still wins. NO
+  mesh-join yet (credentials just persist). This alone makes `get_controller_token`
+  real and unblocks the taOSnet passkey fetch too.
+- **Slice 2 - headless mesh-join** (pending Jay's 2a/2b decision). `mesh_up`,
+  `mesh_status`, install-story changes, Account-pane status. Tests: mock the
+  join call; live-verify on the Pi against hs.taos.my.
+- **Slice 3 - publish caller + static server + Web Studio UI.** Static-site server
+  on the tailnet port, `sites_token` publish/unpublish caller, ShareView publish
+  action. Tests: publish round-trip (mock taos.my), unpublish, mesh-not-joined
+  empty state; live-verify the FQDN resolves once ops lands the cert+proxy.
+
+## Open questions for Jay
+
+1. **Mesh-join mechanism (Unit 2): system `tailscale` (2a, recommended) or
+   userspace `tsnet` (2b)?** This defines a new per-platform install dependency,
+   so it is the gating decision. Everything in Slice 1 is independent of it and
+   can land first regardless.
+2. **Static-site serving (Unit 3): a per-site static server on the tailnet is the
+   v1 plan. Confirm static-only for v1** (dynamic/keep-running containers deferred),
+   consistent with Web Studio's current scope.
+3. Is there already a tailnet brought up on the Pi by the streamed-browser/Neko
+   work that Unit 2 should reuse rather than duplicate? (I will verify in code
+   before building Slice 2.)
+
+## Non-goals (v1)
+
+Dynamic/backend sites + "keep running" containers; custom TLD domains (#168);
+multi-host publish; client (phone/laptop) mesh membership (that is the separate
+tsnet client work website-dev referenced).

--- a/tests/test_mesh_credentials.py
+++ b/tests/test_mesh_credentials.py
@@ -1,0 +1,130 @@
+"""Host-local mesh credential store + the cluster-join poll-intercept that
+populates it (taOSgo Slice 1). The persisted service tokens must land 0600
+server-side and never appear in the browser-facing poll body."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from tinyagentos.taosnet import mesh_credentials, passkey_client
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
+    # Clear any env overrides so the file is the source of truth.
+    monkeypatch.delenv("TAOS_CONTROLLER_TOKEN", raising=False)
+    monkeypatch.delenv("TAOS_SITES_TOKEN", raising=False)
+    return tmp_path
+
+
+_READY = {
+    "status": "ready",
+    "account_id": "acct_1",
+    "host_id": "host_9",
+    "tailnet_name": "jason",
+    "headscale_preauth_key": "SINGLE-USE-SECRET",
+    "controller_token": "ctl.jwt.aaa",
+    "sites_token": "sites.jwt.bbb",
+    "joined_at": "2026-07-10T00:00:00Z",
+}
+
+
+class TestStore:
+    def test_round_trip(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
+        assert mesh_credentials.get_sites_token() == "sites.jwt.bbb"
+        assert mesh_credentials.get_host_id() == "host_9"
+        assert mesh_credentials.has_mesh_credentials() is True
+
+    def test_preauth_key_is_not_persisted(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        on_disk = json.loads((data_dir / "mesh_credentials.json").read_text())
+        assert "headscale_preauth_key" not in on_disk
+        assert on_disk["controller_token"] == "ctl.jwt.aaa"
+
+    def test_file_is_0600(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        mode = stat.S_IMODE(os.stat(data_dir / "mesh_credentials.json").st_mode)
+        assert mode == 0o600
+
+    def test_missing_required_fields_raise(self, data_dir):
+        with pytest.raises(ValueError):
+            mesh_credentials.save_mesh_credentials({"controller_token": "x"})  # no host_id
+        with pytest.raises(ValueError):
+            mesh_credentials.save_mesh_credentials({"host_id": "h"})  # no controller_token
+
+    def test_idempotent_resave(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        mesh_credentials.save_mesh_credentials(_READY)  # re-poll: same data, no error
+        assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
+
+    def test_none_before_join(self, data_dir):
+        assert mesh_credentials.get_controller_token() is None
+        assert mesh_credentials.get_sites_token() is None
+        assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_env_override_wins(self, data_dir, monkeypatch):
+        mesh_credentials.save_mesh_credentials(_READY)
+        monkeypatch.setenv("TAOS_CONTROLLER_TOKEN", "env-override")
+        assert mesh_credentials.get_controller_token() == "env-override"
+
+    def test_clear(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        mesh_credentials.clear()
+        assert mesh_credentials.get_controller_token() is None
+        mesh_credentials.clear()  # no-op when already gone
+
+    def test_passkey_client_delegates(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        # The download-manager import path reads the persisted token now.
+        assert passkey_client.get_controller_token() == "ctl.jwt.aaa"
+
+
+class TestPollIntercept:
+    def _resp(self, body, status=200, media="application/json"):
+        from fastapi import Response
+
+        content = json.dumps(body).encode() if isinstance(body, (dict, list)) else body
+        return Response(content=content, status_code=status, media_type=media)
+
+    def test_ready_payload_persists_and_strips_tokens(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out = _persist_join_credentials(self._resp(_READY))
+        # Persisted server-side.
+        assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
+        assert mesh_credentials.get_sites_token() == "sites.jwt.bbb"
+        # Stripped from the browser-facing body.
+        browser = json.loads(out.body)
+        assert "controller_token" not in browser
+        assert "sites_token" not in browser
+        # Non-secret status fields survive for the UI.
+        assert browser["status"] == "ready"
+        assert browser["tailnet_name"] == "jason"
+
+    def test_pending_payload_untouched(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        pending = {"status": "pending"}
+        out = _persist_join_credentials(self._resp(pending))
+        assert json.loads(out.body) == pending
+        assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_non_200_untouched(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out = _persist_join_credentials(self._resp({"error": "nope"}, status=403))
+        assert out.status_code == 403
+        assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_non_json_untouched(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out = _persist_join_credentials(self._resp(b"<html>oops</html>", media="text/html"))
+        assert out.body == b"<html>oops</html>"
+        assert mesh_credentials.has_mesh_credentials() is False

--- a/tests/test_mesh_credentials.py
+++ b/tests/test_mesh_credentials.py
@@ -79,6 +79,14 @@ class TestStore:
         assert mesh_credentials.get_controller_token() is None
         mesh_credentials.clear()  # no-op when already gone
 
+    def test_corrupt_non_dict_file_is_treated_as_absent(self, data_dir):
+        # An external edit / corruption leaving a non-object must not raise from
+        # the getters (which would break the headless passkey fetch).
+        (data_dir / "mesh_credentials.json").write_text("[1, 2, 3]")
+        assert mesh_credentials.get_controller_token() is None
+        assert mesh_credentials.get_sites_token() is None
+        assert mesh_credentials.has_mesh_credentials() is False
+
     def test_passkey_client_delegates(self, data_dir):
         mesh_credentials.save_mesh_credentials(_READY)
         # The download-manager import path reads the persisted token now.
@@ -128,3 +136,24 @@ class TestPollIntercept:
         out = _persist_join_credentials(self._resp(b"<html>oops</html>", media="text/html"))
         assert out.body == b"<html>oops</html>"
         assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_tokens_stripped_even_when_save_fails(self, data_dir):
+        # controller_token present but host_id missing -> save_mesh_credentials
+        # raises. The token must STILL be stripped (never leaked to compensate).
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        bad = {"status": "ready", "controller_token": "ctl.leak", "sites_token": "s.leak"}
+        out = _persist_join_credentials(self._resp(bad))
+        browser = json.loads(out.body)
+        assert "controller_token" not in browser and "sites_token" not in browser
+        assert mesh_credentials.has_mesh_credentials() is False  # save did fail
+
+    def test_json_without_content_type_is_still_stripped(self, data_dir):
+        # A JSON body served without a Content-Type header must not bypass
+        # stripping (parsing does not depend on media_type).
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out = _persist_join_credentials(self._resp(_READY, media=None))
+        browser = json.loads(out.body)
+        assert "controller_token" not in browser
+        assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -216,28 +216,32 @@ async def cluster_join_deny(request: Request, rid: str):
 
 
 def _persist_join_credentials(resp: Response) -> Response:
-    """When a poll response is the ``ready`` payload carrying the per-host service
-    tokens, persist them server-side (host-bound) and return a copy with those
-    tokens stripped, so the credentials never reach browser JavaScript.
+    """When a poll response carries the per-host service tokens, persist them
+    server-side (host-bound) and return a copy with those tokens ALWAYS stripped,
+    so a bearer credential never reaches browser JavaScript.
 
-    Fail-soft: any non-200, non-JSON, or unparseable body is returned untouched;
-    if persistence fails the body is returned as-is (tokens NOT stripped) rather
-    than dropping credentials the controller could not save. Relayed headers
+    Security ordering: stripping is decoupled from persistence. Once a 200 JSON
+    body is seen to contain a service token it is always stripped, whether or not
+    the save succeeds (a save failure is logged; the credentials are re-delivered
+    on the next poll -- but they are never leaked to the browser to compensate).
+    A non-200 body, or one that does not parse to a dict carrying a service token,
+    is returned untouched. Parsing does not depend on the Content-Type header (a
+    JSON body served without one must not bypass stripping). Relayed headers
     (Set-Cookie etc.) are preserved.
     """
-    if resp.status_code != 200 or "json" not in (resp.media_type or "").lower():
+    if resp.status_code != 200:
         return resp
     try:
         body = json.loads(resp.body)
     except (ValueError, TypeError):
         return resp
-    if not isinstance(body, dict) or not body.get("controller_token"):
+    if not isinstance(body, dict) or not any(body.get(k) for k in _JOIN_SERVICE_TOKENS):
         return resp
+    # Persist best-effort; never let a save error keep the token in the body.
     try:
         mesh_credentials.save_mesh_credentials(body)
-    except Exception as exc:  # noqa: BLE001 - never break the poll on a save error
+    except Exception as exc:  # noqa: BLE001
         logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
-        return resp
     stripped = {k: v for k, v in body.items() if k not in _JOIN_SERVICE_TOKENS}
     out = Response(
         content=json.dumps(stripped).encode("utf-8"),

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -11,6 +11,8 @@ staging testing. (A blank override still yields a 503 'service unavailable'.)
 """
 from __future__ import annotations
 
+import json
+import logging
 import os
 import re
 
@@ -18,7 +20,16 @@ import httpx
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
 
+from tinyagentos.taosnet import mesh_credentials
+
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+# Per-host service tokens the join ready payload carries. They are persisted
+# server-side and stripped from the browser-facing poll body so a bearer
+# credential never sits in browser JavaScript.
+_JOIN_SERVICE_TOKENS = ("controller_token", "sites_token")
 
 # Only these account actions are proxied. The upstream base is operator config
 # (env), never user input, so there is no open-proxy / SSRF surface.
@@ -204,8 +215,44 @@ async def cluster_join_deny(request: Request, rid: str):
     return await _forward_to(request, "POST", f"{_JOIN_BASE}/requests/{rid}/deny")
 
 
+def _persist_join_credentials(resp: Response) -> Response:
+    """When a poll response is the ``ready`` payload carrying the per-host service
+    tokens, persist them server-side (host-bound) and return a copy with those
+    tokens stripped, so the credentials never reach browser JavaScript.
+
+    Fail-soft: any non-200, non-JSON, or unparseable body is returned untouched;
+    if persistence fails the body is returned as-is (tokens NOT stripped) rather
+    than dropping credentials the controller could not save. Relayed headers
+    (Set-Cookie etc.) are preserved.
+    """
+    if resp.status_code != 200 or "json" not in (resp.media_type or "").lower():
+        return resp
+    try:
+        body = json.loads(resp.body)
+    except (ValueError, TypeError):
+        return resp
+    if not isinstance(body, dict) or not body.get("controller_token"):
+        return resp
+    try:
+        mesh_credentials.save_mesh_credentials(body)
+    except Exception as exc:  # noqa: BLE001 - never break the poll on a save error
+        logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
+        return resp
+    stripped = {k: v for k, v in body.items() if k not in _JOIN_SERVICE_TOKENS}
+    out = Response(
+        content=json.dumps(stripped).encode("utf-8"),
+        status_code=200,
+        media_type="application/json",
+    )
+    for raw in resp.raw_headers:
+        if raw[0].decode("latin-1").lower() in ("set-cookie", "location", "cache-control"):
+            out.raw_headers.append(raw)
+    return out
+
+
 @router.get("/api/account/cluster/join/requests/{rid}/poll")
 async def cluster_join_poll(request: Request, rid: str):
     if not _valid_rid(rid):
         return JSONResponse({"error": "invalid request id"}, status_code=400)
-    return await _forward_to(request, "GET", f"{_JOIN_BASE}/requests/{rid}/poll")
+    resp = await _forward_to(request, "GET", f"{_JOIN_BASE}/requests/{rid}/poll")
+    return _persist_join_credentials(resp)

--- a/tinyagentos/taosnet/mesh_credentials.py
+++ b/tinyagentos/taosnet/mesh_credentials.py
@@ -93,9 +93,14 @@ def save_mesh_credentials(payload: dict) -> None:
 
 def _load() -> Optional[dict]:
     try:
-        return json.loads(_path().read_text())
+        data = json.loads(_path().read_text())
     except (OSError, ValueError):
         return None
+    # A corrupt or externally-edited file could parse to a non-object (list,
+    # string, number); the getters do ``(_load() or {}).get(...)`` so a non-dict
+    # would raise AttributeError and break the headless passkey fetch. Treat any
+    # non-object as absent (fail closed to "not joined").
+    return data if isinstance(data, dict) else None
 
 
 def get_controller_token() -> Optional[str]:

--- a/tinyagentos/taosnet/mesh_credentials.py
+++ b/tinyagentos/taosnet/mesh_credentials.py
@@ -1,0 +1,128 @@
+"""Host-local persistence for the per-host taOSgo service credentials.
+
+When this host joins an account mesh (the consent-join flow proxied by
+``routes/account_proxy.py``), taos.my returns a ready payload carrying two
+single-scope, host-bound bearer tokens:
+
+- ``controller_token`` -- scope ``taosnet:passkey`` (fetch the account taOSnet
+  passkey; see ``passkey_client.py``)
+- ``sites_token``      -- scope ``sites:publish`` (publish a Web Studio site to
+  ``<label>.<handle>.taos.my``; taos.my #167)
+
+This module is the *writer* for the ``get_controller_token()`` seam
+``passkey_client.py`` documented: it persists those tokens to a single 0600 file
+under the data dir so headless callers (the download manager, the Web Studio
+publish caller) can present them without a browser session. The single-use
+Headscale preauth key is deliberately NOT stored here -- it is consumed once at
+mesh-join time, not a durable credential.
+
+Resolution mirrors ``create_app``: the data dir is ``TAOS_DATA_DIR`` if set, else
+``<project>/data``. Env overrides (``TAOS_CONTROLLER_TOKEN`` / ``TAOS_SITES_TOKEN``)
+still win, so local dev and existing tests keep working without a join.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_FILENAME = "mesh_credentials.json"
+
+# The fields we persist from the join ready payload. Anything else (notably the
+# single-use headscale_preauth_key) is intentionally dropped.
+_FIELDS = (
+    "account_id",
+    "host_id",
+    "tailnet_name",
+    "controller_token",
+    "sites_token",
+    "joined_at",
+)
+
+
+def _data_dir() -> Path:
+    env = os.environ.get("TAOS_DATA_DIR")
+    if env:
+        return Path(env)
+    # tinyagentos/taosnet/mesh_credentials.py -> project root is two parents up.
+    return Path(__file__).resolve().parent.parent.parent / "data"
+
+
+def _path() -> Path:
+    return _data_dir() / _FILENAME
+
+
+def save_mesh_credentials(payload: dict) -> None:
+    """Persist the join ready-payload service credentials, host-bound, mode 0600.
+
+    Keeps only the ``_FIELDS`` allowlist (drops the single-use preauth key and
+    anything else). Requires at least ``controller_token`` + ``host_id``; raises
+    ``ValueError`` otherwise. Atomic (write temp + ``os.replace``) so a crash
+    mid-write never leaves a partial file. Idempotent: re-saving the same host's
+    payload just rewrites identical data.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a mapping")
+    creds = {k: payload.get(k) for k in _FIELDS}
+    if not creds.get("controller_token") or not creds.get("host_id"):
+        raise ValueError("payload missing controller_token/host_id")
+
+    d = _data_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:  # pragma: no cover - best effort on odd filesystems
+        pass
+
+    p = _path()
+    tmp = p.with_name(p.name + ".tmp")
+    data = json.dumps(creds).encode("utf-8")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+    os.replace(tmp, p)
+    try:
+        os.chmod(p, 0o600)
+    except OSError:  # pragma: no cover
+        pass
+
+
+def _load() -> Optional[dict]:
+    try:
+        return json.loads(_path().read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def get_controller_token() -> Optional[str]:
+    """The persisted ``taosnet:passkey`` token, or ``TAOS_CONTROLLER_TOKEN`` if
+    that dev override is set, or None when this host has not joined a mesh."""
+    return os.getenv("TAOS_CONTROLLER_TOKEN") or (_load() or {}).get("controller_token") or None
+
+
+def get_sites_token() -> Optional[str]:
+    """The persisted ``sites:publish`` token (Web Studio publish caller), or the
+    ``TAOS_SITES_TOKEN`` dev override, or None before join."""
+    return os.getenv("TAOS_SITES_TOKEN") or (_load() or {}).get("sites_token") or None
+
+
+def get_host_id() -> Optional[str]:
+    """The taos.my host row id this instance joined as, or None."""
+    return (_load() or {}).get("host_id") or None
+
+
+def has_mesh_credentials() -> bool:
+    """True once this host has joined an account mesh (a controller token exists)."""
+    return get_controller_token() is not None
+
+
+def clear() -> None:
+    """Forget the persisted mesh credentials (on leave/unjoin). No-op if absent."""
+    try:
+        _path().unlink()
+    except OSError:
+        pass

--- a/tinyagentos/taosnet/passkey_client.py
+++ b/tinyagentos/taosnet/passkey_client.py
@@ -41,12 +41,14 @@ def get_controller_token() -> Optional[str]:
     """The controller token persisted when this host joined an account mesh,
     or None if it has not joined one.
 
-    Read from ``TAOS_CONTROLLER_TOKEN`` for now; this is the seam the
-    cluster-join client writes to (alongside the Headscale key) once that
-    client lands. None means the headless passkey fetch is skipped and the
-    download stays on the web-seed baseline.
+    Delegates to ``mesh_credentials`` (the writer for this seam, populated by the
+    cluster-join poll-intercept); the ``TAOS_CONTROLLER_TOKEN`` env override still
+    wins there. None means the headless passkey fetch is skipped and the download
+    stays on the web-seed baseline.
     """
-    return os.getenv("TAOS_CONTROLLER_TOKEN") or None
+    from tinyagentos.taosnet import mesh_credentials
+
+    return mesh_credentials.get_controller_token()
 
 
 async def fetch_passkey(


### PR DESCRIPTION
Slice 1 of the taOSgo mesh-join foundation (docs/design/taosgo-mesh-join-foundation.md), which unblocks Web Studio publish (#167) and off-LAN remote access.

## Problem
The controller had **no writer** for the `get_controller_token()` seam - it read a placeholder env var. So once a host actually joined an account mesh, the headless taOSnet passkey fetch (and the future Web Studio publish caller) had no credential.

## Change
- **`tinyagentos/taosnet/mesh_credentials.py`** - a host-local **0600** store for the per-host service tokens taos.my returns in the cluster-join ready payload: `controller_token` (scope `taosnet:passkey`) + `sites_token` (scope `sites:publish`). The single-use Headscale preauth key is intentionally **not** persisted. `get_controller_token()`/`get_sites_token()` read it; the `TAOS_CONTROLLER_TOKEN`/`TAOS_SITES_TOKEN` env overrides still win for dev/tests.
- **Poll-intercept** (`routes/account_proxy.py::cluster_join_poll`): persists the ready-payload tokens **server-side** and **strips them from the browser-facing body**, so a bearer credential never sits in browser JavaScript. Fail-soft: non-200 / non-JSON / unparseable bodies and save failures leave the response untouched (never drops a credential it could not save).
- `passkey_client.get_controller_token()` now delegates to the store.

Slice 1 is **credentials only** - no mesh-join yet (that is Slice 2, pending your system-tailscale-vs-tsnet decision). It already makes the headless taOSnet passkey fetch real the moment a host joins.

## Tests
13 new (`tests/test_mesh_credentials.py`): store round-trip, 0600 perms, preauth-key-not-persisted, required-field validation, idempotent re-poll, env override, clear, passkey-client delegation, and the intercept persist+strip + fail-soft matrix (pending/non-200/non-JSON untouched). Existing account-proxy + taosnet suites stay green (82 passed). doc-gate clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Mesh-join credentials are now securely persisted locally for continued controller and site access.
  - Sensitive service tokens are removed from browser-facing join responses.
  - Passkey retrieval can use securely stored credentials, while environment overrides remain supported.

- **Documentation**
  - Added design specifications for offline game-asset generation and mesh-based site publishing.
  - Documents outline planned editor behavior, asset licensing, publishing flows, rollout slices, and v1 scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->