### PR TITLE
release: 1.0.0-beta.40 (consent project picker, PWA web-push, model-aware chat context budget)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.40] - 2026-07-11
+
+### Added
+- Approving an external agent for the project-tasks scope now asks which project to bind it to, with an inline option to create a new one, and the approval adds the agent as a member of that project so it shows up in the project's Members and joins the project channel. Granting project-tasks without picking a project is refused, so an agent's own request can never bind it to a project you did not choose (#1777).
+- taOS notifications can now reach your phone as native web-push. Install the PWA and allow notifications, and access requests and other alerts arrive as OS banners even when the app is closed, delivered best effort so a push failure never blocks the in-app feed (#1778).
+
+### Fixed
+- Agent chat now sizes its history budget to the model's real context window instead of a fixed limit, so a small-context local model no longer overflows and loops. When several agents share one reply the budget follows the smallest known window, and any unknown window keeps the previous safe default (#1740, #1779).
+
 ## [1.0.0-beta.39] - 2026-07-10
 
 ### Added

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.39",
+  "version": "1.0.0-beta.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.39",
+      "version": "1.0.0-beta.40",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.39",
+  "version": "1.0.0-beta.40",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.39"
+version = "1.0.0-beta.40"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.39"
+__version__ = "1.0.0-beta.40"

--- a/uv.lock
+++ b/uv.lock
@@ -3017,7 +3017,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b39"
+version = "1.0.0b40"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release train for 1.0.0-beta.40.

Bundles three PRs already merged to dev:
- #1777 consent project picker for project-tasks approval, plus auto-membership on approve and a guard requiring an explicit project_id
- #1778 OS-level PWA web-push (VAPID) for notifications
- #1779 model-aware agent chat history token budget (#1740), with an unknown-window cap

Version bumps: pyproject.toml, tinyagentos/__init__.py, desktop/package.json, desktop/package-lock.json (x2), uv.lock (1.0.0b40), CHANGELOG. test_version_lock_sync passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-scoped approval for external agents working on project tasks.
  * Added native web-push notifications for phones.

* **Bug Fixes**
  * Corrected agent chat history sizing to prevent overflows and looping with small-context models.

* **Chores**
  * Updated the release version to 1.0.0-beta.40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->