### PR TITLE
feat(hailo): slice 5 runtime detection + provider adapter for Hailo-10H (per design doc)

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import pytest
 import yaml
+from pathlib import Path
 from tinyagentos.config import AppConfig, load_config, save_config, validate_config, normalize_agent, _LITELLM_PORT_NEW, _LITELLM_PORT_LEGACY
 
 class TestLoadConfig:
@@ -407,3 +408,60 @@ def test_load_config_migrates_legacy_rkllama_backend_name(tmp_path):
     # A non-rkllama backend that happens to be named local-npu is untouched.
     ollama = [b for b in cfg.backends if b["type"] == "ollama"][0]
     assert ollama["name"] == "local-npu"
+
+
+_HAILO_MANIFEST = (
+    Path(__file__).resolve().parent.parent
+    / "app-catalog" / "services" / "hailo-ollama" / "manifest.yaml"
+)
+
+
+def _hailo10h_profile(ram_gb: int = 8):
+    """Hardware profile for a Raspberry Pi 5 + Hailo-10H AI HAT+2."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(hardware={
+        "cpu": {"arch": "aarch64"},
+        "npu": {"type": "hailo10h"},
+        "ram_mb": ram_gb * 1024,
+    })
+
+
+def _cpu_profile(ram_gb: int = 8):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(hardware={
+        "cpu": {"arch": "x86_64"},
+        "npu": {"type": "none"},
+        "ram_mb": ram_gb * 1024,
+    })
+
+
+def test_auto_register_hailo_ollama_seeds_local_backend_on_hailo10h(tmp_path):
+    """S5: on a Hailo-10H host the hailo-ollama manifest seeds a
+    local-hailo-ollama backend of type hailo-ollama (the local-<service-id>
+    rule, mirroring rkllama's local-rkllama)."""
+    from tinyagentos.config import AppConfig, auto_register_from_manifest
+
+    cfg = AppConfig(config_path=tmp_path / "config.yaml")
+    added = auto_register_from_manifest(
+        _HAILO_MANIFEST, cfg, hardware_profile=_hailo10h_profile(),
+    )
+    assert added is True
+    seeded = [b for b in cfg.backends if b["name"] == "local-hailo-ollama"]
+    assert len(seeded) == 1
+    assert seeded[0]["type"] == "hailo-ollama"
+    assert seeded[0]["url"] == "http://localhost:7836"
+
+
+def test_auto_register_hailo_ollama_skipped_without_hailo10h(tmp_path):
+    """S5: on non-Hailo hardware (cpu-only tier) the manifest's
+    cpu-only: unsupported tier must keep local-hailo-ollama unregistered."""
+    from tinyagentos.config import AppConfig, auto_register_from_manifest
+
+    cfg = AppConfig(config_path=tmp_path / "config.yaml")
+    added = auto_register_from_manifest(
+        _HAILO_MANIFEST, cfg, hardware_profile=_cpu_profile(),
+    )
+    assert added is False
+    assert [b for b in cfg.backends if b["type"] == "hailo-ollama"] == []

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -309,6 +309,37 @@ class TestGenerateLiteLLMRkllamaBackend:
 
 
 # ---------------------------------------------------------------------------
+# generate_litellm_config -- hailo-ollama backend (S5)
+# ---------------------------------------------------------------------------
+
+class TestGenerateLiteLLMHailoOllamaBackend:
+
+    def test_hailo_ollama_uses_ollama_chat_prefix(self):
+        """hailo-ollama is Ollama-compatible, so the default chat entry must use
+        the ollama_chat prefix and point at the remapped port 7836."""
+        backends = [
+            {"name": "hailo-box", "type": "hailo-ollama", "url": "http://localhost:7836"}
+        ]
+        config = generate_litellm_config(backends)
+        entry = config["model_list"][0]
+        assert entry["litellm_params"]["model"] == "ollama_chat/default"
+        assert entry["litellm_params"]["api_base"] == "http://localhost:7836"
+
+    def test_hailo_ollama_discovered_embedding_emits_ollama_prefix(self):
+        """Registered models keep the ollama/<name> LiteLLM prefix, identical to
+        rkllama (S5)."""
+        backends = [
+            {"name": "hailo-box", "type": "hailo-ollama", "url": "http://h:7836"}
+        ]
+        discovered = {"http://h:7836": ["nomic-embed-text"]}
+        config = generate_litellm_config(backends, discovered=discovered)
+        ml = config["model_list"]
+        embed_entries = [e for e in ml if e.get("model_info", {}).get("mode") == "embedding"]
+        assert len(embed_entries) >= 1
+        assert embed_entries[0]["litellm_params"]["model"] == "ollama/nomic-embed-text"
+
+
+# ---------------------------------------------------------------------------
 # generate_litellm_config -- cloud backends
 # ---------------------------------------------------------------------------
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -615,6 +615,36 @@ class TestDetectBackends:
         for name in names:
             assert "@" not in name, f"backend name must not embed URL: {name!r}"
 
+    async def test_hailo_ollama_running(self):
+        """A Hailo-10H host running hailo-ollama on the taOS remap port 7836
+        must be detected as a live hailo-ollama backend (S5)."""
+        agent = WorkerAgent("http://localhost:6969")
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"models": []}
+
+        with patch("tinyagentos.worker.agent.httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+
+            async def mock_get(url):
+                if "7836" in url:
+                    return mock_response
+                raise Exception("not running")
+
+            mock_client.get = AsyncMock(side_effect=mock_get)
+            mock_client_cls.return_value = mock_client
+
+            backends = await agent.detect_backends()
+
+        hailo = [b for b in backends if b["type"] == "hailo-ollama"]
+        assert len(hailo) == 1
+        assert hailo[0]["url"] == "http://localhost:7836"
+        assert hailo[0]["name"] == "hailo-ollama:7836"
+        # Capability map entry from S1 must surface in the probe.
+        assert "llm-chat" in hailo[0]["capabilities"]
+
     async def test_backend_name_portless_url(self):
         """When a candidate URL has no explicit port, name falls back to bare backend_type."""
         agent = WorkerAgent("http://localhost:6969")

--- a/tinyagentos/backend_adapters.py
+++ b/tinyagentos/backend_adapters.py
@@ -34,7 +34,7 @@ class BackendAdapter(ABC):
 
 
 class OllamaCompatAdapter(BackendAdapter):
-    """Adapter for Ollama-compatible APIs (rkllama, ollama).
+    """Adapter for Ollama-compatible APIs (rkllama, hailo-ollama, ollama).
 
     Uses GET /api/tags to list models and check health.
     """
@@ -231,6 +231,7 @@ ExoAdapter = OpenAICompatAdapter  # Exo exposes OpenAI-compatible API
 
 _ADAPTERS: dict[str, BackendAdapter] = {
     "rkllama": OllamaCompatAdapter(),
+    "hailo-ollama": OllamaCompatAdapter(),
     "ollama": OllamaCompatAdapter(),
     "llama-cpp": OpenAICompatAdapter(),
     "vllm": OpenAICompatAdapter(),

--- a/tinyagentos/litellm_config.py
+++ b/tinyagentos/litellm_config.py
@@ -144,7 +144,7 @@ async def _discover_ollama_backends_concurrent(
     ollama_urls = [
         b.get("url", "").rstrip("/")
         for b in backends
-        if b.get("type", "ollama") in ("ollama", "rkllama") and b.get("url")
+        if b.get("type", "ollama") in ("ollama", "rkllama", "hailo-ollama") and b.get("url")
     ]
     if not ollama_urls:
         return {}
@@ -356,7 +356,7 @@ def generate_litellm_config(
         # found across all backends also claims the stable
         # ``taos-embedding-default`` alias so containers have one name to
         # inject regardless of which rkllama box holds the model.
-        if backend_type in ("ollama", "rkllama"):
+        if backend_type in ("ollama", "rkllama", "hailo-ollama"):
             _probed = (discovered or {}).get(url)
             if _probed is None:
                 _probed = _discover_ollama_models(url)

--- a/tinyagentos/providers/__init__.py
+++ b/tinyagentos/providers/__init__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 ALL_TYPES: set[str] = {
     # -- local LLM backends --
     "rkllama",
+    "hailo-ollama",
     "ollama",
     "llama-cpp",
     "vllm",
@@ -63,6 +64,7 @@ NEEDS_API_BASE_TYPES: set[str] = (LOCAL_TYPES - IMAGE_GEN_TYPES) | {"openai-comp
 BACKEND_TYPE_MAP: dict[str, str] = {
     "ollama": "ollama",
     "rkllama": "ollama",  # rkllama is ollama-compatible on /api/embed too
+    "hailo-ollama": "ollama",  # hailo-ollama is ollama-compatible on /api/embed too
     "llama-cpp": "openai",
     "vllm": "openai",
     "exo": "openai",
@@ -82,4 +84,5 @@ CHAT_BACKEND_TYPE_MAP: dict[str, str] = {
     **BACKEND_TYPE_MAP,
     "ollama": "ollama_chat",
     "rkllama": "ollama_chat",
+    "hailo-ollama": "ollama_chat",
 }

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -127,6 +127,7 @@ class WorkerAgent:
         candidates = [
             ("rkllama", "http://localhost:7833"),
             ("rkllama", "http://localhost:8080"),         # legacy port; existing installs
+            ("hailo-ollama", "http://localhost:7836"),    # Hailo-10H NPU LLM (taOS remap; upstream 8000 banned)
             ("ollama", "http://localhost:11434"),         # user / system Ollama (default port)
             ("ollama", "http://localhost:21434"),         # TAOS-bundled Ollama (taos-ollama.service)
             ("llama-cpp", "http://localhost:8000"),
@@ -266,7 +267,7 @@ class WorkerAgent:
         signal and should never break heartbeat.
         """
         try:
-            if backend_type in ("rkllama", "ollama"):
+            if backend_type in ("rkllama", "ollama", "hailo-ollama"):
                 resp = await client.get(f"{base_url}/api/ps")
                 if resp.status_code != 200:
                     return []
@@ -293,7 +294,7 @@ class WorkerAgent:
         """Ask a backend what models it has loaded. Returns None if the
         backend isn't reachable (not running on this host)."""
         try:
-            if backend_type in ("rkllama", "ollama"):
+            if backend_type in ("rkllama", "ollama", "hailo-ollama"):
                 resp = await client.get(f"{base_url}/api/tags")
                 if resp.status_code != 200:
                     return None


### PR DESCRIPTION
## Summary

Implements SLICE 5 of `docs/design/hailo-llm-backend.md` exactly as written: the runtime detection and provider-adapter half of the Hailo-10H backend, testable without Hailo hardware.

- `tinyagentos/worker/agent.py`: add the `("hailo-ollama", "http://localhost:7836")` live probe candidate and extend the Ollama-compatible model/loaded-model probes to cover `hailo-ollama`.
- `tinyagentos/backend_adapters.py`: register `ADAPTERS["hailo-ollama"] = OllamaCompatAdapter()` next to rkllama/ollama.
- `tinyagentos/litellm_config.py`: extend both ollama-compat membership checks to include `hailo-ollama` so discovery and routing treat it like rkllama.
- `tinyagentos/providers/__init__.py`: register `hailo-ollama` as a valid local backend type with the `ollama` / `ollama_chat` LiteLLM prefixes so `auto_register_from_manifest` seeds `local-hailo-ollama` on Hailo-10H hardware (the `local-<service-id>` rule, mirroring `local-rkllama`).
- Tests: worker detection of a mocked hailo-ollama on 7836; LiteLLM emitting `ollama/<model>` (and `ollama_chat/default`) for a hailo-ollama backend; `auto_register_from_manifest` seeds `local-hailo-ollama` (type `hailo-ollama`) on a Hailo-10H profile and is skipped on cpu-only hardware.

Port 7836 and the `llm-chat` capability entry were added in SLICE 1 (merged). The managed service manifest was added in SLICE 3 (merged) and is what `auto_register_from_manifest` reads.

## Verification

`uv run python -m pytest tests/ -k "worker_agent or litellm_config or config" -q --ignore=tests/e2e` -> all selected tests pass (including the 5 new S5 tests). The exact slice command collects e2e tests that require playwright (unrelated, environmental); those are ignored.

## Test plan

- `tests/test_worker.py::TestDetectBackends::test_hailo_ollama_running` (new)
- `tests/test_litellm_config.py::TestGenerateLiteLLMHailoOllamaBackend` (new)
- `tests/test_config.py::test_auto_register_hailo_ollama_seeds_local_backend_on_hailo10h` (new)
- `tests/test_config.py::test_auto_register_hailo_ollama_skipped_without_hailo10h` (new)

Does not touch `scripts/` or `app-catalog/`, so the doc-gate `Docs-Reviewed` trailer is not required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and using local Hailo-ollama inference backends.
  * Hailo-ollama backends now support chat and embedding models through the standard Ollama-compatible integration.
  * Hailo-10H systems automatically register the local Hailo-ollama service.

* **Bug Fixes**
  * Prevented Hailo-ollama registration on CPU-only systems.
  * Improved backend health checks and model discovery for Hailo-ollama.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->