### PR TITLE
feat(taosgo): headless Headscale mesh-join via system tailscale (Slice 2)

### DIFF
--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,118 @@
+"""Headless Headscale mesh membership (taOSgo Slice 2). Everything shells to
+`tailscale` and must be fail-soft: a host without the binary degrades to a
+structured "not available" result, never raises."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tinyagentos.taosnet import mesh
+
+
+def _run_returns(rc, out="", err=""):
+    async def _fake(args, timeout=30.0):
+        return rc, out, err
+    return _fake
+
+
+class TestInstalledGuard:
+    def test_not_installed_short_circuits(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=False):
+            import asyncio
+            r = asyncio.run(mesh.mesh_up("key", "host"))
+            assert r == {"ok": False, "detail": "tailscale not installed"}
+            s = asyncio.run(mesh.mesh_status())
+            assert s["joined"] is False and "not installed" in s["detail"]
+            assert asyncio.run(mesh.is_joined()) is False
+
+    def test_login_server_env_override(self, monkeypatch):
+        monkeypatch.setenv("TAOS_HEADSCALE_URL", "https://hs.staging.example/")
+        assert mesh.login_server() == "https://hs.staging.example"
+        monkeypatch.delenv("TAOS_HEADSCALE_URL", raising=False)
+        assert mesh.login_server() == "https://hs.taos.my"
+
+
+@pytest.mark.asyncio
+class TestMeshUp:
+    async def test_missing_args(self):
+        assert (await mesh.mesh_up("", "host"))["ok"] is False
+        assert (await mesh.mesh_up("key", ""))["ok"] is False
+
+    async def test_up_success(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0)):
+            r = await mesh.mesh_up("preauth", "myhost", ls="https://hs.taos.my")
+        assert r["ok"] is True and "hs.taos.my" in r["detail"]
+
+    async def test_up_failure_is_fail_soft(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(1, err="invalid key")):
+            r = await mesh.mesh_up("bad", "myhost")
+        assert r["ok"] is False and "invalid key" in r["detail"]
+
+    async def test_up_passes_expected_args(self):
+        captured = {}
+
+        async def _capture(args, timeout=60.0):
+            captured["args"] = args
+            return 0, "", ""
+
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _capture):
+            await mesh.mesh_up("PA", "node-1", ls="https://hs.x")
+        a = captured["args"]
+        assert a[:2] == ["tailscale", "up"]
+        assert "--authkey" in a and "PA" in a
+        assert "--hostname" in a and "node-1" in a
+        assert "--login-server" in a and "https://hs.x" in a
+
+
+@pytest.mark.asyncio
+class TestMeshStatus:
+    _STATUS = {
+        "BackendState": "Running",
+        "CurrentTailnet": {"Name": "jason"},
+        "Self": {"Online": True, "HostName": "node-1", "TailscaleIPs": ["100.64.0.5"]},
+    }
+
+    async def test_joined_parse(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out=json.dumps(self._STATUS))):
+            s = await mesh.mesh_status()
+        assert s["joined"] is True
+        assert s["tailnet"] == "jason"
+        assert s["node_ip"] == "100.64.0.5"
+        assert s["hostname"] == "node-1"
+
+    async def test_not_running_not_joined(self):
+        stopped = {"BackendState": "Stopped", "Self": {}}
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out=json.dumps(stopped))):
+            s = await mesh.mesh_status()
+        assert s["joined"] is False
+
+    async def test_unparseable_status_fail_soft(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out="not-json")):
+            s = await mesh.mesh_status()
+        assert s["joined"] is False and "unparseable" in s["detail"]
+
+    async def test_status_nonzero_fail_soft(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(1, err="not running")):
+            s = await mesh.mesh_status()
+        assert s["joined"] is False and "not running" in s["detail"]
+
+
+@pytest.mark.asyncio
+class TestMeshDown:
+    async def test_down_success(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0)):
+            assert (await mesh.mesh_down())["ok"] is True
+
+    async def test_down_not_installed(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=False):
+            assert (await mesh.mesh_down())["ok"] is False

--- a/tests/test_mesh_credentials.py
+++ b/tests/test_mesh_credentials.py
@@ -103,7 +103,7 @@ class TestPollIntercept:
     def test_ready_payload_persists_and_strips_tokens(self, data_dir):
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
-        out = _persist_join_credentials(self._resp(_READY))
+        out, _ji = _persist_join_credentials(self._resp(_READY))
         # Persisted server-side.
         assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
         assert mesh_credentials.get_sites_token() == "sites.jwt.bbb"
@@ -119,21 +119,21 @@ class TestPollIntercept:
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
         pending = {"status": "pending"}
-        out = _persist_join_credentials(self._resp(pending))
+        out, _ji = _persist_join_credentials(self._resp(pending))
         assert json.loads(out.body) == pending
         assert mesh_credentials.has_mesh_credentials() is False
 
     def test_non_200_untouched(self, data_dir):
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
-        out = _persist_join_credentials(self._resp({"error": "nope"}, status=403))
+        out, _ji = _persist_join_credentials(self._resp({"error": "nope"}, status=403))
         assert out.status_code == 403
         assert mesh_credentials.has_mesh_credentials() is False
 
     def test_non_json_untouched(self, data_dir):
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
-        out = _persist_join_credentials(self._resp(b"<html>oops</html>", media="text/html"))
+        out, _ji = _persist_join_credentials(self._resp(b"<html>oops</html>", media="text/html"))
         assert out.body == b"<html>oops</html>"
         assert mesh_credentials.has_mesh_credentials() is False
 
@@ -143,7 +143,7 @@ class TestPollIntercept:
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
         bad = {"status": "ready", "controller_token": "ctl.leak", "sites_token": "s.leak"}
-        out = _persist_join_credentials(self._resp(bad))
+        out, _ji = _persist_join_credentials(self._resp(bad))
         browser = json.loads(out.body)
         assert "controller_token" not in browser and "sites_token" not in browser
         assert mesh_credentials.has_mesh_credentials() is False  # save did fail
@@ -153,7 +153,24 @@ class TestPollIntercept:
         # stripping (parsing does not depend on media_type).
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
-        out = _persist_join_credentials(self._resp(_READY, media=None))
+        out, _ji = _persist_join_credentials(self._resp(_READY, media=None))
         browser = json.loads(out.body)
         assert "controller_token" not in browser
         assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
+
+    def test_preauth_key_stripped_and_join_intent_returned(self, data_dir):
+        # Slice 2: the single-use preauth key is stripped from the browser body
+        # (consumed server-side) and surfaced as a join intent for the caller.
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out, join_intent = _persist_join_credentials(self._resp(_READY))
+        browser = json.loads(out.body)
+        assert "headscale_preauth_key" not in browser
+        assert join_intent == {"preauth_key": "SINGLE-USE-SECRET", "hostname": "host_9"}
+
+    def test_no_preauth_means_no_join_intent(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        no_pre = {k: v for k, v in _READY.items() if k != "headscale_preauth_key"}
+        _out, join_intent = _persist_join_credentials(self._resp(no_pre))
+        assert join_intent is None

--- a/tests/test_mesh_credentials.py
+++ b/tests/test_mesh_credentials.py
@@ -168,6 +168,18 @@ class TestPollIntercept:
         assert "headscale_preauth_key" not in browser
         assert join_intent == {"preauth_key": "SINGLE-USE-SECRET", "hostname": "host_9"}
 
+    def test_preauth_only_no_service_token_still_stripped(self, data_dir):
+        # A ready payload carrying ONLY the preauth key (no service tokens) must
+        # still fire + strip it -- the "ALWAYS strip" guarantee cannot hinge on a
+        # service token being present.
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        pre_only = {"status": "ready", "host_id": "h", "headscale_preauth_key": "PK"}
+        out, join_intent = _persist_join_credentials(self._resp(pre_only))
+        assert "headscale_preauth_key" not in json.loads(out.body)
+        assert join_intent == {"preauth_key": "PK", "hostname": "h"}
+        assert mesh_credentials.has_mesh_credentials() is False  # no controller token
+
     def test_no_preauth_means_no_join_intent(self, data_dir):
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -11,6 +11,7 @@ staging testing. (A blank override still yields a 503 'service unavailable'.)
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -20,7 +21,7 @@ import httpx
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
 
-from tinyagentos.taosnet import mesh_credentials
+from tinyagentos.taosnet import mesh, mesh_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,10 @@ router = APIRouter()
 # server-side and stripped from the browser-facing poll body so a bearer
 # credential never sits in browser JavaScript.
 _JOIN_SERVICE_TOKENS = ("controller_token", "sites_token")
+# Everything stripped from the browser body: the service tokens plus the
+# single-use Headscale preauth key, which the controller consumes server-side to
+# join the mesh (Slice 2). None of these should ever reach browser JavaScript.
+_STRIP_KEYS = _JOIN_SERVICE_TOKENS + ("headscale_preauth_key",)
 
 # Only these account actions are proxied. The upstream base is operator config
 # (env), never user input, so there is no open-proxy / SSRF surface.
@@ -215,34 +220,45 @@ async def cluster_join_deny(request: Request, rid: str):
     return await _forward_to(request, "POST", f"{_JOIN_BASE}/requests/{rid}/deny")
 
 
-def _persist_join_credentials(resp: Response) -> Response:
+def _persist_join_credentials(resp: Response) -> tuple[Response, dict | None]:
     """When a poll response carries the per-host service tokens, persist them
-    server-side (host-bound) and return a copy with those tokens ALWAYS stripped,
-    so a bearer credential never reaches browser JavaScript.
+    server-side (host-bound) and return a copy with those tokens + the single-use
+    preauth key ALWAYS stripped, so nothing secret reaches browser JavaScript.
 
-    Security ordering: stripping is decoupled from persistence. Once a 200 JSON
-    body is seen to contain a service token it is always stripped, whether or not
-    the save succeeds (a save failure is logged; the credentials are re-delivered
-    on the next poll -- but they are never leaked to the browser to compensate).
-    A non-200 body, or one that does not parse to a dict carrying a service token,
-    is returned untouched. Parsing does not depend on the Content-Type header (a
-    JSON body served without one must not bypass stripping). Relayed headers
+    Returns ``(browser_response, join_intent)``. ``join_intent`` is
+    ``{"preauth_key", "hostname"}`` when the ready payload carried a preauth key
+    for the caller to consume server-side (trigger the mesh-join), else None.
+
+    Security ordering: stripping is decoupled from persistence and from the join.
+    Once a 200 JSON body is seen to contain a service token, the secrets are
+    always stripped, whether or not the save/join succeeds. A non-200 body, or one
+    that does not parse to a dict carrying a service token, is returned untouched.
+    Parsing does not depend on the Content-Type header. Relayed headers
     (Set-Cookie etc.) are preserved.
     """
     if resp.status_code != 200:
-        return resp
+        return resp, None
     try:
         body = json.loads(resp.body)
     except (ValueError, TypeError):
-        return resp
+        return resp, None
     if not isinstance(body, dict) or not any(body.get(k) for k in _JOIN_SERVICE_TOKENS):
-        return resp
+        return resp, None
     # Persist best-effort; never let a save error keep the token in the body.
     try:
         mesh_credentials.save_mesh_credentials(body)
     except Exception as exc:  # noqa: BLE001
         logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
-    stripped = {k: v for k, v in body.items() if k not in _JOIN_SERVICE_TOKENS}
+
+    preauth = body.get("headscale_preauth_key")
+    join_intent = None
+    if preauth:
+        # The Headscale node hostname; the exact value taos.my routes on is the
+        # host row identity, so prefer an explicit hostname field, else host_id.
+        hostname = body.get("hostname") or body.get("host_id") or "taos-host"
+        join_intent = {"preauth_key": preauth, "hostname": str(hostname)}
+
+    stripped = {k: v for k, v in body.items() if k not in _STRIP_KEYS}
     out = Response(
         content=json.dumps(stripped).encode("utf-8"),
         status_code=200,
@@ -251,7 +267,16 @@ def _persist_join_credentials(resp: Response) -> Response:
     for raw in resp.raw_headers:
         if raw[0].decode("latin-1").lower() in ("set-cookie", "location", "cache-control"):
             out.raw_headers.append(raw)
-    return out
+    return out, join_intent
+
+
+async def _run_mesh_join(intent: dict) -> None:
+    """Background task: consume the single-use preauth key to join the mesh.
+    Fail-soft; a host without tailscale (or a failed join) is logged, never
+    raised, so the poll it was triggered from is unaffected."""
+    result = await mesh.mesh_up(intent["preauth_key"], intent["hostname"])
+    if not result.get("ok"):
+        logger.warning("taosgo: background mesh join did not complete: %s", result.get("detail"))
 
 
 @router.get("/api/account/cluster/join/requests/{rid}/poll")
@@ -259,4 +284,15 @@ async def cluster_join_poll(request: Request, rid: str):
     if not _valid_rid(rid):
         return JSONResponse({"error": "invalid request id"}, status_code=400)
     resp = await _forward_to(request, "GET", f"{_JOIN_BASE}/requests/{rid}/poll")
-    return _persist_join_credentials(resp)
+    out, join_intent = _persist_join_credentials(resp)
+    if join_intent and not await mesh.is_joined():
+        # Fire-and-forget so the slow `tailscale up` never blocks the poll.
+        asyncio.create_task(_run_mesh_join(join_intent))
+    return out
+
+
+@router.get("/api/account/mesh/status")
+async def mesh_status(request: Request):
+    """Report this host's mesh membership for the Account pane
+    ({joined, tailnet, node_ip, ...}). Fail-soft (never raises)."""
+    return JSONResponse(await mesh.mesh_status())

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -242,13 +242,18 @@ def _persist_join_credentials(resp: Response) -> tuple[Response, dict | None]:
         body = json.loads(resp.body)
     except (ValueError, TypeError):
         return resp, None
-    if not isinstance(body, dict) or not any(body.get(k) for k in _JOIN_SERVICE_TOKENS):
+    # Fire whenever the body carries ANY secret (a service token or the preauth
+    # key), so a ready payload with only a preauth key is still stripped -- the
+    # "ALWAYS strip" guarantee must not hinge on a service token being present.
+    if not isinstance(body, dict) or not any(body.get(k) for k in _STRIP_KEYS):
         return resp, None
-    # Persist best-effort; never let a save error keep the token in the body.
-    try:
-        mesh_credentials.save_mesh_credentials(body)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
+    # Persist best-effort (only possible when a controller token is present);
+    # never let a save error keep a secret in the body.
+    if body.get("controller_token"):
+        try:
+            mesh_credentials.save_mesh_credentials(body)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
 
     preauth = body.get("headscale_preauth_key")
     join_intent = None
@@ -270,6 +275,18 @@ def _persist_join_credentials(resp: Response) -> tuple[Response, dict | None]:
     return out, join_intent
 
 
+# Preauth keys are single-use: once a join has been attempted for one it cannot
+# be retried, so we do not re-fire on every re-delivered ready poll. In-memory is
+# sufficient (a process restart that loses this simply means a fresh join
+# opportunity, and the key is stale by then anyway).
+_attempted_preauth: set[str] = set()
+
+# Keep a strong reference to in-flight background tasks so they are not
+# garbage-collected mid-run (a bare create_task() can be dropped -> "coroutine
+# was never awaited").
+_mesh_join_tasks: set = set()
+
+
 async def _run_mesh_join(intent: dict) -> None:
     """Background task: consume the single-use preauth key to join the mesh.
     Fail-soft; a host without tailscale (or a failed join) is logged, never
@@ -285,9 +302,18 @@ async def cluster_join_poll(request: Request, rid: str):
         return JSONResponse({"error": "invalid request id"}, status_code=400)
     resp = await _forward_to(request, "GET", f"{_JOIN_BASE}/requests/{rid}/poll")
     out, join_intent = _persist_join_credentials(resp)
-    if join_intent and not await mesh.is_joined():
-        # Fire-and-forget so the slow `tailscale up` never blocks the poll.
-        asyncio.create_task(_run_mesh_join(join_intent))
+    if (
+        join_intent
+        and join_intent["preauth_key"] not in _attempted_preauth
+        and not await mesh.is_joined()
+    ):
+        # A single-use key: mark it attempted so a re-delivered ready poll does
+        # not re-fire a doomed re-join. Fire-and-forget (a slow `tailscale up`
+        # must never block the poll), holding a reference so it is not GC'd.
+        _attempted_preauth.add(join_intent["preauth_key"])
+        task = asyncio.create_task(_run_mesh_join(join_intent))
+        _mesh_join_tasks.add(task)
+        task.add_done_callback(_mesh_join_tasks.discard)
     return out
 
 

--- a/tinyagentos/taosnet/mesh.py
+++ b/tinyagentos/taosnet/mesh.py
@@ -101,9 +101,10 @@ async def mesh_up(
 
 
 async def mesh_status() -> dict:
-    """Report ``{joined, tailnet, node_ip, hostname, detail}`` from
-    ``tailscale status --json``. Fail-soft: not-installed / not-up returns
-    ``joined=False`` with a detail, never raises."""
+    """Report mesh membership from ``tailscale status --json``. On success:
+    ``{joined, online, tailnet, node_ip, hostname}``. On the not-available /
+    error path: ``{joined: False, detail}``. Fail-soft: not-installed / not-up
+    returns ``joined=False`` with a detail, never raises."""
     if not is_tailscale_installed():
         return {"joined": False, "detail": "tailscale not installed"}
     rc, out, err = await _run(["tailscale", "status", "--json"], timeout=10.0)

--- a/tinyagentos/taosnet/mesh.py
+++ b/tinyagentos/taosnet/mesh.py
@@ -1,0 +1,143 @@
+"""Headless Headscale mesh membership for taOSgo (Slice 2).
+
+The always-on host joins the account's Headscale mesh using the single-use
+preauth key from the cluster-join ready payload, so that
+``<label>.<handle>.taos.my`` (Web Studio publish) and off-LAN desktop access can
+route to this host over the tailnet. Jay decided the mechanism is **system
+tailscale** (tailscale + tailscaled managed as a service), not userspace tsnet:
+real kernel networking, boot-persistent, best for the always-on host.
+
+Everything here is fail-soft and never raises to the caller: on a host without
+``tailscale`` installed (dev boxes, CI) every call returns a structured
+"not available" result so the join flow degrades cleanly. The installer is
+responsible for actually placing the ``tailscale`` binary + daemon on supported
+hosts; this module only drives it.
+
+The login server (Headscale) defaults to ``https://hs.taos.my`` and is
+overridable via ``TAOS_HEADSCALE_URL`` for staging/self-hosted control servers.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LOGIN_SERVER = "https://hs.taos.my"
+
+
+def login_server() -> str:
+    """The Headscale control server URL, trailing slash stripped."""
+    return os.environ.get("TAOS_HEADSCALE_URL", _DEFAULT_LOGIN_SERVER).rstrip("/")
+
+
+def is_tailscale_installed() -> bool:
+    """True when the ``tailscale`` CLI is on PATH (the installer provides it on
+    supported hosts). When False, every operation degrades to "not available"."""
+    return shutil.which("tailscale") is not None
+
+
+async def _run(args: list[str], timeout: float = 30.0) -> tuple[int, str, str]:
+    """Run a subprocess, returning ``(returncode, stdout, stderr)``. Fail-soft:
+    a missing binary or timeout yields a non-zero code and a detail string, never
+    raises. On timeout the child is killed and reaped so it is not orphaned."""
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        return proc.returncode, out.decode(errors="replace"), err.decode(errors="replace")
+    except asyncio.TimeoutError:
+        if proc is not None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # pragma: no cover - defensive
+                pass
+        return 124, "", f"timed out after {timeout}s"
+    except FileNotFoundError:
+        return 127, "", "tailscale not installed"
+    except Exception as exc:  # noqa: BLE001 - never raise into the join flow
+        return 1, "", str(exc)[:200]
+
+
+async def mesh_up(
+    preauth_key: str, hostname: str, *, ls: Optional[str] = None, timeout: float = 60.0
+) -> dict:
+    """Join the account Headscale mesh with a single-use preauth key.
+
+    Runs ``tailscale up --login-server <ls> --authkey <key> --hostname <name>``.
+    Returns ``{"ok": bool, "detail": str}``. Fail-soft: a host without tailscale,
+    a bad key, or a timeout all return ``ok=False`` with a reason rather than
+    raising, so a poll that triggers the join is never broken by it.
+    """
+    if not preauth_key or not hostname:
+        return {"ok": False, "detail": "missing preauth key or hostname"}
+    if not is_tailscale_installed():
+        return {"ok": False, "detail": "tailscale not installed"}
+    server = ls or login_server()
+    rc, _out, err = await _run(
+        [
+            "tailscale", "up",
+            "--login-server", server,
+            "--authkey", preauth_key,
+            "--hostname", hostname,
+        ],
+        timeout=timeout,
+    )
+    if rc == 0:
+        logger.info("taosgo: joined mesh %s as %s", server, hostname)
+        return {"ok": True, "detail": f"joined {server}"}
+    detail = (err.strip() or f"exit {rc}")[:200]
+    logger.warning("taosgo: mesh join failed (%s): %s", server, detail)
+    return {"ok": False, "detail": detail}
+
+
+async def mesh_status() -> dict:
+    """Report ``{joined, tailnet, node_ip, hostname, detail}`` from
+    ``tailscale status --json``. Fail-soft: not-installed / not-up returns
+    ``joined=False`` with a detail, never raises."""
+    if not is_tailscale_installed():
+        return {"joined": False, "detail": "tailscale not installed"}
+    rc, out, err = await _run(["tailscale", "status", "--json"], timeout=10.0)
+    if rc != 0:
+        return {"joined": False, "detail": (err.strip() or f"exit {rc}")[:200]}
+    try:
+        data = json.loads(out)
+    except (ValueError, TypeError):
+        return {"joined": False, "detail": "unparseable status"}
+    self_node = data.get("Self") or {}
+    online = bool(self_node.get("Online"))
+    ips = self_node.get("TailscaleIPs") or []
+    # BackendState "Running" + a Self node means we are up on the tailnet.
+    joined = data.get("BackendState") == "Running" and bool(self_node)
+    return {
+        "joined": joined,
+        "online": online,
+        "tailnet": (data.get("CurrentTailnet") or {}).get("Name"),
+        "node_ip": ips[0] if ips else None,
+        "hostname": self_node.get("HostName"),
+    }
+
+
+async def is_joined() -> bool:
+    """True when this host is up on the tailnet (used to avoid a redundant
+    re-join when a poll re-delivers a ready payload)."""
+    return bool((await mesh_status()).get("joined"))
+
+
+async def mesh_down() -> dict:
+    """Leave the mesh (``tailscale logout``). Fail-soft."""
+    if not is_tailscale_installed():
+        return {"ok": False, "detail": "tailscale not installed"}
+    rc, _out, err = await _run(["tailscale", "logout"], timeout=30.0)
+    if rc == 0:
+        return {"ok": True, "detail": "left mesh"}
+    return {"ok": False, "detail": (err.strip() or f"exit {rc}")[:200]}


### PR DESCRIPTION
Slice 2 of the taOSgo mesh-join foundation (docs/design/taosgo-mesh-join-foundation.md), building on the Slice 1 credential store (#1770, merged). You chose **system tailscale** for the always-on host.

## What it does
- **`tinyagentos/taosnet/mesh.py`** - async, fail-soft wrappers over the tailscale CLI: `mesh_up` (`tailscale up --login-server hs.taos.my --authkey <preauth> --hostname`), `mesh_status` (parse `tailscale status --json` -> `{joined, tailnet, node_ip, hostname}`), `is_joined`, `mesh_down`, `is_tailscale_installed`. A host without the binary degrades to a structured "not available" result; nothing ever raises into the join flow. Control server overridable via `TAOS_HEADSCALE_URL`.
- **Poll-intercept wiring** (`routes/account_proxy.py`): the cluster-join poll now consumes the single-use `headscale_preauth_key` **server-side** to join the mesh (fire-and-forget background task, guarded by `is_joined()` so a re-delivered ready payload does not re-join), and **strips the preauth key from the browser body** too. Strip stays decoupled from the join: secrets are always removed whether or not the join succeeds.
- New **`GET /api/account/mesh/status`** for the Account pane.

## Tests
15 for `mesh.py` (up/status/down, installed-guard short-circuit, exact arg shape, and the fail-soft matrix: not-installed / bad-key / unparseable-status / nonzero) + 2 intercept tests (preauth stripped + join intent surfaced). Slice-1 intercept tests updated for the new tuple return. **42 pass** across mesh/creds/account-proxy. doc-gate clean.

## Follow-up (Slice 2b, needs the live Pi)
`install.sh` must install `tailscale` + `tailscaled` on supported hosts, and a real join against `hs.taos.my` must be verified end to end (plus confirming the exact `--hostname` value taos.my routes on). Until that lands this is **inert** on hosts without tailscale (fail-soft), so it is safe to merge now. Slice 3 = the publish caller + static-site server on the tailnet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Headscale mesh connectivity for joining, checking membership, and leaving the mesh.
  - Added a mesh status endpoint for viewing current membership.
  - Cluster join flows now securely process credentials and automatically initiate mesh joining when needed.
  - Sensitive service and preauthorization tokens are removed from browser-visible responses.

- **Bug Fixes**
  - Mesh operations now fail gracefully when Tailscale is unavailable, misconfigured, or encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->