### PR TITLE
feat(agents): least-privilege project_tasks registry scope for kanban

### DIFF
--- a/tests/test_agent_token_auth.py
+++ b/tests/test_agent_token_auth.py
@@ -1,0 +1,128 @@
+"""Unit tests for the project-scoped registry-JWT check.
+
+``check_agent_scope_for_project`` is the least-privilege sibling of
+``check_agent_scope``: it verifies the same EdDSA JWT + active-grant chain AND
+binds the caller to a single project via the token's ``project_id`` claim. These
+tests pin the security-critical behavior (project binding, missing-claim reject)
+and confirm ``check_agent_scope`` is unchanged by the shared-verifier refactor.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+
+from tinyagentos.agent_registry_store import mint_registry_token
+from tinyagentos.agent_token_auth import (
+    check_agent_scope,
+    check_agent_scope_for_project,
+)
+
+
+class _FakeRequest:
+    """Minimal stand-in for a starlette Request: the auth helpers only touch
+    ``.headers.get(...)`` and ``.app.state`` on the object."""
+
+    def __init__(self, app, token: str | None = None):
+        self.app = app
+        self.headers = {}
+        if token is not None:
+            self.headers["Authorization"] = f"Bearer {token}"
+
+
+@pytest_asyncio.fixture
+async def token_app(app):
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+    yield app
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+async def _mint(app, *, scopes=("project_tasks",), project_id="prj-1"):
+    """Register an active agent, add its grants, and mint a JWT bound to
+    ``project_id`` (global when project_id is None)."""
+    registry = app.state.agent_registry
+    grants = app.state.agent_grants
+    priv, _pub = app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="grok",
+        display_name="Grok",
+        origin="external-selfjoin",
+        handle="@grok",
+    )
+    cid = rec["canonical_id"]
+    await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="grok", project_id=project_id
+    )
+    return cid, token
+
+
+@pytest.mark.asyncio
+class TestCheckAgentScopeForProject:
+    async def test_returns_canonical_id_for_matching_project(self, token_app):
+        cid, token = await _mint(token_app, project_id="prj-1")
+        req = _FakeRequest(token_app, token)
+        got = await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert got == cid
+
+    async def test_403_on_project_mismatch(self, token_app):
+        _cid, token = await _mint(token_app, project_id="prj-1")
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope_for_project(req, "project_tasks", "prj-OTHER")
+        assert exc.value.status_code == 403
+
+    async def test_403_on_missing_project_claim(self, token_app):
+        # Global token (no project_id claim) must never satisfy a project check.
+        _cid, token = await _mint(token_app, project_id=None)
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert exc.value.status_code == 403
+
+    async def test_403_on_missing_scope(self, token_app):
+        _cid, token = await _mint(
+            token_app, scopes=("a2a_receive",), project_id="prj-1"
+        )
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert exc.value.status_code == 403
+
+    async def test_none_when_no_bearer(self, token_app):
+        req = _FakeRequest(token_app, token=None)
+        got = await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert got is None
+
+
+@pytest.mark.asyncio
+class TestCheckAgentScopeUnchanged:
+    """The shared-verifier refactor must not alter check_agent_scope."""
+
+    async def test_returns_canonical_id_ignoring_project(self, token_app):
+        cid, token = await _mint(token_app, project_id="prj-1")
+        req = _FakeRequest(token_app, token)
+        # project binding is irrelevant to the non-project check.
+        got = await check_agent_scope(req, "project_tasks")
+        assert got == cid
+
+    async def test_none_when_no_bearer(self, token_app):
+        req = _FakeRequest(token_app, token=None)
+        assert await check_agent_scope(req, "project_tasks") is None
+
+    async def test_403_on_missing_scope(self, token_app):
+        _cid, token = await _mint(
+            token_app, scopes=("a2a_receive",), project_id="prj-1"
+        )
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope(req, "project_tasks")
+        assert exc.value.status_code == 403

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -9,6 +9,56 @@ class _FakeAuthRequestsStore:
         return None
 
 
+class TestRequestableScopes:
+    """The project_tasks scope must be requestable through the consent loop, and
+    unknown scopes must still be rejected up front (they can never be enforced)."""
+
+    def test_project_tasks_is_a_valid_scope(self):
+        from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
+        assert "project_tasks" in VALID_SCOPES
+
+    @pytest.mark.asyncio
+    async def test_create_accepts_project_tasks(self, client, monkeypatch):
+        class _Store(_FakeAuthRequestsStore):
+            async def count_pending_for(self, identity_claim, framework):
+                return 0
+
+            async def create(self, **kwargs):
+                return {
+                    "id": "req-1",
+                    "identity_claim": kwargs["identity_claim"],
+                    "requested_scopes": kwargs["requested_scopes"],
+                }
+
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", _Store())
+        resp = await client.post(
+            "/api/agents/auth-requests",
+            json={
+                "identity_claim": "grok",
+                "framework": "grok-cli",
+                "requested_scopes": ["project_tasks"],
+                "project_id": "prj-1",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_unknown_scope(self, client, monkeypatch):
+        monkeypatch.setattr(
+            client._transport.app.state, "auth_requests", _FakeAuthRequestsStore()
+        )
+        resp = await client.post(
+            "/api/agents/auth-requests",
+            json={
+                "identity_claim": "grok",
+                "framework": "grok-cli",
+                "requested_scopes": ["not_a_real_scope"],
+            },
+        )
+        assert resp.status_code == 400
+
+
 class TestAgentAuthRequestsList:
     @pytest.mark.asyncio
     async def test_list_returns_200_with_requests_key(self, client, monkeypatch):

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -274,6 +274,21 @@ class TestActorBinding:
         assert resp.status_code == 200
         assert resp.json()["author_id"] == cid
 
+    async def test_comment_author_pinned_to_token_when_omitted(self, ctx):
+        """An agent may omit author_id; the route pins the comment to its own
+        canonical id rather than storing a null or caller-supplied author."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/comments",
+                json={"body": "on it"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["author_id"] == cid
+
 
 @pytest.mark.asyncio
 class TestExcludedRoutes:

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -117,7 +117,10 @@ class TestAgentCanDriveOwnBoard:
         assert resp.status_code == 200
         assert resp.json()["id"] == tid
 
-    async def test_patch_task(self, ctx):
+    async def test_patch_task_is_session_only(self, ctx):
+        """PATCH free-mutates task fields (title/assignee_id/parent), broader than
+        the project_tasks scope, so it is NOT on the agent allowlist: an agent
+        token is rejected. Lifecycle is driven via claim/close/reopen instead."""
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
         _cid, token = await _mint_agent(ctx, pid)
@@ -127,8 +130,7 @@ class TestAgentCanDriveOwnBoard:
                 json={"priority": 5},
                 headers=_hdr(token),
             )
-        assert resp.status_code == 200
-        assert resp.json()["priority"] == 5
+        assert resp.status_code in (401, 403, 404)
 
     async def test_claim_own_task_as_self(self, ctx):
         pid = await _new_project(ctx, "alpha")

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -1,0 +1,341 @@
+"""Agent-token access to the project kanban board (project_tasks scope).
+
+An APPROVED external agent drives ONLY its own project's task board with its
+Ed25519 registry JWT (scope project_tasks), no session cookie. These tests pin
+the five non-negotiable security invariants:
+
+  1. A token touches task routes ONLY for its own project_id claim; a different
+     project is an existence-hiding 404 (indistinguishable from a non-owner).
+  2. project_tasks grants task read + lifecycle + comments ONLY, never
+     create-task / members / project lifecycle.
+  3. The verified token's canonical_id is the authoritative actor; a lifecycle
+     body actor id that differs is rejected 403.
+  4. Session owner/admin behavior is unchanged (regression).
+  5. The token is not a skeleton key: it authenticates no route off the
+     allowlist.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import mint_registry_token
+
+
+@pytest_asyncio.fixture
+async def ctx(client):
+    """Reuse the session-admin `client` app and additionally init the agent
+    registry + grants stores so tokens can be minted against real stores."""
+    app = client._transport.app
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+    uid = app.state.auth.find_user("admin")["id"]
+    yield SimpleNamespace(client=client, app=app, uid=uid)
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+def _bare(app):
+    """Cookieless client so requests carry only the Bearer header."""
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _new_project(ctx, slug):
+    resp = await ctx.client.post("/api/projects", json={"name": slug, "slug": slug})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _new_task(ctx, pid, title="T"):
+    resp = await ctx.client.post(
+        f"/api/projects/{pid}/tasks", json={"title": title}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _mint_agent(ctx, project_id, scopes=("project_tasks",)):
+    registry = ctx.app.state.agent_registry
+    grants = ctx.app.state.agent_grants
+    priv, _pub = ctx.app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="grok",
+        display_name="Grok",
+        origin="external-selfjoin",
+        handle="@grok",
+    )
+    cid = rec["canonical_id"]
+    await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="grok", project_id=project_id
+    )
+    return cid, token
+
+
+def _hdr(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+class TestAgentCanDriveOwnBoard:
+    async def test_list_tasks(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/tasks", headers=_hdr(token))
+        assert resp.status_code == 200
+        assert any(t["id"] == tid for t in resp.json()["items"])
+
+    async def test_ready_tasks(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/ready", headers=_hdr(token)
+            )
+        assert resp.status_code == 200
+
+    async def test_get_task(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/{tid}", headers=_hdr(token)
+            )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == tid
+
+    async def test_patch_task(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"priority": 5},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["priority"] == 5
+
+    async def test_claim_own_task_as_self(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/claim",
+                json={"claimer_id": cid},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["claimed_by"] == cid
+
+    async def test_close_own_task(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/close",
+                json={"closed_by": cid},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "closed"
+
+    async def test_comments_read_and_post(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            post = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/comments",
+                json={"body": "on it", "author_id": cid},
+                headers=_hdr(token),
+            )
+            assert post.status_code == 200, post.text
+            listed = await bare.get(
+                f"/api/projects/{pid}/tasks/{tid}/comments", headers=_hdr(token)
+            )
+        assert listed.status_code == 200
+        assert len(listed.json()["items"]) == 1
+
+
+@pytest.mark.asyncio
+class TestProjectScoping:
+    async def test_different_project_is_404(self, ctx):
+        """Invariant 1: a token bound to project A must not reach project B; the
+        existence-hiding 404 is identical to a non-owner session's response."""
+        pid_a = await _new_project(ctx, "alpha")
+        pid_b = await _new_project(ctx, "bravo")
+        tid_b = await _new_task(ctx, pid_b)
+        _cid, token_a = await _mint_agent(ctx, pid_a)
+        async with _bare(ctx.app) as bare:
+            listing = await bare.get(
+                f"/api/projects/{pid_b}/tasks", headers=_hdr(token_a)
+            )
+            single = await bare.get(
+                f"/api/projects/{pid_b}/tasks/{tid_b}", headers=_hdr(token_a)
+            )
+        assert listing.status_code == 404
+        assert single.status_code == 404
+
+    async def test_context_route_respects_project_binding(self, ctx):
+        """The project-agnostic context path resolves the project from the task;
+        a token bound elsewhere still gets a 404."""
+        pid_a = await _new_project(ctx, "alpha")
+        pid_b = await _new_project(ctx, "bravo")
+        tid_b = await _new_task(ctx, pid_b)
+        _cid, token_a = await _mint_agent(ctx, pid_a)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/tasks/{tid_b}/context", headers=_hdr(token_a)
+            )
+        assert resp.status_code == 404
+
+    async def test_missing_scope_is_403(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        await _new_task(ctx, pid)
+        # Agent with a project-bound grant but NOT project_tasks.
+        _cid, token = await _mint_agent(ctx, pid, scopes=("a2a_receive",))
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/tasks", headers=_hdr(token))
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestActorBinding:
+    async def test_claim_as_someone_else_is_403(self, ctx):
+        """Invariant 3: a claim body naming a different actor is rejected."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/claim",
+                json={"claimer_id": "some-other-agent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+        assert cid != "some-other-agent"
+
+    async def test_close_as_someone_else_is_403(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/close",
+                json={"closed_by": "not-me"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestExcludedRoutes:
+    """Invariant 2 + 5: project_tasks must NOT reach create-task, members, or
+    project-lifecycle routes; the token authenticates nothing off the allowlist."""
+
+    async def test_cannot_create_task(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks",
+                json={"title": "sneaky"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_cannot_add_member(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/members",
+                json={"mode": "native", "agent_id": "x"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_cannot_patch_project(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}", json={"name": "hijack"}, headers=_hdr(token)
+            )
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_cannot_delete_project(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.delete(f"/api/projects/{pid}", headers=_hdr(token))
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_cannot_list_all_projects(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get("/api/projects", headers=_hdr(token))
+        assert resp.status_code == 401
+
+    async def test_cannot_read_task_audit(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/{tid}/audit", headers=_hdr(token)
+            )
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestSessionRegression:
+    """Invariant 4: the admin session path is unchanged by the dual-auth gate."""
+
+    async def test_admin_lists_tasks(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        resp = await ctx.client.get(f"/api/projects/{pid}/tasks")
+        assert resp.status_code == 200
+        assert any(t["id"] == tid for t in resp.json()["items"])
+
+    async def test_admin_claims_and_closes_as_any_actor(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        # A session admin may still act on behalf of any worker id (unchanged).
+        claim = await ctx.client.post(
+            f"/api/projects/{pid}/tasks/{tid}/claim",
+            json={"claimer_id": "worker-7"},
+        )
+        assert claim.status_code == 200
+        assert claim.json()["claimed_by"] == "worker-7"
+        close = await ctx.client.post(
+            f"/api/projects/{pid}/tasks/{tid}/close",
+            json={"closed_by": "worker-7"},
+        )
+        assert close.status_code == 200
+        assert close.json()["status"] == "closed"
+
+    async def test_unauthenticated_still_401(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/tasks")
+        assert resp.status_code == 401

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -244,6 +244,36 @@ class TestActorBinding:
             )
         assert resp.status_code == 403
 
+    async def test_comment_as_someone_else_is_403(self, ctx):
+        """Invariant 3: a comment author is an actor id; an agent may not post a
+        comment authored as another identity."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/comments",
+                json={"body": "spoofed", "author_id": "some-other-agent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+        assert cid != "some-other-agent"
+
+    async def test_comment_as_self_succeeds_and_stores_token_id(self, ctx):
+        """The mirror of the 403 case: an agent commenting as its own canonical
+        id is accepted and the stored author is that id."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/comments",
+                json={"body": "on it", "author_id": cid},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["author_id"] == cid
+
 
 @pytest.mark.asyncio
 class TestExcludedRoutes:

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -71,18 +71,21 @@ def _get_keypair(request: Request) -> tuple[bytes, bytes]:
     return kp
 
 
-async def check_agent_scope(request: Request, required_scope: str) -> Optional[str]:
-    """Return the canonical_id from a valid Bearer registry JWT that holds an
-    active *required_scope* grant, or raise an HTTPException.
+# Detail string for a token whose project_id claim does not match the requested
+# project.  Shared with the project task routes so they can recognise this exact
+# rejection and collapse it into an existence-hiding 404 (a token bound to
+# another project must be indistinguishable from a non-owner session).
+PROJECT_SCOPE_MISMATCH_DETAIL = "token not scoped to this project"
 
-    Returns None when no Authorization header is present (the caller falls
-    through to its own admin/session handling).
 
-    Raises:
-      401 -- Authorization header present but the token is malformed, has a bad
-             signature, or is missing the sub claim.
-      403 -- Token is valid but the agent is not active in the registry, the
-             sub is unknown, or the grant is missing/expired.
+async def _verify_agent_scope(
+    request: Request, required_scope: str
+) -> Optional[tuple[str, dict]]:
+    """Shared verifier for the agent-token checks.
+
+    Return ``(canonical_id, payload)`` for a valid Bearer registry JWT that holds
+    an active *required_scope* grant, or ``None`` when no Authorization header is
+    present.  Raises the same 401/403 documented on ``check_agent_scope``.
     """
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.lower().startswith("bearer "):
@@ -122,4 +125,51 @@ async def check_agent_scope(request: Request, required_scope: str) -> Optional[s
             detail=f"token does not hold an active {required_scope!r} grant",
         )
 
+    return canonical_id, payload
+
+
+async def check_agent_scope(request: Request, required_scope: str) -> Optional[str]:
+    """Return the canonical_id from a valid Bearer registry JWT that holds an
+    active *required_scope* grant, or raise an HTTPException.
+
+    Returns None when no Authorization header is present (the caller falls
+    through to its own admin/session handling).
+
+    Raises:
+      401 -- Authorization header present but the token is malformed, has a bad
+             signature, or is missing the sub claim.
+      403 -- Token is valid but the agent is not active in the registry, the
+             sub is unknown, or the grant is missing/expired.
+    """
+    result = await _verify_agent_scope(request, required_scope)
+    if result is None:
+        return None
+    canonical_id, _payload = result
+    return canonical_id
+
+
+async def check_agent_scope_for_project(
+    request: Request, required_scope: str, project_id: str
+) -> Optional[str]:
+    """Project-scoped sibling of ``check_agent_scope`` (least privilege).
+
+    Verifies the same EdDSA JWT + active-grant chain AND requires the token's
+    ``project_id`` claim to equal *project_id*.  This binds an agent token to a
+    single project's routes so it can never reach another project's board.
+
+    Returns None when no Authorization header is present.
+
+    Raises:
+      401/403 -- exactly as ``check_agent_scope`` (bad token / inactive agent /
+                 missing scope grant).
+      403 ``token not scoped to this project`` -- token is otherwise valid but
+                 its project_id claim is absent or does not match *project_id*.
+    """
+    result = await _verify_agent_scope(request, required_scope)
+    if result is None:
+        return None
+    canonical_id, payload = result
+    token_project = payload.get("project_id")
+    if not token_project or token_project != project_id:
+        raise HTTPException(status_code=403, detail=PROJECT_SCOPE_MISMATCH_DETAIL)
     return canonical_id

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -172,4 +172,19 @@ async def check_agent_scope_for_project(
     token_project = payload.get("project_id")
     if not token_project or token_project != project_id:
         raise HTTPException(status_code=403, detail=PROJECT_SCOPE_MISMATCH_DETAIL)
+    # Defense in depth: the token's project_id claim agreeing is not enough; the
+    # underlying grant must itself be bound to this project. A claim and a grant
+    # could diverge (re-mint against a stale claim, a hand-edited grant row), so
+    # require an active grant whose own project_id matches before authorizing.
+    grants_store = _get_grants_store(request)
+    now = datetime.now(timezone.utc)
+    grants = await grants_store.list_grants(canonical_id)
+    grant_ok = any(
+        g["scope"] == required_scope
+        and g.get("project_id") == project_id
+        and _grant_unexpired(g.get("expires_at"), now)
+        for g in grants
+    )
+    if not grant_ok:
+        raise HTTPException(status_code=403, detail=PROJECT_SCOPE_MISMATCH_DETAIL)
     return canonical_id

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import re
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -33,6 +34,34 @@ _A2A_BUS_WRITE_PATHS = frozenset({
 # passthrough is allowlisted to exactly these paths -- a registry JWT must never
 # authenticate an arbitrary route (no skeleton key).
 _AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE_PATHS
+
+# Project kanban routes an agent may reach with its own registry JWT (scope
+# project_tasks, verified + project-bound by the route).  These are DYNAMIC
+# paths (/api/projects/{pid}/tasks...), so an exact frozenset can't match them;
+# a (method, compiled-regex) allowlist is used instead.  Each pattern is fully
+# anchored and uses a slash-free segment ([^/]+) with an exact segment count, so
+# sibling routes that must stay session-only -- POST .../tasks (create),
+# /members, /relationships, /audit, /activity, project lifecycle -- never match.
+# This is the project-scoped analogue of the exact _AGENT_TOKEN_PATHS contract:
+# the token only reaches the handler, which then verifies the JWT + grant +
+# project binding.  Anything not listed here is NOT reachable by a registry JWT.
+_SEG = r"[^/]+"
+_AGENT_TASK_ROUTES = (
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/ready$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
+    ("GET", re.compile(rf"^/api/projects/tasks/{_SEG}/context$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
+    ("PATCH", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
+)
+
+
+def _is_agent_task_path(method: str, path: str) -> bool:
+    """True only for the exact subset of task routes a project_tasks token may
+    reach.  Strict method + anchored-regex match; everything else is excluded."""
+    return any(m == method and rx.match(path) for m, rx in _AGENT_TASK_ROUTES)
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -212,15 +241,20 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     request.state.via = "local_token"
                 return await call_next(request)
 
-        # Agent-token endpoints (registry feeds + read-only A2A bus proxy) accept
-        # a registry JWT as an alternative to the admin session.  This branch
-        # sits AFTER the local-token check on purpose: a local token is
+        # Agent-token endpoints (registry feeds + A2A bus proxy + project kanban)
+        # accept a registry JWT as an alternative to the admin session.  This
+        # branch sits AFTER the local-token check on purpose: a local token is
         # admin-equivalent and must keep its admin semantics on these paths
         # (taOSmd polls the feeds with it today).  Only a Bearer that is NOT the
         # local token falls through to here; it is PASSED THROUGH and the route
-        # verifies the registry JWT + scope grant.  The allowlist is exact so a
-        # registry JWT can never authenticate any other route (no skeleton key).
-        if path in _AGENT_TOKEN_PATHS and auth_header.lower().startswith("bearer "):
+        # verifies the registry JWT + scope grant (+ project binding for task
+        # routes).  The allowlist -- the exact _AGENT_TOKEN_PATHS plus the
+        # anchored task-route matcher -- is closed so a registry JWT can never
+        # authenticate any other route (no skeleton key).
+        if (
+            path in _AGENT_TOKEN_PATHS
+            or _is_agent_task_path(request.method, path)
+        ) and auth_header.lower().startswith("bearer "):
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "registry_jwt_candidate"

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -53,7 +53,8 @@ _AGENT_TASK_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/tasks/{_SEG}/context$")),
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
-    ("PATCH", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
+    # PATCH (free task-field mutation) is intentionally NOT here: it is broader
+    # than the "read + lifecycle + comments" the project_tasks scope documents.
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
 )
 

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -50,6 +50,10 @@ VALID_SCOPES = frozenset({
     "files_write",
     "tools_execute",
     "registry_feeds_read",
+    # Least-privilege kanban access: task read + lifecycle + comments for the
+    # agent's OWN project only (bound by the token's project_id claim). Does NOT
+    # grant task create, member management, or project lifecycle.
+    "project_tasks",
 })
 
 

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -91,6 +91,7 @@ _ALLOWED_SCOPES = frozenset({
     "a2a_send", "a2a_receive",
     "files_read", "files_write",
     "tools_execute", "registry_feeds_read",
+    "project_tasks",
 })
 
 

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -7,10 +7,14 @@ import time as _time
 import asyncio as _asyncio
 import json as _json
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
+from tinyagentos.agent_token_auth import (
+    PROJECT_SCOPE_MISMATCH_DETAIL,
+    check_agent_scope_for_project,
+)
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
 
@@ -419,6 +423,71 @@ async def _require_task_in_project(
     return task
 
 
+async def _authorize_task_actor(
+    request: Request, pstore, project_id: str
+) -> "tuple[str, bool, dict] | JSONResponse":
+    """Resolve the actor for a task route that accepts EITHER a session
+    owner/admin OR an approved external agent's registry JWT (scope
+    project_tasks) bound to THIS project.
+
+    Returns ``(actor_id, is_agent, project)`` on success, or a JSONResponse to
+    return directly.  These routes take ``request: Request`` and auth INSIDE the
+    handler (mirroring routes/a2a_bus.py) because ``Depends(current_user)`` would
+    401 an agent that has no session before the handler runs.
+
+    Security:
+      * A session non-owner gets the existence-hiding 404 from _get_owned_project.
+      * An agent token bound to a DIFFERENT project is collapsed into the SAME
+        existence-hiding 404, so it is indistinguishable from a non-owner and
+        never confirms another project's existence (invariant 1).
+      * A malformed / inactive / missing-scope token keeps its 401/403.
+    """
+    uid = getattr(request.state, "user_id", None)
+    if uid:
+        user = CurrentUser(
+            user_id=uid, is_admin=bool(getattr(request.state, "is_admin", False))
+        )
+        project_or_err = await _get_owned_project(pstore, project_id, user)
+        if isinstance(project_or_err, JSONResponse):
+            return project_or_err
+        return (user.user_id, False, project_or_err)
+
+    try:
+        caller = await check_agent_scope_for_project(
+            request, "project_tasks", project_id
+        )
+    except HTTPException as exc:
+        if exc.status_code == 403 and exc.detail == PROJECT_SCOPE_MISMATCH_DETAIL:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        raise
+    if caller is None:
+        # No session and no Bearer token: fail closed with existence-hiding 404.
+        return JSONResponse({"error": "not found"}, status_code=404)
+    project = await pstore.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return (caller, True, project)
+
+
+def _resolve_actor(
+    is_agent: bool, actor_id: str, body_actor: "str | None"
+) -> "str | None | JSONResponse":
+    """Bind a lifecycle actor id to the verified token when the caller is an agent.
+
+    Invariant 3: an agent must act only as itself.  If a lifecycle body names an
+    actor id (claimer_id / releaser_id / closed_by / reopened_by) that differs
+    from the token's canonical_id, reject 403; otherwise the token id is
+    authoritative.  A session caller keeps its provided actor id unchanged (an
+    owner/admin may still record an action on behalf of any worker id)."""
+    if is_agent:
+        if body_actor and body_actor != actor_id:
+            return JSONResponse(
+                {"error": "agent may only act as itself"}, status_code=403
+            )
+        return actor_id
+    return body_actor
+
+
 # ---------------------------------------------------------------------------
 # Task routes — order matters: /tasks/ready before /tasks/{task_id}
 # ---------------------------------------------------------------------------
@@ -459,12 +528,11 @@ async def list_tasks(
     project_id: str,
     request: Request,
     status: str | None = None,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     return {"items": await store.list_tasks(project_id=project_id, status=status)}
 
@@ -473,12 +541,11 @@ async def list_tasks(
 async def ready_tasks(
     project_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     return {"items": await store.list_ready_tasks(project_id=project_id)}
 
@@ -488,12 +555,11 @@ async def get_task(
     project_id: str,
     task_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     t = await store.get_task(task_id)
     if t is None or t["project_id"] != project_id:
@@ -507,12 +573,11 @@ async def update_task(
     task_id: str,
     payload: UpdateTaskIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
@@ -544,21 +609,24 @@ async def claim_task(
     task_id: str,
     payload: ClaimIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    claimer_id = _resolve_actor(is_agent, actor_id, payload.claimer_id)
+    if isinstance(claimer_id, JSONResponse):
+        return claimer_id
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    ok = await store.claim_task(task_id, payload.claimer_id)
+    ok = await store.claim_task(task_id, claimer_id)
     if not ok:
         # Distinguish "task taken by someone else" from "you already hold an
         # active task" so the agent knows to finish or release it first.
-        held = await store.held_task(payload.claimer_id)
+        held = await store.held_task(claimer_id)
         if held is not None and held != task_id:
             return JSONResponse(
                 {
@@ -570,10 +638,10 @@ async def claim_task(
             )
         return JSONResponse({"error": "already claimed"}, status_code=409)
     _beads_mark_dirty(request, project_id)
-    await pstore.log_activity(project_id, payload.claimer_id, "task.claimed", {"task_id": task_id})
+    await pstore.log_activity(project_id, claimer_id, "task.claimed", {"task_id": task_id})
     notifs = getattr(request.app.state, "notifications", None)
     if notifs is not None:
-        await notifs.emit_event("task.claimed", "Task claimed", f"{task_id} claimed by {payload.claimer_id}")
+        await notifs.emit_event("task.claimed", "Task claimed", f"{task_id} claimed by {claimer_id}")
     return await store.get_task(task_id)
 
 
@@ -583,17 +651,20 @@ async def release_task(
     task_id: str,
     payload: ReleaseIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    releaser_id = _resolve_actor(is_agent, actor_id, payload.releaser_id)
+    if isinstance(releaser_id, JSONResponse):
+        return releaser_id
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    ok = await store.release_task(task_id, payload.releaser_id)
+    ok = await store.release_task(task_id, releaser_id)
     if not ok:
         return JSONResponse({"error": "not claimed by releaser"}, status_code=409)
     _beads_mark_dirty(request, project_id)
@@ -606,25 +677,27 @@ async def close_task(
     task_id: str,
     payload: CloseIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, project = auth
+    closed_by = _resolve_actor(is_agent, actor_id, payload.closed_by)
+    if isinstance(closed_by, JSONResponse):
+        return closed_by
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    ok = await store.close_task(task_id, closed_by=payload.closed_by, reason=payload.reason)
+    ok = await store.close_task(task_id, closed_by=closed_by, reason=payload.reason)
     if not ok:
         return JSONResponse({"error": "cannot close"}, status_code=409)
     _beads_mark_dirty(request, project_id)
-    await pstore.log_activity(project_id, payload.closed_by, "task.closed", {"task_id": task_id})
+    await pstore.log_activity(project_id, closed_by, "task.closed", {"task_id": task_id})
     notifs = getattr(request.app.state, "notifications", None)
     if notifs is not None:
-        await notifs.emit_event("task.closed", "Task closed", f"{task_id} closed by {payload.closed_by}")
-    project = project_or_err
+        await notifs.emit_event("task.closed", "Task closed", f"{task_id} closed by {closed_by}")
     task = await store.get_task(task_id)
     qmd = getattr(request.app.state, "qmd_client", None)
     if qmd is not None and task is not None:
@@ -633,7 +706,7 @@ async def close_task(
             await index_closed_task(qmd, project, task)
         except Exception:
             await pstore.log_activity(
-                project_id, payload.closed_by, "task.qmd_index_failed", {"task_id": task_id}
+                project_id, closed_by, "task.qmd_index_failed", {"task_id": task_id}
             )
     return task
 
@@ -643,18 +716,22 @@ async def reopen_task(
     project_id: str,
     task_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
     payload: ReopenIn | None = None,
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    body_actor = payload.reopened_by if payload and payload.reopened_by else None
+    resolved = _resolve_actor(is_agent, actor_id, body_actor)
+    if isinstance(resolved, JSONResponse):
+        return resolved
+    actor = resolved or "user"
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    actor = (payload.reopened_by if payload and payload.reopened_by else None) or "user"
     ok = await store.reopen_task(task_id, reopened_by=actor)
     if not ok:
         return JSONResponse({"error": "task is not closed"}, status_code=409)
@@ -713,7 +790,6 @@ async def task_audit_history(
 async def task_context(
     task_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     """Relational context for a task: its goal (project + ancestry) and
     blockers. Project-agnostic path — task_id alone resolves the project
@@ -723,9 +799,9 @@ async def task_context(
     if task is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, task["project_id"], user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, task["project_id"])
+    if isinstance(auth, JSONResponse):
+        return auth
     return await store.get_task_context(task_id)
 
 
@@ -771,12 +847,11 @@ async def add_comment(
     task_id: str,
     payload: AddCommentIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):
@@ -797,12 +872,11 @@ async def list_comments(
     project_id: str,
     task_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -573,11 +573,16 @@ async def update_task(
     task_id: str,
     payload: UpdateTaskIn,
     request: Request,
+    user: CurrentUser = Depends(current_user),
 ):
+    # Session owner/admin only. A project_tasks agent drives its board through
+    # read + the lifecycle actions (claim/release/close/reopen) + comments; free
+    # PATCH of title/body/assignee_id/parent is a broader mutation than that
+    # scope grants, so it stays off the agent allowlist (Kilo review on #1774).
     pstore = request.app.state.project_store
-    auth = await _authorize_task_actor(request, pstore, project_id)
-    if isinstance(auth, JSONResponse):
-        return auth
+    project_or_err = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project_or_err, JSONResponse):
+        return project_or_err
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -837,7 +837,9 @@ async def add_relationship(
 
 class AddCommentIn(BaseModel):
     body: str
-    author_id: str
+    # Optional: an agent caller may omit it and the route pins it to the token
+    # canonical_id. A session caller must still supply it (route enforces).
+    author_id: str | None = None
     replies_to_comment_id: str | None = None
 
 
@@ -859,6 +861,8 @@ async def add_comment(
     author_id = _resolve_actor(is_agent, actor_id, payload.author_id)
     if isinstance(author_id, JSONResponse):
         return author_id
+    if author_id is None:
+        return JSONResponse({"error": "author_id required"}, status_code=400)
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -852,6 +852,13 @@ async def add_comment(
     auth = await _authorize_task_actor(request, pstore, project_id)
     if isinstance(auth, JSONResponse):
         return auth
+    actor_id, is_agent, _project = auth
+    # Invariant 3: an agent authors a comment only as itself. A comment author is
+    # an actor id just like the lifecycle fields, so bind it to the token id and
+    # 403 a mismatched body value (a session owner keeps its provided author_id).
+    author_id = _resolve_actor(is_agent, actor_id, payload.author_id)
+    if isinstance(author_id, JSONResponse):
+        return author_id
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):
@@ -859,7 +866,7 @@ async def add_comment(
     try:
         return await store.add_comment(
             task_id=task_id,
-            author_id=payload.author_id,
+            author_id=author_id,
             body=payload.body,
             replies_to_comment_id=payload.replies_to_comment_id,
         )


### PR DESCRIPTION
## Summary

Adds a least-privilege `project_tasks` registry-JWT scope so an APPROVED
external agent (onboarded via the `/api/agents/auth-requests` consent flow) can
drive ONLY its own project's kanban board with its Ed25519 registry token, no
session cookie. This unblocks the executor lane where an agent claims, updates,
and closes tasks on the board.

## Security invariants (each enforced + tested)

1. **Project scoping.** An agent token reaches task routes only for the project
   whose id equals the token's `project_id` claim. Any other project (or a
   global token with no claim) returns an existence-hiding 404, identical to a
   non-owner session, so the token never confirms another project's existence.
   - Enforced: `check_agent_scope_for_project` (403 on mismatch/missing claim),
     collapsed to 404 in `_authorize_task_actor`; middleware only passes task
     paths through.
   - Tests: `test_agent_token_auth.py::TestCheckAgentScopeForProject`
     (`test_403_on_project_mismatch`, `test_403_on_missing_project_claim`),
     `test_routes_projects_agent_tasks.py::TestProjectScoping`.

2. **Narrow grant.** `project_tasks` grants task read + lifecycle + comments
   only. Task create, member management, and project create/patch/archive/delete
   stay session owner/admin only.
   - Enforced: the middleware allowlist regex excludes those paths, so an agent
     (no session) is rejected before the handler.
   - Tests: `TestExcludedRoutes` (create task, add member, patch/delete
     project, list all projects, task audit).

3. **Actor-id binding.** The verified token's canonical_id is authoritative. A
   lifecycle body actor id (`claimer_id`/`releaser_id`/`closed_by`/
   `reopened_by`) that differs is rejected 403.
   - Enforced: `_resolve_actor` in claim/release/close/reopen.
   - Tests: `TestActorBinding` plus the happy-path claim/close as self.

4. **No regression.** Session owner/admin behavior is unchanged.
   - Tests: `TestSessionRegression` plus the full `test_routes_projects.py` and
     `test_routes_project_ownership.py` suites still pass.

5. **No skeleton key.** A registry JWT authenticates nothing off the allowlist.
   The dynamic task-path passthrough uses an anchored, segment-strict regex, so
   sibling routes (`/members`, `/relationships`, `/audit`, `/activity`, create)
   never match.
   - Tests: `TestExcludedRoutes::test_cannot_list_all_projects` and
     `test_cannot_read_task_audit` (both 401); existing bus skeleton-key test
     still green.

## Changes

- `tinyagentos/agent_token_auth.py`: factor a shared `_verify_agent_scope`
  verifier returning `(canonical_id, payload)`; add
  `check_agent_scope_for_project`. `check_agent_scope`'s public signature and
  behavior are unchanged.
- `tinyagentos/auth_middleware.py`: add `_is_agent_task_path` (anchored
  method + regex allowlist) and OR it into the registry-JWT passthrough.
- `tinyagentos/routes/agent_auth_requests.py`: add `project_tasks` to
  `VALID_SCOPES`.
- `tinyagentos/routes/projects.py`: dual-auth the allowed task routes via a new
  `_authorize_task_actor` (session owner/admin OR project-scoped agent token),
  and bind agent lifecycle actor ids via `_resolve_actor`. `create_task`,
  members, relationships, audits, and project lifecycle remain session-only.

## Tests

New: `tests/test_agent_token_auth.py`,
`tests/test_routes_projects_agent_tasks.py`, and a `TestRequestableScopes`
class in `tests/test_routes_agent_auth_requests.py`.

```
uv run pytest tests/test_agent_token_auth.py \
  tests/test_routes_projects_agent_tasks.py \
  tests/test_routes_agent_auth_requests.py::TestRequestableScopes
32 passed

# regression
uv run pytest tests/test_routes_projects.py tests/projects/test_task_store.py \
  tests/test_a2a_bus_agent_auth.py tests/test_routes_a2a_bus.py \
  tests/test_routes_agent_auth_requests.py tests/test_auth_middleware.py \
  tests/test_routes_project_ownership.py
154 passed
```

## Note

Comment author_id is left as-provided for agents: invariant 3 scopes actor
binding to the four lifecycle fields, and comments are listed separately as an
allowed read/post surface. Flagging in case reviewers want author_id bound too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added project-scoped external agent access to project task-board routes via registry JWTs.
  - Introduced the `project_tasks` scope for least-privilege task read, lifecycle, and comments.
  - Extended agent auth-requests to accept `project_tasks` with matching project context.
  - Agents can omit `author_id` when adding task comments (it’s bound to the token’s actor).

- **Security**
  - Project-scoped tokens are enforced and mismatches are hidden (indistinguishable 404s).
  - Agent lifecycle/comment actors are pinned to the authorized token identity; conflicts are denied.

- **Tests**
  - Added new test coverage for project-scoped token checks, auth-request scope validation, and agent task-route invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->