### PR TITLE
feat(hub): identity keypair keystore + directory registration proxy (slice 1)

### DIFF
--- a/tests/test_hub_identity.py
+++ b/tests/test_hub_identity.py
@@ -1,0 +1,118 @@
+"""Hub identity keystore (hub social network slice 1).
+
+The two minted keypairs (Ed25519 signing + X25519 encryption) are generated on
+the node, persist 0600 under the data dir, and round-trip across restarts so the
+author fingerprint is stable. The registration proof is a signature over a
+server challenge; a proof signed by the wrong key must not verify.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from tinyagentos.hub import identity
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+class TestKeystore:
+    def test_keygen_on_first_use(self, data_dir):
+        assert identity.exists() is False
+        ident = identity.load_or_create()
+        assert identity.exists() is True
+        # Both keypairs minted: raw Ed25519 / X25519 keys are 32 bytes = 64 hex.
+        for field in ("signing_private", "signing_public", "encryption_private", "encryption_public"):
+            assert len(bytes.fromhex(ident[field])) == 32
+
+    def test_round_trip_is_stable(self, data_dir):
+        first = identity.load_or_create()
+        # A second call must not re-mint: the identity (and its fingerprint) is
+        # stable across restarts.
+        second = identity.load_or_create()
+        assert first["signing_public"] == second["signing_public"]
+        assert first["signing_private"] == second["signing_private"]
+        assert first["encryption_public"] == second["encryption_public"]
+
+    def test_file_is_0600(self, data_dir):
+        identity.load_or_create()
+        mode = stat.S_IMODE(os.stat(data_dir / "hub" / "identity.json").st_mode)
+        assert mode == 0o600
+
+    def test_private_keys_persist_only_in_the_0600_file(self, data_dir):
+        ident = identity.load_or_create()
+        on_disk = json.loads((data_dir / "hub" / "identity.json").read_text())
+        assert on_disk["signing_private"] == ident["signing_private"]
+        # The registerable view never carries private material.
+        pub = identity.public_identity()
+        assert "signing_private" not in pub
+        assert "encryption_private" not in pub
+
+    def test_public_identity_shape(self, data_dir):
+        ident = identity.load_or_create()
+        pub = identity.public_identity()
+        assert pub["signing_pubkey"] == ident["signing_public"]
+        assert pub["encryption_pubkey"] == ident["encryption_public"]
+        assert pub["fingerprint"] == identity.fingerprint(ident["signing_public"])
+
+    def test_fingerprint_is_sha256_of_signing_pubkey(self, data_dir):
+        import hashlib
+
+        ident = identity.load_or_create()
+        expected = hashlib.sha256(bytes.fromhex(ident["signing_public"])).hexdigest()
+        assert identity.signing_fingerprint() == expected
+
+    def test_corrupt_file_is_treated_as_absent(self, data_dir):
+        (data_dir / "hub").mkdir(parents=True, exist_ok=True)
+        (data_dir / "hub" / "identity.json").write_text("[1, 2, 3]")
+        assert identity.exists() is False
+        # load_or_create recovers by minting a fresh identity.
+        ident = identity.load_or_create()
+        assert ident["signing_public"]
+
+    def test_clear(self, data_dir):
+        identity.load_or_create()
+        identity.clear()
+        assert identity.exists() is False
+        identity.clear()  # no-op when already gone
+
+
+class TestChallengeProof:
+    def test_registration_proof_verifies_with_the_right_key(self, data_dir):
+        reg = identity.build_registration("server-challenge-abc")
+        assert set(reg) == {"signing_pubkey", "encryption_pubkey", "proof"}
+        assert identity.verify_signature(
+            reg["signing_pubkey"], b"server-challenge-abc", reg["proof"]
+        )
+
+    def test_challenge_proof_rejects_a_wrong_key(self, data_dir, tmp_path, monkeypatch):
+        reg = identity.build_registration("server-challenge-abc")
+        # Mint a *different* identity in an isolated data dir and take its pubkey.
+        other_dir = tmp_path / "other"
+        monkeypatch.setenv("TAOS_DATA_DIR", str(other_dir))
+        other = identity.load_or_create()
+        wrong_pubkey = other["signing_public"]
+        assert wrong_pubkey != reg["signing_pubkey"]
+        # The proof was signed by the first key; verifying against the wrong key
+        # must fail.
+        assert (
+            identity.verify_signature(wrong_pubkey, b"server-challenge-abc", reg["proof"])
+            is False
+        )
+
+    def test_proof_rejects_tampered_challenge(self, data_dir):
+        reg = identity.build_registration("server-challenge-abc")
+        assert (
+            identity.verify_signature(reg["signing_pubkey"], b"different", reg["proof"])
+            is False
+        )
+
+    def test_verify_signature_never_raises_on_garbage(self, data_dir):
+        assert identity.verify_signature("nothex", b"x", "alsonothex") is False
+        assert identity.verify_signature("", b"x", "") is False

--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -403,3 +403,155 @@ async def test_subdomains_release_rejects_invalid_name(client, monkeypatch):
     r = await client.post("/api/account/subdomains/release", json={"name": "a/b"})
     assert r.status_code == 400
     assert called["n"] == 0
+
+
+# --- Hub identity directory actions (hub social slice 1) ---
+# The taos.my side (hub_identities/hub_key_log tables + register/lookup/rotate
+# with challenge proof) is the contract; here we assert the controller proxy
+# forwards to the right upstream path, relays the session cookie, and degrades to
+# 503 when the account service is unconfigured.
+@pytest.mark.asyncio
+async def test_hub_identity_register_forwards_body(client, monkeypatch):
+    """POST /api/account/hub/identity/register forwards to
+    {base}/api/hub/identity/register with the keys + proof body and the session
+    cookie passed through."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
+        captured["body"] = kw.get("content", b"").decode("utf-8")
+        return _FakeResp(
+            content=b'{"username":"alice","status":"registered"}',
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post(
+        "/api/account/hub/identity/register",
+        json={"signing_pubkey": "aa", "encryption_pubkey": "bb", "proof": "cc"},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "registered"
+    assert captured["url"] == "https://taos.my/api/hub/identity/register"
+    assert captured["method"] == "POST"
+    assert captured["cookie"]  # session cookie passed through
+    assert "signing_pubkey" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_hub_identity_lookup_forwards_username_and_returns_key_log(client, monkeypatch):
+    """GET /api/account/hub/identity/lookup?username=alice forwards to
+    {base}/api/hub/identity/lookup?username=alice and relays the directory's
+    keys + append-only key log verbatim."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        return _FakeResp(
+            content=(
+                b'{"username":"alice","signing_pubkey":"aa","encryption_pubkey":"bb",'
+                b'"key_log":[{"signing_pubkey":"aa","recovery":false}]}'
+            ),
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/hub/identity/lookup?username=alice")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["signing_pubkey"] == "aa"
+    assert body["key_log"] == [{"signing_pubkey": "aa", "recovery": False}]
+    assert captured["url"] == "https://taos.my/api/hub/identity/lookup?username=alice"
+    assert captured["method"] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_hub_identity_rotate_forwards_body(client, monkeypatch):
+    """POST /api/account/hub/identity/rotate forwards to
+    {base}/api/hub/identity/rotate with the rotation statement body."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        captured["body"] = kw.get("content", b"").decode("utf-8")
+        return _FakeResp(
+            content=b'{"status":"rotated"}',
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post(
+        "/api/account/hub/identity/rotate",
+        json={"new_keys": {"signing_pubkey": "dd"}, "old_key_sig": "ee"},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "rotated"
+    assert captured["url"] == "https://taos.my/api/hub/identity/rotate"
+    assert captured["method"] == "POST"
+    assert "new_keys" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_hub_identity_lookup_rejects_invalid_username(client, monkeypatch):
+    """A username that could inject path/query never reaches the upstream: it is
+    rejected at the validator (400) and no upstream call is made."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    for bad in ["a/b", "a?x=1", "../auth/me", "a;b", "x" * 65, ""]:
+        r = await client.get(f"/api/account/hub/identity/lookup?username={bad}")
+        assert r.status_code == 400, bad
+        assert "invalid username" in r.json().get("error", "")
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hub_identity_503_when_unconfigured(client, monkeypatch):
+    """An explicit blank override disables the proxy; every hub identity action
+    returns 503 without contacting the upstream."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    r1 = await client.post(
+        "/api/account/hub/identity/register",
+        json={"signing_pubkey": "aa", "encryption_pubkey": "bb", "proof": "cc"},
+    )
+    r2 = await client.get("/api/account/hub/identity/lookup?username=alice")
+    r3 = await client.post("/api/account/hub/identity/rotate", json={"new_keys": {}})
+    for r in (r1, r2, r3):
+        assert r.status_code == 503
+        assert "not configured" in r.json().get("error", "")
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hub_identity_register_503_when_upstream_unreachable(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+
+    async def handler(method, url, **kw):
+        raise httpx.ConnectError("down")
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post(
+        "/api/account/hub/identity/register",
+        json={"signing_pubkey": "aa", "encryption_pubkey": "bb", "proof": "cc"},
+    )
+    assert r.status_code == 503
+    assert "unreachable" in r.json().get("error", "")

--- a/tinyagentos/hub/__init__.py
+++ b/tinyagentos/hub/__init__.py
@@ -1,0 +1,8 @@
+"""hub.taos.my node engine (own-your-posts P2P social network).
+
+See ``docs/design/hub-social-network-foundation.md``. This package holds the
+controller-side node engine: the identity keystore (slice 1), and later the
+object store, chain logic, sync workers, and peer server. Directory calls reach
+taos.my through ``tinyagentos/routes/account_proxy.py`` additions; the browser
+never sees the taos.my base URL.
+"""

--- a/tinyagentos/hub/identity.py
+++ b/tinyagentos/hub/identity.py
@@ -1,0 +1,233 @@
+"""Hub identity keystore -- hub social network slice 1.
+
+Registering the free taos.my username mints, *on the user's node*, two keypairs
+(see ``docs/design/hub-social-network-foundation.md``, "Identity and keys"):
+
+- **Signing key** (Ed25519): signs every object the user publishes (profile
+  versions, posts, follows, circle grants, tombstones, rotation statements).
+- **Encryption key** (X25519): receives wrapped content keys for friends-only
+  content addressed to this user.
+
+Private keys are generated locally and never leave the node. They persist in a
+single 0600 file under the data dir (``<data_dir>/hub/identity.json``),
+following the ``mesh_credentials.py`` pattern: atomic write (temp + os.replace),
+an allowlist of persisted fields, and the ``TAOS_DATA_DIR`` override so local
+dev and tests keep working. The node registers the two *public* keys with the
+directory, proving key possession with a signature over a server-issued
+challenge.
+
+The canonical author identifier is the signing public key fingerprint (SHA-256
+of the raw public-key bytes), never the username: the directory maps username to
+key, so a username policy change (rename, reclamation) can never retroactively
+re-attribute signed content.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+logger = logging.getLogger(__name__)
+
+_FILENAME = "identity.json"
+
+# The fields we persist. Private key material stays local (0600); the public
+# keys and creation time round-trip so a restart resolves the same identity.
+_FIELDS = (
+    "signing_private",
+    "signing_public",
+    "encryption_private",
+    "encryption_public",
+    "created_at",
+)
+
+
+def _data_dir() -> Path:
+    env = os.environ.get("TAOS_DATA_DIR")
+    if env:
+        return Path(env)
+    # tinyagentos/hub/identity.py -> project root is two parents up.
+    return Path(__file__).resolve().parent.parent.parent / "data"
+
+
+def _hub_dir() -> Path:
+    return _data_dir() / "hub"
+
+
+def _path() -> Path:
+    return _hub_dir() / _FILENAME
+
+
+# --- low-level key encoding (raw bytes <-> hex) --------------------------------
+
+
+def _priv_raw(key) -> bytes:
+    return key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+
+
+def _pub_raw(key) -> bytes:
+    return key.public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+
+def _save(identity: dict) -> None:
+    """Persist the keystore, mode 0600, atomically.
+
+    Keeps only the ``_FIELDS`` allowlist. Atomic (write temp + ``os.replace``)
+    so a crash mid-write never leaves a partial file. The parent dir is created
+    0700; the file is created 0600 so private key material is never group- or
+    world-readable.
+    """
+    creds = {k: identity.get(k) for k in _FIELDS}
+
+    d = _hub_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:  # pragma: no cover - best effort on odd filesystems
+        pass
+
+    p = _path()
+    tmp = p.with_name(p.name + ".tmp")
+    data = json.dumps(creds).encode("utf-8")
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "wb") as f:
+        f.write(data)
+    os.replace(tmp, p)
+    try:
+        os.chmod(p, 0o600)
+    except OSError:  # pragma: no cover
+        pass
+
+
+def _load() -> Optional[dict]:
+    try:
+        data = json.loads(_path().read_text())
+    except (OSError, ValueError):
+        return None
+    # A corrupt or externally-edited file could parse to a non-object; treat any
+    # non-dict, or one missing the private signing key, as absent (fail closed to
+    # "no identity yet") rather than raising from the getters.
+    if not isinstance(data, dict) or not data.get("signing_private"):
+        return None
+    return data
+
+
+# --- public API ---------------------------------------------------------------
+
+
+def exists() -> bool:
+    """True once this node has minted a hub identity."""
+    return _load() is not None
+
+
+def load_or_create() -> dict:
+    """Return this node's identity, minting the keypairs on first use.
+
+    Idempotent: once the keystore exists it is returned unchanged, so the node
+    keeps the same identity (and therefore the same author fingerprint) across
+    restarts. The returned dict includes private key material; callers that only
+    need the registerable view should use :func:`public_identity`.
+    """
+    existing = _load()
+    if existing is not None:
+        return existing
+
+    signing = Ed25519PrivateKey.generate()
+    encryption = X25519PrivateKey.generate()
+    identity = {
+        "signing_private": _priv_raw(signing).hex(),
+        "signing_public": _pub_raw(signing.public_key()).hex(),
+        "encryption_private": _priv_raw(encryption).hex(),
+        "encryption_public": _pub_raw(encryption.public_key()).hex(),
+        "created_at": time.time(),
+    }
+    _save(identity)
+    return identity
+
+
+def signing_fingerprint() -> str:
+    """The canonical author id: SHA-256 (hex) of the raw signing public key."""
+    identity = load_or_create()
+    return fingerprint(identity["signing_public"])
+
+
+def public_identity() -> dict:
+    """The directory-registerable view: public keys and the author fingerprint.
+
+    No private key material. This is what a client renders and what the register
+    call anchors to the account's username.
+    """
+    identity = load_or_create()
+    return {
+        "signing_pubkey": identity["signing_public"],
+        "encryption_pubkey": identity["encryption_public"],
+        "fingerprint": fingerprint(identity["signing_public"]),
+    }
+
+
+def sign(data: bytes) -> str:
+    """Sign raw bytes with this node's Ed25519 signing key; returns hex."""
+    identity = load_or_create()
+    key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(identity["signing_private"]))
+    return key.sign(data).hex()
+
+
+def build_registration(challenge: str) -> dict:
+    """Build the ``POST /api/hub/identity/register`` body.
+
+    ``proof`` is a signature over the server-issued challenge, showing the node
+    holds the signing private key. The directory verifies it against the
+    submitted ``signing_pubkey`` before anchoring the identity to the username.
+    """
+    pub = public_identity()
+    return {
+        "signing_pubkey": pub["signing_pubkey"],
+        "encryption_pubkey": pub["encryption_pubkey"],
+        "proof": sign(challenge.encode("utf-8")),
+    }
+
+
+def fingerprint(signing_pubkey_hex: str) -> str:
+    """SHA-256 (hex) of a raw signing public key -- the canonical author id."""
+    return hashlib.sha256(bytes.fromhex(signing_pubkey_hex)).hexdigest()
+
+
+def verify_signature(signing_pubkey_hex: str, data: bytes, sig_hex: str) -> bool:
+    """Verify an Ed25519 signature over ``data`` against a hex public key.
+
+    Returns False (never raises) on a bad signature, a wrong key, or malformed
+    hex, so the directory-side challenge check and any client-side object
+    verification degrade cleanly. This is the check a directory runs on the
+    registration proof: a proof signed by the wrong key does not verify.
+    """
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(signing_pubkey_hex))
+        pub.verify(bytes.fromhex(sig_hex), data)
+        return True
+    except (InvalidSignature, ValueError, TypeError):
+        return False
+
+
+def clear() -> None:
+    """Forget the persisted identity. Intended for tests; no-op if absent."""
+    try:
+        _path().unlink()
+    except OSError:
+        pass

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -43,6 +43,14 @@ _ACTIONS: dict[str, tuple[str, str]] = {
     "login": ("POST", "/api/auth/login"),
     "register": ("POST", "/api/auth/register"),
     "logout": ("POST", "/api/auth/logout"),
+    # Hub identity directory (hub social slice 1). The client calls same-origin
+    # /api/account/hub/identity/* and we forward to {base}/api/hub/identity/*
+    # with the session cookie pass-through, exactly like the auth and subdomain
+    # actions above. The taos.my side (tables + register/lookup/rotate with
+    # challenge proof) is the contract; these are its controller-side entries.
+    "hub_identity_register": ("POST", "/api/hub/identity/register"),
+    "hub_identity_lookup": ("GET", "/api/hub/identity/lookup"),
+    "hub_identity_rotate": ("POST", "/api/hub/identity/rotate"),
 }
 
 _TIMEOUT = httpx.Timeout(15.0)
@@ -217,6 +225,33 @@ async def _validate_subdomain_name(request: Request) -> tuple[str | None, Respon
     if not _valid_rid(str(name)):
         return None, JSONResponse({"error": "invalid name"}, status_code=400)
     return str(name), None
+
+
+# --- Hub identity directory actions (hub social slice 1) ---
+# Anchor the node's minted keypairs to the account's username, look an identity's
+# keys + key log up, and rotate keys. The client calls same-origin
+# /api/account/hub/identity/*; we forward to {base}/api/hub/identity/* with the
+# session cookie pass-through, so no new auth surface appears on the client and
+# the taos.my base URL stays server-side. `username` on lookup is validated as a
+# simple rid-style token before it can reach the upstream URL, so a crafted
+# username can never inject path segments or query (../, %2f, ?).
+@router.post("/api/account/hub/identity/register")
+async def hub_identity_register(request: Request):
+    return await _forward(request, "hub_identity_register")
+
+
+@router.get("/api/account/hub/identity/lookup")
+async def hub_identity_lookup(request: Request):
+    username = request.query_params.get("username", "")
+    if not _valid_rid(str(username)):
+        return JSONResponse({"error": "invalid username"}, status_code=400)
+    _method, path = _ACTIONS["hub_identity_lookup"]
+    return await _forward_to(request, "GET", f"{path}?username={username}")
+
+
+@router.post("/api/account/hub/identity/rotate")
+async def hub_identity_rotate(request: Request):
+    return await _forward(request, "hub_identity_rotate")
 
 
 @router.get("/api/account/me")


### PR DESCRIPTION
## Summary

Implements **Slice 1** of the hub.taos.my own-your-posts social network founding design (`docs/design/hub-social-network-foundation.md`, "Slice plan"), nothing beyond it. Website-side directory endpoints are the contract and are mocked in tests.

- `tinyagentos/hub/identity.py`: node keystore that mints an Ed25519 signing key and an X25519 encryption key on first use, persists them 0600 under `<data_dir>/hub/identity.json` following the `mesh_credentials.py` pattern (atomic write, allowlisted fields, `TAOS_DATA_DIR` override for tests). Exposes the registerable public view, the SHA-256 signing-key fingerprint (the canonical author id), and a challenge-proof signer plus a signature verifier.
- `tinyagentos/routes/account_proxy.py`: `_ACTIONS` additions and same-origin routes for hub identity **register / lookup / rotate**, forwarding to `/api/hub/identity/*` with session cookie pass-through, exactly like the auth and subdomain actions. `lookup` validates the `username` as an rid-style token before it can reach the upstream URL (no path/query injection).

## Tests

- Keystore round-trip, 0600 perms, keygen-on-first-use, stable fingerprint across restarts, corrupt-file fail-closed.
- Proxy forwarding for register/lookup/rotate, cookie pass-through, 503 when the account service is unconfigured or unreachable, invalid-username rejection (400, no upstream call).
- Challenge proof rejects a wrong key and a tampered challenge; lookup relays the append-only key log.

Verification: `pytest tests/test_hub_identity.py tests/test_routes_account_proxy.py` -> 38 passed.

## Scope notes

Does not touch `scripts/` or `app-catalog/`. Slices 5 to 7 remain maintainer/design-review-required per the doc. PR targets `dev`; do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent hub identities with signing and encryption keys.
  - Added public identity details, fingerprints, registration proofs, and signature verification.
  - Added hub identity directory endpoints for registration, lookup, and key rotation.
  - Added validation and clear error handling for invalid requests and unavailable directory services.
- **Documentation**
  - Documented the hub node engine and its identity capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->