### PR TITLE
feat(hub): profile object + local hub store (slice 2)

### DIFF
--- a/tests/test_hub_store.py
+++ b/tests/test_hub_store.py
@@ -1,0 +1,187 @@
+"""Local hub object store + canonical helpers (hub social slice 2).
+
+Covers the four things slice 2 in ``docs/design/hub-social-network-foundation.md``
+calls out: canonicalization vectors (the same object always serialises the same
+way, key order irrelevant), sign/verify (a good signature verifies, tampering or
+a wrong key does not), version-wins (a stale profile never clobbers a newer one),
+and store round-trip (objects and blobs come back byte-for-byte).
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.hub import identity
+from tinyagentos.hub import store as hub_store
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    # Colocate the identity keystore and hub store under an isolated dir, exactly
+    # as production resolves them from TAOS_DATA_DIR.
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest_asyncio.fixture
+async def store(data_dir):
+    s = hub_store.HubStore(hub_store.default_db_path())
+    await s.init()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+class TestCanonicalization:
+    def test_key_order_does_not_change_bytes(self):
+        a = {"type": "profile", "author": "aa", "version": 1}
+        b = {"version": 1, "author": "aa", "type": "profile"}
+        assert hub_store.canonical_bytes(a) == hub_store.canonical_bytes(b)
+
+    def test_canonical_json_is_sorted_and_compact(self):
+        obj = {"b": 1, "a": 2}
+        assert hub_store.canonical_json(obj) == '{"a":2,"b":1}'
+
+    def test_sig_is_excluded_from_canonical_bytes(self):
+        # The signature must not be part of what is signed/hashed, so adding it
+        # cannot change the content address.
+        base = {"type": "post", "author": "aa", "seq": 1}
+        with_sig = {**base, "sig": "deadbeef"}
+        assert hub_store.canonical_bytes(base) == hub_store.canonical_bytes(with_sig)
+        assert hub_store.object_hash(base) == hub_store.object_hash(with_sig)
+
+    def test_object_hash_is_stable_and_content_addressed(self):
+        obj = {"type": "profile", "author": "aa", "version": 3}
+        # A known vector: the hash is SHA-256 of the canonical bytes.
+        import hashlib
+
+        expected = hashlib.sha256(hub_store.canonical_bytes(obj)).hexdigest()
+        assert hub_store.object_hash(obj) == expected
+        # Any content change changes the address.
+        changed = {**obj, "version": 4}
+        assert hub_store.object_hash(changed) != expected
+
+
+class TestSignVerify:
+    def test_sign_then_verify_round_trips(self, data_dir):
+        pub = identity.public_identity()["signing_pubkey"]
+        obj = {"type": "profile", "author": identity.signing_fingerprint(), "version": 1}
+        signed = hub_store.sign_object(obj)
+        assert "sig" in signed
+        assert hub_store.verify_object(signed, pub) is True
+
+    def test_tampered_object_fails_verification(self, data_dir):
+        pub = identity.public_identity()["signing_pubkey"]
+        signed = hub_store.sign_object(
+            {"type": "profile", "author": identity.signing_fingerprint(), "version": 1}
+        )
+        tampered = {**signed, "version": 2}
+        assert hub_store.verify_object(tampered, pub) is False
+
+    def test_wrong_key_fails_verification(self, data_dir, tmp_path, monkeypatch):
+        signed = hub_store.sign_object(
+            {"type": "profile", "author": identity.signing_fingerprint(), "version": 1}
+        )
+        # Mint a different identity in an isolated dir; its key must not verify.
+        monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path / "other"))
+        other_pub = identity.public_identity()["signing_pubkey"]
+        assert hub_store.verify_object(signed, other_pub) is False
+
+    def test_verify_never_raises_on_missing_or_garbage_sig(self, data_dir):
+        pub = identity.public_identity()["signing_pubkey"]
+        assert hub_store.verify_object({"type": "x"}, pub) is False
+        assert hub_store.verify_object({"type": "x", "sig": 123}, pub) is False
+
+
+class TestStoreRoundTrip:
+    @pytest.mark.asyncio
+    async def test_object_round_trip(self, store):
+        signed = hub_store.sign_object(
+            {"type": "profile", "author": identity.signing_fingerprint(), "version": 1}
+        )
+        h = await store.put_object(signed)
+        assert h == hub_store.object_hash(signed)
+        got = await store.get_object(h)
+        assert got == signed
+
+    @pytest.mark.asyncio
+    async def test_put_object_is_idempotent(self, store):
+        signed = hub_store.sign_object(
+            {"type": "profile", "author": identity.signing_fingerprint(), "version": 1}
+        )
+        h1 = await store.put_object(signed)
+        h2 = await store.put_object(signed)
+        assert h1 == h2
+
+    @pytest.mark.asyncio
+    async def test_put_object_requires_signature(self, store):
+        with pytest.raises(ValueError):
+            await store.put_object({"type": "profile", "author": "aa"})
+
+    @pytest.mark.asyncio
+    async def test_blob_round_trip(self, store):
+        data = b"\x00\x01\x02 not text \xff"
+        h = await store.put_blob(data, mime="image/webp")
+        blob = await store.get_blob(h)
+        assert blob["data"] == data
+        assert blob["size"] == len(data)
+        assert blob["mime"] == "image/webp"
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self, store):
+        assert await store.get_object("nope") is None
+        assert await store.get_blob("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_author_upsert_round_trip(self, store):
+        await store.upsert_author(
+            "fp1", username="alice", signing_pubkey="aa", encryption_pubkey="bb"
+        )
+        got = await store.get_author("fp1")
+        assert got["username"] == "alice"
+        # Upsert overwrites the mapping (a rename or key rotation).
+        await store.upsert_author("fp1", username="alice2", signing_pubkey="cc")
+        got = await store.get_author("fp1")
+        assert got["username"] == "alice2"
+        assert got["signing_pubkey"] == "cc"
+
+
+class TestProfileVersionWins:
+    def _profile(self, version: int, display_name: str = "Alice") -> dict:
+        return hub_store.sign_object(
+            hub_store.build_profile(
+                version=version,
+                kind="personal",
+                display_name=display_name,
+                author=identity.signing_fingerprint(),
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_highest_version_wins(self, store, data_dir):
+        author = identity.signing_fingerprint()
+        await store.put_profile(self._profile(7, "v7"))
+        assert (await store.get_profile(author))["version"] == 7
+        # A stale (lower) version must not clobber the current profile.
+        stale = self._profile(5, "v5")
+        returned = await store.put_profile(stale)
+        assert returned["version"] == 7
+        assert (await store.get_profile(author))["display_name"] == "v7"
+        # A newer version supersedes.
+        await store.put_profile(self._profile(8, "v8"))
+        current = await store.get_profile(author)
+        assert current["version"] == 8
+        assert current["display_name"] == "v8"
+
+    @pytest.mark.asyncio
+    async def test_equal_version_is_ignored(self, store, data_dir):
+        author = identity.signing_fingerprint()
+        await store.put_profile(self._profile(2, "first"))
+        await store.put_profile(self._profile(2, "second"))
+        assert (await store.get_profile(author))["display_name"] == "first"
+
+    @pytest.mark.asyncio
+    async def test_build_profile_rejects_bad_kind(self, data_dir):
+        with pytest.raises(ValueError):
+            hub_store.build_profile(version=1, kind="robot", display_name="x")

--- a/tests/test_routes_hub.py
+++ b/tests/test_routes_hub.py
@@ -1,0 +1,91 @@
+"""Local hub API routes (hub social slice 2).
+
+The Hub app reads and writes the node's own profile through these routes. The
+tests exercise the degrade states (no identity yet -> ``no-identity``; identity
+but no profile -> ``no-profile``), profile create then update with a version
+bump, and that an unknown kind is rejected. The ``TAOS_DATA_DIR`` override points
+the identity keystore and hub store at the test's temp dir so nothing touches a
+real data dir.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hub_data(tmp_data_dir, monkeypatch):
+    # Both the identity keystore and the hub store resolve from TAOS_DATA_DIR, so
+    # pointing it at the per-test data dir keeps every request hermetic.
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_data_dir))
+    return tmp_data_dir
+
+
+class TestHubProfileRoutes:
+    @pytest.mark.asyncio
+    async def test_get_profile_reports_no_identity_before_first_use(self, client):
+        resp = await client.get("/api/hub/profile")
+        assert resp.status_code == 200
+        assert resp.json() == {"state": "no-identity"}
+
+    @pytest.mark.asyncio
+    async def test_put_then_get_profile(self, client):
+        resp = await client.put(
+            "/api/hub/profile",
+            json={"kind": "personal", "display_name": "Alice", "bio": "hi"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "ok"
+        assert body["profile"]["display_name"] == "Alice"
+        assert body["profile"]["version"] == 1
+        assert body["profile"]["sig"]
+
+        # Reading it back returns the same current profile.
+        resp = await client.get("/api/hub/profile")
+        assert resp.status_code == 200
+        got = resp.json()
+        assert got["state"] == "ok"
+        assert got["profile"]["display_name"] == "Alice"
+        assert got["profile"]["version"] == 1
+
+    @pytest.mark.asyncio
+    async def test_update_bumps_version(self, client):
+        await client.put("/api/hub/profile", json={"display_name": "Alice"})
+        resp = await client.put(
+            "/api/hub/profile", json={"display_name": "Alice B.", "bio": "updated"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["profile"]["version"] == 2
+        assert body["profile"]["display_name"] == "Alice B."
+
+        resp = await client.get("/api/hub/profile")
+        assert resp.json()["profile"]["version"] == 2
+
+    @pytest.mark.asyncio
+    async def test_business_kind_is_accepted(self, client):
+        resp = await client.put(
+            "/api/hub/profile",
+            json={"kind": "business", "display_name": "Acme"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["profile"]["kind"] == "business"
+
+    @pytest.mark.asyncio
+    async def test_invalid_kind_is_rejected(self, client):
+        resp = await client.put(
+            "/api/hub/profile",
+            json={"kind": "robot", "display_name": "x"},
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_profile_is_signed_by_the_node_identity(self, client):
+        from tinyagentos.hub import identity
+        from tinyagentos.hub import store as hub_store
+
+        resp = await client.put("/api/hub/profile", json={"display_name": "Alice"})
+        profile = resp.json()["profile"]
+        pub = identity.public_identity()["signing_pubkey"]
+        assert hub_store.verify_object(profile, pub) is True
+        assert profile["author"] == identity.signing_fingerprint()

--- a/tinyagentos/hub/store.py
+++ b/tinyagentos/hub/store.py
@@ -1,0 +1,312 @@
+"""Local hub object store + canonical-JSON helpers -- hub social slice 2.
+
+See ``docs/design/hub-social-network-foundation.md`` ("Data model" and the
+slice plan). This is the node's own content store: the SQLite home for every
+signed object the node holds (its own and, later, peers'), the raw blobs those
+objects reference, and the authors (username -> key) it has resolved. Slice 2
+makes the *profile* object real end to end (build, sign, store, render) and lays
+the object/blob/author tables the later chain and sync slices build on. There is
+no peer networking here; the only remote calls remain slice 1's directory calls
+through ``account_proxy.py``.
+
+Every object is:
+
+- **canonical-JSON encoded** (sorted keys, compact separators) so the same
+  logical object always serialises to the same bytes on every node;
+- **content-addressed** by the SHA-256 of those canonical bytes *excluding the
+  signature*, so the id can be computed before signing and a cacher cannot alter
+  what it serves without the hash breaking;
+- **signed** by the author's Ed25519 signing key (slice 1's keystore) over the
+  same canonical bytes, so anyone holding the author's public key can verify it.
+
+The canonical author identifier inside an object is the signing-key fingerprint
+(slice 1), never the username, so a username policy change can never
+retroactively re-attribute content.
+
+Profiles are the one *mutable* object: highest signed ``version`` wins and older
+versions are superseded (design "Profile"). We keep every version in the
+content-addressed object store (append-only, cheap) and resolve the current
+profile as the highest version for an author, so ``put_profile`` is idempotent
+and a stale (lower-or-equal version) replica can never clobber a newer one.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Optional
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.hub import identity
+
+# Profiles are personal pages or business pages -- same object, different render
+# (design "Profile"). Any other kind is rejected before signing.
+PROFILE_KINDS = ("personal", "business")
+
+
+# --- canonical encoding / hashing / signing -----------------------------------
+
+
+def canonical_json(obj: dict) -> str:
+    """Deterministic JSON: sorted keys, compact separators, UTF-8 preserved.
+
+    The same logical object serialises to the same string on every node, which
+    is what makes content addressing and signature verification portable.
+    """
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_bytes(obj: dict) -> bytes:
+    """Canonical bytes of an object *excluding* its ``sig`` field.
+
+    Both the content address and the signature are computed over these bytes, so
+    the id is stable whether or not the object is signed yet, and verification
+    recomputes exactly what was signed.
+    """
+    payload = {k: v for k, v in obj.items() if k != "sig"}
+    return canonical_json(payload).encode("utf-8")
+
+
+def object_hash(obj: dict) -> str:
+    """SHA-256 (hex) of the canonical bytes -- the object's content address."""
+    return hashlib.sha256(canonical_bytes(obj)).hexdigest()
+
+
+def sign_object(obj: dict) -> dict:
+    """Return a copy of ``obj`` signed by this node's signing key.
+
+    Any pre-existing ``sig`` is dropped before signing so re-signing is safe.
+    The signature covers the canonical bytes (sig excluded), the same bytes
+    :func:`object_hash` addresses.
+    """
+    unsigned = {k: v for k, v in obj.items() if k != "sig"}
+    unsigned["sig"] = identity.sign(canonical_bytes(unsigned))
+    return unsigned
+
+
+def verify_object(obj: dict, signing_pubkey_hex: str) -> bool:
+    """Verify an object's signature against a signing public key.
+
+    Returns False (never raises) on a missing or malformed signature so callers
+    verifying arbitrary peer objects degrade cleanly. Tampering with any signed
+    field changes the canonical bytes and fails the check.
+    """
+    sig = obj.get("sig")
+    if not isinstance(sig, str) or not sig:
+        return False
+    return identity.verify_signature(signing_pubkey_hex, canonical_bytes(obj), sig)
+
+
+# --- profile object -----------------------------------------------------------
+
+
+def build_profile(
+    *,
+    version: int,
+    kind: str,
+    display_name: str,
+    bio: str = "",
+    avatar: Optional[str] = None,
+    links: Optional[list] = None,
+    author: Optional[str] = None,
+) -> dict:
+    """Build an *unsigned* profile object (design "Profile").
+
+    ``author`` defaults to this node's signing fingerprint, so the common case
+    (rendering/updating your own profile) needs no key handling from the caller.
+    Pass :func:`sign_object` over the result to sign it.
+    """
+    if kind not in PROFILE_KINDS:
+        raise ValueError(f"invalid kind {kind!r}; expected one of {PROFILE_KINDS}")
+    return {
+        "type": "profile",
+        "author": author or identity.signing_fingerprint(),
+        "version": int(version),
+        "kind": kind,
+        "display_name": display_name,
+        "bio": bio,
+        "avatar": avatar,
+        "links": links or [],
+    }
+
+
+# --- SQLite store -------------------------------------------------------------
+
+
+HUB_STORE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS hub_authors (
+    fingerprint       TEXT PRIMARY KEY,
+    username          TEXT,
+    signing_pubkey    TEXT,
+    encryption_pubkey TEXT,
+    updated_at        REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS hub_objects (
+    hash       TEXT PRIMARY KEY,
+    author     TEXT NOT NULL,
+    type       TEXT NOT NULL,
+    seq        INTEGER,   -- chain position for posts/tombstones; NULL for profiles
+    version    INTEGER,   -- profile version; NULL for chain objects
+    body       TEXT NOT NULL,   -- canonical JSON of the full signed object
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_hub_objects_author_type
+    ON hub_objects(author, type);
+CREATE INDEX IF NOT EXISTS idx_hub_objects_profile_version
+    ON hub_objects(author, type, version);
+
+CREATE TABLE IF NOT EXISTS hub_blobs (
+    hash       TEXT PRIMARY KEY,
+    size       INTEGER NOT NULL,
+    mime       TEXT,
+    data       BLOB NOT NULL,
+    created_at REAL NOT NULL
+);
+"""
+
+
+def default_db_path() -> Path:
+    """The node's hub store path, colocated with the slice-1 identity keystore.
+
+    Resolved the same way as ``identity.py`` (``TAOS_DATA_DIR`` override, else the
+    project ``data`` dir), so the identity file and the object store live side by
+    side under ``<data_dir>/hub/`` and tests get a hermetic dir for free.
+    """
+    return identity._hub_dir() / "hub.db"
+
+
+def _row(cursor_desc, row) -> dict:
+    return dict(zip([c[0] for c in cursor_desc], row))
+
+
+class HubStore(BaseStore):
+    """SQLite-backed store for hub objects, blobs, and resolved authors."""
+
+    SCHEMA = HUB_STORE_SCHEMA
+
+    # ---------------------------------------------------------------- objects
+    async def put_object(self, obj: dict) -> str:
+        """Store a signed object, returning its content address.
+
+        Idempotent: content addressing means re-storing the same object is a
+        no-op (``INSERT OR IGNORE``). Requires ``author``, ``type``, and ``sig``
+        so an unsigned or malformed object never reaches the store.
+        """
+        for field in ("author", "type", "sig"):
+            if not obj.get(field):
+                raise ValueError(f"object missing required field {field!r}")
+        h = object_hash(obj)
+        await self._db.execute(
+            "INSERT OR IGNORE INTO hub_objects "
+            "(hash, author, type, seq, version, body, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                h,
+                obj["author"],
+                obj["type"],
+                obj.get("seq"),
+                obj.get("version"),
+                canonical_json(obj),
+                time.time(),
+            ),
+        )
+        await self._db.commit()
+        return h
+
+    async def get_object(self, obj_hash: str) -> dict | None:
+        cur = await self._db.execute(
+            "SELECT body FROM hub_objects WHERE hash = ?", (obj_hash,)
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return json.loads(row[0])
+
+    # ---------------------------------------------------------------- blobs
+    async def put_blob(self, data: bytes, mime: str | None = None) -> str:
+        """Store raw blob bytes content-addressed by SHA-256; idempotent."""
+        h = hashlib.sha256(data).hexdigest()
+        await self._db.execute(
+            "INSERT OR IGNORE INTO hub_blobs (hash, size, mime, data, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (h, len(data), mime, data, time.time()),
+        )
+        await self._db.commit()
+        return h
+
+    async def get_blob(self, blob_hash: str) -> dict | None:
+        cur = await self._db.execute(
+            "SELECT hash, size, mime, data FROM hub_blobs WHERE hash = ?",
+            (blob_hash,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return {"hash": row[0], "size": row[1], "mime": row[2], "data": row[3]}
+
+    # ---------------------------------------------------------------- authors
+    async def upsert_author(
+        self,
+        fingerprint: str,
+        *,
+        username: str | None = None,
+        signing_pubkey: str | None = None,
+        encryption_pubkey: str | None = None,
+    ) -> None:
+        """Record or refresh the username -> key mapping for an author."""
+        await self._db.execute(
+            "INSERT INTO hub_authors "
+            "(fingerprint, username, signing_pubkey, encryption_pubkey, updated_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(fingerprint) DO UPDATE SET "
+            "username=excluded.username, "
+            "signing_pubkey=excluded.signing_pubkey, "
+            "encryption_pubkey=excluded.encryption_pubkey, "
+            "updated_at=excluded.updated_at",
+            (fingerprint, username, signing_pubkey, encryption_pubkey, time.time()),
+        )
+        await self._db.commit()
+
+    async def get_author(self, fingerprint: str) -> dict | None:
+        cur = await self._db.execute(
+            "SELECT * FROM hub_authors WHERE fingerprint = ?", (fingerprint,)
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return _row(cur.description, row)
+
+    # ---------------------------------------------------------------- profiles
+    async def get_profile(self, author: str) -> dict | None:
+        """The current (highest-version) profile object for an author."""
+        cur = await self._db.execute(
+            "SELECT body FROM hub_objects "
+            "WHERE author = ? AND type = 'profile' "
+            "ORDER BY version DESC LIMIT 1",
+            (author,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return json.loads(row[0])
+
+    async def put_profile(self, profile: dict) -> dict:
+        """Store a signed profile with version-wins semantics.
+
+        A profile whose version is not strictly greater than the stored current
+        one is ignored (design: "highest signed version wins, replicas overwrite
+        older versions"), and the existing current profile is returned unchanged.
+        Returns the profile that is current after the call.
+        """
+        if profile.get("type") != "profile":
+            raise ValueError("not a profile object")
+        version = profile.get("version")
+        if not isinstance(version, int):
+            raise ValueError("profile missing integer version")
+        current = await self.get_profile(profile["author"])
+        if current is not None and version <= current["version"]:
+            return current
+        await self.put_object(profile)
+        return profile

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -343,6 +343,10 @@ def register_all_routers(app):
     from tinyagentos.routes.account_proxy import router as account_proxy_router
     app.include_router(account_proxy_router)
 
+    # Local hub API (hub social slice 2): the node's own profile + object store.
+    from tinyagentos.routes.hub import router as hub_router
+    app.include_router(hub_router)
+
     from tinyagentos.routes.office import router as office_router
     app.include_router(office_router)
     from tinyagentos.routes.songs import router as songs_router

--- a/tinyagentos/routes/hub.py
+++ b/tinyagentos/routes/hub.py
@@ -1,0 +1,111 @@
+"""Local hub API the Hub app consumes -- hub social slice 2.
+
+See ``docs/design/hub-social-network-foundation.md`` ("The Hub app (client)").
+This is the controller-side local API, mirroring how the chat routes wrap the
+chat stores: it reads and writes the node's own signed objects in the local hub
+store (``tinyagentos/hub/store.py``) and mints/uses the node's identity keypair
+(slice 1). Directory calls stay in ``account_proxy.py``; peer traffic is a later
+slice. Nothing here talks to a peer.
+
+Slice 2 surfaces the node's own profile: render it and create/update it with a
+version bump. Every response carries an explicit ``state`` so the app can render
+the standard degrade states (design "Client resilience") without guessing:
+
+- ``no-identity``: the node has not minted a hub identity yet.
+- ``no-profile``: identity exists but no profile has been published.
+- ``ok``: a profile is present (returned under ``profile``).
+
+The account signed-out state is handled one layer up by the ``current_user``
+dependency (401), exactly like every other local app route.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.hub import identity, store as hub_store
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ProfileIn(BaseModel):
+    kind: str = "personal"
+    display_name: str = ""
+    bio: str = ""
+    avatar: str | None = None
+    links: list | None = None
+
+
+async def _get_store(request: Request) -> hub_store.HubStore:
+    """Return the node's hub store, opening it lazily on first use.
+
+    Cached on ``app.state`` so repeated calls share one connection. The path is
+    resolved the same way as the identity keystore (``TAOS_DATA_DIR``), so the
+    store and identity file live together under ``<data_dir>/hub/`` and tests get
+    an isolated dir for free.
+    """
+    existing = getattr(request.app.state, "hub_store", None)
+    if existing is not None:
+        return existing
+    store = hub_store.HubStore(Path(hub_store.default_db_path()))
+    await store.init()
+    request.app.state.hub_store = store
+    return store
+
+
+@router.get("/api/hub/profile")
+async def get_own_profile(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Render the node's own profile, with explicit degrade states."""
+    if not identity.exists():
+        return {"state": "no-identity"}
+    store = await _get_store(request)
+    fingerprint = identity.signing_fingerprint()
+    profile = await store.get_profile(fingerprint)
+    if profile is None:
+        return {"state": "no-profile", "identity": identity.public_identity()}
+    return {"state": "ok", "profile": profile}
+
+
+@router.put("/api/hub/profile")
+async def put_own_profile(
+    body: ProfileIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Create or update the node's own profile, bumping the version.
+
+    Minting the identity on first use (design: the free username mints the
+    keypair) so publishing a profile is the natural first act. The new version is
+    one past the current profile's, keeping the highest-version-wins invariant.
+    """
+    # Mint the identity if this is the node's first hub action.
+    identity.load_or_create()
+    store = await _get_store(request)
+    fingerprint = identity.signing_fingerprint()
+    current = await store.get_profile(fingerprint)
+    next_version = (current["version"] + 1) if current else 1
+    try:
+        profile = hub_store.build_profile(
+            version=next_version,
+            kind=body.kind,
+            display_name=body.display_name,
+            bio=body.bio,
+            avatar=body.avatar,
+            links=body.links,
+            author=fingerprint,
+        )
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    signed = hub_store.sign_object(profile)
+    stored = await store.put_profile(signed)
+    return {"state": "ok", "profile": stored}


### PR DESCRIPTION
## Summary
Implements slice 2 of the hub.taos.my own-your-posts social network design (`docs/design/hub-social-network-foundation.md`, "Slice plan"): the profile object and the local hub store. Slice 1 (identity keystore + directory proxy) is merged; this consumes it.

- `tinyagentos/hub/store.py`: canonical-JSON encode/hash/sign/verify helpers plus a SQLite `HubStore` with the objects, blobs, and authors tables. Objects are canonical-JSON encoded (sorted keys, compact), content-addressed by SHA-256 of the canonical bytes excluding the signature, and signed by the slice-1 Ed25519 keystore. Profiles are the one mutable object with highest-version-wins semantics: `put_profile` ignores a stale (lower-or-equal version) replica so it can never clobber a newer one.
- `tinyagentos/routes/hub.py`: the local API the Hub app consumes. Render the node's own profile and create/update it with a version bump, each response carrying an explicit degrade state (`no-identity` / `no-profile` / `ok`) per the design's client-resilience states. The store is opened lazily and colocated with the identity keystore under the data dir. Wired into `routes/__init__.py`.
- No peer networking (that is slice 5+); the only remote calls remain slice 1's directory calls through `account_proxy.py`.

## Verification
The tests the slice calls for, all green:

- `tests/test_hub_store.py`: canonicalization vectors, sign/verify (good sig verifies; tamper and wrong key do not), version-wins, object/blob/author store round-trip.
- `tests/test_routes_hub.py`: profile routes end to end (degrade states, create + version bump, kind validation, signature check).

```
uv run --extra dev python -m pytest tests/test_hub_store.py tests/test_routes_hub.py tests/test_hub_identity.py tests/test_routes_account_proxy.py -q
```

Do not merge; leaving open for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local hub profile support with create, view, and update capabilities.
  * Profiles support personal and business types, display names, biographies, avatars, and links.
  * Added signed profile storage with content-addressed objects and binary blobs.
  * Profile updates automatically increase their version, while older updates are ignored.
  * Added clear profile states for missing identity, missing profile, and available profile.
  * Invalid profile types are rejected with a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->