### PR TITLE
release: 1.0.0-beta.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.39] - 2026-07-10
+
+### Added
+- Game Studio can now generate textures and sprites from a text prompt using a ComfyUI backend on a discrete-GPU worker, writing the image straight into the game's file set. On a host with no capable GPU the panel shows a clear "needs a GPU worker" state instead of failing (#1773).
+- taOSgo cluster-join now completes the network side: a controller joins the account mesh over the system tailscale against the Headscale server, and the per-host service tokens the join returns are persisted host-locally (owner-only) so publishing and passkey fetches keep working after a join (#1770, #1772).
+- Agents post to the coordination bus as themselves through an authenticated send proxy, so a message carries the agent's own identity and cannot be spoofed as another account (#1768).
+- The cluster advertises the models a node can serve from its backend manifest, and installing a backend now registers it as a managed, node-local service that can be started, stopped, and health-checked per node (#1756, #1758, #1760, #1762).
+- An approved external agent can be granted a least-privilege project-tasks scope to read and drive a single project's task board (claim, close, comment) with its own token, scoped so it can never reach another project (#1774).
+
+### Fixed
+- Backend and worker robustness: the model VRAM check reserves atomically before a load so two loads cannot race the same memory, a malformed backend manifest no longer crashes the worker, and the VRAM guard fails closed rather than open on a probe error (#1725, #1767).
+- The RK3588 (RKLLM) install path pins the rkllama server to the verified 1.3.0 reference and guards the fork patches, and a live rkllama port is treated as installed only when it is a managed service (#1755, #1764).
+- Fixed six agent-framework catalog manifests that referenced install scripts which did not exist at the repo root (#1694).
+
 ## [1.0.0-beta.38] - 2026-07-08
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.38",
+  "version": "1.0.0-beta.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.38",
+      "version": "1.0.0-beta.39",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.38",
+  "version": "1.0.0-beta.39",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.38"
+__version__ = "1.0.0-beta.39"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b38"
+version = "1.0.0b39"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump to 1.0.0-beta.39 for the dev->master promotion.

Highlights since beta.38: Game Studio AI textures/sprites (#1773), taOSgo Headscale mesh-join + persisted service credentials (#1770, #1772), authenticated A2A bus send (#1768), managed node-local backend services + model advertisement (#1756/1758/1760/1762), atomic VRAM check-and-reserve (#1725), and the least-privilege project-tasks agent scope (#1774).

Version files bumped: pyproject.toml, tinyagentos/__init__.py, desktop/package.json, desktop/package-lock.json (x2), uv.lock (1.0.0b39), CHANGELOG. test_version_lock_sync passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Game Studio can generate textures and sprites from text prompts when a GPU worker is available.
  - Cluster joining now completes network setup and securely stores returned service credentials.
  - Agent messages preserve verified sender identity.
  - Backend services can be advertised, registered, and controlled per node.
  - Approved external agents receive scoped project access.

- **Bug Fixes**
  - Improved backend and worker reliability, including safer VRAM handling and malformed configuration recovery.
  - Fixed RK3588 installation detection and several agent-framework installation entries.

- **Release**
  - Updated to version **1.0.0-beta.39**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->