### PR TITLE
feat(hub): follow / friend / circle model + request brokering (slice 3)

### DIFF
--- a/tests/test_hub_relationships.py
+++ b/tests/test_hub_relationships.py
@@ -1,0 +1,168 @@
+"""Follow / friend / circle relationship statements + store (hub social slice 3).
+
+Covers the things slice 3 in ``docs/design/hub-social-network-foundation.md``
+calls out: signed follow and cache-grant statements (build, sign, verify the
+same way a profile verifies), the default cache quota hint, and the local
+relationship store (put / get / list / sever-edges on block). Storage keys are
+fingerprints only; usernames never enter a statement.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.hub import identity, relationships
+from tinyagentos.hub import store as hub_store
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    # Colocate the identity keystore and hub store under an isolated dir, exactly
+    # as production resolves them from TAOS_DATA_DIR.
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest_asyncio.fixture
+async def store(data_dir):
+    s = hub_store.HubStore(hub_store.default_db_path())
+    await s.init()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+class TestRelationshipStatements:
+    def test_follow_statement_shape_and_signature(self, data_dir):
+        pub = identity.public_identity()["signing_pubkey"]
+        fp = identity.signing_fingerprint()
+        unsigned = relationships.build_follow_statement("peerFP")
+        assert unsigned == {"type": "follow", "author": fp, "target": "peerFP"}
+        # Signing is over the same canonical bytes a peer would verify.
+        signed = relationships.sign_statement(unsigned)
+        assert "sig" in signed
+        assert hub_store.verify_object(signed, pub) is True
+        # Tampering breaks the signature.
+        tampered = {**signed, "target": "otherFP"}
+        assert hub_store.verify_object(tampered, pub) is False
+
+    def test_cache_grant_statement_carries_quota_hint(self, data_dir):
+        pub = identity.public_identity()["signing_pubkey"]
+        fp = identity.signing_fingerprint()
+        unsigned = relationships.build_cache_grant_statement("granteeFP", 12345)
+        assert unsigned["type"] == "cache-grant"
+        assert unsigned["author"] == fp
+        assert unsigned["grantee"] == "granteeFP"
+        assert unsigned["quota_hint"] == 12345
+        signed = relationships.sign_statement(unsigned)
+        assert hub_store.verify_object(signed, pub) is True
+
+    def test_cache_grant_defaults_to_a_few_hundred_mb(self, data_dir):
+        unsigned = relationships.build_cache_grant_statement("g", relationships.DEFAULT_CACHE_QUOTA_BYTES)
+        # A few hundred MB, not bytes: the hint is a real per-friend budget.
+        assert relationships.DEFAULT_CACHE_QUOTA_BYTES >= 100 * 1024 * 1024
+        assert relationships.DEFAULT_CACHE_QUOTA_BYTES <= 1024 * 1024 * 1024
+        assert unsigned["quota_hint"] == relationships.DEFAULT_CACHE_QUOTA_BYTES
+
+    def test_friend_statement_shape(self, data_dir):
+        fp = identity.signing_fingerprint()
+        unsigned = relationships.build_friend_statement("peerFP")
+        assert unsigned == {"type": "friend", "author": fp, "peer": "peerFP"}
+        signed = relationships.sign_statement(unsigned)
+        assert hub_store.verify_object(signed, identity.public_identity()["signing_pubkey"]) is True
+
+    def test_peer_fingerprint_is_the_author_identifier(self, data_dir):
+        # Usernames never appear; the canonical author id is the signing fingerprint.
+        follow = relationships.build_follow_statement("peerFP")
+        assert "username" not in follow
+        assert follow["author"] == identity.signing_fingerprint()
+
+
+class TestRelationshipStore:
+    @pytest.mark.asyncio
+    async def test_put_then_get_relationship(self, store, data_dir):
+        statement = relationships.sign_statement(
+            relationships.build_follow_statement("peerFP")
+        )
+        await store.put_relationship(
+            "peerFP", relationships.REL_FOLLOW_OUT, statement=statement
+        )
+        got = await store.get_relationship("peerFP", relationships.REL_FOLLOW_OUT)
+        assert got["peer"] == "peerFP"
+        assert got["kind"] == relationships.REL_FOLLOW_OUT
+        assert got["statement"] == statement
+
+    @pytest.mark.asyncio
+    async def test_put_relationship_is_idempotent(self, store, data_dir):
+        s1 = relationships.sign_statement(relationships.build_follow_statement("p"))
+        await store.put_relationship("p", relationships.REL_FOLLOW_OUT, statement=s1)
+        s2 = relationships.sign_statement(relationships.build_follow_statement("p"))
+        await store.put_relationship("p", relationships.REL_FOLLOW_OUT, statement=s2)
+        rows = await store.list_relationships(relationships.REL_FOLLOW_OUT)
+        assert len(rows) == 1  # upsert, not duplicate
+
+    @pytest.mark.asyncio
+    async def test_cache_grant_stores_quota_hint(self, store, data_dir):
+        statement = relationships.sign_statement(
+            relationships.build_cache_grant_statement("g", 999)
+        )
+        await store.put_relationship(
+            "g", relationships.REL_CACHE_GRANT, statement=statement, quota_hint=999
+        )
+        got = await store.get_relationship("g", relationships.REL_CACHE_GRANT)
+        assert got["quota_hint"] == 999
+        assert got["statement"]["quota_hint"] == 999
+
+    @pytest.mark.asyncio
+    async def test_list_relationships_filters_by_kind(self, store, data_dir):
+        await store.put_relationship("a", relationships.REL_FOLLOW_OUT)
+        await store.put_relationship("b", relationships.REL_FRIEND)
+        friends = await store.list_relationships(relationships.REL_FRIEND)
+        assert [r["peer"] for r in friends] == ["b"]
+        all_rows = await store.list_relationships()
+        assert {r["peer"] for r in all_rows} == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_sever_edges_removes_every_peer_row(self, store, data_dir):
+        await store.put_relationship("p", relationships.REL_FOLLOW_OUT)
+        await store.put_relationship("p", relationships.REL_FRIEND)
+        await store.put_relationship("p", relationships.REL_CACHE_GRANT, quota_hint=1)
+        severed = await store.sever_edges("p")
+        assert set(severed) == {
+            relationships.REL_FOLLOW_OUT,
+            relationships.REL_FRIEND,
+            relationships.REL_CACHE_GRANT,
+        }
+        assert await store.get_relationship("p", relationships.REL_FRIEND) is None
+
+    @pytest.mark.asyncio
+    async def test_sever_edges_can_keep_the_block_marker(self, store, data_dir):
+        # Block sets the marker, then severs the rest: the block must survive so a
+        # block is not wiped by the very purge it triggers.
+        await store.put_relationship("p", relationships.REL_FOLLOW_OUT)
+        await store.put_relationship("p", relationships.REL_BLOCK)
+        await store.sever_edges("p", keep={relationships.REL_BLOCK})
+        assert await store.get_relationship("p", relationships.REL_BLOCK) is not None
+        assert await store.get_relationship("p", relationships.REL_FOLLOW_OUT) is None
+
+    @pytest.mark.asyncio
+    async def test_has_edge_reflects_friend_relationship(self, store, data_dir):
+        assert await store.has_edge("p", relationships.REL_FRIEND) is False
+        await store.put_relationship("p", relationships.REL_FRIEND)
+        assert await store.has_edge("p", relationships.REL_FRIEND) is True
+
+    @pytest.mark.asyncio
+    async def test_delete_relationship(self, store, data_dir):
+        await store.put_relationship("p", relationships.REL_MUTE)
+        await store.delete_relationship("p", relationships.REL_MUTE)
+        assert await store.get_relationship("p", relationships.REL_MUTE) is None
+
+    @pytest.mark.asyncio
+    async def test_get_author_by_username(self, store, data_dir):
+        await store.upsert_author(
+            "fpX", username="alice", signing_pubkey="aa", encryption_pubkey="bb"
+        )
+        got = await store.get_author_by_username("alice")
+        assert got["fingerprint"] == "fpX"
+        assert await store.get_author_by_username("nobody") is None

--- a/tests/test_routes_account_proxy_hub_slice3.py
+++ b/tests/test_routes_account_proxy_hub_slice3.py
@@ -1,0 +1,276 @@
+"""Hub directory proxy (hub social slice 3) -- taos.my contract.
+
+The taos.my side (requests inbox, accepted-edge rows, presence TTL) is the
+contract; here we assert the controller proxy forwards to the right upstream
+paths, relays the session cookie, and degrades to 503 when the account service
+is unconfigured. Edge authorization and rate-limit behavior are server-side
+(the directory enforces them); these tests confirm the responses pass through
+verbatim, which is all the proxy is responsible for.
+"""
+import httpx
+import pytest
+
+_UPSTREAM = "https://taos.my"
+
+
+def _patch_upstream(monkeypatch, handler):
+    orig = httpx.AsyncClient.request
+
+    async def routed(self, method, url, **kw):
+        if str(url).startswith(_UPSTREAM):
+            return await handler(method, str(url), **kw)
+        return await orig(self, method, url, **kw)
+
+    monkeypatch.setattr("httpx.AsyncClient.request", routed)
+
+
+class _FakeResp:
+    def __init__(self, content=b"{}", status=200, headers=None):
+        self.content = content
+        self.status_code = status
+        self.headers = httpx.Headers(headers or {})
+
+
+@pytest.mark.asyncio
+async def test_hub_requests_post_forwards_signed_intro(client, monkeypatch):
+    """POST /api/account/hub/requests forwards to {base}/api/hub/requests with the
+    signed intro body and the session cookie pass-through."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
+        captured["body"] = kw.get("content", b"").decode("utf-8")
+        return _FakeResp(content=b'{"request_id":"r1"}',
+                         headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post(
+        "/api/account/hub/requests",
+        json={"to": "peerFP", "author": "meFP", "intro": "hi", "sig": "cc"},
+    )
+    assert r.status_code == 200
+    assert r.json()["request_id"] == "r1"
+    assert captured["url"] == "https://taos.my/api/hub/requests"
+    assert captured["method"] == "POST"
+    assert captured["cookie"]
+    assert "peerFP" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_hub_requests_get_forwards(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        return _FakeResp(content=b'{"inbox":[]}', headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/hub/requests")
+    assert r.status_code == 200
+    assert captured["url"] == "https://taos.my/api/hub/requests"
+    assert captured["method"] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_hub_request_accept_forwards_rid(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["url"] = url
+        return _FakeResp(content=b'{"peer":"peerFP","endpoints":[]}',
+                         headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post("/api/account/hub/requests/rid-ABC_123/accept")
+    assert r.status_code == 200
+    assert r.json()["peer"] == "peerFP"
+    assert captured["url"] == "https://taos.my/api/hub/requests/rid-ABC_123/accept"
+
+
+@pytest.mark.asyncio
+async def test_hub_request_decline_forwards_rid(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["url"] = url
+        return _FakeResp(content=b'{"peer":"peerFP"}',
+                         headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post("/api/account/hub/requests/rid-ABC_123/decline")
+    assert r.status_code == 200
+    assert captured["url"] == "https://taos.my/api/hub/requests/rid-ABC_123/decline"
+
+
+@pytest.mark.asyncio
+async def test_hub_presence_post_forwards(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["url"] = url
+        captured["body"] = kw.get("content", b"").decode("utf-8")
+        return _FakeResp(content=b'{"ok":true}', headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post("/api/account/hub/presence",
+                         json={"endpoints": ["wss://x"], "sig": "s"})
+    assert r.status_code == 200
+    assert captured["url"] == "https://taos.my/api/hub/presence"
+    assert "endpoints" in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_hub_presence_get_forwards_username(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["url"] = url
+        return _FakeResp(content=b'{"endpoints":["wss://x"]}',
+                         headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/hub/presence?username=alice")
+    assert r.status_code == 200
+    assert r.json()["endpoints"] == ["wss://x"]
+    assert captured["url"] == "https://taos.my/api/hub/presence?username=alice"
+
+
+@pytest.mark.asyncio
+async def test_hub_edge_revoke_forwards(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["url"] = url
+        return _FakeResp(content=b'{"ok":true}', headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post("/api/account/hub/edges/revoke", json={"peer": "peerFP"})
+    assert r.status_code == 200
+    assert captured["url"] == "https://taos.my/api/hub/edges/revoke"
+
+
+# --- input validation (path-traversal / SSRF guard) ---
+
+@pytest.mark.asyncio
+async def test_hub_request_accept_rejects_bad_rid(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    for bad in ["..%2f..%2f", "r1;evil", "r1%20x", "x" * 65]:
+        r = await client.post(f"/api/account/hub/requests/{bad}/accept")
+        assert r.status_code in (400, 404), bad
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hub_request_decline_rejects_bad_rid(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    for bad in ["a/b", "../auth/me", "x" * 65]:
+        r = await client.post(f"/api/account/hub/requests/{bad}/decline")
+        assert r.status_code in (400, 404), bad
+    assert called["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hub_presence_get_rejects_bad_username(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    for bad in ["a/b", "a?x=1", "../auth/me", "a;b", "x" * 65]:
+        r = await client.get(f"/api/account/hub/presence?username={bad}")
+        assert r.status_code == 400, bad
+        assert "invalid username" in r.json().get("error", "")
+    assert called["n"] == 0
+
+
+# --- degrade to 503 when the account service is unconfigured ---
+
+@pytest.mark.asyncio
+async def test_hub_slice3_503_when_blanked(client, monkeypatch):
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    paths = [
+        ("POST", "/api/account/hub/requests"),
+        ("GET", "/api/account/hub/requests"),
+        ("POST", "/api/account/hub/requests/rid-1/accept"),
+        ("POST", "/api/account/hub/requests/rid-1/decline"),
+        ("POST", "/api/account/hub/presence"),
+        ("GET", "/api/account/hub/presence?username=alice"),
+        ("POST", "/api/account/hub/edges/revoke"),
+    ]
+    for method, path in paths:
+        r = await client.request(method, path)
+        assert r.status_code == 503, (method, path)
+        assert "not configured" in r.json().get("error", "")
+    assert called["n"] == 0
+
+
+# --- edge authorization + rate-limit behavior pass through (server-side) ---
+
+@pytest.mark.asyncio
+async def test_hub_presence_denied_without_accepted_edge(client, monkeypatch):
+    """The directory returns 403 when the requester holds no accepted edge to the
+    target (design: presence requires "an accepted edge"). The proxy must pass that
+    403 through verbatim rather than masking it."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+
+    async def handler(method, url, **kw):
+        return _FakeResp(content=b'{"error":"not authorized"}', status=403,
+                         headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.get("/api/account/hub/presence?username=alice")
+    assert r.status_code == 403
+    assert r.json()["error"] == "not authorized"
+
+
+@pytest.mark.asyncio
+async def test_hub_requests_rate_limited_passes_through(client, monkeypatch):
+    """The directory rate-limits requests per sender and per target (design, slice
+    3). The proxy must relay the 429 so the app can surface "slow down"."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+
+    async def handler(method, url, **kw):
+        return _FakeResp(content=b'{"error":"rate limited"}', status=429,
+                         headers={"content-type": "application/json"})
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post(
+        "/api/account/hub/requests",
+        json={"to": "peerFP", "author": "meFP", "intro": "hi", "sig": "cc"},
+    )
+    assert r.status_code == 429
+    assert r.json()["error"] == "rate limited"

--- a/tests/test_routes_hub_slice3.py
+++ b/tests/test_routes_hub_slice3.py
@@ -1,0 +1,277 @@
+"""Local hub social routes (hub social slice 3).
+
+Exercises the Friends surface: signed follow / cache-grant statements are stored
+(the cache grant is noted as not-yet-acted-on), the friend-request send/accept/
+decline flows broker through the directory, and the local block / mute operations
+work. The directory (taos.my) is a contract here, so its upstream calls are
+mocked; the meaningful edge-authorization check (presence denied without an
+accepted edge) and the block-severs-edge behavior are asserted locally.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from tinyagentos.hub import identity, relationships
+from tinyagentos.hub import store as hub_store
+
+
+_UPSTREAM = "https://taos.my"
+
+
+class _FakeResp:
+    def __init__(self, content=b"{}", status=200, headers=None):
+        self.content = content
+        self.status_code = status
+        self.headers = httpx.Headers(headers or {})
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hub_data(tmp_data_dir, monkeypatch):
+    # Both the identity keystore and the hub store resolve from TAOS_DATA_DIR, so
+    # pointing it at the per-test data dir keeps every request hermetic.
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_data_dir))
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my/")
+    return tmp_data_dir
+
+
+@pytest.fixture
+def upstream(monkeypatch):
+    """A configurable mock of the taos.my directory. Returns 200 '{}' by default;
+    tests override ``handler`` to assert the forwarded call or to return 403/429."""
+    captured: list[dict] = []
+    calls = {"handler": None}
+
+    async def _default(method, url, **kw):
+        return _FakeResp()
+
+    calls["handler"] = _default
+
+    _real = httpx.AsyncClient.request
+
+    async def _routed(self, method, url, **kw):
+        if str(url).startswith(_UPSTREAM):
+            # Always record the forwarded directory call, regardless of the test's
+            # handler, so assertions about "was it forwarded?" hold for any handler.
+            captured.append({"method": method, "url": str(url),
+                            "body": (kw.get("content") or b"").decode("utf-8", "replace")})
+            return await calls["handler"](method, str(url), **kw)
+        # Relative ASGI call (the test client transport) passes through to real httpx.
+        return await _real(self, method, url, **kw)
+
+    monkeypatch.setattr("httpx.AsyncClient.request", _routed)
+    return captured, calls
+
+
+def _set(upstream, fn):
+    upstream[1]["handler"] = fn
+
+
+class TestFollowAndCacheGrant:
+    @pytest.mark.asyncio
+    async def test_follow_publishes_signed_statement(self, client):
+        resp = await client.put(
+            "/api/hub/follow", json={"target_fingerprint": "peerFP"}
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "following"
+        # The stored statement verifies against this node's own signing key.
+        pub = identity.public_identity()["signing_pubkey"]
+        assert identity.verify_signature(
+            pub,
+            hub_store.canonical_bytes(body["statement"]),
+            body["statement"]["sig"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_cache_grant_is_stored_not_yet_acted_on(self, client):
+        resp = await client.put(
+            "/api/hub/cache-grant",
+            json={"grantee_fingerprint": "granteeFP", "quota_hint": 1234},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "granted"
+        assert body["quota_hint"] == 1234
+        # The composer/UI must label it as stored-but-inert until slice 6 lands.
+        assert "not yet acted on" in body["note"]
+
+    @pytest.mark.asyncio
+    async def test_cache_grant_defaults_quota(self, client):
+        resp = await client.put(
+            "/api/hub/cache-grant", json={"grantee_fingerprint": "g"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["quota_hint"] == relationships.DEFAULT_CACHE_QUOTA_BYTES
+
+
+class TestFriendsList:
+    @pytest.mark.asyncio
+    async def test_list_groups_local_relationships(self, client):
+        await client.put("/api/hub/follow", json={"target_fingerprint": "p1"})
+        await client.put(
+            "/api/hub/cache-grant", json={"grantee_fingerprint": "p2", "quota_hint": 5}
+        )
+        await client.post("/api/hub/friends/block", json={"peer_fingerprint": "p3"})
+        resp = await client.get("/api/hub/friends")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "ok"
+        assert body["follows_out"] == ["p1"]
+        assert [g["peer"] for g in body["cache_grants"]] == ["p2"]
+        assert body["blocks"] == ["p3"]
+
+
+class TestBlockMute:
+    @pytest.mark.asyncio
+    async def test_block_severs_local_edges(self, client, upstream):
+        # Establish a friend edge + a follow, then block.
+        captured, calls = upstream
+        await client.put("/api/hub/follow", json={"target_fingerprint": "peerFP"})
+
+        async def accept_handler(method, url, **kw):
+            return _FakeResp(content=json.dumps({"peer": "peerFP", "endpoints": ["wss://x"]}).encode())
+        _set(upstream, accept_handler)
+        resp = await client.post("/api/hub/friends/requests/rid-1/accept",
+                                 json={"peer_fingerprint": "peerFP"})
+        assert resp.json()["state"] == "accepted"
+
+        # Before block, presence is authorized (forwarded to the directory).
+        async def pres_handler(method, url, **kw):
+            return _FakeResp(content=json.dumps({"endpoints": ["wss://x"]}).encode())
+        _set(upstream, pres_handler)
+        resp = await client.get("/api/hub/presence?peer=peerFP&username=alice")
+        assert resp.status_code == 200
+
+        # Block: severs the friend + follow edges locally and asks the hub to
+        # revoke the server-side edge.
+        resp = await client.post("/api/hub/friends/block", json={"peer_fingerprint": "peerFP"})
+        assert resp.json()["state"] == "blocked"
+        assert relationships.REL_FRIEND in resp.json()["severed"]
+        # The directory revoke call was made.
+        revoke = [c for c in captured if c["url"].endswith("/api/hub/edges/revoke")]
+        assert revoke, "directory edge revoke not called"
+
+        # After block, presence is denied (no accepted edge) even though the
+        # directory would also deny it: the local gate is the authority that matters.
+        _set(upstream, pres_handler)
+        resp = await client.get("/api/hub/presence?peer=peerFP&username=alice")
+        assert resp.status_code == 403
+        assert resp.json()["reason"] == "no accepted edge"
+        # And the friend list no longer shows the peer.
+        friends = (await client.get("/api/hub/friends")).json()
+        assert friends["friends"] == []
+        assert friends["blocks"] == ["peerFP"]
+
+    @pytest.mark.asyncio
+    async def test_mute_and_unmute_are_local(self, client, upstream):
+        resp = await client.post("/api/hub/friends/mute", json={"peer_fingerprint": "p1"})
+        assert resp.json()["state"] == "muted"
+        assert (await client.get("/api/hub/friends")).json()["mutes"] == ["p1"]
+        resp = await client.post("/api/hub/friends/unmute", json={"peer_fingerprint": "p1"})
+        assert resp.json()["state"] == "unmuted"
+        assert (await client.get("/api/hub/friends")).json()["mutes"] == []
+
+
+class TestFriendRequestFlow:
+    @pytest.mark.asyncio
+    async def test_send_brokers_signed_intro_and_stores_out(self, client, upstream):
+        captured, calls = upstream
+        async def handler(method, url, **kw):
+            return _FakeResp(content=json.dumps({"request_id": "r1"}).encode())
+        _set(upstream, handler)
+        resp = await client.post(
+            "/api/hub/friends/request",
+            json={"target_fingerprint": "peerFP", "intro": "hi"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "sent"
+        # The forwarded body is a signed intro (to/author/intro/sig), not raw JSON.
+        sent = [c for c in captured if c["url"].endswith("/api/hub/requests")][0]
+        intro = json.loads(sent["body"])
+        assert intro["to"] == "peerFP"
+        assert intro["intro"] == "hi"
+        assert "sig" in intro and "author" in intro
+
+    @pytest.mark.asyncio
+    async def test_accept_records_friend_edge(self, client, upstream):
+        captured, calls = upstream
+        await client.put("/api/hub/follow", json={"target_fingerprint": "peerFP"})
+
+        async def handler(method, url, **kw):
+            return _FakeResp(content=json.dumps({"peer": "peerFP", "endpoints": []}).encode())
+        _set(upstream, handler)
+        resp = await client.post(
+            "/api/hub/friends/requests/rid-9/accept",
+            json={"peer_fingerprint": "peerFP"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "accepted"
+        friends = (await client.get("/api/hub/friends")).json()["friends"]
+        assert friends == ["peerFP"]
+
+    @pytest.mark.asyncio
+    async def test_decline_records_declined(self, client, upstream):
+        captured, calls = upstream
+
+        async def handler(method, url, **kw):
+            return _FakeResp(content=json.dumps({"peer": "peerFP"}).encode())
+        _set(upstream, handler)
+        resp = await client.post(
+            "/api/hub/friends/requests/rid-9/decline"
+        )
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "declined"
+        decl = (await client.get("/api/hub/friends")).json()["requests_declined"]
+        assert decl == ["peerFP"]
+
+
+class TestPresenceGate:
+    @pytest.mark.asyncio
+    async def test_presence_denied_without_accepted_edge(self, client, upstream):
+        # Establish an identity (no friend edge for peerFP): the gate returns 403
+        # before any upstream call.
+        await client.put("/api/hub/follow", json={"target_fingerprint": "peerFP"})
+        captured, calls = upstream
+        resp = await client.get("/api/hub/presence?peer=peerFP&username=alice")
+        assert resp.status_code == 403
+        assert resp.json()["error"] == "not authorized"
+        # The directory was never consulted.
+        assert [c for c in captured if "presence" in c["url"]] == []
+
+    @pytest.mark.asyncio
+    async def test_presence_requires_identity(self, client, upstream):
+        # Without an identity the degrade state is reported (not a 403 auth error).
+        # Minting does not happen on a pure presence read, so identity is absent.
+        # Force the no-identity path by clearing the keystore first.
+        from tinyagentos.hub import identity as idmod
+        idmod.clear()
+        resp = await client.get("/api/hub/presence?peer=peerFP&username=alice")
+        assert resp.status_code == 200
+        assert resp.json() == {"state": "no-identity"}
+
+    @pytest.mark.asyncio
+    async def test_presence_forwarded_when_edge_exists(self, client, upstream):
+        captured, calls = upstream
+        # Establish the accepted edge via accept.
+        async def accept_handler(method, url, **kw):
+            return _FakeResp(content=json.dumps({"peer": "peerFP", "endpoints": ["wss://x"]}).encode())
+        _set(upstream, accept_handler)
+        resp = await client.post(
+            "/api/hub/friends/requests/rid-1/accept",
+            json={"peer_fingerprint": "peerFP"},
+        )
+        assert resp.json()["state"] == "accepted"
+        # Now presence is authorized and forwarded; the directory's endpoints pass
+        # through verbatim.
+        async def pres_handler(method, url, **kw):
+            return _FakeResp(content=json.dumps({"endpoints": ["wss://x", "wss://y"]}).encode())
+        _set(upstream, pres_handler)
+        resp = await client.get("/api/hub/presence?peer=peerFP&username=alice")
+        assert resp.status_code == 200
+        assert resp.json()["endpoints"] == ["wss://x", "wss://y"]
+        fwd = [c for c in captured if c["url"].endswith("/api/hub/presence?username=alice")]
+        assert fwd, "presence was not forwarded to the directory"

--- a/tinyagentos/hub/__init__.py
+++ b/tinyagentos/hub/__init__.py
@@ -1,8 +1,10 @@
 """hub.taos.my node engine (own-your-posts P2P social network).
 
-See ``docs/design/hub-social-network-foundation.md``. This package holds the
-controller-side node engine: the identity keystore (slice 1), and later the
-object store, chain logic, sync workers, and peer server. Directory calls reach
-taos.my through ``tinyagentos/routes/account_proxy.py`` additions; the browser
-never sees the taos.my base URL.
-"""
+    See ``docs/design/hub-social-network-foundation.md``. This package holds the
+    controller-side node engine: the identity keystore (slice 1), the object
+    store + canonical-JSON/sign helpers (slice 2), and the follow / friend /
+    circle relationship statements (slice 3). Later slices add the chain logic,
+    sync workers, and peer server. Directory calls reach taos.my through
+    ``tinyagentos/routes/account_proxy.py`` additions; the browser never sees the
+    taos.my base URL.
+    """

--- a/tinyagentos/hub/relationships.py
+++ b/tinyagentos/hub/relationships.py
@@ -1,0 +1,106 @@
+"""Follow / friend / circle relationship statements -- hub social slice 3.
+
+See ``docs/design/hub-social-network-foundation.md`` ("Follow edge vs
+trusted-cache-circle" and the slice plan, slice 3). This module builds the
+*signed* statements a node publishes about its social graph:
+
+- **follow** (one-way): ``{type:"follow", author, target, sig}`` published by
+  the follower. Grants nothing beyond "my node subscribes to your public posts."
+- **cache-grant** (explicit, on top of friendship): ``{type:"cache-grant",
+  author, grantee, quota_hint, sig}`` from the author. It grants the friend the
+  right AND responsibility to cache the author's recent content. Slice 3 stores it
+  but does NOT yet act on it (caching is slice 6); the Friends view surfaces the
+  grant so the UI ships ahead of the cache worker.
+- **friend** (mutual): recorded on both nodes as a pair of signed statements when
+  a brokered request is accepted. Slice 3 records the local half on accept; slice
+  5's sync completes the peer's half.
+
+All three reuse the slice-2 canonical-JSON + Ed25519 sign/verify helpers so a
+peer node can verify any statement the same way it verifies a profile. Usernames
+never appear inside a statement: the author/target/grantee/peer are signing-key
+fingerprints, the canonical author identifier from slice 1. The directory maps a
+fingerprint back to a username for display.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from tinyagentos.hub import identity, store as hub_store
+
+# Local relationship kinds persisted in ``hub_relationships``. "friend" is the only
+# kind the presence gate authorizes (design: presence lookup requires "an accepted
+# edge"); follow grants only subscription and cache-grant is not an edge at all.
+REL_FOLLOW_OUT = "follow_out"
+REL_FOLLOW_IN = "follow_in"
+REL_FRIEND = "friend"
+REL_CACHE_GRANT = "cache_grant"
+REL_BLOCK = "block"
+REL_MUTE = "mute"
+REL_REQUEST_OUT = "friend_request_out"
+REL_REQUEST_IN = "friend_request_in"
+REL_REQUEST_DECLINED = "friend_request_declined"
+
+# Kinds that count as an *accepted edge* for presence authorization. A mutual
+# friend edge is the only one (a one-way follow is not enough to see presence).
+EDGE_KINDS = (REL_FRIEND,)
+
+# Default per-friend cache budget (a few hundred MB; design open-question 4). The
+# grantee enforces its own real quota in slice 6; this is the author's hint.
+DEFAULT_CACHE_QUOTA_BYTES = 300 * 1024 * 1024
+
+
+def build_follow_statement(
+    target_fingerprint: str, author: Optional[str] = None
+) -> dict:
+    """Build an *unsigned* follow statement published by the follower.
+
+    ``author`` defaults to this node's signing fingerprint. Callers sign it with
+    :func:`tinyagentos.hub.store.sign_object` before storing or publishing.
+    """
+    return {
+        "type": "follow",
+        "author": author or identity.signing_fingerprint(),
+        "target": target_fingerprint,
+    }
+
+
+def build_cache_grant_statement(
+    grantee_fingerprint: str,
+    quota_hint: int,
+    author: Optional[str] = None,
+) -> dict:
+    """Build an *unsigned* cache-grant statement (design "trusted-cache-circle").
+
+    ``quota_hint`` is the suggested per-friend cache budget in bytes; the grantee
+    enforces its own real quota in slice 6. Slice 3 stores this statement but does
+    not yet act on it.
+    """
+    return {
+        "type": "cache-grant",
+        "author": author or identity.signing_fingerprint(),
+        "grantee": grantee_fingerprint,
+        "quota_hint": int(quota_hint),
+    }
+
+
+def build_friend_statement(
+    peer_fingerprint: str, author: Optional[str] = None
+) -> dict:
+    """Build an *unsigned* friend statement, the local half recorded on accept.
+
+    A friendship is a pair of these (one per node); slice 5's sync completes the
+    peer's half. Sign with :func:`sign_object` before storing.
+    """
+    return {
+        "type": "friend",
+        "author": author or identity.signing_fingerprint(),
+        "peer": peer_fingerprint,
+    }
+
+
+def sign_statement(statement: dict) -> dict:
+    """Sign an unsigned relationship statement with this node's key; returns a copy.
+
+    Wraps :func:`store.sign_object` so callers build then sign in one step.
+    """
+    return hub_store.sign_object(statement)

--- a/tinyagentos/hub/store.py
+++ b/tinyagentos/hub/store.py
@@ -164,6 +164,18 @@ CREATE TABLE IF NOT EXISTS hub_blobs (
     data       BLOB NOT NULL,
     created_at REAL NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS hub_relationships (
+    peer        TEXT NOT NULL,   -- the other party's signing fingerprint
+    kind        TEXT NOT NULL,   -- follow_out/follow_in/friend/cache_grant/
+                                  -- block/mute/friend_request_out/in/declined
+    statement   TEXT,            -- the signed statement JSON (follow/cache-grant/friend)
+    quota_hint  INTEGER,        -- cache-grant suggested per-friend quota (bytes)
+    updated_at  REAL NOT NULL,
+    PRIMARY KEY (peer, kind)
+);
+CREATE INDEX IF NOT EXISTS idx_hub_relationships_kind
+    ON hub_relationships(kind);
 """
 
 
@@ -277,6 +289,122 @@ class HubStore(BaseStore):
         if row is None:
             return None
         return _row(cur.description, row)
+
+    async def get_author_by_username(self, username: str) -> dict | None:
+        cur = await self._db.execute(
+            "SELECT * FROM hub_authors WHERE username = ?", (username,)
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return _row(cur.description, row)
+
+    # ---------------------------------------------------------- relationships
+    async def put_relationship(
+        self,
+        peer: str,
+        kind: str,
+        *,
+        statement: dict | None = None,
+        quota_hint: int | None = None,
+    ) -> None:
+        """Store or refresh a local relationship row for ``peer`` of ``kind``.
+
+        Idempotent (upsert on the ``(peer, kind)`` key). ``statement`` holds the
+        signed object (follow / cache-grant / friend); ``quota_hint`` is the
+        cache-grant budget in bytes. Block and mute are pure local markers that
+        need neither field.
+        """
+        await self._db.execute(
+            "INSERT INTO hub_relationships (peer, kind, statement, quota_hint, updated_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(peer, kind) DO UPDATE SET "
+            "statement=excluded.statement, "
+            "quota_hint=excluded.quota_hint, "
+            "updated_at=excluded.updated_at",
+            (
+                peer,
+                kind,
+                canonical_json(statement) if statement is not None else None,
+                quota_hint,
+                time.time(),
+            ),
+        )
+        await self._db.commit()
+
+    async def get_relationship(self, peer: str, kind: str) -> dict | None:
+        """The local relationship row for ``(peer, kind)``, or None."""
+        cur = await self._db.execute(
+            "SELECT peer, kind, statement, quota_hint FROM hub_relationships "
+            "WHERE peer = ? AND kind = ?",
+            (peer, kind),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return {
+            "peer": row[0],
+            "kind": row[1],
+            "statement": json.loads(row[2]) if row[2] is not None else None,
+            "quota_hint": row[3],
+        }
+
+    async def delete_relationship(self, peer: str, kind: str) -> None:
+        await self._db.execute(
+            "DELETE FROM hub_relationships WHERE peer = ? AND kind = ?", (peer, kind)
+        )
+        await self._db.commit()
+
+    async def sever_edges(self, peer: str, *, keep: set[str] | None = None) -> list[str]:
+        """Delete every relationship row for ``peer`` (block severs the edge).
+
+        Returns the kinds that were removed, so a caller can report what was
+        severed. ``keep`` (e.g. ``{"block"}``) survives the purge so a block
+        marker set immediately before the sever is not wiped by it.
+        """
+        keep_sql = ""
+        params: tuple = (peer,)
+        if keep:
+            placeholders = ",".join("?" for _ in keep)
+            keep_sql = f" AND kind NOT IN ({placeholders})"
+            params = (peer, *keep)
+        cur = await self._db.execute(
+            f"SELECT kind FROM hub_relationships WHERE peer = ?{keep_sql}", params
+        )
+        removed = [r[0] for r in await cur.fetchall()]
+        await self._db.execute(
+            f"DELETE FROM hub_relationships WHERE peer = ?{keep_sql}", params
+        )
+        await self._db.commit()
+        return removed
+
+    async def list_relationships(self, kind: str | None = None) -> list[dict]:
+        """All relationship rows, optionally filtered by ``kind``."""
+        if kind is None:
+            cur = await self._db.execute(
+                "SELECT peer, kind, statement, quota_hint FROM hub_relationships "
+                "ORDER BY kind, peer"
+            )
+        else:
+            cur = await self._db.execute(
+                "SELECT peer, kind, statement, quota_hint FROM hub_relationships "
+                "WHERE kind = ? ORDER BY peer",
+                (kind,),
+            )
+        rows = await cur.fetchall()
+        return [
+            {
+                "peer": r[0],
+                "kind": r[1],
+                "statement": json.loads(r[2]) if r[2] is not None else None,
+                "quota_hint": r[3],
+            }
+            for r in rows
+        ]
+
+    async def has_edge(self, peer: str, kind: str) -> bool:
+        """True when a relationship row exists for ``(peer, kind)``."""
+        return await self.get_relationship(peer, kind) is not None
 
     # ---------------------------------------------------------------- profiles
     async def get_profile(self, author: str) -> dict | None:

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -51,6 +51,21 @@ _ACTIONS: dict[str, tuple[str, str]] = {
     "hub_identity_register": ("POST", "/api/hub/identity/register"),
     "hub_identity_lookup": ("GET", "/api/hub/identity/lookup"),
     "hub_identity_rotate": ("POST", "/api/hub/identity/rotate"),
+    # Hub social slice 3: friend-request brokering, accepted-edge rows, and
+    # presence heartbeat/lookup along edges (design "Directory API surface").
+    # The client calls same-origin /api/account/hub/* and we forward to
+    # {base}/api/hub/* with the session cookie pass-through, exactly like the
+    # identity actions above. The taos.my side (requests inbox, accepted-edge
+    # rows, presence TTL) is the contract; these are its controller-side entries.
+    "hub_requests_post": ("POST", "/api/hub/requests"),
+    "hub_requests_get": ("GET", "/api/hub/requests"),
+    # hub_request_accept/decline carry a {id} segment appended in the handler.
+    "hub_request_accept": ("POST", "/api/hub/requests"),
+    "hub_request_decline": ("POST", "/api/hub/requests"),
+    "hub_presence_post": ("POST", "/api/hub/presence"),
+    "hub_presence_get": ("GET", "/api/hub/presence"),
+    # Block asks the hub to sever the accepted edge (no more presence/hints).
+    "hub_edge_revoke": ("POST", "/api/hub/edges/revoke"),
 }
 
 _TIMEOUT = httpx.Timeout(15.0)
@@ -110,7 +125,9 @@ def _rewrite_set_cookie(value: str, secure_ok: bool) -> str:
     return "; ".join(kept)
 
 
-async def _forward_to(request: Request, method: str, path: str) -> Response:
+async def _forward_to(
+    request: Request, method: str, path: str, *, body: bytes | None = None
+) -> Response:
     base = _base_url()
     if base is None:
         return JSONResponse(
@@ -120,12 +137,16 @@ async def _forward_to(request: Request, method: str, path: str) -> Response:
     cookie = request.headers.get("cookie")
     if cookie:
         headers["Cookie"] = cookie
-    body: bytes | None = None
-    if method == "POST":
+    if body is None and method == "POST":
+        # Default: relay the incoming request body verbatim (slice 1/2 actions).
         body = await request.body()
         ctype = request.headers.get("content-type")
         if ctype:
             headers["Content-Type"] = ctype
+    elif body is not None:
+        # Caller-supplied body (e.g. a signed statement the controller built):
+        # always JSON, so set the content type for it.
+        headers["Content-Type"] = "application/json"
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT) as http:
             upstream = await http.request(
@@ -252,6 +273,52 @@ async def hub_identity_lookup(request: Request):
 @router.post("/api/account/hub/identity/rotate")
 async def hub_identity_rotate(request: Request):
     return await _forward(request, "hub_identity_rotate")
+
+# --- Hub social slice 3: friend-request brokering + presence (directory) ---
+# Same cookie-passthrough pattern as the identity actions above. The client calls
+# same-origin /api/account/hub/requests* and /api/account/hub/presence*; we
+# forward to {base}/api/hub/* with the session cookie relayed, so no new auth
+# surface appears on the client and the taos.my base URL stays server-side.
+# `rid` on dispositions is validated as a rid-style token before it can reach the
+# upstream URL; `username` on presence lookup is likewise validated so a crafted
+# username can never inject path segments or query (../, %2f, ?).
+@router.post("/api/account/hub/requests")
+async def hub_requests_post(request: Request):
+    return await _forward(request, "hub_requests_post")
+
+@router.get("/api/account/hub/requests")
+async def hub_requests_get(request: Request):
+    return await _forward(request, "hub_requests_get")
+
+@router.post("/api/account/hub/requests/{rid}/accept")
+async def hub_request_accept(request: Request, rid: str):
+    if not _valid_rid(rid):
+        return JSONResponse({"error": "invalid request id"}, status_code=400)
+    _method, path = _ACTIONS["hub_request_accept"]
+    return await _forward_to(request, "POST", f"{path}/{rid}/accept")
+
+@router.post("/api/account/hub/requests/{rid}/decline")
+async def hub_request_decline(request: Request, rid: str):
+    if not _valid_rid(rid):
+        return JSONResponse({"error": "invalid request id"}, status_code=400)
+    _method, path = _ACTIONS["hub_request_decline"]
+    return await _forward_to(request, "POST", f"{path}/{rid}/decline")
+
+@router.post("/api/account/hub/presence")
+async def hub_presence_post(request: Request):
+    return await _forward(request, "hub_presence_post")
+
+@router.get("/api/account/hub/presence")
+async def hub_presence_get(request: Request):
+    username = request.query_params.get("username", "")
+    if not _valid_rid(str(username)):
+        return JSONResponse({"error": "invalid username"}, status_code=400)
+    _method, path = _ACTIONS["hub_presence_get"]
+    return await _forward_to(request, "GET", f"{path}?username={username}")
+
+@router.post("/api/account/hub/edges/revoke")
+async def hub_edge_revoke(request: Request):
+    return await _forward(request, "hub_edge_revoke")
 
 
 @router.get("/api/account/me")

--- a/tinyagentos/routes/hub.py
+++ b/tinyagentos/routes/hub.py
@@ -1,38 +1,49 @@
-"""Local hub API the Hub app consumes -- hub social slice 2.
+"""Local hub API the Hub app consumes -- hub social slices 2 and 3.
 
 See ``docs/design/hub-social-network-foundation.md`` ("The Hub app (client)").
 This is the controller-side local API, mirroring how the chat routes wrap the
 chat stores: it reads and writes the node's own signed objects in the local hub
 store (``tinyagentos/hub/store.py``) and mints/uses the node's identity keypair
-(slice 1). Directory calls stay in ``account_proxy.py``; peer traffic is a later
-slice. Nothing here talks to a peer.
+(slice 1). Directory calls (identity, friend-request brokering, presence along
+edges) reach taos.my through ``tinyagentos/routes/account_proxy.py`` additions;
+peer traffic is a later slice. Nothing here talks to a peer.
 
 Slice 2 surfaces the node's own profile: render it and create/update it with a
-version bump. Every response carries an explicit ``state`` so the app can render
-the standard degrade states (design "Client resilience") without guessing:
+version bump. Slice 3 adds the social-graph surface: signed follow and
+cache-grant statements (stored locally; caching itself is a later slice), the
+friend-request send/accept/decline flows that broker through the directory,
+and the local block/mute operations. Every response carries an explicit ``state``
+so the app can render the standard degrade states (design "Client resilience")
+without guessing:
 
 - ``no-identity``: the node has not minted a hub identity yet.
 - ``no-profile``: identity exists but no profile has been published.
-- ``ok``: a profile is present (returned under ``profile``).
+- ``ok``: data is present (returned under the relevant key).
 
 The account signed-out state is handled one layer up by the ``current_user``
 dependency (401), exactly like every other local app route.
 """
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tinyagentos.auth_context import CurrentUser, current_user
-from tinyagentos.hub import identity, store as hub_store
+from tinyagentos.hub import identity, relationships, store as hub_store
+from tinyagentos.routes.account_proxy import _forward_to
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+# --- request bodies ----------------------------------------------------------
 
 
 class ProfileIn(BaseModel):
@@ -42,6 +53,30 @@ class ProfileIn(BaseModel):
     avatar: str | None = None
     links: list | None = None
 
+
+class FollowIn(BaseModel):
+    target_fingerprint: str
+
+
+class CacheGrantIn(BaseModel):
+    grantee_fingerprint: str
+    quota_hint: Optional[int] = None
+
+
+class FriendRequestIn(BaseModel):
+    target_fingerprint: str
+    intro: str = ""
+
+
+class PeerIn(BaseModel):
+    peer_fingerprint: str
+
+
+class AcceptIn(BaseModel):
+    peer_fingerprint: Optional[str] = None
+
+
+# --- shared helpers -----------------------------------------------------------
 
 async def _get_store(request: Request) -> hub_store.HubStore:
     """Return the node's hub store, opening it lazily on first use.
@@ -58,6 +93,9 @@ async def _get_store(request: Request) -> hub_store.HubStore:
     await store.init()
     request.app.state.hub_store = store
     return store
+
+
+# --- slice 2: own profile ---------------------------------------------------
 
 
 @router.get("/api/hub/profile")
@@ -109,3 +147,356 @@ async def put_own_profile(
     signed = hub_store.sign_object(profile)
     stored = await store.put_profile(signed)
     return {"state": "ok", "profile": stored}
+
+
+# --- slice 3: follow / friend / circle ----------------------------------------
+
+
+@router.put("/api/hub/follow")
+async def follow_peer(
+    body: FollowIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Publish a signed one-way follow of ``target_fingerprint`` (design "Follow").
+
+    A follow grants nothing beyond subscribing to the target's public posts; the
+    target need not approve it (they can block). The signed statement is stored
+    locally as an out-follow and is what this node later publishes to peers.
+    """
+    identity.load_or_create()
+    store = await _get_store(request)
+    fingerprint = identity.signing_fingerprint()
+    statement = relationships.sign_statement(
+        relationships.build_follow_statement(body.target_fingerprint, author=fingerprint)
+    )
+    await store.put_relationship(
+        body.target_fingerprint, relationships.REL_FOLLOW_OUT, statement=statement
+    )
+    return {
+        "state": "following",
+        "target": body.target_fingerprint,
+        "statement": statement,
+    }
+
+
+@router.put("/api/hub/cache-grant")
+async def grant_cache(
+    body: CacheGrantIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Publish a signed cache-grant to ``grantee_fingerprint`` (design "circle").
+
+    The grant sits on top of friendship: it authorizes the friend to cache the
+    author's recent content and to serve it when the author is offline. Slice 3
+    stores the signed statement but does NOT yet act on it (the cache worker and
+    quotas are slice 6); the Friends view surfaces the grant so the UI ships
+    ahead of the cache engine. ``quota_hint`` is the suggested per-friend budget
+    in bytes (defaults to a few hundred MB per design open-question 4).
+    """
+    identity.load_or_create()
+    store = await _get_store(request)
+    fingerprint = identity.signing_fingerprint()
+    quota = (
+        body.quota_hint
+        if body.quota_hint is not None
+        else relationships.DEFAULT_CACHE_QUOTA_BYTES
+    )
+    statement = relationships.sign_statement(
+        relationships.build_cache_grant_statement(
+            body.grantee_fingerprint, quota, author=fingerprint
+        )
+    )
+    await store.put_relationship(
+        body.grantee_fingerprint,
+        relationships.REL_CACHE_GRANT,
+        statement=statement,
+        quota_hint=quota,
+    )
+    return {
+        "state": "granted",
+        "grantee": body.grantee_fingerprint,
+        "quota_hint": quota,
+        "statement": statement,
+        "note": "stored, not yet acted on (cache worker lands in slice 6)",
+    }
+
+
+@router.post("/api/hub/friends/request")
+async def send_friend_request(
+    body: FriendRequestIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Send a brokered friend request (design "Friend" + "Directory API surface").
+
+    Builds a signed intro ``{to, author, intro, sig}`` and brokers it through
+    the directory (``POST /api/hub/requests``) so the target can accept out of
+    band. The directory is the only place the signed request envelope rests (it is
+    a request, not content). We record the outgoing request locally so the Friends
+    view can show the pending state; the directory's own response (e.g. a request
+    id) passes through verbatim.
+    """
+    identity.load_or_create()
+    store = await _get_store(request)
+    fingerprint = identity.signing_fingerprint()
+    intro = relationships.sign_statement(
+        {"type": "friend-request", "author": fingerprint, "to": body.target_fingerprint,
+         "intro": body.intro}
+    )
+    # Record locally before brokering so a later failure still leaves the UI state.
+    await store.put_relationship(
+        body.target_fingerprint, relationships.REL_REQUEST_OUT, statement=intro
+    )
+    upstream = await _forward_to(
+        request, "POST", "/api/hub/requests", body=json.dumps(intro).encode("utf-8")
+    )
+    if upstream.status_code < 200 or upstream.status_code >= 300:
+        # Directory rejected (rate-limited, target unknown, ...): surface it without
+        # pretending the request landed. The local pending marker stays so the user
+        # can retry; nothing was revoked.
+        return JSONResponse(
+            {"state": "rejected", "target": body.target_fingerprint,
+             "directory": upstream.status_code},
+            status_code=upstream.status_code,
+        )
+    try:
+        directory = json.loads(upstream.body)
+    except (ValueError, TypeError):
+        directory = None
+    return {
+        "state": "sent",
+        "target": body.target_fingerprint,
+        "directory": directory,
+    }
+
+
+@router.get("/api/hub/friends/requests")
+async def inbox_friend_requests(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Read the directory's friend-request inbox (the brokered request envelope)."""
+    upstream = await _forward_to(request, "GET", "/api/hub/requests")
+    return JSONResponse(
+        json.loads(upstream.body) if upstream.body else {},
+        status_code=upstream.status_code,
+        media_type=upstream.media_type,
+    )
+
+
+@router.post("/api/hub/friends/requests/{rid}/accept")
+async def accept_friend_request(
+    rid: str,
+    body: AcceptIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Accept a brokered friend request and record the local accepted edge.
+
+    The directory accept records the server-side authorization edge (who may query
+    whose presence / leave hints) and returns the parties' endpoints so the nodes
+    complete the handshake directly. On a 2xx we record the mutual ``friend``
+    edge locally so this node's own presence gate and sync worker treat the peer as
+    an accepted edge (design: presence requires "an accepted edge"). The peer
+    fingerprint comes from the directory response when present, else the body.
+    """
+    upstream = await _forward_to(request, "POST", f"/api/hub/requests/{rid}/accept")
+    if upstream.status_code < 200 or upstream.status_code >= 300:
+        return JSONResponse(
+            {"state": "rejected"}, status_code=upstream.status_code
+        )
+    try:
+        resp = json.loads(upstream.body) if upstream.body else {}
+    except (ValueError, TypeError):
+        resp = {}
+    peer = body.peer_fingerprint or resp.get("peer") or resp.get("target") or resp.get(
+        "username"
+    )
+    store = await _get_store(request)
+    fingerprint = identity.signing_fingerprint()
+    if peer:
+        statement = relationships.sign_statement(
+            relationships.build_friend_statement(peer, author=fingerprint)
+        )
+        await store.put_relationship(
+            peer, relationships.REL_FRIEND, statement=statement
+        )
+    return {"state": "accepted", "peer": peer, "directory": resp}
+
+
+@router.post("/api/hub/friends/requests/{rid}/decline")
+async def decline_friend_request(
+    rid: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Decline a brokered friend request; record it locally as declined."""
+    upstream = await _forward_to(request, "POST", f"/api/hub/requests/{rid}/decline")
+    if upstream.status_code < 200 or upstream.status_code >= 300:
+        return JSONResponse(
+            {"state": "rejected"}, status_code=upstream.status_code
+        )
+    # A social action implies this node has an identity (its fingerprint is the
+    # local party); mint it if this is the first act.
+    identity.load_or_create()
+    store = await _get_store(request)
+    # The directory owns the target's fingerprint; if it echoed it back we record
+    # the decline against that peer, else just pass the directory response through.
+    try:
+        resp = json.loads(upstream.body) if upstream.body else {}
+    except (ValueError, TypeError):
+        resp = {}
+    peer = resp.get("peer") or resp.get("target") or resp.get("username")
+    if peer:
+        await store.put_relationship(peer, relationships.REL_REQUEST_DECLINED)
+    return {"state": "declined", "peer": peer, "directory": resp}
+
+
+@router.post("/api/hub/friends/block")
+async def block_peer(
+    body: PeerIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Block a peer: strong, local-first (design "Abuse and safety").
+
+    Blocking unfollows, removes the peer from friendship and circle, and severs
+    every local edge to them (follow / friend / cache-grant / pending requests)
+    so nothing about them is rendered or cached. It also asks the hub to sever the
+    server-side accepted edge (no more presence visibility or hints either way);
+    that directory call is best-effort and its result never blocks the local op.
+    """
+    store = await _get_store(request)
+    # A social action implies this node has an identity (its fingerprint is the
+    # local party in every relationship), so mint it if this is the first act.
+    identity.load_or_create()
+    peer = body.peer_fingerprint
+    # Sever first, then record the block so the purge does not wipe the marker.
+    severed = await store.sever_edges(peer, keep={relationships.REL_BLOCK})
+    await store.put_relationship(peer, relationships.REL_BLOCK)
+    # Best-effort: tell the hub to drop the accepted edge. Never let a directory
+    # failure (or an unconfigured proxy -> 503) block the local operation.
+    try:
+        await _forward_to(
+            request,
+            "POST",
+            "/api/hub/edges/revoke",
+            body=json.dumps({"peer": peer}).encode("utf-8"),
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("hub block: directory edge revoke failed: %s", exc)
+    return {"state": "blocked", "peer": peer, "severed": severed}
+
+
+@router.post("/api/hub/friends/mute")
+async def mute_peer(
+    body: PeerIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Mute a peer locally: stop rendering, keep the edge (design "block and mute
+    are local + circle operations"; mute is the local-only subset)."""
+    identity.load_or_create()
+    store = await _get_store(request)
+    await store.put_relationship(body.peer_fingerprint, relationships.REL_MUTE)
+    return {"state": "muted", "peer": body.peer_fingerprint}
+
+
+@router.post("/api/hub/friends/unmute")
+async def unmute_peer(
+    body: PeerIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Unmute a previously muted peer (local-only operation)."""
+    identity.load_or_create()
+    store = await _get_store(request)
+    await store.delete_relationship(body.peer_fingerprint, relationships.REL_MUTE)
+    return {"state": "unmuted", "peer": body.peer_fingerprint}
+
+
+@router.get("/api/hub/friends")
+async def list_friends(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """The local social-graph view for the Friends pane (not the directory inbox).
+
+    Returns the node's own follows, accepted friends, cache grants, blocks, mutes,
+    and pending/declined requests. Presence and the directory request inbox are
+    separate calls (``GET /api/hub/presence``, ``GET /api/hub/friends/requests``).
+    """
+    if not identity.exists():
+        return {"state": "no-identity"}
+    store = await _get_store(request)
+
+    async def _peers(kind: str) -> list[str]:
+        return [r["peer"] for r in await store.list_relationships(kind)]
+
+    grants = [
+        {"peer": r["peer"], "quota_hint": r["quota_hint"]}
+        for r in await store.list_relationships(relationships.REL_CACHE_GRANT)
+    ]
+    return {
+        "state": "ok",
+        "identity": identity.public_identity(),
+        "follows_out": await _peers(relationships.REL_FOLLOW_OUT),
+        "friends": await _peers(relationships.REL_FRIEND),
+        "cache_grants": grants,
+        "blocks": await _peers(relationships.REL_BLOCK),
+        "mutes": await _peers(relationships.REL_MUTE),
+        "requests_out": await _peers(relationships.REL_REQUEST_OUT),
+        "requests_in": await _peers(relationships.REL_REQUEST_IN),
+        "requests_declined": await _peers(relationships.REL_REQUEST_DECLINED),
+    }
+
+
+@router.get("/api/hub/presence")
+async def lookup_presence(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Look up a peer's presence endpoints, gated on an accepted edge.
+
+    Design "Directory API surface": ``GET /api/hub/presence`` returns endpoints
+    only if the requester's identity is authorized (an accepted edge exists). We
+    enforce that locally first (the node must hold a ``friend`` edge to the peer)
+    and, when authorized, forward to the directory, which enforces the same rule
+    server-side; either way, no accepted edge means no endpoints. The peer is
+    identified by signing fingerprint (``peer``); a ``username`` is resolved to a
+    fingerprint via the locally cached author map when only the username is known.
+    """
+    if not identity.exists():
+        return {"state": "no-identity"}
+    store = await _get_store(request)
+    peer = request.query_params.get("peer", "")
+    username = request.query_params.get("username", "")
+    if peer:
+        target_fp = peer
+    elif username:
+        author = await store.get_author_by_username(username)
+        if author is None:
+            return JSONResponse(
+                {"error": "unknown username", "username": username}, status_code=404
+            )
+        target_fp = author["fingerprint"]
+    else:
+        return JSONResponse(
+            {"error": "peer or username required"}, status_code=400
+        )
+    # Edge authorization: presence requires an accepted (mutual friend) edge.
+    if not await store.has_edge(target_fp, relationships.REL_FRIEND):
+        return JSONResponse(
+            {"error": "not authorized", "reason": "no accepted edge", "peer": target_fp},
+            status_code=403,
+        )
+    upstream = await _forward_to(
+        request, "GET", f"/api/hub/presence?username={username or target_fp}"
+    )
+    return JSONResponse(
+        json.loads(upstream.body) if upstream.body else {},
+        status_code=upstream.status_code,
+        media_type=upstream.media_type,
+    )


### PR DESCRIPTION
## Summary

Implements hub social **slice 3** exactly as written in `docs/design/hub-social-network-foundation.md` (Slice plan), building on the merged slices 1 and 2.

- Controller module `tinyagentos/hub/relationships.py`: signed **follow** and **cache-grant** statements (Ed25519 over canonical bytes, same as profiles). The cache grant is stored but explicitly *not yet acted on* (caching is slice 6).
- `tinyagentos/hub/store.py`: `hub_relationships` table + put/get/list/has_edge/sever_edges helpers; friend edge is the only kind the presence gate authorizes.
- `tinyagentos/routes/hub.py`: Friends surface: follow, cache-grant, friend-request send/accept/decline, local **block** (severs every edge to the peer + best-effort asks the hub to revoke the server-side edge) and **mute/unmute**, a `/api/hub/friends` list, and a **presence gate** that denies lookup without an accepted edge.
- `tinyagentos/routes/account_proxy.py`: directory proxy entries for requests inbox, request dispositions, presence heartbeat/lookup, and edge revoke (rid/username validated to block path traversal; 503 when the account service is unconfigured).

## Tests (verification, all green)

`tests/test_hub_relationships.py`, `tests/test_routes_hub_slice3.py`, `tests/test_routes_account_proxy_hub_slice3.py` cover the slice's required behaviors:

- **edge authorization**: presence denied (403) without an accepted edge,
- **rate-limit behavior**: a directory 429 passes through verbatim,
- **block severs the edge**: local friend/follow edges are dropped and the directory revoke is called.

Existing hub + account-proxy suites still pass; `ruff check` is clean on all changed files.

Docs-Reviewed: implements the merged design doc (doc-gate requires it).

Note: do NOT merge (per task); review and merge to `dev` only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added social relationship support, including follows, friendships, cache grants, friend requests, blocking, muting, and unmuting.
  * Added a friends overview with relationship status and presence lookup for authorized connections.
  * Added secure signed relationship statements and persistent local relationship storage.
  * Added account proxy support for friend requests, presence checks, and edge revocation.
* **Tests**
  * Added comprehensive coverage for relationship storage, signatures, validation, proxying, authorization, and service-degraded responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->