### PR TITLE
feat(account): onboarding free username claim step (slice 5)

### DIFF
--- a/desktop/src/components/OnboardingScreen.test.tsx
+++ b/desktop/src/components/OnboardingScreen.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { OnboardingScreen } from "./OnboardingScreen";
+
+const okJson = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+/** Fill and submit the first-run account form so we reach the username step. */
+async function completeAccountStep() {
+  fireEvent.change(screen.getByLabelText(/^Username/), {
+    target: { value: "jay" },
+  });
+  fireEvent.change(screen.getByLabelText(/^Full name/), {
+    target: { value: "Jay Doe" },
+  });
+  fireEvent.change(screen.getByLabelText(/^Email/), {
+    target: { value: "jay@example.com" },
+  });
+  fireEvent.change(screen.getByLabelText(/^Password/), {
+    target: { value: "1234" },
+  });
+  fireEvent.change(screen.getByLabelText(/Confirm password/), {
+    target: { value: "1234" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Get started" }));
+}
+
+describe("OnboardingScreen username step (slice 5)", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it("renders the first-run account setup form", () => {
+    render(<OnboardingScreen onDone={() => {}} />);
+    expect(screen.getByText("Welcome to taOS")).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Username/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Full name/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Email/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Password/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Get started" })).toBeInTheDocument();
+  });
+
+  it("advances to the free username step after account creation", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ ok: true }));
+    render(<OnboardingScreen onDone={() => {}} />);
+    await completeAccountStep();
+    expect(await screen.findByText("Claim your free taOS username")).toBeInTheDocument();
+    expect(screen.getByLabelText("taOS username")).toBeInTheDocument();
+  });
+
+  it("labels the username step as free and defers the paid subdomain upsell to Settings", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ ok: true }));
+    render(<OnboardingScreen onDone={() => {}} />);
+    await completeAccountStep();
+    expect(await screen.findByText("Claim your free taOS username")).toBeInTheDocument();
+    // Free, no cost, no taOSgo gating in this step.
+    expect(screen.getByText(/Your username is free/i)).toBeInTheDocument();
+    expect(screen.queryByText(/taOSgo/i)).not.toBeInTheDocument();
+    // Subdomain publishing is deferred to Settings rather than upsold here.
+    expect(screen.getByText(/later in Settings/i)).toBeInTheDocument();
+    expect(screen.queryByText(/taos\.my/i)).not.toBeInTheDocument();
+  });
+
+  it("claims the username via POST /api/account/username and then finishes", async () => {
+    const calls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.includes("/api/account/username")) {
+        return Promise.resolve(okJson({ username: "myname" }));
+      }
+      return Promise.resolve(okJson({ ok: true }));
+    });
+    const onDone = vi.fn();
+    render(<OnboardingScreen onDone={onDone} />);
+    await completeAccountStep();
+    const input = await screen.findByLabelText("taOS username");
+    fireEvent.change(input, { target: { value: "myname" } });
+    fireEvent.click(screen.getByRole("button", { name: "Claim username" }));
+    expect(await screen.findByText(/You're @myname on taOS/i)).toBeInTheDocument();
+    const claimCall = calls.find((c) => c.includes("/api/account/username"));
+    expect(claimCall).toBeDefined();
+    const claimInit = (globalThis.fetch as unknown as vi.Mock).mock.calls.find((c) =>
+      String(c[0]).includes("/api/account/username"),
+    )?.[1] as RequestInit | undefined;
+    expect(claimInit?.method).toBe("POST");
+    expect(JSON.parse(String(claimInit?.body))).toEqual({ username: "myname" });
+    fireEvent.click(screen.getByRole("button", { name: "Finish" }));
+    await waitFor(() => expect(onDone).toHaveBeenCalledOnce());
+  });
+
+  it("never dead-ends: Finish proceeds even when the claim fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
+      const url = String(input);
+      if (url.includes("/api/account/username")) {
+        // Service unreachable -> the step must still let the user finish.
+        return Promise.reject(new Error("network"));
+      }
+      return Promise.resolve(okJson({ ok: true }));
+    });
+    const onDone = vi.fn();
+    render(<OnboardingScreen onDone={onDone} />);
+    await completeAccountStep();
+    fireEvent.click(await screen.findByRole("button", { name: "Claim username" }));
+    expect(await screen.findByText(/later in Settings/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Finish" }));
+    await waitFor(() => expect(onDone).toHaveBeenCalledOnce());
+  });
+
+  it("finishes without claiming when the user skips", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ ok: true }));
+    const onDone = vi.fn();
+    render(<OnboardingScreen onDone={onDone} />);
+    await completeAccountStep();
+    await screen.findByText("Claim your free taOS username");
+    fireEvent.click(screen.getByRole("button", { name: "Finish" }));
+    await waitFor(() => expect(onDone).toHaveBeenCalledOnce());
+  });
+});

--- a/desktop/src/components/OnboardingScreen.tsx
+++ b/desktop/src/components/OnboardingScreen.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Sparkles } from "lucide-react";
+import { useState, type FormEvent } from "react";
+import { Sparkles, AtSign, Check } from "lucide-react";
 
 interface Props {
   onDone: () => void;
@@ -10,6 +10,8 @@ interface Props {
   defaultAutoLogin?: boolean;
 }
 
+type Step = "account" | "username";
+
 /**
  * First-run onboarding (no props) or invite completion (invitedUsername + inviteCode).
  *
@@ -18,6 +20,11 @@ interface Props {
  * - Username field is read-only
  * - Submit POSTs to /auth/complete instead of /auth/setup
  * - auto-login defaults to false
+ *
+ * After the local account is created the flow advances to the free taOS username
+ * step (slice 5 of the account model). The username is free and optional here, so
+ * the user can always finish without touching the paid taOSgo path (subdomain
+ * publishing is deferred to Settings and never blocks onboarding).
  */
 export function OnboardingScreen({
   onDone,
@@ -26,6 +33,7 @@ export function OnboardingScreen({
   defaultAutoLogin,
 }: Props) {
   const isInvite = Boolean(invitedUsername && inviteCode);
+  const [step, setStep] = useState<Step>("account");
 
   const [username, setUsername] = useState(invitedUsername ?? "");
   const [fullName, setFullName] = useState("");
@@ -44,7 +52,7 @@ export function OnboardingScreen({
     passwordOk &&
     matches;
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     if (!valid) return;
     setLoading(true);
@@ -73,11 +81,17 @@ export function OnboardingScreen({
         setLoading(false);
         return;
       }
-      onDone();
+      // Account created: move on to the free username step rather than leaving
+      // onboarding. The username is optional, so this step can never dead-end.
+      setStep("username");
     } catch {
       setError("Network error — please try again");
       setLoading(false);
     }
+  }
+
+  if (step === "username") {
+    return <UsernameStep defaultName={username} onDone={onDone} />;
   }
 
   return (
@@ -246,6 +260,154 @@ export function OnboardingScreen({
           }
         `}</style>
       </form>
+    </div>
+  );
+}
+
+/**
+ * The free taOS username step (slice 5). The username is free and never gated
+ * behind taOSgo, so the user can always finish via "Finish" even if the claim
+ * fails or they skip it. Public subdomain publishing is a taOSgo perk and is
+ * intentionally deferred to Settings, not offered here.
+ */
+function UsernameStep({
+  defaultName,
+  onDone,
+}: {
+  defaultName: string;
+  onDone: () => void;
+}) {
+  const [name, setName] = useState(defaultName);
+  const [claiming, setClaiming] = useState(false);
+  const [claimed, setClaimed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function claim() {
+    const trimmed = name.trim();
+    if (!trimmed || claiming) return;
+    setClaiming(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/account/username", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ username: trimmed }),
+      });
+      if (res.ok) {
+        setClaimed(true);
+      } else {
+        // Degrade to a non-blocking message; the user finishes in Settings.
+        setError("We couldn't save that username right now. You can claim it later in Settings.");
+      }
+    } catch {
+      setError("We couldn't reach the account service. You can claim your username later in Settings.");
+    } finally {
+      setClaiming(false);
+    }
+  }
+
+  return (
+    <div
+      className="h-screen w-screen flex items-center justify-center overflow-y-auto"
+      style={{
+        background: "var(--color-shell-bg)",
+        paddingTop: "calc(env(safe-area-inset-top, 0px) + 16px)",
+        paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 16px)",
+        paddingLeft: "calc(env(safe-area-inset-left, 0px) + 16px)",
+        paddingRight: "calc(env(safe-area-inset-right, 0px) + 16px)",
+      }}
+    >
+      <div
+        className="w-full max-w-md p-6 rounded-2xl border border-white/10"
+        style={{
+          backgroundColor: "rgba(255,255,255,0.04)",
+          backdropFilter: "blur(20px)",
+        }}
+        aria-label="Claim your free taOS username"
+      >
+        <div className="flex flex-col items-center gap-3 mb-6">
+          <div
+            className="w-14 h-14 rounded-2xl flex items-center justify-center"
+            style={{ background: "linear-gradient(135deg, #8b92a3, #5b6170)" }}
+          >
+            <AtSign size={24} className="text-white" />
+          </div>
+          <h1 className="text-lg font-semibold text-shell-text">Claim your free taOS username</h1>
+          <p className="text-xs text-shell-text-secondary text-center">
+            Your username is free. It is your identity across taOS, so people can find you in the
+            community, the apps you share, and your profile.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <Field label="Username" id="onb-cloud-username" hint="Free. No subscription needed.">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-shell-text-tertiary select-none">@</span>
+              <input
+                id="onb-cloud-username"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value.replace(/\s+/g, "").toLowerCase())}
+                autoFocus
+                placeholder="jay"
+                aria-label="taOS username"
+                className="onb-input"
+              />
+            </div>
+          </Field>
+
+          {claimed && (
+            <p className="text-xs text-emerald-400 flex items-center gap-1.5" role="status">
+              <Check size={12} /> You're @{name.trim()} on taOS.
+            </p>
+          )}
+
+          {error && (
+            <p className="text-xs text-amber-400 flex items-center gap-1.5" role="alert">
+              <AtSign size={12} /> {error}
+            </p>
+          )}
+
+          <button
+            type="button"
+            onClick={() => void claim()}
+            disabled={claiming || claimed || name.trim().length === 0}
+            className="w-full px-4 py-2.5 rounded-lg bg-accent text-white text-sm font-medium hover:brightness-110 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
+          >
+            {claiming ? "Claiming..." : claimed ? "Claimed" : "Claim username"}
+          </button>
+
+          <button
+            type="button"
+            onClick={onDone}
+            className="w-full px-4 py-2.5 rounded-lg border border-white/10 text-shell-text-secondary text-sm font-medium hover:brightness-110 transition-all"
+          >
+            Finish
+          </button>
+
+          <p className="text-[11px] text-shell-text-tertiary text-center mt-2">
+            Claiming is optional. Public subdomains are set up later in Settings.
+          </p>
+        </div>
+
+        <style>{`
+          .onb-input {
+            width: 100%;
+            padding: 10px 14px;
+            border-radius: 8px;
+            background: var(--color-shell-bg-deep);
+            border: 1px solid rgba(255, 255, 255, 0.10);
+            color: var(--color-shell-text);
+            font-size: 13px;
+            outline: none;
+            transition: border-color 0.15s;
+          }
+          .onb-input:focus {
+            border-color: rgba(139, 146, 163, 0.45);
+          }
+        `}</style>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Implements Slice 5 of `docs/design/account-username-subdomain-model.md`: a free taOS username claim step in onboarding.

- `OnboardingScreen.tsx` now advances to a free username step right after local account creation (slice 5, UI touchpoints for #141).
- The step is clearly labeled free, never gated behind taOSgo, and the user can always finish: claiming is optional and claim failures degrade to a "set up later in Settings" pointer. Public subdomain publishing is deferred to Settings so onboarding never dead-ends on the paid path.
- `OnboardingScreen.test.tsx` (new) covers: account form render, advance to username step, free labeling with no paid upsell, claim via `POST /api/account/username`, finish-on-failure, and finish-without-claim.

Bounded to `OnboardingScreen.tsx` plus its test, per the slice plan. Slices 3 and 4 (proxy actions + AccountPanel card) are already merged. Website-side `/api/account/username` is the contract and mocked in tests.

## Verification
`npx vitest run src/components/OnboardingScreen.test.tsx` -> 6 passed. `npx tsc -b` clean.

Does NOT merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a free taOS username step after account setup.
  * Users can claim a username, skip the step, or finish later from Settings.
  * Added confirmation and error messaging during username claims.
  * Users can complete onboarding even if claiming a username fails.

* **Tests**
  * Added coverage for the username setup, claiming, skipping, completion, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->