### PR TITLE
fix(desktop): Registry poll no longer resets scroll (#1761)

### DIFF
--- a/desktop/src/apps/agents/RegistryPanel.test.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.test.tsx
@@ -1,6 +1,11 @@
 import { render, screen, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { stripAt, RegistryPanel, type RegistryEntry } from "./RegistryPanel";
+import {
+  stripAt,
+  registryEntriesEqual,
+  RegistryPanel,
+  type RegistryEntry,
+} from "./RegistryPanel";
 
 /* ------------------------------------------------------------------ */
 /*  stripAt — pure unit tests (no timers needed)                       */
@@ -25,6 +30,47 @@ describe("stripAt", () => {
 
   it("handles string that is just @", () => {
     expect(stripAt("@")).toBe("");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  registryEntriesEqual — poll no-op comparison                       */
+/* ------------------------------------------------------------------ */
+
+describe("registryEntriesEqual", () => {
+  const base: RegistryEntry = {
+    canonical_id: "id-1",
+    framework: "openclaw",
+    display_name: "Agent",
+    user_id: "user-1",
+    origin: "external-selfjoin",
+    handle: "",
+    role: null,
+    capabilities: ["a2a_send"],
+    status: "active",
+    registered_at: "2026-01-01T00:00:00Z",
+    updated_at: null,
+    revoked_at: null,
+  };
+
+  it("returns true for identical snapshots", () => {
+    expect(registryEntriesEqual([base], [{ ...base, capabilities: ["a2a_send"] }])).toBe(true);
+  });
+
+  it("returns false when status changes", () => {
+    expect(
+      registryEntriesEqual([base], [{ ...base, status: "suspended" }]),
+    ).toBe(false);
+  });
+
+  it("returns false when length differs", () => {
+    expect(registryEntriesEqual([base], [])).toBe(false);
+  });
+
+  it("returns false when capabilities differ", () => {
+    expect(
+      registryEntriesEqual([base], [{ ...base, capabilities: ["a2a_send", "memory_read"] }]),
+    ).toBe(false);
   });
 });
 
@@ -197,5 +243,33 @@ describe("RegistryPanel polling", () => {
     });
     // Should have triggered an additional registry fetch (post-action reload)
     expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBeforeAction);
+  });
+
+  it("unchanged poll does not show loading spinner (scroll stays mounted)", async () => {
+    const mockFetch = makeFetch();
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+    await act(async () => { await Promise.resolve(); });
+
+    // Initial load finished; row is visible
+    expect(screen.getByText("taOSmd-dev")).toBeInTheDocument();
+    expect(screen.queryByText(/Loading registry/i)).not.toBeInTheDocument();
+
+    const callsBefore = mockFetch.mock.calls.length;
+
+    // Quiet poll with identical payload must not flash the loading UI
+    await act(async () => {
+      vi.advanceTimersByTime(5_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(callsBefore);
+    expect(screen.queryByText(/Loading registry/i)).not.toBeInTheDocument();
+    expect(screen.getByText("taOSmd-dev")).toBeInTheDocument();
   });
 });

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -48,6 +48,35 @@ export function stripAt(s: string): string {
   return s.startsWith("@") ? s.slice(1) : s;
 }
 
+/** True when two registry snapshots are identical by id and content (poll no-op). */
+export function registryEntriesEqual(a: RegistryEntry[], b: RegistryEntry[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (
+      x.canonical_id !== y.canonical_id ||
+      x.framework !== y.framework ||
+      x.display_name !== y.display_name ||
+      x.user_id !== y.user_id ||
+      x.origin !== y.origin ||
+      x.handle !== y.handle ||
+      x.role !== y.role ||
+      x.status !== y.status ||
+      x.registered_at !== y.registered_at ||
+      x.updated_at !== y.updated_at ||
+      x.revoked_at !== y.revoked_at
+    ) {
+      return false;
+    }
+    const xc = x.capabilities;
+    const yc = y.capabilities;
+    if (xc.length !== yc.length || xc.some((c, j) => c !== yc[j])) return false;
+  }
+  return true;
+}
+
 function relativeTime(ts: string | null): string {
   if (!ts) return "—";
   const d = new Date(ts);
@@ -373,10 +402,13 @@ export function RegistryPanel() {
   // Monotonic counter — only the latest in-flight response is applied.
   const loadSeq = useRef(0);
 
-  const load = useCallback(async () => {
+  /** Load registry. quiet=true skips the loading spinner so polls do not unmount the list. */
+  const load = useCallback(async ({ quiet = false }: { quiet?: boolean } = {}) => {
     const seq = ++loadSeq.current;
-    setLoading(true);
-    setErr(null);
+    if (!quiet) {
+      setLoading(true);
+      setErr(null);
+    }
     try {
       const [statusResp, registryResp] = await Promise.all([
         fetch("/auth/status", { credentials: "include" }),
@@ -385,20 +417,27 @@ export function RegistryPanel() {
       if (seq !== loadSeq.current) return; // stale — a newer load fired; discard
       if (statusResp.ok) {
         const s = await statusResp.json();
-        setIsAdmin(!!s.user?.is_admin);
-        setCurrentUserId(s.user?.id ?? "");
+        const nextAdmin = !!s.user?.is_admin;
+        const nextUserId = (s.user?.id as string | undefined) ?? "";
+        setIsAdmin((prev) => (prev === nextAdmin ? prev : nextAdmin));
+        setCurrentUserId((prev) => (prev === nextUserId ? prev : nextUserId));
       }
       if (registryResp.ok) {
         const data = await registryResp.json();
-        setEntries(Array.isArray(data) ? data : []);
+        const next: RegistryEntry[] = Array.isArray(data) ? data : [];
+        // Unchanged poll is a no-op so React keeps the scroll container mounted.
+        setEntries((prev) => (registryEntriesEqual(prev, next) ? prev : next));
+        if (quiet) setErr((prev) => (prev === null ? prev : null));
       } else if (registryResp.status !== 404) {
-        setErr(`Failed to load registry (${registryResp.status})`);
+        const msg = `Failed to load registry (${registryResp.status})`;
+        setErr((prev) => (prev === msg ? prev : msg));
       }
     } catch (e: unknown) {
       if (seq !== loadSeq.current) return;
-      setErr(e instanceof Error ? e.message : "Network error");
+      const msg = e instanceof Error ? e.message : "Network error";
+      setErr((prev) => (prev === msg ? prev : msg));
     } finally {
-      if (seq === loadSeq.current) setLoading(false);
+      if (seq === loadSeq.current && !quiet) setLoading(false);
     }
   }, []);
 
@@ -411,7 +450,8 @@ export function RegistryPanel() {
     let timer: ReturnType<typeof setInterval> | null = null;
 
     const startPolling = () => {
-      if (timer === null) timer = setInterval(() => void load(), 5_000);
+      // Quiet polls: no spinner, and setEntries is a no-op when data is unchanged.
+      if (timer === null) timer = setInterval(() => void load({ quiet: true }), 5_000);
     };
     const stopPolling = () => {
       if (timer !== null) {
@@ -423,7 +463,7 @@ export function RegistryPanel() {
       if (document.hidden) {
         stopPolling();
       } else {
-        void load();
+        void load({ quiet: true });
         startPolling();
       }
     };
@@ -431,7 +471,7 @@ export function RegistryPanel() {
     // (covers alt-tab / dock-click without a tab switch).
     const onFocus = () => {
       if (!document.hidden) {
-        void load();
+        void load({ quiet: true });
         startPolling();
       }
     };
@@ -451,7 +491,7 @@ export function RegistryPanel() {
     action: "approve" | "reject" | "suspend" | "reactivate" | "revoke",
   ) {
     await registryAction(canonical_id, action);
-    await load();
+    await load({ quiet: true });
   }
 
   const pendingCount = entries.filter((e) => e.status === "pending").length;

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -43,7 +43,7 @@ export interface RegistryEntry {
 /*  Helpers                                                             */
 /* ------------------------------------------------------------------ */
 
-/** Strip a leading "@" for display only — "@" is bus-addressing syntax, not a name. */
+/** Strip a leading "@" for display only, "@" is bus-addressing syntax, not a name. */
 export function stripAt(s: string): string {
   return s.startsWith("@") ? s.slice(1) : s;
 }
@@ -55,6 +55,7 @@ export function registryEntriesEqual(a: RegistryEntry[], b: RegistryEntry[]): bo
   for (let i = 0; i < a.length; i++) {
     const x = a[i];
     const y = b[i];
+    if (!x || !y) return false;
     if (
       x.canonical_id !== y.canonical_id ||
       x.framework !== y.framework ||
@@ -399,7 +400,7 @@ export function RegistryPanel() {
   const [currentUserId, setCurrentUserId] = useState("");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-  // Monotonic counter — only the latest in-flight response is applied.
+  // Monotonic counter, only the latest in-flight response is applied.
   const loadSeq = useRef(0);
 
   /** Load registry. quiet=true skips the loading spinner so polls do not unmount the list. */
@@ -414,7 +415,7 @@ export function RegistryPanel() {
         fetch("/auth/status", { credentials: "include" }),
         fetch("/api/agents/registry", { credentials: "include" }),
       ]);
-      if (seq !== loadSeq.current) return; // stale — a newer load fired; discard
+      if (seq !== loadSeq.current) return; // stale, a newer load fired; discard
       if (statusResp.ok) {
         const s = await statusResp.json();
         const nextAdmin = !!s.user?.is_admin;


### PR DESCRIPTION
## Summary
- Agents Registry panel polled every 5s and each refresh set `loading` true, which unmounted the entry list and reset scroll.
- Background polls are now quiet (no spinner). `setEntries` only applies when data actually changed via `registryEntriesEqual` (id + content).
- Focus/visibility refreshes and post-action reloads use the same quiet path.
- Tests: pure equality unit tests plus a poll that asserts the loading spinner does not appear and the row stays mounted.

Closes nothing (board task #1761 / taOS issue #1761). Do not merge from this agent.

## Test plan
- [x] `cd desktop && npx vitest run src/apps/agents/RegistryPanel.test.tsx` (14 passed)
- [ ] Manual: expand Agent Registry, scroll mid-list, wait >5s, confirm scroll position holds
- [ ] Manual: while scrolled, approve/suspend an entry and confirm list still updates without a full loading flash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry polling to prevent unnecessary loading indicators and row replacements when data has not changed.
  * Preserved the current agent list during background refreshes for a smoother experience.
  * Prevented outdated registry responses from overwriting newer results.
  * Improved refresh behavior when returning to the app or completing registry actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->