### PR TITLE
fix(projects): show consent-flow external agents in the External section

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectMembers.test.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ProjectMembers } from "./ProjectMembers";
+import type { Project } from "@/lib/projects";
+
+function mockFetch(
+  responses: Record<string, { ok: boolean; status?: number; body: unknown }>,
+) {
+  return vi.fn().mockImplementation((input: string) => {
+    const hit = responses[input] ?? responses["*"];
+    if (!hit) throw new Error(`Unmocked fetch: ${input}`);
+    return Promise.resolve({
+      ok: hit.ok,
+      status: hit.status ?? (hit.ok ? 200 : 500),
+      json: () => Promise.resolve(hit.body),
+      text: () => Promise.resolve(""),
+    });
+  });
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+const project = { id: "prj-test", name: "taOS", slug: "taos" } as unknown as Project;
+
+// A consent-flow external agent: the member row keys on the canonical id, and
+// the registry entry has an EMPTY handle (this is what the approve flow writes).
+const externalMember = {
+  project_id: "prj-test",
+  member_id: "grok-taos-20260711-000736",
+  member_kind: "native",
+  role: "member",
+  is_lead: 0,
+  can_edit_canvas: 0,
+};
+
+const registryEntry = {
+  canonical_id: "grok-taos-20260711-000736",
+  handle: "",
+  display_name: "grok-taOS",
+  framework: "grok",
+  origin: "external-selfjoin",
+  status: "active",
+};
+
+describe("ProjectMembers external-agent categorisation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a consent-flow agent (empty handle, member keyed by canonical id) under External / Connected agents", async () => {
+    vi.stubGlobal(
+      "fetch",
+      mockFetch({
+        "/api/projects/prj-test/members": { ok: true, body: { items: [externalMember] } },
+        "/api/agents": { ok: true, body: [] },
+        "/api/agents/registry": { ok: true, body: [registryEntry] },
+      }),
+    );
+
+    render(<ProjectMembers project={project} onChanged={vi.fn()} />);
+    await flush();
+
+    // The section heading only renders when at least one member is classified
+    // external, so its presence is the regression guard: before the canonical-id
+    // match this agent fell into the plain Members list.
+    expect(screen.getByText("External / Connected agents")).toBeInTheDocument();
+    expect(screen.getByText("grok-taOS")).toBeInTheDocument();
+    // The framework badge resolves via the canonical-id keyed lookup, and "grok"
+    // (not only "grok-build") maps to the friendly Grok label.
+    expect(screen.getByText("Grok")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -13,6 +13,7 @@ interface AgentSummary {
 
 interface ExternalAgentSummary {
   handle: string;
+  canonical_id?: string;
   display_name?: string;
   framework?: string;
 }
@@ -26,6 +27,7 @@ function frameworkLabel(fw?: string): string {
     opencode: "opencode",
     hermes: "Hermes",
     "grok-build": "Grok",
+    grok: "Grok",
   };
   return map[fw] || fw;
 }
@@ -229,8 +231,14 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
           );
           setExternalAgents(
             active.map(
-              (entry: { handle?: string; display_name?: string; framework?: string }) => ({
+              (entry: {
+                handle?: string;
+                canonical_id?: string;
+                display_name?: string;
+                framework?: string;
+              }) => ({
                 handle: entry.handle || "",
+                canonical_id: entry.canonical_id,
                 display_name: entry.display_name,
                 framework: entry.framework,
               }),
@@ -256,6 +264,11 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
   const byHandle = useMemo(() => {
     const m = new Map<string, ExternalAgentSummary>();
     for (const a of externalAgents) {
+      // A project member references an external agent by its canonical id
+      // (consent-flow agents), while older identities like @taOS-dev reference
+      // it by handle. Key on both so an approved agent lands in the External
+      // section either way.
+      if (a.canonical_id) m.set(a.canonical_id, a);
       if (a.handle) m.set(a.handle, a);
     }
     return m;


### PR DESCRIPTION
Approved external CLI agents (grok-taOS, kilo-taOS) were listed as plain project Members instead of under "External / Connected agents" alongside the other connected agents.

Root cause: ProjectMembers only classified a member as external when its member_id matched a registry agent's **handle** (`byHandle`). The consent approve flow registers external-selfjoin agents with an empty handle and adds the member row keyed by the **canonical id**, so the match never fired and they fell into the main list. `@taOS-dev` only worked because its handle equals its member_id.

Fix (frontend-only, surgical):
- Capture `canonical_id` from `/api/agents/registry` and key the external-agent map by both canonical id and handle, so a member matches either way.
- Add `grok` (not only `grok-build`) to the framework label map so the badge reads "Grok".
- New regression test asserting an empty-handle, canonical-id-keyed agent renders under the External section with the Grok badge.

Verified against the live Pi: grok-taos-20260711-000736 and kilo-taos-20260711-000740 are registry external-selfjoin/active with empty handles and are members of the taOS project.