### PR TITLE
release: promote dev to master (1.0.0-beta.39)

### DIFF
--- a/.github/workflows/doc-gate.yml
+++ b/.github/workflows/doc-gate.yml
@@ -35,3 +35,8 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: python scripts/check_doc_gate.py diff-gate --base "origin/$BASE_REF"
+
+      - name: Managed backend manifest lint
+        run: |
+          python -m pip install --quiet pyyaml
+          python scripts/check_manifests.py managed-lint

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data/.setup_complete
 data/.auth_password
 data/.auth_sessions
 data/.auth_local_token
+data/mesh_credentials.json
 data/agents.json
 data/images/
 data/videos/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.39] - 2026-07-10
+
+### Added
+- Game Studio can now generate textures and sprites from a text prompt using a ComfyUI backend on a discrete-GPU worker, writing the image straight into the game's file set. On a host with no capable GPU the panel shows a clear "needs a GPU worker" state instead of failing (#1773).
+- taOSgo cluster-join now completes the network side: a controller joins the account mesh over the system tailscale against the Headscale server, and the per-host service tokens the join returns are persisted host-locally (owner-only) so publishing and passkey fetches keep working after a join (#1770, #1772).
+- Agents post to the coordination bus as themselves through an authenticated send proxy, so a message carries the agent's own identity and cannot be spoofed as another account (#1768).
+- The cluster advertises the models a node can serve from its backend manifest, and installing a backend now registers it as a managed, node-local service that can be started, stopped, and health-checked per node (#1756, #1758, #1760, #1762).
+- An approved external agent can be granted a least-privilege project-tasks scope to read and drive a single project's task board (claim, close, comment) with its own token, scoped so it can never reach another project (#1774).
+
+### Fixed
+- Backend and worker robustness: the model VRAM check reserves atomically before a load so two loads cannot race the same memory, a malformed backend manifest no longer crashes the worker, and the VRAM guard fails closed rather than open on a probe error (#1725, #1767).
+- The RK3588 (RKLLM) install path pins the rkllama server to the verified 1.3.0 reference and guards the fork patches, and a live rkllama port is treated as installed only when it is a managed service (#1755, #1764).
+- Fixed six agent-framework catalog manifests that referenced install scripts which did not exist at the repo root (#1694).
+
 ## [1.0.0-beta.38] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -578,6 +578,20 @@ curl -fsSL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-
 
 See [docs/mirror-policy.md](docs/mirror-policy.md) for the mirror governance policy, what is mirrored, when it updates, how to verify integrity independently, and how to self-host the mirror for air-gapped deployments. The same policy will extend to RK3576, Raspberry Pi 4, Mac mini / Apple Silicon, and x86 classes as those verified install paths land.
 
+## Agent Framework Install Scripts
+
+Several agent frameworks ship with dedicated install scripts under `scripts/install-*.sh` that are invoked automatically by the catalog installer when deploying the corresponding framework:
+
+| Script | Framework | Build toolchain |
+|---|---|---|
+| `scripts/install-agent-zero.sh` | [Agent Zero](https://github.com/frdel/agent-zero) | Clones repo to `/opt/agent-zero` and installs with pip |
+| `scripts/install-deer-flow.sh` | [DeerFlow](https://github.com/bytedance/deer-flow) | Clones repo to `/opt/deer-flow` and provisions with `uv` (Python 3.12) |
+| `scripts/install-moltis.sh` | [Moltis](https://github.com/moltis-org/moltis) | Installs via `cargo install` from crates.io (or git tag) |
+| `scripts/install-openclaw.sh` | [OpenClaw](https://github.com/openclaw/openclaw) | Clones repo to `/opt/openclaw` and installs with pip |
+| `scripts/install-picoclaw.sh` | [PicoClaw](https://github.com/sipeed/picoclaw) | Clones repo to `/opt/picoclaw` and builds with `cmake` |
+
+Hermes Agent uses `install: {method: pip, package: hermes-agent}` in its catalog manifest (available on PyPI from Nous Research) and does not need a separate install script.
+
 ## TurboQuant KV cache compression
 
 **768K context window on a single RTX 3060 (12 GB).** taOS integrates Google's TurboQuant (ICLR 2026) KV cache quantization via TheTom/llama-cpp-turboquant. Unlike weight quantization, which compresses model files, TurboQuant compresses the per-request KV cache -- the per-token memory that scales with context length and is the actual bottleneck on consumer hardware.

--- a/app-catalog/agents/agent-zero/manifest.yaml
+++ b/app-catalog/agents/agent-zero/manifest.yaml
@@ -14,6 +14,10 @@ requires:
 install:
   method: script
   script: scripts/install-agent-zero.sh
+  note: |
+    Clones frdel/agent-zero into /opt/agent-zero and installs with pip.
+    No PyPI package — the `agent-zero` package on PyPI is an unrelated
+    voice-agent framework. Agent Zero is clone-and-run only.
 
 hardware_tiers:
   arm-npu-16gb: full

--- a/app-catalog/agents/deer-flow/manifest.yaml
+++ b/app-catalog/agents/deer-flow/manifest.yaml
@@ -14,12 +14,11 @@ requires:
 
 install:
   method: script
-  script: scripts/install.sh
+  script: scripts/install-deer-flow.sh
   note: |
     Clones bytedance/deer-flow into /opt/deer-flow and provisions the backend
-    with uv (Python 3.12). Writes a config.yaml pointing DeerFlow at the taOS
-    LiteLLM proxy and a systemd unit that serves the backend runs API on 8001.
-    The bridge adapter (deer_flow_adapter.py) lives in the taOS controller.
+    with uv (Python 3.12). The bridge adapter (deer_flow_adapter.py) lives in
+    the taOS controller.
 
 config_schema:
   - name: model

--- a/app-catalog/agents/hermes/manifest.yaml
+++ b/app-catalog/agents/hermes/manifest.yaml
@@ -13,12 +13,8 @@ requires:
   python: ">=3.10"
 
 install:
-  method: script
-  script: scripts/install.sh
-  note: |
-    Installs hermes-agent from PyPI inside the agent container.
-    Configures the Hermes → TAOS bridge adapter (hermes_adapter.py)
-    and a systemd unit that connects to TAOS channels via SSE.
+  method: pip
+  package: hermes-agent
 
 config_schema:
   - name: model

--- a/app-catalog/agents/openclaw/manifest.yaml
+++ b/app-catalog/agents/openclaw/manifest.yaml
@@ -13,7 +13,11 @@ requires:
 
 install:
   method: script
-  script: scripts/install.sh
+  script: scripts/install-openclaw.sh
+  note: |
+    Clones openclaw/openclaw into /opt/openclaw and installs with pip.
+    No PyPI package — `openclaw` on PyPI resolves to an unrelated CMDOP
+    plugin. OpenClaw is clone-and-run only.
 
 config_schema:
   - name: model

--- a/app-catalog/services/rkllama/manifest.yaml
+++ b/app-catalog/services/rkllama/manifest.yaml
@@ -31,6 +31,13 @@ lifecycle:
   backend_type: rkllama
   default_url: http://localhost:7833
   auto_manage: true
+  # Managed as a systemd service (see scripts/install-rknpu.sh install_systemd_unit).
+  # taOS manages the unit per node: start/stop/restart default to `systemctl <verb> <unit>`.
+  unit: rkllama.service
+  scope: system
+  health:
+    url: "http://localhost:7833/api/tags"
+    expect: '"models"'
   keep_alive_minutes: 0
   start_cmd: "systemctl start rkllama"
   stop_cmd: "systemctl stop rkllama"

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.38",
+  "version": "1.0.0-beta.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.38",
+      "version": "1.0.0-beta.39",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.38",
+  "version": "1.0.0-beta.39",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src/apps/designstudio/DesignView.test.tsx
+++ b/desktop/src/apps/designstudio/DesignView.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { useState } from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+/* react-konva needs a real <canvas> (the `canvas` npm package), which is not
+ * installed in the jsdom test env. Mock the primitives to inert passthroughs so
+ * DesignView's toolbar / layers / properties logic can be exercised without a
+ * Konva stage. Because the Stage/Transformer refs are never populated, the
+ * canvas-only effects (transformer wiring, PNG export) safely no-op. */
+vi.mock("react-konva", () => ({
+  Stage: ({ children }: { children?: React.ReactNode }) => <div data-konva="stage">{children}</div>,
+  Layer: ({ children }: { children?: React.ReactNode }) => <div data-konva="layer">{children}</div>,
+  Rect: () => null,
+  Text: () => null,
+  Image: () => null,
+  Ellipse: () => null,
+  Line: () => null,
+  Transformer: () => null,
+}));
+
+import { DesignView } from "./DesignView";
+import { DEFAULT_ARTBOARD, type CanvasElement } from "./types";
+
+/** DesignView is a controlled component: it hands the next elements array back
+ * through onElementsChange and re-reads it from props. This host mirrors how
+ * DesignStudioApp owns that state, and exposes the latest array for assertions. */
+let latest: CanvasElement[] = [];
+function Host() {
+  const [els, setEls] = useState<CanvasElement[]>([]);
+  latest = els;
+  return <DesignView elements={els} onElementsChange={setEls} artboard={DEFAULT_ARTBOARD} />;
+}
+
+function renderView() {
+  return render(<Host />);
+}
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  latest = [];
+  vi.clearAllMocks();
+});
+
+describe("DesignView", () => {
+  it("renders the empty state with export/undo/redo disabled", () => {
+    renderView();
+    expect(screen.getByText(/Add an element or generate with Magic/i)).toBeDefined();
+    expect((screen.getByLabelText("Export as PNG") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Undo") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Redo") as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/No layers yet/i)).toBeDefined();
+  });
+
+  it("keeps the coming-soon Star tile disabled", () => {
+    renderView();
+    expect((screen.getByLabelText("Star") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Text") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("adding a text element updates state and adds a layer, enabling export/undo", () => {
+    renderView();
+    fireEvent.click(screen.getByLabelText("Text"));
+
+    expect(latest).toHaveLength(1);
+    expect(latest[0].type).toBe("text");
+    expect(screen.getByLabelText(/Select layer/i)).toBeDefined();
+    expect((screen.getByLabelText("Export as PNG") as HTMLButtonElement).disabled).toBe(false);
+    expect((screen.getByLabelText("Undo") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("adding a shape creates a rect and auto-selects it (properties panel appears)", () => {
+    renderView();
+    fireEvent.click(screen.getByLabelText("Shape"));
+
+    expect(latest[0].type).toBe("rect");
+    // Auto-selection surfaces the shape's fill/stroke controls.
+    expect(screen.getByLabelText("Fill color")).toBeDefined();
+    expect(screen.getByText("Rectangle")).toBeDefined();
+  });
+
+  it("adding a circle creates an ellipse", () => {
+    renderView();
+    fireEvent.click(screen.getByLabelText("Circle"));
+    expect(latest[0].type).toBe("ellipse");
+  });
+
+  it("adding a line creates a line element", () => {
+    renderView();
+    fireEvent.click(screen.getByLabelText("Line"));
+    expect(latest[0].type).toBe("line");
+  });
+
+  it("undo removes a just-added element and returns to the empty state", () => {
+    renderView();
+    fireEvent.click(screen.getByLabelText("Text"));
+    expect(latest).toHaveLength(1);
+    fireEvent.click(screen.getByLabelText("Undo"));
+    expect(latest).toHaveLength(0);
+    expect(screen.getByText(/Add an element or generate with Magic/i)).toBeDefined();
+  });
+
+  it("brand swatches are disabled until a fillable element is selected", () => {
+    renderView();
+    expect((screen.getByLabelText("Apply #6b7689") as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByLabelText("Shape"));
+    expect((screen.getByLabelText("Apply #6b7689") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("exposes zoom controls that fit the artboard to the stage", () => {
+    renderView();
+    const zoom = screen.getByLabelText("Zoom level") as HTMLSelectElement;
+    // The view fits the artboard on mount, so the zoom is a positive percentage.
+    expect(Number(zoom.value)).toBeGreaterThan(0);
+    expect(screen.getByLabelText("Zoom in")).toBeDefined();
+    expect(screen.getByLabelText("Zoom out")).toBeDefined();
+    expect(screen.getByLabelText("Fit to screen")).toBeDefined();
+  });
+
+  it("shows the artboard name and dimensions in the header", () => {
+    renderView();
+    expect(screen.getByText(DEFAULT_ARTBOARD.name)).toBeDefined();
+    expect(
+      screen.getByText(`${DEFAULT_ARTBOARD.width} x ${DEFAULT_ARTBOARD.height}`),
+    ).toBeDefined();
+  });
+});

--- a/desktop/src/apps/designstudio/LayersPanel.test.tsx
+++ b/desktop/src/apps/designstudio/LayersPanel.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LayersPanel } from "./LayersPanel";
+import type { CanvasElement } from "./types";
+
+function text(id: string, zIndex: number, over: Partial<CanvasElement> = {}): CanvasElement {
+  return {
+    id,
+    type: "text",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 40,
+    rotation: 0,
+    zIndex,
+    visible: true,
+    text: "Hello world",
+    fontSize: 32,
+    fontFamily: "Inter",
+    fill: "#fff",
+    align: "left",
+    ...over,
+  } as CanvasElement;
+}
+
+function baseProps() {
+  return {
+    onSelect: vi.fn(),
+    onToggleVisibility: vi.fn(),
+    onReorder: vi.fn(),
+    onDelete: vi.fn(),
+  };
+}
+
+describe("LayersPanel", () => {
+  it("shows an empty state with no layers", () => {
+    render(<LayersPanel elements={[]} selectedId={null} {...baseProps()} />);
+    expect(screen.getByText(/No layers yet/i)).toBeDefined();
+  });
+
+  it("lists layers top-most (highest zIndex) first", () => {
+    const els = [text("low", 0, { text: "Bottom" }), text("high", 5, { text: "Top" })];
+    render(<LayersPanel elements={els} selectedId={null} {...baseProps()} />);
+    const labels = screen.getAllByText(/Top|Bottom/).map((n) => n.textContent);
+    expect(labels[0]).toBe("Top");
+    expect(labels[1]).toBe("Bottom");
+  });
+
+  it("labels typed layers by their content", () => {
+    const els = [
+      text("t", 3),
+      { ...text("r", 2), type: "rect", fill: "#000", stroke: "#fff", strokeWidth: 0 } as CanvasElement,
+      { ...text("l", 1), type: "line", stroke: "#fff", strokeWidth: 3 } as CanvasElement,
+    ];
+    render(<LayersPanel elements={els} selectedId={null} {...baseProps()} />);
+    expect(screen.getByText("Hello world")).toBeDefined();
+    expect(screen.getByText("Rectangle")).toBeDefined();
+    expect(screen.getByText("Line")).toBeDefined();
+  });
+
+  it("fires onSelect with the clicked layer id", () => {
+    const props = baseProps();
+    render(<LayersPanel elements={[text("a", 0)]} selectedId={null} {...props} />);
+    fireEvent.click(screen.getByLabelText(/Select layer/i));
+    expect(props.onSelect).toHaveBeenCalledWith("a");
+  });
+
+  it("marks the selected layer via aria-pressed", () => {
+    render(<LayersPanel elements={[text("a", 0)]} selectedId="a" {...baseProps()} />);
+    expect(screen.getByLabelText(/Select layer/i).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("disables move-up on the top layer and move-down on the bottom layer", () => {
+    const els = [text("bottom", 0, { text: "Bottom" }), text("top", 5, { text: "Top" })];
+    render(<LayersPanel elements={els} selectedId={null} {...baseProps()} />);
+    // Top row (rendered first) can't move up; bottom row can't move down.
+    expect((screen.getByLabelText("Move Top up") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Move Bottom down") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Move Top down") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("fires onReorder with the direction", () => {
+    const props = baseProps();
+    const els = [text("bottom", 0, { text: "Bottom" }), text("top", 5, { text: "Top" })];
+    render(<LayersPanel elements={els} selectedId={null} {...props} />);
+    fireEvent.click(screen.getByLabelText("Move Top down"));
+    expect(props.onReorder).toHaveBeenCalledWith("top", "down");
+  });
+
+  it("toggles visibility with the correct label per state", () => {
+    const props = baseProps();
+    const els = [text("a", 0), text("b", 1, { visible: false, text: "Hidden" })];
+    render(<LayersPanel elements={els} selectedId={null} {...props} />);
+    fireEvent.click(screen.getByLabelText("Hide Hello world"));
+    expect(props.onToggleVisibility).toHaveBeenCalledWith("a");
+    expect(screen.getByLabelText("Show Hidden")).toBeDefined();
+  });
+
+  it("fires onDelete for the layer", () => {
+    const props = baseProps();
+    render(<LayersPanel elements={[text("a", 0)]} selectedId={null} {...props} />);
+    fireEvent.click(screen.getByLabelText("Delete Hello world"));
+    expect(props.onDelete).toHaveBeenCalledWith("a");
+  });
+});

--- a/desktop/src/apps/designstudio/LibraryView.test.tsx
+++ b/desktop/src/apps/designstudio/LibraryView.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { LibraryView } from "./LibraryView";
+
+const DESIGN = { id: "d1", name: "My Poster", updated_at: Math.floor(Date.now() / 1000) };
+
+function ok(body: unknown) {
+  return { ok: true, status: 200, json: () => Promise.resolve(body) } as Response;
+}
+
+describe("LibraryView", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shows an empty state when there are no saved designs", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(ok([]))) as unknown as typeof fetch);
+    render(<LibraryView onOpenDesign={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/No saved designs yet/i)).toBeDefined());
+  });
+
+  it("renders a saved design and opens it on click", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(ok([DESIGN]))) as unknown as typeof fetch);
+    const onOpen = vi.fn();
+    render(<LibraryView onOpenDesign={onOpen} />);
+    await waitFor(() => expect(screen.getByText("My Poster")).toBeDefined());
+    fireEvent.click(screen.getByLabelText("Open My Poster"));
+    expect(onOpen).toHaveBeenCalledWith("d1");
+  });
+
+  it("surfaces a load error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) } as Response)) as unknown as typeof fetch,
+    );
+    render(<LibraryView onOpenDesign={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toMatch(/could not load designs/i));
+  });
+
+  it("delete is backend-confirmed: refetches the list and reports the rename callback", async () => {
+    let deleted = false;
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "/api/designs" && method === "GET") {
+        return Promise.resolve(ok(deleted ? [] : [DESIGN]));
+      }
+      if (url === "/api/designs/d1" && method === "DELETE") {
+        deleted = true;
+        return Promise.resolve(ok({}));
+      }
+      return Promise.resolve(ok({}));
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    render(<LibraryView onOpenDesign={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("My Poster")).toBeDefined());
+
+    fireEvent.click(screen.getByLabelText("Delete My Poster"));
+    await waitFor(() => expect(screen.queryByText("My Poster")).toBeNull());
+    await waitFor(() => expect(screen.getByText(/No saved designs yet/i)).toBeDefined());
+  });
+
+  it("does not delete when the user cancels the confirm", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(ok([DESIGN])));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    render(<LibraryView onOpenDesign={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("My Poster")).toBeDefined());
+
+    fireEvent.click(screen.getByLabelText("Delete My Poster"));
+    // No DELETE was issued -- only the initial list GET happened.
+    expect(fetchMock.mock.calls.every((c) => (c[1]?.method ?? "GET") === "GET")).toBe(true);
+  });
+
+  it("renames a design and notifies via onRenamed", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (method === "PUT") return Promise.resolve(ok({ id: "d1", name: "Renamed", content: "{}" }));
+      return Promise.resolve(ok([DESIGN]));
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(window, "prompt").mockReturnValue("Renamed");
+    const onRenamed = vi.fn();
+
+    render(<LibraryView onOpenDesign={vi.fn()} onRenamed={onRenamed} />);
+    await waitFor(() => expect(screen.getByText("My Poster")).toBeDefined());
+
+    fireEvent.click(screen.getByLabelText("Rename My Poster"));
+    await waitFor(() => expect(onRenamed).toHaveBeenCalledWith("d1", "Renamed"));
+  });
+
+  it("skips the rename when the prompt is cancelled or unchanged", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(ok([DESIGN])));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    vi.spyOn(window, "prompt").mockReturnValue(null);
+
+    render(<LibraryView onOpenDesign={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("My Poster")).toBeDefined());
+
+    fireEvent.click(screen.getByLabelText("Rename My Poster"));
+    expect(fetchMock.mock.calls.every((c) => (c[1]?.method ?? "GET") === "GET")).toBe(true);
+  });
+});

--- a/desktop/src/apps/designstudio/MagicView.test.tsx
+++ b/desktop/src/apps/designstudio/MagicView.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MagicView } from "./MagicView";
+import type { GeneratedImage } from "./types";
+
+function props(over: Partial<Parameters<typeof MagicView>[0]> = {}) {
+  return {
+    prompt: "",
+    onPromptChange: vi.fn(),
+    style: null as string | null,
+    onStyleChange: vi.fn(),
+    results: [] as GeneratedImage[],
+    generating: false,
+    canGenerate: true,
+    error: null as string | null,
+    errorNeedsModel: false,
+    needsModel: false,
+    onGenerate: vi.fn(),
+    onPickModel: vi.fn(),
+    onUseResult: vi.fn(),
+    ...over,
+  };
+}
+
+describe("MagicView", () => {
+  it("edits the prompt through onPromptChange", () => {
+    const p = props();
+    render(<MagicView {...p} />);
+    fireEvent.change(screen.getByLabelText("Design prompt"), { target: { value: "a poster" } });
+    expect(p.onPromptChange).toHaveBeenCalledWith("a poster");
+  });
+
+  it("disables Generate when canGenerate is false", () => {
+    render(<MagicView {...props({ canGenerate: false })} />);
+    expect((screen.getByRole("button", { name: /Generate/ }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("fires onGenerate when enabled and clicked", () => {
+    const p = props({ canGenerate: true });
+    render(<MagicView {...p} />);
+    fireEvent.click(screen.getByRole("button", { name: /Generate/ }));
+    expect(p.onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the busy label while generating", () => {
+    render(<MagicView {...props({ generating: true })} />);
+    expect(screen.getByText(/Generating\.\.\./)).toBeDefined();
+  });
+
+  it("toggles a style chip on and off", () => {
+    const p = props({ style: null });
+    const { rerender } = render(<MagicView {...p} />);
+    fireEvent.click(screen.getByRole("button", { name: "Bold" }));
+    expect(p.onStyleChange).toHaveBeenCalledWith("Bold");
+
+    // When a chip is already active, clicking clears it.
+    p.onStyleChange.mockClear();
+    rerender(<MagicView {...props({ ...p, style: "Bold" })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Bold" }));
+    expect(p.onStyleChange).toHaveBeenCalledWith(null);
+  });
+
+  it("shows the install-a-model prompt and wires Browse models", () => {
+    const p = props({ needsModel: true });
+    render(<MagicView {...p} />);
+    expect(screen.getByText(/Install an image generation model/i)).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Browse models" }));
+    expect(p.onPickModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an error and, when it needs a model, an install action", () => {
+    const p = props({ error: "boom", errorNeedsModel: true });
+    render(<MagicView {...p} />);
+    expect(screen.getByText("boom")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Install a model" }));
+    expect(p.onPickModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show an install action for a plain error", () => {
+    render(<MagicView {...props({ error: "just a message", errorNeedsModel: false })} />);
+    expect(screen.getByText("just a message")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Install a model" })).toBeNull();
+  });
+
+  it("renders results and fires onUseResult with the picked image", () => {
+    const img: GeneratedImage = { id: "g1", url: "/x.png", prompt: "a cat poster" };
+    const p = props({ results: [img] });
+    render(<MagicView {...p} />);
+    const tile = screen.getByAltText("a cat poster");
+    fireEvent.click(tile);
+    expect(p.onUseResult).toHaveBeenCalledWith(img);
+  });
+});

--- a/desktop/src/apps/designstudio/PropertiesPanel.test.tsx
+++ b/desktop/src/apps/designstudio/PropertiesPanel.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PropertiesPanel } from "./PropertiesPanel";
+import type { CanvasElement } from "./types";
+
+function textEl(over: Partial<CanvasElement> = {}): CanvasElement {
+  return {
+    id: "t",
+    type: "text",
+    x: 12.4,
+    y: 40.6,
+    width: 100,
+    height: 40,
+    rotation: 0,
+    zIndex: 0,
+    visible: true,
+    text: "Hi",
+    fontSize: 32,
+    fontFamily: "Inter",
+    fill: "#ffffff",
+    align: "left",
+    ...over,
+  } as CanvasElement;
+}
+
+function rectEl(over: Partial<CanvasElement> = {}): CanvasElement {
+  return {
+    id: "r",
+    type: "rect",
+    x: 0,
+    y: 0,
+    width: 50,
+    height: 60,
+    rotation: 0,
+    zIndex: 0,
+    visible: true,
+    fill: "#112233",
+    stroke: "#445566",
+    strokeWidth: 2,
+    ...over,
+  } as CanvasElement;
+}
+
+function lineEl(): CanvasElement {
+  return {
+    id: "l",
+    type: "line",
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 2,
+    rotation: 0,
+    zIndex: 0,
+    visible: true,
+    stroke: "#abcdef",
+    strokeWidth: 3,
+  } as CanvasElement;
+}
+
+function props(over: Partial<Parameters<typeof PropertiesPanel>[0]> = {}) {
+  return {
+    onUpdate: vi.fn(),
+    onDuplicate: vi.fn(),
+    onDelete: vi.fn(),
+    ...over,
+  };
+}
+
+describe("PropertiesPanel", () => {
+  it("prompts to select an element when nothing is selected", () => {
+    render(<PropertiesPanel selected={null} {...props()} />);
+    expect(screen.getByText(/Select an element/i)).toBeDefined();
+  });
+
+  it("shows text controls for a text element and emits font-size updates", () => {
+    const p = props();
+    render(<PropertiesPanel selected={textEl()} {...p} />);
+    const size = screen.getByLabelText("Font size") as HTMLInputElement;
+    expect(size.value).toBe("32");
+    fireEvent.change(size, { target: { value: "48" } });
+    expect(p.onUpdate).toHaveBeenCalledWith({ fontSize: 48 });
+  });
+
+  it("emits text color and alignment updates", () => {
+    const p = props();
+    render(<PropertiesPanel selected={textEl()} {...p} />);
+    fireEvent.change(screen.getByLabelText("Text color"), { target: { value: "#ff0000" } });
+    expect(p.onUpdate).toHaveBeenCalledWith({ fill: "#ff0000" });
+    fireEvent.click(screen.getByLabelText("Align center"));
+    expect(p.onUpdate).toHaveBeenCalledWith({ align: "center" });
+  });
+
+  it("reflects the active alignment via aria-pressed", () => {
+    render(<PropertiesPanel selected={textEl({ align: "right" })} {...props()} />);
+    expect(screen.getByLabelText("Align right").getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByLabelText("Align left").getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("shows fill/stroke controls for a rect and emits updates", () => {
+    const p = props();
+    render(<PropertiesPanel selected={rectEl()} {...p} />);
+    fireEvent.change(screen.getByLabelText("Fill color"), { target: { value: "#000000" } });
+    expect(p.onUpdate).toHaveBeenCalledWith({ fill: "#000000" });
+    fireEvent.change(screen.getByLabelText("Stroke width"), { target: { value: "5" } });
+    expect(p.onUpdate).toHaveBeenCalledWith({ strokeWidth: 5 });
+    // Text-only controls must not appear for a shape.
+    expect(screen.queryByLabelText("Font size")).toBeNull();
+  });
+
+  it("shows only a stroke control for a line (no fill)", () => {
+    render(<PropertiesPanel selected={lineEl()} {...props()} />);
+    expect(screen.getByLabelText("Stroke color")).toBeDefined();
+    expect(screen.queryByLabelText("Fill color")).toBeNull();
+  });
+
+  it("rounds and displays position and size", () => {
+    render(<PropertiesPanel selected={textEl({ x: 12.4, y: 40.6, width: 100, height: 40 })} {...props()} />);
+    expect(screen.getByText("X 12")).toBeDefined();
+    expect(screen.getByText("Y 41")).toBeDefined();
+    expect(screen.getByText("W 100")).toBeDefined();
+    expect(screen.getByText("H 40")).toBeDefined();
+  });
+
+  it("wires the duplicate and delete buttons", () => {
+    const p = props();
+    render(<PropertiesPanel selected={rectEl()} {...p} />);
+    fireEvent.click(screen.getByLabelText("Duplicate element"));
+    expect(p.onDuplicate).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByLabelText("Delete element"));
+    expect(p.onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the coming-soon Magic chips as disabled", () => {
+    render(<PropertiesPanel selected={rectEl()} {...props()} />);
+    const chip = screen.getByRole("button", { name: "Make it bolder" }) as HTMLButtonElement;
+    expect(chip.disabled).toBe(true);
+  });
+});

--- a/desktop/src/apps/designstudio/TemplatesView.test.tsx
+++ b/desktop/src/apps/designstudio/TemplatesView.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TemplatesView } from "./TemplatesView";
+
+describe("TemplatesView", () => {
+  it("renders the template grid and filter pills", () => {
+    render(<TemplatesView onSelectTemplate={vi.fn()} />);
+    expect(screen.getByText("Instagram Post")).toBeDefined();
+    expect(screen.getByText("Presentation")).toBeDefined();
+    expect(screen.getByRole("button", { name: "All" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Logos" })).toBeDefined();
+  });
+
+  it("selecting a template reports its name and dimensions", () => {
+    const onSelect = vi.fn();
+    render(<TemplatesView onSelectTemplate={onSelect} />);
+    fireEvent.click(screen.getByText("Instagram Post"));
+    expect(onSelect).toHaveBeenCalledWith({ name: "Instagram Post", width: 1080, height: 1080 });
+  });
+
+  it("reports the correct dimensions for a non-square template", () => {
+    const onSelect = vi.fn();
+    render(<TemplatesView onSelectTemplate={onSelect} />);
+    fireEvent.click(screen.getByText("Presentation"));
+    expect(onSelect).toHaveBeenCalledWith({ name: "Presentation", width: 1920, height: 1080 });
+  });
+
+  it("does not fire selection when only switching filter pills", () => {
+    const onSelect = vi.fn();
+    render(<TemplatesView onSelectTemplate={onSelect} />);
+    fireEvent.click(screen.getByRole("button", { name: "Posters" }));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/designstudio/designs-api.test.ts
+++ b/desktop/src/apps/designstudio/designs-api.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  createDesign,
+  deleteDesign,
+  getDesign,
+  listDesigns,
+  renameDesign,
+  updateDesign,
+} from "./designs-api";
+
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 400): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe("designs-api", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("listDesigns GETs /api/designs and returns the array", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(jsonResponse([{ id: "d1", name: "A", updated_at: 2 }])),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const designs = await listDesigns();
+    expect(fetchMock).toHaveBeenCalledWith("/api/designs", { credentials: "include" });
+    expect(designs).toEqual([{ id: "d1", name: "A", updated_at: 2 }]);
+  });
+
+  it("listDesigns throws a friendly error on a failed request", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(jsonResponse({}, false, 500))));
+    await expect(listDesigns()).rejects.toThrow(/could not load designs/i);
+  });
+
+  it("getDesign fetches a single record by (encoded) id", async () => {
+    const doc = { id: "d 1", name: "A", content: "{}" };
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(doc)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const got = await getDesign("d 1");
+    expect(fetchMock).toHaveBeenCalledWith("/api/designs/d%201", { credentials: "include" });
+    expect(got).toEqual(doc);
+  });
+
+  it("getDesign throws when the record can't be opened", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(jsonResponse({}, false, 404))));
+    await expect(getDesign("nope")).rejects.toThrow(/could not open design/i);
+  });
+
+  it("createDesign POSTs name + content and returns the saved doc", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe("/api/designs");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ name: "Poster", content: "{}" });
+      return Promise.resolve(jsonResponse({ id: "d1", name: "Poster", content: "{}" }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const saved = await createDesign("Poster", "{}");
+    expect(saved.id).toBe("d1");
+  });
+
+  it("createDesign surfaces the server's error message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(jsonResponse({ error: "name is required" }, false, 400))),
+    );
+    await expect(createDesign("", "{}")).rejects.toThrow("name is required");
+  });
+
+  it("createDesign falls back to a generic message when the body has no error", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(jsonResponse({}, false, 413))));
+    await expect(createDesign("x", "{}")).rejects.toThrow(/save failed/i);
+  });
+
+  it("updateDesign PUTs only the provided fields", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe("/api/designs/d1");
+      expect(init?.method).toBe("PUT");
+      const body = JSON.parse(String(init?.body));
+      // name was undefined, so it must be omitted from the payload.
+      expect(body).toEqual({ content: "{}" });
+      return Promise.resolve(jsonResponse({ id: "d1", name: "A", content: "{}" }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await updateDesign("d1", undefined, "{}");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renameDesign PUTs just the name", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ name: "New" });
+      return Promise.resolve(jsonResponse({ id: "d1", name: "New", content: "{}" }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const renamed = await renameDesign("d1", "New");
+    expect(renamed.name).toBe("New");
+  });
+
+  it("deleteDesign DELETEs the record", async () => {
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      expect(input).toBe("/api/designs/d1");
+      expect(init?.method).toBe("DELETE");
+      return Promise.resolve(jsonResponse({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await deleteDesign("d1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("deleteDesign throws on failure", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(jsonResponse({}, false, 500))));
+    await expect(deleteDesign("d1")).rejects.toThrow(/delete failed/i);
+  });
+});

--- a/desktop/src/apps/designstudio/elementFactory.test.ts
+++ b/desktop/src/apps/designstudio/elementFactory.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  createImageElement,
+  createLineElement,
+  createShapeElement,
+  createTextElement,
+  duplicateElement,
+  nextZIndex,
+} from "./elementFactory";
+import type { CanvasElement } from "./types";
+
+const AW = 1080;
+const AH = 1350;
+
+describe("nextZIndex", () => {
+  it("returns 0 for an empty canvas", () => {
+    expect(nextZIndex([])).toBe(0);
+  });
+
+  it("returns one above the current max zIndex", () => {
+    const els = [
+      { zIndex: 0 } as CanvasElement,
+      { zIndex: 4 } as CanvasElement,
+      { zIndex: 2 } as CanvasElement,
+    ];
+    expect(nextZIndex(els)).toBe(5);
+  });
+});
+
+describe("createTextElement", () => {
+  it("creates a centered text element with sane defaults", () => {
+    const el = createTextElement([], AW, AH);
+    expect(el.type).toBe("text");
+    expect(el.visible).toBe(true);
+    expect(el.rotation).toBe(0);
+    expect(el.zIndex).toBe(0);
+    if (el.type === "text") {
+      expect(el.fontSize).toBeGreaterThan(0);
+      expect(el.text.length).toBeGreaterThan(0);
+    }
+    // Centered horizontally: left margin + width + right margin == artboard.
+    expect(el.x).toBe(Math.round((AW - el.width) / 2));
+    expect(el.y).toBe(Math.round((AH - el.height) / 2));
+  });
+
+  it("caps text width at 320 for a wide artboard", () => {
+    const el = createTextElement([], 4000, 4000);
+    expect(el.width).toBe(320);
+  });
+
+  it("stacks zIndex above existing elements", () => {
+    const first = createTextElement([], AW, AH);
+    const second = createTextElement([first], AW, AH);
+    expect(second.zIndex).toBe(1);
+  });
+});
+
+describe("createShapeElement", () => {
+  it("creates a square rect centered on the artboard", () => {
+    const el = createShapeElement([], "rect", AW, AH);
+    expect(el.type).toBe("rect");
+    expect(el.width).toBe(el.height);
+    expect(el.x).toBe(Math.round((AW - el.width) / 2));
+  });
+
+  it("honors the requested kind (ellipse)", () => {
+    const el = createShapeElement([], "ellipse", AW, AH);
+    expect(el.type).toBe("ellipse");
+  });
+
+  it("caps size at 220 for a wide artboard", () => {
+    const el = createShapeElement([], "rect", 4000, 4000);
+    expect(el.width).toBe(220);
+  });
+});
+
+describe("createLineElement", () => {
+  it("creates a thin horizontal line", () => {
+    const el = createLineElement([], AW, AH);
+    expect(el.type).toBe("line");
+    expect(el.height).toBe(2);
+    expect(el.width).toBeGreaterThan(el.height);
+  });
+});
+
+describe("createImageElement", () => {
+  it("creates a square image carrying its src and prompt", () => {
+    const el = createImageElement([], "data:image/png;base64,AA", AW, AH, "a cat");
+    expect(el.type).toBe("image");
+    expect(el.src).toBe("data:image/png;base64,AA");
+    expect(el.prompt).toBe("a cat");
+    expect(el.width).toBe(el.height);
+  });
+
+  it("leaves the prompt undefined when not supplied", () => {
+    const el = createImageElement([], "data:x", AW, AH);
+    expect(el.prompt).toBeUndefined();
+  });
+});
+
+describe("id uniqueness", () => {
+  it("every factory produces a distinct id even in the same tick", () => {
+    const els = [
+      createTextElement([], AW, AH),
+      createShapeElement([], "rect", AW, AH),
+      createLineElement([], AW, AH),
+      createImageElement([], "data:x", AW, AH),
+    ];
+    const ids = els.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("ids are prefixed by their type family", () => {
+    expect(createTextElement([], AW, AH).id).toMatch(/^text-/);
+    expect(createShapeElement([], "ellipse", AW, AH).id).toMatch(/^ellipse-/);
+    expect(createLineElement([], AW, AH).id).toMatch(/^line-/);
+    expect(createImageElement([], "data:x", AW, AH).id).toMatch(/^image-/);
+  });
+});
+
+describe("duplicateElement", () => {
+  it("offsets the copy by 16px, gives it a fresh id and the top zIndex", () => {
+    const original = createShapeElement([], "rect", AW, AH);
+    const existing = [original];
+    const copy = duplicateElement(original, existing);
+    expect(copy.id).not.toBe(original.id);
+    expect(copy.x).toBe(original.x + 16);
+    expect(copy.y).toBe(original.y + 16);
+    expect(copy.zIndex).toBe(nextZIndex(existing));
+    // Everything else (fill, size, type) is preserved.
+    expect(copy.type).toBe(original.type);
+    expect(copy.width).toBe(original.width);
+  });
+
+  it("does not mutate the source element", () => {
+    const original = createShapeElement([], "rect", AW, AH);
+    const snapshot = { ...original };
+    duplicateElement(original, [original]);
+    expect(original).toEqual(snapshot);
+  });
+});

--- a/desktop/src/apps/designstudio/types.test.ts
+++ b/desktop/src/apps/designstudio/types.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_ARTBOARD,
+  MAGIC_STYLE_CHIPS,
+  ZOOM_STEPS,
+  hasFill,
+  hasStroke,
+  isValidDesignContent,
+  type CanvasElement,
+  type DesignContent,
+} from "./types";
+
+function textEl(over: Partial<CanvasElement> = {}): CanvasElement {
+  return {
+    id: "t1",
+    type: "text",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 40,
+    rotation: 0,
+    zIndex: 0,
+    visible: true,
+    text: "Hi",
+    fontSize: 32,
+    fontFamily: "Inter",
+    fill: "#fff",
+    align: "left",
+    ...over,
+  } as CanvasElement;
+}
+
+function rectEl(): CanvasElement {
+  return {
+    id: "r1",
+    type: "rect",
+    x: 0,
+    y: 0,
+    width: 50,
+    height: 50,
+    rotation: 0,
+    zIndex: 1,
+    visible: true,
+    fill: "#000",
+    stroke: "#fff",
+    strokeWidth: 1,
+  } as CanvasElement;
+}
+
+function lineEl(): CanvasElement {
+  return {
+    id: "l1",
+    type: "line",
+    x: 0,
+    y: 0,
+    width: 80,
+    height: 2,
+    rotation: 0,
+    zIndex: 2,
+    visible: true,
+    stroke: "#fff",
+    strokeWidth: 3,
+  } as CanvasElement;
+}
+
+function imageEl(): CanvasElement {
+  return {
+    id: "i1",
+    type: "image",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    rotation: 0,
+    zIndex: 3,
+    visible: true,
+    src: "data:image/png;base64,AAAA",
+  } as CanvasElement;
+}
+
+describe("hasFill", () => {
+  it("is true for text, rect and ellipse", () => {
+    expect(hasFill(textEl())).toBe(true);
+    expect(hasFill(rectEl())).toBe(true);
+    expect(hasFill({ ...rectEl(), type: "ellipse" } as CanvasElement)).toBe(true);
+  });
+
+  it("is false for line and image", () => {
+    expect(hasFill(lineEl())).toBe(false);
+    expect(hasFill(imageEl())).toBe(false);
+  });
+});
+
+describe("hasStroke", () => {
+  it("is true for rect, ellipse and line", () => {
+    expect(hasStroke(rectEl())).toBe(true);
+    expect(hasStroke({ ...rectEl(), type: "ellipse" } as CanvasElement)).toBe(true);
+    expect(hasStroke(lineEl())).toBe(true);
+  });
+
+  it("is false for text and image", () => {
+    expect(hasStroke(textEl())).toBe(false);
+    expect(hasStroke(imageEl())).toBe(false);
+  });
+});
+
+describe("isValidDesignContent", () => {
+  const valid: DesignContent = {
+    artboard: { name: "Poster", width: 1080, height: 1350 },
+    elements: [textEl(), rectEl()],
+  };
+
+  it("accepts a well-formed design with elements", () => {
+    expect(isValidDesignContent(valid)).toBe(true);
+  });
+
+  it("accepts an empty elements array", () => {
+    expect(isValidDesignContent({ ...valid, elements: [] })).toBe(true);
+  });
+
+  it.each([
+    ["null", null],
+    ["a string", "nope"],
+    ["a number", 5],
+    ["undefined", undefined],
+  ])("rejects %s", (_label, value) => {
+    expect(isValidDesignContent(value)).toBe(false);
+  });
+
+  it("rejects a missing artboard", () => {
+    expect(isValidDesignContent({ elements: [] })).toBe(false);
+  });
+
+  it("rejects an artboard with non-numeric dimensions", () => {
+    expect(
+      isValidDesignContent({ artboard: { name: "x", width: "1080", height: 1350 }, elements: [] }),
+    ).toBe(false);
+  });
+
+  it("rejects an artboard without a name", () => {
+    expect(
+      isValidDesignContent({ artboard: { width: 1080, height: 1350 }, elements: [] }),
+    ).toBe(false);
+  });
+
+  it("rejects when elements is not an array", () => {
+    expect(isValidDesignContent({ artboard: valid.artboard, elements: {} })).toBe(false);
+  });
+
+  it("rejects an element missing an id or type", () => {
+    expect(
+      isValidDesignContent({ artboard: valid.artboard, elements: [{ type: "text" }] }),
+    ).toBe(false);
+    expect(
+      isValidDesignContent({ artboard: valid.artboard, elements: [{ id: "x" }] }),
+    ).toBe(false);
+  });
+
+  it("rejects a non-object element (e.g. null in the array)", () => {
+    expect(isValidDesignContent({ artboard: valid.artboard, elements: [null] })).toBe(false);
+  });
+});
+
+describe("constants", () => {
+  it("DEFAULT_ARTBOARD is a valid design's artboard", () => {
+    expect(isValidDesignContent({ artboard: DEFAULT_ARTBOARD, elements: [] })).toBe(true);
+    expect(DEFAULT_ARTBOARD.width).toBeGreaterThan(0);
+    expect(DEFAULT_ARTBOARD.height).toBeGreaterThan(0);
+  });
+
+  it("ZOOM_STEPS are ascending and include 100%", () => {
+    const arr = [...ZOOM_STEPS];
+    expect(arr).toContain(1);
+    expect([...arr].sort((a, b) => a - b)).toEqual(arr);
+  });
+
+  it("MAGIC_STYLE_CHIPS is a non-empty unique list", () => {
+    expect(MAGIC_STYLE_CHIPS.length).toBeGreaterThan(0);
+    expect(new Set(MAGIC_STYLE_CHIPS).size).toBe(MAGIC_STYLE_CHIPS.length);
+  });
+});

--- a/desktop/src/apps/designstudio/useElementHistory.test.ts
+++ b/desktop/src/apps/designstudio/useElementHistory.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useElementHistory } from "./useElementHistory";
+import type { CanvasElement } from "./types";
+
+function el(id: string, zIndex = 0): CanvasElement {
+  return {
+    id,
+    type: "rect",
+    x: 0,
+    y: 0,
+    width: 10,
+    height: 10,
+    rotation: 0,
+    zIndex,
+    visible: true,
+    fill: "#000",
+    stroke: "#fff",
+    strokeWidth: 0,
+  } as CanvasElement;
+}
+
+/**
+ * The hook records the *previous* elements array on commit, so undo/redo only
+ * make sense against a `current` value that tracks what was last applied. This
+ * harness re-renders the hook with the latest applied array, mirroring how
+ * DesignView feeds `elements` back in from parent state.
+ */
+function setup(initial: CanvasElement[] = []) {
+  let current = initial;
+  const onChange = vi.fn((next: CanvasElement[]) => {
+    current = next;
+  });
+  const hook = renderHook(({ els }) => useElementHistory(els, onChange), {
+    initialProps: { els: current },
+  });
+  const sync = () => hook.rerender({ els: current });
+  return { hook, onChange, get current() { return current; }, sync };
+}
+
+describe("useElementHistory", () => {
+  it("starts with nothing to undo or redo", () => {
+    const { hook } = setup();
+    expect(hook.result.current.canUndo).toBe(false);
+    expect(hook.result.current.canRedo).toBe(false);
+  });
+
+  it("commit applies the new state and enables undo", () => {
+    const { hook, onChange, sync } = setup([]);
+    const next = [el("a")];
+    act(() => hook.result.current.commit(next));
+    expect(onChange).toHaveBeenLastCalledWith(next);
+    expect(hook.result.current.canUndo).toBe(true);
+    expect(hook.result.current.canRedo).toBe(false);
+    sync();
+  });
+
+  it("undo restores the prior snapshot and enables redo", () => {
+    const start = [el("a")];
+    const { hook, onChange, sync } = setup(start);
+
+    act(() => hook.result.current.commit([el("a"), el("b", 1)]));
+    sync();
+
+    act(() => hook.result.current.undo());
+    // Undo replays the array as it was *before* the commit.
+    expect(onChange).toHaveBeenLastCalledWith(start);
+    expect(hook.result.current.canRedo).toBe(true);
+    expect(hook.result.current.canUndo).toBe(false);
+    sync();
+  });
+
+  it("redo re-applies an undone change", () => {
+    const start = [el("a")];
+    const committed = [el("a"), el("b", 1)];
+    const { hook, onChange, sync } = setup(start);
+
+    act(() => hook.result.current.commit(committed));
+    sync();
+    act(() => hook.result.current.undo());
+    sync();
+    act(() => hook.result.current.redo());
+
+    expect(onChange).toHaveBeenLastCalledWith(committed);
+    expect(hook.result.current.canRedo).toBe(false);
+    expect(hook.result.current.canUndo).toBe(true);
+    sync();
+  });
+
+  it("a fresh commit clears the redo stack", () => {
+    const { hook, sync } = setup([el("a")]);
+    act(() => hook.result.current.commit([el("b")]));
+    sync();
+    act(() => hook.result.current.undo());
+    sync();
+    expect(hook.result.current.canRedo).toBe(true);
+
+    act(() => hook.result.current.commit([el("c")]));
+    sync();
+    expect(hook.result.current.canRedo).toBe(false);
+  });
+
+  it("undo/redo are no-ops when their stacks are empty", () => {
+    const { hook, onChange } = setup([el("a")]);
+    act(() => hook.result.current.undo());
+    act(() => hook.result.current.redo());
+    expect(onChange).not.toHaveBeenCalled();
+    expect(hook.result.current.canUndo).toBe(false);
+    expect(hook.result.current.canRedo).toBe(false);
+  });
+
+  it("caps the undo history and still restores the most recent snapshot", () => {
+    const { hook, onChange, sync } = setup([el("v0")]);
+    // Push well past the 100-entry cap.
+    for (let i = 1; i <= 130; i++) {
+      act(() => hook.result.current.commit([el(`v${i}`)]));
+      sync();
+    }
+    expect(hook.result.current.canUndo).toBe(true);
+
+    // Undo once returns the immediately-previous applied state, not a
+    // corrupted/evicted one.
+    act(() => hook.result.current.undo());
+    expect(onChange).toHaveBeenLastCalledWith([el("v129")]);
+
+    // Eviction branch: walk undo to exhaustion. Because the history is capped,
+    // the oldest snapshots (including the original v0) were evicted, so we can
+    // never restore v0 and the undo depth is bounded by the cap, not by the 130
+    // commits pushed.
+    let undos = 1; // the undo above
+    while (hook.result.current.canUndo) {
+      act(() => hook.result.current.undo());
+      undos++;
+      if (undos > 200) break; // safety: never loop forever if the cap regressed
+    }
+    expect(undos).toBeLessThanOrEqual(100);
+    expect(onChange).not.toHaveBeenLastCalledWith([el("v0")]);
+  });
+});

--- a/desktop/src/apps/designstudio/useHtmlImage.test.ts
+++ b/desktop/src/apps/designstudio/useHtmlImage.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useHtmlImage } from "./useHtmlImage";
+
+/** A controllable stand-in for the browser's HTMLImageElement so tests can
+ * drive the load/error lifecycle deterministically. */
+class FakeImage {
+  static last: FakeImage | undefined;
+  crossOrigin = "";
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  private _src = "";
+  constructor() {
+    FakeImage.last = this;
+  }
+  set src(v: string) {
+    this._src = v;
+  }
+  get src() {
+    return this._src;
+  }
+}
+
+describe("useHtmlImage", () => {
+  beforeEach(() => {
+    FakeImage.last = undefined;
+    vi.stubGlobal("Image", FakeImage as unknown as typeof Image);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns no image and no failure for an undefined src", () => {
+    const { result } = renderHook(() => useHtmlImage(undefined));
+    expect(result.current.image).toBeUndefined();
+    expect(result.current.failed).toBe(false);
+    expect(FakeImage.last).toBeUndefined();
+  });
+
+  it("exposes the loaded image once onload fires", () => {
+    const { result } = renderHook(() => useHtmlImage("data:image/png;base64,AAAA"));
+    expect(result.current.image).toBeUndefined();
+    act(() => FakeImage.last!.onload!());
+    expect(result.current.image).toBe(FakeImage.last);
+    expect(result.current.failed).toBe(false);
+  });
+
+  it("sets failed and keeps no image when onerror fires", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() => useHtmlImage("data:broken"));
+    act(() => FakeImage.last!.onerror!());
+    expect(result.current.failed).toBe(true);
+    expect(result.current.image).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("requests images anonymously (crossOrigin) so exported canvases stay untainted", () => {
+    renderHook(() => useHtmlImage("data:x"));
+    expect(FakeImage.last!.crossOrigin).toBe("anonymous");
+    expect(FakeImage.last!.src).toBe("data:x");
+  });
+
+  it("ignores a late onload after the src was cleared (unmount cancellation)", () => {
+    const { result, rerender } = renderHook(({ src }) => useHtmlImage(src), {
+      initialProps: { src: "data:first" as string | undefined },
+    });
+    const first = FakeImage.last!;
+    // Switch to no src: the effect cleanup marks the first load cancelled.
+    rerender({ src: undefined });
+    act(() => first.onload!());
+    expect(result.current.image).toBeUndefined();
+  });
+});

--- a/desktop/src/apps/gamestudio/AssetsPanel.test.tsx
+++ b/desktop/src/apps/gamestudio/AssetsPanel.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { AssetsPanel } from "./AssetsPanel";
+
+const TEXTURE_URL = "/api/games/g1/assets/texture";
+
+function fetchOnce(body: unknown, ok = true, status = 200) {
+  return vi.fn((input: RequestInfo | URL) => {
+    expect(String(input)).toBe(TEXTURE_URL);
+    return Promise.resolve({
+      ok,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response);
+  });
+}
+
+describe("AssetsPanel", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the prompt input and a disabled Generate button when empty", () => {
+    render(<AssetsPanel gameId="g1" activePath="index.html" onInsert={vi.fn()} />);
+    expect(screen.getByLabelText("Describe the texture or sprite")).toBeDefined();
+    expect((screen.getByRole("button", { name: "Generate" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("generates a texture and shows a preview + insert action", async () => {
+    const onInsert = vi.fn();
+    const fetchMock = fetchOnce({
+      available: true,
+      status: "generated",
+      filename: "texture-1-abcd.png",
+      path: "/api/games/g1/preview/texture-1-abcd.png",
+      kind: "texture",
+      tier: "sdxl",
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AssetsPanel gameId="g1" activePath="index.html" onInsert={onInsert} />);
+    fireEvent.change(screen.getByLabelText("Describe the texture or sprite"), {
+      target: { value: "a mossy stone wall" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    const img = (await screen.findByAltText("Generated texture")) as HTMLImageElement;
+    expect(img.src).toContain("/api/games/g1/preview/texture-1-abcd.png");
+
+    // Insert calls the callback with the generated filename.
+    fireEvent.click(screen.getByRole("button", { name: /Insert into index\.html/ }));
+    expect(onInsert).toHaveBeenCalledWith("texture-1-abcd.png");
+    // Sending the request used the right body.
+    const sentBody = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body));
+    expect(sentBody.prompt).toBe("a mossy stone wall");
+    expect(sentBody.kind).toBe("texture");
+  });
+
+  it("shows a 'Needs a GPU worker' state when the tier is unavailable", async () => {
+    const fetchMock = fetchOnce({ available: false, reason: "No GPU or NPU worker available." });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AssetsPanel gameId="g1" activePath="index.html" onInsert={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Describe the texture or sprite"), {
+      target: { value: "a texture" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    await waitFor(() => expect(screen.getByText("Needs a GPU worker")).toBeDefined());
+    expect(screen.getByText("No GPU or NPU worker available.")).toBeDefined();
+    // No preview / insert button in the unavailable state.
+    expect(screen.queryByRole("button", { name: /Insert/ })).toBeNull();
+  });
+
+  it("surfaces a backend error", async () => {
+    const fetchMock = fetchOnce({ error: "Texture generation failed." }, false, 502);
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AssetsPanel gameId="g1" activePath="index.html" onInsert={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Describe the texture or sprite"), {
+      target: { value: "a texture" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Texture generation failed.");
+  });
+
+  it("disables insert when no file is open", async () => {
+    const fetchMock = fetchOnce({
+      available: true,
+      status: "generated",
+      filename: "texture-1.png",
+      path: "/api/games/g1/preview/texture-1.png",
+      kind: "texture",
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    render(<AssetsPanel gameId="g1" activePath={null} onInsert={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Describe the texture or sprite"), {
+      target: { value: "a texture" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Generate" }));
+
+    const insert = (await screen.findByRole("button", { name: /Open a file to insert/ })) as HTMLButtonElement;
+    expect(insert.disabled).toBe(true);
+  });
+});

--- a/desktop/src/apps/gamestudio/AssetsPanel.tsx
+++ b/desktop/src/apps/gamestudio/AssetsPanel.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { ImagePlus, Loader2, AlertCircle, Sparkles, Check, Cpu } from "lucide-react";
+import { generateTexture, type AssetKind, type TextureResult } from "./game-assets-api";
+
+/* ------------------------------------------------------------------ */
+/*  AssetsPanel -- AI texture/sprite generation for the Game Studio     */
+/*                                                                     */
+/*  Prompt + size/tileable controls drive POST /assets/texture. The     */
+/*  backend writes the PNG into the game's file set and returns its      */
+/*  preview path; "Insert" appends a reference to the current file. When  */
+/*  the backend reports available:false (no GPU/NPU worker) the panel     */
+/*  shows a clear disabled state rather than a broken Generate button --  */
+/*  mirroring the Images Studio tier-gate precedent.                     */
+/* ------------------------------------------------------------------ */
+
+export interface AssetsPanelProps {
+  gameId: string;
+  /** The file the generated reference will be appended to (null = no file). */
+  activePath: string | null;
+  /** Append a reference to the generated asset into the current file. */
+  onInsert: (filename: string) => void;
+}
+
+const SIZES = [256, 512, 768, 1024] as const;
+
+export function AssetsPanel({ gameId, activePath, onInsert }: AssetsPanelProps) {
+  const [prompt, setPrompt] = useState("");
+  const [kind, setKind] = useState<AssetKind>("texture");
+  const [size, setSize] = useState<number>(512);
+  const [tileable, setTileable] = useState(false);
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<TextureResult | null>(null);
+  const [inserted, setInserted] = useState(false);
+
+  const unavailable = result?.available === false;
+
+  const handleGenerate = async () => {
+    const text = prompt.trim();
+    if (!text || busy) return;
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    setInserted(false);
+    try {
+      const res = await generateTexture(gameId, {
+        prompt: text,
+        width: size,
+        height: size,
+        tileable,
+        kind,
+      });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleInsert = () => {
+    if (!result?.filename || !activePath) return;
+    onInsert(result.filename);
+    setInserted(true);
+  };
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-2 border-b border-shell-border px-3.5 py-3">
+        <ImagePlus size={15} className="text-accent" />
+        <h3 className="text-[13px] font-bold">Generate an asset</h3>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto px-3 py-3">
+        {/* prompt */}
+        <label htmlFor="gs-asset-prompt" className="mb-1 block text-[11px] font-semibold text-shell-text-secondary">
+          Describe the texture or sprite
+        </label>
+        <textarea
+          id="gs-asset-prompt"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={3}
+          placeholder="a mossy stone wall, top-down"
+          className="mb-3 w-full resize-none rounded-lg border border-shell-border bg-shell-surface px-2.5 py-2 text-[12px] text-shell-text placeholder:text-shell-text-tertiary focus-visible:border-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20"
+        />
+
+        {/* controls */}
+        <div className="mb-3 grid grid-cols-2 gap-2">
+          <div>
+            <label htmlFor="gs-asset-kind" className="mb-1 block text-[11px] font-semibold text-shell-text-secondary">
+              Kind
+            </label>
+            <select
+              id="gs-asset-kind"
+              value={kind}
+              onChange={(e) => setKind(e.target.value as AssetKind)}
+              className="w-full rounded-lg border border-shell-border bg-shell-surface px-2 py-1.5 text-[12px] text-shell-text"
+            >
+              <option value="texture">Texture</option>
+              <option value="sprite">Sprite</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="gs-asset-size" className="mb-1 block text-[11px] font-semibold text-shell-text-secondary">
+              Size
+            </label>
+            <select
+              id="gs-asset-size"
+              value={size}
+              onChange={(e) => setSize(Number(e.target.value))}
+              className="w-full rounded-lg border border-shell-border bg-shell-surface px-2 py-1.5 text-[12px] text-shell-text"
+            >
+              {SIZES.map((s) => (
+                <option key={s} value={s}>
+                  {s}×{s}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <label className="mb-3 flex items-center gap-2 text-[12px] text-shell-text-secondary">
+          <input
+            type="checkbox"
+            checked={tileable}
+            onChange={(e) => setTileable(e.target.checked)}
+            className="h-3.5 w-3.5 accent-accent"
+          />
+          Tileable / seamless
+        </label>
+
+        <button
+          type="button"
+          onClick={() => void handleGenerate()}
+          disabled={busy || !prompt.trim()}
+          className="flex h-9 w-full items-center justify-center gap-1.5 rounded-lg bg-accent px-3 text-[12px] font-bold text-white disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {busy ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={14} />}
+          {busy ? "Generating..." : "Generate"}
+        </button>
+
+        {/* tier-gated: no GPU/NPU worker */}
+        {unavailable && (
+          <div
+            role="status"
+            className="mt-3 flex items-start gap-2 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2.5 text-[12px] text-amber-200"
+          >
+            <Cpu size={15} className="mt-0.5 flex-none" />
+            <div>
+              <div className="font-bold">Needs a GPU worker</div>
+              <div className="text-amber-200/80">
+                {result?.reason ?? "Connect a GPU or NPU worker to generate assets."}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* error */}
+        {error && (
+          <div role="alert" className="mt-3 flex items-center gap-2 rounded-xl border border-red-500/30 bg-red-500/10 px-3 py-2 text-[12px] text-red-300">
+            <AlertCircle size={14} className="flex-none" />
+            {error}
+          </div>
+        )}
+
+        {/* preview + insert */}
+        {result?.available && result.path && (
+          <div className="mt-3 rounded-xl border border-shell-border bg-shell-surface p-2.5">
+            <img
+              src={result.path}
+              alt={`Generated ${result.kind ?? "asset"}`}
+              className="mb-2 w-full rounded-lg border border-shell-border"
+            />
+            <div className="mb-2 truncate text-[11px] text-shell-text-tertiary">
+              {result.filename}
+              {result.tier ? ` · ${result.tier}` : ""}
+            </div>
+            <button
+              type="button"
+              onClick={handleInsert}
+              disabled={!activePath || inserted}
+              className="flex h-8 w-full items-center justify-center gap-1.5 rounded-lg border border-accent/40 bg-accent-soft px-3 text-[12px] font-bold text-shell-text disabled:opacity-60"
+            >
+              <Check size={13} />
+              {inserted ? "Inserted" : activePath ? `Insert into ${activePath}` : "Open a file to insert"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/gamestudio/EditorView.tsx
+++ b/desktop/src/apps/gamestudio/EditorView.tsx
@@ -9,9 +9,12 @@ import {
   AlertCircle,
   Check,
   Sparkles,
+  ImagePlus,
 } from "lucide-react";
 import { streamTaosAgentChat } from "../appstudio/stream-chat";
 import { FileEditor } from "./FileEditor";
+import { AssetsPanel } from "./AssetsPanel";
+import { buildAssetReference } from "./asset-reference";
 import { parseFileBlocks, type ParsedFile } from "./file-blocks";
 import { buildEditSystemPrompt, isVendorFile } from "./game-authoring-prompt";
 import { getGame, gamePreviewUrl, saveGame } from "./games-api";
@@ -60,6 +63,7 @@ export function EditorView({ gameId }: EditorViewProps) {
   const [chatError, setChatError] = useState<string | null>(null);
   const [pendingEdit, setPendingEdit] = useState<PendingEdit | null>(null);
   const [applying, setApplying] = useState(false);
+  const [rightTab, setRightTab] = useState<"chat" | "assets">("chat");
 
   const filesRef = useRef(files);
   filesRef.current = files;
@@ -263,6 +267,22 @@ export function EditorView({ gameId }: EditorViewProps) {
     setApplying(false);
   }, [pendingEdit, flushSave]);
 
+  /* ── insert a generated asset reference into the active file ──────── */
+
+  const handleInsertAsset = useCallback(
+    (filename: string) => {
+      const path = activePath;
+      if (!path) return;
+      const ref = buildAssetReference(path, filename);
+      setFiles((prev) => {
+        const next = { ...prev, [path]: (prev[path] ?? "") + ref };
+        void flushSave(next);
+        return next;
+      });
+    },
+    [activePath, flushSave],
+  );
+
   /* ── render ─────────────────────────────────────────────────────── */
 
   if (loading) {
@@ -394,13 +414,39 @@ export function EditorView({ gameId }: EditorViewProps) {
           </div>
         </div>
 
-        {/* AI chat sidebar */}
+        {/* AI chat + assets sidebar */}
         <div className="flex min-h-0 flex-col border-l border-shell-border">
-          <div className="flex items-center gap-2 border-b border-shell-border px-3.5 py-3">
-            <Sparkles size={15} className="text-accent" />
-            <h3 className="text-[13px] font-bold">Ask the agent</h3>
+          <div role="tablist" aria-label="Editor sidebar" className="flex flex-none items-center gap-1 border-b border-shell-border px-2.5 py-2">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={rightTab === "chat"}
+              onClick={() => setRightTab("chat")}
+              className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[12px] font-bold ${
+                rightTab === "chat" ? "bg-shell-surface-active text-shell-text" : "text-shell-text-secondary hover:bg-shell-surface"
+              }`}
+            >
+              <Sparkles size={14} className="text-accent" />
+              Ask the agent
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={rightTab === "assets"}
+              onClick={() => setRightTab("assets")}
+              className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[12px] font-bold ${
+                rightTab === "assets" ? "bg-shell-surface-active text-shell-text" : "text-shell-text-secondary hover:bg-shell-surface"
+              }`}
+            >
+              <ImagePlus size={14} className="text-accent" />
+              Assets
+            </button>
           </div>
 
+          {rightTab === "assets" ? (
+            <AssetsPanel gameId={gameId} activePath={activePath} onInsert={handleInsertAsset} />
+          ) : (
+          <>
           <div className="min-h-0 flex-1 overflow-auto px-3 py-2">
             {chat.length === 0 && (
               <p className="px-1 py-2 text-[12px] text-shell-text-tertiary">
@@ -493,6 +539,8 @@ export function EditorView({ gameId }: EditorViewProps) {
               {chatBusy ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
             </button>
           </div>
+          </>
+          )}
         </div>
       </div>
     </div>

--- a/desktop/src/apps/gamestudio/asset-reference.test.ts
+++ b/desktop/src/apps/gamestudio/asset-reference.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { buildAssetReference } from "./asset-reference";
+
+describe("buildAssetReference", () => {
+  it("emits an <img> tag for html files", () => {
+    expect(buildAssetReference("index.html", "texture-1.png")).toContain(
+      '<img src="./texture-1.png"',
+    );
+  });
+
+  it("emits a JS const for js files with a filename-derived name", () => {
+    const ref = buildAssetReference("game.js", "sprite-2.png");
+    expect(ref).toContain('const sprite_2Url = "./sprite-2.png";');
+  });
+
+  it("derives distinct const names so repeated inserts don't collide", () => {
+    const a = buildAssetReference("game.js", "texture-a.png");
+    const b = buildAssetReference("game.js", "texture-b.png");
+    expect(a).toContain("const texture_aUrl =");
+    expect(b).toContain("const texture_bUrl =");
+    expect(a).not.toEqual(b);
+  });
+
+  it("emits a CSS background rule for css files", () => {
+    expect(buildAssetReference("style.css", "tex.png")).toContain(
+      'background-image: url("./tex.png")',
+    );
+  });
+
+  it("falls back to a comment for unknown extensions", () => {
+    expect(buildAssetReference("data.txt", "tex.png")).toBe("\n/* asset: ./tex.png */");
+  });
+});

--- a/desktop/src/apps/gamestudio/asset-reference.ts
+++ b/desktop/src/apps/gamestudio/asset-reference.ts
@@ -1,0 +1,25 @@
+/** Derive a unique, valid JS identifier from an asset filename so repeated
+ *  inserts into the same JS file don't emit a colliding ``const`` declaration. */
+function assetVarName(filename: string): string {
+  const base = filename.replace(/\.[^.]+$/, "").replace(/[^a-zA-Z0-9]+/g, "_");
+  const safe = /^[a-zA-Z_]/.test(base) ? base : `_${base}`;
+  return `${safe}Url`;
+}
+
+/** Build a code reference to a generated asset, tailored to the file it will be
+ *  appended to. The asset already lives in the game's file set, so a relative
+ *  ``./{filename}`` resolves under the game's preview base. */
+export function buildAssetReference(activePath: string, filename: string): string {
+  const ext = activePath.slice(activePath.lastIndexOf(".") + 1).toLowerCase();
+  const rel = `./${filename}`;
+  if (ext === "html" || ext === "htm") {
+    return `\n<img src="${rel}" alt="" />`;
+  }
+  if (ext === "css") {
+    return `\n/* generated asset */\n.generated-asset { background-image: url("${rel}"); }`;
+  }
+  if (ext === "js" || ext === "mjs" || ext === "ts") {
+    return `\n// generated asset\nconst ${assetVarName(filename)} = "${rel}";`;
+  }
+  return `\n/* asset: ${rel} */`;
+}

--- a/desktop/src/apps/gamestudio/game-assets-api.ts
+++ b/desktop/src/apps/gamestudio/game-assets-api.ts
@@ -1,0 +1,49 @@
+/** Thin client for tinyagentos/routes/game_assets.py -- Game Studio AI assets. */
+
+export type AssetKind = "texture" | "sprite";
+
+export interface GenerateTextureBody {
+  prompt: string;
+  width?: number;
+  height?: number;
+  tileable?: boolean;
+  kind?: AssetKind;
+}
+
+/** Shape of POST /api/games/{id}/assets/texture.
+ *  ``available:false`` is a tier-gate signal (no GPU/NPU worker), NOT an error,
+ *  so the UI shows a "needs a GPU worker" state rather than a failure toast. */
+export interface TextureResult {
+  available: boolean;
+  reason?: string;
+  status?: string;
+  filename?: string;
+  path?: string;
+  kind?: AssetKind;
+  tier?: string;
+  tileable?: boolean;
+  seed?: number;
+}
+
+async function readError(res: Response): Promise<string> {
+  try {
+    const body = await res.json();
+    if (body?.error) return String(body.error);
+  } catch {
+    // non-JSON error body; fall through to the status-based message
+  }
+  return `Request failed (${res.status})`;
+}
+
+export async function generateTexture(
+  gameId: string,
+  body: GenerateTextureBody,
+): Promise<TextureResult> {
+  const res = await fetch(`/api/games/${encodeURIComponent(gameId)}/assets/texture`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(await readError(res));
+  return (await res.json()) as TextureResult;
+}

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -81,6 +81,20 @@ POST <bus>/a2a/send
 - After posting to a specific thread, verify it landed there (read the thread
   back and confirm your message id is present) before assuming it was delivered.
 
+The raw bus above is unauthenticated on the LAN and trusts the `from` field, so
+reaching it means either the owner's account or an SSH hop. A registered agent
+should instead post through the controller's authenticated proxy, which forces
+`from` to the agent's own registry handle (no spoofing) — so it posts as itself,
+not the owner:
+
+```
+POST <controller>/api/a2a/bus/send   (Authorization: Bearer <registry JWT, scope a2a_send>)
+{"thread": "build", "body": "...", "reply_to": <id>?}
+```
+
+An admin session may also call it and set an explicit `from`. On a bus failure
+the proxy returns 502 (the read proxies degrade to an empty 200 instead).
+
 These rules are deliberately lightweight. The goal is not process for its own
 sake; it is to let many hands move quickly on the same codebase without undoing
 each other's work.

--- a/docs/design/cluster-backend-service-management.md
+++ b/docs/design/cluster-backend-service-management.md
@@ -1,0 +1,112 @@
+# Cluster-aware Backend Service Management — Design
+
+**Status:** Approved design (2026-07-09). Phase 1 to build now; Phase 2 spec'd, deferred.
+
+## Goal
+
+Installing a model-inference backend (rkllama, qmd, llama.cpp, vllm, ollama, ...) must reliably make it a **managed systemd service** on the node it lands on, and because backends migrate across cluster nodes, that management is **reconciled per node** (adopt/enable on arrival, stop/disable on departure). Backends expose a uniform start/stop/restart/health interface so recovery (#1743) and cluster placement/migration work the same everywhere.
+
+## Motivation (audit, 2026-07-09)
+
+- **qmd** is a proper managed systemd unit (installed + `enable --now` by `install-server.sh`, which every box runs). It survives reboots and is `systemctl`-restartable.
+- **rkllama** on the production Pi was a **hand-started bare process** (PPID 1, launched from a login session, no unit) with no boot persistence, and the Activity "Restart AI Services" (#1743) could not restart it (`_restart_ai_unit` returns `"not installed"` when no unit exists).
+- Root cause: the store wrapper `scripts/install-rkllama.sh` short-circuited `exit 0` the moment any process answered the port, before delegating to `install-rknpu.sh::install_systemd_unit()` — so a hand-start permanently blocked unit creation. **Fixed in PR #1755** (a live port only counts as installed if `rkllama.service` is enabled; otherwise fall through and adopt under systemd). That fix is the first brick of this design.
+- The manifest contract is inconsistent: only 1 service manifest sets `auto_manage: true` (rkllama); rk-llama-cpp's installer creates a unit but its manifest says `auto_manage: false`; most services declare neither. taOS has no reliable declared view of which backends it manages.
+- No reconciler ties "desired backend placement" to "managed unit state per node". The controller is HTTP/poll-only (health via `/api/tags` or `/health`, routing via LiteLLM) and delegates lifecycle to systemd, but nothing guarantees the unit exists.
+
+## Existing building blocks (reuse, do not reinvent)
+
+- **Worker agent + router** (`tinyagentos/cluster/router.py`, `worker_protocol.py`): the controller routes to each node's worker-agent HTTP API (`worker.url`); cross-host callers go through the agent, never dial a backend URL directly. Worker endpoints are protected by HMAC (`cluster/worker_auth.py`).
+- **local_worker** (`cluster/local_worker.py`): the controller's own node acts as a worker in-process.
+- **Capability heartbeat** (`routes/cluster_capability.py`): nodes report capabilities/status on a cadence.
+- **Placement optimiser** (`cluster/optimiser.py`): advisory `PlacementSuggestion`s (not enforced).
+- **Service migrator** (`cluster/service_migrator.py`): migrates LXC-hosted services; does NOT yet cover host systemd backends like rkllama/qmd.
+- **#1743 recovery** (`routes/system.py::restart_ai_stack` / `_restart_ai_unit`): fails soft per unit, resolves user-vs-system scope with `systemctl cat`; today assumes a local unit.
+- **Backend adapters** (`backend_adapters.py`): `OllamaCompatAdapter.health()` (rkllama), qmd `/health`.
+
+## Decisions (locked)
+
+1. **Scope:** Phase 1 now (uniform contract + per-node ensure/self-heal + #1743 rewire + Cluster UI); Phase 2 (cross-node reconciler + adaptive migration) spec'd and deferred.
+2. **Enactment:** via the existing worker-agent API (controller sends desired state; agent runs local systemctl/install; controller node uses `local_worker` in-process). No SSH, no new per-node daemon.
+3. **Migration cutover:** adaptive by capability — health-gated drain where the accelerator has headroom for both model loads; stop-source-first then start-target on single-NPU / single-GPU nodes; chosen from the capability map.
+4. **Contract:** mandatory + CI-gated, with a one-time normalization of existing manifests and a short grandfather allowlist.
+
+## Design
+
+### A. The managed-service manifest contract
+
+Service manifests already carry a `lifecycle:` block (`backend_type`, `default_url`, `auto_manage`, `start_cmd`, `stop_cmd`, `startup_timeout_seconds`). We EXTEND that block (do not invent a new one) with `unit`, `scope`, and `health`, and require it on host-managed backends:
+
+```yaml
+lifecycle:
+  backend_type: rkllama
+  default_url: http://localhost:7833
+  auto_manage: true
+  unit: rkllama.service        # systemd unit name (must match the installer's unit)
+  scope: system                # system | user
+  health:
+    url: "http://localhost:7833/api/tags"
+    expect: '"models"'         # substring assertion on a 200 body
+  # start/stop/restart default to `systemctl <verb> <unit>`; keep start_cmd/stop_cmd only for non-systemd
+  startup_timeout_seconds: 60
+```
+
+- The installer that provisions the backend MUST create a unit whose name/port match the manifest.
+- **Current state (audit):** of the 10 `category: llm-runtime` service manifests, only rkllama sets `auto_manage: true`; llama-cpp/mlc-llm/openllm/rk-llama-cpp set `false`; exo/ezrknpu/litellm/ollama/vllm set none; NONE declare a `unit`.
+- **Rule:** any `llm-runtime` service with `auto_manage: true` MUST declare `unit` + `scope` + `health`. A grandfather allowlist covers `auto_manage: false` / not-yet-migrated ones. Normalize the host-managed backends first (rkllama, qmd, rk-llama-cpp), which already ship real systemd units (`rkllama.service`, `qmd.service`, `rkllamacpp.service`).
+- **CI:** a new `scripts/check_manifests.py managed-lint` (the existing `scripts/audit-manifests.py` is not run in CI) added as a step to `.github/workflows/doc-gate.yml`.
+
+### B. Phase 1 — node-local Backend Service Manager (in the worker agent)
+
+New module `cluster/backend_services.py` + worker-agent endpoints (HMAC-auth), mirrored in `local_worker`:
+
+- `GET /worker/backends` → for each managed backend installed on this node: `{unit, enabled, active, health: {ok, detail}}`.
+- `POST /worker/backends/{unit}/ensure` → idempotent: unit missing but backend installed → run the installer's systemd path / adopt an orphan (the installer `ExecStartPre` pkill reaps the bare process so the unit can bind the port); unit present → `enable --now`.
+- `POST /worker/backends/{unit}/{start|stop|restart}` → systemctl verb, health-gated, fail-soft per unit (reuse the `_restart_ai_unit` scope-resolution + kill/reap-on-timeout logic, promoted into `backend_services`).
+
+**Self-heal:** on worker-agent start and on each capability heartbeat, reconcile installed managed backends → enabled units. This would have auto-adopted the Pi's hand-started rkllama.
+
+**#1743 rewire:** `restart_ai_stack` calls the node's `POST /worker/backends/{unit}/restart` (via `local_worker` for the controller node), so recovery works uniformly cluster-wide instead of assuming a local unit. `AI_STACK_UNITS` is derived from the node's managed manifests, not hardcoded.
+
+### C. Cluster-app UI surface
+
+**Read path:** each worker object in the existing `/api/cluster/workers` payload carries per-backend `{unit, enabled, active, health}` (sourced from the agent's `GET /worker/backends`, cached from the heartbeat) — the Cluster app already fetches `/api/cluster/workers`, so no new poll. **Action path:** a dedicated admin-gated `POST /api/cluster/workers/{node}/backends/{unit}/{start|stop|restart}` that the controller proxies to that node's worker agent (or `local_worker`). In `desktop/src/apps/ClusterApp.tsx`, each worker detail card gains a **Backend Services** subsection (replacing today's read-only `worker.backends` chips): per backend a name, a unit-state pill (enabled/active/failed), a health dot, and **admin-only** per-row Restart / Stop / Start actions plus a per-node "Restart AI Services" (the #1743 action, node-scoped).
+
+### D. CI gate
+
+A manifest-lint (extend `scripts/check_doc_gate.py` or a new `scripts/check_manifests.py`) fails any PR that adds/alters a backend service manifest without a valid `managed` block. Ships with a one-time normalization of current manifests and a grandfather allowlist. Unit-tested with valid/invalid/grandfathered fixtures.
+
+### E. Phase 2 (spec, defer build) — cross-node reconciler
+
+- Extend the capability/worker registry with `desired_backends` per node, fed by the placement `optimiser`.
+- A controller reconcile loop diffs desired vs actual (from the `GET /worker/backends` heartbeat) and drives `ensure`/`stop` on the owning node's agent to converge.
+- Migration cutover = adaptive (decision 3), extending `service_migrator` to host (non-LXC) backends: health-gated drain where headroom exists, else stop-source-first then start-target; roll back to source if the target never reports healthy within a timeout.
+
+### F. Error handling
+
+- Every action fails soft and reports per-unit: `not-installed`, `permission-denied` (polkit / interactive auth), `timeout` (kill + reap the child), `health-never-up`. Never a 500.
+- Reconcile is idempotent and convergent; an unreachable node is skipped and retried on the next heartbeat, never blocking others.
+- Migration rolls back to the source backend if the target does not report healthy within the cutover timeout.
+
+### G. Testing
+
+- **Manifest-lint:** unit tests over valid / invalid / grandfathered manifest fixtures.
+- **Backend Service Manager:** unit tests with mocked `systemctl` (mirroring `tests/test_routes_system.py::TestRestartAiUnit`) covering ensure / start / stop / restart / health, adopt-orphan, and every fail-soft path.
+- **Cluster UI:** component tests for the Backend Services rows (state pills, health, admin-gated actions), mocking the fetch.
+- **Phase 2:** reconcile convergence tests against a fake worker agent (desired vs actual).
+- **Acceptance:** on the Pi, adopt the hand-started rkllama under systemd via `ensure` and confirm it survives a simulated restart and is restartable from the Cluster UI.
+
+## Units / boundaries (independently testable)
+
+1. `managed` manifest schema + CI lint.
+2. `cluster/backend_services.py` node backend-service manager + worker-agent endpoints (+ `local_worker`).
+3. `#1743` rewire onto the node manager.
+4. Cluster-app Backend Services UI + the `/api/cluster/workers` payload extension.
+5. (Phase 2) controller reconcile loop + adaptive host-backend migration.
+
+Phase 1 = units 1-4. Phase 2 = unit 5, its own spec/plan.
+
+## Out of scope
+
+- Non-systemd platforms (macOS/Windows launchd/services) — Phase 1 is systemd/Linux nodes; the contract's overridable start/stop leaves room for a later adapter.
+- Model-weight placement/distribution (taOSnet) — separate epic; this manages the *service*, not the weights.

--- a/docs/design/game-studio-asset-generation.md
+++ b/docs/design/game-studio-asset-generation.md
@@ -1,0 +1,89 @@
+# Game Studio offline asset-generation stack (design spec)
+
+Status: DRAFT for Jay review (#55). Game Studio already works as an LLM-authored
+three.js maker; this adds offline generation of the game's ART + AUDIO assets so a
+generated game is not limited to code-drawn primitives. Author: taOS-dev.
+
+## Why this exists
+
+Game Studio v1 is functional: an agent authors a three.js game (HTML + JS file
+set) from a prompt, the game previews sandboxed, packages as `.taosapp`, and shares
+to the store. Today the visuals are whatever the model can draw with three.js
+primitives + procedural code, and audio is absent or web-synth. #55 adds real
+asset generation - textures/sprites, sound effects + music, and (stretch) 3D
+meshes - all offline, tier-aware, reusing the backends taOS already ships. This
+mirrors the Images Studio pattern: the app calls tier-aware backends, degrading
+gracefully on low-end hardware.
+
+## Asset types, in ascending difficulty
+
+1. **Textures / sprites / skyboxes (2D images).** Highest value, lowest new cost:
+   reuse the EXISTING image-generation backend (SD on the RTX 3060 per the image
+   stack; RK image-gen on the NPU as the arms-length low tier). A game asks for
+   "a mossy stone texture, tileable" or "a pixel-art spaceship sprite sheet"; the
+   backend returns a PNG the game references. Tileable/seamless + transparent-bg
+   (sprite) are prompt/pipeline options, not new models.
+2. **Audio - SFX + music.** SFX (jump, hit, coin) and short loops. Reuse MusicGen
+   for music loops (already in the stack, license-gated CC-BY-NC per the licensing
+   work) and a small text-to-SFX path (e.g. a lightweight audio model or a curated
+   procedural/sample fallback). Output: ogg/mp3 the game loads.
+3. **3D meshes (stretch, gated).** The hard one: text/image-to-3D (TripoSR,
+   Shap-E, InstantMesh, or image-to-mesh). Heavy, GPU-bound, quality is rough, and
+   glTF export + three.js loading add complexity. Ship LAST, tier-gated to the
+   discrete-GPU tier only, behind a clear "experimental" flag. Many good three.js
+   games never need generated meshes (primitives + textures go far).
+
+## Design (tier-aware, backend-reusing)
+
+- **Backend contract.** One controller route surface, `routes/game_assets.py`,
+  with `POST /api/games/{id}/assets/texture`, `.../assets/audio`, and (later)
+  `.../assets/mesh`. Each resolves the tier-appropriate backend the same way the
+  Images Studio edit backends do (hardware tier -> concrete backend), writes the
+  asset into the game's file set (so it packages + previews with the game), and
+  returns the asset path. No new per-asset infra: textures go through the existing
+  image backend, audio through MusicGen + the SFX path.
+- **Frontend.** Game Studio's Editor gains an "Assets" panel: generate a
+  texture/sprite/audio from a prompt, preview it, and insert a reference into the
+  current file (the authoring agent already manages the file set, so an inserted
+  asset is just another file + a code reference the agent or user wires up).
+  Tier-gated UI: unavailable backends show a clear "needs a GPU worker" state
+  rather than a broken button (matches the Images Studio + reduce-effects
+  precedent).
+- **License + provenance.** Reuse the existing license-accept gate (MusicGen /
+  FLUX weights are CC-BY-NC; SD/Apache-clean is the default). A game that bundles
+  generated assets records their provenance in the package, consistent with the
+  app-security-analyzer + provenance work.
+- **Offline-first.** Everything runs on the local/worker GPU; no cloud. On a
+  GPU-less host (Pi core alone) textures fall back to the NPU RK backend or a
+  curated built-in pack; 3D is simply unavailable.
+
+## Slice plan (spec -> build -> harden, per Jay)
+
+- **Slice 1 - textures/sprites** (build first; highest value/lowest cost). Route +
+  tier-aware image-backend call + Editor Assets panel (texture/sprite) + tests.
+  Live-verify a generated texture appears in a previewed game on the 3060 tier.
+- **Slice 2 - audio (SFX + music).** MusicGen loop + SFX path + Assets-panel audio
+  tab + license gate + tests.
+- **Slice 3 - 3D meshes (experimental, gated).** Text/image-to-3D on the
+  discrete-GPU tier only, glTF export, three.js loader wiring, behind an
+  experimental flag. Only if Slices 1-2 land clean.
+- **Harden (last, per your ordering):** test coverage across the asset routes +
+  panel, and screenshot-verify a real generated game with generated assets on the
+  Pi.
+
+## Open questions for Jay
+
+1. **SFX model choice** for Slice 2: a dedicated text-to-SFX model vs a
+   curated-sample + light-synth fallback. MusicGen covers music loops already;
+   SFX is the gap. Recommend starting with the fallback + MusicGen and adding a
+   model only if quality demands it.
+2. **3D scope (Slice 3):** ship it experimental on the 3060 tier, or defer 3D
+   entirely for now and stop at textures + audio? (Textures + audio deliver most
+   of the value; 3D is heavy and rough.)
+3. Confirm the target build/verify hardware: the RTX 3060 (Fedora worker) for the
+   GPU tiers, RK NPU (Pi) for the low tier - consistent with the existing image
+   stack.
+
+## Non-goals (v1)
+
+Animation/rigging, video, voice/TTS dialogue, and any cloud generation.

--- a/docs/design/taosgo-mesh-join-foundation.md
+++ b/docs/design/taosgo-mesh-join-foundation.md
@@ -1,0 +1,170 @@
+# taOSgo mesh-join foundation (design spec)
+
+Status: DRAFT for Jay review. Unblocks Web Studio publish (#167) and, more
+broadly, off-LAN remote access (taOSgo). Author: taOS-dev.
+
+## Why this exists
+
+Web Studio v1 is a complete static-site builder (generate -> edit -> preview ->
+install/export). Its one missing feature, publish to `<label>.<handle>.taos.my`,
+is blocked, and so is off-LAN remote access to the desktop. The block is not a
+small wiring gap: the taOS **controller has no mesh-join code at all**. There is
+no `tailscale up`, no preauth-key consumption, no Headscale connection, and no
+persistence of the per-host service credentials taos.my hands back at join time.
+
+taos.my's side is DONE and deployed: the cluster-join ready payload emits a
+`headscale_preauth_key`, a `controller_token` (scope `taosnet:passkey`), and a
+`sites_token` (scope `sites:publish`) -- each single-scope and host-bound -- and
+the routing endpoints (`/api/relay/authorize-site`, `/api/sites/*`) are live and
+fail-closed. What is missing is entirely on the taOS controller side.
+
+## Current state (verified in code)
+
+- `routes/account_proxy.py` is a thin cookie-passthrough proxy: it forwards the
+  browser's join request / approve / deny / poll to taos.my `/api/cluster/join/*`.
+  The **ready payload lands in the browser**, not on the controller.
+- `taosnet/passkey_client.py::get_controller_token()` is a READER seam: it reads
+  `TAOS_CONTROLLER_TOKEN` from the env and its own docstring says it is "the seam
+  the cluster-join client writes to once that client lands." That writer does not
+  exist.
+- No code anywhere consumes the `headscale_preauth_key` or brings up a tailnet
+  interface. The Pi's current LAN clustering uses a different, non-Headscale path.
+
+So three things are missing, in dependency order: (1) a server-side way to obtain
++ persist the ready-payload credentials; (2) an actual headless mesh-join; (3)
+the publish caller + a server for the published static site.
+
+## Design
+
+### Unit 1 - credential store + persistence (the `get_controller_token` writer)
+
+A small host-local credential store, `taosnet/mesh_credentials.py`, persisting the
+ready-payload service credentials to a single file under the data dir
+(`<data_dir>/mesh/credentials.json`, mode 0600, dir 0700). Fields:
+`{account_id, host_id, tailnet_name, controller_token, sites_token, joined_at}`.
+The preauth key is consumed immediately by Unit 2 and NOT persisted (it is
+single-use). Public API:
+
+- `save_mesh_credentials(payload: dict) -> None` (atomic write; validates the
+  expected keys; refuses to widen scope silently)
+- `get_controller_token() -> str | None` and `get_sites_token() -> str | None`
+  (replace the env-var placeholder in `passkey_client.py`; keep the env var as a
+  dev override that wins if set, so existing tests + local dev keep working)
+- `get_host_id() -> str | None`, `clear()` (on leave/unjoin)
+
+**How the controller obtains the payload - two options:**
+
+- **(A) Poll-intercept (recommended).** `cluster_join_poll` in `account_proxy.py`
+  already forwards the poll and receives the ready payload on its way to the
+  browser. When the forwarded response is a `ready` with the credentials, extract
+  and `save_mesh_credentials(...)` server-side *before* returning to the browser,
+  and strip the raw `controller_token`/`sites_token` from the browser-facing body
+  (the browser only needs join status + whatever the UI shows; the service tokens
+  must not sit in browser JS). Minimal new surface, reuses the existing proxy, and
+  keeps the credentials server-side by construction.
+- (B) Explicit `POST /api/account/cluster/join/finalize` the browser calls after
+  approval, which makes the controller do its own authenticated poll + persist.
+  More moving parts, another endpoint to auth. Rejected unless (A) proves awkward.
+
+Decision: **A.** Note the one subtlety to verify at build time: confirm the poll
+response shape so the intercept keys off `ready` state correctly and never
+double-consumes a single-use preauth key (idempotent: if credentials already
+persisted for this host_id, skip re-save).
+
+### Unit 2 - headless Headscale mesh-join (the open infra decision)
+
+This is the real fork and the reason this is a spec, not a straight build. The
+controller must bring up a tailnet interface using the one-shot
+`headscale_preauth_key` against the account's Headscale control server
+(`hs.taos.my`). Options, with tradeoffs:
+
+- **(2a) System `tailscale` + `tailscaled`.** `tailscale up --login-server
+  https://hs.taos.my --authkey <preauth> --hostname <handle-host>`. Simplest and
+  most robust (real kernel networking, standard tooling), but adds a system
+  dependency + a privileged daemon, and the install/upgrade path must ship it per
+  platform (Pi/Debian, Fedora, macOS). Best for a device that IS the always-on
+  host.
+- **(2b) `tsnet` (userspace Tailscale, in-process).** taOS embeds a userspace
+  tailnet in the controller process (Go `tsnet`, or a Python binding / sidecar).
+  No system daemon, no root, self-contained. But taOS is Python; this means a Go
+  sidecar or a userspace-WireGuard lib, and userspace perf/reliability is lower.
+  The website side already anticipates a `tsnet` menubar app for clients (bus
+  discussion), so there is precedent for tsnet on the CLIENT; the QUESTION is
+  whether the always-on HOST should also be userspace or system.
+- (2c) Reuse whatever the streamed-browser / Neko work uses for its tailnet, if
+  it already brings up a tailnet on the Pi. To verify at build time.
+
+**Recommendation: 2a (system tailscale) for the always-on host**, because the
+published site + remote desktop need a stable, performant, boot-persistent mesh
+membership, and the host is a managed device where installing a package + service
+is acceptable (it already manages systemd units per the backend-service work).
+Keep 2b (tsnet) for the light clients. But this is Jay's call - it defines a new
+per-platform install dependency, so it belongs in the installer story. If 2a: the
+join sequence is `mesh_up(preauth, hostname)` -> shell out to `tailscale up`
+(fail-soft, structured error), then record membership; on reboot, tailscaled
+rejoins automatically and Unit 1's persisted credentials remain valid.
+
+Health/observability: a `mesh_status()` that reports `{joined, tailnet_name,
+node_ip}` for the Account pane and the routing (the published_sites `host_id` maps
+to this node in taos.my's hosts table).
+
+### Unit 3 - publish caller + static-site server
+
+Once Units 1+2 land, publishing a Web Studio site is:
+
+1. **Serve the static export.** The controller serves the site's already-built
+   static bundle (the same `/api/web/sites/{id}/package` / preview content) on a
+   dedicated internal port bound to the tailnet interface (not the LAN). A tiny
+   static file server per published site, or one server keyed by label. Static
+   only in v1 (matches Web Studio's stated scope); "dynamic + keep-running"
+   containers are a later phase.
+2. **Register the route.** `POST hs.taos.my.../api/sites/publish` with
+   `Authorization: Bearer <sites_token>` and `{label, port, host_id}` -- handle is
+   derived server-side from the token (the anti-spoof we already reviewed in #94).
+   The label is validated client-side against the same reserved rules, but taos.my
+   re-validates.
+3. **Web Studio UI.** ShareView gains a "Publish to <handle>.taos.my" action
+   (alongside install/export): pick a label, POST, show the resulting FQDN + a
+   copy link, and an "unpublish". Gated on the host having joined a mesh
+   (`mesh_status().joined`) with a clear "connect your taOS account first" empty
+   state otherwise.
+
+The ops half (wildcard `*.taos.my` DNS-01 cert + the front proxy that calls
+`/api/relay/authorize-site`) is already flagged for Jay/@hermes and is
+independent of this controller work.
+
+## Slice plan (each independently shippable + testable)
+
+- **Slice 1 - credential store + poll-intercept persistence.** `mesh_credentials.py`
+  + `save/get` API, `get_controller_token`/`get_sites_token` backed by it, the
+  `cluster_join_poll` intercept that persists server-side and strips tokens from
+  the browser body. Tests: persistence round-trip, 0600 perms, idempotent
+  re-poll, browser body has no raw tokens, env-var dev override still wins. NO
+  mesh-join yet (credentials just persist). This alone makes `get_controller_token`
+  real and unblocks the taOSnet passkey fetch too.
+- **Slice 2 - headless mesh-join** (pending Jay's 2a/2b decision). `mesh_up`,
+  `mesh_status`, install-story changes, Account-pane status. Tests: mock the
+  join call; live-verify on the Pi against hs.taos.my.
+- **Slice 3 - publish caller + static server + Web Studio UI.** Static-site server
+  on the tailnet port, `sites_token` publish/unpublish caller, ShareView publish
+  action. Tests: publish round-trip (mock taos.my), unpublish, mesh-not-joined
+  empty state; live-verify the FQDN resolves once ops lands the cert+proxy.
+
+## Open questions for Jay
+
+1. **Mesh-join mechanism (Unit 2): system `tailscale` (2a, recommended) or
+   userspace `tsnet` (2b)?** This defines a new per-platform install dependency,
+   so it is the gating decision. Everything in Slice 1 is independent of it and
+   can land first regardless.
+2. **Static-site serving (Unit 3): a per-site static server on the tailnet is the
+   v1 plan. Confirm static-only for v1** (dynamic/keep-running containers deferred),
+   consistent with Web Studio's current scope.
+3. Is there already a tailnet brought up on the Pi by the streamed-browser/Neko
+   work that Unit 2 should reuse rather than duplicate? (I will verify in code
+   before building Slice 2.)
+
+## Non-goals (v1)
+
+Dynamic/backend sites + "keep running" containers; custom TLD domains (#168);
+multi-host publish; client (phone/laptop) mesh membership (that is the separate
+tsnet client work website-dev referenced).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.38"
+version = "1.0.0-beta.39"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/scripts/check_manifests.py
+++ b/scripts/check_manifests.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Catalog manifest lints that run in CI (separate from audit-manifests.py,
+which is a one-off migration checker and is not wired into CI).
+
+Currently implements the managed-backend-service contract lint (Phase 1 of the
+cluster-aware backend service management design,
+docs/design/cluster-backend-service-management.md):
+
+    A service manifest whose ``lifecycle.auto_manage`` is true MUST declare
+    ``lifecycle.unit`` (systemd unit name), ``lifecycle.scope`` ("system" or
+    "user"), and ``lifecycle.health`` with ``url`` + ``expect``. This is what
+    lets taOS treat the backend as a managed systemd service uniformly across
+    cluster nodes (boot persistence, the Activity "Restart AI Services"
+    recovery, and placement/migration all depend on it). Without the lint a
+    backend can ship claiming auto_manage while giving taOS no unit to manage,
+    which is how the production rkllama ended up a hand-started orphan.
+
+Usage:
+    python scripts/check_manifests.py managed-lint [--root app-catalog]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+# Services that declare auto_manage but are legitimately not yet a systemd unit
+# on the host (or are managed by a non-manifest installer). Empty today; add an
+# id here with a one-line reason only as a deliberate, temporary exception.
+GRANDFATHER: dict[str, str] = {}
+
+VALID_SCOPES = {"system", "user"}
+
+
+def lint_managed(root: Path) -> list[str]:
+    """Return a list of human-readable errors for the managed-service contract.
+
+    ``lifecycle.health.expect`` is a literal substring matched against the
+    backend's health-endpoint response body (a 200 body must contain it).
+    """
+    errors: list[str] = []
+    services_dir = root / "services"
+    for manifest in sorted(services_dir.glob("*/manifest.yaml")):
+        sid_dir = manifest.parent.name
+        # An unparseable or non-mapping manifest is an error, not a silent skip
+        # (silently skipping gave a false "clean").
+        try:
+            data = yaml.safe_load(manifest.read_text())
+        except yaml.YAMLError as exc:
+            first = str(exc).splitlines()[0] if str(exc) else "parse error"
+            errors.append(f"{sid_dir}: manifest.yaml is not valid YAML ({first[:120]})")
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"{sid_dir}: manifest.yaml top-level is not a mapping")
+            continue
+
+        sid = str(data.get("id") or sid_dir)
+        lifecycle = data.get("lifecycle")
+        if not isinstance(lifecycle, dict):
+            continue
+
+        auto_manage = lifecycle.get("auto_manage")
+        if not auto_manage:
+            continue  # None / False / 0 / "" -> not claiming to be managed
+
+        if sid in GRANDFATHER:
+            continue
+
+        # Truthy but not a real bool (e.g. quoted "true", 1) would otherwise slip
+        # past an identity check and bypass the contract -- flag it, and still
+        # enforce the rest since it is clearly meant to be managed.
+        if auto_manage is not True:
+            errors.append(
+                f"{sid}: lifecycle.auto_manage must be a boolean true, got {auto_manage!r}"
+            )
+
+        missing: list[str] = []
+        unit = lifecycle.get("unit")
+        if not unit:
+            missing.append("lifecycle.unit")
+        elif not str(unit).endswith(".service"):
+            errors.append(
+                f"{sid}: lifecycle.unit '{unit}' should be a systemd unit name ending in .service"
+            )
+
+        scope = lifecycle.get("scope")
+        if not scope:
+            missing.append("lifecycle.scope")
+        elif scope not in VALID_SCOPES:
+            errors.append(
+                f"{sid}: lifecycle.scope is '{scope}', must be one of {sorted(VALID_SCOPES)}"
+            )
+
+        health = lifecycle.get("health")
+        if not isinstance(health, dict):
+            missing.append("lifecycle.health")
+        else:
+            if not health.get("url"):
+                missing.append("lifecycle.health.url")
+            expect = health.get("expect")
+            if not expect:
+                missing.append("lifecycle.health.expect")
+            elif not isinstance(expect, str):
+                errors.append(
+                    f"{sid}: lifecycle.health.expect must be a string (a substring "
+                    f"matched against the health response body), got {type(expect).__name__}"
+                )
+
+        if missing:
+            errors.append(
+                f"{sid}: lifecycle.auto_manage is true but is missing "
+                f"{', '.join(missing)} (managed backends must declare their "
+                f"systemd unit + health so taOS can manage them per node)"
+            )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["managed-lint"])
+    parser.add_argument("--root", default="app-catalog", help="catalog root dir")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    errors = lint_managed(root)
+    if errors:
+        print("MANIFEST-LINT FAIL (managed-service contract):", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+    print("manifest managed-lint: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-agent-zero.sh
+++ b/scripts/install-agent-zero.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# tinyagentos installer for Agent Zero (https://github.com/frdel/agent-zero)
+# ---------------------------------------------------------------------------
+# Agent Zero — autonomous AI agent with self-correcting workflows, tool
+# creation, and computer control. License: MIT.
+# Clones the repo into /opt/agent-zero and installs with pip.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+AGENT_ZERO_VERSION="${TAOS_AGENT_ZERO_VERSION:-main}"
+AGENT_ZERO_REPO="https://github.com/frdel/agent-zero.git"
+AGENT_ZERO_HOME="/opt/agent-zero"
+
+log() { echo -e "\033[1;34m[agent-zero]\033[0m $*"; }
+die() { echo -e "\033[1;31m[agent-zero]\033[0m $*" >&2; exit 1; }
+
+# --- prerequisites ---------------------------------------------------------
+command -v git >/dev/null 2>&1 || die "git not found — install git and retry"
+command -v python3 >/dev/null 2>&1 || die "python3 not found — install Python 3.10+ and retry"
+
+# --- clone / update --------------------------------------------------------
+if [[ -d "${AGENT_ZERO_HOME}/.git" ]]; then
+    log "agent-zero already cloned at ${AGENT_ZERO_HOME}; updating"
+    git -C "$AGENT_ZERO_HOME" fetch origin "$AGENT_ZERO_VERSION"
+    git -C "$AGENT_ZERO_HOME" checkout "$AGENT_ZERO_VERSION"
+    git -C "$AGENT_ZERO_HOME" pull origin "$AGENT_ZERO_VERSION" || true
+else
+    log "cloning agent-zero ${AGENT_ZERO_VERSION} into ${AGENT_ZERO_HOME}"
+    sudo mkdir -p "$AGENT_ZERO_HOME"
+    sudo chown "$(whoami)" "$AGENT_ZERO_HOME"
+    git clone --branch "$AGENT_ZERO_VERSION" "$AGENT_ZERO_REPO" "$AGENT_ZERO_HOME"
+fi
+
+# --- install with pip ------------------------------------------------------
+log "installing agent-zero with pip"
+cd "$AGENT_ZERO_HOME"
+pip install -e . || die "pip install failed in ${AGENT_ZERO_HOME}"
+
+log "agent-zero ${AGENT_ZERO_VERSION} installed at ${AGENT_ZERO_HOME}"

--- a/scripts/install-deer-flow.sh
+++ b/scripts/install-deer-flow.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# tinyagentos installer for DeerFlow (https://github.com/bytedance/deer-flow)
+# ---------------------------------------------------------------------------
+# DeerFlow — ByteDance LangGraph SuperAgent harness. License: MIT.
+# Clones the repo into /opt/deer-flow and provisions with uv (Python 3.12).
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+DEERFLOW_VERSION="${TAOS_DEERFLOW_VERSION:-main}"
+DEERFLOW_REPO="https://github.com/bytedance/deer-flow.git"
+DEERFLOW_HOME="/opt/deer-flow"
+
+log() { echo -e "\033[1;34m[deer-flow]\033[0m $*"; }
+die() { echo -e "\033[1;31m[deer-flow]\033[0m $*" >&2; exit 1; }
+
+# --- prerequisites ---------------------------------------------------------
+command -v git >/dev/null 2>&1 || die "git not found — install git and retry"
+command -v uv >/dev/null 2>&1 || die "uv not found — install uv (https://docs.astral.sh/uv/) and retry"
+
+# --- clone / update --------------------------------------------------------
+if [[ -d "${DEERFLOW_HOME}/.git" ]]; then
+    log "deer-flow already cloned at ${DEERFLOW_HOME}; updating"
+    git -C "$DEERFLOW_HOME" fetch origin "$DEERFLOW_VERSION"
+    git -C "$DEERFLOW_HOME" checkout "$DEERFLOW_VERSION"
+    git -C "$DEERFLOW_HOME" pull origin "$DEERFLOW_VERSION" || true
+else
+    log "cloning deer-flow ${DEERFLOW_VERSION} into ${DEERFLOW_HOME}"
+    sudo mkdir -p "$DEERFLOW_HOME"
+    sudo chown "$(whoami)" "$DEERFLOW_HOME"
+    git clone --branch "$DEERFLOW_VERSION" "$DEERFLOW_REPO" "$DEERFLOW_HOME"
+fi
+
+# --- provision with uv -----------------------------------------------------
+log "provisioning deer-flow backend with uv (Python 3.12)"
+cd "$DEERFLOW_HOME"
+uv sync --python 3.12 || die "uv sync failed in ${DEERFLOW_HOME}"
+
+log "deer-flow ${DEERFLOW_VERSION} installed at ${DEERFLOW_HOME}"

--- a/scripts/install-moltis.sh
+++ b/scripts/install-moltis.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# tinyagentos installer for Moltis (https://github.com/moltis-org/moltis)
+# ---------------------------------------------------------------------------
+# Moltis — enterprise Rust agent framework. License: MIT.
+# Installs via cargo (Rust toolchain required).
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+MOLTIS_VERSION="${TAOS_MOLTIS_VERSION:-latest}"
+MOLTIS_REPO="https://github.com/moltis-org/moltis.git"
+MOLTIS_HOME="/opt/moltis"
+
+log() { echo -e "\033[1;34m[moltis]\033[0m $*"; }
+die() { echo -e "\033[1;31m[moltis]\033[0m $*" >&2; exit 1; }
+
+# --- prerequisites ---------------------------------------------------------
+command -v cargo >/dev/null 2>&1 || die "cargo not found — install Rust (https://rustup.rs) and retry"
+
+# --- install via cargo -----------------------------------------------------
+if command -v moltis >/dev/null 2>&1; then
+    log "moltis already installed: $(moltis --version 2>&1 | head -1)"
+    exit 0
+fi
+
+# Try crates.io first (fast path)
+if cargo install --list 2>/dev/null | grep -q '^moltis '; then
+    log "moltis already installed via cargo"
+    exit 0
+fi
+
+if [[ "$MOLTIS_VERSION" == "latest" ]]; then
+    log "installing latest moltis from crates.io"
+    cargo install moltis || die "cargo install moltis failed"
+else
+    log "installing moltis from git at ${MOLTIS_VERSION}"
+    cargo install --git "$MOLTIS_REPO" --tag "$MOLTIS_VERSION" moltis \
+        || die "cargo install moltis from git failed"
+fi
+
+log "moltis installed: $(moltis --version 2>&1 | head -1)"

--- a/scripts/install-openclaw.sh
+++ b/scripts/install-openclaw.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# tinyagentos installer for OpenClaw (https://github.com/openclaw/openclaw)
+# ---------------------------------------------------------------------------
+# OpenClaw — full-featured agent framework with multi-channel support
+# (Discord, Telegram, Slack, Signal). License: MIT.
+# Clones the repo into /opt/openclaw and installs with pip.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+OPENCLAW_VERSION="${TAOS_OPENCLAW_VERSION:-main}"
+OPENCLAW_REPO="https://github.com/openclaw/openclaw.git"
+OPENCLAW_HOME="/opt/openclaw"
+
+log() { echo -e "\033[1;34m[openclaw]\033[0m $*"; }
+die() { echo -e "\033[1;31m[openclaw]\033[0m $*" >&2; exit 1; }
+
+# --- prerequisites ---------------------------------------------------------
+command -v git >/dev/null 2>&1 || die "git not found — install git and retry"
+command -v python3 >/dev/null 2>&1 || die "python3 not found — install Python 3.10+ and retry"
+
+# --- clone / update --------------------------------------------------------
+if [[ -d "${OPENCLAW_HOME}/.git" ]]; then
+    log "openclaw already cloned at ${OPENCLAW_HOME}; updating"
+    git -C "$OPENCLAW_HOME" fetch origin "$OPENCLAW_VERSION"
+    git -C "$OPENCLAW_HOME" checkout "$OPENCLAW_VERSION"
+    git -C "$OPENCLAW_HOME" pull origin "$OPENCLAW_VERSION" || true
+else
+    log "cloning openclaw ${OPENCLAW_VERSION} into ${OPENCLAW_HOME}"
+    sudo mkdir -p "$OPENCLAW_HOME"
+    sudo chown "$(whoami)" "$OPENCLAW_HOME"
+    git clone --branch "$OPENCLAW_VERSION" "$OPENCLAW_REPO" "$OPENCLAW_HOME"
+fi
+
+# --- install with pip ------------------------------------------------------
+log "installing openclaw with pip"
+cd "$OPENCLAW_HOME"
+pip install -e . || die "pip install failed in ${OPENCLAW_HOME}"
+
+log "openclaw ${OPENCLAW_VERSION} installed at ${OPENCLAW_HOME}"

--- a/scripts/install-picoclaw.sh
+++ b/scripts/install-picoclaw.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# tinyagentos installer for PicoClaw (https://github.com/sipeed/picoclaw)
+# ---------------------------------------------------------------------------
+# PicoClaw — Sipeed NPU-aware micro agent. License: MIT.
+# Under 10MB RAM, designed for ARM boards with NPU acceleration.
+# Clones the repo and builds for the target platform.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+PICOCLAW_VERSION="${TAOS_PICOCLAW_VERSION:-main}"
+PICOCLAW_REPO="https://github.com/sipeed/picoclaw.git"
+PICOCLAW_HOME="/opt/picoclaw"
+
+log() { echo -e "\033[1;34m[picoclaw]\033[0m $*"; }
+die() { echo -e "\033[1;31m[picoclaw]\033[0m $*" >&2; exit 1; }
+
+# --- prerequisites ---------------------------------------------------------
+command -v git >/dev/null 2>&1 || die "git not found — install git and retry"
+command -v cmake >/dev/null 2>&1 || die "cmake not found — install cmake and retry"
+
+# --- clone / update --------------------------------------------------------
+if [[ -d "${PICOCLAW_HOME}/.git" ]]; then
+    log "picoclaw already cloned at ${PICOCLAW_HOME}; updating"
+    git -C "$PICOCLAW_HOME" fetch origin "$PICOCLAW_VERSION"
+    git -C "$PICOCLAW_HOME" checkout "$PICOCLAW_VERSION"
+    git -C "$PICOCLAW_HOME" pull origin "$PICOCLAW_VERSION" || true
+else
+    log "cloning picoclaw ${PICOCLAW_VERSION} into ${PICOCLAW_HOME}"
+    sudo mkdir -p "$PICOCLAW_HOME"
+    sudo chown "$(whoami)" "$PICOCLAW_HOME"
+    git clone --branch "$PICOCLAW_VERSION" "$PICOCLAW_REPO" "$PICOCLAW_HOME"
+fi
+
+# --- build -----------------------------------------------------------------
+log "building picoclaw"
+cd "$PICOCLAW_HOME"
+if [[ -f CMakeLists.txt ]]; then
+    mkdir -p build && cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Release || die "cmake failed"
+    make -j"$(nproc)" || die "make failed"
+elif [[ -f Makefile ]]; then
+    make -j"$(nproc)" || die "make failed"
+else
+    die "no recognized build system found in ${PICOCLAW_HOME}"
+fi
+
+# --- install ----------------------------------------------------------------
+log "installing picoclaw to system"
+if [[ -d build ]]; then
+    cd "$PICOCLAW_HOME/build"
+fi
+if grep -q 'install' Makefile 2>/dev/null || grep -q 'install' ../Makefile 2>/dev/null; then
+    sudo make install || log "make install failed — binary may need manual PATH setup"
+else
+    log "no install target in Makefile — picoclaw binary at ${PICOCLAW_HOME}/build"
+fi
+
+log "picoclaw ${PICOCLAW_VERSION} built at ${PICOCLAW_HOME}"

--- a/scripts/install-rkllama.sh
+++ b/scripts/install-rkllama.sh
@@ -24,16 +24,29 @@ PROJECT_DIR="${1:-$(pwd)}"
 PORT="${TAOS_RKLLAMA_PORT:-7833}"
 LEGACY_PORT=8080
 
-# 1. Idempotent short-circuit: a live rkllama already satisfies the install.
-#    Require an rkllama/Ollama-shaped /api/tags body (a "models" key), not just
-#    any HTTP 200 -- another local service on these ports must not be mistaken
-#    for an installed rkllama. Mirrors _port_responds_with_rkllama() in the
-#    Python installer.
+# 1. Idempotent short-circuit: a live AND MANAGED rkllama already satisfies the
+#    install. Two conditions, both required:
+#      (a) an rkllama/Ollama-shaped /api/tags body (a "models" key), not just any
+#          HTTP 200 -- another local service on these ports must not be mistaken
+#          for rkllama. Mirrors _port_responds_with_rkllama() in the Python installer.
+#      (b) the rkllama.service systemd unit is enabled. taOS manages backends as
+#          systemd services (boot persistence, the Activity "Restart AI Services"
+#          recovery in routes/system.py, and cluster placement/migration all
+#          depend on it). A hand-started bare process answers (a) but has no unit,
+#          which used to short-circuit the install and leave rkllama permanently
+#          unmanaged (no reboot survival, not systemctl-controllable). If the unit
+#          is missing we fall through to install-rknpu.sh, whose install_systemd_unit
+#          adopts the running instance under systemd (its ExecStartPre reaps the
+#          orphan so the unit can bind the port).
 for p in "$PORT" "$LEGACY_PORT"; do
     body="$(curl -fsS --max-time 2 "http://localhost:${p}/api/tags" 2>/dev/null || true)"
     if printf '%s' "$body" | grep -q '"models"'; then
-        echo "rkllama already running on port ${p} — nothing to install"
-        exit 0
+        if systemctl is-enabled rkllama.service >/dev/null 2>&1; then
+            echo "rkllama already running on port ${p} and managed by systemd — nothing to install"
+            exit 0
+        fi
+        echo "rkllama answers on port ${p} but is not a managed systemd service — running the installer to adopt it under systemd"
+        break
     fi
 done
 

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -631,10 +631,11 @@ pull_models() {
 install_systemd_unit() {
     local unit="/etc/systemd/system/rkllama.service"
     local exec_start
-    # This ExecStart line is copy-of-truth from the live orange pi:
-    #   rkllama_server --processor rk3588 --port 8080 \
-    #     --models /home/jay/rkllama/models \
-    #     --preload qwen3-embedding-0.6b,qwen3-reranker-0.6b,qmd-query-expansion
+    # Matches the unit shape running on the reference RK3588 deployment
+    # (port 7833, unified models root, --preload of the three shared
+    # models). Kept in sync with the live Pi unit as of the 1.3.0 deploy;
+    # the audit flagged the previous comment as stale (it referenced the
+    # old port 8080 and the pre-consolidation models path).
     exec_start="$RKLLAMA_VENV/bin/python $RKLLAMA_VENV/bin/rkllama_server --processor $SOC --port $RKLLAMA_PORT --models $RKLLAMA_MODELS --preload qwen3-embedding-0.6b,qwen3-reranker-0.6b,qmd-query-expansion"
 
     log "installing $unit"

--- a/scripts/install-rknpu.sh
+++ b/scripts/install-rknpu.sh
@@ -25,7 +25,7 @@
 #     TAOS_RKNPU_SETUP        set to 1/true to skip interactive confirmation
 #     TAOS_RKLLAMA_DIR        install dir (default: ~<user>/rkllama)
 #     TAOS_RKLLAMA_REPO       git remote (default: https://github.com/jaylfc/rkllama.git)
-#     TAOS_RKLLAMA_REF        git ref  (default: 58038c956623e9e18eb39f1ef089f812dd82b6bc)
+#     TAOS_RKLLAMA_REF        git ref  (default: dadea413fb38bc28000f18ed7b1d529bb3d18db7)
 #     TAOS_RKLLAMA_PORT       HTTP port (default: 7833)
 #     TAOS_QMD_EXPANSION_URL  override URL for qmd-query-expansion-1.7B-rk3588.rkllm
 #                             (default is the TAOS HF mirror at
@@ -63,7 +63,10 @@ LIBRKNNRT_DEST="/usr/lib/librknnrt.so"
 LIBRKNNRT_EXPECTED_VERSION="2.3.0"
 
 RKLLAMA_REPO="${TAOS_RKLLAMA_REPO:-https://github.com/jaylfc/rkllama.git}"
-RKLLAMA_REF="${TAOS_RKLLAMA_REF:-58038c956623e9e18eb39f1ef089f812dd82b6bc}"
+# rknn-llm 1.3.0: feat/rknpu-1.3.0 @ dadea41 (upstream 1.3.0 base + the 6 fork
+# patches + the rerank-ABI adaptation for 1.3.0). Deployed + smoke-verified on
+# RK3588 2026-07-09. Was 58038c95 (1.2.3).
+RKLLAMA_REF="${TAOS_RKLLAMA_REF:-dadea413fb38bc28000f18ed7b1d529bb3d18db7}"
 RKLLAMA_PORT="${TAOS_RKLLAMA_PORT:-7833}"
 
 # Qwen3-Embedding-0.6B rk3588 rkllm weights.
@@ -447,6 +450,18 @@ install_rkllama() {
     fi
     run_as_user git -C "$RKLLAMA_DIR" checkout --quiet "$RKLLAMA_REF"
     log "rkllama pinned to $(run_as_user git -C "$RKLLAMA_DIR" rev-parse --short HEAD)"
+
+    # Guard (issue #1730): a past ref bump silently dropped the --preload flag,
+    # which broke the preloaded embed/rerank/expand models. Refuse to build
+    # against any ref that is missing the taOS fork patches we rely on. Static
+    # source check, so it fails fast before the venv install and service start.
+    local _missing_patch=()
+    grep -rqs -- '--preload' "$RKLLAMA_DIR/src" || _missing_patch+=("--preload flag")
+    grep -rqs 'context_length_exceeded' "$RKLLAMA_DIR/src" || _missing_patch+=("context-overflow payload")
+    if (( ${#_missing_patch[@]} )); then
+        die "pinned rkllama ref ${RKLLAMA_REF:0:12} is missing required taOS fork patches: ${_missing_patch[*]}. Refusing to install a ref that dropped them (issue #1730). Update taOS for a current pin."
+    fi
+    log "rkllama fork patches present (--preload, context-overflow)"
 
     # rkllama's transitive deps (notably webrtcvad) need a C toolchain to
     # build wheels from source — Pi images often ship without these. Pull

--- a/tests/test_a2a_bus_agent_auth.py
+++ b/tests/test_a2a_bus_agent_auth.py
@@ -271,3 +271,136 @@ class TestBusAgentAuth:
             )
         # Falls through middleware to the session gate: API request -> 401.
         assert resp.status_code == 401
+
+
+def _mock_bus_post(json_payload: dict, *, raise_on_status: bool = False):
+    """A mock httpx.AsyncClient whose async ctx yields a client whose
+    .post().json() returns *json_payload*. If *raise_on_status* the mocked
+    response.raise_for_status() raises, simulating a bus error."""
+    mock_resp = MagicMock()
+    if raise_on_status:
+        mock_resp.raise_for_status = MagicMock(side_effect=RuntimeError("bus 500"))
+    else:
+        mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = json_payload
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_resp
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+    return mock_ctx, mock_client
+
+
+@pytest.mark.asyncio
+class TestBusAgentSend:
+    """Authenticated write path: agents post as themselves, never spoofing."""
+
+    async def test_agent_send_derives_from_from_registry_handle(self, bus_client):
+        # _make_agent_token registers handle "@bus-reader".
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        ctx, client = _mock_bus_post({"id": 1, "from": "@bus-reader", "thread": "build"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "build", "body": "hi", "from": "@somebody-else"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["from"] == "@bus-reader"
+        # Anti-spoof: the body's "from" is ignored; the bus is called with the
+        # agent's own registry handle.
+        sent = client.post.call_args.kwargs["json"]
+        assert sent["from"] == "@bus-reader"
+        assert sent["thread"] == "build" and sent["body"] == "hi"
+
+    async def test_agent_without_send_scope_forbidden(self, bus_client):
+        # Only a2a_receive -> cannot send.
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_receive",))
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "build", "body": "hi"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 403
+
+    async def test_no_auth_rejected(self, bus_client):
+        # No Bearer header at all: the auth middleware rejects the API request
+        # with 401 before it reaches the route (no credentials presented). The
+        # route's own 403 covers a *valid* token that lacks the a2a_send grant.
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "build", "body": "hi"},
+            )
+        assert resp.status_code == 401
+
+    async def test_admin_may_send_with_explicit_from(self, bus_client):
+        ctx, client = _mock_bus_post({"id": 2, "from": "@operator", "thread": "general"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            resp = await bus_client.post(
+                "/api/a2a/bus/send",
+                json={"thread": "general", "body": "ops note", "from": "@release-bot"},
+            )
+        assert resp.status_code == 200
+        # Admin's explicit from is honored.
+        assert client.post.call_args.kwargs["json"]["from"] == "@release-bot"
+
+    async def test_missing_thread_or_body_400(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "  ", "body": "hi"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 400
+
+    async def test_reply_to_must_be_positive(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        async with _bare(bus_client._app) as bare:
+            resp = await bare.post(
+                "/api/a2a/bus/send",
+                json={"thread": "build", "body": "hi", "reply_to": 0},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 400
+
+    async def test_body_is_trimmed_before_forwarding(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        ctx, client = _mock_bus_post({"id": 9, "from": "@bus-reader", "thread": "build"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "build", "body": "  padded  "},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 200
+        assert client.post.call_args.kwargs["json"]["body"] == "padded"
+
+    async def test_admin_from_control_chars_stripped(self, bus_client):
+        ctx, client = _mock_bus_post({"id": 10, "from": "@x", "thread": "general"})
+        with patch(_BUS_PATCH, return_value=ctx):
+            resp = await bus_client.post(
+                "/api/a2a/bus/send",
+                json={"thread": "general", "body": "hi", "from": "@evil\nInjected: x"},
+            )
+        assert resp.status_code == 200
+        # Newline/control chars removed so nothing can be injected downstream.
+        assert "\n" not in client.post.call_args.kwargs["json"]["from"]
+
+    async def test_bus_error_surfaces_502(self, bus_client):
+        _cid, token = await _make_agent_token(bus_client._app, scopes=("a2a_send",))
+        ctx, _client = _mock_bus_post({}, raise_on_status=True)
+        with patch(_BUS_PATCH, return_value=ctx):
+            async with _bare(bus_client._app) as bare:
+                resp = await bare.post(
+                    "/api/a2a/bus/send",
+                    json={"thread": "build", "body": "hi"},
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        assert resp.status_code == 502

--- a/tests/test_agent_token_auth.py
+++ b/tests/test_agent_token_auth.py
@@ -1,0 +1,128 @@
+"""Unit tests for the project-scoped registry-JWT check.
+
+``check_agent_scope_for_project`` is the least-privilege sibling of
+``check_agent_scope``: it verifies the same EdDSA JWT + active-grant chain AND
+binds the caller to a single project via the token's ``project_id`` claim. These
+tests pin the security-critical behavior (project binding, missing-claim reject)
+and confirm ``check_agent_scope`` is unchanged by the shared-verifier refactor.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+
+from tinyagentos.agent_registry_store import mint_registry_token
+from tinyagentos.agent_token_auth import (
+    check_agent_scope,
+    check_agent_scope_for_project,
+)
+
+
+class _FakeRequest:
+    """Minimal stand-in for a starlette Request: the auth helpers only touch
+    ``.headers.get(...)`` and ``.app.state`` on the object."""
+
+    def __init__(self, app, token: str | None = None):
+        self.app = app
+        self.headers = {}
+        if token is not None:
+            self.headers["Authorization"] = f"Bearer {token}"
+
+
+@pytest_asyncio.fixture
+async def token_app(app):
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+    yield app
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+async def _mint(app, *, scopes=("project_tasks",), project_id="prj-1"):
+    """Register an active agent, add its grants, and mint a JWT bound to
+    ``project_id`` (global when project_id is None)."""
+    registry = app.state.agent_registry
+    grants = app.state.agent_grants
+    priv, _pub = app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="grok",
+        display_name="Grok",
+        origin="external-selfjoin",
+        handle="@grok",
+    )
+    cid = rec["canonical_id"]
+    await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="grok", project_id=project_id
+    )
+    return cid, token
+
+
+@pytest.mark.asyncio
+class TestCheckAgentScopeForProject:
+    async def test_returns_canonical_id_for_matching_project(self, token_app):
+        cid, token = await _mint(token_app, project_id="prj-1")
+        req = _FakeRequest(token_app, token)
+        got = await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert got == cid
+
+    async def test_403_on_project_mismatch(self, token_app):
+        _cid, token = await _mint(token_app, project_id="prj-1")
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope_for_project(req, "project_tasks", "prj-OTHER")
+        assert exc.value.status_code == 403
+
+    async def test_403_on_missing_project_claim(self, token_app):
+        # Global token (no project_id claim) must never satisfy a project check.
+        _cid, token = await _mint(token_app, project_id=None)
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert exc.value.status_code == 403
+
+    async def test_403_on_missing_scope(self, token_app):
+        _cid, token = await _mint(
+            token_app, scopes=("a2a_receive",), project_id="prj-1"
+        )
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert exc.value.status_code == 403
+
+    async def test_none_when_no_bearer(self, token_app):
+        req = _FakeRequest(token_app, token=None)
+        got = await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert got is None
+
+
+@pytest.mark.asyncio
+class TestCheckAgentScopeUnchanged:
+    """The shared-verifier refactor must not alter check_agent_scope."""
+
+    async def test_returns_canonical_id_ignoring_project(self, token_app):
+        cid, token = await _mint(token_app, project_id="prj-1")
+        req = _FakeRequest(token_app, token)
+        # project binding is irrelevant to the non-project check.
+        got = await check_agent_scope(req, "project_tasks")
+        assert got == cid
+
+    async def test_none_when_no_bearer(self, token_app):
+        req = _FakeRequest(token_app, token=None)
+        assert await check_agent_scope(req, "project_tasks") is None
+
+    async def test_403_on_missing_scope(self, token_app):
+        _cid, token = await _mint(
+            token_app, scopes=("a2a_receive",), project_id="prj-1"
+        )
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope(req, "project_tasks")
+        assert exc.value.status_code == 403

--- a/tests/test_asset_gen_comfyui.py
+++ b/tests/test_asset_gen_comfyui.py
@@ -1,0 +1,168 @@
+"""Unit tests for the ComfyUI client + workflow builder (all HTTP mocked).
+
+ComfyUI is not installed in CI, so every test patches httpx so no real network
+call is made — mirroring tests/test_routes_games.py's httpx.AsyncClient mocking.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ConnectError, Request as HttpxRequest, Response
+
+from tinyagentos.asset_gen.comfyui_client import ComfyUIClient, ComfyUIResult
+from tinyagentos.asset_gen.workflows import build_texture_workflow
+
+# Minimal valid 1x1 PNG (magic header is what _looks_like_image checks).
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+_PROMPT_ID = "abc123"
+
+
+def _resp(url: str, *, json=None, content=None) -> Response:
+    req = HttpxRequest("GET", url)
+    if content is not None:
+        return Response(status_code=200, content=content, request=req)
+    return Response(status_code=200, json=json, request=req)
+
+
+def _history_with_image() -> dict:
+    return {
+        _PROMPT_ID: {
+            "outputs": {
+                "9": {"images": [{"filename": "out.png", "subfolder": "", "type": "output"}]}
+            }
+        }
+    }
+
+
+def _install_mock(monkeypatch_target, mock_instance):
+    """Patch the client's httpx.AsyncClient to yield *mock_instance*."""
+    mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+    mock_instance.__aexit__ = AsyncMock(return_value=False)
+    return patch(
+        "tinyagentos.asset_gen.comfyui_client.httpx.AsyncClient",
+        return_value=mock_instance,
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_success_returns_image_bytes():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={"prompt_id": _PROMPT_ID})
+
+    def get_side_effect(url, **kwargs):
+        if "/history/" in url:
+            return _resp(url, json=_history_with_image())
+        return _resp(url, content=PNG_BYTES)  # /view
+
+    inst.get.side_effect = get_side_effect
+
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+
+    assert isinstance(result, ComfyUIResult)
+    assert result.image_bytes == PNG_BYTES
+    assert result.prompt_id == _PROMPT_ID
+    # /view was called with the ref parsed out of history.
+    view_call = [c for c in inst.get.call_args_list if "/view" in c.args[0]][0]
+    assert view_call.kwargs["params"]["filename"] == "out.png"
+
+
+@pytest.mark.asyncio
+async def test_generate_no_prompt_id_returns_none():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={})
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+    assert result is None
+    inst.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_job_finishes_without_image_returns_none():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={"prompt_id": _PROMPT_ID})
+    inst.get.side_effect = lambda url, **kw: _resp(url, json={_PROMPT_ID: {"outputs": {}}})
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_non_image_view_returns_none():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={"prompt_id": _PROMPT_ID})
+
+    def get_side_effect(url, **kwargs):
+        if "/history/" in url:
+            return _resp(url, json=_history_with_image())
+        return _resp(url, content=b'{"error":"boom"}')  # /view non-image body
+
+    inst.get.side_effect = get_side_effect
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_connect_error_is_fail_soft():
+    inst = AsyncMock()
+    inst.post.side_effect = ConnectError("refused")
+    with _install_mock(None, inst):
+        result = await ComfyUIClient("http://comfy").generate({"1": {}})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_generate_poll_timeout_returns_none():
+    inst = AsyncMock()
+    inst.post.return_value = _resp("http://x/prompt", json={"prompt_id": _PROMPT_ID})
+    # History never contains the prompt id -> poll spins until the deadline.
+    inst.get.side_effect = lambda url, **kw: _resp(url, json={})
+    with _install_mock(None, inst):
+        client = ComfyUIClient("http://comfy", poll_timeout=0.05, poll_interval=0.01)
+        result = await client.generate({"1": {}})
+    assert result is None
+
+
+def test_default_base_url_from_env(monkeypatch):
+    monkeypatch.setenv("TAOS_COMFYUI_URL", "http://gpu-box:8188/")
+    # Trailing slash is stripped.
+    assert ComfyUIClient().base == "http://gpu-box:8188"
+
+
+def test_default_base_url_fallback(monkeypatch):
+    monkeypatch.delenv("TAOS_COMFYUI_URL", raising=False)
+    assert ComfyUIClient().base == "http://127.0.0.1:8188"
+
+
+class TestBuildTextureWorkflow:
+    def test_stamps_prompt_size_seed_checkpoint(self):
+        wf = build_texture_workflow(
+            prompt="mossy stone", width=768, height=512, seed=42,
+            checkpoint="my.safetensors",
+        )
+        assert wf["6"]["inputs"]["text"] == "mossy stone"
+        assert wf["5"]["inputs"]["width"] == 768
+        assert wf["5"]["inputs"]["height"] == 512
+        assert wf["3"]["inputs"]["seed"] == 42
+        assert wf["4"]["inputs"]["ckpt_name"] == "my.safetensors"
+
+    def test_tileable_augments_prompt(self):
+        wf = build_texture_workflow(prompt="brick wall", tileable=True)
+        assert "seamless tileable" in wf["6"]["inputs"]["text"]
+
+    def test_tileable_not_duplicated_when_already_seamless(self):
+        wf = build_texture_workflow(prompt="a seamless grass texture", tileable=True)
+        assert wf["6"]["inputs"]["text"].count("seamless") == 1
+
+    def test_returns_fresh_copy(self):
+        a = build_texture_workflow(prompt="one")
+        b = build_texture_workflow(prompt="two")
+        assert a["6"]["inputs"]["text"] == "one"
+        assert b["6"]["inputs"]["text"] == "two"

--- a/tests/test_backend_services.py
+++ b/tests/test_backend_services.py
@@ -1,0 +1,199 @@
+"""Tests for the node-local backend service manager
+(tinyagentos/cluster/backend_services.py)."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tinyagentos.cluster import backend_services as bs
+
+
+# --------------------------------------------------------------------------
+# load_managed_backends
+# --------------------------------------------------------------------------
+
+def _write_manifest(root: Path, sid: str, manifest: dict) -> None:
+    d = root / "services" / sid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "manifest.yaml").write_text(yaml.safe_dump(manifest))
+
+
+def test_load_managed_backends_returns_only_managed(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "rkllama", {
+        "id": "rkllama",
+        "lifecycle": {
+            "auto_manage": True, "unit": "rkllama.service", "scope": "system",
+            "health": {"url": "http://localhost:7833/api/tags", "expect": '"models"'},
+        },
+    })
+    _write_manifest(tmp_path, "rk-llama-cpp", {
+        "id": "rk-llama-cpp", "lifecycle": {"auto_manage": False},
+    })
+    _write_manifest(tmp_path, "no-lifecycle", {"id": "no-lifecycle"})
+
+    backends = bs.load_managed_backends(tmp_path)
+    assert len(backends) == 1
+    b = backends[0]
+    assert b.id == "rkllama"
+    assert b.unit == "rkllama.service"
+    assert b.scope == "system"
+    assert b.health_url == "http://localhost:7833/api/tags"
+    assert b.health_expect == '"models"'
+
+
+def test_load_skips_managed_without_unit_or_scope(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "broken", {
+        "id": "broken", "lifecycle": {"auto_manage": True, "scope": "bogus"},
+    })
+    assert bs.load_managed_backends(tmp_path) == []
+
+
+# --------------------------------------------------------------------------
+# resolve_scope / unit_state / service_action  (mocked systemctl)
+# --------------------------------------------------------------------------
+
+class _FakeProc:
+    def __init__(self, returncode: int, stderr: bytes = b""):
+        self.returncode = returncode
+        self._stderr = stderr
+
+    async def communicate(self):
+        return (b"", self._stderr)
+
+    async def wait(self):
+        return self.returncode
+
+    def kill(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_resolve_scope_prefers_manifest_scope(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    async def fake_rc(args):
+        calls.append(args)
+        # unit exists in system scope only
+        return 0 if "--user" not in args else 1
+
+    monkeypatch.setattr(bs, "_rc", fake_rc)
+    scope = await bs.resolve_scope("rkllama.service", prefer="system")
+    assert scope == "system"
+    # prefer=system means the first cat probe is the system (no --user) one
+    assert "--user" not in calls[0]
+
+
+@pytest.mark.asyncio
+async def test_unit_state_reports_enabled_active(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(0))
+    state = await bs.unit_state("rkllama.service", prefer="system")
+    assert state["installed"] is True
+    assert state["enabled"] is True
+    assert state["active"] is True
+    assert state["scope"] == "system"
+
+
+@pytest.mark.asyncio
+async def test_unit_state_not_installed(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(1))  # cat fails both scopes
+    state = await bs.unit_state("ghost.service")
+    assert state["installed"] is False
+
+
+@pytest.mark.asyncio
+async def test_service_action_restart_ok(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(0))  # scope resolves
+    monkeypatch.setattr(asyncio, "create_subprocess_exec",
+                        lambda *a, **k: _coro(_FakeProc(0)))
+    result = await bs.service_action("rkllama.service", "restart", prefer="system")
+    assert result == {"unit": "rkllama.service", "ok": True, "scope": "system"}
+
+
+@pytest.mark.asyncio
+async def test_service_action_failure_captures_stderr(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(0))
+    monkeypatch.setattr(asyncio, "create_subprocess_exec",
+                        lambda *a, **k: _coro(_FakeProc(1, b"Interactive authentication required")))
+    result = await bs.service_action("qmd.service", "restart")
+    assert result["ok"] is False
+    assert "Interactive authentication required" in result["detail"]
+
+
+@pytest.mark.asyncio
+async def test_service_action_not_installed(monkeypatch) -> None:
+    monkeypatch.setenv("INVOCATION_ID", "test")
+    monkeypatch.setattr(bs, "_rc", lambda args: _coro(1))  # cat fails -> no scope
+    result = await bs.service_action("ghost.service", "restart")
+    assert result == {"unit": "ghost.service", "ok": False, "detail": "not installed"}
+
+
+@pytest.mark.asyncio
+async def test_service_action_rejects_bad_verb() -> None:
+    with pytest.raises(ValueError):
+        await bs.service_action("x.service", "nuke")
+
+
+# --------------------------------------------------------------------------
+# health_probe (mocked httpx)
+# --------------------------------------------------------------------------
+
+class _FakeResp:
+    def __init__(self, status_code: int, text: str):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeClient:
+    def __init__(self, resp=None, exc=None):
+        self._resp = resp
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def get(self, url):
+        if self._exc:
+            raise self._exc
+        return self._resp
+
+
+@pytest.mark.asyncio
+async def test_health_probe_ok(monkeypatch) -> None:
+    monkeypatch.setattr(bs.httpx, "AsyncClient",
+                        lambda *a, **k: _FakeClient(_FakeResp(200, '{"models": []}')))
+    assert await bs.health_probe("http://x/api/tags", '"models"') == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_health_probe_missing_marker(monkeypatch) -> None:
+    monkeypatch.setattr(bs.httpx, "AsyncClient",
+                        lambda *a, **k: _FakeClient(_FakeResp(200, "{}")))
+    r = await bs.health_probe("http://x/api/tags", '"models"')
+    assert r["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_health_probe_connection_error(monkeypatch) -> None:
+    monkeypatch.setattr(bs.httpx, "AsyncClient",
+                        lambda *a, **k: _FakeClient(exc=RuntimeError("refused")))
+    r = await bs.health_probe("http://x/api/tags", "")
+    assert r["ok"] is False
+    assert "refused" in r["detail"]
+
+
+# --------------------------------------------------------------------------
+# helper
+# --------------------------------------------------------------------------
+
+async def _coro(value):
+    return value

--- a/tests/test_check_manifests.py
+++ b/tests/test_check_manifests.py
@@ -1,0 +1,133 @@
+"""Tests for the managed-service manifest contract lint
+(scripts/check_manifests.py)."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_manifests",
+    Path(__file__).resolve().parent.parent / "scripts" / "check_manifests.py",
+)
+check_manifests = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(check_manifests)  # type: ignore[union-attr]
+
+
+def _write(root: Path, sid: str, manifest: dict) -> None:
+    d = root / "services" / sid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "manifest.yaml").write_text(yaml.safe_dump(manifest))
+
+
+def _managed_ok(sid: str = "rkllama") -> dict:
+    return {
+        "id": sid,
+        "type": "service",
+        "category": "llm-runtime",
+        "lifecycle": {
+            "backend_type": "rkllama",
+            "auto_manage": True,
+            "unit": f"{sid}.service",
+            "scope": "system",
+            "health": {"url": "http://localhost:7833/api/tags", "expect": '"models"'},
+        },
+    }
+
+
+def test_valid_managed_manifest_passes(tmp_path: Path) -> None:
+    _write(tmp_path, "rkllama", _managed_ok())
+    assert check_manifests.lint_managed(tmp_path) == []
+
+
+def test_auto_manage_without_unit_fails(tmp_path: Path) -> None:
+    m = _managed_ok()
+    del m["lifecycle"]["unit"]
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert len(errors) == 1
+    assert "lifecycle.unit" in errors[0]
+
+
+def test_auto_manage_without_health_fails(tmp_path: Path) -> None:
+    m = _managed_ok()
+    del m["lifecycle"]["health"]
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert "lifecycle.health" in errors[0]
+
+
+def test_invalid_scope_fails(tmp_path: Path) -> None:
+    m = _managed_ok()
+    m["lifecycle"]["scope"] = "root"
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("scope is 'root'" in e for e in errors)
+
+
+def test_non_managed_service_is_ignored(tmp_path: Path) -> None:
+    # auto_manage false -> not claiming managed, no unit/health required
+    m = {
+        "id": "rk-llama-cpp",
+        "type": "service",
+        "category": "llm-runtime",
+        "lifecycle": {"backend_type": "openai-compatible", "auto_manage": False},
+    }
+    _write(tmp_path, "rk-llama-cpp", m)
+    assert check_manifests.lint_managed(tmp_path) == []
+
+
+def test_service_without_lifecycle_is_ignored(tmp_path: Path) -> None:
+    _write(tmp_path, "ollama", {"id": "ollama", "type": "service"})
+    assert check_manifests.lint_managed(tmp_path) == []
+
+
+def test_grandfathered_service_is_skipped(tmp_path: Path, monkeypatch) -> None:
+    m = _managed_ok("legacy-backend")
+    del m["lifecycle"]["unit"]  # would normally fail
+    _write(tmp_path, "legacy-backend", m)
+    monkeypatch.setattr(
+        check_manifests, "GRANDFATHER", {"legacy-backend": "pre-systemd, tracked in #NNNN"}
+    )
+    assert check_manifests.lint_managed(tmp_path) == []
+
+
+def test_non_bool_auto_manage_is_flagged_and_enforced(tmp_path: Path) -> None:
+    # A quoted "true" must not slip past the identity check.
+    m = _managed_ok()
+    m["lifecycle"]["auto_manage"] = "true"
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("must be a boolean true" in e for e in errors)
+
+
+def test_unparseable_yaml_is_an_error(tmp_path: Path) -> None:
+    d = tmp_path / "services" / "broken"
+    d.mkdir(parents=True)
+    (d / "manifest.yaml").write_text("id: broken\nlifecycle: {: bad")
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("not valid YAML" in e for e in errors)
+
+
+def test_unit_without_service_suffix_is_flagged(tmp_path: Path) -> None:
+    m = _managed_ok()
+    m["lifecycle"]["unit"] = "rkllama"  # missing .service
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("ending in .service" in e for e in errors)
+
+
+def test_non_string_expect_is_flagged(tmp_path: Path) -> None:
+    m = _managed_ok()
+    m["lifecycle"]["health"]["expect"] = ["models"]
+    _write(tmp_path, "rkllama", m)
+    errors = check_manifests.lint_managed(tmp_path)
+    assert any("expect must be a string" in e for e in errors)
+
+
+def test_real_catalog_is_clean() -> None:
+    """The shipped app-catalog must pass the managed-service lint."""
+    root = Path(__file__).resolve().parent.parent / "app-catalog"
+    errors = check_manifests.lint_managed(root)
+    assert errors == [], "real catalog failed managed-lint:\n" + "\n".join(errors)

--- a/tests/test_cluster_worker_protocol.py
+++ b/tests/test_cluster_worker_protocol.py
@@ -201,3 +201,188 @@ class TestHeartbeatVram:
         w = mgr.get_worker("w1")
         assert w.free_vram_mb == 0
         assert w.used_vram_mb == 0
+
+
+# ---------------------------------------------------------------------------
+# WorkerInfo available_models field (local worker manifest)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerInfoAvailableModels:
+    def test_default_is_empty_list(self):
+        """available_models defaults to empty list when not provided."""
+        w = WorkerInfo(name="w", url="http://localhost:9000")
+        assert w.available_models == []
+
+    def test_custom_value_stored(self):
+        w = WorkerInfo(
+            name="w",
+            url="http://localhost:9000",
+            available_models=[
+                {"model_id": "qwen3-embedding-8b", "status": "available"},
+            ],
+        )
+        assert len(w.available_models) == 1
+        assert w.available_models[0]["model_id"] == "qwen3-embedding-8b"
+
+    def test_serialises_via_asdict(self):
+        w = WorkerInfo(
+            name="w",
+            url="http://localhost:9000",
+            available_models=[
+                {"model_id": "kokoro-v1.0", "status": "available"},
+            ],
+        )
+        d = asdict(w)
+        assert "available_models" in d
+        assert d["available_models"][0]["model_id"] == "kokoro-v1.0"
+
+    def test_roundtrip(self):
+        models = [
+            {"model_id": "a", "status": "loaded"},
+            {"model_id": "b", "status": "available"},
+        ]
+        w = WorkerInfo(
+            name="w",
+            url="http://localhost:9000",
+            available_models=models,
+        )
+        d = asdict(w)
+        w2 = WorkerInfo(**{k: v for k, v in d.items() if not isinstance(v, bytes)})
+        assert w2.available_models == models
+
+    def test_roundtrip_default(self):
+        w = WorkerInfo(name="w", url="http://localhost:9000")
+        d = asdict(w)
+        w2 = WorkerInfo(**{k: v for k, v in d.items() if not isinstance(v, bytes)})
+        assert w2.available_models == []
+
+
+# ---------------------------------------------------------------------------
+# ClusterManager heartbeat available_models derivation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestHeartbeatAvailableModels:
+    async def _register(self, mgr: ClusterManager, name: str) -> WorkerInfo:
+        w = WorkerInfo(name=name, url=f"http://localhost:900{name[-1]}")
+        await mgr.register_worker(w)
+        return w
+
+    async def test_heartbeat_derives_from_backends(self):
+        """available_models is derived from backend entries at heartbeat."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        backends = [
+            {
+                "name": "llama-cpp:8080",
+                "type": "llama-cpp",
+                "url": "http://localhost:8080",
+                "available_models": [
+                    {"model_id": "qwen3-embedding-8b", "status": "available"},
+                    {"model_id": "phi4", "status": "loaded"},
+                ],
+            },
+        ]
+        mgr.heartbeat("w1", backends=backends)
+        w = mgr.get_worker("w1")
+        assert len(w.available_models) == 2
+        model_ids = {m["model_id"] for m in w.available_models}
+        assert model_ids == {"qwen3-embedding-8b", "phi4"}
+
+    async def test_heartbeat_dedupes_across_backends(self):
+        """Duplicate model_ids across backends are deduplicated."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        backends = [
+            {
+                "name": "llama-cpp:8080",
+                "type": "llama-cpp",
+                "url": "http://localhost:8080",
+                "available_models": [
+                    {"model_id": "qwen3-embedding-8b", "status": "available"},
+                ],
+            },
+            {
+                "name": "llama-cpp:8081",
+                "type": "llama-cpp",
+                "url": "http://localhost:8081",
+                "available_models": [
+                    {"model_id": "qwen3-embedding-8b", "status": "loaded"},
+                ],
+            },
+        ]
+        mgr.heartbeat("w1", backends=backends)
+        w = mgr.get_worker("w1")
+        # Deduplicated: same model_id appears once.
+        assert len(w.available_models) == 1
+        assert w.available_models[0]["model_id"] == "qwen3-embedding-8b"
+
+    async def test_heartbeat_additive_across_backends(self):
+        """Different model_ids from different backends all appear."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        backends = [
+            {
+                "name": "llama-cpp:8080",
+                "type": "llama-cpp",
+                "url": "http://localhost:8080",
+                "available_models": [
+                    {"model_id": "a", "status": "available"},
+                ],
+            },
+            {
+                "name": "kokoro:8880",
+                "type": "kokoro",
+                "url": "http://localhost:8880",
+                "available_models": [
+                    {"model_id": "b", "status": "available"},
+                ],
+            },
+        ]
+        mgr.heartbeat("w1", backends=backends)
+        w = mgr.get_worker("w1")
+        assert len(w.available_models) == 2
+
+    async def test_heartbeat_empty_backends_clears(self):
+        """Heartbeat with no backends (or no available_models) clears the list."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        # First heartbeat with models
+        mgr.heartbeat("w1", backends=[
+            {
+                "name": "llama-cpp:8080",
+                "type": "llama-cpp",
+                "url": "http://localhost:8080",
+                "available_models": [
+                    {"model_id": "a", "status": "available"},
+                ],
+            },
+        ])
+        w = mgr.get_worker("w1")
+        assert len(w.available_models) == 1
+
+        # Heartbeat with empty backends — no available_models
+        mgr.heartbeat("w1", backends=[])
+        w = mgr.get_worker("w1")
+        assert w.available_models == []
+
+    async def test_heartbeat_no_backends_preserves_prior(self):
+        """Heartbeat without backends parameter preserves prior available_models."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        mgr.heartbeat(
+            "w1",
+            backends=[{
+                "name": "t",
+                "type": "llama-cpp",
+                "url": "http://localhost:8000",
+                "available_models": [{"model_id": "x", "status": "loaded"}],
+            }],
+        )
+        # Sparse heartbeat — only load, no backends
+        mgr.heartbeat("w1", load=0.5)
+        w = mgr.get_worker("w1")
+        assert len(w.available_models) == 1
+        assert w.available_models[0]["model_id"] == "x"

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -1,0 +1,118 @@
+"""Headless Headscale mesh membership (taOSgo Slice 2). Everything shells to
+`tailscale` and must be fail-soft: a host without the binary degrades to a
+structured "not available" result, never raises."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from tinyagentos.taosnet import mesh
+
+
+def _run_returns(rc, out="", err=""):
+    async def _fake(args, timeout=30.0):
+        return rc, out, err
+    return _fake
+
+
+class TestInstalledGuard:
+    def test_not_installed_short_circuits(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=False):
+            import asyncio
+            r = asyncio.run(mesh.mesh_up("key", "host"))
+            assert r == {"ok": False, "detail": "tailscale not installed"}
+            s = asyncio.run(mesh.mesh_status())
+            assert s["joined"] is False and "not installed" in s["detail"]
+            assert asyncio.run(mesh.is_joined()) is False
+
+    def test_login_server_env_override(self, monkeypatch):
+        monkeypatch.setenv("TAOS_HEADSCALE_URL", "https://hs.staging.example/")
+        assert mesh.login_server() == "https://hs.staging.example"
+        monkeypatch.delenv("TAOS_HEADSCALE_URL", raising=False)
+        assert mesh.login_server() == "https://hs.taos.my"
+
+
+@pytest.mark.asyncio
+class TestMeshUp:
+    async def test_missing_args(self):
+        assert (await mesh.mesh_up("", "host"))["ok"] is False
+        assert (await mesh.mesh_up("key", ""))["ok"] is False
+
+    async def test_up_success(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0)):
+            r = await mesh.mesh_up("preauth", "myhost", ls="https://hs.taos.my")
+        assert r["ok"] is True and "hs.taos.my" in r["detail"]
+
+    async def test_up_failure_is_fail_soft(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(1, err="invalid key")):
+            r = await mesh.mesh_up("bad", "myhost")
+        assert r["ok"] is False and "invalid key" in r["detail"]
+
+    async def test_up_passes_expected_args(self):
+        captured = {}
+
+        async def _capture(args, timeout=60.0):
+            captured["args"] = args
+            return 0, "", ""
+
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _capture):
+            await mesh.mesh_up("PA", "node-1", ls="https://hs.x")
+        a = captured["args"]
+        assert a[:2] == ["tailscale", "up"]
+        assert "--authkey" in a and "PA" in a
+        assert "--hostname" in a and "node-1" in a
+        assert "--login-server" in a and "https://hs.x" in a
+
+
+@pytest.mark.asyncio
+class TestMeshStatus:
+    _STATUS = {
+        "BackendState": "Running",
+        "CurrentTailnet": {"Name": "jason"},
+        "Self": {"Online": True, "HostName": "node-1", "TailscaleIPs": ["100.64.0.5"]},
+    }
+
+    async def test_joined_parse(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out=json.dumps(self._STATUS))):
+            s = await mesh.mesh_status()
+        assert s["joined"] is True
+        assert s["tailnet"] == "jason"
+        assert s["node_ip"] == "100.64.0.5"
+        assert s["hostname"] == "node-1"
+
+    async def test_not_running_not_joined(self):
+        stopped = {"BackendState": "Stopped", "Self": {}}
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out=json.dumps(stopped))):
+            s = await mesh.mesh_status()
+        assert s["joined"] is False
+
+    async def test_unparseable_status_fail_soft(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out="not-json")):
+            s = await mesh.mesh_status()
+        assert s["joined"] is False and "unparseable" in s["detail"]
+
+    async def test_status_nonzero_fail_soft(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(1, err="not running")):
+            s = await mesh.mesh_status()
+        assert s["joined"] is False and "not running" in s["detail"]
+
+
+@pytest.mark.asyncio
+class TestMeshDown:
+    async def test_down_success(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0)):
+            assert (await mesh.mesh_down())["ok"] is True
+
+    async def test_down_not_installed(self):
+        with patch.object(mesh, "is_tailscale_installed", return_value=False):
+            assert (await mesh.mesh_down())["ok"] is False

--- a/tests/test_mesh_credentials.py
+++ b/tests/test_mesh_credentials.py
@@ -103,7 +103,7 @@ class TestPollIntercept:
     def test_ready_payload_persists_and_strips_tokens(self, data_dir):
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
-        out = _persist_join_credentials(self._resp(_READY))
+        out, _ji = _persist_join_credentials(self._resp(_READY))
         # Persisted server-side.
         assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
         assert mesh_credentials.get_sites_token() == "sites.jwt.bbb"
@@ -119,21 +119,21 @@ class TestPollIntercept:
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
         pending = {"status": "pending"}
-        out = _persist_join_credentials(self._resp(pending))
+        out, _ji = _persist_join_credentials(self._resp(pending))
         assert json.loads(out.body) == pending
         assert mesh_credentials.has_mesh_credentials() is False
 
     def test_non_200_untouched(self, data_dir):
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
-        out = _persist_join_credentials(self._resp({"error": "nope"}, status=403))
+        out, _ji = _persist_join_credentials(self._resp({"error": "nope"}, status=403))
         assert out.status_code == 403
         assert mesh_credentials.has_mesh_credentials() is False
 
     def test_non_json_untouched(self, data_dir):
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
-        out = _persist_join_credentials(self._resp(b"<html>oops</html>", media="text/html"))
+        out, _ji = _persist_join_credentials(self._resp(b"<html>oops</html>", media="text/html"))
         assert out.body == b"<html>oops</html>"
         assert mesh_credentials.has_mesh_credentials() is False
 
@@ -143,7 +143,7 @@ class TestPollIntercept:
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
         bad = {"status": "ready", "controller_token": "ctl.leak", "sites_token": "s.leak"}
-        out = _persist_join_credentials(self._resp(bad))
+        out, _ji = _persist_join_credentials(self._resp(bad))
         browser = json.loads(out.body)
         assert "controller_token" not in browser and "sites_token" not in browser
         assert mesh_credentials.has_mesh_credentials() is False  # save did fail
@@ -153,7 +153,36 @@ class TestPollIntercept:
         # stripping (parsing does not depend on media_type).
         from tinyagentos.routes.account_proxy import _persist_join_credentials
 
-        out = _persist_join_credentials(self._resp(_READY, media=None))
+        out, _ji = _persist_join_credentials(self._resp(_READY, media=None))
         browser = json.loads(out.body)
         assert "controller_token" not in browser
         assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
+
+    def test_preauth_key_stripped_and_join_intent_returned(self, data_dir):
+        # Slice 2: the single-use preauth key is stripped from the browser body
+        # (consumed server-side) and surfaced as a join intent for the caller.
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out, join_intent = _persist_join_credentials(self._resp(_READY))
+        browser = json.loads(out.body)
+        assert "headscale_preauth_key" not in browser
+        assert join_intent == {"preauth_key": "SINGLE-USE-SECRET", "hostname": "host_9"}
+
+    def test_preauth_only_no_service_token_still_stripped(self, data_dir):
+        # A ready payload carrying ONLY the preauth key (no service tokens) must
+        # still fire + strip it -- the "ALWAYS strip" guarantee cannot hinge on a
+        # service token being present.
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        pre_only = {"status": "ready", "host_id": "h", "headscale_preauth_key": "PK"}
+        out, join_intent = _persist_join_credentials(self._resp(pre_only))
+        assert "headscale_preauth_key" not in json.loads(out.body)
+        assert join_intent == {"preauth_key": "PK", "hostname": "h"}
+        assert mesh_credentials.has_mesh_credentials() is False  # no controller token
+
+    def test_no_preauth_means_no_join_intent(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        no_pre = {k: v for k, v in _READY.items() if k != "headscale_preauth_key"}
+        _out, join_intent = _persist_join_credentials(self._resp(no_pre))
+        assert join_intent is None

--- a/tests/test_mesh_credentials.py
+++ b/tests/test_mesh_credentials.py
@@ -1,0 +1,159 @@
+"""Host-local mesh credential store + the cluster-join poll-intercept that
+populates it (taOSgo Slice 1). The persisted service tokens must land 0600
+server-side and never appear in the browser-facing poll body."""
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from tinyagentos.taosnet import mesh_credentials, passkey_client
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
+    # Clear any env overrides so the file is the source of truth.
+    monkeypatch.delenv("TAOS_CONTROLLER_TOKEN", raising=False)
+    monkeypatch.delenv("TAOS_SITES_TOKEN", raising=False)
+    return tmp_path
+
+
+_READY = {
+    "status": "ready",
+    "account_id": "acct_1",
+    "host_id": "host_9",
+    "tailnet_name": "jason",
+    "headscale_preauth_key": "SINGLE-USE-SECRET",
+    "controller_token": "ctl.jwt.aaa",
+    "sites_token": "sites.jwt.bbb",
+    "joined_at": "2026-07-10T00:00:00Z",
+}
+
+
+class TestStore:
+    def test_round_trip(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
+        assert mesh_credentials.get_sites_token() == "sites.jwt.bbb"
+        assert mesh_credentials.get_host_id() == "host_9"
+        assert mesh_credentials.has_mesh_credentials() is True
+
+    def test_preauth_key_is_not_persisted(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        on_disk = json.loads((data_dir / "mesh_credentials.json").read_text())
+        assert "headscale_preauth_key" not in on_disk
+        assert on_disk["controller_token"] == "ctl.jwt.aaa"
+
+    def test_file_is_0600(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        mode = stat.S_IMODE(os.stat(data_dir / "mesh_credentials.json").st_mode)
+        assert mode == 0o600
+
+    def test_missing_required_fields_raise(self, data_dir):
+        with pytest.raises(ValueError):
+            mesh_credentials.save_mesh_credentials({"controller_token": "x"})  # no host_id
+        with pytest.raises(ValueError):
+            mesh_credentials.save_mesh_credentials({"host_id": "h"})  # no controller_token
+
+    def test_idempotent_resave(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        mesh_credentials.save_mesh_credentials(_READY)  # re-poll: same data, no error
+        assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
+
+    def test_none_before_join(self, data_dir):
+        assert mesh_credentials.get_controller_token() is None
+        assert mesh_credentials.get_sites_token() is None
+        assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_env_override_wins(self, data_dir, monkeypatch):
+        mesh_credentials.save_mesh_credentials(_READY)
+        monkeypatch.setenv("TAOS_CONTROLLER_TOKEN", "env-override")
+        assert mesh_credentials.get_controller_token() == "env-override"
+
+    def test_clear(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        mesh_credentials.clear()
+        assert mesh_credentials.get_controller_token() is None
+        mesh_credentials.clear()  # no-op when already gone
+
+    def test_corrupt_non_dict_file_is_treated_as_absent(self, data_dir):
+        # An external edit / corruption leaving a non-object must not raise from
+        # the getters (which would break the headless passkey fetch).
+        (data_dir / "mesh_credentials.json").write_text("[1, 2, 3]")
+        assert mesh_credentials.get_controller_token() is None
+        assert mesh_credentials.get_sites_token() is None
+        assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_passkey_client_delegates(self, data_dir):
+        mesh_credentials.save_mesh_credentials(_READY)
+        # The download-manager import path reads the persisted token now.
+        assert passkey_client.get_controller_token() == "ctl.jwt.aaa"
+
+
+class TestPollIntercept:
+    def _resp(self, body, status=200, media="application/json"):
+        from fastapi import Response
+
+        content = json.dumps(body).encode() if isinstance(body, (dict, list)) else body
+        return Response(content=content, status_code=status, media_type=media)
+
+    def test_ready_payload_persists_and_strips_tokens(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out = _persist_join_credentials(self._resp(_READY))
+        # Persisted server-side.
+        assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"
+        assert mesh_credentials.get_sites_token() == "sites.jwt.bbb"
+        # Stripped from the browser-facing body.
+        browser = json.loads(out.body)
+        assert "controller_token" not in browser
+        assert "sites_token" not in browser
+        # Non-secret status fields survive for the UI.
+        assert browser["status"] == "ready"
+        assert browser["tailnet_name"] == "jason"
+
+    def test_pending_payload_untouched(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        pending = {"status": "pending"}
+        out = _persist_join_credentials(self._resp(pending))
+        assert json.loads(out.body) == pending
+        assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_non_200_untouched(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out = _persist_join_credentials(self._resp({"error": "nope"}, status=403))
+        assert out.status_code == 403
+        assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_non_json_untouched(self, data_dir):
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out = _persist_join_credentials(self._resp(b"<html>oops</html>", media="text/html"))
+        assert out.body == b"<html>oops</html>"
+        assert mesh_credentials.has_mesh_credentials() is False
+
+    def test_tokens_stripped_even_when_save_fails(self, data_dir):
+        # controller_token present but host_id missing -> save_mesh_credentials
+        # raises. The token must STILL be stripped (never leaked to compensate).
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        bad = {"status": "ready", "controller_token": "ctl.leak", "sites_token": "s.leak"}
+        out = _persist_join_credentials(self._resp(bad))
+        browser = json.loads(out.body)
+        assert "controller_token" not in browser and "sites_token" not in browser
+        assert mesh_credentials.has_mesh_credentials() is False  # save did fail
+
+    def test_json_without_content_type_is_still_stripped(self, data_dir):
+        # A JSON body served without a Content-Type header must not bypass
+        # stripping (parsing does not depend on media_type).
+        from tinyagentos.routes.account_proxy import _persist_join_credentials
+
+        out = _persist_join_credentials(self._resp(_READY, media=None))
+        browser = json.loads(out.body)
+        assert "controller_token" not in browser
+        assert mesh_credentials.get_controller_token() == "ctl.jwt.aaa"

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -9,6 +9,56 @@ class _FakeAuthRequestsStore:
         return None
 
 
+class TestRequestableScopes:
+    """The project_tasks scope must be requestable through the consent loop, and
+    unknown scopes must still be rejected up front (they can never be enforced)."""
+
+    def test_project_tasks_is_a_valid_scope(self):
+        from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
+        assert "project_tasks" in VALID_SCOPES
+
+    @pytest.mark.asyncio
+    async def test_create_accepts_project_tasks(self, client, monkeypatch):
+        class _Store(_FakeAuthRequestsStore):
+            async def count_pending_for(self, identity_claim, framework):
+                return 0
+
+            async def create(self, **kwargs):
+                return {
+                    "id": "req-1",
+                    "identity_claim": kwargs["identity_claim"],
+                    "requested_scopes": kwargs["requested_scopes"],
+                }
+
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", _Store())
+        resp = await client.post(
+            "/api/agents/auth-requests",
+            json={
+                "identity_claim": "grok",
+                "framework": "grok-cli",
+                "requested_scopes": ["project_tasks"],
+                "project_id": "prj-1",
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_unknown_scope(self, client, monkeypatch):
+        monkeypatch.setattr(
+            client._transport.app.state, "auth_requests", _FakeAuthRequestsStore()
+        )
+        resp = await client.post(
+            "/api/agents/auth-requests",
+            json={
+                "identity_claim": "grok",
+                "framework": "grok-cli",
+                "requested_scopes": ["not_a_real_scope"],
+            },
+        )
+        assert resp.status_code == 400
+
+
 class TestAgentAuthRequestsList:
     @pytest.mark.asyncio
     async def test_list_returns_200_with_requests_key(self, client, monkeypatch):

--- a/tests/test_routes_game_assets.py
+++ b/tests/test_routes_game_assets.py
@@ -1,0 +1,201 @@
+"""Route tests for the Game Studio texture/sprite generation endpoint.
+
+ComfyUI is not installed in CI, so the ComfyUI client is patched in every test
+that reaches a backend — no real generation happens.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tinyagentos.asset_gen.comfyui_client import ComfyUIResult
+
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\x00\x01"
+    b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+GAME_FILES = {"index.html": "<!doctype html><html></html>", "game.js": "// game"}
+
+
+def _set_gpu_tier(app):
+    """Give the host a discrete GPU so the resolver picks the SDXL tier."""
+    app.state.backend_catalog = None
+    app.state.hardware_profile = SimpleNamespace(
+        gpu=SimpleNamespace(cuda=True, rocm=False),
+        npu=SimpleNamespace(type="none"),
+    )
+
+
+def _set_no_accelerator(app):
+    app.state.backend_catalog = None
+    app.state.hardware_profile = SimpleNamespace(
+        gpu=SimpleNamespace(cuda=False, rocm=False),
+        npu=SimpleNamespace(type="none"),
+    )
+
+
+def _patch_client(result):
+    """Patch ComfyUIClient so .generate() returns *result* without any network."""
+    fake = MagicMock()
+    fake.generate = AsyncMock(return_value=result)
+    return patch("tinyagentos.routes.game_assets.ComfyUIClient", return_value=fake)
+
+
+async def _save_game(client, game_id="tex-game"):
+    resp = await client.put(f"/api/games/{game_id}", json={"name": "Tex", "files": GAME_FILES})
+    assert resp.status_code == 200
+    return game_id
+
+
+@pytest.mark.asyncio
+class TestGenerateTexture:
+    async def test_success_writes_asset_and_returns_path(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client)
+
+        with _patch_client(ComfyUIResult(image_bytes=PNG_BYTES, prompt_id="p1")):
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a mossy stone texture", "kind": "texture"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["available"] is True
+        assert data["status"] == "generated"
+        assert data["tier"] == "sdxl"
+        assert data["filename"].startswith("texture-")
+        assert data["path"] == f"/api/games/{gid}/preview/{data['filename']}"
+
+        # The PNG is really in the game's file set: the preview route serves it.
+        preview = await client.get(data["path"])
+        assert preview.status_code == 200
+        assert preview.content == PNG_BYTES
+
+    async def test_sprite_kind_prefixes_filename(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "sprite-game")
+        with _patch_client(ComfyUIResult(image_bytes=PNG_BYTES, prompt_id="p1")):
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a pixel-art ship", "kind": "sprite"},
+            )
+        assert resp.json()["filename"].startswith("sprite-")
+
+    async def test_tier_unavailable_returns_available_false(self, client):
+        app = client._transport.app
+        _set_no_accelerator(app)
+        gid = await _save_game(client, "no-gpu-game")
+
+        # No client is patched: the route must short-circuit before generating.
+        resp = await client.post(
+            f"/api/games/{gid}/assets/texture",
+            json={"prompt": "a texture"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["available"] is False
+        assert "reason" in data
+
+    async def test_comfyui_failure_is_fail_soft_502(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "fail-game")
+        with _patch_client(None):  # client swallowed the error, returned None
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a texture"},
+            )
+        assert resp.status_code == 502
+        data = resp.json()
+        assert "error" in data
+        # `available` is a 200-only tier-gate signal; a 502 error body omits it
+        # (the client throws on non-2xx and reads only `.error`).
+        assert "available" not in data
+
+    async def test_asset_count_cap_returns_409(self, client, monkeypatch):
+        import tinyagentos.routes.game_assets as ga
+
+        monkeypatch.setattr(ga, "_MAX_ASSET_FILES", 1)
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "cap-game")
+        with _patch_client(ComfyUIResult(image_bytes=PNG_BYTES, prompt_id="p1")):
+            first = await client.post(
+                f"/api/games/{gid}/assets/texture", json={"prompt": "one"}
+            )
+            assert first.status_code == 200  # wrote the 1st (and only allowed) asset
+            second = await client.post(
+                f"/api/games/{gid}/assets/texture", json={"prompt": "two"}
+            )
+        assert second.status_code == 409
+        assert "error" in second.json()
+
+    async def test_empty_prompt_rejected(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "empty-prompt-game")
+        resp = await client.post(
+            f"/api/games/{gid}/assets/texture",
+            json={"prompt": "   "},
+        )
+        assert resp.status_code == 400
+
+    async def test_invalid_size_rejected(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        gid = await _save_game(client, "bad-size-game")
+        for bad in ({"width": 513}, {"width": 32}, {"height": 4096}):
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a texture", **bad},
+            )
+            assert resp.status_code == 400, bad
+
+    async def test_unknown_game_returns_404(self, client):
+        app = client._transport.app
+        _set_gpu_tier(app)
+        resp = await client.post(
+            "/api/games/does-not-exist/assets/texture",
+            json={"prompt": "a texture"},
+        )
+        assert resp.status_code == 404
+
+    async def test_invalid_game_id_returns_400(self, client):
+        resp = await client.post(
+            "/api/games/Not_Valid!/assets/texture",
+            json={"prompt": "a texture"},
+        )
+        assert resp.status_code == 400
+
+    async def test_catalog_comfyui_backend_wins(self, client):
+        """A live ComfyUI backend in the catalog resolves to the SDXL tier and
+        its URL is used to build the client."""
+        app = client._transport.app
+        catalog = MagicMock()
+        catalog.backends_with_capability.return_value = [
+            SimpleNamespace(type="comfyui", url="http://gpu-worker:8188")
+        ]
+        app.state.backend_catalog = catalog
+        app.state.hardware_profile = None
+        gid = await _save_game(client, "catalog-game")
+
+        with patch(
+            "tinyagentos.routes.game_assets.ComfyUIClient",
+            return_value=MagicMock(generate=AsyncMock(
+                return_value=ComfyUIResult(image_bytes=PNG_BYTES, prompt_id="p1")
+            )),
+        ) as MockClient:
+            resp = await client.post(
+                f"/api/games/{gid}/assets/texture",
+                json={"prompt": "a texture"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["tier"] == "sdxl"
+        MockClient.assert_called_once_with("http://gpu-worker:8188")

--- a/tests/test_routes_games.py
+++ b/tests/test_routes_games.py
@@ -199,6 +199,26 @@ class TestGamesCrud:
         resp = await client.get("/api/games/my-game")
         assert resp.json()["files"] == {"index.html": GAME_FILES["index.html"]}
 
+    async def test_save_preserves_binary_assets(self, client):
+        """Generated binary assets (textures/sprites) live in the game dir but
+        never appear in the text file set the editor PUTs. A save must not sweep
+        them, or a generated texture would vanish on the next edit."""
+        app = client._transport.app
+        await client.put("/api/games/asset-game", json={"name": "A", "files": GAME_FILES})
+        # Simulate a generated PNG written into the game dir out-of-band.
+        game_dir = app.state.data_dir / "games" / "asset-game"
+        png = b"\x89PNG\r\n\x1a\n\x00binary-not-utf8\xff\xfe"
+        (game_dir / "texture-1.png").write_bytes(png)
+        # A subsequent text-only save (full-replace) must leave the PNG intact.
+        resp = await client.put(
+            "/api/games/asset-game",
+            json={"files": {"index.html": GAME_FILES["index.html"]}},
+        )
+        assert resp.status_code == 200
+        assert (game_dir / "texture-1.png").read_bytes() == png
+        # The stale text file game.js was still swept as before.
+        assert not (game_dir / "game.js").exists()
+
     async def test_list_after_save(self, client):
         await client.put("/api/games/game-a", json={"name": "A", "files": GAME_FILES})
         await client.put("/api/games/game-b", json={"name": "B", "files": GAME_FILES})

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -1,0 +1,388 @@
+"""Agent-token access to the project kanban board (project_tasks scope).
+
+An APPROVED external agent drives ONLY its own project's task board with its
+Ed25519 registry JWT (scope project_tasks), no session cookie. These tests pin
+the five non-negotiable security invariants:
+
+  1. A token touches task routes ONLY for its own project_id claim; a different
+     project is an existence-hiding 404 (indistinguishable from a non-owner).
+  2. project_tasks grants task read + lifecycle + comments ONLY, never
+     create-task / members / project lifecycle.
+  3. The verified token's canonical_id is the authoritative actor; a lifecycle
+     body actor id that differs is rejected 403.
+  4. Session owner/admin behavior is unchanged (regression).
+  5. The token is not a skeleton key: it authenticates no route off the
+     allowlist.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import mint_registry_token
+
+
+@pytest_asyncio.fixture
+async def ctx(client):
+    """Reuse the session-admin `client` app and additionally init the agent
+    registry + grants stores so tokens can be minted against real stores."""
+    app = client._transport.app
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+    uid = app.state.auth.find_user("admin")["id"]
+    yield SimpleNamespace(client=client, app=app, uid=uid)
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+def _bare(app):
+    """Cookieless client so requests carry only the Bearer header."""
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _new_project(ctx, slug):
+    resp = await ctx.client.post("/api/projects", json={"name": slug, "slug": slug})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _new_task(ctx, pid, title="T"):
+    resp = await ctx.client.post(
+        f"/api/projects/{pid}/tasks", json={"title": title}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _mint_agent(ctx, project_id, scopes=("project_tasks",)):
+    registry = ctx.app.state.agent_registry
+    grants = ctx.app.state.agent_grants
+    priv, _pub = ctx.app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="grok",
+        display_name="Grok",
+        origin="external-selfjoin",
+        handle="@grok",
+    )
+    cid = rec["canonical_id"]
+    await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="grok", project_id=project_id
+    )
+    return cid, token
+
+
+def _hdr(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+class TestAgentCanDriveOwnBoard:
+    async def test_list_tasks(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/tasks", headers=_hdr(token))
+        assert resp.status_code == 200
+        assert any(t["id"] == tid for t in resp.json()["items"])
+
+    async def test_ready_tasks(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/ready", headers=_hdr(token)
+            )
+        assert resp.status_code == 200
+
+    async def test_get_task(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/{tid}", headers=_hdr(token)
+            )
+        assert resp.status_code == 200
+        assert resp.json()["id"] == tid
+
+    async def test_patch_task_is_session_only(self, ctx):
+        """PATCH free-mutates task fields (title/assignee_id/parent), broader than
+        the project_tasks scope, so it is NOT on the agent allowlist: an agent
+        token is rejected. Lifecycle is driven via claim/close/reopen instead."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"priority": 5},
+                headers=_hdr(token),
+            )
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_claim_own_task_as_self(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/claim",
+                json={"claimer_id": cid},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["claimed_by"] == cid
+
+    async def test_close_own_task(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/close",
+                json={"closed_by": cid},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "closed"
+
+    async def test_comments_read_and_post(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            post = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/comments",
+                json={"body": "on it", "author_id": cid},
+                headers=_hdr(token),
+            )
+            assert post.status_code == 200, post.text
+            listed = await bare.get(
+                f"/api/projects/{pid}/tasks/{tid}/comments", headers=_hdr(token)
+            )
+        assert listed.status_code == 200
+        assert len(listed.json()["items"]) == 1
+
+
+@pytest.mark.asyncio
+class TestProjectScoping:
+    async def test_different_project_is_404(self, ctx):
+        """Invariant 1: a token bound to project A must not reach project B; the
+        existence-hiding 404 is identical to a non-owner session's response."""
+        pid_a = await _new_project(ctx, "alpha")
+        pid_b = await _new_project(ctx, "bravo")
+        tid_b = await _new_task(ctx, pid_b)
+        _cid, token_a = await _mint_agent(ctx, pid_a)
+        async with _bare(ctx.app) as bare:
+            listing = await bare.get(
+                f"/api/projects/{pid_b}/tasks", headers=_hdr(token_a)
+            )
+            single = await bare.get(
+                f"/api/projects/{pid_b}/tasks/{tid_b}", headers=_hdr(token_a)
+            )
+        assert listing.status_code == 404
+        assert single.status_code == 404
+
+    async def test_context_route_respects_project_binding(self, ctx):
+        """The project-agnostic context path resolves the project from the task;
+        a token bound elsewhere still gets a 404."""
+        pid_a = await _new_project(ctx, "alpha")
+        pid_b = await _new_project(ctx, "bravo")
+        tid_b = await _new_task(ctx, pid_b)
+        _cid, token_a = await _mint_agent(ctx, pid_a)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/tasks/{tid_b}/context", headers=_hdr(token_a)
+            )
+        assert resp.status_code == 404
+
+    async def test_missing_scope_is_403(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        await _new_task(ctx, pid)
+        # Agent with a project-bound grant but NOT project_tasks.
+        _cid, token = await _mint_agent(ctx, pid, scopes=("a2a_receive",))
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/tasks", headers=_hdr(token))
+        assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestActorBinding:
+    async def test_claim_as_someone_else_is_403(self, ctx):
+        """Invariant 3: a claim body naming a different actor is rejected."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/claim",
+                json={"claimer_id": "some-other-agent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+        assert cid != "some-other-agent"
+
+    async def test_close_as_someone_else_is_403(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/close",
+                json={"closed_by": "not-me"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+    async def test_comment_as_someone_else_is_403(self, ctx):
+        """Invariant 3: a comment author is an actor id; an agent may not post a
+        comment authored as another identity."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/comments",
+                json={"body": "spoofed", "author_id": "some-other-agent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+        assert cid != "some-other-agent"
+
+    async def test_comment_as_self_succeeds_and_stores_token_id(self, ctx):
+        """The mirror of the 403 case: an agent commenting as its own canonical
+        id is accepted and the stored author is that id."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/comments",
+                json={"body": "on it", "author_id": cid},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["author_id"] == cid
+
+    async def test_comment_author_pinned_to_token_when_omitted(self, ctx):
+        """An agent may omit author_id; the route pins the comment to its own
+        canonical id rather than storing a null or caller-supplied author."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/comments",
+                json={"body": "on it"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert resp.json()["author_id"] == cid
+
+
+@pytest.mark.asyncio
+class TestExcludedRoutes:
+    """Invariant 2 + 5: project_tasks must NOT reach create-task, members, or
+    project-lifecycle routes; the token authenticates nothing off the allowlist."""
+
+    async def test_cannot_create_task(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks",
+                json={"title": "sneaky"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_cannot_add_member(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/members",
+                json={"mode": "native", "agent_id": "x"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_cannot_patch_project(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}", json={"name": "hijack"}, headers=_hdr(token)
+            )
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_cannot_delete_project(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.delete(f"/api/projects/{pid}", headers=_hdr(token))
+        assert resp.status_code in (401, 403, 404)
+
+    async def test_cannot_list_all_projects(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get("/api/projects", headers=_hdr(token))
+        assert resp.status_code == 401
+
+    async def test_cannot_read_task_audit(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/{tid}/audit", headers=_hdr(token)
+            )
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestSessionRegression:
+    """Invariant 4: the admin session path is unchanged by the dual-auth gate."""
+
+    async def test_admin_lists_tasks(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        resp = await ctx.client.get(f"/api/projects/{pid}/tasks")
+        assert resp.status_code == 200
+        assert any(t["id"] == tid for t in resp.json()["items"])
+
+    async def test_admin_claims_and_closes_as_any_actor(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        # A session admin may still act on behalf of any worker id (unchanged).
+        claim = await ctx.client.post(
+            f"/api/projects/{pid}/tasks/{tid}/claim",
+            json={"claimer_id": "worker-7"},
+        )
+        assert claim.status_code == 200
+        assert claim.json()["claimed_by"] == "worker-7"
+        close = await ctx.client.post(
+            f"/api/projects/{pid}/tasks/{tid}/close",
+            json={"closed_by": "worker-7"},
+        )
+        assert close.status_code == 200
+        assert close.json()["status"] == "closed"
+
+    async def test_unauthenticated_still_401(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/tasks")
+        assert resp.status_code == 401

--- a/tests/test_routes_system.py
+++ b/tests/test_routes_system.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -239,17 +238,6 @@ class TestRestartStatus:
         assert "error" in data
 
 
-class _FakeProc:
-    """Minimal asyncio subprocess stand-in for _restart_ai_unit tests."""
-
-    def __init__(self, returncode: int, stderr: bytes = b""):
-        self.returncode = returncode
-        self._stderr = stderr
-
-    async def communicate(self):
-        return (b"", self._stderr)
-
-
 async def _member_client(app) -> AsyncClient:
     """Cookie'd client for a non-admin member session (mirrors settings authz)."""
     auth_mgr = app.state.auth
@@ -265,15 +253,23 @@ async def _member_client(app) -> AsyncClient:
 
 
 class TestRestartAiStack:
-    """POST /api/system/ai-stack/restart -- issue #1743 backend recovery."""
+    """POST /api/system/ai-stack/restart -- issue #1743 backend recovery.
+
+    The endpoint derives its target set via ``_managed_ai_units`` (tested
+    separately below) and restarts each via ``backend_services.service_action``;
+    these tests stub both to exercise the aggregation/status logic.
+    """
 
     @pytest.mark.asyncio
     async def test_all_ok(self, client, monkeypatch):
         monkeypatch.setattr(
-            system_routes,
-            "_restart_ai_unit",
+            system_routes, "_managed_ai_units",
+            AsyncMock(return_value=[("rkllama.service", "system"), ("qmd.service", "system")]),
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "service_action",
             AsyncMock(side_effect=[
-                {"unit": "rkllama.service", "ok": True, "scope": "user"},
+                {"unit": "rkllama.service", "ok": True, "scope": "system"},
                 {"unit": "qmd.service", "ok": True, "scope": "system"},
             ]),
         )
@@ -287,10 +283,13 @@ class TestRestartAiStack:
     @pytest.mark.asyncio
     async def test_partial_recovery_reports_partial(self, client, monkeypatch):
         monkeypatch.setattr(
-            system_routes,
-            "_restart_ai_unit",
+            system_routes, "_managed_ai_units",
+            AsyncMock(return_value=[("rkllama.service", "system"), ("qmd.service", "system")]),
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "service_action",
             AsyncMock(side_effect=[
-                {"unit": "rkllama.service", "ok": True, "scope": "user"},
+                {"unit": "rkllama.service", "ok": True, "scope": "system"},
                 {"unit": "qmd.service", "ok": False, "detail": "not installed"},
             ]),
         )
@@ -304,8 +303,11 @@ class TestRestartAiStack:
     @pytest.mark.asyncio
     async def test_all_fail_reports_failed(self, client, monkeypatch):
         monkeypatch.setattr(
-            system_routes,
-            "_restart_ai_unit",
+            system_routes, "_managed_ai_units",
+            AsyncMock(return_value=[("rkllama.service", "system"), ("qmd.service", "system")]),
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "service_action",
             AsyncMock(side_effect=[
                 {"unit": "rkllama.service", "ok": False, "detail": "auth required"},
                 {"unit": "qmd.service", "ok": False, "detail": "auth required"},
@@ -317,57 +319,92 @@ class TestRestartAiStack:
         assert len(data["failed"]) == 2
 
     @pytest.mark.asyncio
+    async def test_noop_when_no_managed_backends_installed(self, client, monkeypatch):
+        # No managed backend installed on this node (e.g. non-systemd dev host):
+        # report noop rather than a misleading "failed", and never call restart.
+        monkeypatch.setattr(
+            system_routes, "_managed_ai_units", AsyncMock(return_value=[]),
+        )
+        action = AsyncMock()
+        monkeypatch.setattr(system_routes.backend_services, "service_action", action)
+        data = (await client.post("/api/system/ai-stack/restart")).json()
+        assert data["status"] == "noop"
+        assert data["restarted"] == [] and data["failed"] == []
+        action.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_non_admin_rejected_403(self, client, app, monkeypatch):
         # Guard should reject before any restart is attempted.
-        monkeypatch.setattr(
-            system_routes, "_restart_ai_unit", AsyncMock(return_value={"ok": True})
-        )
+        units = AsyncMock(return_value=[("qmd.service", "system")])
+        monkeypatch.setattr(system_routes, "_managed_ai_units", units)
         member_client = await _member_client(app)
         try:
             resp = await member_client.post("/api/system/ai-stack/restart")
         finally:
             await member_client.aclose()
         assert resp.status_code == 403
+        units.assert_not_called()
 
 
-class TestRestartAiUnit:
-    """_restart_ai_unit scope resolution + fail-soft behaviour."""
+class TestManagedAiUnits:
+    """_managed_ai_units: derive core + manifest units, filter to installed."""
+
+    def _request(self, tmp_path):
+        req = MagicMock()
+        req.app.state.registry.catalog_dir = tmp_path
+        return req
 
     @pytest.mark.asyncio
-    async def test_restart_user_scope_ok(self, monkeypatch):
-        monkeypatch.setenv("INVOCATION_ID", "test")  # force systemd-present path
-        # cat finds the unit in --user scope (rc 0), so restart uses --user.
-        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=0))
-        monkeypatch.setattr(
-            asyncio, "create_subprocess_exec", AsyncMock(return_value=_FakeProc(0))
+    async def test_unions_core_and_manifest_when_installed(self, tmp_path, monkeypatch):
+        from tinyagentos.cluster.backend_services import ManagedBackend
+
+        rk = ManagedBackend(
+            id="rkllama", unit="rkllama.service", scope="system",
+            health_url="http://localhost:7833/api/tags", health_expect='"models"',
         )
-        result = await system_routes._restart_ai_unit("rkllama.service")
-        assert result == {"unit": "rkllama.service", "ok": True, "scope": "user"}
-
-    @pytest.mark.asyncio
-    async def test_restart_failure_captures_stderr(self, monkeypatch):
-        monkeypatch.setenv("INVOCATION_ID", "test")
-        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=0))
         monkeypatch.setattr(
-            asyncio,
-            "create_subprocess_exec",
-            AsyncMock(return_value=_FakeProc(1, b"Interactive authentication required")),
+            system_routes.backend_services, "load_managed_backends", lambda root: [rk]
         )
-        result = await system_routes._restart_ai_unit("qmd.service")
-        assert result["ok"] is False
-        assert "Interactive authentication required" in result["detail"]
+        monkeypatch.setattr(
+            system_routes.backend_services, "unit_state",
+            AsyncMock(return_value={"installed": True}),
+        )
+        units = await system_routes._managed_ai_units(self._request(tmp_path))
+        # qmd (core, no manifest) + rkllama (from manifest), both installed.
+        assert set(u for u, _ in units) == {"qmd.service", "rkllama.service"}
 
     @pytest.mark.asyncio
-    async def test_not_installed_when_cat_fails_both_scopes(self, monkeypatch):
-        monkeypatch.setenv("INVOCATION_ID", "test")
-        monkeypatch.setattr(system_routes, "_systemctl_rc", AsyncMock(return_value=1))
-        result = await system_routes._restart_ai_unit("rkllama.service")
-        assert result == {"unit": "rkllama.service", "ok": False, "detail": "not installed"}
+    async def test_skips_units_not_installed_on_node(self, tmp_path, monkeypatch):
+        from tinyagentos.cluster.backend_services import ManagedBackend
+
+        rk = ManagedBackend(
+            id="rkllama", unit="rkllama.service", scope="system",
+            health_url="", health_expect="",
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "load_managed_backends", lambda root: [rk]
+        )
+
+        async def fake_state(unit, prefer=None):
+            # rkllama has migrated to another node; only qmd is installed here.
+            return {"installed": unit == "qmd.service"}
+
+        monkeypatch.setattr(system_routes.backend_services, "unit_state", fake_state)
+        units = await system_routes._managed_ai_units(self._request(tmp_path))
+        assert [u for u, _ in units] == ["qmd.service"]
 
     @pytest.mark.asyncio
-    async def test_no_systemd_fails_soft(self, monkeypatch):
-        monkeypatch.delenv("INVOCATION_ID", raising=False)
-        monkeypatch.setattr(system_routes.os.path, "exists", lambda p: False)
-        result = await system_routes._restart_ai_unit("qmd.service")
-        assert result["ok"] is False
-        assert "systemd not available" in result["detail"]
+    async def test_catalog_load_failure_still_yields_core(self, tmp_path, monkeypatch):
+        # A broken catalog must not drop qmd from recovery.
+        def boom(root):
+            raise RuntimeError("catalog unreadable")
+
+        monkeypatch.setattr(
+            system_routes.backend_services, "load_managed_backends", boom
+        )
+        monkeypatch.setattr(
+            system_routes.backend_services, "unit_state",
+            AsyncMock(return_value={"installed": True}),
+        )
+        units = await system_routes._managed_ai_units(self._request(tmp_path))
+        assert [u for u, _ in units] == ["qmd.service"]

--- a/tests/test_vram_reservation.py
+++ b/tests/test_vram_reservation.py
@@ -236,3 +236,46 @@ class TestRealProbe:
         # this will fail — that's fine, the test is a best-effort smoke.
         if res is not None:
             mgr.release(res.reservation_id)
+
+
+# ── no-probe hardware (AMD / Apple / Rockchip): fail open ────────────
+
+
+def _manager_without_probe() -> VramReservationManager:
+    """Return a manager whose probe reports no VRAM visibility (None)."""
+    mgr = VramReservationManager()
+    mgr._probe_vram = staticmethod(lambda: None)  # type: ignore[method-assign]
+    return mgr
+
+
+class TestNoProbeFailOpen:
+    """Without a VRAM probe we cannot prove insufficiency, so admission
+    fails OPEN (bookkeeping only), matching cluster claim_lease semantics.
+    A closed fail here 503s every model pull on non-NVIDIA hosts."""
+
+    @pytest.mark.asyncio
+    async def test_reserve_admits_without_probe(self):
+        mgr = _manager_without_probe()
+        res = await mgr.reserve(4096, caller="rkllama-pull:test")
+        assert res is not None
+        assert res.vram_mb == 4096
+        # Bookkeeping still recorded so a future probe-aware path sees it.
+        assert mgr.reserved_vram_mb == 4096
+        assert mgr.pending_count == 1
+        mgr.release(res.reservation_id)
+        assert mgr.reserved_vram_mb == 0
+
+    @pytest.mark.asyncio
+    async def test_stats_reports_probe_unavailable(self):
+        mgr = _manager_without_probe()
+        s = mgr.stats()
+        assert s["probe_available"] is False
+        assert s["free_vram_mb"] == 0 and s["total_vram_mb"] == 0
+
+    @pytest.mark.asyncio
+    async def test_probe_present_still_denies_real_insufficiency(self):
+        # Regression guard: fail-open applies ONLY to the no-probe case; a
+        # real probe showing insufficient VRAM must still deny.
+        mgr = _manager_with_probe(free_mb=1024, total_mb=8192)
+        res = await mgr.reserve(4096, caller="too-big")
+        assert res is None

--- a/tests/test_vram_reservation.py
+++ b/tests/test_vram_reservation.py
@@ -1,0 +1,238 @@
+"""Tests for atomic VRAM reservation (taOS #1706 TOCTOU fix).
+
+Verifies that:
+- Concurrent reserve calls cannot over-commit VRAM.
+- reserve() returns None when there's not enough VRAM.
+- release() correctly returns VRAM to the pool.
+- release() is idempotent.
+- Zero-VRAM reservations always succeed.
+- stats() reflects the current state.
+"""
+
+import asyncio
+
+import pytest
+
+from tinyagentos.vram_reservation import VramReservationManager
+
+
+# ── test helpers ────────────────────────────────────────────────────
+
+
+def _manager_with_probe(free_mb: int, total_mb: int) -> VramReservationManager:
+    """Return a manager whose _probe_vram returns fixed values."""
+    mgr = VramReservationManager()
+
+    def _fake_probe() -> tuple[int, int]:
+        return free_mb, total_mb
+
+    mgr._probe_vram = staticmethod(_fake_probe)  # type: ignore[method-assign]
+    return mgr
+
+
+# ── basic reserve / release ─────────────────────────────────────────
+
+
+class TestReserveRelease:
+    """Happy-path reserve and release."""
+
+    @pytest.mark.asyncio
+    async def test_reserve_when_vram_available(self):
+        """reserve() succeeds when enough VRAM is free."""
+        mgr = _manager_with_probe(8192, 8192)
+        reservation = await mgr.reserve(4096, caller="test")
+        assert reservation is not None
+        assert reservation.vram_mb == 4096
+        assert reservation.caller == "test"
+        assert mgr.reserved_vram_mb == 4096
+        assert mgr.pending_count == 1
+
+    @pytest.mark.asyncio
+    async def test_reserve_denied_when_insufficient(self):
+        """reserve() returns None when VRAM is too low."""
+        mgr = _manager_with_probe(2048, 8192)
+        reservation = await mgr.reserve(4096, caller="test")
+        assert reservation is None
+        assert mgr.reserved_vram_mb == 0
+        assert mgr.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_release_returns_vram(self):
+        """release() returns reserved VRAM to the pool."""
+        mgr = _manager_with_probe(8192, 8192)
+        res = await mgr.reserve(4096, caller="test")
+        assert res is not None
+
+        released = mgr.release(res.reservation_id)
+        assert released is True
+        assert mgr.reserved_vram_mb == 0
+        assert mgr.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_release_idempotent(self):
+        """release() is safe to call multiple times."""
+        mgr = _manager_with_probe(8192, 8192)
+        res = await mgr.reserve(4096, caller="test")
+        assert res is not None
+
+        assert mgr.release(res.reservation_id) is True
+        assert mgr.release(res.reservation_id) is False  # already released
+        assert mgr.release("non-existent") is False
+        assert mgr.reserved_vram_mb == 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_reservations_serial(self):
+        """Serial reservations accumulate correctly."""
+        mgr = _manager_with_probe(8192, 8192)
+
+        r1 = await mgr.reserve(2000, caller="a")
+        r2 = await mgr.reserve(3000, caller="b")
+        assert r1 is not None
+        assert r2 is not None
+        assert mgr.reserved_vram_mb == 5000
+        assert mgr.pending_count == 2
+
+        mgr.release(r1.reservation_id)
+        assert mgr.reserved_vram_mb == 3000
+
+        mgr.release(r2.reservation_id)
+        assert mgr.reserved_vram_mb == 0
+
+    @pytest.mark.asyncio
+    async def test_reserve_at_boundary(self):
+        """Reserving exactly the free amount succeeds."""
+        mgr = _manager_with_probe(4096, 8192)
+        res = await mgr.reserve(4096, caller="test")
+        assert res is not None
+        assert mgr.reserved_vram_mb == 4096
+
+    @pytest.mark.asyncio
+    async def test_reserve_one_more_than_free_fails(self):
+        """Reserving free+1 fails."""
+        mgr = _manager_with_probe(4096, 8192)
+        res = await mgr.reserve(4097, caller="test")
+        assert res is None
+
+
+# ── concurrent safety ───────────────────────────────────────────────
+
+
+class TestConcurrentSafety:
+    """Two concurrent reserve calls cannot over-commit."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_reserve_only_one_admitted(self):
+        """With 8192 MiB free and each needing 5000 MiB, only one admitted."""
+        mgr = _manager_with_probe(8192, 8192)
+        results: list[bool] = []
+
+        async def try_reserve(caller: str):
+            res = await mgr.reserve(5000, caller=caller)
+            results.append(res is not None)
+
+        await asyncio.gather(try_reserve("a"), try_reserve("b"))
+
+        admitted = sum(results)
+        assert admitted == 1, f"Expected 1 admission, got {admitted}: {results}"
+        assert mgr.reserved_vram_mb == 5000
+
+    @pytest.mark.asyncio
+    async def test_concurrent_vram_accounting(self):
+        """After two serial reserves filling VRAM, a third fails."""
+        mgr = _manager_with_probe(8192, 8192)
+
+        r1 = await mgr.reserve(4000, caller="a")
+        r2 = await mgr.reserve(4000, caller="b")
+        assert r1 is not None
+        assert r2 is not None
+
+        # Third should fail — only 192 MiB effective left.
+        r3 = await mgr.reserve(4000, caller="c")
+        assert r3 is None
+        assert mgr.reserved_vram_mb == 8000
+
+
+# ── zero / negative VRAM ────────────────────────────────────────────
+
+
+class TestZeroVram:
+    """Zero-VRAM reservations always succeed as lightweight markers."""
+
+    @pytest.mark.asyncio
+    async def test_zero_vram_reservation(self):
+        mgr = _manager_with_probe(0, 0)
+        res = await mgr.reserve(0, caller="noop")
+        assert res is not None
+        assert res.vram_mb == 0
+        assert mgr.reserved_vram_mb == 0
+        assert mgr.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_negative_vram_reservation(self):
+        mgr = _manager_with_probe(8192, 8192)
+        res = await mgr.reserve(-1, caller="test")
+        assert res is not None
+        assert res.vram_mb == 0
+        assert mgr.reserved_vram_mb == 0
+        assert mgr.pending_count == 0
+
+
+# ── available_vram / stats ──────────────────────────────────────────
+
+
+class TestAvailableVram:
+    """available_vram() and stats() reflect current state."""
+
+    @pytest.mark.asyncio
+    async def test_available_vram_no_reservations(self):
+        mgr = _manager_with_probe(8192, 16384)
+        free, total = mgr.available_vram()
+        assert free == 8192
+        assert total == 16384
+
+    @pytest.mark.asyncio
+    async def test_available_vram_with_reservations(self):
+        mgr = _manager_with_probe(8192, 16384)
+        res = await mgr.reserve(3000, caller="test")
+        assert res is not None
+
+        free, total = mgr.available_vram()
+        assert free == 5192  # 8192 - 3000
+        assert total == 16384
+
+    @pytest.mark.asyncio
+    async def test_stats(self):
+        mgr = _manager_with_probe(8192, 16384)
+
+        s = mgr.stats()
+        assert s["free_vram_mb"] == 8192
+        assert s["total_vram_mb"] == 16384
+        assert s["reserved_vram_mb"] == 0
+        assert s["effective_free_mb"] == 8192
+        assert s["pending_reservations"] == 0
+
+        res = await mgr.reserve(4096, caller="test")
+        assert res is not None
+
+        s = mgr.stats()
+        assert s["reserved_vram_mb"] == 4096
+        assert s["effective_free_mb"] == 4096
+        assert s["pending_reservations"] == 1
+
+
+# ── real probe (integration smoke test) ─────────────────────────────
+
+
+class TestRealProbe:
+    """Smoke-test with the real nvidia-smi probe (if available)."""
+
+    @pytest.mark.asyncio
+    async def test_reserve_with_real_probe(self):
+        """Reserving 1 MiB should always succeed on a real GPU."""
+        mgr = VramReservationManager()
+        res = await mgr.reserve(1, caller="smoke-test")
+        # On a system with nvidia-smi and some free VRAM, this should succeed.
+        # On a system without nvidia-smi, the probe returns (0, 0) so
+        # this will fail — that's fine, the test is a best-effort smoke.
+        if res is not None:
+            mgr.release(res.reservation_id)

--- a/tests/test_worker_manifest.py
+++ b/tests/test_worker_manifest.py
@@ -1,0 +1,225 @@
+"""Tests for tinyagentos.worker.worker_manifest — local manifest parser."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from tinyagentos.worker.worker_manifest import (
+    DEFAULT_MANIFEST_PATH,
+    SOFTWARE_TO_BACKEND_TYPE,
+    load_manifest,
+)
+
+
+# ---------------------------------------------------------------------------
+# SOFTWARE_TO_BACKEND_TYPE mapping
+# ---------------------------------------------------------------------------
+
+
+class TestSoftwareMapping:
+    def test_llamacpp_maps_to_llama_cpp(self):
+        assert SOFTWARE_TO_BACKEND_TYPE["llamacpp"] == "llama-cpp"
+
+    def test_embed_maps_to_llama_cpp(self):
+        assert SOFTWARE_TO_BACKEND_TYPE["embed"] == "llama-cpp"
+
+    def test_kokoro_maps_to_kokoro(self):
+        assert SOFTWARE_TO_BACKEND_TYPE["kokoro"] == "kokoro"
+
+    def test_whisper_maps_to_whisper(self):
+        assert SOFTWARE_TO_BACKEND_TYPE["whisper"] == "whisper"
+
+
+# ---------------------------------------------------------------------------
+# load_manifest — file-based tests
+# ---------------------------------------------------------------------------
+
+
+class TestLoadManifest:
+    def test_returns_empty_on_missing_file(self):
+        """When the manifest file does not exist, return an empty manifest."""
+        result = load_manifest("/nonexistent/path/worker-models.json")
+        assert result == {"resource_id": "", "models": []}
+
+    def test_parses_valid_manifest(self):
+        """A valid JSON manifest is parsed correctly."""
+        manifest = {
+            "resource_id": "worker-1:gpu-cuda-0",
+            "models": [
+                {
+                    "model_id": "qwen3-embedding-8b",
+                    "capability": "embed",
+                    "software": "embed",
+                    "port": 8080,
+                    "vram_required_gb": 8.0,
+                    "health_url": "http://localhost:8080/health",
+                },
+                {
+                    "model_id": "kokoro-v1.0",
+                    "capability": "tts",
+                    "software": "kokoro",
+                    "port": 8880,
+                    "vram_required_gb": 0.5,
+                    "health_url": "http://localhost:8880/health",
+                },
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(manifest, f)
+            tmp_path = f.name
+
+        try:
+            result = load_manifest(tmp_path)
+            assert result["resource_id"] == "worker-1:gpu-cuda-0"
+            assert len(result["models"]) == 2
+            assert result["models"][0]["model_id"] == "qwen3-embedding-8b"
+            assert result["models"][1]["model_id"] == "kokoro-v1.0"
+        finally:
+            os.unlink(tmp_path)
+
+    def test_manifest_with_empty_models(self):
+        """A manifest with an empty models list."""
+        manifest = {"resource_id": "worker-1:gpu-cuda-0", "models": []}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(manifest, f)
+            tmp_path = f.name
+
+        try:
+            result = load_manifest(tmp_path)
+            assert result["resource_id"] == "worker-1:gpu-cuda-0"
+            assert result["models"] == []
+        finally:
+            os.unlink(tmp_path)
+
+    def test_invalid_json_raises(self):
+        """Invalid JSON raises json.JSONDecodeError."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            f.write("not valid json {{{")
+            tmp_path = f.name
+
+        try:
+            with pytest.raises(json.JSONDecodeError):
+                load_manifest(tmp_path)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_env_var_overrides_path(self, monkeypatch):
+        """TAOS_WORKER_MANIFEST env var overrides the default path."""
+        manifest = {"resource_id": "custom-path", "models": []}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(manifest, f)
+            tmp_path = f.name
+
+        try:
+            monkeypatch.setenv("TAOS_WORKER_MANIFEST", tmp_path)
+            result = load_manifest()
+            assert result["resource_id"] == "custom-path"
+        finally:
+            os.unlink(tmp_path)
+
+    def test_explicit_path_overrides_env_var(self, monkeypatch):
+        """Explicit path argument wins over the env var."""
+        manifest_env = {"resource_id": "from-env", "models": []}
+        manifest_arg = {"resource_id": "from-arg", "models": []}
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(manifest_env, f)
+            env_path = f.name
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(manifest_arg, f)
+            arg_path = f.name
+
+        try:
+            monkeypatch.setenv("TAOS_WORKER_MANIFEST", env_path)
+            result = load_manifest(arg_path)
+            assert result["resource_id"] == "from-arg"
+        finally:
+            os.unlink(env_path)
+            os.unlink(arg_path)
+
+    def test_default_path_fallback(self, monkeypatch):
+        """Without env var or explicit path, DEFAULT_MANIFEST_PATH is used."""
+        monkeypatch.delenv("TAOS_WORKER_MANIFEST", raising=False)
+        # The default path won't exist in test, so we get empty manifest.
+        result = load_manifest()
+        assert result == {"resource_id": "", "models": []}
+        # Verify the constant is what we expect.
+        assert DEFAULT_MANIFEST_PATH == "/etc/taos/worker-models.json"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestLoadManifestEdgeCases:
+    def test_empty_file_raises(self):
+        """An empty file is not valid JSON."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            f.write("")
+            tmp_path = f.name
+
+        try:
+            with pytest.raises(json.JSONDecodeError):
+                load_manifest(tmp_path)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_missing_model_id_handled(self):
+        """Model entries missing model_id are still parsed."""
+        manifest = {
+            "resource_id": "w1",
+            "models": [
+                {"capability": "chat", "software": "llamacpp"},
+            ],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(manifest, f)
+            tmp_path = f.name
+
+        try:
+            result = load_manifest(tmp_path)
+            assert len(result["models"]) == 1
+            # load_manifest doesn't validate individual fields —
+            # that's the enrichment layer's job.
+        finally:
+            os.unlink(tmp_path)
+
+    def test_extra_fields_preserved(self):
+        """Unknown fields in the manifest are passed through."""
+        manifest = {
+            "resource_id": "w1",
+            "models": [{"model_id": "test", "extra_field": "surprise"}],
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(manifest, f)
+            tmp_path = f.name
+
+        try:
+            result = load_manifest(tmp_path)
+            assert "extra_field" in result["models"][0]
+            assert result["models"][0]["extra_field"] == "surprise"
+        finally:
+            os.unlink(tmp_path)

--- a/tests/test_worker_manifest.py
+++ b/tests/test_worker_manifest.py
@@ -99,8 +99,9 @@ class TestLoadManifest:
         finally:
             os.unlink(tmp_path)
 
-    def test_invalid_json_raises(self):
-        """Invalid JSON raises json.JSONDecodeError."""
+    def test_invalid_json_degrades_to_empty(self):
+        """Invalid JSON is external input: it must degrade to the empty
+        manifest (logged), never raise and take the worker down."""
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".json", delete=False
         ) as f:
@@ -108,8 +109,22 @@ class TestLoadManifest:
             tmp_path = f.name
 
         try:
-            with pytest.raises(json.JSONDecodeError):
-                load_manifest(tmp_path)
+            result = load_manifest(tmp_path)
+            assert result == {"resource_id": "", "models": []}
+        finally:
+            os.unlink(tmp_path)
+
+    def test_non_object_top_level_degrades_to_empty(self):
+        """A JSON array / scalar top level degrades to the empty manifest."""
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            f.write('["not", "an", "object"]')
+            tmp_path = f.name
+
+        try:
+            result = load_manifest(tmp_path)
+            assert result == {"resource_id": "", "models": []}
         finally:
             os.unlink(tmp_path)
 
@@ -169,8 +184,9 @@ class TestLoadManifest:
 
 
 class TestLoadManifestEdgeCases:
-    def test_empty_file_raises(self):
-        """An empty file is not valid JSON."""
+    def test_empty_file_degrades_to_empty(self):
+        """An empty file is not valid JSON; it degrades to the empty
+        manifest rather than raising (bad input must not brick the worker)."""
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".json", delete=False
         ) as f:
@@ -178,8 +194,8 @@ class TestLoadManifestEdgeCases:
             tmp_path = f.name
 
         try:
-            with pytest.raises(json.JSONDecodeError):
-                load_manifest(tmp_path)
+            result = load_manifest(tmp_path)
+            assert result == {"resource_id": "", "models": []}
         finally:
             os.unlink(tmp_path)
 

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.38"
+__version__ = "1.0.0-beta.39"

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -71,18 +71,21 @@ def _get_keypair(request: Request) -> tuple[bytes, bytes]:
     return kp
 
 
-async def check_agent_scope(request: Request, required_scope: str) -> Optional[str]:
-    """Return the canonical_id from a valid Bearer registry JWT that holds an
-    active *required_scope* grant, or raise an HTTPException.
+# Detail string for a token whose project_id claim does not match the requested
+# project.  Shared with the project task routes so they can recognise this exact
+# rejection and collapse it into an existence-hiding 404 (a token bound to
+# another project must be indistinguishable from a non-owner session).
+PROJECT_SCOPE_MISMATCH_DETAIL = "token not scoped to this project"
 
-    Returns None when no Authorization header is present (the caller falls
-    through to its own admin/session handling).
 
-    Raises:
-      401 -- Authorization header present but the token is malformed, has a bad
-             signature, or is missing the sub claim.
-      403 -- Token is valid but the agent is not active in the registry, the
-             sub is unknown, or the grant is missing/expired.
+async def _verify_agent_scope(
+    request: Request, required_scope: str
+) -> Optional[tuple[str, dict]]:
+    """Shared verifier for the agent-token checks.
+
+    Return ``(canonical_id, payload)`` for a valid Bearer registry JWT that holds
+    an active *required_scope* grant, or ``None`` when no Authorization header is
+    present.  Raises the same 401/403 documented on ``check_agent_scope``.
     """
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.lower().startswith("bearer "):
@@ -122,4 +125,66 @@ async def check_agent_scope(request: Request, required_scope: str) -> Optional[s
             detail=f"token does not hold an active {required_scope!r} grant",
         )
 
+    return canonical_id, payload
+
+
+async def check_agent_scope(request: Request, required_scope: str) -> Optional[str]:
+    """Return the canonical_id from a valid Bearer registry JWT that holds an
+    active *required_scope* grant, or raise an HTTPException.
+
+    Returns None when no Authorization header is present (the caller falls
+    through to its own admin/session handling).
+
+    Raises:
+      401 -- Authorization header present but the token is malformed, has a bad
+             signature, or is missing the sub claim.
+      403 -- Token is valid but the agent is not active in the registry, the
+             sub is unknown, or the grant is missing/expired.
+    """
+    result = await _verify_agent_scope(request, required_scope)
+    if result is None:
+        return None
+    canonical_id, _payload = result
+    return canonical_id
+
+
+async def check_agent_scope_for_project(
+    request: Request, required_scope: str, project_id: str
+) -> Optional[str]:
+    """Project-scoped sibling of ``check_agent_scope`` (least privilege).
+
+    Verifies the same EdDSA JWT + active-grant chain AND requires the token's
+    ``project_id`` claim to equal *project_id*.  This binds an agent token to a
+    single project's routes so it can never reach another project's board.
+
+    Returns None when no Authorization header is present.
+
+    Raises:
+      401/403 -- exactly as ``check_agent_scope`` (bad token / inactive agent /
+                 missing scope grant).
+      403 ``token not scoped to this project`` -- token is otherwise valid but
+                 its project_id claim is absent or does not match *project_id*.
+    """
+    result = await _verify_agent_scope(request, required_scope)
+    if result is None:
+        return None
+    canonical_id, payload = result
+    token_project = payload.get("project_id")
+    if not token_project or token_project != project_id:
+        raise HTTPException(status_code=403, detail=PROJECT_SCOPE_MISMATCH_DETAIL)
+    # Defense in depth: the token's project_id claim agreeing is not enough; the
+    # underlying grant must itself be bound to this project. A claim and a grant
+    # could diverge (re-mint against a stale claim, a hand-edited grant row), so
+    # require an active grant whose own project_id matches before authorizing.
+    grants_store = _get_grants_store(request)
+    now = datetime.now(timezone.utc)
+    grants = await grants_store.list_grants(canonical_id)
+    grant_ok = any(
+        g["scope"] == required_scope
+        and g.get("project_id") == project_id
+        and _grant_unexpired(g.get("expires_at"), now)
+        for g in grants
+    )
+    if not grant_ok:
+        raise HTTPException(status_code=403, detail=PROJECT_SCOPE_MISMATCH_DETAIL)
     return canonical_id

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -43,6 +43,7 @@ from tinyagentos.auth import AuthManager
 from tinyagentos.backend_fallback import BackendFallback
 from tinyagentos.capabilities import CapabilityChecker
 from tinyagentos.cluster.manager import ClusterManager
+from tinyagentos.vram_reservation import VramReservationManager
 from tinyagentos.cluster.router import TaskRouter
 from tinyagentos.config import auto_register_from_manifest, load_config, save_config, save_config_locked
 from tinyagentos.lifecycle_manager import LifecycleManager
@@ -1140,6 +1141,12 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         except Exception:
             logger.exception("resource scheduler failed to build — routes will use static config")
             app.state.resource_scheduler = None
+
+        # VRAM reservation manager — atomic check-and-reserve so two
+        # concurrent model loads cannot both pass a VRAM check before
+        # either consumes physical VRAM (TOCTOU race, taOS #1706).
+        app.state.vram_reservation = VramReservationManager()
+
         # Detect and set container runtime
         from tinyagentos.containers.backend import configure_container_runtime
         configure_container_runtime(config)

--- a/tinyagentos/asset_gen/__init__.py
+++ b/tinyagentos/asset_gen/__init__.py
@@ -1,0 +1,7 @@
+"""Game Studio offline asset generation.
+
+Slice 1 (textures/sprites) drives a ComfyUI server to turn a text prompt into a
+PNG the game references. The backend is tier-aware and reuses the same catalog
++ hardware-profile signals the Images Studio uses; see
+``docs/design/game-studio-asset-generation.md``.
+"""

--- a/tinyagentos/asset_gen/comfyui_client.py
+++ b/tinyagentos/asset_gen/comfyui_client.py
@@ -1,0 +1,157 @@
+"""Async ComfyUI API client for offline asset generation.
+
+ComfyUI (https://github.com/comfyanonymous/ComfyUI) exposes a small HTTP API:
+
+  POST {base}/prompt            submit a workflow graph -> {"prompt_id": "..."}
+  GET  {base}/history/{id}      poll for completion -> {id: {outputs: {...}}}
+  GET  {base}/view?filename=... fetch an output image (raw bytes)
+
+This client submits a (already-parameterised) workflow, polls history until the
+job produces an image, and fetches that image. It is deliberately *fail-soft*:
+ComfyUI is an optional, store-installed backend that is not present in CI or on
+GPU-less hosts, so every failure path (unreachable server, timeout, malformed
+response, non-image body) is caught and turned into ``None`` rather than raised
+at the caller. The route layer maps ``None`` to a clean HTTP response.
+
+The base URL comes from the ``base_url`` argument, else the ``TAOS_COMFYUI_URL``
+environment variable, else ``http://127.0.0.1:8188``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Optional
+from uuid import uuid4
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COMFYUI_URL = "http://127.0.0.1:8188"
+
+
+def default_base_url() -> str:
+    """Resolve the ComfyUI base URL from the environment, with a local default."""
+    return os.environ.get("TAOS_COMFYUI_URL", DEFAULT_COMFYUI_URL)
+
+
+@dataclass
+class ComfyUIResult:
+    """A completed ComfyUI generation: the output image bytes + the prompt id."""
+
+    image_bytes: bytes
+    prompt_id: str
+
+
+def _looks_like_image(data: bytes) -> bool:
+    """True if *data* starts with a known image magic signature.
+
+    ComfyUI can answer 200 with a JSON/text error body on /view; those bytes
+    would otherwise be saved as a ``.png`` and reported as success. Reject any
+    body that is not clearly an image so it routes into the fail-soft path.
+    """
+    return (
+        data.startswith(b"\x89PNG\r\n\x1a\n")  # PNG
+        or data.startswith(b"\xff\xd8\xff")  # JPEG
+        or (data[:4] == b"RIFF" and data[8:12] == b"WEBP")  # WEBP
+    )
+
+
+class ComfyUIClient:
+    """Thin async client for a single ComfyUI server.
+
+    ``timeout`` bounds each individual HTTP call; ``poll_timeout`` bounds the
+    total time spent waiting for a submitted workflow to finish (generation can
+    take tens of seconds on modest GPUs); ``poll_interval`` is the gap between
+    history polls.
+    """
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        *,
+        timeout: float = 30.0,
+        poll_timeout: float = 180.0,
+        poll_interval: float = 1.0,
+    ):
+        self.base = (base_url or default_base_url()).rstrip("/")
+        self._timeout = timeout
+        self._poll_timeout = poll_timeout
+        self._poll_interval = poll_interval
+
+    async def generate(self, workflow: dict) -> Optional[ComfyUIResult]:
+        """Submit *workflow*, wait for it to finish, and return its first output
+        image. Returns ``None`` on any failure (never raises)."""
+        client_id = uuid4().hex
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
+                submit = await client.post(
+                    f"{self.base}/prompt",
+                    json={"prompt": workflow, "client_id": client_id},
+                )
+                submit.raise_for_status()
+                prompt_id = (submit.json() or {}).get("prompt_id")
+                if not prompt_id:
+                    logger.warning("ComfyUI /prompt returned no prompt_id")
+                    return None
+
+                image_ref = await self._poll_history(client, prompt_id)
+                if image_ref is None:
+                    return None
+
+                view = await client.get(f"{self.base}/view", params=image_ref)
+                view.raise_for_status()
+                data = view.content
+                if not _looks_like_image(data):
+                    logger.warning(
+                        "ComfyUI /view returned a non-image body: %s",
+                        view.text[:200],
+                    )
+                    return None
+                return ComfyUIResult(image_bytes=data, prompt_id=str(prompt_id))
+        except Exception:  # noqa: BLE001 — fail-soft: any error -> None
+            logger.warning("ComfyUI generation failed", exc_info=True)
+            return None
+
+    async def _poll_history(
+        self, client: httpx.AsyncClient, prompt_id: str
+    ) -> Optional[dict]:
+        """Poll /history/{id} until the job produces an image, then return the
+        {filename, subfolder, type} ref for /view. Returns ``None`` on timeout
+        or when the job finished without an image."""
+        deadline = time.monotonic() + self._poll_timeout
+        while time.monotonic() < deadline:
+            resp = await client.get(f"{self.base}/history/{prompt_id}")
+            resp.raise_for_status()
+            entry = (resp.json() or {}).get(prompt_id)
+            if entry:
+                ref = _first_image_ref(entry.get("outputs") or {})
+                if ref is not None:
+                    return ref
+                # The job is in history but yielded no image: it is done and
+                # failed, so stop polling rather than spin to the deadline.
+                logger.warning("ComfyUI job %s finished with no image", prompt_id)
+                return None
+            await asyncio.sleep(self._poll_interval)
+        logger.warning("ComfyUI history poll timed out for %s", prompt_id)
+        return None
+
+
+def _first_image_ref(outputs: dict) -> Optional[dict]:
+    """Return the first output image's {filename, subfolder, type} ref, or None.
+
+    ``outputs`` is ``{node_id: {"images": [{filename, subfolder, type}, ...]}}``.
+    """
+    for node in outputs.values():
+        for image in node.get("images") or []:
+            filename = image.get("filename")
+            if filename:
+                return {
+                    "filename": filename,
+                    "subfolder": image.get("subfolder", ""),
+                    "type": image.get("type", "output"),
+                }
+    return None

--- a/tinyagentos/asset_gen/workflows.py
+++ b/tinyagentos/asset_gen/workflows.py
@@ -1,0 +1,80 @@
+"""Curated ComfyUI workflow templates + parameterisation for asset generation.
+
+Slice 1 ships one real, minimal workflow: SDXL text->image (``texture_sdxl.json``,
+a standard checkpoint -> CLIP encode -> KSampler -> VAE decode -> save graph in
+ComfyUI's API format). ``build_texture_workflow`` loads the template and stamps
+in the caller's prompt, size, seed, and checkpoint, returning a fresh dict ready
+for :meth:`ComfyUIClient.generate`.
+
+Tileable/seamless textures: ComfyUI core has no asymmetric-tiling toggle without
+a custom node (e.g. the "Seamless" / circular-padding nodes), so Slice 1 nudges
+the diffusion toward a repeating result through the prompt only. Wiring true
+asymmetric tiling is a documented follow-up (TODO: seamless custom node).
+"""
+from __future__ import annotations
+
+import copy
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+_WORKFLOWS_DIR = Path(__file__).parent / "workflows"
+
+# Node ids in texture_sdxl.json (kept in one place so the template and the
+# parameteriser never drift).
+_POSITIVE_NODE = "6"
+_NEGATIVE_NODE = "7"
+_LATENT_NODE = "5"
+_SAMPLER_NODE = "3"
+_CHECKPOINT_NODE = "4"
+
+_DEFAULT_NEGATIVE = "blurry, low quality, watermark, text, signature"
+
+
+@lru_cache(maxsize=None)
+def load_template(name: str) -> dict:
+    """Load a checked-in workflow template by name (without the .json suffix).
+
+    Cached: the set of templates is fixed and small, and every caller goes
+    through ``build_texture_workflow``, which deep-copies before mutating, so
+    the cached dict is never mutated in place.
+    """
+    path = _WORKFLOWS_DIR / f"{name}.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _tileable_hint(prompt: str) -> str:
+    """Append a seamless-texture hint if not already implied by the prompt."""
+    if "seamless" in prompt.lower() or "tileable" in prompt.lower():
+        return prompt
+    return f"{prompt}, seamless tileable texture, repeating pattern"
+
+
+def build_texture_workflow(
+    *,
+    prompt: str,
+    width: int = 512,
+    height: int = 512,
+    seed: int = 0,
+    tileable: bool = False,
+    checkpoint: Optional[str] = None,
+    negative_prompt: str = _DEFAULT_NEGATIVE,
+    template: str = "texture_sdxl",
+) -> dict:
+    """Return a ready-to-submit ComfyUI workflow for a text->image texture.
+
+    A deep copy of the template is returned so concurrent callers never share
+    (and mutate) the same graph.
+    """
+    workflow = copy.deepcopy(load_template(template))
+
+    positive = _tileable_hint(prompt) if tileable else prompt
+    workflow[_POSITIVE_NODE]["inputs"]["text"] = positive
+    workflow[_NEGATIVE_NODE]["inputs"]["text"] = negative_prompt
+    workflow[_LATENT_NODE]["inputs"]["width"] = int(width)
+    workflow[_LATENT_NODE]["inputs"]["height"] = int(height)
+    workflow[_SAMPLER_NODE]["inputs"]["seed"] = int(seed)
+    if checkpoint:
+        workflow[_CHECKPOINT_NODE]["inputs"]["ckpt_name"] = checkpoint
+    return workflow

--- a/tinyagentos/asset_gen/workflows/texture_sdxl.json
+++ b/tinyagentos/asset_gen/workflows/texture_sdxl.json
@@ -1,0 +1,59 @@
+{
+  "3": {
+    "class_type": "KSampler",
+    "inputs": {
+      "seed": 0,
+      "steps": 25,
+      "cfg": 7.0,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1.0,
+      "model": ["4", 0],
+      "positive": ["6", 0],
+      "negative": ["7", 0],
+      "latent_image": ["5", 0]
+    }
+  },
+  "4": {
+    "class_type": "CheckpointLoaderSimple",
+    "inputs": {
+      "ckpt_name": "sd_xl_base_1.0.safetensors"
+    }
+  },
+  "5": {
+    "class_type": "EmptyLatentImage",
+    "inputs": {
+      "width": 512,
+      "height": 512,
+      "batch_size": 1
+    }
+  },
+  "6": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "",
+      "clip": ["4", 1]
+    }
+  },
+  "7": {
+    "class_type": "CLIPTextEncode",
+    "inputs": {
+      "text": "blurry, low quality, watermark, text, signature",
+      "clip": ["4", 1]
+    }
+  },
+  "8": {
+    "class_type": "VAEDecode",
+    "inputs": {
+      "samples": ["3", 0],
+      "vae": ["4", 2]
+    }
+  },
+  "9": {
+    "class_type": "SaveImage",
+    "inputs": {
+      "filename_prefix": "taos_texture",
+      "images": ["8", 0]
+    }
+  }
+}

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -23,10 +23,16 @@ _A2A_BUS_READ_PATHS = frozenset({
     "/api/a2a/bus/channels",
     "/api/a2a/bus/messages",
 })
+# Authenticated A2A bus WRITE path: an agent may POST here with its own registry
+# JWT (scope a2a_send, verified by the route, which forces the bus `from` to the
+# agent's own handle so it posts as itself instead of the owner's account).
+_A2A_BUS_WRITE_PATHS = frozenset({
+    "/api/a2a/bus/send",
+})
 # Every path that accepts a registry JWT in place of the admin session.  The
 # passthrough is allowlisted to exactly these paths -- a registry JWT must never
 # authenticate an arbitrary route (no skeleton key).
-_AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS
+_AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE_PATHS
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ipaddress
+import re
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -33,6 +34,35 @@ _A2A_BUS_WRITE_PATHS = frozenset({
 # passthrough is allowlisted to exactly these paths -- a registry JWT must never
 # authenticate an arbitrary route (no skeleton key).
 _AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE_PATHS
+
+# Project kanban routes an agent may reach with its own registry JWT (scope
+# project_tasks, verified + project-bound by the route).  These are DYNAMIC
+# paths (/api/projects/{pid}/tasks...), so an exact frozenset can't match them;
+# a (method, compiled-regex) allowlist is used instead.  Each pattern is fully
+# anchored and uses a slash-free segment ([^/]+) with an exact segment count, so
+# sibling routes that must stay session-only -- POST .../tasks (create),
+# /members, /relationships, /audit, /activity, project lifecycle -- never match.
+# This is the project-scoped analogue of the exact _AGENT_TOKEN_PATHS contract:
+# the token only reaches the handler, which then verifies the JWT + grant +
+# project binding.  Anything not listed here is NOT reachable by a registry JWT.
+_SEG = r"[^/]+"
+_AGENT_TASK_ROUTES = (
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/ready$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
+    ("GET", re.compile(rf"^/api/projects/tasks/{_SEG}/context$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
+    # PATCH (free task-field mutation) is intentionally NOT here: it is broader
+    # than the "read + lifecycle + comments" the project_tasks scope documents.
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
+)
+
+
+def _is_agent_task_path(method: str, path: str) -> bool:
+    """True only for the exact subset of task routes a project_tasks token may
+    reach.  Strict method + anchored-regex match; everything else is excluded."""
+    return any(m == method and rx.match(path) for m, rx in _AGENT_TASK_ROUTES)
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -212,15 +242,20 @@ class AuthMiddleware(BaseHTTPMiddleware):
                     request.state.via = "local_token"
                 return await call_next(request)
 
-        # Agent-token endpoints (registry feeds + read-only A2A bus proxy) accept
-        # a registry JWT as an alternative to the admin session.  This branch
-        # sits AFTER the local-token check on purpose: a local token is
+        # Agent-token endpoints (registry feeds + A2A bus proxy + project kanban)
+        # accept a registry JWT as an alternative to the admin session.  This
+        # branch sits AFTER the local-token check on purpose: a local token is
         # admin-equivalent and must keep its admin semantics on these paths
         # (taOSmd polls the feeds with it today).  Only a Bearer that is NOT the
         # local token falls through to here; it is PASSED THROUGH and the route
-        # verifies the registry JWT + scope grant.  The allowlist is exact so a
-        # registry JWT can never authenticate any other route (no skeleton key).
-        if path in _AGENT_TOKEN_PATHS and auth_header.lower().startswith("bearer "):
+        # verifies the registry JWT + scope grant (+ project binding for task
+        # routes).  The allowlist -- the exact _AGENT_TOKEN_PATHS plus the
+        # anchored task-route matcher -- is closed so a registry JWT can never
+        # authenticate any other route (no skeleton key).
+        if (
+            path in _AGENT_TOKEN_PATHS
+            or _is_agent_task_path(request.method, path)
+        ) and auth_header.lower().startswith("bearer "):
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "registry_jwt_candidate"

--- a/tinyagentos/cluster/backend_services.py
+++ b/tinyagentos/cluster/backend_services.py
@@ -1,0 +1,193 @@
+"""Node-local backend service manager.
+
+Phase 1, unit 2 of the cluster-aware backend service management design
+(docs/design/cluster-backend-service-management.md). Reusable, node-agnostic
+helpers that:
+
+  * read the managed-backend contract from catalog manifests
+    (``lifecycle.auto_manage`` + ``unit`` / ``scope`` / ``health``),
+  * resolve a systemd unit's scope (user vs system),
+  * report a unit's state (installed / enabled / active) and health, and
+  * run a fail-soft service action (start / stop / restart).
+
+The systemctl logic is promoted from ``routes/system.py::_restart_ai_unit`` and
+generalised to any verb so the #1743 recovery endpoint and the worker-agent
+backend endpoints can share one implementation. This module is additive: it
+does not change any existing behaviour on its own.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+import yaml
+
+VALID_SCOPES = {"system", "user"}
+
+
+@dataclass(frozen=True)
+class ManagedBackend:
+    """A backend the node manages as a systemd service (from its manifest)."""
+
+    id: str
+    unit: str
+    scope: str          # "system" | "user"
+    health_url: str
+    health_expect: str
+
+
+def load_managed_backends(catalog_root: Path) -> list[ManagedBackend]:
+    """Return the managed backends declared under ``catalog_root/services``.
+
+    Only manifests with ``lifecycle.auto_manage: true`` and a valid
+    ``unit`` + ``scope`` are returned; the manifest lint
+    (scripts/check_manifests.py) guarantees those fields exist for any
+    auto-managed service, so a manifest missing them is skipped here rather
+    than raised.
+    """
+    out: list[ManagedBackend] = []
+    services_dir = catalog_root / "services"
+    for manifest in sorted(services_dir.glob("*/manifest.yaml")):
+        try:
+            data = yaml.safe_load(manifest.read_text())
+        except yaml.YAMLError:
+            continue
+        if not isinstance(data, dict):
+            continue
+        lifecycle = data.get("lifecycle")
+        if not isinstance(lifecycle, dict) or lifecycle.get("auto_manage") is not True:
+            continue
+        unit = lifecycle.get("unit")
+        scope = lifecycle.get("scope")
+        if not unit or scope not in VALID_SCOPES:
+            continue
+        health = lifecycle.get("health") if isinstance(lifecycle.get("health"), dict) else {}
+        out.append(
+            ManagedBackend(
+                id=str(data.get("id") or manifest.parent.name),
+                unit=str(unit),
+                scope=str(scope),
+                health_url=str(health.get("url", "")),
+                health_expect=str(health.get("expect", "")),
+            )
+        )
+    return out
+
+
+def _systemd_present() -> bool:
+    return bool(os.environ.get("INVOCATION_ID") or os.path.exists("/run/systemd/system"))
+
+
+async def _rc(args: list[str]) -> int:
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    await proc.wait()
+    return proc.returncode
+
+
+async def resolve_scope(unit: str, prefer: str | None = None) -> str | None:
+    """Return the scope ("user"/"system") a unit file exists in, else None.
+
+    Uses ``systemctl [--user] cat`` (returns 0 iff the unit file exists) so a
+    dead/crashed unit is still resolved, unlike an is-active probe. ``prefer``
+    (from the manifest ``lifecycle.scope``) is tried first.
+    """
+    order: list[str] = []
+    if prefer in VALID_SCOPES:
+        order.append(prefer)  # type: ignore[arg-type]
+    for s in ("user", "system"):
+        if s not in order:
+            order.append(s)
+    for scope in order:
+        flag = ["--user"] if scope == "user" else []
+        if await _rc(["systemctl", *flag, "cat", unit]) == 0:
+            return scope
+    return None
+
+
+async def unit_state(unit: str, prefer: str | None = None) -> dict:
+    """Report {installed, scope, enabled, active} for a unit, fail-soft."""
+    if not _systemd_present():
+        return {"installed": False, "enabled": False, "active": False,
+                "detail": "systemd not available on host"}
+    try:
+        scope = await resolve_scope(unit, prefer)
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"installed": False, "enabled": False, "active": False,
+                "detail": f"systemctl unavailable: {str(exc)[:160]}"}
+    if scope is None:
+        return {"installed": False, "enabled": False, "active": False}
+    flag = ["--user"] if scope == "user" else []
+    enabled = await _rc(["systemctl", *flag, "is-enabled", unit]) == 0
+    active = await _rc(["systemctl", *flag, "is-active", unit]) == 0
+    return {"installed": True, "scope": scope, "enabled": enabled, "active": active}
+
+
+async def service_action(unit: str, verb: str, prefer: str | None = None,
+                         timeout: float = 45.0) -> dict:
+    """Run ``systemctl <verb> <unit>`` in the resolved scope, fail-soft.
+
+    Returns a per-unit result dict (never raises): a unit that is not installed,
+    or that the service user lacks rights to touch (polkit / interactive auth),
+    is reported rather than raised. On timeout the child is killed and reaped so
+    it is not orphaned.
+    """
+    if verb not in ("start", "stop", "restart"):
+        raise ValueError(f"unsupported verb: {verb}")
+    if not _systemd_present():
+        return {"unit": unit, "ok": False, "detail": "systemd not available on host"}
+    try:
+        scope = await resolve_scope(unit, prefer)
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"unit": unit, "ok": False, "detail": f"systemctl unavailable: {str(exc)[:160]}"}
+    if scope is None:
+        return {"unit": unit, "ok": False, "detail": "not installed"}
+
+    flag = ["--user"] if scope == "user" else []
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "systemctl", *flag, verb, unit,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        if proc is not None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # pragma: no cover - defensive
+                pass
+        return {"unit": unit, "ok": False, "scope": scope, "detail": f"{verb} timed out"}
+    except Exception as exc:  # pragma: no cover - defensive
+        return {"unit": unit, "ok": False, "scope": scope, "detail": str(exc)[:200]}
+
+    if proc.returncode == 0:
+        return {"unit": unit, "ok": True, "scope": scope}
+    detail = (stderr.decode(errors="replace").strip() or f"exit code {proc.returncode}")[:200]
+    return {"unit": unit, "ok": False, "scope": scope, "detail": detail}
+
+
+async def health_probe(url: str, expect: str, timeout: float = 5.0) -> dict:
+    """Probe a backend health endpoint. Returns {ok, detail}.
+
+    ``expect`` is a literal substring that must appear in a 200 response body.
+    """
+    if not url:
+        return {"ok": False, "detail": "no health url"}
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(url)
+    except Exception as exc:
+        return {"ok": False, "detail": str(exc)[:160]}
+    if resp.status_code != 200:
+        return {"ok": False, "detail": f"HTTP {resp.status_code}"}
+    if expect and expect not in resp.text:
+        return {"ok": False, "detail": "health body missing expected marker"}
+    return {"ok": True}

--- a/tinyagentos/cluster/backend_services.py
+++ b/tinyagentos/cluster/backend_services.py
@@ -18,12 +18,15 @@ does not change any existing behaviour on its own.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
 import yaml
+
+logger = logging.getLogger(__name__)
 
 VALID_SCOPES = {"system", "user"}
 
@@ -54,8 +57,10 @@ def load_managed_backends(catalog_root: Path) -> list[ManagedBackend]:
         try:
             data = yaml.safe_load(manifest.read_text())
         except yaml.YAMLError:
+            logger.warning("skipping unparseable service manifest %s", manifest)
             continue
         if not isinstance(data, dict):
+            logger.warning("skipping non-mapping service manifest %s", manifest)
             continue
         lifecycle = data.get("lifecycle")
         if not isinstance(lifecycle, dict) or lifecycle.get("auto_manage") is not True:
@@ -63,6 +68,13 @@ def load_managed_backends(catalog_root: Path) -> list[ManagedBackend]:
         unit = lifecycle.get("unit")
         scope = lifecycle.get("scope")
         if not unit or scope not in VALID_SCOPES:
+            # The CI lint guarantees these fields for auto-managed services;
+            # a device-side catalog edit that breaks the contract would
+            # silently drop the backend out of recovery, so say so.
+            logger.warning(
+                "skipping managed backend %s: lifecycle.unit/scope invalid "
+                "(unit=%r scope=%r)", manifest, unit, scope,
+            )
             continue
         health = lifecycle.get("health") if isinstance(lifecycle.get("health"), dict) else {}
         out.append(

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -217,6 +217,18 @@ class ClusterManager:
                     if name_m and name_m not in flat_models:
                         flat_models.append(name_m)
             worker.models = flat_models
+            # Derive available_models from the live backend catalog.
+            # Each backend may carry a manifest-enriched
+            # available_models list; flatten across all backends.
+            flat_available: list[dict] = []
+            seen_ids: set[str] = set()
+            for b in backends:
+                for m in b.get("available_models") or []:
+                    model_id = m.get("model_id") or ""
+                    if model_id and model_id not in seen_ids:
+                        seen_ids.add(model_id)
+                        flat_available.append(m)
+            worker.available_models = flat_available
         if capabilities is not None:
             worker.capabilities = list(capabilities)
         if kv_cache_quant_support is not None:

--- a/tinyagentos/cluster/worker_protocol.py
+++ b/tinyagentos/cluster/worker_protocol.py
@@ -16,6 +16,7 @@ class WorkerInfo:
     # Cross-host callers must route through the worker agent (worker.url) -- never dial backend url directly.
     backends: list[dict] = field(default_factory=list)  # Available inference backends; name is "type:port"
     models: list[str] = field(default_factory=list)     # Currently loaded models
+    available_models: list[dict] = field(default_factory=list)  # Models this worker CAN load (from local manifest)
     capabilities: list[str] = field(default_factory=list)  # embed, chat, rerank, image-gen, tts, etc
     status: str = "online"            # online | offline | busy
     last_heartbeat: float = 0

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -197,6 +197,9 @@ def register_all_routers(app):
     from tinyagentos.routes.games import router as games_router
     app.include_router(games_router)
 
+    from tinyagentos.routes.game_assets import router as game_assets_router
+    app.include_router(game_assets_router)
+
     from tinyagentos.routes.terminal import router as terminal_router
     app.include_router(terminal_router)
 

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -6,15 +6,21 @@ with the controller (default http://127.0.0.1:7900). It is where cross-product
 agents (@taOS, @taOSmd, @hermes) coordinate. This is DISTINCT from taOS's own
 internal per-project a2a channels (tinyagentos/projects/a2a.py).
 
-These endpoints are a thin READ-ONLY proxy: the Messages app can list bus
-channels and read messages, but there is no send/post path here. The bus is
-unauthenticated on the LAN; the URL is resolved from ``TAOS_A2A_BUS_URL``.
+These endpoints proxy the bus: the Messages app can list bus channels and read
+messages (read paths), and a registry-authenticated agent (or an admin) can post
+a message (POST /api/a2a/bus/send). The raw bus is unauthenticated on the LAN and
+trusts its ``from`` field, so the send proxy is the authenticated write path --
+an agent posts as its OWN registry handle (scope ``a2a_send``), never able to
+spoof another identity or borrow the owner's account. The URL is resolved from
+``TAOS_A2A_BUS_URL``.
 
 Bus API (verified live):
-  GET {bus}/a2a/channels
-      -> {"channels":[{"channel","members","message_count","created_ts","last_ts"}, ...]}
-  GET {bus}/a2a/messages?thread={channel}&limit={n}
-      -> {"messages":[{"id","ts","from","body","thread","reply_to"}, ...]}
+  GET  {bus}/a2a/channels
+       -> {"channels":[{"channel","members","message_count","created_ts","last_ts"}, ...]}
+  GET  {bus}/a2a/messages?thread={channel}&limit={n}
+       -> {"messages":[{"id","ts","from","body","thread","reply_to"}, ...]}
+  POST {bus}/a2a/send  {"from","thread","body","reply_to"?}
+       -> {"id","from","thread","reply_to"}
 """
 from __future__ import annotations
 
@@ -24,6 +30,7 @@ import os
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
 
 from tinyagentos.agent_token_auth import check_agent_scope
 
@@ -118,3 +125,94 @@ async def bus_messages(request: Request, channel: str = "", limit: int = 100):
 
     messages = data.get("messages", []) if isinstance(data, dict) else []
     return {"messages": messages, "available": True}
+
+
+class BusSendBody(BaseModel):
+    """A message to post to a coordination-bus thread.
+
+    ``from_`` (JSON key ``from``) is honored ONLY for admin callers, so an
+    operator can post as any handle. For an agent-token caller it is ignored and
+    the ``from`` is derived from the agent's own registry handle -- one agent can
+    never post as another.
+    """
+
+    thread: str
+    body: str
+    reply_to: int | None = None
+    from_: str | None = Field(default=None, alias="from")
+
+    model_config = {"populate_by_name": True}
+
+
+async def _resolve_send_identity(request: Request, body_from: str | None) -> str:
+    """Return the bus ``from`` handle authorized for this send, or raise.
+
+    - Admin (session cookie or local token): may set an explicit ``from``
+      (operator posts as any handle); defaults to ``@operator`` when omitted.
+    - Otherwise the caller must present a registry JWT holding an active
+      ``a2a_send`` grant. The ``from`` is DERIVED from that agent's registry
+      handle; a client-supplied ``from`` is ignored, so an agent cannot spoof
+      another agent's identity. ``check_agent_scope`` raises 401/403; a missing
+      Bearer header returns None and is rejected here as 403 (fail closed).
+    """
+    if getattr(request.state, "is_admin", False):
+        # Admin may post as an explicit handle, but keep it a single clean token
+        # so it cannot inject newlines/control chars into the bus record or logs.
+        handle = (body_from or "").strip()
+        handle = "".join(c for c in handle if c.isprintable())[:64].strip()
+        return handle or "@operator"
+
+    caller = await check_agent_scope(request, "a2a_send")
+    if caller is None:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    registry = getattr(request.app.state, "agent_registry", None)
+    record = await registry.get(caller) if registry is not None else None
+    handle = ((record or {}).get("handle") or "").strip()
+    if not handle:
+        # An active a2a_send grant with no bus handle cannot be safely attributed.
+        raise HTTPException(status_code=403, detail="agent has no bus handle")
+    return handle
+
+
+@router.post("/api/a2a/bus/send")
+async def bus_send(request: Request, body: BusSendBody):
+    """Post a message to a coordination-bus thread as the authenticated identity.
+
+    Authorized senders: an admin session / host local token (may set ``from``),
+    or an active agent registry JWT holding the ``a2a_send`` scope (``from`` is
+    forced to the agent's own handle). This is the authenticated write path so
+    agents post as themselves instead of sharing the owner's account.
+
+    Unlike the read endpoints, a bus failure surfaces as 502: a caller must know
+    when its message did not land.
+    """
+    from_handle = await _resolve_send_identity(request, body.from_)
+
+    thread = body.thread.strip()
+    text = body.body.strip()
+    if not thread or not text:
+        return JSONResponse({"error": "thread and body required"}, status_code=400)
+    # reply_to is a bus message id (a SQLite rowid): must be a positive integer
+    # within the signed-64-bit id space. The bus owns id existence; the proxy
+    # only rejects values that could never be a real id.
+    if body.reply_to is not None and not (0 < body.reply_to <= 2**63 - 1):
+        return JSONResponse(
+            {"error": "reply_to must be a positive message id"}, status_code=400
+        )
+
+    payload: dict = {"from": from_handle, "thread": thread, "body": text}
+    if body.reply_to is not None:
+        payload["reply_to"] = body.reply_to
+
+    bus = _bus_url()
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(f"{bus}/a2a/send", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("A2A bus send failed (%s): %s", bus, exc)
+        raise HTTPException(status_code=502, detail="a2a bus unavailable")
+
+    return {"ok": True, "from": from_handle, "message": data}

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -11,6 +11,8 @@ staging testing. (A blank override still yields a 503 'service unavailable'.)
 """
 from __future__ import annotations
 
+import json
+import logging
 import os
 import re
 
@@ -18,7 +20,16 @@ import httpx
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
 
+from tinyagentos.taosnet import mesh_credentials
+
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
+
+# Per-host service tokens the join ready payload carries. They are persisted
+# server-side and stripped from the browser-facing poll body so a bearer
+# credential never sits in browser JavaScript.
+_JOIN_SERVICE_TOKENS = ("controller_token", "sites_token")
 
 # Only these account actions are proxied. The upstream base is operator config
 # (env), never user input, so there is no open-proxy / SSRF surface.
@@ -204,8 +215,48 @@ async def cluster_join_deny(request: Request, rid: str):
     return await _forward_to(request, "POST", f"{_JOIN_BASE}/requests/{rid}/deny")
 
 
+def _persist_join_credentials(resp: Response) -> Response:
+    """When a poll response carries the per-host service tokens, persist them
+    server-side (host-bound) and return a copy with those tokens ALWAYS stripped,
+    so a bearer credential never reaches browser JavaScript.
+
+    Security ordering: stripping is decoupled from persistence. Once a 200 JSON
+    body is seen to contain a service token it is always stripped, whether or not
+    the save succeeds (a save failure is logged; the credentials are re-delivered
+    on the next poll -- but they are never leaked to the browser to compensate).
+    A non-200 body, or one that does not parse to a dict carrying a service token,
+    is returned untouched. Parsing does not depend on the Content-Type header (a
+    JSON body served without one must not bypass stripping). Relayed headers
+    (Set-Cookie etc.) are preserved.
+    """
+    if resp.status_code != 200:
+        return resp
+    try:
+        body = json.loads(resp.body)
+    except (ValueError, TypeError):
+        return resp
+    if not isinstance(body, dict) or not any(body.get(k) for k in _JOIN_SERVICE_TOKENS):
+        return resp
+    # Persist best-effort; never let a save error keep the token in the body.
+    try:
+        mesh_credentials.save_mesh_credentials(body)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
+    stripped = {k: v for k, v in body.items() if k not in _JOIN_SERVICE_TOKENS}
+    out = Response(
+        content=json.dumps(stripped).encode("utf-8"),
+        status_code=200,
+        media_type="application/json",
+    )
+    for raw in resp.raw_headers:
+        if raw[0].decode("latin-1").lower() in ("set-cookie", "location", "cache-control"):
+            out.raw_headers.append(raw)
+    return out
+
+
 @router.get("/api/account/cluster/join/requests/{rid}/poll")
 async def cluster_join_poll(request: Request, rid: str):
     if not _valid_rid(rid):
         return JSONResponse({"error": "invalid request id"}, status_code=400)
-    return await _forward_to(request, "GET", f"{_JOIN_BASE}/requests/{rid}/poll")
+    resp = await _forward_to(request, "GET", f"{_JOIN_BASE}/requests/{rid}/poll")
+    return _persist_join_credentials(resp)

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -11,6 +11,7 @@ staging testing. (A blank override still yields a 503 'service unavailable'.)
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -20,7 +21,7 @@ import httpx
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import JSONResponse
 
-from tinyagentos.taosnet import mesh_credentials
+from tinyagentos.taosnet import mesh, mesh_credentials
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,10 @@ router = APIRouter()
 # server-side and stripped from the browser-facing poll body so a bearer
 # credential never sits in browser JavaScript.
 _JOIN_SERVICE_TOKENS = ("controller_token", "sites_token")
+# Everything stripped from the browser body: the service tokens plus the
+# single-use Headscale preauth key, which the controller consumes server-side to
+# join the mesh (Slice 2). None of these should ever reach browser JavaScript.
+_STRIP_KEYS = _JOIN_SERVICE_TOKENS + ("headscale_preauth_key",)
 
 # Only these account actions are proxied. The upstream base is operator config
 # (env), never user input, so there is no open-proxy / SSRF surface.
@@ -215,34 +220,50 @@ async def cluster_join_deny(request: Request, rid: str):
     return await _forward_to(request, "POST", f"{_JOIN_BASE}/requests/{rid}/deny")
 
 
-def _persist_join_credentials(resp: Response) -> Response:
+def _persist_join_credentials(resp: Response) -> tuple[Response, dict | None]:
     """When a poll response carries the per-host service tokens, persist them
-    server-side (host-bound) and return a copy with those tokens ALWAYS stripped,
-    so a bearer credential never reaches browser JavaScript.
+    server-side (host-bound) and return a copy with those tokens + the single-use
+    preauth key ALWAYS stripped, so nothing secret reaches browser JavaScript.
 
-    Security ordering: stripping is decoupled from persistence. Once a 200 JSON
-    body is seen to contain a service token it is always stripped, whether or not
-    the save succeeds (a save failure is logged; the credentials are re-delivered
-    on the next poll -- but they are never leaked to the browser to compensate).
-    A non-200 body, or one that does not parse to a dict carrying a service token,
-    is returned untouched. Parsing does not depend on the Content-Type header (a
-    JSON body served without one must not bypass stripping). Relayed headers
+    Returns ``(browser_response, join_intent)``. ``join_intent`` is
+    ``{"preauth_key", "hostname"}`` when the ready payload carried a preauth key
+    for the caller to consume server-side (trigger the mesh-join), else None.
+
+    Security ordering: stripping is decoupled from persistence and from the join.
+    Once a 200 JSON body is seen to contain a service token, the secrets are
+    always stripped, whether or not the save/join succeeds. A non-200 body, or one
+    that does not parse to a dict carrying a service token, is returned untouched.
+    Parsing does not depend on the Content-Type header. Relayed headers
     (Set-Cookie etc.) are preserved.
     """
     if resp.status_code != 200:
-        return resp
+        return resp, None
     try:
         body = json.loads(resp.body)
     except (ValueError, TypeError):
-        return resp
-    if not isinstance(body, dict) or not any(body.get(k) for k in _JOIN_SERVICE_TOKENS):
-        return resp
-    # Persist best-effort; never let a save error keep the token in the body.
-    try:
-        mesh_credentials.save_mesh_credentials(body)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
-    stripped = {k: v for k, v in body.items() if k not in _JOIN_SERVICE_TOKENS}
+        return resp, None
+    # Fire whenever the body carries ANY secret (a service token or the preauth
+    # key), so a ready payload with only a preauth key is still stripped -- the
+    # "ALWAYS strip" guarantee must not hinge on a service token being present.
+    if not isinstance(body, dict) or not any(body.get(k) for k in _STRIP_KEYS):
+        return resp, None
+    # Persist best-effort (only possible when a controller token is present);
+    # never let a save error keep a secret in the body.
+    if body.get("controller_token"):
+        try:
+            mesh_credentials.save_mesh_credentials(body)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
+
+    preauth = body.get("headscale_preauth_key")
+    join_intent = None
+    if preauth:
+        # The Headscale node hostname; the exact value taos.my routes on is the
+        # host row identity, so prefer an explicit hostname field, else host_id.
+        hostname = body.get("hostname") or body.get("host_id") or "taos-host"
+        join_intent = {"preauth_key": preauth, "hostname": str(hostname)}
+
+    stripped = {k: v for k, v in body.items() if k not in _STRIP_KEYS}
     out = Response(
         content=json.dumps(stripped).encode("utf-8"),
         status_code=200,
@@ -251,7 +272,28 @@ def _persist_join_credentials(resp: Response) -> Response:
     for raw in resp.raw_headers:
         if raw[0].decode("latin-1").lower() in ("set-cookie", "location", "cache-control"):
             out.raw_headers.append(raw)
-    return out
+    return out, join_intent
+
+
+# Preauth keys are single-use: once a join has been attempted for one it cannot
+# be retried, so we do not re-fire on every re-delivered ready poll. In-memory is
+# sufficient (a process restart that loses this simply means a fresh join
+# opportunity, and the key is stale by then anyway).
+_attempted_preauth: set[str] = set()
+
+# Keep a strong reference to in-flight background tasks so they are not
+# garbage-collected mid-run (a bare create_task() can be dropped -> "coroutine
+# was never awaited").
+_mesh_join_tasks: set = set()
+
+
+async def _run_mesh_join(intent: dict) -> None:
+    """Background task: consume the single-use preauth key to join the mesh.
+    Fail-soft; a host without tailscale (or a failed join) is logged, never
+    raised, so the poll it was triggered from is unaffected."""
+    result = await mesh.mesh_up(intent["preauth_key"], intent["hostname"])
+    if not result.get("ok"):
+        logger.warning("taosgo: background mesh join did not complete: %s", result.get("detail"))
 
 
 @router.get("/api/account/cluster/join/requests/{rid}/poll")
@@ -259,4 +301,24 @@ async def cluster_join_poll(request: Request, rid: str):
     if not _valid_rid(rid):
         return JSONResponse({"error": "invalid request id"}, status_code=400)
     resp = await _forward_to(request, "GET", f"{_JOIN_BASE}/requests/{rid}/poll")
-    return _persist_join_credentials(resp)
+    out, join_intent = _persist_join_credentials(resp)
+    if (
+        join_intent
+        and join_intent["preauth_key"] not in _attempted_preauth
+        and not await mesh.is_joined()
+    ):
+        # A single-use key: mark it attempted so a re-delivered ready poll does
+        # not re-fire a doomed re-join. Fire-and-forget (a slow `tailscale up`
+        # must never block the poll), holding a reference so it is not GC'd.
+        _attempted_preauth.add(join_intent["preauth_key"])
+        task = asyncio.create_task(_run_mesh_join(join_intent))
+        _mesh_join_tasks.add(task)
+        task.add_done_callback(_mesh_join_tasks.discard)
+    return out
+
+
+@router.get("/api/account/mesh/status")
+async def mesh_status(request: Request):
+    """Report this host's mesh membership for the Account pane
+    ({joined, tailnet, node_ip, ...}). Fail-soft (never raises)."""
+    return JSONResponse(await mesh.mesh_status())

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -50,6 +50,10 @@ VALID_SCOPES = frozenset({
     "files_write",
     "tools_execute",
     "registry_feeds_read",
+    # Least-privilege kanban access: task read + lifecycle + comments for the
+    # agent's OWN project only (bound by the token's project_id claim). Does NOT
+    # grant task create, member management, or project lifecycle.
+    "project_tasks",
 })
 
 

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -91,6 +91,7 @@ _ALLOWED_SCOPES = frozenset({
     "a2a_send", "a2a_receive",
     "files_read", "files_write",
     "tools_execute", "registry_feeds_read",
+    "project_tasks",
 })
 
 

--- a/tinyagentos/routes/game_assets.py
+++ b/tinyagentos/routes/game_assets.py
@@ -1,0 +1,208 @@
+"""Tier-aware AI asset generation for the Game Studio (Slice 1: textures/sprites).
+
+A game is a flat file set stored under ``data/games/{id}/`` (see routes/games.py).
+This route turns a text prompt into a PNG *inside that same file set* by driving
+a ComfyUI backend, so the texture previews and travels with the game — no new
+storage is invented.
+
+Tier resolution mirrors the Images Studio (routes/images_edit.py): the concrete
+backend is resolved from the live backend catalog first, falling back to the
+host hardware profile. A discrete GPU (e.g. the RTX 3060 worker) serves the SDXL
+tier; a host with no discrete-GPU texture backend has no capable pipeline (RK
+NPU SD tiling is a documented follow-up, not yet wired), so the route returns
+``{available: false}`` (HTTP 200) and the UI shows a "needs a GPU worker" state
+instead of a crash or an always-failing tier.
+"""
+from __future__ import annotations
+
+import logging
+import random
+import time
+from dataclasses import dataclass
+from typing import Literal, Optional
+from uuid import uuid4
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.asset_gen.comfyui_client import ComfyUIClient, default_base_url
+from tinyagentos.asset_gen.workflows import build_texture_workflow
+from tinyagentos.routes.games import (
+    _SLUG_RE,
+    _games_dir,
+    _is_safe_filename,
+    _load_meta,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Size bounds. SDXL/latent geometry requires multiples of 8; keep a sane range
+# so a texture request can't ask the GPU for an 8K canvas.
+_MIN_SIZE = 64
+_MAX_SIZE = 2048
+_SIZE_MULTIPLE = 8
+
+# The discrete-GPU tier checkpoint. (RK NPU SD is a documented follow-up; there
+# is no wired NPU texture backend yet, so it is not resolved here.)
+_SDXL_CHECKPOINT = "sd_xl_base_1.0.safetensors"
+
+# Generated PNGs share the game's flat file set. Cap both the per-image size and
+# the number of assets so a runaway/loop request can't fill the disk.
+_MAX_ASSET_BYTES = 12 * 1024 * 1024  # a 2048x2048 PNG fits comfortably
+_MAX_ASSET_FILES = 200
+
+
+class TextureRequest(BaseModel):
+    prompt: str
+    width: int = 512
+    height: int = 512
+    tileable: bool = False
+    kind: Literal["texture", "sprite"] = "texture"
+
+
+@dataclass
+class TextureBackend:
+    """The resolved backend for a texture request."""
+
+    base_url: str
+    tier: str          # "sdxl" | "sd15"
+    checkpoint: str
+    workflow: str      # workflow template name
+
+
+def resolve_texture_backend(request: Request) -> Optional[TextureBackend]:
+    """Resolve the tier-appropriate ComfyUI backend, or ``None`` when the host
+    has no capable accelerator.
+
+    Priority mirrors the Images Studio routing:
+      1. A live ComfyUI backend advertised in the catalog (e.g. the RTX 3060
+         worker) — the SDXL/GPU tier.
+      2. A local discrete GPU (CUDA/ROCm) — SDXL at the local ComfyUI URL.
+      3. Otherwise unavailable. (An NPU-only host has no wired texture backend
+         yet, so it resolves to unavailable rather than an always-failing tier.)
+    """
+    catalog = getattr(request.app.state, "backend_catalog", None)
+    if catalog is not None:
+        try:
+            for backend in catalog.backends_with_capability("image-generation"):
+                if getattr(backend, "type", "") == "comfyui" and getattr(backend, "url", None):
+                    return TextureBackend(backend.url, "sdxl", _SDXL_CHECKPOINT, "texture_sdxl")
+        except Exception:  # noqa: BLE001 — a flaky catalog must not crash the route
+            logger.warning("backend catalog lookup failed", exc_info=True)
+
+    hw = getattr(request.app.state, "hardware_profile", None)
+    gpu = getattr(hw, "gpu", None)
+    if gpu is not None and (getattr(gpu, "cuda", False) or getattr(gpu, "rocm", False)):
+        return TextureBackend(default_base_url(), "sdxl", _SDXL_CHECKPOINT, "texture_sdxl")
+
+    return None
+
+
+def _valid_size(value: int) -> bool:
+    return _MIN_SIZE <= value <= _MAX_SIZE and value % _SIZE_MULTIPLE == 0
+
+
+def _asset_filename(kind: str) -> str:
+    """A unique, filesystem-safe PNG name for a generated asset."""
+    return f"{kind}-{int(time.time())}-{uuid4().hex[:8]}.png"
+
+
+@router.post("/api/games/{game_id}/assets/texture")
+async def generate_texture(request: Request, game_id: str, body: TextureRequest):
+    """Generate a texture/sprite PNG via ComfyUI and write it into the game's
+    file set. Returns the asset's preview path on success.
+
+    Never raises to the client: an unavailable tier returns 200
+    ``{available: false, reason}`` and a backend failure returns a clean 502.
+    """
+    if not _SLUG_RE.match(game_id):
+        return JSONResponse({"error": "invalid game id"}, status_code=400)
+
+    prompt = (body.prompt or "").strip()
+    if not prompt:
+        return JSONResponse({"error": "prompt must not be empty"}, status_code=400)
+    if not _valid_size(body.width) or not _valid_size(body.height):
+        return JSONResponse(
+            {
+                "error": (
+                    f"width/height must be a multiple of {_SIZE_MULTIPLE} "
+                    f"between {_MIN_SIZE} and {_MAX_SIZE}"
+                )
+            },
+            status_code=400,
+        )
+
+    game_dir = _games_dir(request) / game_id
+    if _load_meta(game_dir) is None:
+        return JSONResponse({"error": f"game '{game_id}' not found"}, status_code=404)
+
+    backend = resolve_texture_backend(request)
+    if backend is None:
+        # Tier-gated: no capable accelerator. NOT an error — the UI shows a
+        # "needs a GPU worker" state, so answer 200 with a clear reason.
+        return {
+            "available": False,
+            "reason": "No GPU worker available for texture generation.",
+        }
+
+    # Refuse before spending a GPU call if the game is already at the asset cap.
+    try:
+        asset_count = sum(1 for p in game_dir.iterdir() if p.is_file() and p.suffix == ".png")
+    except OSError:
+        asset_count = 0
+    if asset_count >= _MAX_ASSET_FILES:
+        return JSONResponse(
+            {"available": True, "error": f"asset limit reached (max {_MAX_ASSET_FILES})"},
+            status_code=409,
+        )
+
+    seed = random.randint(0, 2**32 - 1)
+    workflow = build_texture_workflow(
+        prompt=prompt,
+        width=body.width,
+        height=body.height,
+        seed=seed,
+        tileable=body.tileable,
+        checkpoint=backend.checkpoint,
+        template=backend.workflow,
+    )
+
+    client = ComfyUIClient(backend.base_url)
+    result = await client.generate(workflow)
+    if result is None:
+        # Fail-soft: the client swallowed the underlying error and returned
+        # None. Surface a clean 502 (not a 500 crash) so the UI can retry.
+        return JSONResponse(
+            {"error": "Texture generation failed. Is the ComfyUI backend running?"},
+            status_code=502,
+        )
+
+    if len(result.image_bytes) > _MAX_ASSET_BYTES:
+        logger.warning("generated texture exceeded size cap: %d bytes", len(result.image_bytes))
+        return JSONResponse(
+            {"error": "generated image exceeded the size limit"}, status_code=502
+        )
+
+    filename = _asset_filename(body.kind)
+    if not _is_safe_filename(filename):  # defensive; the generator is safe
+        return JSONResponse({"error": "internal filename error"}, status_code=500)
+    try:
+        game_dir.mkdir(parents=True, exist_ok=True)
+        (game_dir / filename).write_bytes(result.image_bytes)
+    except OSError as exc:
+        logger.exception("failed to write generated texture")
+        return JSONResponse({"error": f"could not save asset: {exc}"}, status_code=500)
+
+    return {
+        "available": True,
+        "status": "generated",
+        "filename": filename,
+        "path": f"/api/games/{game_id}/preview/{filename}",
+        "kind": body.kind,
+        "tier": backend.tier,
+        "tileable": body.tileable,
+        "seed": seed,
+    }

--- a/tinyagentos/routes/games.py
+++ b/tinyagentos/routes/games.py
@@ -30,6 +30,14 @@ _SLUG_RE = re.compile(r"^[a-z0-9-]{1,64}$")
 _MAX_FILE_BYTES = 2 * 1024 * 1024
 _MAX_FILES = 40
 
+# Generated binary assets (game_assets.py textures now; audio/3D meshes later)
+# that the text editor does not manage; a full-replace save must never sweep
+# them, even if their bytes happen to decode as UTF-8.
+_BINARY_ASSET_EXTS = {
+    ".png", ".jpg", ".jpeg", ".webp", ".gif",
+    ".glb", ".gltf", ".wav", ".mp3", ".ogg",
+}
+
 
 class GameSaveRequest(BaseModel):
     name: str | None = None
@@ -129,8 +137,23 @@ async def save_game(request: Request, game_id: str, body: GameSaveRequest):
     game_dir.mkdir(parents=True, exist_ok=True)
 
     for p in game_dir.iterdir():
-        if p.is_file() and p.name != "game.json" and p.name not in body.files:
-            p.unlink()
+        if not (p.is_file() and p.name != "game.json" and p.name not in body.files):
+            continue
+        # The editor's file set is text-only (_list_game_files skips undecodable
+        # files), so generated binary assets (textures/sprites written by
+        # routes/game_assets.py) never appear in `body.files`. Preserve them
+        # instead of sweeping them: full-replace semantics apply only to the
+        # text files the editor actually manages. Match a known binary-asset
+        # extension first (a binary payload that happens to decode as UTF-8 —
+        # e.g. a GLB whose bytes are coincidentally valid — must not be swept),
+        # then fall back to an undecodable-bytes check for anything unlisted.
+        if p.suffix.lower() in _BINARY_ASSET_EXTS:
+            continue
+        try:
+            p.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        p.unlink()
     for name, content in body.files.items():
         (game_dir / name).write_text(content, encoding="utf-8")
 

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -33,6 +33,7 @@ class DeleteRequest(BaseModel):
 
 class PullRequest(BaseModel):
     model_name: str
+    required_vram_mb: int = 0
 
 
 router = APIRouter()
@@ -376,36 +377,68 @@ async def download_model(request: Request, body: DownloadRequest):
         installer = RkllamaInstaller(rkllama_url=resolve_rkllama_url(None))
         catalog = getattr(request.app.state, "backend_catalog", None)
 
-        async def _install_and_record(on_progress):
-            result = await installer.install(
-                body.app_id, {}, variant=variant, on_progress=on_progress
+        # Atomic VRAM check-and-reserve (TOCTOU fix, taOS #1706).
+        # rkllama pulls the model into its backend, which loads it
+        # into VRAM — two concurrent pulls could both pass the VRAM
+        # check and OOM.
+        vram_mgr = getattr(request.app.state, "vram_reservation", None)
+        reservation = None
+        # TODO(#1725): replace min_ram_mb heuristic with a real per-model VRAM
+        # estimate.  On CUDA GGUF the host-RAM floor over-reserves and causes
+        # occasional false 503s in multi-model setups.  Safe for v1 (fails
+        # closed), but a model-card estimate would be more accurate.
+        estimated_vram = int(variant.get("min_ram_mb", 0) or 0)  # heuristic
+        if vram_mgr is not None and estimated_vram > 0:
+            reservation = await vram_mgr.reserve(
+                estimated_vram, caller=f"rkllama-pull:{body.app_id}",
             )
-            if result.get("success"):
-                # rkllama pulls the weight into its own model store, not
-                # models_dir, so the disk scan in list_models() never sees it.
-                # Record the install as a registry breadcrumb (corroborated by
-                # live-backend evidence, see _model_to_dict) and force an
-                # immediate catalog refresh so the newly pulled model shows up
-                # in all_models() right away instead of waiting for the next
-                # poll tick.
-                try:
-                    registry.mark_installed(
-                        body.app_id, variant.get("id") or "latest", state="installed"
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to record rkllama install for %s in registry",
-                        body.app_id, exc_info=True,
-                    )
-                if catalog is not None:
+            if reservation is None:
+                effective_free, _total = vram_mgr.available_vram()
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"Insufficient VRAM: need ~{estimated_vram} MiB, "
+                            f"have {effective_free} MiB available. "
+                            f"Try a smaller model or free VRAM first."
+                        ),
+                    },
+                    status_code=503,
+                )
+
+        async def _install_and_record(on_progress):
+            try:
+                result = await installer.install(
+                    body.app_id, {}, variant=variant, on_progress=on_progress
+                )
+                if result.get("success"):
+                    # rkllama pulls the weight into its own model store, not
+                    # models_dir, so the disk scan in list_models() never sees it.
+                    # Record the install as a registry breadcrumb (corroborated by
+                    # live-backend evidence, see _model_to_dict) and force an
+                    # immediate catalog refresh so the newly pulled model shows up
+                    # in all_models() right away instead of waiting for the next
+                    # poll tick.
                     try:
-                        await catalog.refresh()
+                        registry.mark_installed(
+                            body.app_id, variant.get("id") or "latest", state="installed"
+                        )
                     except Exception:
                         logger.warning(
-                            "Backend catalog refresh after rkllama install failed for %s",
+                            "Failed to record rkllama install for %s in registry",
                             body.app_id, exc_info=True,
                         )
-            return result
+                    if catalog is not None:
+                        try:
+                            await catalog.refresh()
+                        except Exception:
+                            logger.warning(
+                                "Backend catalog refresh after rkllama install failed for %s",
+                                body.app_id, exc_info=True,
+                            )
+                return result
+            finally:
+                if vram_mgr is not None and reservation is not None:
+                    vram_mgr.release(reservation.reservation_id)
 
         dm.start_installer_task(download_id, _install_and_record)
         return {
@@ -611,6 +644,28 @@ async def pull_model(request: Request, body: PullRequest):
     model_name = body.model_name.strip()
     if not model_name:
         return JSONResponse({"error": "model_name is required"}, status_code=400)
+
+    # Atomic VRAM check-and-reserve (TOCTOU fix, taOS #1706) —
+    # two concurrent pulls could both see free VRAM and OOM.
+    vram_mgr = getattr(request.app.state, "vram_reservation", None)
+    reservation = None
+    if vram_mgr is not None and body.required_vram_mb > 0:
+        reservation = await vram_mgr.reserve(
+            body.required_vram_mb, caller=f"ollama-pull:{model_name}",
+        )
+        if reservation is None:
+            effective_free, _total = vram_mgr.available_vram()
+            return JSONResponse(
+                {
+                    "error": (
+                        f"Insufficient VRAM: need {body.required_vram_mb} MiB, "
+                        f"have {effective_free} MiB available. "
+                        f"Try a smaller model or free VRAM first."
+                    ),
+                },
+                status_code=503,
+            )
+
     try:
         http_client = request.app.state.http_client
         config = request.app.state.config
@@ -635,6 +690,22 @@ async def pull_model(request: Request, body: PullRequest):
     except Exception as e:
         logger.warning(f"Ollama pull failed: {e}")
         return JSONResponse({"error": str(e)}, status_code=502)
+    finally:
+        if vram_mgr is not None and reservation is not None:
+            vram_mgr.release(reservation.reservation_id)
+
+
+@router.get("/api/models/vram-reservations")
+async def vram_reservation_stats(request: Request):
+    """Return VRAM reservation manager stats for monitoring.
+
+    Includes real-time free/total VRAM from nvidia-smi, in-flight
+    reservations, and effective free VRAM after subtracting reservations.
+    """
+    vram_mgr = getattr(request.app.state, "vram_reservation", None)
+    if vram_mgr is None:
+        return {"available": False}
+    return vram_mgr.stats()
 
 
 @router.get("/api/models/recommended")

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -385,9 +385,18 @@ async def download_model(request: Request, body: DownloadRequest):
         reservation = None
         # TODO(#1725): replace min_ram_mb heuristic with a real per-model VRAM
         # estimate.  On CUDA GGUF the host-RAM floor over-reserves and causes
-        # occasional false 503s in multi-model setups.  Safe for v1 (fails
-        # closed), but a model-card estimate would be more accurate.
-        estimated_vram = int(variant.get("min_ram_mb", 0) or 0)  # heuristic
+        # occasional false 503s in multi-model setups.
+        # The real requirement lives on the backend requirements, not the
+        # variant top level: every rkllm variant in the catalog has
+        # variant-level min_ram_mb 0 with the true value (e.g. 2048) under
+        # requires.backends[].min_ram_mb, so reading only the variant key made
+        # this gate dead code (audit follow-up, #1766). Take the max across
+        # required backends, falling back to the variant-level key.
+        _backend_reqs = (variant.get("requires") or {}).get("backends") or []
+        estimated_vram = max(
+            [int(b.get("min_ram_mb", 0) or 0) for b in _backend_reqs if isinstance(b, dict)]
+            + [int(variant.get("min_ram_mb", 0) or 0)]
+        )
         if vram_mgr is not None and estimated_vram > 0:
             reservation = await vram_mgr.reserve(
                 estimated_vram, caller=f"rkllama-pull:{body.app_id}",

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -7,10 +7,14 @@ import time as _time
 import asyncio as _asyncio
 import json as _json
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
+from tinyagentos.agent_token_auth import (
+    PROJECT_SCOPE_MISMATCH_DETAIL,
+    check_agent_scope_for_project,
+)
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
 
@@ -419,6 +423,71 @@ async def _require_task_in_project(
     return task
 
 
+async def _authorize_task_actor(
+    request: Request, pstore, project_id: str
+) -> "tuple[str, bool, dict] | JSONResponse":
+    """Resolve the actor for a task route that accepts EITHER a session
+    owner/admin OR an approved external agent's registry JWT (scope
+    project_tasks) bound to THIS project.
+
+    Returns ``(actor_id, is_agent, project)`` on success, or a JSONResponse to
+    return directly.  These routes take ``request: Request`` and auth INSIDE the
+    handler (mirroring routes/a2a_bus.py) because ``Depends(current_user)`` would
+    401 an agent that has no session before the handler runs.
+
+    Security:
+      * A session non-owner gets the existence-hiding 404 from _get_owned_project.
+      * An agent token bound to a DIFFERENT project is collapsed into the SAME
+        existence-hiding 404, so it is indistinguishable from a non-owner and
+        never confirms another project's existence (invariant 1).
+      * A malformed / inactive / missing-scope token keeps its 401/403.
+    """
+    uid = getattr(request.state, "user_id", None)
+    if uid:
+        user = CurrentUser(
+            user_id=uid, is_admin=bool(getattr(request.state, "is_admin", False))
+        )
+        project_or_err = await _get_owned_project(pstore, project_id, user)
+        if isinstance(project_or_err, JSONResponse):
+            return project_or_err
+        return (user.user_id, False, project_or_err)
+
+    try:
+        caller = await check_agent_scope_for_project(
+            request, "project_tasks", project_id
+        )
+    except HTTPException as exc:
+        if exc.status_code == 403 and exc.detail == PROJECT_SCOPE_MISMATCH_DETAIL:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        raise
+    if caller is None:
+        # No session and no Bearer token: fail closed with existence-hiding 404.
+        return JSONResponse({"error": "not found"}, status_code=404)
+    project = await pstore.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return (caller, True, project)
+
+
+def _resolve_actor(
+    is_agent: bool, actor_id: str, body_actor: "str | None"
+) -> "str | None | JSONResponse":
+    """Bind a lifecycle actor id to the verified token when the caller is an agent.
+
+    Invariant 3: an agent must act only as itself.  If a lifecycle body names an
+    actor id (claimer_id / releaser_id / closed_by / reopened_by) that differs
+    from the token's canonical_id, reject 403; otherwise the token id is
+    authoritative.  A session caller keeps its provided actor id unchanged (an
+    owner/admin may still record an action on behalf of any worker id)."""
+    if is_agent:
+        if body_actor and body_actor != actor_id:
+            return JSONResponse(
+                {"error": "agent may only act as itself"}, status_code=403
+            )
+        return actor_id
+    return body_actor
+
+
 # ---------------------------------------------------------------------------
 # Task routes — order matters: /tasks/ready before /tasks/{task_id}
 # ---------------------------------------------------------------------------
@@ -459,12 +528,11 @@ async def list_tasks(
     project_id: str,
     request: Request,
     status: str | None = None,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     return {"items": await store.list_tasks(project_id=project_id, status=status)}
 
@@ -473,12 +541,11 @@ async def list_tasks(
 async def ready_tasks(
     project_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     return {"items": await store.list_ready_tasks(project_id=project_id)}
 
@@ -488,12 +555,11 @@ async def get_task(
     project_id: str,
     task_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     t = await store.get_task(task_id)
     if t is None or t["project_id"] != project_id:
@@ -509,6 +575,10 @@ async def update_task(
     request: Request,
     user: CurrentUser = Depends(current_user),
 ):
+    # Session owner/admin only. A project_tasks agent drives its board through
+    # read + the lifecycle actions (claim/release/close/reopen) + comments; free
+    # PATCH of title/body/assignee_id/parent is a broader mutation than that
+    # scope grants, so it stays off the agent allowlist (Kilo review on #1774).
     pstore = request.app.state.project_store
     project_or_err = await _get_owned_project(pstore, project_id, user)
     if isinstance(project_or_err, JSONResponse):
@@ -544,21 +614,24 @@ async def claim_task(
     task_id: str,
     payload: ClaimIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    claimer_id = _resolve_actor(is_agent, actor_id, payload.claimer_id)
+    if isinstance(claimer_id, JSONResponse):
+        return claimer_id
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    ok = await store.claim_task(task_id, payload.claimer_id)
+    ok = await store.claim_task(task_id, claimer_id)
     if not ok:
         # Distinguish "task taken by someone else" from "you already hold an
         # active task" so the agent knows to finish or release it first.
-        held = await store.held_task(payload.claimer_id)
+        held = await store.held_task(claimer_id)
         if held is not None and held != task_id:
             return JSONResponse(
                 {
@@ -570,10 +643,10 @@ async def claim_task(
             )
         return JSONResponse({"error": "already claimed"}, status_code=409)
     _beads_mark_dirty(request, project_id)
-    await pstore.log_activity(project_id, payload.claimer_id, "task.claimed", {"task_id": task_id})
+    await pstore.log_activity(project_id, claimer_id, "task.claimed", {"task_id": task_id})
     notifs = getattr(request.app.state, "notifications", None)
     if notifs is not None:
-        await notifs.emit_event("task.claimed", "Task claimed", f"{task_id} claimed by {payload.claimer_id}")
+        await notifs.emit_event("task.claimed", "Task claimed", f"{task_id} claimed by {claimer_id}")
     return await store.get_task(task_id)
 
 
@@ -583,17 +656,20 @@ async def release_task(
     task_id: str,
     payload: ReleaseIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    releaser_id = _resolve_actor(is_agent, actor_id, payload.releaser_id)
+    if isinstance(releaser_id, JSONResponse):
+        return releaser_id
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    ok = await store.release_task(task_id, payload.releaser_id)
+    ok = await store.release_task(task_id, releaser_id)
     if not ok:
         return JSONResponse({"error": "not claimed by releaser"}, status_code=409)
     _beads_mark_dirty(request, project_id)
@@ -606,25 +682,27 @@ async def close_task(
     task_id: str,
     payload: CloseIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, project = auth
+    closed_by = _resolve_actor(is_agent, actor_id, payload.closed_by)
+    if isinstance(closed_by, JSONResponse):
+        return closed_by
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    ok = await store.close_task(task_id, closed_by=payload.closed_by, reason=payload.reason)
+    ok = await store.close_task(task_id, closed_by=closed_by, reason=payload.reason)
     if not ok:
         return JSONResponse({"error": "cannot close"}, status_code=409)
     _beads_mark_dirty(request, project_id)
-    await pstore.log_activity(project_id, payload.closed_by, "task.closed", {"task_id": task_id})
+    await pstore.log_activity(project_id, closed_by, "task.closed", {"task_id": task_id})
     notifs = getattr(request.app.state, "notifications", None)
     if notifs is not None:
-        await notifs.emit_event("task.closed", "Task closed", f"{task_id} closed by {payload.closed_by}")
-    project = project_or_err
+        await notifs.emit_event("task.closed", "Task closed", f"{task_id} closed by {closed_by}")
     task = await store.get_task(task_id)
     qmd = getattr(request.app.state, "qmd_client", None)
     if qmd is not None and task is not None:
@@ -633,7 +711,7 @@ async def close_task(
             await index_closed_task(qmd, project, task)
         except Exception:
             await pstore.log_activity(
-                project_id, payload.closed_by, "task.qmd_index_failed", {"task_id": task_id}
+                project_id, closed_by, "task.qmd_index_failed", {"task_id": task_id}
             )
     return task
 
@@ -643,18 +721,22 @@ async def reopen_task(
     project_id: str,
     task_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
     payload: ReopenIn | None = None,
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    body_actor = payload.reopened_by if payload and payload.reopened_by else None
+    resolved = _resolve_actor(is_agent, actor_id, body_actor)
+    if isinstance(resolved, JSONResponse):
+        return resolved
+    actor = resolved or "user"
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    actor = (payload.reopened_by if payload and payload.reopened_by else None) or "user"
     ok = await store.reopen_task(task_id, reopened_by=actor)
     if not ok:
         return JSONResponse({"error": "task is not closed"}, status_code=409)
@@ -713,7 +795,6 @@ async def task_audit_history(
 async def task_context(
     task_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     """Relational context for a task: its goal (project + ancestry) and
     blockers. Project-agnostic path — task_id alone resolves the project
@@ -723,9 +804,9 @@ async def task_context(
     if task is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, task["project_id"], user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, task["project_id"])
+    if isinstance(auth, JSONResponse):
+        return auth
     return await store.get_task_context(task_id)
 
 
@@ -761,7 +842,9 @@ async def add_relationship(
 
 class AddCommentIn(BaseModel):
     body: str
-    author_id: str
+    # Optional: an agent caller may omit it and the route pins it to the token
+    # canonical_id. A session caller must still supply it (route enforces).
+    author_id: str | None = None
     replies_to_comment_id: str | None = None
 
 
@@ -771,12 +854,20 @@ async def add_comment(
     task_id: str,
     payload: AddCommentIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    # Invariant 3: an agent authors a comment only as itself. A comment author is
+    # an actor id just like the lifecycle fields, so bind it to the token id and
+    # 403 a mismatched body value (a session owner keeps its provided author_id).
+    author_id = _resolve_actor(is_agent, actor_id, payload.author_id)
+    if isinstance(author_id, JSONResponse):
+        return author_id
+    if author_id is None:
+        return JSONResponse({"error": "author_id required"}, status_code=400)
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):
@@ -784,7 +875,7 @@ async def add_comment(
     try:
         return await store.add_comment(
             task_id=task_id,
-            author_id=payload.author_id,
+            author_id=author_id,
             body=payload.body,
             replies_to_comment_id=payload.replies_to_comment_id,
         )
@@ -797,12 +888,11 @@ async def list_comments(
     project_id: str,
     task_id: str,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
     store = request.app.state.project_task_store
     guard = await _require_task_in_project(store, project_id, task_id)
     if isinstance(guard, JSONResponse):

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -5,10 +5,12 @@ import logging
 import os
 import sys
 from dataclasses import asdict
+from pathlib import Path
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from tinyagentos.cluster import backend_services
 from tinyagentos.restart_orchestrator import write_pending_restart, read_pending_restart
 
 logger = logging.getLogger(__name__)
@@ -119,12 +121,52 @@ async def _do_restart(app_state) -> None:
         await _emit_fail(str(exc))
 
 
-# AI-stack services a recovery action restarts (issue #1743). These are the
-# local inference backends that can stall independently of the controller:
-# rkllama (NPU model server, a system unit per install-rknpu.sh) and qmd (shared
-# model provider, a system unit). The controller itself is deliberately NOT here --
-# bouncing it is the separate /api/system/restart/prepare path.
-AI_STACK_UNITS = ("rkllama.service", "qmd.service")
+# Core AI backends taOS manages as systemd services that have NO store manifest
+# (installed by install-server.sh, not via the store): qmd, the shared model
+# provider. Store-installed managed backends (rkllama and any future NPU/GPU
+# runtime) are discovered from their catalog manifests instead
+# (lifecycle.auto_manage), so new managed backends join #1743 recovery
+# automatically without editing this list. The controller itself is deliberately
+# NOT here -- bouncing it is the separate /api/system/restart/prepare path.
+# Value is the preferred systemctl scope for scope resolution.
+CORE_MANAGED_UNITS: dict[str, str] = {"qmd.service": "system"}
+
+
+def _catalog_root(request: Request) -> Path:
+    """Locate the app-catalog root the same way the app wires the registry."""
+    registry = getattr(request.app.state, "registry", None)
+    catalog_dir = getattr(registry, "catalog_dir", None)
+    if catalog_dir is not None:
+        return Path(catalog_dir)
+    return Path(__file__).resolve().parent.parent.parent / "app-catalog"
+
+
+async def _managed_ai_units(request: Request) -> list[tuple[str, str | None]]:
+    """Return (unit, prefer_scope) for every managed AI backend installed here.
+
+    The target set for #1743 recovery is the core-managed units (no store
+    manifest) unioned with the store-declared managed backends
+    (lifecycle.auto_manage in their catalog manifest), then narrowed to units
+    whose systemd file actually exists on THIS node. A backend that has migrated
+    to another cluster node is skipped rather than reported as a spurious
+    failure, and a newly installed managed backend is picked up with no code
+    change. Membership is resolved with ``systemctl cat`` (via
+    ``backend_services.unit_state``) so a dead/crashed unit -- exactly what
+    recovery targets -- still counts as installed.
+    """
+    prefer: dict[str, str | None] = dict(CORE_MANAGED_UNITS)
+    try:
+        for mb in backend_services.load_managed_backends(_catalog_root(request)):
+            prefer.setdefault(mb.unit, mb.scope)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("failed to load managed backends from catalog")
+
+    async def _installed(unit: str, scope: str | None):
+        state = await backend_services.unit_state(unit, scope)
+        return (unit, scope) if state.get("installed") else None
+
+    checks = await asyncio.gather(*(_installed(u, s) for u, s in prefer.items()))
+    return [c for c in checks if c is not None]
 
 
 def _is_admin_or_local_token(request: Request) -> bool:
@@ -142,87 +184,37 @@ def _is_admin_or_local_token(request: Request) -> bool:
     return getattr(request.state, "via", None) == "local_token"
 
 
-async def _systemctl_rc(args: list[str]) -> int:
-    proc = await asyncio.create_subprocess_exec(
-        *args,
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=asyncio.subprocess.DEVNULL,
-    )
-    await proc.wait()
-    return proc.returncode
-
-
-async def _restart_ai_unit(unit: str) -> dict:
-    """Restart one AI-stack systemd unit, resolving user vs system scope.
-
-    Fails soft: a unit that is not installed, or that the service user lacks
-    rights to restart (polkit / interactive auth), is reported rather than
-    raised, so restarting one backend still helps when the other cannot be
-    touched. Scope is resolved with ``systemctl [--user] cat`` (returns 0 iff
-    the unit file exists) so a dead/crashed unit -- exactly what recovery
-    targets -- is still restarted, unlike an is-active probe.
-    """
-    if not (os.environ.get("INVOCATION_ID") or os.path.exists("/run/systemd/system")):
-        return {"unit": unit, "ok": False, "detail": "systemd not available on host"}
-
-    # Resolve scope. Guarded so a missing/unusable systemctl is reported rather
-    # than raised (keeps the documented "reported, not raised" contract).
-    scope_flag: list[str] | None = None
-    try:
-        for candidate in (["--user"], []):
-            if await _systemctl_rc(["systemctl", *candidate, "cat", unit]) == 0:
-                scope_flag = candidate
-                break
-    except Exception as exc:  # pragma: no cover - defensive
-        return {"unit": unit, "ok": False, "detail": f"systemctl unavailable: {str(exc)[:160]}"}
-    if scope_flag is None:
-        return {"unit": unit, "ok": False, "detail": "not installed"}
-
-    scope_name = "user" if scope_flag else "system"
-    proc = None
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "systemctl",
-            *scope_flag,
-            "restart",
-            unit,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=45)
-    except asyncio.TimeoutError:
-        # Kill and reap the child so a hung systemctl is not orphaned.
-        if proc is not None:
-            try:
-                proc.kill()
-                await proc.wait()
-            except Exception:  # pragma: no cover - defensive
-                pass
-        return {"unit": unit, "ok": False, "scope": scope_name, "detail": "restart timed out"}
-    except Exception as exc:  # pragma: no cover - defensive
-        return {"unit": unit, "ok": False, "scope": scope_name, "detail": str(exc)[:200]}
-
-    if proc.returncode == 0:
-        return {"unit": unit, "ok": True, "scope": scope_name}
-    detail = (stderr.decode(errors="replace").strip() or f"exit code {proc.returncode}")[:200]
-    return {"unit": unit, "ok": False, "scope": scope_name, "detail": detail}
-
-
 @router.post("/api/system/ai-stack/restart")
 async def restart_ai_stack(request: Request):
-    """Restart the local AI inference stack (rkllama + qmd) -- issue #1743.
+    """Restart the local AI inference stack -- issue #1743.
 
     A recovery action for edge devices where a model stalls (endless NPU
     generation, unresponsive inference) while the controller itself stays up.
-    Restarts the backend services without bouncing the controller or agents.
-    Admin (or host local token) only. Fails soft per service so a partial
-    recovery still reports what was restarted. The units are restarted
+    Restarts the managed backend services without bouncing the controller or
+    agents. The target set is derived from the managed-backend contract (core
+    units plus store manifests) and narrowed to backends actually installed on
+    this node, so it stays correct as backends are added or migrated across
+    cluster nodes. Admin (or host local token) only. Fails soft per service so a
+    partial recovery still reports what was restarted. Units are restarted
     concurrently so worst-case latency is one unit's timeout, not their sum.
     """
     if not _is_admin_or_local_token(request):
         return JSONResponse({"error": "forbidden"}, status_code=403)
 
-    results = list(await asyncio.gather(*(_restart_ai_unit(u) for u in AI_STACK_UNITS)))
+    targets = await _managed_ai_units(request)
+    if not targets:
+        return {
+            "status": "noop",
+            "restarted": [],
+            "failed": [],
+            "results": [],
+            "detail": "no managed AI backends installed on this node",
+        }
+
+    results = list(await asyncio.gather(
+        *(backend_services.service_action(unit, "restart", prefer)
+          for unit, prefer in targets)
+    ))
     restarted = [r["unit"] for r in results if r.get("ok")]
     failed = [r for r in results if not r.get("ok")]
     return {

--- a/tinyagentos/routes/system.py
+++ b/tinyagentos/routes/system.py
@@ -121,8 +121,8 @@ async def _do_restart(app_state) -> None:
 
 # AI-stack services a recovery action restarts (issue #1743). These are the
 # local inference backends that can stall independently of the controller:
-# rkllama (NPU model server, installed as a user unit) and qmd (shared model
-# provider, a system unit). The controller itself is deliberately NOT here --
+# rkllama (NPU model server, a system unit per install-rknpu.sh) and qmd (shared
+# model provider, a system unit). The controller itself is deliberately NOT here --
 # bouncing it is the separate /api/system/restart/prepare path.
 AI_STACK_UNITS = ("rkllama.service", "qmd.service")
 

--- a/tinyagentos/scheduler/backend_catalog.py
+++ b/tinyagentos/scheduler/backend_catalog.py
@@ -40,6 +40,8 @@ BACKEND_CAPABILITIES: dict[str, set[str]] = {
     "openai": {"llm-chat", "embedding"},
     "anthropic": {"llm-chat"},
     "sd-cpp": {"image-generation"},
+    # ComfyUI: node-graph diffusion server — the Game Studio texture/sprite tier.
+    "comfyui": {"image-generation"},
     # IOPaint (lama-cleaner successor): LaMa erase/inpaint + rembg + RealESRGAN.
     "iopaint": {"image-editing", "background-removal", "upscale"},
     # FLUX.1-Fill served via an inpaint/outpaint endpoint — the quality tier.

--- a/tinyagentos/taosnet/mesh.py
+++ b/tinyagentos/taosnet/mesh.py
@@ -1,0 +1,144 @@
+"""Headless Headscale mesh membership for taOSgo (Slice 2).
+
+The always-on host joins the account's Headscale mesh using the single-use
+preauth key from the cluster-join ready payload, so that
+``<label>.<handle>.taos.my`` (Web Studio publish) and off-LAN desktop access can
+route to this host over the tailnet. Jay decided the mechanism is **system
+tailscale** (tailscale + tailscaled managed as a service), not userspace tsnet:
+real kernel networking, boot-persistent, best for the always-on host.
+
+Everything here is fail-soft and never raises to the caller: on a host without
+``tailscale`` installed (dev boxes, CI) every call returns a structured
+"not available" result so the join flow degrades cleanly. The installer is
+responsible for actually placing the ``tailscale`` binary + daemon on supported
+hosts; this module only drives it.
+
+The login server (Headscale) defaults to ``https://hs.taos.my`` and is
+overridable via ``TAOS_HEADSCALE_URL`` for staging/self-hosted control servers.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LOGIN_SERVER = "https://hs.taos.my"
+
+
+def login_server() -> str:
+    """The Headscale control server URL, trailing slash stripped."""
+    return os.environ.get("TAOS_HEADSCALE_URL", _DEFAULT_LOGIN_SERVER).rstrip("/")
+
+
+def is_tailscale_installed() -> bool:
+    """True when the ``tailscale`` CLI is on PATH (the installer provides it on
+    supported hosts). When False, every operation degrades to "not available"."""
+    return shutil.which("tailscale") is not None
+
+
+async def _run(args: list[str], timeout: float = 30.0) -> tuple[int, str, str]:
+    """Run a subprocess, returning ``(returncode, stdout, stderr)``. Fail-soft:
+    a missing binary or timeout yields a non-zero code and a detail string, never
+    raises. On timeout the child is killed and reaped so it is not orphaned."""
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        out, err = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        return proc.returncode, out.decode(errors="replace"), err.decode(errors="replace")
+    except asyncio.TimeoutError:
+        if proc is not None:
+            try:
+                proc.kill()
+                await proc.wait()
+            except Exception:  # pragma: no cover - defensive
+                pass
+        return 124, "", f"timed out after {timeout}s"
+    except FileNotFoundError:
+        return 127, "", "tailscale not installed"
+    except Exception as exc:  # noqa: BLE001 - never raise into the join flow
+        return 1, "", str(exc)[:200]
+
+
+async def mesh_up(
+    preauth_key: str, hostname: str, *, ls: Optional[str] = None, timeout: float = 60.0
+) -> dict:
+    """Join the account Headscale mesh with a single-use preauth key.
+
+    Runs ``tailscale up --login-server <ls> --authkey <key> --hostname <name>``.
+    Returns ``{"ok": bool, "detail": str}``. Fail-soft: a host without tailscale,
+    a bad key, or a timeout all return ``ok=False`` with a reason rather than
+    raising, so a poll that triggers the join is never broken by it.
+    """
+    if not preauth_key or not hostname:
+        return {"ok": False, "detail": "missing preauth key or hostname"}
+    if not is_tailscale_installed():
+        return {"ok": False, "detail": "tailscale not installed"}
+    server = ls or login_server()
+    rc, _out, err = await _run(
+        [
+            "tailscale", "up",
+            "--login-server", server,
+            "--authkey", preauth_key,
+            "--hostname", hostname,
+        ],
+        timeout=timeout,
+    )
+    if rc == 0:
+        logger.info("taosgo: joined mesh %s as %s", server, hostname)
+        return {"ok": True, "detail": f"joined {server}"}
+    detail = (err.strip() or f"exit {rc}")[:200]
+    logger.warning("taosgo: mesh join failed (%s): %s", server, detail)
+    return {"ok": False, "detail": detail}
+
+
+async def mesh_status() -> dict:
+    """Report mesh membership from ``tailscale status --json``. On success:
+    ``{joined, online, tailnet, node_ip, hostname}``. On the not-available /
+    error path: ``{joined: False, detail}``. Fail-soft: not-installed / not-up
+    returns ``joined=False`` with a detail, never raises."""
+    if not is_tailscale_installed():
+        return {"joined": False, "detail": "tailscale not installed"}
+    rc, out, err = await _run(["tailscale", "status", "--json"], timeout=10.0)
+    if rc != 0:
+        return {"joined": False, "detail": (err.strip() or f"exit {rc}")[:200]}
+    try:
+        data = json.loads(out)
+    except (ValueError, TypeError):
+        return {"joined": False, "detail": "unparseable status"}
+    self_node = data.get("Self") or {}
+    online = bool(self_node.get("Online"))
+    ips = self_node.get("TailscaleIPs") or []
+    # BackendState "Running" + a Self node means we are up on the tailnet.
+    joined = data.get("BackendState") == "Running" and bool(self_node)
+    return {
+        "joined": joined,
+        "online": online,
+        "tailnet": (data.get("CurrentTailnet") or {}).get("Name"),
+        "node_ip": ips[0] if ips else None,
+        "hostname": self_node.get("HostName"),
+    }
+
+
+async def is_joined() -> bool:
+    """True when this host is up on the tailnet (used to avoid a redundant
+    re-join when a poll re-delivers a ready payload)."""
+    return bool((await mesh_status()).get("joined"))
+
+
+async def mesh_down() -> dict:
+    """Leave the mesh (``tailscale logout``). Fail-soft."""
+    if not is_tailscale_installed():
+        return {"ok": False, "detail": "tailscale not installed"}
+    rc, _out, err = await _run(["tailscale", "logout"], timeout=30.0)
+    if rc == 0:
+        return {"ok": True, "detail": "left mesh"}
+    return {"ok": False, "detail": (err.strip() or f"exit {rc}")[:200]}

--- a/tinyagentos/taosnet/mesh_credentials.py
+++ b/tinyagentos/taosnet/mesh_credentials.py
@@ -1,0 +1,133 @@
+"""Host-local persistence for the per-host taOSgo service credentials.
+
+When this host joins an account mesh (the consent-join flow proxied by
+``routes/account_proxy.py``), taos.my returns a ready payload carrying two
+single-scope, host-bound bearer tokens:
+
+- ``controller_token`` -- scope ``taosnet:passkey`` (fetch the account taOSnet
+  passkey; see ``passkey_client.py``)
+- ``sites_token``      -- scope ``sites:publish`` (publish a Web Studio site to
+  ``<label>.<handle>.taos.my``; taos.my #167)
+
+This module is the *writer* for the ``get_controller_token()`` seam
+``passkey_client.py`` documented: it persists those tokens to a single 0600 file
+under the data dir so headless callers (the download manager, the Web Studio
+publish caller) can present them without a browser session. The single-use
+Headscale preauth key is deliberately NOT stored here -- it is consumed once at
+mesh-join time, not a durable credential.
+
+Resolution mirrors ``create_app``: the data dir is ``TAOS_DATA_DIR`` if set, else
+``<project>/data``. Env overrides (``TAOS_CONTROLLER_TOKEN`` / ``TAOS_SITES_TOKEN``)
+still win, so local dev and existing tests keep working without a join.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_FILENAME = "mesh_credentials.json"
+
+# The fields we persist from the join ready payload. Anything else (notably the
+# single-use headscale_preauth_key) is intentionally dropped.
+_FIELDS = (
+    "account_id",
+    "host_id",
+    "tailnet_name",
+    "controller_token",
+    "sites_token",
+    "joined_at",
+)
+
+
+def _data_dir() -> Path:
+    env = os.environ.get("TAOS_DATA_DIR")
+    if env:
+        return Path(env)
+    # tinyagentos/taosnet/mesh_credentials.py -> project root is two parents up.
+    return Path(__file__).resolve().parent.parent.parent / "data"
+
+
+def _path() -> Path:
+    return _data_dir() / _FILENAME
+
+
+def save_mesh_credentials(payload: dict) -> None:
+    """Persist the join ready-payload service credentials, host-bound, mode 0600.
+
+    Keeps only the ``_FIELDS`` allowlist (drops the single-use preauth key and
+    anything else). Requires at least ``controller_token`` + ``host_id``; raises
+    ``ValueError`` otherwise. Atomic (write temp + ``os.replace``) so a crash
+    mid-write never leaves a partial file. Idempotent: re-saving the same host's
+    payload just rewrites identical data.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a mapping")
+    creds = {k: payload.get(k) for k in _FIELDS}
+    if not creds.get("controller_token") or not creds.get("host_id"):
+        raise ValueError("payload missing controller_token/host_id")
+
+    d = _data_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:  # pragma: no cover - best effort on odd filesystems
+        pass
+
+    p = _path()
+    tmp = p.with_name(p.name + ".tmp")
+    data = json.dumps(creds).encode("utf-8")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+    os.replace(tmp, p)
+    try:
+        os.chmod(p, 0o600)
+    except OSError:  # pragma: no cover
+        pass
+
+
+def _load() -> Optional[dict]:
+    try:
+        data = json.loads(_path().read_text())
+    except (OSError, ValueError):
+        return None
+    # A corrupt or externally-edited file could parse to a non-object (list,
+    # string, number); the getters do ``(_load() or {}).get(...)`` so a non-dict
+    # would raise AttributeError and break the headless passkey fetch. Treat any
+    # non-object as absent (fail closed to "not joined").
+    return data if isinstance(data, dict) else None
+
+
+def get_controller_token() -> Optional[str]:
+    """The persisted ``taosnet:passkey`` token, or ``TAOS_CONTROLLER_TOKEN`` if
+    that dev override is set, or None when this host has not joined a mesh."""
+    return os.getenv("TAOS_CONTROLLER_TOKEN") or (_load() or {}).get("controller_token") or None
+
+
+def get_sites_token() -> Optional[str]:
+    """The persisted ``sites:publish`` token (Web Studio publish caller), or the
+    ``TAOS_SITES_TOKEN`` dev override, or None before join."""
+    return os.getenv("TAOS_SITES_TOKEN") or (_load() or {}).get("sites_token") or None
+
+
+def get_host_id() -> Optional[str]:
+    """The taos.my host row id this instance joined as, or None."""
+    return (_load() or {}).get("host_id") or None
+
+
+def has_mesh_credentials() -> bool:
+    """True once this host has joined an account mesh (a controller token exists)."""
+    return get_controller_token() is not None
+
+
+def clear() -> None:
+    """Forget the persisted mesh credentials (on leave/unjoin). No-op if absent."""
+    try:
+        _path().unlink()
+    except OSError:
+        pass

--- a/tinyagentos/taosnet/passkey_client.py
+++ b/tinyagentos/taosnet/passkey_client.py
@@ -41,12 +41,14 @@ def get_controller_token() -> Optional[str]:
     """The controller token persisted when this host joined an account mesh,
     or None if it has not joined one.
 
-    Read from ``TAOS_CONTROLLER_TOKEN`` for now; this is the seam the
-    cluster-join client writes to (alongside the Headscale key) once that
-    client lands. None means the headless passkey fetch is skipped and the
-    download stays on the web-seed baseline.
+    Delegates to ``mesh_credentials`` (the writer for this seam, populated by the
+    cluster-join poll-intercept); the ``TAOS_CONTROLLER_TOKEN`` env override still
+    wins there. None means the headless passkey fetch is skipped and the download
+    stays on the web-seed baseline.
     """
-    return os.getenv("TAOS_CONTROLLER_TOKEN") or None
+    from tinyagentos.taosnet import mesh_credentials
+
+    return mesh_credentials.get_controller_token()
 
 
 async def fetch_passkey(

--- a/tinyagentos/vram_reservation.py
+++ b/tinyagentos/vram_reservation.py
@@ -1,0 +1,186 @@
+"""
+Atomic VRAM reservation — check-and-reserve to prevent TOCTOU races.
+
+When two concurrent model loads both check available VRAM before either
+consumes it, they can both pass and cause OOM.  This module provides
+atomic check-and-reserve semantics: check available VRAM, reserve what
+you need, then load the model.  Concurrent callers see the reserved
+capacity and back off.
+
+Pattern:
+
+    mgr = VramReservationManager()
+    reservation = await mgr.reserve(vram_mb=4096, caller="ollama-pull")
+    if reservation is not None:
+        try:
+            await load_model()
+        finally:
+            mgr.release(reservation.reservation_id)
+    else:
+        raise RuntimeError("Not enough VRAM")
+
+The reservation is *not* a context manager — callers must release
+explicitly (typically in a ``finally`` block) so the reservation can
+outlive a single ``async with`` block while the model loads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VramReservation:
+    """A held VRAM reservation.  Release via manager.release()."""
+
+    reservation_id: str
+    vram_mb: int
+    caller: str
+    created_at: float
+
+
+class VramReservationManager:
+    """Atomic VRAM check-and-reserve for model loads.
+
+    Thread-safe via ``asyncio.Lock``.  Reads real-time VRAM from
+    nvidia-smi and subtracts in-flight reservations so concurrent
+    callers see the capacity already promised to others.
+
+    Zero-VRAM reservations (``vram_mb <= 0``) always succeed as a
+    lightweight marker — no lock acquisition, no probe, no accounting.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._reserved_vram_mb: int = 0
+        self._pending: dict[str, VramReservation] = {}
+
+    # ── public API ──────────────────────────────────────────────────
+
+    async def reserve(
+        self,
+        vram_mb: int,
+        caller: str = "",
+    ) -> VramReservation | None:
+        """Atomically check available VRAM and reserve *vram_mb* MiB.
+
+        Returns a ``VramReservation`` if admitted, ``None`` if
+        insufficient VRAM.  Caller **must** call :meth:`release` when
+        done — this object is not a context manager so the reservation
+        can outlive a single ``async with`` block while the model loads.
+
+        *vram_mb* ≤ 0 always succeeds without probing VRAM or acquiring
+        the lock (a lightweight no-op marker).
+        """
+        if vram_mb <= 0:
+            return VramReservation(
+                reservation_id=f"vr_{secrets.token_hex(4)}",
+                vram_mb=0,
+                caller=caller or "noop",
+                created_at=time.time(),
+            )
+
+        async with self._lock:
+            free_mb, total_mb = self._probe_vram()
+            effective_free = max(0, free_mb - self._reserved_vram_mb)
+
+            if effective_free < vram_mb:
+                logger.debug(
+                    "vram-reservation: denied — need %d MiB, have %d MiB "
+                    "(%d free − %d reserved)",
+                    vram_mb, effective_free, free_mb, self._reserved_vram_mb,
+                )
+                return None
+
+            reservation_id = f"vr_{secrets.token_hex(4)}"
+            reservation = VramReservation(
+                reservation_id=reservation_id,
+                vram_mb=vram_mb,
+                caller=caller,
+                created_at=time.time(),
+            )
+            self._reserved_vram_mb += vram_mb
+            self._pending[reservation_id] = reservation
+
+            logger.info(
+                "vram-reservation: granted %d MiB to %r (id=%s, "
+                "total reserved=%d MiB, effective free=%d MiB)",
+                vram_mb, caller, reservation_id,
+                self._reserved_vram_mb, effective_free - vram_mb,
+            )
+            return reservation
+
+    def release(self, reservation_id: str) -> bool:
+        """Release a reservation.  Idempotent — safe to call repeatedly.
+
+        Returns ``True`` if a reservation was actually released,
+        ``False`` if *reservation_id* was unknown or already released.
+        """
+        reservation = self._pending.pop(reservation_id, None)
+        if reservation is not None:
+            self._reserved_vram_mb -= reservation.vram_mb
+            logger.debug(
+                "vram-reservation: released %d MiB for %r (id=%s, "
+                "total reserved=%d MiB)",
+                reservation.vram_mb, reservation.caller,
+                reservation_id, self._reserved_vram_mb,
+            )
+            return True
+        return False
+
+    # ── read-only accessors ─────────────────────────────────────────
+
+    @property
+    def reserved_vram_mb(self) -> int:
+        """Total VRAM currently reserved (MiB)."""
+        return self._reserved_vram_mb
+
+    @property
+    def pending_count(self) -> int:
+        """Number of active reservations."""
+        return len(self._pending)
+
+    def available_vram(self) -> tuple[int, int]:
+        """Return ``(effective_free_mb, total_mb)`` after subtracting
+        in-flight reservations from the hardware probe."""
+        free_mb, total_mb = self._probe_vram()
+        effective_free = max(0, free_mb - self._reserved_vram_mb)
+        return effective_free, total_mb
+
+    def stats(self) -> dict:
+        """Return a snapshot for monitoring / debug endpoints."""
+        free_mb, total_mb = self._probe_vram()
+        return {
+            "free_vram_mb": free_mb,
+            "total_vram_mb": total_mb,
+            "reserved_vram_mb": self._reserved_vram_mb,
+            "effective_free_mb": max(0, free_mb - self._reserved_vram_mb),
+            "pending_reservations": self.pending_count,
+        }
+
+    # ── internal ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _probe_vram() -> tuple[int, int]:
+        """Probe real-time free/total VRAM via nvidia-smi.
+
+        Returns ``(free_mb, total_mb)``, or ``(0, 0)`` when no
+        nvidia-smi is available or the probe fails.
+        """
+        try:
+            from tinyagentos.system_stats import read_nvidia_vram
+
+            pair = read_nvidia_vram()
+            if pair is not None:
+                used_mb, total_mb = pair
+                free_mb = max(0, total_mb - used_mb)
+                return free_mb, total_mb
+        except Exception:
+            logger.debug("vram-reservation: probe failed", exc_info=True)
+        return 0, 0

--- a/tinyagentos/vram_reservation.py
+++ b/tinyagentos/vram_reservation.py
@@ -87,16 +87,32 @@ class VramReservationManager:
             )
 
         async with self._lock:
-            free_mb, total_mb = self._probe_vram()
-            effective_free = max(0, free_mb - self._reserved_vram_mb)
-
-            if effective_free < vram_mb:
-                logger.debug(
-                    "vram-reservation: denied — need %d MiB, have %d MiB "
-                    "(%d free − %d reserved)",
-                    vram_mb, effective_free, free_mb, self._reserved_vram_mb,
+            # Probe in a thread: nvidia-smi is a blocking subprocess and this
+            # runs on a request hot path while holding the lock.
+            probe = await asyncio.to_thread(self._probe_vram)
+            if probe is None:
+                # No VRAM probe on this hardware (AMD/Apple/Rockchip or a
+                # failed nvidia-smi). Fail OPEN, matching the cluster lease
+                # ledger's convention (manager.claim_lease): we cannot prove
+                # insufficiency, so admit and keep bookkeeping only. A closed
+                # fail here would 503 every model pull on non-NVIDIA hosts.
+                free_mb, total_mb = 0, 0
+                effective_free = vram_mb  # unknown; grant-log then shows 0
+                logger.info(
+                    "vram-reservation: no VRAM probe available; admitting %d "
+                    "MiB for %r unenforced (bookkeeping only)", vram_mb, caller,
                 )
-                return None
+            else:
+                free_mb, total_mb = probe
+                effective_free = max(0, free_mb - self._reserved_vram_mb)
+
+                if effective_free < vram_mb:
+                    logger.debug(
+                        "vram-reservation: denied — need %d MiB, have %d MiB "
+                        "(%d free − %d reserved)",
+                        vram_mb, effective_free, free_mb, self._reserved_vram_mb,
+                    )
+                    return None
 
             reservation_id = f"vr_{secrets.token_hex(4)}"
             reservation = VramReservation(
@@ -148,15 +164,25 @@ class VramReservationManager:
 
     def available_vram(self) -> tuple[int, int]:
         """Return ``(effective_free_mb, total_mb)`` after subtracting
-        in-flight reservations from the hardware probe."""
-        free_mb, total_mb = self._probe_vram()
+        in-flight reservations from the hardware probe.
+
+        When no probe is available, returns ``(0, 0)``; callers on that
+        path should already have been admitted fail-open by :meth:`reserve`
+        (a deny message never reports these zeros as real capacity).
+        """
+        probe = self._probe_vram()
+        if probe is None:
+            return 0, 0
+        free_mb, total_mb = probe
         effective_free = max(0, free_mb - self._reserved_vram_mb)
         return effective_free, total_mb
 
     def stats(self) -> dict:
         """Return a snapshot for monitoring / debug endpoints."""
-        free_mb, total_mb = self._probe_vram()
+        probe = self._probe_vram()
+        free_mb, total_mb = probe if probe is not None else (0, 0)
         return {
+            "probe_available": probe is not None,
             "free_vram_mb": free_mb,
             "total_vram_mb": total_mb,
             "reserved_vram_mb": self._reserved_vram_mb,
@@ -167,11 +193,13 @@ class VramReservationManager:
     # ── internal ────────────────────────────────────────────────────
 
     @staticmethod
-    def _probe_vram() -> tuple[int, int]:
+    def _probe_vram() -> tuple[int, int] | None:
         """Probe real-time free/total VRAM via nvidia-smi.
 
-        Returns ``(free_mb, total_mb)``, or ``(0, 0)`` when no
-        nvidia-smi is available or the probe fails.
+        Returns ``(free_mb, total_mb)``, or ``None`` when no nvidia-smi
+        is available or the probe fails. ``None`` (cannot know) is
+        deliberately distinct from ``(0, 0)`` (known-full): admission
+        fails open on ``None``, matching cluster claim_lease semantics.
         """
         try:
             from tinyagentos.system_stats import read_nvidia_vram
@@ -183,4 +211,4 @@ class VramReservationManager:
                 return free_mb, total_mb
         except Exception:
             logger.debug("vram-reservation: probe failed", exc_info=True)
-        return 0, 0
+        return None

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -161,6 +161,42 @@ class WorkerAgent:
                     # its cluster-level kv_cache_quant_support advertisement.
                     "kv_quant_support": kv_quant,
                 })
+
+        # Enrich each backend with available models from the local worker
+        # manifest.  The manifest declares which models this machine *can*
+        # run (per the GPU catalog), independently of what is currently
+        # loaded.  The controller then sees both "loaded" and "available"
+        # states so the cluster-wide view reflects total capacity.
+        from tinyagentos.worker.worker_manifest import (
+            load_manifest,
+            SOFTWARE_TO_BACKEND_TYPE,
+        )
+
+        manifest = load_manifest()
+        if manifest.get("models"):
+            for backend in backends:
+                backend_type = backend["type"]
+                probed_names = {
+                    m.get("name", "") for m in backend.get("models", [])
+                }
+                available = []
+                for m in manifest["models"]:
+                    if SOFTWARE_TO_BACKEND_TYPE.get(m.get("software", "")) != backend_type:
+                        continue
+                    model_id = m["model_id"]
+                    status = "loaded" if model_id in probed_names else "available"
+                    available.append({
+                        "model_id": model_id,
+                        "capability": m.get("capability", ""),
+                        "software": m.get("software", ""),
+                        "port": m.get("port", 0),
+                        "vram_required_gb": m.get("vram_required_gb", 0.0),
+                        "health_url": m.get("health_url", ""),
+                        "status": status,
+                    })
+                if available:
+                    backend["available_models"] = available
+
         return backends
 
     async def _probe_kv_quant(

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -172,30 +172,44 @@ class WorkerAgent:
             SOFTWARE_TO_BACKEND_TYPE,
         )
 
-        manifest = load_manifest()
-        if manifest.get("models"):
-            for backend in backends:
-                backend_type = backend["type"]
-                probed_names = {
-                    m.get("name", "") for m in backend.get("models", [])
-                }
-                available = []
-                for m in manifest["models"]:
-                    if SOFTWARE_TO_BACKEND_TYPE.get(m.get("software", "")) != backend_type:
-                        continue
-                    model_id = m["model_id"]
-                    status = "loaded" if model_id in probed_names else "available"
-                    available.append({
-                        "model_id": model_id,
-                        "capability": m.get("capability", ""),
-                        "software": m.get("software", ""),
-                        "port": m.get("port", 0),
-                        "vram_required_gb": m.get("vram_required_gb", 0.0),
-                        "health_url": m.get("health_url", ""),
-                        "status": status,
-                    })
-                if available:
-                    backend["available_models"] = available
+        # The manifest is external input: a malformed file or entry must
+        # degrade to "no manifest" (logged), never crash detect_backends()
+        # and take the whole worker down with it.
+        try:
+            manifest = load_manifest()
+            if manifest.get("models"):
+                for backend in backends:
+                    backend_type = backend["type"]
+                    probed_names = {
+                        m.get("name", "") for m in backend.get("models", [])
+                    }
+                    available = []
+                    for m in manifest["models"]:
+                        if not isinstance(m, dict):
+                            continue
+                        if SOFTWARE_TO_BACKEND_TYPE.get(m.get("software", "")) != backend_type:
+                            continue
+                        model_id = m.get("model_id")
+                        if not model_id:
+                            logger.warning(
+                                "skipping worker-manifest entry without model_id: %r", m
+                            )
+                            continue
+                        status = "loaded" if model_id in probed_names else "available"
+                        available.append({
+                            "model_id": model_id,
+                            "capability": m.get("capability", ""),
+                            "software": m.get("software", ""),
+                            "port": m.get("port", 0),
+                            "vram_required_gb": m.get("vram_required_gb", 0.0),
+                            "health_url": m.get("health_url", ""),
+                            "status": status,
+                        })
+                    if available:
+                        backend["available_models"] = available
+        except Exception:  # noqa: BLE001 - manifest must never brick the worker
+            logger.warning("worker-manifest enrichment failed; continuing without it",
+                           exc_info=True)
 
         return backends
 
@@ -567,7 +581,11 @@ class WorkerAgent:
                     headers=auth_headers,
                 )
                 return resp.status_code
-        except Exception:
+        except Exception as exc:  # noqa: BLE001
+            # Log before swallowing: a payload-build bug (not just a network
+            # blip) would otherwise drop the worker offline with zero
+            # diagnostics, masquerading as controller unreachability.
+            logger.warning("heartbeat send failed: %s: %s", type(exc).__name__, exc)
             return 0
 
     def _log_repair_instruction(self) -> None:

--- a/tinyagentos/worker/worker_manifest.py
+++ b/tinyagentos/worker/worker_manifest.py
@@ -1,0 +1,67 @@
+"""Read a local worker manifest that declares which models this machine
+*can* run, independently of whatever is currently loaded in RAM.
+
+The manifest is a simple JSON file (default ``/etc/taos/worker-models.json``,
+configurable via ``TAOS_WORKER_MANIFEST``).  Any external platform (Skald,
+a custom scheduler, a config-management tool) may write it.  TAOS core
+reads it to advertise *available* (not-yet-loaded) models alongside the
+*loaded* models discovered by live backend probing.  The controller's
+cluster view then knows what a worker *could* load without having to
+consult an external catalog.
+
+The file format is::
+
+    {
+      "resource_id": "<machine id>",
+      "models": [
+        {
+          "model_id": "<logical name>",
+          "software": "llamacpp|embed|kokoro|whisper",
+          "port": 9090,
+          "vram_required_gb": 5.3,
+          "health_url": "http://127.0.0.1:9090/health",
+          "capability": "text|embed|tts|asr"
+        }
+      ]
+    }
+
+When the file is absent the worker simply reports an empty available-models
+list — no error, no behaviour change for deployments that do not use the
+feature.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MANIFEST_PATH = "/etc/taos/worker-models.json"
+
+# Map software names to TAOS backend types so the worker can attach manifest
+# entries to the correct backend dict.
+SOFTWARE_TO_BACKEND_TYPE: dict[str, str] = {
+    "llamacpp": "llama-cpp",
+    "embed": "llama-cpp",
+    "kokoro": "kokoro",
+    "whisper": "whisper",
+}
+
+
+def load_manifest(path: str | None = None) -> dict[str, Any]:
+    """Read the worker-models manifest from disk.
+
+    Args:
+        path: Override path.  Falls back to ``TAOS_WORKER_MANIFEST`` env
+              var, then ``/etc/taos/worker-models.json``.
+
+    Returns:
+        Dict with keys ``resource_id`` (str) and ``models`` (list of dicts).
+        Returns an empty manifest when the file is absent (the worker may
+        not run with a manifest).
+    """
+    manifest_path = Path(path or os.getenv("TAOS_WORKER_MANIFEST", DEFAULT_MANIFEST_PATH))
+    if not manifest_path.exists():
+        return {"resource_id": "", "models": []}
+    return json.loads(manifest_path.read_text())

--- a/tinyagentos/worker/worker_manifest.py
+++ b/tinyagentos/worker/worker_manifest.py
@@ -33,9 +33,12 @@ feature.
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MANIFEST_PATH = "/etc/taos/worker-models.json"
 
@@ -58,10 +61,26 @@ def load_manifest(path: str | None = None) -> dict[str, Any]:
 
     Returns:
         Dict with keys ``resource_id`` (str) and ``models`` (list of dicts).
-        Returns an empty manifest when the file is absent (the worker may
-        not run with a manifest).
+        Returns an empty manifest when the file is absent OR unreadable/
+        malformed. The manifest is external input (any platform may write
+        it), so a typo in it must never take the worker down -- a bad file
+        is logged and treated as no-manifest rather than raised.
     """
     manifest_path = Path(path or os.getenv("TAOS_WORKER_MANIFEST", DEFAULT_MANIFEST_PATH))
+    empty: dict[str, Any] = {"resource_id": "", "models": []}
     if not manifest_path.exists():
-        return {"resource_id": "", "models": []}
-    return json.loads(manifest_path.read_text())
+        return empty
+    try:
+        data = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "ignoring malformed worker manifest %s: %s", manifest_path, exc
+        )
+        return empty
+    if not isinstance(data, dict) or not isinstance(data.get("models", []), list):
+        logger.warning(
+            "ignoring worker manifest %s: top level must be an object with a "
+            "'models' list", manifest_path,
+        )
+        return empty
+    return data

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b38"
+version = "1.0.0b39"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Promotion of dev to master for the 1.0.0-beta.39 release.

Includes the 16 PRs merged since beta.38: Game Studio AI textures/sprites (#1773), taOSgo Headscale mesh-join + persisted service credentials (#1770, #1772), authenticated A2A bus send (#1768), managed node-local backend services + model advertisement (#1756/1758/1760/1762), atomic VRAM check-and-reserve (#1725), audit hotfixes (#1767), rkllama 1.3.0 pin (#1764), catalog install-script fixes (#1694), and the least-privilege project-tasks agent scope (#1774). Full notes in CHANGELOG under [1.0.0-beta.39].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Game Studio can generate textures and sprites with prompt-based AI workflows, preview results, and insert assets into projects.
  * Added project-scoped task-board access for external agents and authenticated coordination-bus posting.
  * Added mesh joining/status support and secure credential persistence.
  * Added cluster model advertisements and managed backend service controls.
  * Added VRAM reservation safeguards for model operations.

* **Bug Fixes**
  * Binary game assets are preserved during saves.
  * Improved backend installation, health checks, recovery, and manifest validation.

* **Documentation**
  * Added guidance for agent installers, asset generation, mesh joining, and backend management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->