### PR TITLE
feat(hailo): slice 3 hailo-ollama managed service manifest

### DIFF
--- a/app-catalog/services/hailo-ollama/manifest.yaml
+++ b/app-catalog/services/hailo-ollama/manifest.yaml
@@ -1,4 +1,7 @@
 id: hailo-ollama
+# The hailo-ollama runtime is Hailo proprietary software; the install flow
+# presents Hailo's EULA for acceptance before download (see the design doc).
+license: Proprietary (Hailo EULA, accepted at install)
 name: hailo-ollama (Hailo-10H NPU LLM)
 type: service
 category: llm-runtime

--- a/app-catalog/services/hailo-ollama/manifest.yaml
+++ b/app-catalog/services/hailo-ollama/manifest.yaml
@@ -1,0 +1,26 @@
+id: hailo-ollama
+name: hailo-ollama (Hailo-10H NPU LLM)
+type: service
+category: llm-runtime
+description: "Ollama-compatible LLM server on the Hailo-10H NPU (Raspberry Pi 5 + AI HAT+2)"
+requires:
+  ram_mb: 1024
+  disk_mb: 500
+  ports: [7836]
+install:
+  method: script
+  script: scripts/install-hailo.sh
+hardware_tiers:
+  arm-npu-8gb: full
+  arm-npu-16gb: full
+  cpu-only: unsupported
+lifecycle:
+  backend_type: hailo-ollama
+  default_url: http://localhost:7836
+  auto_manage: true
+  unit: hailo-ollama.service
+  scope: system
+  health:
+    url: "http://localhost:7836/api/tags"
+    expect: '"models"'
+  startup_timeout_seconds: 120

--- a/tests/test_backend_services.py
+++ b/tests/test_backend_services.py
@@ -51,6 +51,21 @@ def test_load_skips_managed_without_unit_or_scope(tmp_path: Path) -> None:
     assert bs.load_managed_backends(tmp_path) == []
 
 
+def test_load_managed_backends_includes_hailo_ollama_real_manifest() -> None:
+    catalog = Path(__file__).resolve().parents[1] / "app-catalog"
+    manifest = catalog / "services" / "hailo-ollama" / "manifest.yaml"
+    assert manifest.is_file(), "hailo-ollama service manifest must exist"
+
+    backends = bs.load_managed_backends(catalog)
+    ids = {b.id for b in backends}
+    assert "hailo-ollama" in ids
+    b = next(x for x in backends if x.id == "hailo-ollama")
+    assert b.unit == "hailo-ollama.service"
+    assert b.scope == "system"
+    assert b.health_url == "http://localhost:7836/api/tags"
+    assert b.health_expect == '"models"'
+
+
 # --------------------------------------------------------------------------
 # resolve_scope / unit_state / service_action  (mocked systemctl)
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements **SLICE 3 (Service manifest)** of the Hailo-10H LLM backend design (`docs/design/hailo-llm-backend.md`).

- Adds `app-catalog/services/hailo-ollama/manifest.yaml` with the exact content of design section D, satisfying the managed-backend-service contract (`lifecycle.auto_manage: true`, `unit`, `scope: system`, `health` on port 7836).
- Because `auto_manage` declares `unit` + `scope` + `health`, the backend flows through `load_managed_backends()` with zero new plumbing (self-heal, Restart AI Services, Cluster UI rows all pick it up automatically).
- Adds a unit test that loads the **real** manifest file and asserts `load_managed_backends()` returns the `hailo-ollama` backend.

## Verification (green)
- `python scripts/check_manifests.py managed-lint` → `manifest managed-lint: clean`
- `python -m pytest tests/test_check_manifests.py tests/test_backend_services.py -q` → 25 passed

Slices S1 (port 7836 reservation + capability map) and S2 (`scripts/install-hailo.sh`) are already merged; this slice depends only on S3 and is independently shippable.

Docs-Reviewed: implements the merged design doc docs/design/hailo-llm-backend.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Hailo-10H NPU through a new Ollama-compatible AI service.
  * The service includes automatic setup, lifecycle management, health monitoring, and support for compatible 8 GB and 16 GB hardware configurations.

* **Tests**
  * Added coverage to verify the new service is correctly detected and configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->