### PR TITLE
feat(consent): project picker for project_tasks approval

### DIFF
--- a/desktop/src/apps/DecisionsApp.tsx
+++ b/desktop/src/apps/DecisionsApp.tsx
@@ -64,6 +64,7 @@ interface AuthRequest {
   requested_scopes: string[];
   reason?: string;
   created_ts?: string;
+  project_id?: string;
 }
 
 // created_at is stored as an epoch-seconds REAL on the backend, but the API
@@ -493,6 +494,7 @@ function AuthRequestCard({
       <ConsentActions
         requestId={req.id}
         scopes={req.requested_scopes}
+        requestedProjectId={req.project_id}
         onResolved={onResolved}
       />
     </li>

--- a/desktop/src/components/ConsentActions.test.tsx
+++ b/desktop/src/components/ConsentActions.test.tsx
@@ -131,4 +131,39 @@ describe("ConsentActions", () => {
     fireEvent.change(select, { target: { value: "p2" } });
     expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled();
   });
+
+  it("creates a project inline and grants project_tasks against the new project", async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      const u = String(url);
+      if (u === "/api/projects?status=active") {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ items: [] }) });
+      }
+      if (u === "/api/projects" && init?.method === "POST") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: "pnew", name: "Fresh" }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: "ok" }) });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onResolved = vi.fn();
+    render(<ConsentActions requestId="req-c" scopes={["project_tasks"]} onResolved={onResolved} />);
+
+    await screen.findByLabelText(/Grant project_tasks for project/i);
+    expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /new/i }));
+    fireEvent.change(screen.getByLabelText(/New project name/i), { target: { value: "Fresh" } });
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+
+    const approve = fetchMock.mock.calls.find((c) => String(c[0]).includes("/approve"));
+    expect(approve).toBeTruthy();
+    expect(JSON.parse((approve![1] as RequestInit).body as string)).toEqual({
+      granted_scopes: ["project_tasks"],
+      project_id: "pnew",
+    });
+  });
 });

--- a/desktop/src/components/ConsentActions.test.tsx
+++ b/desktop/src/components/ConsentActions.test.tsx
@@ -79,4 +79,56 @@ describe("ConsentActions", () => {
     await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("forbidden"));
     expect(onResolved).not.toHaveBeenCalled();
   });
+
+  it("shows a project picker for a project_tasks request and sends the chosen project_id", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).startsWith("/api/projects")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ items: [{ id: "p1", name: "taOS Core" }] }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: "ok" }) });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const onResolved = vi.fn();
+    render(
+      <ConsentActions requestId="req-p" scopes={["project_tasks", "a2a_send"]} onResolved={onResolved} />,
+    );
+    // The picker appears and the single project is auto-selected.
+    await screen.findByLabelText(/Grant project_tasks for project/i);
+
+    fireEvent.click(screen.getByRole("button", { name: /allow/i }));
+    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+
+    const approveCall = fetchMock.mock.calls.find((c) => String(c[0]).includes("/approve"));
+    expect(approveCall).toBeTruthy();
+    expect(JSON.parse((approveCall![1] as RequestInit).body as string)).toEqual({
+      granted_scopes: ["project_tasks", "a2a_send"],
+      project_id: "p1",
+    });
+  });
+
+  it("gates Allow until a project is chosen when several projects exist", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).startsWith("/api/projects")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({ items: [{ id: "p1", name: "Alpha" }, { id: "p2", name: "Bravo" }] }),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ status: "ok" }) });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ConsentActions requestId="req-m" scopes={["project_tasks"]} />);
+
+    const select = await screen.findByLabelText(/Grant project_tasks for project/i);
+    expect(screen.getByRole("button", { name: /allow/i })).toBeDisabled();
+
+    fireEvent.change(select, { target: { value: "p2" } });
+    expect(screen.getByRole("button", { name: /allow/i })).not.toBeDisabled();
+  });
 });

--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -48,7 +48,10 @@ export function ConsentActions({
   const [error, setError] = useState<string | null>(null);
   const [projects, setProjects] = useState<ProjectOption[]>([]);
   const [loadingProjects, setLoadingProjects] = useState(false);
-  const [selectedProjectId, setSelectedProjectId] = useState<string>(requestedProjectId ?? "");
+  // Start empty on purpose: a requestedProjectId is only adopted after it is
+  // verified to exist in the fetched project list (below), so a stale or
+  // unowned id from the request can never be sent to approve.
+  const [selectedProjectId, setSelectedProjectId] = useState<string>("");
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
 
@@ -97,12 +100,18 @@ export function ConsentActions({
       setError((d as { error?: string }).error ?? `Could not create project (${res.status})`);
       return null;
     }
-    const p = (await res.json()) as ProjectOption;
-    setProjects((prev) => [p, ...prev]);
-    setSelectedProjectId(p.id);
+    const p = (await res.json().catch(() => null)) as Partial<ProjectOption> | null;
+    const id = typeof p?.id === "string" ? p.id : "";
+    if (!id) {
+      setError("Project created but the response was unexpected; reload and pick it from the list.");
+      return null;
+    }
+    const created: ProjectOption = { id, name: typeof p?.name === "string" ? p.name : id };
+    setProjects((prev) => [created, ...prev]);
+    setSelectedProjectId(id);
     setCreating(false);
     setNewName("");
-    return p.id;
+    return id;
   }
 
   async function decide(approved: boolean) {

--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CheckCircle, XCircle } from "lucide-react";
 
 /**
@@ -6,28 +6,132 @@ import { CheckCircle, XCircle } from "lucide-react";
  *
  * Rendered in the compact consent surfaces — the bell notification and the
  * non-blocking toast (mirroring AgentPausedActions) and reused in the Decisions
- * app. The granted scope set is exactly the requested scopes; per-scope control
- * lives in the full request record / Decisions app, not these compact surfaces.
+ * app. The granted scope set is exactly the requested scopes.
+ *
+ * When the request includes the `project_tasks` scope, that scope is bound to a
+ * single project, so the approver must choose which project it applies to before
+ * allowing. The picker lists the operator's projects and can create one inline,
+ * so a request that named no project (or the wrong one) can still be assigned the
+ * right project at approval time. The chosen project id is passed to the approve
+ * endpoint, which mints the token bound to it.
  */
+const PROJECT_SCOPE = "project_tasks";
+
+interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 63) || "project"
+  );
+}
+
 export function ConsentActions({
   requestId,
   scopes,
+  requestedProjectId,
   onResolved,
 }: {
   requestId: string;
   scopes: string[];
+  requestedProjectId?: string;
   onResolved?: () => void;
 }) {
+  const needsProject = scopes.includes(PROJECT_SCOPE);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+  const [loadingProjects, setLoadingProjects] = useState(false);
+  const [selectedProjectId, setSelectedProjectId] = useState<string>(requestedProjectId ?? "");
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  useEffect(() => {
+    if (!needsProject) return;
+    let cancelled = false;
+    setLoadingProjects(true);
+    fetch("/api/projects?status=active", { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : { items: [] }))
+      .then((d: { items?: ProjectOption[] }) => {
+        if (cancelled) return;
+        const items = Array.isArray(d.items) ? d.items : [];
+        setProjects(items);
+        // Preselect the requested project if it exists, else auto-pick when there
+        // is exactly one project. Never overwrite an operator's manual choice.
+        setSelectedProjectId((cur) => {
+          if (cur) return cur;
+          if (requestedProjectId && items.some((p) => p.id === requestedProjectId)) {
+            return requestedProjectId;
+          }
+          return items.length === 1 && items[0] ? items[0].id : "";
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setProjects([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingProjects(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [needsProject, requestedProjectId]);
+
+  async function createProject(): Promise<string | null> {
+    const name = newName.trim();
+    if (!name) return null;
+    const res = await fetch("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ name, slug: slugify(name) }),
+    });
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}));
+      setError((d as { error?: string }).error ?? `Could not create project (${res.status})`);
+      return null;
+    }
+    const p = (await res.json()) as ProjectOption;
+    setProjects((prev) => [p, ...prev]);
+    setSelectedProjectId(p.id);
+    setCreating(false);
+    setNewName("");
+    return p.id;
+  }
 
   async function decide(approved: boolean) {
     setBusy(true);
     setError(null);
+    let projectId = selectedProjectId;
+    // If approving with project_tasks while mid-create, create the project first.
+    if (approved && needsProject && creating && newName.trim()) {
+      const created = await createProject();
+      if (!created) {
+        setBusy(false);
+        return;
+      }
+      projectId = created;
+    }
+    if (approved && needsProject && !projectId) {
+      setError("Select or create a project to grant project_tasks.");
+      setBusy(false);
+      return;
+    }
     const url = approved
       ? `/api/agents/auth-requests/${encodeURIComponent(requestId)}/approve`
       : `/api/agents/auth-requests/${encodeURIComponent(requestId)}/deny`;
-    const body = approved ? JSON.stringify({ granted_scopes: scopes }) : undefined;
+    let body: string | undefined;
+    if (approved) {
+      const payload: { granted_scopes: string[]; project_id?: string } = { granted_scopes: scopes };
+      if (needsProject && projectId) payload.project_id = projectId;
+      body = JSON.stringify(payload);
+    }
     try {
       const res = await fetch(url, {
         method: "POST",
@@ -48,13 +152,88 @@ export function ConsentActions({
     }
   }
 
+  const allowDisabled =
+    busy || (needsProject && !selectedProjectId && !(creating && newName.trim().length > 0));
+
   return (
     <div className="mt-2" role="group" aria-label="Consent actions">
+      {needsProject && (
+        <div className="mb-2">
+          <label
+            htmlFor={`consent-project-${requestId}`}
+            className="block text-[11px] text-shell-text-secondary mb-1"
+          >
+            Grant project_tasks for project
+          </label>
+          {!creating ? (
+            <div className="flex items-center gap-1.5">
+              <select
+                id={`consent-project-${requestId}`}
+                value={selectedProjectId}
+                onChange={(e) => {
+                  e.stopPropagation();
+                  setSelectedProjectId(e.target.value);
+                }}
+                onClick={(e) => e.stopPropagation()}
+                disabled={busy || loadingProjects}
+                className="flex-1 min-w-0 px-2 py-1 rounded-md text-[11px] bg-white/5 border border-white/10 text-shell-text disabled:opacity-50"
+              >
+                <option value="">{loadingProjects ? "Loading..." : "Select a project"}</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setCreating(true);
+                }}
+                disabled={busy}
+                className="px-2 py-1 rounded-md text-[11px] bg-white/5 hover:bg-white/10 border border-white/10 text-shell-text-secondary disabled:opacity-50"
+              >
+                New
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1.5">
+              <input
+                aria-label="New project name"
+                value={newName}
+                onChange={(e) => {
+                  e.stopPropagation();
+                  setNewName(e.target.value);
+                }}
+                onClick={(e) => e.stopPropagation()}
+                placeholder="New project name"
+                className="flex-1 min-w-0 px-2 py-1 rounded-md text-[11px] bg-white/5 border border-white/10 text-shell-text"
+              />
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setCreating(false);
+                  setNewName("");
+                }}
+                disabled={busy}
+                className="px-2 py-1 rounded-md text-[11px] bg-white/5 hover:bg-white/10 border border-white/10 text-shell-text-secondary disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      )}
       <div className="flex flex-wrap gap-1.5">
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); decide(true); }}
-          disabled={busy}
+          onClick={(e) => {
+            e.stopPropagation();
+            decide(true);
+          }}
+          disabled={allowDisabled}
           className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-emerald-500/15 hover:bg-emerald-500/25 text-emerald-400 border border-emerald-500/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <CheckCircle size={11} />
@@ -62,7 +241,10 @@ export function ConsentActions({
         </button>
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); decide(false); }}
+          onClick={(e) => {
+            e.stopPropagation();
+            decide(false);
+          }}
           disabled={busy}
           className="flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-white/5 hover:bg-red-500/15 hover:text-red-300 text-shell-text-secondary border border-white/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
@@ -79,15 +261,17 @@ export function ConsentActions({
   );
 }
 
-/** Pull the consent payload (request id + requested scopes) out of a
- *  notification's `data` field. Returns null when the shape is missing. */
+/** Pull the consent payload (request id + requested scopes + any requested
+ *  project) out of a notification's `data` field. Returns null when the shape
+ *  is missing. */
 export function consentPayload(
   data: Record<string, unknown> | undefined,
-): { requestId: string; scopes: string[] } | null {
+): { requestId: string; scopes: string[]; projectId?: string } | null {
   if (!data) return null;
   const requestId = data.request_id;
   if (typeof requestId !== "string") return null;
   const raw = data.requested_scopes;
   const scopes = Array.isArray(raw) ? raw.filter((s): s is string => typeof s === "string") : [];
-  return { requestId, scopes };
+  const projectId = typeof data.project_id === "string" ? data.project_id : undefined;
+  return { requestId, scopes, projectId };
 }

--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -162,7 +162,7 @@ export function ConsentActions({
   }
 
   const allowDisabled =
-    busy || (needsProject && !selectedProjectId && !(creating && newName.trim().length > 0));
+    busy || (needsProject && (creating ? !newName.trim() : !selectedProjectId));
 
   return (
     <div className="mt-2" role="group" aria-label="Consent actions">

--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -70,6 +70,7 @@ function NotificationItem({
           <ConsentActions
             requestId={consent.requestId}
             scopes={consent.scopes}
+            requestedProjectId={consent.projectId}
             onResolved={() => onResolveConsent(n.id)}
           />
         </div>

--- a/desktop/src/components/NotificationToast.tsx
+++ b/desktop/src/components/NotificationToast.tsx
@@ -306,6 +306,7 @@ function ToastItem({ notif, onExpire }: { notif: Notification; onExpire: () => v
           <ConsentActions
             requestId={consent.requestId}
             scopes={consent.scopes}
+            requestedProjectId={consent.projectId}
             onResolved={() => archiveRead(notif.id)}
           />
         )}

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -161,6 +161,60 @@ class TestApproveDisplayNameNormalization:
         await grants.close()
 
     @pytest.mark.asyncio
+    async def test_approve_project_tasks_requires_explicit_project_id(
+        self, client, monkeypatch, tmp_path
+    ):
+        """Granting project_tasks without a picked project_id is rejected, so an
+        unauthenticated request cannot bind a task token to a project the
+        operator never validated in the picker."""
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+
+        registry = AgentRegistryStore(tmp_path / "reg.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants.db")
+        await grants.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys")
+
+        # The request names a project, but the picker did not send one on approve.
+        record = await auth_store.create(
+            identity_claim="grok",
+            framework="grok",
+            requested_scopes=["project_tasks"],
+            requested_skills=None,
+            reason="",
+            duration_secs=None,
+            project_id="prj-agent-named",
+        )
+
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(
+            client._transport.app.state, "agent_registry_keypair", (priv, pub)
+        )
+
+        resp = await client.post(
+            f"/api/agents/auth-requests/{record['id']}/approve",
+            json={"granted_scopes": ["project_tasks"]},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "project_id" in resp.text
+
+        # No agent should have been registered by the rejected approval.
+        assert await registry.list_all() == []
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+
+    @pytest.mark.asyncio
     async def test_approve_preserves_name_without_at(
         self, client, monkeypatch, tmp_path
     ):

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -348,6 +348,37 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
         # permission-check path (can_communicate etc.) is aware of the agent.
         await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
 
+    # If the agent was granted project_tasks and bound to a project, add it as a
+    # member of that project so it shows up in the project's Members and joins the
+    # project a2a channel (membership is synced into the channel). Best-effort: a
+    # membership failure never blocks the approval, which the token + grant already
+    # authorize.
+    if effective_project and "project_tasks" in body.granted_scopes:
+        try:
+            pstore = getattr(request.app.state, "project_store", None)
+            if pstore is not None:
+                await pstore.add_member(
+                    project_id=effective_project,
+                    member_id=canonical_id,
+                    member_kind="native",
+                    role="member",
+                )
+                from tinyagentos.projects.a2a import ensure_a2a_channel
+
+                await ensure_a2a_channel(
+                    request.app.state.chat_channels,
+                    pstore,
+                    effective_project,
+                    config=getattr(request.app.state, "config", None),
+                )
+        except Exception:  # noqa: BLE001 - membership is best-effort, never blocks approval
+            logger.warning(
+                "auth-approve: could not add %s as a member of project %s",
+                canonical_id,
+                effective_project,
+                exc_info=True,
+            )
+
     # Atomically commit the decision.
     result = await auth_store.set_decision(
         request_id,

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -298,6 +298,19 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
             ),
         )
 
+    # project_tasks binds the token to a specific project and adds a membership
+    # row, so require the human to pick that project explicitly in the consent
+    # card. Never fall back to the agent-supplied project_id for a task grant:
+    # POST /api/agents/auth-requests is unauthenticated, so the request could
+    # name any existing project the operator never validated. Other scopes keep
+    # the fallback so global tokens still work. Checked before any registration
+    # so a rejected approval never leaves an orphaned agent.
+    if "project_tasks" in body.granted_scopes and body.project_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="project_id is required when granting project_tasks",
+        )
+
     registry = _get_registry_store(request)
     private_pem, _public_pem = _get_keypair(request)
     grants_store = _get_grants_store(request)
@@ -373,7 +386,7 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
                 )
         except Exception:  # noqa: BLE001 - membership is best-effort, never blocks approval
             logger.warning(
-                "auth-approve: could not add %s as a member of project %s",
+                "auth-approve: could not sync %s membership/a2a channel for project %s",
                 canonical_id,
                 effective_project,
                 exc_info=True,


### PR DESCRIPTION
When approving an external-agent access request that includes the project_tasks scope, the consent card now shows a project selector (list the operator's projects, preselect a requested or single project, create one inline) and gates Allow until a project is chosen. The chosen project_id is passed to the approve endpoint so the token binds to the right project. Surfaces the gap noticed on the grok-taOS request: the card listed scopes but gave no way to see or assign the project. Non project_tasks requests are unchanged. 6 ConsentActions tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project selection for approving project-task requests.
  * Auto-selects the project when there’s only one available.
  * Supports creating a new project inline during approval.
  * Sends the chosen/created project ID as part of the approval request.

* **Bug Fixes**
  * Improved consent error handling to prefer API-provided detail messages.

* **Tests**
  * Expanded coverage for the project-tasks consent flow, including single/multiple projects and inline project creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->