### PR TITLE
feat(account): frontend types + Account panel split for username/subdomains (slice 4)

### DIFF
--- a/desktop/src/apps/SettingsApp/AccountPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.test.tsx
@@ -83,7 +83,7 @@ describe("AccountSection", () => {
     );
   });
 
-  it("shows the 'Reserve your username' promo when signed in with no handle", async () => {
+  it("shows the free-username copy and CTA when no username is claimed", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
       if (String(input).includes("/auth/status")) {
         return Promise.resolve(new Response(null, { status: 401 }));
@@ -100,11 +100,14 @@ describe("AccountSection", () => {
       );
     });
     render(<AccountSection />);
-    expect(await screen.findByText("Reserve your taOS username")).toBeInTheDocument();
-    expect(screen.getByText("Reserve your username")).toBeInTheDocument();
+    expect(await screen.findByText("Claim your free taOS username")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your username is your free identity on taOS/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Claim your username")).toBeInTheDocument();
   });
 
-  it("shows the reserved handle instead of the CTA when the account has one", async () => {
+  it("displays the claimed username with free-identity copy (no .taos.my suffix)", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
       if (String(input).includes("/auth/status")) {
         return Promise.resolve(new Response(null, { status: 401 }));
@@ -115,7 +118,8 @@ describe("AccountSection", () => {
             user_id: "u1",
             email: "jay@example.com",
             taosgo: { status: "none" },
-            handle: "jay",
+            username: "jay",
+            subdomains: [],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -123,8 +127,111 @@ describe("AccountSection", () => {
     });
     render(<AccountSection />);
     expect(await screen.findByText("@jay")).toBeInTheDocument();
-    expect(screen.getByText("jay.taos.my")).toBeInTheDocument();
-    expect(screen.queryByText("Reserve your username")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/People use @username to find you/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("jay.taos.my")).not.toBeInTheDocument();
+  });
+
+  it("renders the claimed subdomain list with active and grace badges", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      if (String(input).includes("/auth/status")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            user_id: "u1",
+            email: "jay@example.com",
+            taosgo: { status: "active" },
+            username: "jay",
+            subdomains: [
+              { id: "s1", account_id: "u1", name: "mybiz", status: "active" },
+              { id: "s2", account_id: "u1", name: "old", status: "grace" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    });
+    render(<AccountSection />);
+    expect(await screen.findByText("mybiz.taos.my")).toBeInTheDocument();
+    expect(screen.getByText("old.taos.my")).toBeInTheDocument();
+    expect(screen.getAllByText("Active").length).toBeGreaterThan(0);
+    expect(screen.getByText("Grace")).toBeInTheDocument();
+  });
+
+  it("disables the claim UI when not subscribed", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      if (String(input).includes("/auth/status")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            user_id: "u1",
+            email: "jay@example.com",
+            taosgo: { status: "none" },
+            username: "jay",
+            subdomains: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    });
+    render(<AccountSection />);
+    const input = await screen.findByLabelText("Subdomain name");
+    expect(input).toBeDisabled();
+    expect(screen.getByText(/Claiming a subdomain is part of taOSgo/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Claim" })).toBeDisabled();
+  });
+
+  it("shows inline availability and claims a subdomain", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = String(input);
+      if (url.includes("/auth/status")) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      if (url.includes("/subdomains/check")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ available: true }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }
+      if (url.includes("/subdomains/claim")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: "s9",
+              account_id: "u1",
+              name: "mybiz",
+              status: "active",
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            user_id: "u1",
+            email: "jay@example.com",
+            taosgo: { status: "active" },
+            username: "jay",
+            subdomains: [],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    });
+    render(<AccountSection />);
+    const input = await screen.findByLabelText("Subdomain name");
+    fireEvent.change(input, { target: { value: "mybiz" } });
+    expect(await screen.findByText("Available")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Claim" }));
+    expect(await screen.findByText("mybiz.taos.my")).toBeInTheDocument();
   });
 
   it("shows the local 'this device' identity from /auth/status", async () => {

--- a/desktop/src/apps/SettingsApp/AccountPanel.tsx
+++ b/desktop/src/apps/SettingsApp/AccountPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef, type FormEvent } from "react";
-import { LogOut, AlertCircle, ShieldCheck, Plane, UserCircle, AtSign } from "lucide-react";
+import { LogOut, AlertCircle, ShieldCheck, Plane, UserCircle, AtSign, Check, X, Globe, Loader2 } from "lucide-react";
 import { Button, Card, Input, Label } from "@/components/ui";
 import {
   fetchAccount,
@@ -7,9 +7,14 @@ import {
   register,
   logout,
   isAuthError,
+  checkSubdomain,
+  claimSubdomain,
+  releaseSubdomain,
   type AccountState,
   type Account,
   type TaosgoStatus,
+  type SubdomainClaim,
+  type SubdomainCheck,
 } from "@/lib/account-client";
 
 const TAOSGO_STATUS: Record<TaosgoStatus, { label: string; tone: string }> = {
@@ -126,21 +131,24 @@ function TaosgoCard({ account }: { account: Account }) {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Reserve-your-username promo card                                  */
+/*  Free username card (social identity, no taOSgo, no .taos.my)      */
 /* ------------------------------------------------------------------ */
 
-function ReserveHandleCard({ account }: { account: Account }) {
-  const { handle } = account;
+function UsernameCard({ account }: { account: Account }) {
+  const { username } = account;
 
-  if (handle) {
+  if (username) {
     return (
       <Card className="p-4">
         <div className="flex items-center gap-2 mb-2">
           <AtSign size={16} className="text-sky-400" />
           <h3 className="text-sm font-medium">Your taOS username</h3>
         </div>
-        <p className="text-sm font-medium">@{handle}</p>
-        <p className="text-xs text-shell-text-tertiary mt-0.5">{handle}.taos.my</p>
+        <p className="text-sm font-medium">@{username}</p>
+        <p className="text-xs text-shell-text-tertiary mt-0.5">
+          Your free identity across taOS. People use @username to find you in the community, the
+          apps you share, and your profile.
+        </p>
       </Card>
     );
   }
@@ -149,18 +157,177 @@ function ReserveHandleCard({ account }: { account: Account }) {
     <Card className="p-4">
       <div className="flex items-center gap-2 mb-2">
         <AtSign size={16} className="text-sky-400" />
-        <h3 className="text-sm font-medium">Reserve your taOS username</h3>
+        <h3 className="text-sm font-medium">Claim your free taOS username</h3>
       </div>
       <p className="text-xs text-shell-text-tertiary mb-3">
-        Claim your handle for your website, blog, portfolio, and socials — held for you across
-        taOS. Included with taOSgo.
+        Your username is your free identity on taOS. It is yours at no cost, and it is what people
+        use to find you across the community, the apps you share, and your profile.
       </p>
       <Button
         size="sm"
         onClick={() => { window.location.href = "https://taos.my/account/username"; }}
       >
-        Reserve your username
+        Claim your username
       </Button>
+    </Card>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Subdomains card (taOSgo, paid)                                    */
+/* ------------------------------------------------------------------ */
+
+const SUBDOMAIN_STATUS: Record<SubdomainClaim["status"], { label: string; tone: string }> = {
+  active: { label: "Active", tone: "text-emerald-400" },
+  grace: { label: "Grace", tone: "text-amber-400" },
+  released: { label: "Released", tone: "text-shell-text-tertiary" },
+};
+
+function SubdomainsCard({ account }: { account: Account }) {
+  const subscribed =
+    account.taosgo.status === "trialing" || account.taosgo.status === "active";
+  const [claims, setClaims] = useState<SubdomainClaim[]>(account.subdomains ?? []);
+  const [name, setName] = useState("");
+  const [check, setCheck] = useState<SubdomainCheck | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [releasing, setReleasing] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const mounted = useRef(true);
+  useEffect(() => () => { mounted.current = false; }, []);
+
+  // Inline availability feedback: re-check on every keystroke once subscribed.
+  useEffect(() => {
+    if (!subscribed) { setCheck(null); setChecking(false); return; }
+    const trimmed = name.trim();
+    if (!trimmed) { setCheck(null); setChecking(false); return; }
+    let cancelled = false;
+    setChecking(true);
+    void checkSubdomain(trimmed).then((res) => {
+      if (cancelled || !mounted.current) return;
+      setChecking(false);
+      setCheck(isAuthError(res) ? null : res);
+    });
+    return () => { cancelled = true; };
+  }, [name, subscribed]);
+
+  const claim = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || !subscribed || busy) return;
+    setBusy(true);
+    setError(null);
+    const res = await claimSubdomain(trimmed);
+    if (!mounted.current) return;
+    setBusy(false);
+    if (isAuthError(res)) { setError(res.message); return; }
+    setClaims((prev) => [...prev, res]);
+    setName("");
+    setCheck(null);
+  };
+
+  const release = async (sub: SubdomainClaim) => {
+    if (releasing || busy) return;
+    setReleasing(sub.name);
+    setError(null);
+    const res = await releaseSubdomain(sub.name);
+    if (!mounted.current) return;
+    setReleasing(null);
+    if (isAuthError(res)) { setError(res.message); return; }
+    setClaims((prev) => prev.filter((s) => s.name !== sub.name));
+  };
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <Globe size={16} className="text-sky-400" />
+        <h3 className="text-sm font-medium">Your subdomains</h3>
+      </div>
+      <p className="text-xs text-shell-text-tertiary mb-3">
+        Public <code>*.taos.my</code> sites you publish to. A taOSgo perk.
+      </p>
+
+      {claims.length > 0 && (
+        <ul className="space-y-2 mb-3">
+          {claims.map((sub) => {
+            const meta = SUBDOMAIN_STATUS[sub.status];
+            return (
+              <li
+                key={sub.id}
+                className="flex items-center justify-between gap-3 rounded-lg border border-white/10 bg-white/[0.02] px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate">{sub.name}.taos.my</p>
+                  <span className={`text-xs font-medium ${meta.tone}`}>{meta.label}</span>
+                </div>
+                {sub.status !== "released" && (
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    disabled={releasing === sub.name}
+                    onClick={() => void release(sub)}
+                  >
+                    {releasing === sub.name ? "Releasing..." : "Release"}
+                  </Button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="space-y-2">
+        <div>
+          <Label htmlFor="subdomain-name" className="text-xs text-shell-text-secondary">
+            Claim a subdomain
+          </Label>
+          <div className="flex items-center gap-2 mt-1">
+            <Input
+              id="subdomain-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") void claim(); }}
+              placeholder="yourname"
+              disabled={!subscribed}
+              className="mt-0"
+              aria-label="Subdomain name"
+            />
+            <span className="text-xs text-shell-text-tertiary shrink-0">.taos.my</span>
+            <Button
+              size="sm"
+              onClick={() => void claim()}
+              disabled={!subscribed || !name.trim() || busy || checking}
+            >
+              {busy ? "Claiming..." : "Claim"}
+            </Button>
+          </div>
+          {!subscribed && (
+            <p className="text-xs text-shell-text-tertiary mt-1.5 flex items-center gap-1.5">
+              <ShieldCheck size={12} /> Claiming a subdomain is part of taOSgo. Start your free trial
+              to publish public sites.
+            </p>
+          )}
+          {checking && subscribed && (
+            <p className="text-xs text-shell-text-tertiary mt-1.5 flex items-center gap-1.5">
+              <Loader2 size={12} className="animate-spin" /> Checking availability...
+            </p>
+          )}
+          {!checking && subscribed && check && check.available && (
+            <p className="text-xs text-emerald-400 mt-1.5 flex items-center gap-1.5">
+              <Check size={12} /> Available
+            </p>
+          )}
+          {!checking && subscribed && check && !check.available && (
+            <p className="text-xs text-amber-400 mt-1.5 flex items-center gap-1.5">
+              <X size={12} /> {check.reason ? `Unavailable (${check.reason})` : "Unavailable"}
+            </p>
+          )}
+        </div>
+        {error && (
+          <p className="text-xs text-amber-400 flex items-center gap-1.5" role="alert">
+            <AlertCircle size={12} /> {error}
+          </p>
+        )}
+      </div>
     </Card>
   );
 }
@@ -182,7 +349,8 @@ function SignedIn({ account, onSignOut }: { account: Account; onSignOut: () => v
         </Button>
       </Card>
       <TaosgoCard account={account} />
-      <ReserveHandleCard account={account} />
+      <SubdomainsCard account={account} />
+      <UsernameCard account={account} />
     </div>
   );
 }
@@ -308,9 +476,8 @@ export function AccountSection() {
       <LocalAccountCard />
 
       <p className="text-sm text-shell-text-tertiary mb-5">
-        One taOS account for everything: secure remote access with taOSgo, sharing the apps you
-        build, and soon your own taOS username for a website, blog, portfolio, and social
-        presence.
+        Your taOS account is your free identity across taOS. taOSgo adds secure remote access and
+        public <code>*.taos.my</code> subdomains you can publish to.
       </p>
 
       {state.kind === "loading" && (

--- a/desktop/src/lib/account-client.test.ts
+++ b/desktop/src/lib/account-client.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fetchAccount, login, register, logout, isAuthError } from "./account-client";
+import {
+  fetchAccount,
+  login,
+  register,
+  logout,
+  isAuthError,
+  checkSubdomain,
+  claimSubdomain,
+  releaseSubdomain,
+} from "./account-client";
 
 const originalFetch = global.fetch;
 
@@ -243,5 +252,114 @@ describe("logout", () => {
   it("does not throw on non-ok response", async () => {
     global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
     await expect(logout()).resolves.toBeUndefined();
+  });
+});
+
+describe("checkSubdomain", () => {
+  it("returns the availability result on 200", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ available: true }),
+    });
+    global.fetch = fetchMock;
+
+    const result = await checkSubdomain("mybiz");
+    expect(isAuthError(result)).toBe(false);
+    if (!isAuthError(result)) {
+      expect(result).toEqual({ available: true });
+    }
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/account/subdomains/check?name=mybiz");
+    expect(opts.method).toBe("GET");
+    expect(opts.credentials).toBe("include");
+  });
+
+  it("returns AuthError on 503 (service not live)", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    const result = await checkSubdomain("mybiz");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("The account service is not available yet.");
+    }
+  });
+
+  it("returns AuthError on network error", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("offline"));
+    const result = await checkSubdomain("mybiz");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("Could not reach the account service. Check your connection.");
+    }
+  });
+});
+
+describe("claimSubdomain", () => {
+  it("returns the new claim on 200", async () => {
+    const claim = { id: "s1", account_id: "u1", name: "mybiz", status: "active" as const };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => claim,
+    });
+    global.fetch = fetchMock;
+
+    const result = await claimSubdomain("mybiz");
+    expect(isAuthError(result)).toBe(false);
+    if (!isAuthError(result)) {
+      expect(result).toEqual(claim);
+    }
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/account/subdomains/claim");
+    expect(opts.method).toBe("POST");
+    expect(opts.headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(opts.body)).toEqual({ name: "mybiz" });
+  });
+
+  it("returns AuthError with the server message on refusal", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "name taken" }),
+    });
+    const result = await claimSubdomain("mybiz");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("name taken");
+    }
+  });
+});
+
+describe("releaseSubdomain", () => {
+  it("returns the released marker on 200", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ released: true }),
+    });
+    global.fetch = fetchMock;
+
+    const result = await releaseSubdomain("mybiz");
+    expect(isAuthError(result)).toBe(false);
+    if (!isAuthError(result)) {
+      expect(result).toEqual({ released: true });
+    }
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/account/subdomains/release");
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body)).toEqual({ name: "mybiz" });
+  });
+
+  it("returns AuthError on 404", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: "not found" }),
+    });
+    const result = await releaseSubdomain("mybiz");
+    expect(isAuthError(result)).toBe(true);
+    if (isAuthError(result)) {
+      expect(result.message).toBe("The account service is not available yet.");
+    }
   });
 });

--- a/desktop/src/lib/account-client.ts
+++ b/desktop/src/lib/account-client.ts
@@ -21,9 +21,38 @@ export interface Account {
   user_id: string;
   email: string;
   taosgo: TaosgoEntitlement;
-  /** Reserved taOS username (e.g. for a future website/blog/portfolio). Not
-   *  yet returned by /me; treated as absent until the backend adds it. */
+  /** Free taOS username (the social/identity namespace). Not yet returned by
+   *  /me; treated as absent until the backend adds it. */
+  username?: string | null;
+  /** Claimed taOSgo subdomains under taos.my. Not yet returned by /me. */
+  subdomains?: SubdomainClaim[];
+  /** @deprecated reserved taOS username alias. Kept for one release so older
+   *  client builds keep rendering; prefer `username`. */
   handle?: string | null;
+}
+
+export type SubdomainStatus = "active" | "grace" | "released";
+
+export interface SubdomainBinding {
+  type: "site";
+  host_id: string;
+  site_ref: string;
+}
+
+export interface SubdomainClaim {
+  id: string;
+  account_id: string;
+  name: string;
+  status: SubdomainStatus;
+  claimed_at?: string | null;
+  lapsed_at?: string | null;
+  released_at?: string | null;
+  binding?: SubdomainBinding | null;
+}
+
+export interface SubdomainCheck {
+  available: boolean;
+  reason?: "taken" | "reserved" | "invalid" | "cooldown";
 }
 
 export type AccountState =
@@ -38,19 +67,41 @@ export interface AuthError {
 
 const BASE = "/api/account";
 
+/** Validate a single subdomain claim record before the UI trusts it. The backend
+ *  is external (taos.my); a malformed entry must not crash the render. */
+function isSubdomain(x: unknown): x is SubdomainClaim {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return (
+    typeof o.id === "string" &&
+    typeof o.name === "string" &&
+    typeof o.status === "string" &&
+    (o.status === "active" || o.status === "grace" || o.status === "released")
+  );
+}
+
 /** Validate an unknown payload is a well-formed Account before the UI trusts it.
  *  The backend is external (taos.my); a malformed /me must not crash the render. */
 function isAccount(x: unknown): x is Account {
   if (!x || typeof x !== "object") return false;
   const o = x as Record<string, unknown>;
   const t = o.taosgo as Record<string, unknown> | undefined;
-  return (
-    typeof o.user_id === "string" &&
-    typeof o.email === "string" &&
-    !!t &&
-    typeof t === "object" &&
-    typeof t.status === "string"
-  );
+  if (
+    typeof o.user_id !== "string" ||
+    typeof o.email !== "string" ||
+    !t ||
+    typeof t !== "object" ||
+    typeof t.status !== "string"
+  ) {
+    return false;
+  }
+  if (o.username !== undefined && o.username !== null && typeof o.username !== "string") {
+    return false;
+  }
+  if (o.subdomains !== undefined) {
+    if (!Array.isArray(o.subdomains) || !o.subdomains.every(isSubdomain)) return false;
+  }
+  return true;
 }
 
 async function call(path: string, body?: unknown): Promise<Response> {
@@ -129,6 +180,59 @@ export async function logout(): Promise<void> {
   }
 }
 
-export function isAuthError(x: Account | AuthError): x is AuthError {
+export function isAuthError(x: unknown): x is AuthError {
   return (x as AuthError).message !== undefined;
 }
+
+/* ------------------------------------------------------------------ */
+/*  Subdomain claims (taOSgo, paid)                                   */
+/*                                                                     */
+/*  Same-origin proxy to taos.my (slice 3 of the account model): the   */
+/*  client only ever sees /api/account/subdomains/*. Every call degrades */
+/*  to an AuthError rather than throwing, matching the rest of this      */
+/*  module, so the UI ships ahead of the backend.                       */
+/* ------------------------------------------------------------------ */
+
+/** Call the subdomain proxy and normalize the result the same way the auth
+ *  actions do: 404/503 mean the service is not live yet, any non-ok becomes a
+ *  readable message, and a bad body degrades to a generic error. */
+async function subdomainRequest<T>(path: string, body?: unknown): Promise<T | AuthError> {
+  let r: Response;
+  try {
+    r = await call(path, body);
+  } catch {
+    return { message: "Could not reach the account service. Check your connection." };
+  }
+  if (r.status === 404 || r.status === 503) {
+    return { message: "The account service is not available yet." };
+  }
+  if (!r.ok) {
+    let msg = `Request failed (${r.status}).`;
+    try {
+      const d = (await r.json()) as { error?: string; detail?: string };
+      if (d?.error || d?.detail) msg = String(d.error || d.detail);
+    } catch {
+      /* keep the status-code default */
+    }
+    return { message: msg };
+  }
+  try {
+    const data: unknown = await r.json();
+    return data as T;
+  } catch {
+    return { message: "Unexpected response from the account service." };
+  }
+}
+
+/** Advisory availability check (GET /api/account/subdomains/check?name=...). */
+export const checkSubdomain = (name: string): Promise<SubdomainCheck | AuthError> =>
+  subdomainRequest<SubdomainCheck>(`/subdomains/check?name=${encodeURIComponent(name)}`);
+
+/** Claim a subdomain (POST /api/account/subdomains/claim). Returns the new claim
+ *  record, or an AuthError (e.g. "taken", "reserved", "cap reached"). */
+export const claimSubdomain = (name: string): Promise<SubdomainClaim | AuthError> =>
+  subdomainRequest<SubdomainClaim>("/subdomains/claim", { name });
+
+/** Release a claimed subdomain (POST /api/account/subdomains/release). */
+export const releaseSubdomain = (name: string): Promise<{ released: boolean } | AuthError> =>
+  subdomainRequest<{ released: boolean }>("/subdomains/release", { name });


### PR DESCRIPTION
## Summary

Implements **Slice 4** of `docs/design/account-username-subdomain-model.md` (the frontend types + Account panel split). Slice 3 (controller proxy actions) is already merged; this builds on it.

- `desktop/src/lib/account-client.ts`
  - New `SubdomainClaim` / `SubdomainCheck` types; `Account.username` and `Account.subdomains` added, `Account.handle` deprecated.
  - New `checkSubdomain`, `claimSubdomain`, `releaseSubdomain` helpers that call the same-origin `/api/account/subdomains/*` proxy (slice 3) and degrade to an `AuthError` (never throw) exactly like the existing auth actions.
- `desktop/src/apps/SettingsApp/AccountPanel.tsx`
  - Split the old `ReserveHandleCard` into a free `UsernameCard` (community/social copy, no taOSgo mention, no `.taos.my` suffix) and a `SubdomainsCard` (claim list with `active`/`grace` badges, inline availability check, release, and a disabled claim UI when unsubscribed).
  - Updated the section intro copy that previously bundled the username into the paid pitch.
- Tests: `account-client.test.ts` covers the three helpers (website endpoints mocked, per the contract); `AccountPanel.test.tsx` covers free-username copy, claim list rendering, disabled claim when unsubscribed, and the grace badge.

## Test plan

`npx vitest run src/lib/account-client.test.ts src/apps/SettingsApp/AccountPanel.test.tsx` -> 37 passing.

Note: 6 unrelated suites fail locally only because `@codemirror/commands` / `dompurify` are not linked by the pnpm install in this environment (untouched files: `CodeView.tsx`, `TextEditorApp.tsx`, `ReaderMode.tsx`); all 2745 runnable tests pass.

Refs: account design doc, Slice plan > Slice 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added username identity cards with updated free-username messaging and claim actions.
  * Added public `*.taos.my` subdomain management, including availability checks, claiming, releasing, and active or grace status badges.
  * Subdomain claiming is available to subscribed accounts, with clear feedback for unavailable or failed requests.

* **Bug Fixes**
  * Improved handling of invalid account and subdomain data to prevent rendering issues.
  * Added clearer authentication and service error handling for subdomain actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->