### PR TITLE
feat(account): controller proxy actions for subdomain check/claim/release (slice 3)

### DIFF
--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -233,3 +233,173 @@ async def test_cluster_join_503_when_explicitly_blanked(client, monkeypatch):
     monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "")
     r = await client.get("/api/account/cluster/join/requests")
     assert r.status_code == 503
+
+
+# --- Account subdomain actions (account model slice 3) ---
+@pytest.mark.asyncio
+async def test_subdomains_check_forwards_name(client, monkeypatch):
+    """GET /api/account/subdomains/check?name=x forwards to
+    {base}/api/subdomains/check?name=x, relaying the session cookie."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
+        return _FakeResp(
+            content=b'{"available":true}',
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/subdomains/check?name=mybiz")
+    assert r.status_code == 200
+    assert r.json()["available"] is True
+    assert captured["url"] == "https://taos.my/api/subdomains/check?name=mybiz"
+    assert captured["method"] == "GET"
+    assert captured["cookie"]  # session cookie passed through
+
+
+@pytest.mark.asyncio
+async def test_subdomains_claim_forwards_body(client, monkeypatch):
+    """POST /api/account/subdomains/claim forwards to {base}/api/subdomains/claim
+    with the validated name in the body and the session cookie passed through."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
+        captured["body"] = kw.get("content", b"").decode("utf-8")
+        return _FakeResp(
+            content=b'{"id":"c1","name":"mybiz","status":"active"}',
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post("/api/account/subdomains/claim", json={"name": "mybiz"})
+    assert r.status_code == 200
+    assert r.json()["name"] == "mybiz"
+    assert captured["url"] == "https://taos.my/api/subdomains/claim"
+    assert captured["method"] == "POST"
+    assert captured["cookie"]
+    assert "mybiz" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_subdomains_release_forwards_body(client, monkeypatch):
+    """POST /api/account/subdomains/release forwards to
+    {base}/api/subdomains/release with the validated name in the body."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        captured["body"] = kw.get("content", b"").decode("utf-8")
+        return _FakeResp(
+            content=b'{"name":"mybiz","status":"released"}',
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post("/api/account/subdomains/release", json={"name": "mybiz"})
+    assert r.status_code == 200
+    assert captured["url"] == "https://taos.my/api/subdomains/release"
+    assert captured["method"] == "POST"
+    assert "mybiz" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_subdomains_check_503_when_unconfigured(client, monkeypatch):
+    """An explicit blank override disables the proxy; every subdomain action
+    returns 503 without contacting the upstream."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/subdomains/check?name=mybiz")
+    assert r.status_code == 503
+    assert "not configured" in r.json().get("error", "")
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subdomains_claim_503_when_unconfigured(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post("/api/account/subdomains/claim", json={"name": "mybiz"})
+    assert r.status_code == 503
+    assert "not configured" in r.json().get("error", "")
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subdomains_check_rejects_invalid_name(client, monkeypatch):
+    """A name that could inject path/query never reaches the upstream: it is
+    rejected at the validator (400) and no upstream call is made."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    for bad in ["..%2f..%2f", "a/b", "a?x=1", "a;b", "../auth/me", "x" * 65]:
+        r = await client.get(f"/api/account/subdomains/check?name={bad}")
+        assert r.status_code == 400, bad
+        assert "invalid name" in r.json().get("error", "")
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subdomains_claim_rejects_invalid_name(client, monkeypatch):
+    """A malformed name in the claim/release body is rejected (400) before the
+    upstream is contacted."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    for bad in ["a/b", "a?x=1", "../auth/me", "x" * 65, ""]:
+        r = await client.post("/api/account/subdomains/claim", json={"name": bad})
+        assert r.status_code == 400, bad
+    # A non-JSON / non-dict body is also rejected (400), not forwarded.
+    r = await client.post(
+        "/api/account/subdomains/claim",
+        content=b"not json",
+        headers={"content-type": "application/json"},
+    )
+    assert r.status_code == 400
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_subdomains_release_rejects_invalid_name(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post("/api/account/subdomains/release", json={"name": "a/b"})
+    assert r.status_code == 400
+    assert called["n"] == 0

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -167,6 +167,58 @@ def _valid_rid(rid: str) -> bool:
     return bool(_RID_RE.match(rid))
 
 
+# --- Account subdomain actions (account model slice 3) ---
+# Proxy to the taos.my subdomain claims service (slices 1 and 2 of the account
+# model). The client calls same-origin /api/account/subdomains/*; we forward to
+# {base}/api/subdomains/* with the session cookie pass-through, exactly like the
+# auth and cluster-join actions above. The `name` field is validated as a simple
+# rid-style token before it can reach the upstream URL, so a crafted name can
+# never inject path segments or query (../, %2f, ?) into the forwarded request.
+@router.get("/api/account/subdomains/check")
+async def subdomains_check(request: Request):
+    name, err = await _validate_subdomain_name(request)
+    if err is not None:
+        return err
+    return await _forward_to(request, "GET", f"/api/subdomains/check?name={name}")
+
+
+@router.post("/api/account/subdomains/claim")
+async def subdomains_claim(request: Request):
+    name, err = await _validate_subdomain_name(request)
+    if err is not None:
+        return err
+    return await _forward_to(request, "POST", "/api/subdomains/claim")
+
+
+@router.post("/api/account/subdomains/release")
+async def subdomains_release(request: Request):
+    name, err = await _validate_subdomain_name(request)
+    if err is not None:
+        return err
+    return await _forward_to(request, "POST", "/api/subdomains/release")
+
+
+async def _validate_subdomain_name(request: Request) -> tuple[str | None, Response | None]:
+    """Validate a subdomain `name` (query param for GET, JSON `name` in the body
+    for POST) as a simple rid-style token. Returns ``(name, None)`` on success,
+    or ``(None, error_response)`` when the name is missing or malformed. A bad
+    name must never reach the upstream, so it is rejected here with 400 and no
+    forwarding happens."""
+    if request.method == "GET":
+        name = request.query_params.get("name", "")
+    else:
+        try:
+            payload = await request.json()
+        except Exception:  # noqa: BLE001
+            return None, JSONResponse({"error": "invalid body"}, status_code=400)
+        if not isinstance(payload, dict):
+            return None, JSONResponse({"error": "invalid body"}, status_code=400)
+        name = payload.get("name", "")
+    if not _valid_rid(str(name)):
+        return None, JSONResponse({"error": "invalid name"}, status_code=400)
+    return str(name), None
+
+
 @router.get("/api/account/me")
 async def account_me(request: Request):
     return await _forward(request, "me")


### PR DESCRIPTION
## Summary

Implements **account design doc slice 3** (docs/design/account-username-subdomain-model.md, "Slice plan"): the controller proxy actions for the subdomain claims service.

- `tinyagentos/routes/account_proxy.py`: new same-origin routes `/api/account/subdomains/{check,claim,release}` that forward to `{TAOS_ACCOUNT_BASE_URL}/api/subdomains/{check,claim,release}` with the session cookie passthrough, mirroring the existing auth and cluster-join proxy actions.
- The `name` field (query for `check`, JSON body for `claim`/`release`) is validated rid-style before it can reach the upstream URL, so a crafted name cannot inject path segments or query (path-traversal / SSRF guard). Invalid names are rejected 400 with no upstream call; an unconfigured service returns 503.

Slices 1 and 2 (the taos-website endpoints) are the contract and are mocked in the tests. This PR implements only slice 3.

## Test plan

- `uv run --extra dev pytest tests/test_routes_account_proxy.py -q` -> 20 passed (12 pre-existing + 8 new).
- New tests cover forwarding (check query name, claim/release body name) with cookie passthrough, 503 when unconfigured, and 400 on invalid names with no upstream call.

Refs: docs/design/account-username-subdomain-model.md (Slice plan, slice 3).