### PR TITLE
feat(gamestudio): AI texture/sprite generation via ComfyUI backend (Slice 1)

### DIFF
--- a/desktop/src/apps/gamestudio/AssetsPanel.test.tsx
+++ b/desktop/src/apps/gamestudio/AssetsPanel.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { AssetsPanel } from "./AssetsPanel";
+
+const TEXTURE_URL = "/api/games/g1/assets/texture";
+
+function fetchOnce(body: unknown, ok = true, status = 200) {
+  return vi.fn((input: RequestInfo | URL) => {
+    expect(String(input)).toBe(TEXTURE_URL);
+    return Promise.resolve({
+      ok,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response);
+  });
+}
+
+describe("AssetsPanel", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the prompt input and a disabled Generate button when empty", () => {
+    render(<AssetsPanel gameId="g1" activePath="index.html" onInsert={vi.fn()} />);
+    expect(screen.getByLabelText("Describe the texture or sprite")).toBeDefined();
+    expect((screen.getByRole("button", { name: "Generate" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("generates a texture and shows a preview + insert action", async () => {
+    const onInsert = vi.fn();
+    const fetchMock = fetchOnce({
+      available: true,
+      status: "generated",
+      filename: "texture-1-abcd.png",
+      path: "/api/games/g1/preview/texture-1-abcd.png",
+      kind: "texture",
+      tier: "sdxl",
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AssetsPanel gameId="g1" activePath="index.html" onInsert={onInsert} />);
+    fireEvent.change(screen.getByLabelText("Describe the texture or sprite"), {
+      target: { value: "a mossy stone wall" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    const img = (await screen.findByAltText("Generated texture")) as HTMLImageElement;
+    expect(img.src).toContain("/api/games/g1/preview/texture-1-abcd.png");
+
+    // Insert calls the callback with the generated filename.
+    fireEvent.click(screen.getByRole("button", { name: /Insert into index\.html/ }));
+    expect(onInsert).toHaveBeenCalledWith("texture-1-abcd.png");
+    // Sending the request used the right body.
+    const sentBody = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(sentBody.prompt).toBe("a mossy stone wall");
+    expect(sentBody.kind).toBe("texture");
+  });
+
+  it("shows a 'Needs a GPU worker' state when the tier is unavailable", async () => {
+    const fetchMock = fetchOnce({ available: false, reason: "No GPU or NPU worker available." });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AssetsPanel gameId="g1" activePath="index.html" onInsert={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Describe the texture or sprite"), {
+      target: { value: "a texture" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    await waitFor(() => expect(screen.getByText("Needs a GPU worker")).toBeDefined());
+    expect(screen.getByText("No GPU or NPU worker available.")).toBeDefined();
+    // No preview / insert button in the unavailable state.
+    expect(screen.queryByRole("button", { name: /Insert/ })).toBeNull();
+  });
+
+  it("surfaces a backend error", async () => {
+    const fetchMock = fetchOnce({ error: "Texture generation failed." }, false, 502);
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AssetsPanel gameId="g1" activePath="index.html" onInsert={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Describe the texture or sprite"), {
+      target: { value: "a texture" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Texture generation failed.");
+  });
+
+  it("disables insert when no file is open", async () => {
+    const fetchMock = fetchOnce({
+      available: true,
+      status: "generated",
+      filename: "texture-1.png",
+      path: "/api/games/g1/preview/texture-1.png",
+      kind: "texture",
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AssetsPanel gameId="g1" activePath={null} onInsert={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Describe the texture or sprite"), {
+      target: { value: "a texture" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    const insert = (await screen.findByRole("button", { name: /Open a file to insert/ })) as HTMLButtonElement;
+    expect(insert.disabled).toBe(true);
+  });
+});

--- a/desktop/src/apps/gamestudio/AssetsPanel.tsx
+++ b/desktop/src/apps/gamestudio/AssetsPanel.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { ImagePlus, Loader2, AlertCircle, Sparkles, Check, Cpu } from "lucide-react";
+import { generateTexture, type AssetKind, type TextureResult } from "./game-assets-api";
+
+/* ------------------------------------------------------------------ */
+/*  AssetsPanel -- AI texture/sprite generation for the Game Studio     */
+/*                                                                     */
+/*  Prompt + size/tileable controls drive POST /assets/texture. The     */
+/*  backend writes the PNG into the game's file set and returns its      */
+/*  preview path; "Insert" appends a reference to the current file. When  */
+/*  the backend reports available:false (no GPU/NPU worker) the panel     */
+/*  shows a clear disabled state rather than a broken Generate button --  */
+/*  mirroring the Images Studio tier-gate precedent.                     */
+/* ------------------------------------------------------------------ */
+
+export interface AssetsPanelProps {
+  gameId: string;
+  /** The file the generated reference will be appended to (null = no file). */
+  activePath: string | null;
+  /** Append a reference to the generated asset into the current file. */
+  onInsert: (filename: string) => void;
+}
+
+const SIZES = [256, 512, 768, 1024] as const;
+
+export function AssetsPanel({ gameId, activePath, onInsert }: AssetsPanelProps) {
+  const [prompt, setPrompt] = useState("");
+  const [kind, setKind] = useState<AssetKind>("texture");
+  const [size, setSize] = useState<number>(512);
+  const [tileable, setTileable] = useState(false);
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<TextureResult | null>(null);
+  const [inserted, setInserted] = useState(false);
+
+  const unavailable = result?.available === false;
+
+  const handleGenerate = async () => {
+    const text = prompt.trim();
+    if (!text || busy) return;
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    setInserted(false);
+    try {
+      const res = await generateTexture(gameId, {
+        prompt: text,
+        width: size,
+        height: size,
+        tileable,
+        kind,
+      });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleInsert = () => {
+    if (!result?.filename || !activePath) return;
+    onInsert(result.filename);
+    setInserted(true);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-2 border-b border-shell-border px-3.5 py-3">
+        <ImagePlus size={15} className="text-accent" />
+        <h3 className="text-[13px] font-bold">Generate an asset</h3>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto px-3 py-3">
+        {/* prompt */}
+        <label htmlFor="gs-asset-prompt" className="mb-1 block text-[11px] font-semibold text-shell-text-secondary">
+          Describe the texture or sprite
+        </label>
+        <textarea
+          id="gs-asset-prompt"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={3}
+          placeholder="a mossy stone wall, top-down"
+          className="mb-3 w-full resize-none rounded-lg border border-shell-border bg-shell-surface px-2.5 py-2 text-[12px] text-shell-text placeholder:text-shell-text-tertiary focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20"
+        />
+
+        {/* controls */}
+        <div className="mb-3 grid grid-cols-2 gap-2">
+          <div>
+            <label htmlFor="gs-asset-kind" className="mb-1 block text-[11px] font-semibold text-shell-text-secondary">
+              Kind
+            </label>
+            <select
+              id="gs-asset-kind"
+              value={kind}
+              onChange={(e) => setKind(e.target.value as AssetKind)}
+              className="w-full rounded-lg border border-shell-border bg-shell-surface px-2 py-1.5 text-[12px] text-shell-text"
+            >
+              <option value="texture">Texture</option>
+              <option value="sprite">Sprite</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="gs-asset-size" className="mb-1 block text-[11px] font-semibold text-shell-text-secondary">
+              Size
+            </label>
+            <select
+              id="gs-asset-size"
+              value={size}
+              onChange={(e) => setSize(Number(e.target.value))}
+              className="w-full rounded-lg border border-shell-border bg-shell-surface px-2 py-1.5 text-[12px] text-shell-text"
+            >
+              {SIZES.map((s) => (
+                <option key={s} value={s}>
+                  {s}×{s}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <label className="mb-3 flex items-center gap-2 text-[12px] text-shell-text-secondary">
+          <input
+            type="checkbox"
+            checked={tileable}
+            onChange={(e) => setTileable(e.target.checked)}
+            className="h-3.5 w-3.5 accent-accent"
+          />
+          Tileable / seamless
+        </label>
+
+        <button
+          type="button"
+          onClick={() => void handleGenerate()}
+          disabled={busy || !prompt.trim()}
+          className="flex h-9 w-full items-center justify-center gap-1.5 rounded-lg bg-accent px-3 text-[12px] font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {busy ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={14} />}
+          {busy ? "Generating..." : "Generate"}
+        </button>
+
+        {/* tier-gated: no GPU/NPU worker */}
+        {unavailable && (
+          <div
+            role="status"
+            className="mt-3 flex items-start gap-2 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-[12px] text-amber-200"
+          >
+            <Cpu size={15} className="mt-0.5 flex-none" />
+            <div>
+              <div className="font-bold">Needs a GPU worker</div>
+              <div className="text-amber-200/80">
+                {result?.reason ?? "Connect a GPU or NPU worker to generate assets."}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* error */}
+        {error && (
+          <div role="alert" className="mt-3 flex items-center gap-2 rounded-xl border border-red-500/30 bg-red-500/10 px-3 py-2 text-[12px] text-red-300">
+            <AlertCircle size={14} className="flex-none" />
+            {error}
+          </div>
+        )}
+
+        {/* preview + insert */}
+        {result?.available && result.path && (
+          <div className="mt-3 rounded-xl border border-shell-border bg-shell-surface p-2.5">
+            <img
+              src={result.path}
+              alt={`Generated ${result.kind ?? "asset"}`}
+              className="mb-2 w-full rounded-lg border border-shell-border"
+            />
+            <div className="mb-2 truncate text-[11px] text-shell-text-tertiary">
+              {result.filename}
+              {result.tier ? ` · ${result.tier}` : ""}
+            </div>
+            <button
+              type="button"
+              onClick={handleInsert}
+              disabled={!activePath || inserted}
+              className="flex h-8 w-full items-center justify-center gap-1.5 rounded-lg border border-accent/40 bg-accent-soft px-3 text-[12px] font-bold text-shell-text disabled:opacity-60"
+            >
+              <Check size={13} />
+              {inserted ? "Inserted" : activePath ? `Insert into ${activePath}` : "Open a file to insert"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/gamestudio/EditorView.tsx
+++ b/desktop/src/apps/gamestudio/EditorView.tsx
@@ -9,9 +9,12 @@ import {
   AlertCircle,
   Check,
   Sparkles,
+  ImagePlus,
 } from "lucide-react";
 import { streamTaosAgentChat } from "../appstudio/stream-chat";
 import { FileEditor } from "./FileEditor";
+import { AssetsPanel } from "./AssetsPanel";
+import { buildAssetReference } from "./asset-reference";
 import { parseFileBlocks, type ParsedFile } from "./file-blocks";
 import { buildEditSystemPrompt, isVendorFile } from "./game-authoring-prompt";
 import { getGame, gamePreviewUrl, saveGame } from "./games-api";
@@ -60,6 +63,7 @@ export function EditorView({ gameId }: EditorViewProps) {
   const [chatError, setChatError] = useState<string | null>(null);
   const [pendingEdit, setPendingEdit] = useState<PendingEdit | null>(null);
   const [applying, setApplying] = useState(false);
+  const [rightTab, setRightTab] = useState<"chat" | "assets">("chat");
 
   const filesRef = useRef(files);
   filesRef.current = files;
@@ -263,6 +267,22 @@ export function EditorView({ gameId }: EditorViewProps) {
     setApplying(false);
   }, [pendingEdit, flushSave]);
 
+  /* ── insert a generated asset reference into the active file ──────── */
+
+  const handleInsertAsset = useCallback(
+    (filename: string) => {
+      const path = activePath;
+      if (!path) return;
+      const ref = buildAssetReference(path, filename);
+      setFiles((prev) => {
+        const next = { ...prev, [path]: (prev[path] ?? "") + ref };
+        void flushSave(next);
+        return next;
+      });
+    },
+    [activePath, flushSave],
+  );
+
   /* ── render ─────────────────────────────────────────────────────── */
 
   if (loading) {
@@ -394,13 +414,39 @@ export function EditorView({ gameId }: EditorViewProps) {
           </div>
         </div>
 
-        {/* AI chat sidebar */}
+        {/* AI chat + assets sidebar */}
         <div className="flex min-h-0 flex-col border-l border-shell-border">
-          <div className="flex items-center gap-2 border-b border-shell-border px-3.5 py-3">
-            <Sparkles size={15} className="text-accent" />
-            <h3 className="text-[13px] font-bold">Ask the agent</h3>
+          <div role="tablist" aria-label="Editor sidebar" className="flex flex-none items-center gap-1 border-b border-shell-border px-2.5 py-2">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={rightTab === "chat"}
+              onClick={() => setRightTab("chat")}
+              className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[12px] font-bold ${
+                rightTab === "chat" ? "bg-shell-surface-active text-shell-text" : "text-shell-text-secondary hover:bg-shell-surface"
+              }`}
+            >
+              <Sparkles size={14} className="text-accent" />
+              Ask the agent
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={rightTab === "assets"}
+              onClick={() => setRightTab("assets")}
+              className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[12px] font-bold ${
+                rightTab === "assets" ? "bg-shell-surface-active text-shell-text" : "text-shell-text-secondary hover:bg-shell-surface"
+              }`}
+            >
+              <ImagePlus size={14} className="text-accent" />
+              Assets
+            </button>
           </div>
 
+          {rightTab === "assets" ? (
+            <AssetsPanel gameId={gameId} activePath={activePath} onInsert={handleInsertAsset} />
+          ) : (
+          <>
           <div className="min-h-0 flex-1 overflow-auto px-3 py-2">
             {chat.length === 0 && (
               <p className="px-1 py-2 text-[12px] text-shell-text-tertiary">
@@ -493,6 +539,8 @@ export function EditorView({ gameId }: EditorViewProps) {
               {chatBusy ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
             </button>
           </div>
+          </>
+          )}
         </div>
       </div>
     </div>

--- a/desktop/src/apps/gamestudio/asset-reference.test.ts
+++ b/desktop/src/apps/gamestudio/asset-reference.test.ts
@@ -8,9 +8,17 @@ describe("buildAssetReference", () => {
     );
   });
 
-  it("emits a JS const for js files", () => {
+  it("emits a JS const for js files with a filename-derived name", () => {
     const ref = buildAssetReference("game.js", "sprite-2.png");
-    expect(ref).toContain('const assetUrl = "./sprite-2.png";');
+    expect(ref).toContain('const sprite_2Url = "./sprite-2.png";');
+  });
+
+  it("derives distinct const names so repeated inserts don't collide", () => {
+    const a = buildAssetReference("game.js", "texture-a.png");
+    const b = buildAssetReference("game.js", "texture-b.png");
+    expect(a).toContain("const texture_aUrl =");
+    expect(b).toContain("const texture_bUrl =");
+    expect(a).not.toEqual(b);
   });
 
   it("emits a CSS background rule for css files", () => {

--- a/desktop/src/apps/gamestudio/asset-reference.test.ts
+++ b/desktop/src/apps/gamestudio/asset-reference.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { buildAssetReference } from "./asset-reference";
+
+describe("buildAssetReference", () => {
+  it("emits an <img> tag for html files", () => {
+    expect(buildAssetReference("index.html", "texture-1.png")).toContain(
+      '<img src="./texture-1.png"',
+    );
+  });
+
+  it("emits a JS const for js files", () => {
+    const ref = buildAssetReference("game.js", "sprite-2.png");
+    expect(ref).toContain('const assetUrl = "./sprite-2.png";');
+  });
+
+  it("emits a CSS background rule for css files", () => {
+    expect(buildAssetReference("style.css", "tex.png")).toContain(
+      'background-image: url("./tex.png")',
+    );
+  });
+
+  it("falls back to a comment for unknown extensions", () => {
+    expect(buildAssetReference("data.txt", "tex.png")).toBe("\n/* asset: ./tex.png */");
+  });
+});

--- a/desktop/src/apps/gamestudio/asset-reference.ts
+++ b/desktop/src/apps/gamestudio/asset-reference.ts
@@ -1,3 +1,11 @@
+/** Derive a unique, valid JS identifier from an asset filename so repeated
+ *  inserts into the same JS file don't emit a colliding ``const`` declaration. */
+function assetVarName(filename: string): string {
+  const base = filename.replace(/\.[^.]+$/, "").replace(/[^a-zA-Z0-9]+/g, "_");
+  const safe = /^[a-zA-Z_]/.test(base) ? base : `_${base}`;
+  return `${safe}Url`;
+}
+
 /** Build a code reference to a generated asset, tailored to the file it will be
  *  appended to. The asset already lives in the game's file set, so a relative
  *  ``./{filename}`` resolves under the game's preview base. */
@@ -11,7 +19,7 @@ export function buildAssetReference(activePath: string, filename: string): strin
     return `\n/* generated asset */\n.generated-asset { background-image: url("${rel}"); }`;
   }
   if (ext === "js" || ext === "mjs" || ext === "ts") {
-    return `\n// generated asset\nconst assetUrl = "${rel}";`;
+    return `\n// generated asset\nconst ${assetVarName(filename)} = "${rel}";`;
   }
   return `\n/* asset: ${rel} */`;
 }

--- a/desktop/src/apps/gamestudio/asset-reference.ts
+++ b/desktop/src/apps/gamestudio/asset-reference.ts
@@ -1,0 +1,17 @@
+/** Build a code reference to a generated asset, tailored to the file it will be
+ *  appended to. The asset already lives in the game's file set, so a relative
+ *  ``./{filename}`` resolves under the game's preview base. */
+export function buildAssetReference(activePath: string, filename: string): string {
+  const ext = activePath.slice(activePath.lastIndexOf(".") + 1).toLowerCase();
+  const rel = `./${filename}`;
+  if (ext === "html" || ext === "htm") {
+    return `\n<img src="${rel}" alt="" />`;
+  }
+  if (ext === "css") {
+    return `\n/* generated asset */\n.generated-asset { background-image: url("${rel}"); }`;
+  }
+  if (ext === "js" || ext === "mjs" || ext === "ts") {
+    return `\n// generated asset\nconst assetUrl = "${rel}";`;
+  }
+  return `\n/* asset: ${rel} */`;
+}

--- a/desktop/src/apps/gamestudio/game-assets-api.ts
+++ b/desktop/src/apps/gamestudio/game-assets-api.ts
@@ -1,0 +1,49 @@
+/** Thin client for tinyagentos/routes/game_assets.py -- Game Studio AI assets. */
+
+export type AssetKind = "texture" | "sprite";
+
+export interface GenerateTextureBody {
+  prompt: string;
+  width?: number;
+  height?: number;
+  tileable?: boolean;
+  kind?: AssetKind;
+}
+
+/** Shape of POST /api/games/{id}/assets/texture.
+ *  ``available:false`` is a tier-gate signal (no GPU/NPU worker), NOT an error,
+ *  so the UI shows a "needs a GPU worker" state rather than a failure toast. */
+export interface TextureResult {
+  available: boolean;
+  reason?: string;
+  status?: string;
+  filename?: string;
+  path?: string;
+  kind?: AssetKind;
+  tier?: string;
+  tileable?: boolean;
+  seed?: number;
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = await res.json();
+    if (body?.error) return String(body.error);
+  } catch {
+    // non-JSON error body; fall through to the status-based message
+  }
+  return `Request failed (${res.status})`;
+}
+
+export async function generateTexture(
+  gameId: string,
+  body: GenerateTextureBody,
+): Promise<TextureResult> {
+  const res = await fetch(`/api/games/${encodeURIComponent(gameId)}/assets/texture`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as TextureResult;
+}

--- a/tests/test_asset_gen_comfyui.py
+++ b/tests/test_asset_gen_comfyui.py
@@ -1,0 +1,168 @@
+"""Unit tests for the ComfyUI client + workflow builder (all HTTP mocked).
+
+ComfyUI is not installed in CI, so every test patches httpx so no real network
+call is made — mirroring tests/test_routes_games.py's httpx.AsyncClient mocking.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ConnectError, Request as HttpxRequest, Response
+
+from tinyagentos.asset_gen.comfyui_client import ComfyUIClient, ComfyUIResult
+from tinyagentos.asset_gen.workflows import build_texture_workflow
+
+# Minimal valid 1x1 PNG (magic header is what _looks_like_image checks).
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+_PROMPT_ID = "abc123"
+
+
+def _resp(url: str, *, json=None, content=None) -> Response:
+    req = HttpxRequest("GET", url)
+    if content is not None:
+        return Response(status_code=200, content=content, request=req)
+    return Response(status_code=200, json=json, request=req)
+
+
+def _history_with_image() -> dict:
+    return {
+        _PROMPT_ID: {
+            "outputs": {
+                "9": {"images": [{"filename": "out.png", "subfolder": "", "type": "output"}]}
+            }
+        }
+    }
+
+
+def _install_mock(monkeypatch_target, mock_instance):
+    """Patch the client's httpx.AsyncClient to yield *mock_instance*."""
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=False)
+    return patch(
+        "tinyagentos.asset_gen.comfyui_client.httpx.AsyncClient",
+        return_value=mock_instance,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_success_returns_image_bytes():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={"prompt_id": _PROMPT_ID})
+
+    def get_side_effect(url, **kwargs):
+        if "/history/" in url:
+            return _resp(url, json=_history_with_image())
+        return _resp(url, content=PNG_BYTES)  # /view
+
+    inst.get.side_effect = get_side_effect
+
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+
+    assert isinstance(result, ComfyUIResult)
+    assert result.image_bytes == PNG_BYTES
+    assert result.prompt_id == _PROMPT_ID
+    # /view was called with the ref parsed out of history.
+    view_call = [c for c in inst.get.call_args_list if "/view" in c.args[0]][0]
+    assert view_call.kwargs["params"]["filename"] == "out.png"
+
+
+@pytest.mark.asyncio
+async def test_generate_no_prompt_id_returns_none():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={})
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+    assert result is None
+    inst.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_job_finishes_without_image_returns_none():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={"prompt_id": _PROMPT_ID})
+    inst.get.side_effect = lambda url, **kw: _resp(url, json={_PROMPT_ID: {"outputs": {}}})
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_non_image_view_returns_none():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={"prompt_id": _PROMPT_ID})
+
+    def get_side_effect(url, **kwargs):
+        if "/history/" in url:
+            return _resp(url, json=_history_with_image())
+        return _resp(url, content=b'{"error":"boom"}')  # /view non-image body
+
+    inst.get.side_effect = get_side_effect
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_connect_error_is_fail_soft():
+    inst = AsyncMock()
+    inst.post.side_effect = ConnectError("refused")
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_poll_timeout_returns_none():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={"prompt_id": _PROMPT_ID})
+    # History never contains the prompt id -> poll spins until the deadline.
+    inst.get.side_effect = lambda url, **kw: _resp(url, json={})
+    with _install_mock(None, inst):
+        client = ComfyUIClient("http://comfy", poll_timeout=0.05, poll_interval=0.01)
+        result = await client.generate({"1": {}})
+    assert result is None
+
+
+def test_default_base_url_from_env(monkeypatch):
+    monkeypatch.setenv("TAOS_COMFYUI_URL", "http://gpu-box:8188/")
+    # Trailing slash is stripped.
+    assert ComfyUIClient().base == "http://gpu-box:8188"
+
+
+def test_default_base_url_fallback(monkeypatch):
+    monkeypatch.delenv("TAOS_COMFYUI_URL", raising=False)
+    assert ComfyUIClient().base == "http://127.0.0.1:8188"
+
+
+class TestBuildTextureWorkflow:
+    def test_stamps_prompt_size_seed_checkpoint(self):
+        wf = build_texture_workflow(
+            prompt="mossy stone", width=768, height=512, seed=42,
+            checkpoint="my.safetensors",
+        )
+        assert wf["6"]["inputs"]["text"] == "mossy stone"
+        assert wf["5"]["inputs"]["width"] == 768
+        assert wf["5"]["inputs"]["height"] == 512
+        assert wf["3"]["inputs"]["seed"] == 42
+        assert wf["4"]["inputs"]["ckpt_name"] == "my.safetensors"
+
+    def test_tileable_augments_prompt(self):
+        wf = build_texture_workflow(prompt="brick wall", tileable=True)
+        assert "seamless tileable" in wf["6"]["inputs"]["text"]
+
+    def test_tileable_not_duplicated_when_already_seamless(self):
+        wf = build_texture_workflow(prompt="a seamless grass texture", tileable=True)
+        assert wf["6"]["inputs"]["text"].count("seamless") == 1
+
+    def test_returns_fresh_copy(self):
+        a = build_texture_workflow(prompt="one")
+        b = build_texture_workflow(prompt="two")
+        assert a["6"]["inputs"]["text"] == "one"
+        assert b["6"]["inputs"]["text"] == "two"

--- a/tests/test_routes_game_assets.py
+++ b/tests/test_routes_game_assets.py
@@ -1,0 +1,181 @@
+"""Route tests for the Game Studio texture/sprite generation endpoint.
+
+ComfyUI is not installed in CI, so the ComfyUI client is patched in every test
+that reaches a backend — no real generation happens.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tinyagentos.asset_gen.comfyui_client import ComfyUIResult
+
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+GAME_FILES = {"index.html": "<!doctype html><html></html>", "game.js": "// game"}
+
+
+def _set_gpu_tier(app):
+    """Give the host a discrete GPU so the resolver picks the SDXL tier."""
+    app.state.backend_catalog = None
+    app.state.hardware_profile = SimpleNamespace(
+        gpu=SimpleNamespace(cuda=True, rocm=False),
+        npu=SimpleNamespace(type="none"),
+    )
+
+
+def _set_no_accelerator(app):
+    app.state.backend_catalog = None
+    app.state.hardware_profile = SimpleNamespace(
+        gpu=SimpleNamespace(cuda=False, rocm=False),
+        npu=SimpleNamespace(type="none"),
+    )
+
+
+def _patch_client(result):
+    """Patch ComfyUIClient so .generate() returns *result* without any network."""
+    fake = MagicMock()
+    fake.generate = AsyncMock(return_value=result)
+    return patch("tinyagentos.routes.game_assets.ComfyUIClient", return_value=fake)
+
+
+async def _save_game(client, game_id="tex-game"):
+    resp = await client.put(f"/api/games/{game_id}", json={"name": "Tex", "files": GAME_FILES})
+    assert resp.status_code == 200
+    return game_id
+
+
+@pytest.mark.asyncio
+class TestGenerateTexture:
+    async def test_success_writes_asset_and_returns_path(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client)
+
+        with _patch_client(ComfyUIResult(image_bytes=PNG_BYTES, prompt_id="p1")):
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a mossy stone texture", "kind": "texture"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["available"] is True
+        assert data["status"] == "generated"
+        assert data["tier"] == "sdxl"
+        assert data["filename"].startswith("texture-")
+        assert data["path"] == f"/api/games/{gid}/preview/{data['filename']}"
+
+        # The PNG is really in the game's file set: the preview route serves it.
+        preview = await client.get(data["path"])
+        assert preview.status_code == 200
+        assert preview.content == PNG_BYTES
+
+    async def test_sprite_kind_prefixes_filename(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "sprite-game")
+        with _patch_client(ComfyUIResult(image_bytes=PNG_BYTES, prompt_id="p1")):
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a pixel-art ship", "kind": "sprite"},
+            )
+        assert resp.json()["filename"].startswith("sprite-")
+
+    async def test_tier_unavailable_returns_available_false(self, client):
+        app = client._transport.app
+        _set_no_accelerator(app)
+        gid = await _save_game(client, "no-gpu-game")
+
+        # No client is patched: the route must short-circuit before generating.
+        resp = await client.post(
+            f"/api/games/{gid}/assets/texture",
+            json={"prompt": "a texture"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["available"] is False
+        assert "reason" in data
+
+    async def test_comfyui_failure_is_fail_soft_502(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "fail-game")
+        with _patch_client(None):  # client swallowed the error, returned None
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a texture"},
+            )
+        assert resp.status_code == 502
+        data = resp.json()
+        assert data["available"] is True
+        assert "error" in data
+
+    async def test_empty_prompt_rejected(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "empty-prompt-game")
+        resp = await client.post(
+            f"/api/games/{gid}/assets/texture",
+            json={"prompt": "   "},
+        )
+        assert resp.status_code == 400
+
+    async def test_invalid_size_rejected(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "bad-size-game")
+        for bad in ({"width": 513}, {"width": 32}, {"height": 4096}):
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a texture", **bad},
+            )
+            assert resp.status_code == 400, bad
+
+    async def test_unknown_game_returns_404(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        resp = await client.post(
+            "/api/games/does-not-exist/assets/texture",
+            json={"prompt": "a texture"},
+        )
+        assert resp.status_code == 404
+
+    async def test_invalid_game_id_returns_400(self, client):
+        resp = await client.post(
+            "/api/games/Not_Valid!/assets/texture",
+            json={"prompt": "a texture"},
+        )
+        assert resp.status_code == 400
+
+    async def test_catalog_comfyui_backend_wins(self, client):
+        """A live ComfyUI backend in the catalog resolves to the SDXL tier and
+        its URL is used to build the client."""
+        app = client._transport.app
+        catalog = MagicMock()
+        catalog.backends_with_capability.return_value = [
+            SimpleNamespace(type="comfyui", url="http://gpu-worker:8188")
+        ]
+        app.state.backend_catalog = catalog
+        app.state.hardware_profile = None
+        gid = await _save_game(client, "catalog-game")
+
+        with patch(
+            "tinyagentos.routes.game_assets.ComfyUIClient",
+            return_value=MagicMock(generate=AsyncMock(
+                return_value=ComfyUIResult(image_bytes=PNG_BYTES, prompt_id="p1")
+            )),
+        ) as MockClient:
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a texture"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["tier"] == "sdxl"
+        MockClient.assert_called_once_with("http://gpu-worker:8188")

--- a/tests/test_routes_game_assets.py
+++ b/tests/test_routes_game_assets.py
@@ -114,8 +114,28 @@ class TestGenerateTexture:
             )
         assert resp.status_code == 502
         data = resp.json()
-        assert data["available"] is True
         assert "error" in data
+        # `available` is a 200-only tier-gate signal; a 502 error body omits it
+        # (the client throws on non-2xx and reads only `.error`).
+        assert "available" not in data
+
+    async def test_asset_count_cap_returns_409(self, client, monkeypatch):
+        import tinyagentos.routes.game_assets as ga
+
+        monkeypatch.setattr(ga, "_MAX_ASSET_FILES", 1)
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "cap-game")
+        with _patch_client(ComfyUIResult(image_bytes=PNG_BYTES, prompt_id="p1")):
+            first = await client.post(
+                f"/api/games/{gid}/assets/texture", json={"prompt": "one"}
+            )
+            assert first.status_code == 200  # wrote the 1st (and only allowed) asset
+            second = await client.post(
+                f"/api/games/{gid}/assets/texture", json={"prompt": "two"}
+            )
+        assert second.status_code == 409
+        assert "error" in second.json()
 
     async def test_empty_prompt_rejected(self, client):
         app = client._transport.app

--- a/tests/test_routes_games.py
+++ b/tests/test_routes_games.py
@@ -199,6 +199,26 @@ class TestGamesCrud:
         resp = await client.get("/api/games/my-game")
         assert resp.json()["files"] == {"index.html": GAME_FILES["index.html"]}
 
+    async def test_save_preserves_binary_assets(self, client):
+        """Generated binary assets (textures/sprites) live in the game dir but
+        never appear in the text file set the editor PUTs. A save must not sweep
+        them, or a generated texture would vanish on the next edit."""
+        app = client._transport.app
+        await client.put("/api/games/asset-game", json={"name": "A", "files": GAME_FILES})
+        # Simulate a generated PNG written into the game dir out-of-band.
+        game_dir = app.state.data_dir / "games" / "asset-game"
+        png = b"\x89PNG\r\n\x1a\n\x00binary-not-utf8\xff\xfe"
+        (game_dir / "texture-1.png").write_bytes(png)
+        # A subsequent text-only save (full-replace) must leave the PNG intact.
+        resp = await client.put(
+            "/api/games/asset-game",
+            json={"files": {"index.html": GAME_FILES["index.html"]}},
+        )
+        assert resp.status_code == 200
+        assert (game_dir / "texture-1.png").read_bytes() == png
+        # The stale text file game.js was still swept as before.
+        assert not (game_dir / "game.js").exists()
+
     async def test_list_after_save(self, client):
         await client.put("/api/games/game-a", json={"name": "A", "files": GAME_FILES})
         await client.put("/api/games/game-b", json={"name": "B", "files": GAME_FILES})

--- a/tinyagentos/asset_gen/__init__.py
+++ b/tinyagentos/asset_gen/__init__.py
@@ -1,0 +1,7 @@
+"""Game Studio offline asset generation.
+
+Slice 1 (textures/sprites) drives a ComfyUI server to turn a text prompt into a
+PNG the game references. The backend is tier-aware and reuses the same catalog
++ hardware-profile signals the Images Studio uses; see
+``docs/design/game-studio-asset-generation.md``.
+"""

--- a/tinyagentos/asset_gen/comfyui_client.py
+++ b/tinyagentos/asset_gen/comfyui_client.py
@@ -1,0 +1,157 @@
+"""Async ComfyUI API client for offline asset generation.
+
+ComfyUI (https://github.com/comfyanonymous/ComfyUI) exposes a small HTTP API:
+
+  POST {base}/prompt            submit a workflow graph -> {"prompt_id": "..."}
+  GET  {base}/history/{id}      poll for completion -> {id: {outputs: {...}}}
+  GET  {base}/view?filename=... fetch an output image (raw bytes)
+
+This client submits a (already-parameterised) workflow, polls history until the
+job produces an image, and fetches that image. It is deliberately *fail-soft*:
+ComfyUI is an optional, store-installed backend that is not present in CI or on
+GPU-less hosts, so every failure path (unreachable server, timeout, malformed
+response, non-image body) is caught and turned into ``None`` rather than raised
+at the caller. The route layer maps ``None`` to a clean HTTP response.
+
+The base URL comes from the ``base_url`` argument, else the ``TAOS_COMFYUI_URL``
+environment variable, else ``http://127.0.0.1:8188``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Optional
+from uuid import uuid4
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COMFYUI_URL = "http://127.0.0.1:8188"
+
+
+def default_base_url() -> str:
+    """Resolve the ComfyUI base URL from the environment, with a local default."""
+    return os.environ.get("TAOS_COMFYUI_URL", DEFAULT_COMFYUI_URL)
+
+
+@dataclass
+class ComfyUIResult:
+    """A completed ComfyUI generation: the output image bytes + the prompt id."""
+
+    image_bytes: bytes
+    prompt_id: str
+
+
+def _looks_like_image(data: bytes) -> bool:
+    """True if *data* starts with a known image magic signature.
+
+    ComfyUI can answer 200 with a JSON/text error body on /view; those bytes
+    would otherwise be saved as a ``.png`` and reported as success. Reject any
+    body that is not clearly an image so it routes into the fail-soft path.
+    """
+    return (
+        data.startswith(b"\x89PNG\r\n\x1a\n")  # PNG
+        or data.startswith(b"\xff\xd8\xff")  # JPEG
+        or (data[:4] == b"RIFF" and data[8:12] == b"WEBP")  # WEBP
+    )
+
+
+class ComfyUIClient:
+    """Thin async client for a single ComfyUI server.
+
+    ``timeout`` bounds each individual HTTP call; ``poll_timeout`` bounds the
+    total time spent waiting for a submitted workflow to finish (generation can
+    take tens of seconds on modest GPUs); ``poll_interval`` is the gap between
+    history polls.
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        *,
+        timeout: float = 30.0,
+        poll_timeout: float = 180.0,
+        poll_interval: float = 1.0,
+    ):
+        self.base = (base_url or default_base_url()).rstrip("/")
+        self._timeout = timeout
+        self._poll_timeout = poll_timeout
+        self._poll_interval = poll_interval
+
+    async def generate(self, workflow: dict) -> Optional[ComfyUIResult]:
+        """Submit *workflow*, wait for it to finish, and return its first output
+        image. Returns ``None`` on any failure (never raises)."""
+        client_id = uuid4().hex
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                submit = await client.post(
+                    f"{self.base}/prompt",
+                    json={"prompt": workflow, "client_id": client_id},
+                )
+                submit.raise_for_status()
+                prompt_id = (submit.json() or {}).get("prompt_id")
+                if not prompt_id:
+                    logger.warning("ComfyUI /prompt returned no prompt_id")
+                    return None
+
+                image_ref = await self._poll_history(client, prompt_id)
+                if image_ref is None:
+                    return None
+
+                view = await client.get(f"{self.base}/view", params=image_ref)
+                view.raise_for_status()
+                data = view.content
+                if not _looks_like_image(data):
+                    logger.warning(
+                        "ComfyUI /view returned a non-image body: %s",
+                        view.text[:200],
+                    )
+                    return None
+                return ComfyUIResult(image_bytes=data, prompt_id=str(prompt_id))
+        except Exception:  # noqa: BLE001 — fail-soft: any error -> None
+            logger.warning("ComfyUI generation failed", exc_info=True)
+            return None
+
+    async def _poll_history(
+        self, client: httpx.AsyncClient, prompt_id: str
+    ) -> Optional[dict]:
+        """Poll /history/{id} until the job produces an image, then return the
+        {filename, subfolder, type} ref for /view. Returns ``None`` on timeout
+        or when the job finished without an image."""
+        deadline = time.monotonic() + self._poll_timeout
+        while time.monotonic() < deadline:
+            resp = await client.get(f"{self.base}/history/{prompt_id}")
+            resp.raise_for_status()
+            entry = (resp.json() or {}).get(prompt_id)
+            if entry:
+                ref = _first_image_ref(entry.get("outputs") or {})
+                if ref is not None:
+                    return ref
+                # The job is in history but yielded no image: it is done and
+                # failed, so stop polling rather than spin to the deadline.
+                logger.warning("ComfyUI job %s finished with no image", prompt_id)
+                return None
+            await asyncio.sleep(self._poll_interval)
+        logger.warning("ComfyUI history poll timed out for %s", prompt_id)
+        return None
+
+
+def _first_image_ref(outputs: dict) -> Optional[dict]:
+    """Return the first output image's {filename, subfolder, type} ref, or None.
+
+    ``outputs`` is ``{node_id: {"images": [{filename, subfolder, type}, ...]}}``.
+    """
+    for node in outputs.values():
+        for image in node.get("images") or []:
+            filename = image.get("filename")
+            if filename:
+                return {
+                    "filename": filename,
+                    "subfolder": image.get("subfolder", ""),
+                    "type": image.get("type", "output"),
+                }
+    return None

--- a/tinyagentos/asset_gen/workflows.py
+++ b/tinyagentos/asset_gen/workflows.py
@@ -1,0 +1,73 @@
+"""Curated ComfyUI workflow templates + parameterisation for asset generation.
+
+Slice 1 ships one real, minimal workflow: SDXL text->image (``texture_sdxl.json``,
+a standard checkpoint -> CLIP encode -> KSampler -> VAE decode -> save graph in
+ComfyUI's API format). ``build_texture_workflow`` loads the template and stamps
+in the caller's prompt, size, seed, and checkpoint, returning a fresh dict ready
+for :meth:`ComfyUIClient.generate`.
+
+Tileable/seamless textures: ComfyUI core has no asymmetric-tiling toggle without
+a custom node (e.g. the "Seamless" / circular-padding nodes), so Slice 1 nudges
+the diffusion toward a repeating result through the prompt only. Wiring true
+asymmetric tiling is a documented follow-up (TODO: seamless custom node).
+"""
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Optional
+
+_WORKFLOWS_DIR = Path(__file__).parent / "workflows"
+
+# Node ids in texture_sdxl.json (kept in one place so the template and the
+# parameteriser never drift).
+_POSITIVE_NODE = "6"
+_NEGATIVE_NODE = "7"
+_LATENT_NODE = "5"
+_SAMPLER_NODE = "3"
+_CHECKPOINT_NODE = "4"
+
+_DEFAULT_NEGATIVE = "blurry, low quality, watermark, text, signature"
+
+
+def load_template(name: str) -> dict:
+    """Load a checked-in workflow template by name (without the .json suffix)."""
+    path = _WORKFLOWS_DIR / f"{name}.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _tileable_hint(prompt: str) -> str:
+    """Append a seamless-texture hint if not already implied by the prompt."""
+    if "seamless" in prompt.lower() or "tileable" in prompt.lower():
+        return prompt
+    return f"{prompt}, seamless tileable texture, repeating pattern"
+
+
+def build_texture_workflow(
+    *,
+    prompt: str,
+    width: int = 512,
+    height: int = 512,
+    seed: int = 0,
+    tileable: bool = False,
+    checkpoint: Optional[str] = None,
+    negative_prompt: str = _DEFAULT_NEGATIVE,
+    template: str = "texture_sdxl",
+) -> dict:
+    """Return a ready-to-submit ComfyUI workflow for a text->image texture.
+
+    A deep copy of the template is returned so concurrent callers never share
+    (and mutate) the same graph.
+    """
+    workflow = copy.deepcopy(load_template(template))
+
+    positive = _tileable_hint(prompt) if tileable else prompt
+    workflow[_POSITIVE_NODE]["inputs"]["text"] = positive
+    workflow[_NEGATIVE_NODE]["inputs"]["text"] = negative_prompt
+    workflow[_LATENT_NODE]["inputs"]["width"] = int(width)
+    workflow[_LATENT_NODE]["inputs"]["height"] = int(height)
+    workflow[_SAMPLER_NODE]["inputs"]["seed"] = int(seed)
+    if checkpoint:
+        workflow[_CHECKPOINT_NODE]["inputs"]["ckpt_name"] = checkpoint
+    return workflow

--- a/tinyagentos/asset_gen/workflows.py
+++ b/tinyagentos/asset_gen/workflows.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import copy
 import json
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -31,8 +32,14 @@ _CHECKPOINT_NODE = "4"
 _DEFAULT_NEGATIVE = "blurry, low quality, watermark, text, signature"
 
 
+@lru_cache(maxsize=None)
 def load_template(name: str) -> dict:
-    """Load a checked-in workflow template by name (without the .json suffix)."""
+    """Load a checked-in workflow template by name (without the .json suffix).
+
+    Cached: the set of templates is fixed and small, and every caller goes
+    through ``build_texture_workflow``, which deep-copies before mutating, so
+    the cached dict is never mutated in place.
+    """
     path = _WORKFLOWS_DIR / f"{name}.json"
     return json.loads(path.read_text(encoding="utf-8"))
 

--- a/tinyagentos/asset_gen/workflows/texture_sdxl.json
+++ b/tinyagentos/asset_gen/workflows/texture_sdxl.json
@@ -1,0 +1,59 @@
+{
+  "3": {
+    "class_type": "KSampler",
+    "inputs": {
+      "seed": 0,
+      "steps": 25,
+      "cfg": 7.0,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1.0,
+      "model": ["4", 0],
+      "positive": ["6", 0],
+      "negative": ["7", 0],
+      "latent_image": ["5", 0]
+    }
+  },
+  "4": {
+    "class_type": "CheckpointLoaderSimple",
+    "inputs": {
+      "ckpt_name": "sd_xl_base_1.0.safetensors"
+    }
+  },
+  "5": {
+    "class_type": "EmptyLatentImage",
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    }
+  },
+  "6": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "",
+      "clip": ["4", 1]
+    }
+  },
+  "7": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "blurry, low quality, watermark, text, signature",
+      "clip": ["4", 1]
+    }
+  },
+  "8": {
+    "class_type": "VAEDecode",
+    "inputs": {
+      "samples": ["3", 0],
+      "vae": ["4", 2]
+    }
+  },
+  "9": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "filename_prefix": "taos_texture",
+      "images": ["8", 0]
+    }
+  }
+}

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -197,6 +197,9 @@ def register_all_routers(app):
     from tinyagentos.routes.games import router as games_router
     app.include_router(games_router)
 
+    from tinyagentos.routes.game_assets import router as game_assets_router
+    app.include_router(game_assets_router)
+
     from tinyagentos.routes.terminal import router as terminal_router
     app.include_router(terminal_router)
 

--- a/tinyagentos/routes/game_assets.py
+++ b/tinyagentos/routes/game_assets.py
@@ -8,9 +8,10 @@ storage is invented.
 Tier resolution mirrors the Images Studio (routes/images_edit.py): the concrete
 backend is resolved from the live backend catalog first, falling back to the
 host hardware profile. A discrete GPU (e.g. the RTX 3060 worker) serves the SDXL
-tier; an NPU host (RK3588) serves a low SD-1.5 placeholder tier; a host with no
-accelerator has no capable backend, so the route returns ``{available: false}``
-(HTTP 200) and the UI shows a "needs a GPU worker" state instead of a crash.
+tier; a host with no discrete-GPU texture backend has no capable pipeline (RK
+NPU SD tiling is a documented follow-up, not yet wired), so the route returns
+``{available: false}`` (HTTP 200) and the UI shows a "needs a GPU worker" state
+instead of a crash or an always-failing tier.
 """
 from __future__ import annotations
 
@@ -44,10 +45,14 @@ _MIN_SIZE = 64
 _MAX_SIZE = 2048
 _SIZE_MULTIPLE = 8
 
-# Per-tier checkpoint. SDXL is the discrete-GPU tier; SD 1.5 is the NPU
-# low/placeholder tier (see the design doc — real RK NPU tiling is a follow-up).
+# The discrete-GPU tier checkpoint. (RK NPU SD is a documented follow-up; there
+# is no wired NPU texture backend yet, so it is not resolved here.)
 _SDXL_CHECKPOINT = "sd_xl_base_1.0.safetensors"
-_SD15_CHECKPOINT = "v1-5-pruned-emaonly.safetensors"
+
+# Generated PNGs share the game's flat file set. Cap both the per-image size and
+# the number of assets so a runaway/loop request can't fill the disk.
+_MAX_ASSET_BYTES = 12 * 1024 * 1024  # a 2048x2048 PNG fits comfortably
+_MAX_ASSET_FILES = 200
 
 
 class TextureRequest(BaseModel):
@@ -76,8 +81,8 @@ def resolve_texture_backend(request: Request) -> Optional[TextureBackend]:
       1. A live ComfyUI backend advertised in the catalog (e.g. the RTX 3060
          worker) — the SDXL/GPU tier.
       2. A local discrete GPU (CUDA/ROCm) — SDXL at the local ComfyUI URL.
-      3. A local NPU (RK3588) — the SD-1.5 low/placeholder tier.
-      4. Otherwise unavailable.
+      3. Otherwise unavailable. (An NPU-only host has no wired texture backend
+         yet, so it resolves to unavailable rather than an always-failing tier.)
     """
     catalog = getattr(request.app.state, "backend_catalog", None)
     if catalog is not None:
@@ -92,9 +97,6 @@ def resolve_texture_backend(request: Request) -> Optional[TextureBackend]:
     gpu = getattr(hw, "gpu", None)
     if gpu is not None and (getattr(gpu, "cuda", False) or getattr(gpu, "rocm", False)):
         return TextureBackend(default_base_url(), "sdxl", _SDXL_CHECKPOINT, "texture_sdxl")
-    npu = getattr(hw, "npu", None)
-    if npu is not None and getattr(npu, "type", "none") not in ("none", None):
-        return TextureBackend(default_base_url(), "sd15", _SD15_CHECKPOINT, "texture_sdxl")
 
     return None
 
@@ -143,8 +145,19 @@ async def generate_texture(request: Request, game_id: str, body: TextureRequest)
         # "needs a GPU worker" state, so answer 200 with a clear reason.
         return {
             "available": False,
-            "reason": "No GPU or NPU worker available for texture generation.",
+            "reason": "No GPU worker available for texture generation.",
         }
+
+    # Refuse before spending a GPU call if the game is already at the asset cap.
+    try:
+        asset_count = sum(1 for p in game_dir.iterdir() if p.is_file() and p.suffix == ".png")
+    except OSError:
+        asset_count = 0
+    if asset_count >= _MAX_ASSET_FILES:
+        return JSONResponse(
+            {"available": True, "error": f"asset limit reached (max {_MAX_ASSET_FILES})"},
+            status_code=409,
+        )
 
     seed = random.randint(0, 2**32 - 1)
     workflow = build_texture_workflow(
@@ -163,11 +176,14 @@ async def generate_texture(request: Request, game_id: str, body: TextureRequest)
         # Fail-soft: the client swallowed the underlying error and returned
         # None. Surface a clean 502 (not a 500 crash) so the UI can retry.
         return JSONResponse(
-            {
-                "available": True,
-                "error": "Texture generation failed. Is the ComfyUI backend running?",
-            },
+            {"error": "Texture generation failed. Is the ComfyUI backend running?"},
             status_code=502,
+        )
+
+    if len(result.image_bytes) > _MAX_ASSET_BYTES:
+        logger.warning("generated texture exceeded size cap: %d bytes", len(result.image_bytes))
+        return JSONResponse(
+            {"error": "generated image exceeded the size limit"}, status_code=502
         )
 
     filename = _asset_filename(body.kind)

--- a/tinyagentos/routes/game_assets.py
+++ b/tinyagentos/routes/game_assets.py
@@ -1,0 +1,192 @@
+"""Tier-aware AI asset generation for the Game Studio (Slice 1: textures/sprites).
+
+A game is a flat file set stored under ``data/games/{id}/`` (see routes/games.py).
+This route turns a text prompt into a PNG *inside that same file set* by driving
+a ComfyUI backend, so the texture previews and travels with the game — no new
+storage is invented.
+
+Tier resolution mirrors the Images Studio (routes/images_edit.py): the concrete
+backend is resolved from the live backend catalog first, falling back to the
+host hardware profile. A discrete GPU (e.g. the RTX 3060 worker) serves the SDXL
+tier; an NPU host (RK3588) serves a low SD-1.5 placeholder tier; a host with no
+accelerator has no capable backend, so the route returns ``{available: false}``
+(HTTP 200) and the UI shows a "needs a GPU worker" state instead of a crash.
+"""
+from __future__ import annotations
+
+import logging
+import random
+import time
+from dataclasses import dataclass
+from typing import Literal, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.asset_gen.comfyui_client import ComfyUIClient, default_base_url
+from tinyagentos.asset_gen.workflows import build_texture_workflow
+from tinyagentos.routes.games import (
+    _SLUG_RE,
+    _games_dir,
+    _is_safe_filename,
+    _load_meta,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Size bounds. SDXL/latent geometry requires multiples of 8; keep a sane range
+# so a texture request can't ask the GPU for an 8K canvas.
+_MIN_SIZE = 64
+_MAX_SIZE = 2048
+_SIZE_MULTIPLE = 8
+
+# Per-tier checkpoint. SDXL is the discrete-GPU tier; SD 1.5 is the NPU
+# low/placeholder tier (see the design doc — real RK NPU tiling is a follow-up).
+_SDXL_CHECKPOINT = "sd_xl_base_1.0.safetensors"
+_SD15_CHECKPOINT = "v1-5-pruned-emaonly.safetensors"
+
+
+class TextureRequest(BaseModel):
+    prompt: str
+    width: int = 512
+    height: int = 512
+    tileable: bool = False
+    kind: Literal["texture", "sprite"] = "texture"
+
+
+@dataclass
+class TextureBackend:
+    """The resolved backend for a texture request."""
+
+    base_url: str
+    tier: str          # "sdxl" | "sd15"
+    checkpoint: str
+    workflow: str      # workflow template name
+
+
+def resolve_texture_backend(request: Request) -> Optional[TextureBackend]:
+    """Resolve the tier-appropriate ComfyUI backend, or ``None`` when the host
+    has no capable accelerator.
+
+    Priority mirrors the Images Studio routing:
+      1. A live ComfyUI backend advertised in the catalog (e.g. the RTX 3060
+         worker) — the SDXL/GPU tier.
+      2. A local discrete GPU (CUDA/ROCm) — SDXL at the local ComfyUI URL.
+      3. A local NPU (RK3588) — the SD-1.5 low/placeholder tier.
+      4. Otherwise unavailable.
+    """
+    catalog = getattr(request.app.state, "backend_catalog", None)
+    if catalog is not None:
+        try:
+            for backend in catalog.backends_with_capability("image-generation"):
+                if getattr(backend, "type", "") == "comfyui" and getattr(backend, "url", None):
+                    return TextureBackend(backend.url, "sdxl", _SDXL_CHECKPOINT, "texture_sdxl")
+        except Exception:  # noqa: BLE001 — a flaky catalog must not crash the route
+            logger.warning("backend catalog lookup failed", exc_info=True)
+
+    hw = getattr(request.app.state, "hardware_profile", None)
+    gpu = getattr(hw, "gpu", None)
+    if gpu is not None and (getattr(gpu, "cuda", False) or getattr(gpu, "rocm", False)):
+        return TextureBackend(default_base_url(), "sdxl", _SDXL_CHECKPOINT, "texture_sdxl")
+    npu = getattr(hw, "npu", None)
+    if npu is not None and getattr(npu, "type", "none") not in ("none", None):
+        return TextureBackend(default_base_url(), "sd15", _SD15_CHECKPOINT, "texture_sdxl")
+
+    return None
+
+
+def _valid_size(value: int) -> bool:
+    return _MIN_SIZE <= value <= _MAX_SIZE and value % _SIZE_MULTIPLE == 0
+
+
+def _asset_filename(kind: str) -> str:
+    """A unique, filesystem-safe PNG name for a generated asset."""
+    return f"{kind}-{int(time.time())}-{uuid4().hex[:8]}.png"
+
+
+@router.post("/api/games/{game_id}/assets/texture")
+async def generate_texture(request: Request, game_id: str, body: TextureRequest):
+    """Generate a texture/sprite PNG via ComfyUI and write it into the game's
+    file set. Returns the asset's preview path on success.
+
+    Never raises to the client: an unavailable tier returns 200
+    ``{available: false, reason}`` and a backend failure returns a clean 502.
+    """
+    if not _SLUG_RE.match(game_id):
+        return JSONResponse({"error": "invalid game id"}, status_code=400)
+
+    prompt = (body.prompt or "").strip()
+    if not prompt:
+        return JSONResponse({"error": "prompt must not be empty"}, status_code=400)
+    if not _valid_size(body.width) or not _valid_size(body.height):
+        return JSONResponse(
+            {
+                "error": (
+                    f"width/height must be a multiple of {_SIZE_MULTIPLE} "
+                    f"between {_MIN_SIZE} and {_MAX_SIZE}"
+                )
+            },
+            status_code=400,
+        )
+
+    game_dir = _games_dir(request) / game_id
+    if _load_meta(game_dir) is None:
+        return JSONResponse({"error": f"game '{game_id}' not found"}, status_code=404)
+
+    backend = resolve_texture_backend(request)
+    if backend is None:
+        # Tier-gated: no capable accelerator. NOT an error — the UI shows a
+        # "needs a GPU worker" state, so answer 200 with a clear reason.
+        return {
+            "available": False,
+            "reason": "No GPU or NPU worker available for texture generation.",
+        }
+
+    seed = random.randint(0, 2**32 - 1)
+    workflow = build_texture_workflow(
+        prompt=prompt,
+        width=body.width,
+        height=body.height,
+        seed=seed,
+        tileable=body.tileable,
+        checkpoint=backend.checkpoint,
+        template=backend.workflow,
+    )
+
+    client = ComfyUIClient(backend.base_url)
+    result = await client.generate(workflow)
+    if result is None:
+        # Fail-soft: the client swallowed the underlying error and returned
+        # None. Surface a clean 502 (not a 500 crash) so the UI can retry.
+        return JSONResponse(
+            {
+                "available": True,
+                "error": "Texture generation failed. Is the ComfyUI backend running?",
+            },
+            status_code=502,
+        )
+
+    filename = _asset_filename(body.kind)
+    if not _is_safe_filename(filename):  # defensive; the generator is safe
+        return JSONResponse({"error": "internal filename error"}, status_code=500)
+    try:
+        game_dir.mkdir(parents=True, exist_ok=True)
+        (game_dir / filename).write_bytes(result.image_bytes)
+    except OSError as exc:
+        logger.exception("failed to write generated texture")
+        return JSONResponse({"error": f"could not save asset: {exc}"}, status_code=500)
+
+    return {
+        "available": True,
+        "status": "generated",
+        "filename": filename,
+        "path": f"/api/games/{game_id}/preview/{filename}",
+        "kind": body.kind,
+        "tier": backend.tier,
+        "tileable": body.tileable,
+        "seed": seed,
+    }

--- a/tinyagentos/routes/games.py
+++ b/tinyagentos/routes/games.py
@@ -30,6 +30,14 @@ _SLUG_RE = re.compile(r"^[a-z0-9-]{1,64}$")
 _MAX_FILE_BYTES = 2 * 1024 * 1024
 _MAX_FILES = 40
 
+# Generated binary assets (game_assets.py textures now; audio/3D meshes later)
+# that the text editor does not manage; a full-replace save must never sweep
+# them, even if their bytes happen to decode as UTF-8.
+_BINARY_ASSET_EXTS = {
+    ".png", ".jpg", ".jpeg", ".webp", ".gif",
+    ".glb", ".gltf", ".wav", ".mp3", ".ogg",
+}
+
 
 class GameSaveRequest(BaseModel):
     name: str | None = None
@@ -135,7 +143,12 @@ async def save_game(request: Request, game_id: str, body: GameSaveRequest):
         # files), so generated binary assets (textures/sprites written by
         # routes/game_assets.py) never appear in `body.files`. Preserve them
         # instead of sweeping them: full-replace semantics apply only to the
-        # text files the editor actually manages.
+        # text files the editor actually manages. Match a known binary-asset
+        # extension first (a binary payload that happens to decode as UTF-8 —
+        # e.g. a GLB whose bytes are coincidentally valid — must not be swept),
+        # then fall back to an undecodable-bytes check for anything unlisted.
+        if p.suffix.lower() in _BINARY_ASSET_EXTS:
+            continue
         try:
             p.read_text(encoding="utf-8")
         except (UnicodeDecodeError, OSError):

--- a/tinyagentos/routes/games.py
+++ b/tinyagentos/routes/games.py
@@ -129,8 +129,18 @@ async def save_game(request: Request, game_id: str, body: GameSaveRequest):
     game_dir.mkdir(parents=True, exist_ok=True)
 
     for p in game_dir.iterdir():
-        if p.is_file() and p.name != "game.json" and p.name not in body.files:
-            p.unlink()
+        if not (p.is_file() and p.name != "game.json" and p.name not in body.files):
+            continue
+        # The editor's file set is text-only (_list_game_files skips undecodable
+        # files), so generated binary assets (textures/sprites written by
+        # routes/game_assets.py) never appear in `body.files`. Preserve them
+        # instead of sweeping them: full-replace semantics apply only to the
+        # text files the editor actually manages.
+        try:
+            p.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        p.unlink()
     for name, content in body.files.items():
         (game_dir / name).write_text(content, encoding="utf-8")
 

--- a/tinyagentos/scheduler/backend_catalog.py
+++ b/tinyagentos/scheduler/backend_catalog.py
@@ -40,6 +40,8 @@ BACKEND_CAPABILITIES: dict[str, set[str]] = {
     "openai": {"llm-chat", "embedding"},
     "anthropic": {"llm-chat"},
     "sd-cpp": {"image-generation"},
+    # ComfyUI: node-graph diffusion server — the Game Studio texture/sprite tier.
+    "comfyui": {"image-generation"},
     # IOPaint (lama-cleaner successor): LaMa erase/inpaint + rembg + RealESRGAN.
     "iopaint": {"image-editing", "background-removal", "upscale"},
     # FLUX.1-Fill served via an inpaint/outpaint endpoint — the quality tier.


### PR DESCRIPTION
## What

Slice 1 of the Game Studio asset-generation stack (design: `docs/design/game-studio-asset-generation.md`, Jay-approved: adopt ComfyUI, textures first, 3D deferred): offline, tier-aware AI texture/sprite generation, wired end to end.

A game is a flat file set under `data/games/{id}/`. A generated texture is just another file in that set plus a code reference, so it previews and travels with the game. No new storage is invented.

## Backend

- **ComfyUI client** (`tinyagentos/asset_gen/comfyui_client.py`): async httpx client. Submits a workflow to `POST /prompt`, polls `GET /history/{id}` to completion, fetches the output via `GET /view`. Base URL from `TAOS_COMFYUI_URL` (default `http://127.0.0.1:8188`). Fully fail-soft: every failure path (unreachable, timeout, non-image body, no `prompt_id`, job finished without an image) returns `None`, never raises. Bounded per-call timeout + overall poll deadline.
- **Curated workflow** (`tinyagentos/asset_gen/workflows/texture_sdxl.json` + `workflows.py`): a real, minimal SDXL text-to-image graph (checkpoint -> CLIP encode -> KSampler -> VAE decode -> save) in ComfyUI API format, parameterised by prompt / size / seed / checkpoint. Tileable applies a seamless-texture prompt hint; true asymmetric tiling needs a custom node and is a documented TODO.
- **Route** (`tinyagentos/routes/game_assets.py`): `POST /api/games/{id}/assets/texture` with body `{prompt, width?, height?, tileable?, kind}`. Resolves tier by mirroring the Images Studio pattern: a live ComfyUI backend in the catalog (e.g. the RTX 3060 worker) -> SDXL; else local GPU (CUDA/ROCm) -> SDXL; else local NPU (RK3588) -> SD 1.5 placeholder; else none. When no capable backend exists it returns **HTTP 200 `{available:false, reason}`** (not a 500) so the UI shows a "needs a GPU worker" state. On success it drives the workflow, writes the PNG into the game's file set, and returns the preview path. Validates prompt non-empty and size bounds. ComfyUI failure -> clean 502, never a crash.
- **Registered** in `tinyagentos/routes/__init__.py`; `comfyui` now advertises `image-generation` in the backend catalog.
- **games.py**: the save full-replace previously swept any file not in the (text-only) editor file set, which would delete a generated PNG on the next edit. Save now preserves binary assets.

## Frontend

- **Assets panel** (`desktop/src/apps/gamestudio/AssetsPanel.tsx`), wired into `EditorView` as a Chat/Assets tab: prompt + kind/size/tileable controls, Generate, preview, and "Insert into {file}". When the backend returns `available:false` it shows a disabled "Needs a GPU worker" state (mirrors the Images Studio / reduce-effects precedent), never a broken button.
- Thin client `game-assets-api.ts` and a pure `asset-reference.ts` helper (builds an `<img>` / JS const / CSS rule by file type) used by the insert action.

## Tests (all green)

- **Python: 51 passed** — `tests/test_asset_gen_comfyui.py` (client success / no prompt_id / job-without-image / non-image body / connect-error fail-soft / poll timeout / env base URL / workflow builder) and `tests/test_routes_game_assets.py` (success writes asset + returns path, sprite prefix, tier-unavailable `available:false`, ComfyUI-failure 502, empty-prompt + bad-size validation, 404/400, catalog-backend wins) and the games binary-preservation test. All ComfyUI HTTP is mocked (patched httpx / `ComfyUIClient`), matching the existing games/a2a test patterns.
- **Desktop: 9 new passed** (46 in the gamestudio suite) — `AssetsPanel.test.tsx` (render, generate + preview + insert, tier-unavailable state, backend error, insert disabled with no file) and `asset-reference.test.ts`. `tsc -b` clean.

## Follow-up

- **Live-verify on the RTX 3060 with a real ComfyUI** (install the SDXL checkpoint, generate a texture, confirm it appears in a previewed game). This PR deliberately does not require or wire a live ComfyUI; that verification is a separate step.
- Binary-asset packaging: the `.taosapp` packager is text-only, so a bundled PNG previews but is not yet packaged. Out of Slice 1 scope.
- True asymmetric/seamless tiling via a ComfyUI custom node (currently a prompt hint).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered texture and sprite generation in Game Studio.
  * Added asset settings for prompt, size, asset type, and tileability.
  * Added previews and one-click insertion into HTML, JavaScript, CSS, and other files.
  * Added GPU availability messaging and graceful generation error handling.
  * Added backend support for ComfyUI-based asset generation.

* **Bug Fixes**
  * Generated binary assets are now preserved when saving game files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->