### PR TITLE
feat(hailo): slice 1 port reservation + capability map (#1771)

### DIFF
--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -26,6 +26,10 @@ class TestReservedPorts:
     def test_llamacpp_port_reserved(self):
         assert 7835 in RESERVED_PORTS
 
+    def test_hailo_ollama_port_reserved(self):
+        """7836 is the hailo-ollama NPU backend; apps must never be allocated it."""
+        assert 7836 in RESERVED_PORTS
+
 
 class TestAllocateHostPort:
     def test_deterministic_for_same_app_id(self):
@@ -35,6 +39,14 @@ class TestAllocateHostPort:
         port = allocate_host_port("some-app")
         assert _POOL_START <= port < _POOL_END
         assert port not in RESERVED_PORTS
+
+    def test_never_allocates_hailo_ollama_port(self):
+        """7836 must stay reserved so no app host-port can squat hailo-ollama."""
+        assert 7836 in RESERVED_PORTS
+        for i in range(50):
+            port = allocate_host_port(f"hailo-port-guard-{i}")
+            assert port != 7836
+            assert port not in RESERVED_PORTS
 
     def test_walks_past_a_bound_port(self):
         preferred = allocate_host_port("walk-test-app")

--- a/tests/test_backend_catalog_lifecycle.py
+++ b/tests/test_backend_catalog_lifecycle.py
@@ -1,7 +1,17 @@
 from __future__ import annotations
 import asyncio
 import pytest
-from tinyagentos.scheduler.backend_catalog import BackendCatalog, BackendEntry
+from tinyagentos.scheduler.backend_catalog import (
+    BACKEND_CAPABILITIES,
+    BackendCatalog,
+    BackendEntry,
+)
+
+
+def test_hailo_ollama_capability_entry_exists():
+    """Hailo-10H backend claims llm-chat only in v1 (design slice S1)."""
+    assert "hailo-ollama" in BACKEND_CAPABILITIES
+    assert BACKEND_CAPABILITIES["hailo-ollama"] == {"llm-chat"}
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/installers/port_allocator.py
+++ b/tinyagentos/installers/port_allocator.py
@@ -43,6 +43,7 @@ RESERVED_PORTS: frozenset[int] = frozenset({
     7833,  # taOS rkllama NPU backend
     7834,  # taOS LiteLLM proxy (new default host port)
     7835,  # taOS llama-cpp server (default local LLM backend: CUDA/ROCm/Metal/CPU)
+    7836,  # taOS hailo-ollama NPU backend
     7900,  # taosmd A2A bus
     8000,  # Django / generic dev
     8080,  # Tomcat / common web app default

--- a/tinyagentos/scheduler/backend_catalog.py
+++ b/tinyagentos/scheduler/backend_catalog.py
@@ -39,6 +39,7 @@ BACKEND_CAPABILITIES: dict[str, set[str]] = {
     "mlx": {"llm-chat"},
     "openai": {"llm-chat", "embedding"},
     "anthropic": {"llm-chat"},
+    "hailo-ollama": {"llm-chat"},
     "sd-cpp": {"image-generation"},
     # ComfyUI: node-graph diffusion server — the Game Studio texture/sprite tier.
     "comfyui": {"image-generation"},


### PR DESCRIPTION
## Summary
Implements **slice S1** of `docs/design/hailo-llm-backend.md` for the Hailo-10H LLM backend (#1771).

- Reserve host port **7836** in `RESERVED_PORTS` (`# taOS hailo-ollama NPU backend`) so user apps cannot squat the NPU backend port.
- Register **`hailo-ollama`: `{"llm-chat"}`** in `BACKEND_CAPABILITIES`.
- Tests: 7836 is reserved and never allocated; capability entry exists.

No other slices in this PR.

## Test plan
- [x] `python3 -m pytest tests/ --ignore=tests/e2e -k "port_alloc or backend_catalog" -q` (28 passed; `--ignore=tests/e2e` only for local collection without playwright)
- [x] `grep -n 7836 tinyagentos/installers/port_allocator.py` shows the reservation line

Refs: docs/design/hailo-llm-backend.md (Slice plan S1), #1771