### PR TITLE
feat(notifications): OS-level PWA web-push (VAPID) for taOS notifications

### DIFF
--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -1,9 +1,15 @@
-import { useState } from "react";
-import { X, Bell, CheckCheck, Trash2, History } from "lucide-react";
+import { useState, useEffect } from "react";
+import { X, Bell, BellOff, CheckCheck, Trash2, History } from "lucide-react";
 import { useNotificationStore, type Notification } from "@/stores/notification-store";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
 import { markServerRead, markAllServerRead } from "@/lib/server-notifications";
+import {
+  getPushState,
+  enableNotificationsPush,
+  disableNotificationsPush,
+  type PushState,
+} from "@/lib/notifications-push";
 import { SetupChecklist } from "./SetupChecklist";
 import { ConsentActions, consentPayload } from "./ConsentActions";
 
@@ -74,6 +80,78 @@ function NotificationItem({
           />
         </div>
       )}
+    </div>
+  );
+}
+
+// "Enable notifications on this device" control. Registers a PWA web-push
+// subscription so OS notifications (e.g. agent access-requests) reach this
+// device even when taOS is closed. On iOS the PWA must be added to the Home
+// Screen before push can be enabled (Safari limitation).
+function PushToggle() {
+  const [state, setState] = useState<PushState | "loading" | "working">("loading");
+
+  useEffect(() => {
+    let alive = true;
+    getPushState()
+      .then((s) => alive && setState(s))
+      .catch(() => alive && setState("disabled"));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (state === "loading" || state === "unsupported") return null;
+
+  if (state === "needs-install") {
+    return (
+      <div className="flex items-start gap-2 px-4 py-2.5 border-b border-white/5 text-[11px] text-shell-text-tertiary">
+        <Bell size={13} className="mt-0.5 shrink-0" />
+        <span>Add taOS to your Home Screen to get notifications on this device.</span>
+      </div>
+    );
+  }
+
+  if (state === "denied") {
+    return (
+      <div className="flex items-start gap-2 px-4 py-2.5 border-b border-white/5 text-[11px] text-shell-text-tertiary">
+        <BellOff size={13} className="mt-0.5 shrink-0" />
+        <span>Notifications are blocked. Enable them for taOS in your browser settings.</span>
+      </div>
+    );
+  }
+
+  const enabled = state === "enabled";
+  const busy = state === "working";
+  const toggle = async () => {
+    setState("working");
+    try {
+      const next = enabled ? await disableNotificationsPush() : await enableNotificationsPush();
+      setState(next);
+    } catch {
+      setState(await getPushState().catch(() => "disabled"));
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-white/5">
+      <div className="flex items-center gap-2 min-w-0">
+        {enabled ? (
+          <Bell size={13} className="text-accent shrink-0" />
+        ) : (
+          <BellOff size={13} className="text-shell-text-tertiary shrink-0" />
+        )}
+        <span className="text-[11px] text-shell-text-secondary truncate">
+          {enabled ? "Notifications on this device" : "Enable notifications on this device"}
+        </span>
+      </div>
+      <button
+        onClick={toggle}
+        disabled={busy}
+        className="text-[11px] font-medium text-accent hover:underline disabled:opacity-50 shrink-0"
+      >
+        {busy ? "..." : enabled ? "Turn off" : "Enable"}
+      </button>
     </div>
   );
 }
@@ -206,6 +284,7 @@ export function NotificationCentre() {
         <div className="flex-1 overflow-y-auto">
           {tab === "inbox" && (
             <>
+              <PushToggle />
               {!checklistDismissed && (
                 <SetupChecklist onDismissed={() => setChecklistDismissed(true)} />
               )}

--- a/desktop/src/lib/__tests__/sw-push-handlers.test.ts
+++ b/desktop/src/lib/__tests__/sw-push-handlers.test.ts
@@ -58,6 +58,17 @@ async function handleNotificationClick(
   openWindow: ((url: string) => Promise<null>) | null,
 ): Promise<unknown> {
   const data = notificationData || {};
+  // Same-origin guard mirroring sw.ts: resolve the deep link against our own
+  // origin and refuse anything cross-origin before openWindow.
+  let target = typeof data["url"] === "string" && data["url"] ? (data["url"] as string) : "/";
+  try {
+    const u = new URL(target, origin);
+    target = u.origin === origin && u.pathname.startsWith("/")
+      ? u.pathname + u.search
+      : "/";
+  } catch {
+    target = "/";
+  }
   for (const client of clients) {
     if (client.url && new URL(client.url).origin === origin) {
       client.postMessage({ type: "taos-push:click", data });
@@ -65,7 +76,7 @@ async function handleNotificationClick(
     }
   }
   if (openWindow) {
-    return openWindow("/");
+    return openWindow(target);
   }
   return null;
 }
@@ -150,6 +161,24 @@ describe("sw notificationclick handler — handleNotificationClick", () => {
   it("calls openWindow('/') when no matching client exists", async () => {
     const openWindow = vi.fn().mockResolvedValue(null);
     await handleNotificationClick({}, [], origin, openWindow);
+    expect(openWindow).toHaveBeenCalledWith("/");
+  });
+
+  it("opens the notification's deep link (data.url) when no client is open", async () => {
+    const openWindow = vi.fn().mockResolvedValue(null);
+    await handleNotificationClick({ url: "/desktop" }, [], origin, openWindow);
+    expect(openWindow).toHaveBeenCalledWith("/desktop");
+  });
+
+  it("refuses a cross-origin url and opens '/' instead", async () => {
+    const openWindow = vi.fn().mockResolvedValue(null);
+    await handleNotificationClick({ url: "https://evil.example.com/phish" }, [], origin, openWindow);
+    expect(openWindow).toHaveBeenCalledWith("/");
+  });
+
+  it("refuses a protocol-relative //host url and opens '/' instead", async () => {
+    const openWindow = vi.fn().mockResolvedValue(null);
+    await handleNotificationClick({ url: "//evil.example.com/phish" }, [], origin, openWindow);
     expect(openWindow).toHaveBeenCalledWith("/");
   });
 

--- a/desktop/src/lib/notifications-push-api.ts
+++ b/desktop/src/lib/notifications-push-api.ts
@@ -1,0 +1,42 @@
+/**
+ * Fetch wrappers for /api/notifications/push/* (OS-level PWA web-push).
+ * Separate key + subscription store from the Browser copilot push.
+ * Read operations throw on error (the caller surfaces state); write
+ * operations throw so the caller can reflect failure.
+ */
+
+export async function getVapidPublicKey(): Promise<string> {
+  const resp = await fetch("/api/notifications/push/vapid-public-key", {
+    credentials: "include",
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  const body = await resp.json();
+  if (typeof body?.public_key !== "string") throw new Error("Missing public_key in response");
+  return body.public_key;
+}
+
+export async function subscribePush(subscription: {
+  endpoint: string;
+  keys: { p256dh: string; auth: string };
+}): Promise<{ ok: true }> {
+  const resp = await fetch("/api/notifications/push/subscribe", {
+    method: "POST",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ subscription }),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return { ok: true };
+}
+
+export async function unsubscribePush(endpoint: string): Promise<{ ok: boolean }> {
+  const resp = await fetch("/api/notifications/push/unsubscribe", {
+    method: "POST",
+    credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ endpoint }),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  const body = await resp.json();
+  return { ok: typeof body?.ok === "boolean" ? body.ok : true };
+}

--- a/desktop/src/lib/notifications-push.test.ts
+++ b/desktop/src/lib/notifications-push.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "./notifications-push-api";
+import {
+  urlBase64ToUint8Array,
+  isPushSupported,
+  getPushState,
+  enableNotificationsPush,
+  disableNotificationsPush,
+} from "./notifications-push";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// urlBase64ToUint8Array
+// ---------------------------------------------------------------------------
+
+describe("urlBase64ToUint8Array", () => {
+  it("decodes a base64url VAPID key to the expected bytes", () => {
+    // "AQID" base64 -> [1,2,3]; base64url is identical here.
+    expect(Array.from(urlBase64ToUint8Array("AQID"))).toEqual([1, 2, 3]);
+  });
+
+  it("pads and translates -_ back to +/ before decoding", () => {
+    const b64 = btoa("\xfb\xff\xfe").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    expect(Array.from(urlBase64ToUint8Array(b64))).toEqual([251, 255, 254]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// support detection + state
+// ---------------------------------------------------------------------------
+
+function stubSupported(permission: NotificationPermission, existing: unknown) {
+  const pushManager = {
+    getSubscription: vi.fn().mockResolvedValue(existing),
+    subscribe: vi.fn(),
+  };
+  const registration = { pushManager };
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: { ready: Promise.resolve(registration), register: vi.fn() },
+  });
+  vi.stubGlobal("PushManager", class PushManager {});
+  vi.stubGlobal("Notification", {
+    permission,
+    requestPermission: vi.fn().mockResolvedValue(permission),
+  });
+  return { pushManager, registration };
+}
+
+describe("isPushSupported", () => {
+  it("false when PushManager/Notification are absent", () => {
+    vi.stubGlobal("PushManager", undefined);
+    // Notification may be defined by jsdom; force it absent for the check.
+    vi.stubGlobal("Notification", undefined);
+    expect(isPushSupported()).toBe(false);
+  });
+
+  it("true when serviceWorker + PushManager + Notification exist", () => {
+    stubSupported("default", null);
+    expect(isPushSupported()).toBe(true);
+  });
+});
+
+describe("getPushState", () => {
+  it("reports needs-install on iOS Safari before add-to-home-screen", async () => {
+    vi.stubGlobal("PushManager", undefined);
+    vi.stubGlobal("Notification", undefined);
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "Mozilla/5.0 (iPhone; CPU iPhone OS 16_4 like Mac OS X) Safari",
+    });
+    Object.defineProperty(navigator, "standalone", { configurable: true, value: false });
+    expect(await getPushState()).toBe("needs-install");
+  });
+
+  it("reports disabled when supported but no subscription exists", async () => {
+    stubSupported("granted", null);
+    expect(await getPushState()).toBe("disabled");
+  });
+
+  it("reports enabled when a subscription already exists", async () => {
+    stubSupported("granted", { endpoint: "https://push.example.com/ep" });
+    expect(await getPushState()).toBe("enabled");
+  });
+
+  it("reports denied when permission is denied", async () => {
+    stubSupported("denied", null);
+    expect(await getPushState()).toBe("denied");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enable / disable
+// ---------------------------------------------------------------------------
+
+describe("enableNotificationsPush", () => {
+  it("subscribes and POSTs the subscription to /subscribe", async () => {
+    const { pushManager } = stubSupported("granted", null);
+    pushManager.subscribe = vi.fn().mockResolvedValue({
+      endpoint: "https://push.example.com/ep",
+      getKey: (name: string) => {
+        if (name === "p256dh") return new Uint8Array([1, 2, 3]).buffer;
+        if (name === "auth") return new Uint8Array([4, 5]).buffer;
+        return null;
+      },
+    });
+    vi.spyOn(api, "getVapidPublicKey").mockResolvedValue("AQID");
+    const subscribeSpy = vi.spyOn(api, "subscribePush").mockResolvedValue({ ok: true });
+
+    const result = await enableNotificationsPush();
+
+    expect(result).toBe("enabled");
+    expect(pushManager.subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ userVisibleOnly: true }),
+    );
+    expect(subscribeSpy).toHaveBeenCalledOnce();
+    const arg = subscribeSpy.mock.calls[0][0];
+    expect(arg.endpoint).toBe("https://push.example.com/ep");
+    expect(arg.keys.p256dh).toBe("AQID"); // base64url of [1,2,3]
+  });
+
+  it("returns denied when permission is refused and never subscribes", async () => {
+    const { pushManager } = stubSupported("granted", null);
+    (Notification.requestPermission as ReturnType<typeof vi.fn>).mockResolvedValue("denied");
+    const subscribeSpy = vi.spyOn(api, "subscribePush");
+
+    const result = await enableNotificationsPush();
+
+    expect(result).toBe("denied");
+    expect(pushManager.subscribe).not.toHaveBeenCalled();
+    expect(subscribeSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("disableNotificationsPush", () => {
+  it("unsubscribes the SW and tells the server to drop the endpoint", async () => {
+    const unsub = vi.fn().mockResolvedValue(true);
+    const { pushManager } = stubSupported("granted", {
+      endpoint: "https://push.example.com/ep",
+      unsubscribe: unsub,
+    });
+    void pushManager;
+    const unsubSpy = vi.spyOn(api, "unsubscribePush").mockResolvedValue({ ok: true });
+
+    const result = await disableNotificationsPush();
+
+    expect(result).toBe("disabled");
+    expect(unsub).toHaveBeenCalledOnce();
+    expect(unsubSpy).toHaveBeenCalledWith("https://push.example.com/ep");
+  });
+});

--- a/desktop/src/lib/notifications-push.ts
+++ b/desktop/src/lib/notifications-push.ts
@@ -1,0 +1,133 @@
+/**
+ * OS-level PWA web-push enable/disable for taOS notifications.
+ *
+ * Wires the shell service worker (/sw.js, whose push + notificationclick
+ * handlers already live in sw.ts) to the /api/notifications/push/* endpoints
+ * so notifications reach an installed PWA even when taOS is closed.
+ *
+ * iOS caveat: Safari only exposes PushManager when the site has been added to
+ * the Home Screen (running standalone). Before that, getPushState() reports
+ * "needs-install" so the UI can tell the user to install first.
+ */
+
+import { getVapidPublicKey, subscribePush, unsubscribePush } from "./notifications-push-api";
+
+export type PushState =
+  | "enabled"
+  | "disabled"
+  | "denied"
+  | "unsupported"
+  | "needs-install";
+
+export function urlBase64ToUint8Array(b64url: string): Uint8Array {
+  const padding = "=".repeat((4 - (b64url.length % 4)) % 4);
+  const base64 = (b64url + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  return Uint8Array.from(raw, (c) => c.charCodeAt(0));
+}
+
+function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+/** True when running as an installed / standalone PWA. */
+function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  const mm = typeof window.matchMedia === "function"
+    && window.matchMedia("(display-mode: standalone)").matches;
+  // iOS Safari exposes the legacy navigator.standalone flag.
+  const iosStandalone = (navigator as unknown as { standalone?: boolean }).standalone === true;
+  return Boolean(mm || iosStandalone);
+}
+
+/** True when Notification + PushManager + serviceWorker are all present. */
+export function isPushSupported(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    "serviceWorker" in navigator &&
+    typeof window !== "undefined" &&
+    "PushManager" in window &&
+    typeof Notification !== "undefined"
+  );
+}
+
+/**
+ * Report the current push state for this device without prompting or
+ * subscribing. On iOS, an uninstalled PWA reports "needs-install".
+ */
+export async function getPushState(): Promise<PushState> {
+  if (!isPushSupported()) {
+    // On iOS the PushManager API is hidden until the PWA is installed. Detect
+    // that case so the UI can prompt to add-to-Home-Screen rather than saying
+    // "unsupported".
+    const isIOS = typeof navigator !== "undefined"
+      && /iP(hone|ad|od)/.test(navigator.userAgent)
+      && !isStandalone();
+    return isIOS ? "needs-install" : "unsupported";
+  }
+  if (Notification.permission === "denied") return "denied";
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const existing = await registration.pushManager.getSubscription();
+    return existing ? "enabled" : "disabled";
+  } catch {
+    return "disabled";
+  }
+}
+
+/**
+ * Enable OS notifications on this device: request permission, subscribe the
+ * shell SW to the server VAPID key, and POST the subscription. Returns the
+ * resulting state.
+ */
+export async function enableNotificationsPush(): Promise<PushState> {
+  if (!isPushSupported()) return getPushState();
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") {
+    return permission === "denied" ? "denied" : "disabled";
+  }
+  const registration = await navigator.serviceWorker.ready;
+  let subscription = await registration.pushManager.getSubscription();
+  if (!subscription) {
+    const vapidPublicKey = await getVapidPublicKey();
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapidPublicKey) as unknown as BufferSource,
+    });
+  }
+  const p256dh = subscription.getKey("p256dh");
+  const auth = subscription.getKey("auth");
+  await subscribePush({
+    endpoint: subscription.endpoint,
+    keys: {
+      p256dh: p256dh ? arrayBufferToBase64Url(p256dh) : "",
+      auth: auth ? arrayBufferToBase64Url(auth) : "",
+    },
+  });
+  return "enabled";
+}
+
+/**
+ * Disable OS notifications on this device: unsubscribe the SW and tell the
+ * server to drop the subscription. Idempotent.
+ */
+export async function disableNotificationsPush(): Promise<PushState> {
+  if (!isPushSupported()) return getPushState();
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+    if (subscription) {
+      const endpoint = subscription.endpoint;
+      await subscription.unsubscribe();
+      await unsubscribePush(endpoint);
+    }
+  } catch {
+    // Best-effort: even if the SW/network hiccups, report the intended state.
+  }
+  return "disabled";
+}

--- a/desktop/src/sw.ts
+++ b/desktop/src/sw.ts
@@ -198,10 +198,23 @@ self.addEventListener("push", (event: PushEvent) => {
 
 self.addEventListener("notificationclick", (event: NotificationEvent) => {
   // Close the notification, then focus an existing same-origin window
-  // (posting the click data so the shell can route to the right tab)
-  // or open a new one at root.
+  // (posting the click data so the shell can route to the right tab) or
+  // open a new one at the notification's deep link (data.url), falling back
+  // to root.
   event.notification.close();
   const data = (event.notification.data as Record<string, unknown>) || {};
+  // Resolve the deep link against our own origin and refuse anything
+  // cross-origin (open-redirect / phishing guard): a hostile push cannot make
+  // openWindow() navigate to an external site.
+  let target = typeof data["url"] === "string" && data["url"] ? (data["url"] as string) : "/";
+  try {
+    const u = new URL(target, self.location.origin);
+    target = u.origin === self.location.origin && u.pathname.startsWith("/")
+      ? u.pathname + u.search
+      : "/";
+  } catch {
+    target = "/";
+  }
   event.waitUntil(
     self.clients
       .matchAll({ type: "window", includeUncontrolled: true })
@@ -213,7 +226,7 @@ self.addEventListener("notificationclick", (event: NotificationEvent) => {
           }
         }
         if (self.clients.openWindow) {
-          return self.clients.openWindow("/");
+          return self.clients.openWindow(target);
         }
         return null;
       })

--- a/tests/test_notifications_push.py
+++ b/tests/test_notifications_push.py
@@ -1,0 +1,416 @@
+"""Tests for OS-level PWA web-push: store, best-effort send, add() wiring, routes."""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import tempfile
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+import requests
+from pywebpush import WebPushException
+
+from tinyagentos.notifications import NotificationStore
+from tinyagentos.notifications_push import NotificationPushStore, send_web_push
+from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+
+# A real VAPID keypair once for the whole module - pywebpush parses the PEM,
+# but every send is mocked so no network call is ever made.
+_VAPID_TMPDIR = tempfile.mkdtemp()
+FAKE_VAPID = load_or_create_vapid_keypair(pathlib.Path(_VAPID_TMPDIR), filename="notif_vapid.pem")
+
+_ENDPOINT_A = "https://push.example.com/sub/device_a"
+_ENDPOINT_B = "https://push.example.com/sub/device_b"
+
+
+def _response(status_code: int) -> requests.Response:
+    r = requests.Response()
+    r.status_code = status_code
+    r.reason = str(status_code)
+    return r
+
+
+@pytest_asyncio.fixture
+async def push_store(tmp_path):
+    store = NotificationPushStore(tmp_path / "notif_push.db")
+    await store.init()
+    yield store
+    await store.close()
+
+
+async def _seed(store, endpoint, user_id="u1"):
+    await store.upsert(user_id=user_id, endpoint=endpoint, p256dh="p256dh_key", auth="auth_key")
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestNotificationPushStore:
+    async def test_upsert_and_list_all(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        await _seed(push_store, _ENDPOINT_B)
+        subs = await push_store.list_all()
+        assert {s["endpoint"] for s in subs} == {_ENDPOINT_A, _ENDPOINT_B}
+        assert subs[0]["p256dh"] == "p256dh_key"
+        assert subs[0]["auth"] == "auth_key"
+
+    async def test_upsert_is_idempotent_on_endpoint(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        first = (await push_store.list_all())[0]["created_at"]
+        # Re-subscribe same endpoint with new keys - one row, created_at kept.
+        await push_store.upsert(user_id="u1", endpoint=_ENDPOINT_A, p256dh="new_p", auth="new_a")
+        subs = await push_store.list_all()
+        assert len(subs) == 1
+        assert subs[0]["p256dh"] == "new_p"
+        assert subs[0]["created_at"] == first
+
+    async def test_list_for_user_scopes_and_hides_secrets(self, push_store):
+        await _seed(push_store, _ENDPOINT_A, user_id="u1")
+        await _seed(push_store, _ENDPOINT_B, user_id="u2")
+        rows = await push_store.list_for_user("u1")
+        assert len(rows) == 1
+        assert rows[0]["endpoint"] == _ENDPOINT_A
+        assert "p256dh" not in rows[0] and "auth" not in rows[0]
+
+    async def test_delete_by_endpoint(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        assert await push_store.delete_by_endpoint(_ENDPOINT_A) == 1
+        assert await push_store.list_all() == []
+        assert await push_store.delete_by_endpoint(_ENDPOINT_A) == 0
+
+    async def test_upsert_never_changes_owner(self, push_store):
+        # user_a owns the endpoint; user_b re-subscribing the same endpoint must
+        # NOT hijack the row or overwrite its keys.
+        await _seed(push_store, _ENDPOINT_A, user_id="user_a")
+        await push_store.upsert(
+            user_id="user_b", endpoint=_ENDPOINT_A, p256dh="hijack_p", auth="hijack_a"
+        )
+        subs = await push_store.list_all()
+        assert len(subs) == 1
+        assert subs[0]["user_id"] == "user_a"
+        assert subs[0]["p256dh"] == "p256dh_key"  # unchanged
+        # The real owner can still refresh their own keys.
+        await push_store.upsert(
+            user_id="user_a", endpoint=_ENDPOINT_A, p256dh="new_p", auth="new_a"
+        )
+        subs = await push_store.list_all()
+        assert subs[0]["p256dh"] == "new_p"
+
+    async def test_delete_for_user_is_ownership_scoped(self, push_store):
+        await _seed(push_store, _ENDPOINT_A, user_id="user_a")
+        # user_b cannot delete user_a's endpoint.
+        assert await push_store.delete_for_user("user_b", _ENDPOINT_A) == 0
+        assert len(await push_store.list_all()) == 1
+        # The owner can.
+        assert await push_store.delete_for_user("user_a", _ENDPOINT_A) == 1
+        assert await push_store.list_all() == []
+
+    async def test_upsert_rejects_empty_fields(self, push_store):
+        with pytest.raises(ValueError):
+            await push_store.upsert(user_id="", endpoint=_ENDPOINT_A, p256dh="p", auth="a")
+        with pytest.raises(ValueError):
+            await push_store.upsert(user_id="u1", endpoint="", p256dh="p", auth="a")
+
+
+# ---------------------------------------------------------------------------
+# send_web_push - best-effort fan-out
+# ---------------------------------------------------------------------------
+
+_ROW = {"id": 7, "title": "Access request", "message": "agent x wants chat",
+        "source": "auth_requests", "data": {"request_id": "r1"}}
+
+
+@pytest.mark.asyncio
+class TestSendWebPush:
+    async def test_one_send_per_subscription(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        await _seed(push_store, _ENDPOINT_B)
+        with patch("pywebpush.webpush") as mock:
+            result = await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
+        assert mock.call_count == 2
+        assert result == {"sent": 2, "failed": 0, "removed": 0}
+
+    async def test_payload_maps_notification_fields(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        with patch("pywebpush.webpush") as mock:
+            await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
+        import json
+        payload = json.loads(mock.call_args.kwargs["data"])
+        assert payload["title"] == "Access request"
+        assert payload["body"] == "agent x wants chat"
+        assert payload["tag"] == "auth_requests:7"
+        assert payload["source"] == "auth_requests"
+        # No explicit url on the row -> desktop shell deep link.
+        assert payload["data"]["url"] == "/desktop"
+
+    async def test_uses_row_deep_link_when_present(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        row = {**_ROW, "data": {"url": "/desktop/decisions"}}
+        with patch("pywebpush.webpush") as mock:
+            await send_web_push(row, store=push_store, vapid=FAKE_VAPID)
+        import json
+        payload = json.loads(mock.call_args.kwargs["data"])
+        assert payload["data"]["url"] == "/desktop/decisions"
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "https://evil.example.com/phish",
+            "//evil.example.com/phish",
+            "javascript:alert(1)",
+            "\\evil",
+            "desktop",  # no leading slash
+        ],
+    )
+    async def test_rejects_unsafe_deep_link(self, push_store, bad_url):
+        await _seed(push_store, _ENDPOINT_A)
+        row = {**_ROW, "data": {"url": bad_url}}
+        with patch("pywebpush.webpush") as mock:
+            await send_web_push(row, store=push_store, vapid=FAKE_VAPID)
+        import json
+        payload = json.loads(mock.call_args.kwargs["data"])
+        assert payload["data"]["url"] == "/desktop"
+
+    async def test_410_prunes_subscription(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+
+        def _gone(*a, **k):
+            raise WebPushException("gone", response=_response(410))
+
+        with patch("pywebpush.webpush", side_effect=_gone):
+            result = await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
+        assert result == {"sent": 0, "failed": 0, "removed": 1}
+        assert await push_store.list_all() == []
+
+    async def test_404_prunes_subscription(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+
+        def _missing(*a, **k):
+            raise WebPushException("missing", response=_response(404))
+
+        with patch("pywebpush.webpush", side_effect=_missing):
+            result = await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
+        assert result["removed"] == 1
+        assert await push_store.list_all() == []
+
+    async def test_transient_error_keeps_subscription_and_does_not_raise(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+
+        def _boom(*a, **k):
+            raise WebPushException("503", response=_response(503))
+
+        with patch("pywebpush.webpush", side_effect=_boom):
+            result = await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
+        assert result == {"sent": 0, "failed": 1, "removed": 0}
+        assert len(await push_store.list_all()) == 1
+
+    async def test_unexpected_exception_is_swallowed(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        with patch("pywebpush.webpush", side_effect=RuntimeError("kaboom")):
+            result = await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
+        assert result["failed"] == 1
+
+    async def test_no_vapid_is_noop(self, push_store):
+        await _seed(push_store, _ENDPOINT_A)
+        with patch("pywebpush.webpush") as mock:
+            result = await send_web_push(_ROW, store=push_store, vapid=None)
+        mock.assert_not_called()
+        assert result == {"sent": 0, "failed": 0, "removed": 0}
+
+    async def test_no_subscriptions_is_noop(self, push_store):
+        with patch("pywebpush.webpush") as mock:
+            result = await send_web_push(_ROW, store=push_store, vapid=FAKE_VAPID)
+        mock.assert_not_called()
+        assert result == {"sent": 0, "failed": 0, "removed": 0}
+
+
+# ---------------------------------------------------------------------------
+# NotificationStore.add() wiring - best-effort, off-loop, never breaks add()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestAddTriggersPush:
+    async def test_add_dispatches_to_push_sender(self, tmp_path):
+        store = NotificationStore(tmp_path / "notif.db")
+        await store.init()
+        try:
+            seen: list[dict] = []
+
+            async def sender(row: dict) -> None:
+                seen.append(row)
+
+            store.set_push_sender(sender)
+            await store.add("Hi", "there", source="auth_requests", data={"request_id": "r1"})
+            # Dispatch is a background task - let it run.
+            await asyncio.sleep(0)
+            assert len(seen) == 1
+            assert seen[0]["title"] == "Hi"
+            assert seen[0]["source"] == "auth_requests"
+            assert seen[0]["data"] == {"request_id": "r1"}
+        finally:
+            await store.close()
+
+    async def test_failing_sender_does_not_break_add(self, tmp_path):
+        store = NotificationStore(tmp_path / "notif.db")
+        await store.init()
+        try:
+            async def boom(row: dict) -> None:
+                raise RuntimeError("push blew up")
+
+            store.set_push_sender(boom)
+            # add() must succeed and persist the row despite the sender raising.
+            await store.add("Still", "works", source="test")
+            await asyncio.sleep(0)  # let the failing task run + get swallowed
+            items = await store.list()
+            assert len(items) == 1
+            assert items[0]["title"] == "Still"
+        finally:
+            await store.close()
+
+    async def test_no_sender_behaves_as_before(self, tmp_path):
+        store = NotificationStore(tmp_path / "notif.db")
+        await store.init()
+        try:
+            await store.add("Plain", "notif")
+            assert len(await store.list()) == 1
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# HTTP routes
+# ---------------------------------------------------------------------------
+
+
+def _build_app(tmp_path):
+    import yaml
+    from tinyagentos.app import create_app
+
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    return create_app(data_dir=tmp_path)
+
+
+@pytest_asyncio.fixture
+async def route_app(tmp_path):
+    app = _build_app(tmp_path)
+    # Lifespan-owned objects - init eagerly for ASGITransport (no lifespan run).
+    await app.state.notif_push_store.init()
+    app.state.notif_vapid_keypair = FAKE_VAPID
+    yield app
+    await app.state.notif_push_store.close()
+
+
+def _admin_token(app):
+    auth_mgr = app.state.auth
+    if not auth_mgr.is_configured():
+        auth_mgr.setup_user("admin", "Admin", "", "adminpass1")
+    record = auth_mgr.find_user("admin")
+    return auth_mgr.create_session(user_id=record["id"], long_lived=True)
+
+
+def _second_user_token(app):
+    """A non-admin user_b, created via the invite flow (admin must exist)."""
+    auth_mgr = app.state.auth
+    _admin_token(app)  # ensure admin exists first
+    if auth_mgr.find_user("user_b") is None:
+        code = auth_mgr.add_user_invite("user_b", "admin")
+        auth_mgr.complete_invite("user_b", code, "user_b", "", "pass_b_ok1")
+    record = auth_mgr.find_user("user_b")
+    return auth_mgr.create_session(user_id=record["id"], long_lived=True)
+
+
+_SUB_BODY = {
+    "subscription": {
+        "endpoint": "https://push.example.com/send/xyz",
+        "keys": {"p256dh": "p256dh_key", "auth": "auth_key"},
+    }
+}
+
+
+@pytest.mark.asyncio
+class TestPushRoutes:
+    async def _client(self, app, authed=True):
+        from httpx import ASGITransport, AsyncClient
+
+        cookies = {"taos_session": _admin_token(app)} if authed else {}
+        return AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test", cookies=cookies
+        )
+
+    async def test_vapid_public_key_requires_auth(self, route_app):
+        async with await self._client(route_app, authed=False) as c:
+            resp = await c.get("/api/notifications/push/vapid-public-key")
+        assert resp.status_code == 401
+
+    async def test_vapid_public_key_returns_key_for_session(self, route_app):
+        async with await self._client(route_app) as c:
+            resp = await c.get("/api/notifications/push/vapid-public-key")
+        assert resp.status_code == 200
+        assert resp.json()["public_key"] == FAKE_VAPID[0]
+
+    async def test_subscribe_then_unsubscribe(self, route_app):
+        async with await self._client(route_app) as c:
+            r1 = await c.post("/api/notifications/push/subscribe", json=_SUB_BODY)
+            assert r1.status_code == 200 and r1.json()["ok"] is True
+            subs = await route_app.state.notif_push_store.list_all()
+            assert len(subs) == 1
+            assert subs[0]["endpoint"] == _SUB_BODY["subscription"]["endpoint"]
+
+            r2 = await c.post(
+                "/api/notifications/push/unsubscribe",
+                json={"endpoint": _SUB_BODY["subscription"]["endpoint"]},
+            )
+            assert r2.status_code == 200 and r2.json()["ok"] is True
+            assert await route_app.state.notif_push_store.list_all() == []
+
+    async def test_subscribe_rejects_non_https_endpoint(self, route_app):
+        bad = {"subscription": {"endpoint": "http://x/y", "keys": {"p256dh": "p", "auth": "a"}}}
+        async with await self._client(route_app) as c:
+            resp = await c.post("/api/notifications/push/subscribe", json=bad)
+        assert resp.status_code == 422
+
+    async def test_user_cannot_unsubscribe_another_users_endpoint(self, route_app):
+        from httpx import ASGITransport, AsyncClient
+
+        endpoint = _SUB_BODY["subscription"]["endpoint"]
+        # user_a (admin) subscribes.
+        async with await self._client(route_app) as c:
+            r = await c.post("/api/notifications/push/subscribe", json=_SUB_BODY)
+            assert r.status_code == 200
+
+        # user_b tries to unsubscribe user_a's endpoint -> 404, not-owned oracle
+        # cannot leak, and user_a's row must survive.
+        token_b = _second_user_token(route_app)
+        async with AsyncClient(
+            transport=ASGITransport(app=route_app),
+            base_url="http://test",
+            cookies={"taos_session": token_b},
+        ) as cb:
+            r = await cb.post(
+                "/api/notifications/push/unsubscribe", json={"endpoint": endpoint}
+            )
+        assert r.status_code == 404
+        assert r.json()["ok"] is False
+        subs = await route_app.state.notif_push_store.list_all()
+        assert len(subs) == 1 and subs[0]["endpoint"] == endpoint
+
+    async def test_unsubscribe_missing_endpoint_returns_404(self, route_app):
+        async with await self._client(route_app) as c:
+            resp = await c.post(
+                "/api/notifications/push/unsubscribe",
+                json={"endpoint": "https://push.example.com/never-subscribed"},
+            )
+        assert resp.status_code == 404

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -51,6 +51,7 @@ from tinyagentos.channels import ChannelStore
 from tinyagentos.download_manager import DownloadManager
 from tinyagentos.metrics import MetricsStore
 from tinyagentos.notifications import NotificationStore
+from tinyagentos.notifications_push import NotificationPushStore
 from tinyagentos.coding_workspaces import CodingWorkspaceStore
 from tinyagentos.install_registry import InstallRegistryStore
 from tinyagentos.store_submissions import StoreSubmissionStore
@@ -276,6 +277,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
     metrics_store = MetricsStore(data_dir / "metrics.db")
     notif_store = NotificationStore(data_dir / "notifications.db")
+    notif_push_store = NotificationPushStore(data_dir / "notif_push.db")
     mcp_store = MCPServerStore(data_dir / "mcp.db")
     qmd_client = QmdClient(config.qmd.get("url", "http://localhost:7832"))
     http_client = httpx.AsyncClient(timeout=30)
@@ -485,6 +487,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.capability_map = capability_map_store
         await metrics_store.init()
         await notif_store.init()
+        await notif_push_store.init()
         await qmd_client.init()
         await secrets_store.init()
         await broker_store.init()
@@ -781,6 +784,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.models_root.mkdir(parents=True, exist_ok=True)
         app.state.metrics = metrics_store
         app.state.notifications = notif_store
+        app.state.notif_push_store = notif_push_store
         app.state.qmd_client = qmd_client
         app.state.http_client = http_client
         app.state.download_manager = download_manager
@@ -1263,6 +1267,31 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
         notif_store.set_event_emitter(_notify_emitter)
 
+        # Wire NotificationStore -> OS-level PWA web-push so notifications reach
+        # an installed PWA even when taOS is closed. Uses its own VAPID keypair
+        # (separate file + purpose from the Browser copilot push). Strictly
+        # best-effort: keypair-load failure disables push but never blocks
+        # startup, and the sender itself is dispatched off-loop inside add().
+        try:
+            from tinyagentos.routes.desktop_browser.vapid import load_or_create_vapid_keypair
+            from tinyagentos.notifications_push import send_web_push
+
+            app.state.notif_vapid_keypair = load_or_create_vapid_keypair(
+                data_dir, filename="notif_vapid.pem"
+            )
+
+            async def _web_push_sender(row: dict) -> None:
+                await send_web_push(
+                    row,
+                    store=app.state.notif_push_store,
+                    vapid=app.state.notif_vapid_keypair,
+                )
+
+            notif_store.set_push_sender(_web_push_sender)
+        except Exception:
+            app.state.notif_vapid_keypair = None
+            logger.warning("notif web-push disabled: VAPID keypair unavailable", exc_info=True)
+
         # All startup init complete — allow requests through.
         app.state._startup_complete = True
         logger.info("startup complete — accepting requests")
@@ -1402,6 +1431,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await broker_store.close()
         await mail_store.close()
         await notif_store.close()
+        await notif_push_store.close()
         await app.state.system_events.close()
         await metrics_store.close()
         await qmd_client.close()
@@ -1491,6 +1521,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.agent_memory_dir.mkdir(parents=True, exist_ok=True)
     app.state.metrics = metrics_store
     app.state.notifications = notif_store
+    app.state.notif_push_store = notif_push_store
+    app.state.notif_vapid_keypair = None
     app.state.qmd_client = qmd_client
     app.state.http_client = http_client
     app.state.download_manager = download_manager

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -64,6 +65,8 @@ class NotificationStore(BaseStore):
         super().__init__(*args, **kwargs)
         self._webhook_notifier = None
         self._event_emitter = None  # async callable: (row: dict) -> None
+        self._push_sender = None  # async callable: (row: dict) -> None
+        self._push_tasks: set = set()  # strong refs so fire-and-forget tasks aren't GC'd
 
     def set_webhook_notifier(self, notifier) -> None:
         """Attach a WebhookNotifier to fire on every notification."""
@@ -78,6 +81,24 @@ class NotificationStore(BaseStore):
         a failing emitter never breaks add().
         """
         self._event_emitter = emitter
+
+    def set_push_sender(self, sender) -> None:
+        """Attach an async callable called with each new notification row dict.
+
+        The sender delivers the notification as an OS-level PWA web-push so a
+        user gets the banner even when the taOS app is closed. It receives the
+        same row shape as the event emitter. Strictly best-effort and off the
+        event loop: it is dispatched as a background task, and any error is
+        swallowed so a push failure or a missing VAPID key never breaks add().
+        """
+        self._push_sender = sender
+
+    async def _dispatch_push(self, row: dict) -> None:
+        """Run the web-push sender, isolating every failure from add()."""
+        try:
+            await self._push_sender(row)
+        except Exception:
+            logger.warning("NotificationStore: web-push sender failed", exc_info=True)
 
     async def _post_init(self) -> None:
         # `archived` was added after the initial notifications ship. Guarded
@@ -121,21 +142,33 @@ class NotificationStore(BaseStore):
             except Exception as e:
                 logger.warning(f"Webhook notification error: {e}")
         # Push to EventBus broadcast for SSE delivery — best-effort, never breaks add()
+        row = {
+            "id": cursor.lastrowid,
+            "timestamp": ts,
+            "level": level,
+            "title": title,
+            "message": message,
+            "read": False,
+            "source": source,
+            "data": data,
+        }
         if self._event_emitter:
             try:
-                row = {
-                    "id": cursor.lastrowid,
-                    "timestamp": ts,
-                    "level": level,
-                    "title": title,
-                    "message": message,
-                    "read": False,
-                    "source": source,
-                    "data": data,
-                }
                 await self._event_emitter(row)
             except Exception:
                 logger.warning("NotificationStore: event emitter failed", exc_info=True)
+        # Fire the OS-level PWA web-push off the event loop: strictly
+        # best-effort. Scheduled as a background task so a slow or failing push
+        # (network round-trip) never stalls or breaks add().
+        if self._push_sender:
+            try:
+                task = asyncio.create_task(self._dispatch_push(row))
+                # Hold a strong ref until done: a bare create_task() can be
+                # garbage-collected mid-flight (see asyncio.create_task docs).
+                self._push_tasks.add(task)
+                task.add_done_callback(self._push_tasks.discard)
+            except Exception:
+                logger.warning("NotificationStore: could not schedule web-push", exc_info=True)
 
     async def list(self, limit: int = 20, unread_only: bool = False) -> list[dict]:
         # Active feed: archived (dismissed) notifications are excluded.

--- a/tinyagentos/notifications_push.py
+++ b/tinyagentos/notifications_push.py
@@ -1,0 +1,255 @@
+"""OS-level Web Push for taOS notifications.
+
+Delivers ``NotificationStore.add()`` notifications (in particular the external
+agent access-request / consent notifications, source="auth_requests") to an
+installed PWA as a real web-push, so the banner shows even when the taOS app is
+backgrounded or closed. This is separate from the Browser copilot push under
+``routes/desktop_browser`` (a different VAPID key and purpose); only the
+send/subscribe patterns are shared.
+
+Design notes
+------------
+* The subscription store is a small SQLite table keyed by the push endpoint.
+  Subscriptions are recorded per user_id, but taOS notifications are currently
+  global (add() has no target user), so the send path fans out to every
+  subscription.
+* pywebpush.webpush() is synchronous (uses requests). Each send runs in a
+  worker thread via asyncio.to_thread so the event loop is never blocked.
+* The whole send path is strictly best-effort: a missing VAPID key, no
+  subscriptions, or any push error must never raise back into add().
+* A 404/410 from the push service means the subscription is permanently gone,
+  so its row is pruned.
+* Secrets (auth, p256dh, private PEM) are never logged.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from urllib.parse import urlsplit
+
+from tinyagentos.base_store import BaseStore
+
+logger = logging.getLogger(__name__)
+
+_VAPID_SUB = "mailto:admin@taos.local"
+_SEND_TIMEOUT = 5.0  # seconds per upstream push-service call
+
+NOTIF_PUSH_SCHEMA = """
+CREATE TABLE IF NOT EXISTS notif_push_subscriptions (
+    endpoint TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    p256dh TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notif_push_user ON notif_push_subscriptions(user_id);
+"""
+
+
+class NotificationPushStore(BaseStore):
+    """Per-user store of PWA web-push subscriptions for OS notifications."""
+
+    SCHEMA = NOTIF_PUSH_SCHEMA
+
+    async def upsert(self, user_id: str, endpoint: str, p256dh: str, auth: str) -> None:
+        """Insert-or-update a subscription, keyed by its push endpoint.
+
+        Idempotent for the owner: re-subscribing the same endpoint refreshes its
+        keys and leaves created_at at the first-insert value. A subscription row
+        NEVER changes owner: the DO UPDATE is guarded by
+        `WHERE user_id = excluded.user_id`, so a conflicting insert from a
+        different user is a no-op (it cannot hijack another user's endpoint).
+        """
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not endpoint:
+            raise ValueError("endpoint is required")
+        if not p256dh:
+            raise ValueError("p256dh is required")
+        if not auth:
+            raise ValueError("auth is required")
+        assert self._db is not None
+        now = int(time.time())
+        await self._db.execute(
+            "INSERT INTO notif_push_subscriptions (endpoint, user_id, p256dh, auth, created_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(endpoint) DO UPDATE SET "
+            "  p256dh = excluded.p256dh, "
+            "  auth = excluded.auth "
+            "WHERE user_id = excluded.user_id",
+            (endpoint, user_id, p256dh, auth, now),
+        )
+        await self._db.commit()
+
+    async def list_all(self) -> list[dict]:
+        """Every subscription across users. Used by the send fan-out."""
+        assert self._db is not None
+        async with self._db.execute(
+            "SELECT endpoint, user_id, p256dh, auth, created_at FROM notif_push_subscriptions"
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [
+            {"endpoint": r[0], "user_id": r[1], "p256dh": r[2], "auth": r[3], "created_at": r[4]}
+            for r in rows
+        ]
+
+    async def list_for_user(self, user_id: str) -> list[dict]:
+        """Subscriptions owned by one user (endpoints + created_at, no secrets)."""
+        if not user_id:
+            raise ValueError("user_id is required")
+        assert self._db is not None
+        async with self._db.execute(
+            "SELECT endpoint, created_at FROM notif_push_subscriptions WHERE user_id = ? "
+            "ORDER BY created_at DESC",
+            (user_id,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [{"endpoint": r[0], "created_at": r[1]} for r in rows]
+
+    async def delete_by_endpoint(self, endpoint: str) -> int:
+        """Delete the subscription for this endpoint, ignoring ownership.
+
+        For the internal 404/410 send-path cleanup only: a dead endpoint must be
+        pruned regardless of which user owns it. NEVER call this from a
+        user-facing route (see delete_for_user for that). Returns rows deleted.
+        """
+        if not endpoint:
+            raise ValueError("endpoint is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM notif_push_subscriptions WHERE endpoint = ?", (endpoint,)
+        )
+        await self._db.commit()
+        return cursor.rowcount or 0
+
+    async def delete_for_user(self, user_id: str, endpoint: str) -> int:
+        """Delete this endpoint only if it belongs to user_id. Returns rows deleted.
+
+        Ownership-scoped so one user cannot unsubscribe (or probe) another
+        user's subscription. Returns 0 when the endpoint is absent or owned by
+        someone else, so it cannot be used as an ownership oracle.
+        """
+        if not user_id:
+            raise ValueError("user_id is required")
+        if not endpoint:
+            raise ValueError("endpoint is required")
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "DELETE FROM notif_push_subscriptions WHERE endpoint = ? AND user_id = ?",
+            (endpoint, user_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount or 0
+
+
+def _safe_url(raw, fallback: str = "/desktop") -> str:
+    """Return raw only if it is an app-root-relative path, else the fallback.
+
+    Guards notificationclick against open-redirect / phishing: the service
+    worker eventually passes this to clients.openWindow(). Only a single-leading-
+    slash path (``^/[^/]``) is accepted, which forbids a scheme (``https:``,
+    ``javascript:``), a protocol-relative ``//host`` target, and a backslash
+    that some URL parsers treat as a slash.
+    """
+    if not isinstance(raw, str) or not raw:
+        return fallback
+    if not raw.startswith("/"):
+        return fallback
+    if raw.startswith("//") or "\\" in raw:
+        return fallback
+    return raw
+
+
+def _build_payload(row: dict) -> dict:
+    """Map a notification row to the web-push payload the service worker reads.
+
+    ``url`` is the notification's own deep link if it carries a safe one in its
+    JSON data, else the desktop shell. ``tag`` collapses re-notifies for the
+    same source+id so a newer push replaces the older banner.
+    """
+    data = row.get("data") if isinstance(row.get("data"), dict) else {}
+    url = _safe_url(data.get("url"))
+    return {
+        "title": row.get("title") or "taOS",
+        "body": row.get("message") or "",
+        "tag": f"{row.get('source', 'system')}:{row.get('id', '')}",
+        "source": row.get("source", "system"),
+        "data": {"url": url},
+    }
+
+
+def _sync_send(subscription_info: dict, data: str, private_pem: str, vapid_claims: dict) -> None:
+    """Blocking pywebpush call - run in a worker thread."""
+    import pywebpush
+
+    pywebpush.webpush(
+        subscription_info=subscription_info,
+        data=data,
+        vapid_private_key=private_pem,
+        vapid_claims=vapid_claims,
+        timeout=_SEND_TIMEOUT,
+    )
+
+
+async def _send_one(sub: dict, data_str: str, private_pem: str, store: NotificationPushStore) -> str:
+    """Send to one subscription. Returns "sent", "failed", or "removed"."""
+    from pywebpush import WebPushException
+
+    endpoint = sub["endpoint"]
+    parsed = urlsplit(endpoint)
+    subscription_info = {
+        "endpoint": endpoint,
+        "keys": {"p256dh": sub["p256dh"], "auth": sub["auth"]},
+    }
+    vapid_claims = {"sub": _VAPID_SUB, "aud": f"{parsed.scheme}://{parsed.netloc}"}
+    ep_hash = hash(endpoint) & 0xFFFFFFFF
+    try:
+        await asyncio.to_thread(_sync_send, subscription_info, data_str, private_pem, vapid_claims)
+        return "sent"
+    except WebPushException as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        if status in (404, 410):
+            logger.info("notif-push: endpoint gone (hash=%08x), pruning subscription", ep_hash)
+            await store.delete_by_endpoint(endpoint)
+            return "removed"
+        logger.warning("notif-push: delivery failed for endpoint hash=%08x status=%s", ep_hash, status)
+        return "failed"
+    except Exception as exc:  # noqa: BLE001 - best-effort, never propagate
+        logger.warning("notif-push: unexpected error for endpoint hash=%08x: %s", ep_hash, exc)
+        return "failed"
+
+
+async def send_web_push(row: dict, *, store: NotificationPushStore, vapid: tuple[str, str] | None) -> dict:
+    """Best-effort fan-out of one notification row to every subscription.
+
+    Returns {"sent", "failed", "removed"} counts (also useful for tests). Never
+    raises: a missing VAPID key or no subscriptions is a no-op, and every
+    per-subscription error is caught and counted.
+    """
+    if not vapid:
+        return {"sent": 0, "failed": 0, "removed": 0}
+    _, private_pem = vapid
+    try:
+        subs = await store.list_all()
+    except Exception:  # noqa: BLE001 - store read must never break add()
+        logger.warning("notif-push: failed to list subscriptions", exc_info=True)
+        return {"sent": 0, "failed": 0, "removed": 0}
+    if not subs:
+        return {"sent": 0, "failed": 0, "removed": 0}
+
+    data_str = json.dumps(_build_payload(row))
+    results = await asyncio.gather(
+        *[_send_one(sub, data_str, private_pem, store) for sub in subs],
+        return_exceptions=True,
+    )
+    sent = failed = removed = 0
+    for r in results:
+        if r == "sent":
+            sent += 1
+        elif r == "removed":
+            removed += 1
+        else:
+            failed += 1
+    return {"sent": sent, "failed": failed, "removed": removed}

--- a/tinyagentos/routes/desktop_browser/vapid.py
+++ b/tinyagentos/routes/desktop_browser/vapid.py
@@ -20,18 +20,24 @@ from py_vapid import Vapid01
 _VAPID_FILENAME = "vapid.pem"
 
 
-def load_or_create_vapid_keypair(data_dir: pathlib.Path) -> tuple[str, str]:
+def load_or_create_vapid_keypair(
+    data_dir: pathlib.Path, filename: str = _VAPID_FILENAME
+) -> tuple[str, str]:
     """Return (public_key_b64url, private_key_pem_str).
 
-    Loads from <data_dir>/vapid.pem if present; otherwise generates a fresh
+    Loads from <data_dir>/<filename> if present; otherwise generates a fresh
     P-256 keypair, persists the private key PEM to disk with mode 0600, and
     returns both keys. Idempotent — second call returns same keys.
+
+    ``filename`` lets callers persist independent keypairs side by side (e.g.
+    the OS notification push key vs the Browser copilot push key), each with
+    its own purpose and audience.
 
     The public key is returned in uncompressed-point base64url-without-padding
     form (the format applicationServerKey expects in PushManager.subscribe).
     """
     data_dir.mkdir(parents=True, exist_ok=True)
-    pem_path = data_dir / _VAPID_FILENAME
+    pem_path = data_dir / filename
 
     if pem_path.exists():
         vapid = Vapid01.from_pem(pem_path.read_bytes())

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import json
 import time
+from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
+from pydantic import BaseModel, field_validator
+
+from tinyagentos.auth import get_current_user
 
 router = APIRouter()
 
@@ -109,3 +113,99 @@ async def set_notification_pref(request: Request, event_type: str):
     muted = bool(muted_raw)
     await store.set_event_muted(event_type, muted)
     return {"event_type": event_type, "muted": muted}
+
+
+# ---------------------------------------------------------------------------
+# OS-level PWA web-push (VAPID). Separate key + store from the Browser copilot
+# push. All three routes require a session (the auth middleware also gates
+# /api/*), so the public key is only handed to a logged-in user.
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/notifications/push/vapid-public-key")
+async def get_notifications_vapid_public_key(
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> dict[str, str]:
+    """Return the server's VAPID public key for PushManager.subscribe()."""
+    keypair = getattr(request.app.state, "notif_vapid_keypair", None)
+    if not keypair:
+        return JSONResponse({"error": "web push not available"}, status_code=503)
+    public_key, _ = keypair
+    return {"public_key": public_key}
+
+
+class _NotifSubscribeKeys(BaseModel):
+    p256dh: str
+    auth: str
+
+    @field_validator("p256dh", "auth")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("key must not be empty")
+        return v
+
+
+class _NotifSubscription(BaseModel):
+    endpoint: str
+    keys: _NotifSubscribeKeys
+
+    @field_validator("endpoint")
+    @classmethod
+    def _https(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("endpoint must start with https://")
+        return v
+
+
+class NotifSubscribeRequest(BaseModel):
+    subscription: _NotifSubscription
+
+
+@router.post("/api/notifications/push/subscribe")
+async def subscribe_notifications_push(
+    request: Request,
+    body: NotifSubscribeRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    store = getattr(request.app.state, "notif_push_store", None)
+    if store is None:
+        return JSONResponse({"error": "web push not available"}, status_code=503)
+    sub = body.subscription
+    await store.upsert(
+        user_id=user_id,
+        endpoint=sub.endpoint,
+        p256dh=sub.keys.p256dh,
+        auth=sub.keys.auth,
+    )
+    return {"ok": True}
+
+
+class NotifUnsubscribeRequest(BaseModel):
+    endpoint: str
+
+
+@router.post("/api/notifications/push/unsubscribe")
+async def unsubscribe_notifications_push(
+    request: Request,
+    body: NotifUnsubscribeRequest,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+):
+    user_id = str(current_user.get("id") or "")
+    if not user_id:
+        return JSONResponse({"error": "session has no user id"}, status_code=401)
+    store = getattr(request.app.state, "notif_push_store", None)
+    if store is None:
+        return JSONResponse({"error": "web push not available"}, status_code=503)
+    # Ownership-scoped: a user can only unsubscribe their own endpoint. Deleting
+    # by endpoint alone would let any authed user drop (or probe) another user's
+    # subscription. Return 404 when nothing was deleted so the endpoint cannot
+    # be used as an ownership oracle.
+    deleted = await store.delete_for_user(user_id, body.endpoint)
+    if deleted == 0:
+        return JSONResponse({"ok": False, "error": "not found"}, status_code=404)
+    return {"ok": True}


### PR DESCRIPTION
## What

Deliver taOS OS notifications (in particular the external-agent access-request / consent notifications, `source="auth_requests"`, and any `notifications.add()` call) as a real web-push to an installed PWA on iOS 16.4+ and Android, so a user gets the banner even when taOS is backgrounded or closed. Today notifications are SSE + in-app feed only, so the "approve an agent from your phone" flow requires the app to be open.

Builds on the existing infra (pywebpush dependency, the shell service worker's push handlers, the VAPID loader) rather than duplicating the separate Browser copilot push under `routes/desktop_browser`.

## Flow

1. In the Notification Centre, "Enable notifications on this device" requests Notification permission and calls `pushManager.subscribe({userVisibleOnly, applicationServerKey})` against the OS VAPID public key, then POSTs the subscription.
2. The subscription is stored per `user_id`, keyed on endpoint (idempotent upsert).
3. On every `NotificationStore.add()`, after the SSE broadcast, a web-push is scheduled as an off-loop background task to every subscription. Payload: `{title, body, url, tag (source:id), source, data:{url}}`.
4. The shell service worker's `push` handler shows the banner; `notificationclick` focuses an open client or opens the notification's deep link (`data.url`, default `/desktop`).

## Best-effort by construction

The send path can never break `add()`:
- `add()` builds the row, does the SSE broadcast, then schedules the push as a fire-and-forget `asyncio.create_task` wrapped in a try/except that swallows and logs any error (a strong ref is held so the task is not GC'd).
- `send_web_push()` no-ops when there is no VAPID key or no subscriptions, runs each blocking pywebpush call in `asyncio.to_thread`, and catches every per-subscription exception. A 404/410 prunes the dead subscription; other errors are counted and the subscription kept.
- Keypair-load failure at startup disables push and logs, but never blocks boot.

Covered by a test that makes the sender raise and asserts `add()` still persists the row.

## VAPID / store separation

Its own P-256 keypair at `data_dir/notif_vapid.pem` (mode 0600), independent of the Browser copilot push key. The public-key loader gained an optional `filename` argument so the two keys sit side by side.

## Endpoints (session auth)

- `GET  /api/notifications/push/vapid-public-key`
- `POST /api/notifications/push/subscribe`   body `{subscription:{endpoint,keys:{p256dh,auth}}}`
- `POST /api/notifications/push/unsubscribe` body `{endpoint}`

## iOS caveat

On iOS/iPadOS, Safari only exposes `PushManager` once the PWA has been added to the Home Screen (running standalone). Before that, the control shows "Add taOS to your Home Screen to get notifications on this device" instead of an enable button. Android and desktop PWAs can enable it directly.

Note: a browser allows only one push subscription per service-worker registration. If the in-OS Browser copilot push (a separate, opt-in feature) is already active on the same shell SW, the two share that single subscription; the OS notification push is the primary path for the access-request flow and works on its own.

## Tests

- pytest `tests/test_notifications_push.py`: store CRUD + idempotent upsert; send fan-out (one send per subscription, 404/410 prunes the row, transient/unexpected errors swallowed, no-op without VAPID/subscriptions); `add()`-triggers-send including a failing sender not breaking `add()`; the three routes (401 without a session, 200 with).
- vitest `notifications-push.test.ts` + updated `sw-push-handlers.test.ts`: `urlBase64ToUint8Array`, support/state detection (incl. iOS needs-install), enable/disable subscribe+POST, and the deep-link `notificationclick` handler.

All affected pytest + vitest pass; `tsc --noEmit` clean.