### PR TITLE
fix(agents): model-aware history token budget for agent chat (#1740)

### DIFF
--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -1,7 +1,7 @@
 import asyncio
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from tinyagentos.agent_chat_router import AgentChatRouter
 
@@ -14,6 +14,24 @@ class _FakeBridge:
 
     async def enqueue_user_message(self, slug: str, msg: dict) -> None:
         self.calls.append((slug, msg))
+
+
+class _FakeManifest:
+    def __init__(self, mid, context_window):
+        self.id = mid
+        self.type = "model"
+        self.context_window = context_window
+
+
+class _FakeRegistry:
+    def __init__(self, by_id):
+        self._by_id = by_id
+
+    def get(self, model_id):
+        return self._by_id.get(model_id)
+
+    def list_available(self, type_filter=None):
+        return list(self._by_id.values())
 
 
 def _state_for(agent_record: dict | None, *, bridge: _FakeBridge | None = None):
@@ -82,6 +100,79 @@ class TestAgentChatRouter:
         assert enqueued["channel_id"] == "c1"
         # System-reply path must NOT have been triggered.
         state.chat_messages.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_context_budget_uses_smallest_recipient_window(self):
+        """Shared context budgets for the smallest known window (#1740)."""
+        bridge = _FakeBridge()
+        agents = [
+            {"name": "big", "status": "running", "model": "big-model"},
+            {"name": "small", "status": "running", "model": "small-model"},
+        ]
+        state = MagicMock()
+        state.config = MagicMock()
+        state.config.agents = agents
+        state.chat_messages = MagicMock()
+        state.chat_messages.send_message = AsyncMock(return_value={
+            "id": "m1", "channel_id": "c1", "author_id": "big",
+            "author_type": "agent", "content": "", "created_at": 1.0,
+        })
+        state.chat_messages.get_messages = AsyncMock(return_value=[
+            {"author_id": "user", "author_type": "user", "content": "hello"},
+        ])
+        state.chat_channels = MagicMock()
+        state.chat_channels.update_last_message_at = AsyncMock()
+        state.chat_hub = MagicMock()
+        state.chat_hub.broadcast = AsyncMock()
+        state.chat_hub.next_seq = MagicMock(return_value=1)
+        state.bridge_sessions = bridge
+        state.registry = _FakeRegistry({
+            "big-model": _FakeManifest("big-model", 32768),
+            "small-model": _FakeManifest("small-model", 8192),
+        })
+        # lively group fans out to both agents so min window applies
+        channel = {
+            "id": "c1", "type": "group",
+            "members": ["user", "big", "small"],
+            "settings": {
+                "response_mode": "lively", "max_hops": 3,
+                "cooldown_seconds": 0, "rate_cap_per_minute": 100, "muted": [],
+            },
+        }
+        message = {
+            "id": "m1", "channel_id": "c1", "author_id": "user",
+            "author_type": "user", "content": "hello", "created_at": 1.0,
+        }
+        with patch(
+            "tinyagentos.chat.context_window.build_context_window",
+            return_value=[],
+        ) as build:
+            await AgentChatRouter(state)._route(message, channel)
+        build.assert_called_once()
+        # min known window is 8192 -> floor budget 512
+        assert build.call_args.kwargs["max_tokens"] == 512
+
+    @pytest.mark.asyncio
+    async def test_context_budget_defaults_when_windows_unknown(self):
+        bridge = _FakeBridge()
+        agent = {"name": "openclaw", "status": "running", "model": "gpt-4o"}
+        state = _state_for(agent, bridge=bridge)
+        state.registry = _FakeRegistry({})
+        state.chat_messages.get_messages = AsyncMock(return_value=[
+            {"author_id": "user", "author_type": "user", "content": "hello"},
+        ])
+        message = {
+            "id": "m1", "channel_id": "c1", "author_id": "user",
+            "author_type": "user", "content": "hello", "created_at": 1.0,
+        }
+        channel = {"id": "c1", "type": "dm", "members": ["user", "openclaw"]}
+        with patch(
+            "tinyagentos.chat.context_window.build_context_window",
+            return_value=[],
+        ) as build:
+            await AgentChatRouter(state)._route(message, channel)
+        build.assert_called_once()
+        assert build.call_args.kwargs["max_tokens"] == 4000
 
     @pytest.mark.asyncio
     async def test_skips_non_user_messages(self):

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -175,6 +175,59 @@ class TestAgentChatRouter:
         assert build.call_args.kwargs["max_tokens"] == 4000
 
     @pytest.mark.asyncio
+    async def test_context_budget_capped_when_a_recipient_window_is_unknown(self):
+        """A mix of known-large and unknown-window recipients never budgets
+        above the historical default, so the unknown recipient cannot be
+        overflowed by the larger one (#1740 follow-up)."""
+        bridge = _FakeBridge()
+        agents = [
+            {"name": "big", "status": "running", "model": "big-model"},
+            {"name": "cloud", "status": "running", "model": "gpt-4o"},
+        ]
+        state = MagicMock()
+        state.config = MagicMock()
+        state.config.agents = agents
+        state.chat_messages = MagicMock()
+        state.chat_messages.send_message = AsyncMock(return_value={
+            "id": "m1", "channel_id": "c1", "author_id": "big",
+            "author_type": "agent", "content": "", "created_at": 1.0,
+        })
+        state.chat_messages.get_messages = AsyncMock(return_value=[
+            {"author_id": "user", "author_type": "user", "content": "hello"},
+        ])
+        state.chat_channels = MagicMock()
+        state.chat_channels.update_last_message_at = AsyncMock()
+        state.chat_hub = MagicMock()
+        state.chat_hub.broadcast = AsyncMock()
+        state.chat_hub.next_seq = MagicMock(return_value=1)
+        state.bridge_sessions = bridge
+        # "big-model" resolves to a 32768 window; "gpt-4o" is not in the
+        # registry, so its real window is unknown.
+        state.registry = _FakeRegistry({
+            "big-model": _FakeManifest("big-model", 32768),
+        })
+        channel = {
+            "id": "c1", "type": "group",
+            "members": ["user", "big", "cloud"],
+            "settings": {
+                "response_mode": "lively", "max_hops": 3,
+                "cooldown_seconds": 0, "rate_cap_per_minute": 100, "muted": [],
+            },
+        }
+        message = {
+            "id": "m1", "channel_id": "c1", "author_id": "user",
+            "author_type": "user", "content": "hello", "created_at": 1.0,
+        }
+        with patch(
+            "tinyagentos.chat.context_window.build_context_window",
+            return_value=[],
+        ) as build:
+            await AgentChatRouter(state)._route(message, channel)
+        build.assert_called_once()
+        # 32768 alone would give 21744; the unknown recipient caps it at 4000.
+        assert build.call_args.kwargs["max_tokens"] == 4000
+
+    @pytest.mark.asyncio
     async def test_skips_non_user_messages(self):
         bridge = _FakeBridge()
         state = _state_for({"name": "openclaw", "status": "running"}, bridge=bridge)

--- a/tests/test_chat_context_window.py
+++ b/tests/test_chat_context_window.py
@@ -1,8 +1,38 @@
-from tinyagentos.chat.context_window import build_context_window, estimate_tokens
+from tinyagentos.chat.context_window import (
+    build_context_window,
+    estimate_tokens,
+    history_token_budget,
+)
 
 
 def _msg(author, content, kind="user"):
     return {"author_id": author, "author_type": kind, "content": content}
+
+
+def test_history_token_budget_unknown_returns_default():
+    # Cloud/aliased models have no local context window; keep today's 4000.
+    assert history_token_budget(None) == 4000
+    assert history_token_budget(0) == 4000
+    assert history_token_budget(False) == 4000
+
+
+def test_history_token_budget_small_window_is_smaller_than_default():
+    # 8192 - 10000 system reserve - 1024 response reserve underflows,
+    # so the floor applies; result must be below the unknown-model default.
+    budget = history_token_budget(8192)
+    assert budget < 4000
+    assert budget == 512
+
+
+def test_history_token_budget_floored_at_512():
+    # Tiny windows still leave a usable history slice of at least 512.
+    assert history_token_budget(100) == 512
+    assert history_token_budget(1) == 512
+
+
+def test_history_token_budget_large_window_subtracts_reserves():
+    # 32768 - 10000 - 1024 = 21744
+    assert history_token_budget(32768) == 21744
 
 
 def test_build_preserves_order_oldest_first():

--- a/tests/test_chat_reactions.py
+++ b/tests/test_chat_reactions.py
@@ -1,7 +1,24 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from tinyagentos.chat.reactions import maybe_trigger_semantic, WantsReplyRegistry
+
+
+class _FakeManifest:
+    def __init__(self, context_window):
+        self.type = "model"
+        self.context_window = context_window
+
+
+class _FakeRegistry:
+    def __init__(self, by_id):
+        self._by_id = by_id
+
+    def get(self, model_id):
+        return self._by_id.get(model_id)
+
+    def list_available(self, type_filter=None):
+        return list(self._by_id.values())
 
 
 @pytest.mark.asyncio
@@ -37,6 +54,48 @@ async def test_regenerate_triggered_for_thumbs_down_on_agent_reply():
     assert call.args[1]["text"] == "what's 2+2?"
     assert call.args[1]["trace_id"] == "user-msg-1"
     assert len(call.args[1]["context"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_regenerate_uses_agent_model_history_budget():
+    """Small-context agent model floors history max_tokens at 512 (#1740)."""
+    bridge = MagicMock()
+    bridge.enqueue_user_message = AsyncMock()
+    msg_store = MagicMock()
+    msg_store.get_message = AsyncMock(return_value={
+        "id": "user-msg-1", "channel_id": "c1", "content": "hi",
+    })
+    msg_store.get_messages = AsyncMock(return_value=[
+        {"author_id": "user", "author_type": "user", "content": "hi"},
+        {"author_id": "tom", "author_type": "agent", "content": "nope"},
+    ])
+    config = MagicMock()
+    config.agents = [{"name": "tom", "model": "tiny-rkllm"}]
+    registry = _FakeRegistry({"tiny-rkllm": _FakeManifest(4096)})
+    state = MagicMock(
+        bridge_sessions=bridge,
+        chat_messages=msg_store,
+        config=config,
+        registry=registry,
+    )
+    state.wants_reply = WantsReplyRegistry()
+    message = {
+        "id": "m1", "channel_id": "c1", "author_id": "tom",
+        "author_type": "agent", "content": "nope",
+        "metadata": {"trace_id": "user-msg-1"},
+    }
+    channel = {"id": "c1", "members": ["user", "tom"], "type": "dm", "settings": {}}
+
+    with patch(
+        "tinyagentos.chat.context_window.build_context_window",
+        return_value=[{"author_id": "user", "author_type": "user", "content": "hi"}],
+    ) as build:
+        await maybe_trigger_semantic(
+            emoji="👎", message=message, reactor_id="user", reactor_type="user",
+            channel=channel, state=state,
+        )
+    build.assert_called_once()
+    assert build.call_args.kwargs["max_tokens"] == 512
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/agent_chat_router.py
+++ b/tinyagentos/agent_chat_router.py
@@ -163,10 +163,40 @@ class AgentChatRouter:
         policy = getattr(self._state, "group_policy", None)
 
         # Build the context window once per routed message, not per recipient.
+        # Budget for the smallest known model context among recipients so no
+        # recipient overflows (#1740). Unknown windows keep the 4000 default.
         context = []
         if hasattr(self._state, "chat_messages"):
             try:
-                from tinyagentos.chat.context_window import build_context_window
+                from tinyagentos.chat.context_window import (
+                    build_context_window,
+                    history_token_budget,
+                )
+                from tinyagentos.cluster.model_resolver import _find_model_manifest
+
+                known_windows: list[int] = []
+                registry = getattr(self._state, "registry", None)
+                for agent_name in recipients:
+                    agent = find_agent(config, agent_name)
+                    if agent is None:
+                        continue
+                    model_id = agent.get("model") or ""
+                    if not model_id:
+                        continue
+                    try:
+                        manifest = _find_model_manifest(registry, model_id)
+                        ctx = (
+                            int(getattr(manifest, "context_window", 0) or 0)
+                            if manifest
+                            else 0
+                        )
+                        if ctx > 0:
+                            known_windows.append(ctx)
+                    except Exception:  # noqa: BLE001 - advisory lookup only
+                        continue
+                min_window = min(known_windows) if known_windows else 0
+                max_tokens = history_token_budget(min_window)
+
                 if thread_id:
                     recent = await self._state.chat_messages.get_thread_messages(
                         channel_id=channel["id"], parent_id=thread_id, limit=30,
@@ -179,7 +209,7 @@ class AgentChatRouter:
                     recent = await self._state.chat_messages.get_messages(
                         channel_id=channel["id"], limit=30,
                     )
-                context = build_context_window(recent, limit=20, max_tokens=4000)
+                context = build_context_window(recent, limit=20, max_tokens=max_tokens)
             except Exception:
                 logger.warning("context fetch failed for channel %s", channel.get("id"), exc_info=True)
                 context = []

--- a/tinyagentos/agent_chat_router.py
+++ b/tinyagentos/agent_chat_router.py
@@ -169,12 +169,14 @@ class AgentChatRouter:
         if hasattr(self._state, "chat_messages"):
             try:
                 from tinyagentos.chat.context_window import (
+                    DEFAULT_HISTORY_MAX_TOKENS,
                     build_context_window,
                     history_token_budget,
                 )
                 from tinyagentos.cluster.model_resolver import _find_model_manifest
 
                 known_windows: list[int] = []
+                any_unknown = False
                 registry = getattr(self._state, "registry", None)
                 for agent_name in recipients:
                     agent = find_agent(config, agent_name)
@@ -182,6 +184,7 @@ class AgentChatRouter:
                         continue
                     model_id = agent.get("model") or ""
                     if not model_id:
+                        any_unknown = True
                         continue
                     try:
                         manifest = _find_model_manifest(registry, model_id)
@@ -192,10 +195,19 @@ class AgentChatRouter:
                         )
                         if ctx > 0:
                             known_windows.append(ctx)
+                        else:
+                            any_unknown = True
                     except Exception:  # noqa: BLE001 - advisory lookup only
+                        any_unknown = True
                         continue
                 min_window = min(known_windows) if known_windows else 0
                 max_tokens = history_token_budget(min_window)
+                # A recipient whose window we cannot read (aliased/cloud model or
+                # missing manifest) may have a small real window, so never let a
+                # known large-window recipient raise the shared budget above the
+                # historical default for it.
+                if any_unknown and known_windows:
+                    max_tokens = min(max_tokens, DEFAULT_HISTORY_MAX_TOKENS)
 
                 if thread_id:
                     recent = await self._state.chat_messages.get_thread_messages(

--- a/tinyagentos/chat/context_window.py
+++ b/tinyagentos/chat/context_window.py
@@ -7,11 +7,36 @@ excluded entirely.
 """
 from __future__ import annotations
 
+# History budget when the model context window is unknown (cloud/aliased).
+DEFAULT_HISTORY_MAX_TOKENS = 4000
+# Agent system prompt + tool definitions are roughly this large (#1740).
+SYSTEM_PROMPT_RESERVE = 10000
+# Leave room for the model to produce a reply.
+RESPONSE_RESERVE = 1024
+# Never starve history entirely, even on tiny windows.
+MIN_HISTORY_MAX_TOKENS = 512
+
 
 def estimate_tokens(text: str) -> int:
     if not text:
         return 0
     return max(1, len(text) // 4)
+
+
+def history_token_budget(context_window: int | None) -> int:
+    """Compute the history ``max_tokens`` for :func:`build_context_window`.
+
+    When *context_window* is unknown or falsy (cloud or aliased models with no
+    local manifest), return the historical default of 4000 so today's behavior
+    is preserved. Otherwise reserve room for the agent system prompt and a
+    response, flooring at 512 so a tiny window still gets a usable slice.
+    """
+    if not context_window:
+        return DEFAULT_HISTORY_MAX_TOKENS
+    return max(
+        MIN_HISTORY_MAX_TOKENS,
+        int(context_window) - SYSTEM_PROMPT_RESERVE - RESPONSE_RESERVE,
+    )
 
 
 def build_context_window(messages: list[dict], *, limit: int, max_tokens: int) -> list[dict]:

--- a/tinyagentos/chat/reactions.py
+++ b/tinyagentos/chat/reactions.py
@@ -56,9 +56,35 @@ async def maybe_trigger_semantic(
         context = []
         if msg_store is not None:
             try:
-                from tinyagentos.chat.context_window import build_context_window
+                from tinyagentos.chat.context_window import (
+                    build_context_window,
+                    history_token_budget,
+                )
+                from tinyagentos.cluster.model_resolver import _find_model_manifest
+
+                # Budget from the regenerating agent's model context window.
+                ctx_window = 0
+                config = getattr(state, "config", None)
+                author_id = message.get("author_id")
+                if config is not None and author_id:
+                    from tinyagentos.agent_db import find_agent
+
+                    agent = find_agent(config, author_id)
+                    model_id = (agent or {}).get("model") or ""
+                    if model_id:
+                        try:
+                            registry = getattr(state, "registry", None)
+                            manifest = _find_model_manifest(registry, model_id)
+                            ctx_window = (
+                                int(getattr(manifest, "context_window", 0) or 0)
+                                if manifest
+                                else 0
+                            )
+                        except Exception:  # noqa: BLE001 - advisory lookup only
+                            ctx_window = 0
+                max_tokens = history_token_budget(ctx_window)
                 recent = await msg_store.get_messages(channel_id=message.get("channel_id"), limit=30)
-                context = build_context_window(recent, limit=20, max_tokens=4000)
+                context = build_context_window(recent, limit=20, max_tokens=max_tokens)
             except Exception:
                 context = []
 


### PR DESCRIPTION
## Summary

Closes the remaining gap from #1740 after #1744 (which already rejects embedding models as agent chat models and warns on small-context assignments).

The agent history budget was hardcoded `max_tokens=4000` at two call sites (`agent_chat_router.py`, `chat/reactions.py`). Stacked with the ~10k-token agent system prompt, that overflows small and mid context models and causes looping or off-topic output.

This change:

- Adds `history_token_budget(context_window)` next to `build_context_window`
- Returns **4000** when the window is unknown/falsy (cloud or aliased models; preserves today's behavior)
- Otherwise returns `max(512, context_window - 10000 - 1024)` (system + response reserves)
- Resolves each recipient's model context window from the model manifest via `_find_model_manifest`
- For multi-recipient routing, budgets for the **smallest** known window so no recipient overflows
- Wires the computed budget into both call sites only; no hot-path restructure

## Test plan

- [x] Unit tests for `history_token_budget` (unknown -> 4000, small window smaller than default, floor 512, large window subtracts reserves)
- [x] Router: smallest known window among recipients; unknown defaults to 4000
- [x] Reactions regenerate path: agent model window floors budget at 512
- [x] `uv run pytest tests/test_chat_context_window.py tests/test_chat_reactions.py tests/test_agent_chat_router.py` -> 42 passed