### PR TITLE
feat(projects): nested element store, CRUD routes, and task element tags (slice 1)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,10 @@ async def client(app, tmp_data_dir):
     if project_task_store._db is not None:
         await project_task_store.close()
     await project_task_store.init()
+    project_element_store = app.state.project_element_store
+    if project_element_store._db is not None:
+        await project_element_store.close()
+    await project_element_store.init()
     routine_store = app.state.routine_store
     if routine_store._db is not None:
         await routine_store.close()
@@ -436,6 +440,7 @@ async def client(app, tmp_data_dir):
     await coding_session_store.close()
     await feedback_store.close()
     await client_log_store.close()
+    await project_element_store.close()
     await app.state.qmd_client.close()
     await app.state.http_client.aclose()
     await _browser_store.close()
@@ -571,6 +576,10 @@ async def client_with_qmd(app_with_qmd):
     if project_task_store._db is not None:
         await project_task_store.close()
     await project_task_store.init()
+    project_element_store = app_with_qmd.state.project_element_store
+    if project_element_store._db is not None:
+        await project_element_store.close()
+    await project_element_store.init()
     routine_store = app_with_qmd.state.routine_store
     if routine_store._db is not None:
         await routine_store.close()
@@ -611,5 +620,6 @@ async def client_with_qmd(app_with_qmd):
     await secrets_store.close()
     await notif_store.close()
     await store.close()
+    await project_element_store.close()
     await app_with_qmd.state.qmd_client.close()
     await app_with_qmd.state.http_client.aclose()

--- a/tests/projects/test_element_store.py
+++ b/tests/projects/test_element_store.py
@@ -1,0 +1,169 @@
+"""Unit tests for the project element store (slice 1).
+
+Covers schema, CRUD, slug handling, the counts query, archive, and the
+delete modes (strict vs untag). The store is exercised directly against a
+temp database; the task store shares the same projects.db so element item
+counts can be verified without the HTTP layer.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.projects.element_store import ProjectElementStore, slugify_element_name
+from tinyagentos.projects.task_store import ProjectTaskStore
+
+
+@pytest.mark.asyncio
+async def test_slugify_element_name():
+    assert slugify_element_name("Website") == "website"
+    assert slugify_element_name("My Cool Design!") == "my-cool-design"
+    assert slugify_element_name("") == "element"
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_element(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    el = await estore.create_element(project_id="prj-1", name="Website")
+    assert el["id"].startswith("elm-")
+    assert el["slug"] == "website"
+    assert el["type"] == "generic"
+    assert el["project_id"] == "prj-1"
+    assert el["archived_at"] is None
+
+    fetched = await estore.get_element(el["id"])
+    assert fetched["id"] == el["id"]
+    by_slug = await estore.get_element_by_slug("prj-1", "website")
+    assert by_slug["id"] == el["id"]
+
+
+@pytest.mark.asyncio
+async def test_create_element_explicit_slug_and_type(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    el = await estore.create_element(
+        project_id="prj-1",
+        name="Designs",
+        slug="designs",
+        type="design",
+        description="art",
+        assignee_id="agent-9",
+        settings={"repo_url": "https://x"},
+    )
+    assert el["slug"] == "designs"
+    assert el["type"] == "design"
+    assert el["description"] == "art"
+    assert el["assignee_id"] == "agent-9"
+    assert el["settings"] == {"repo_url": "https://x"}
+
+
+@pytest.mark.asyncio
+async def test_create_element_bad_slug_rejected(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    with pytest.raises(ValueError):
+        await estore.create_element(project_id="prj-1", name="X", slug="UPPER")
+
+
+@pytest.mark.asyncio
+async def test_duplicate_slug_raises(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    await estore.create_element(project_id="prj-1", name="Website", slug="website")
+    with pytest.raises(ValueError):
+        await estore.create_element(project_id="prj-1", name="Website 2", slug="website")
+    # A different project may reuse the slug.
+    other = await estore.create_element(project_id="prj-2", name="Website", slug="website")
+    assert other["project_id"] == "prj-2"
+
+
+@pytest.mark.asyncio
+async def test_update_element(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    el = await estore.create_element(project_id="prj-1", name="Website")
+    updated = await estore.update_element(
+        el["id"], name="Site", type="website", description="d", assignee_id="agent-1",
+        settings={"url": "https://s"},
+    )
+    assert updated["name"] == "Site"
+    assert updated["type"] == "website"
+    assert updated["assignee_id"] == "agent-1"
+    assert updated["settings"] == {"url": "https://s"}
+    # Updating only one field leaves the rest intact.
+    again = await estore.update_element(el["id"], description="changed")
+    assert again["name"] == "Site"
+    assert again["description"] == "changed"
+
+
+@pytest.mark.asyncio
+async def test_archive_element(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    el = await estore.create_element(project_id="prj-1", name="Website")
+    assert await estore.archive_element(el["id"]) is True
+    archived = await estore.get_element(el["id"])
+    assert archived["archived_at"] is not None
+    # list_elements still includes archived elements (the grid hides them).
+    assert any(e["id"] == el["id"] for e in await estore.list_elements("prj-1"))
+
+
+@pytest.mark.asyncio
+async def test_list_elements_counts(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    tstore = ProjectTaskStore(tmp_path / "projects.db")
+    await tstore.init()
+
+    el = await estore.create_element(project_id="prj-1", name="Website")
+    # untagged task (project-level)
+    await tstore.create_task(project_id="prj-1", title="general", created_by="u")
+    # two tasks tagged with the element, one open and one closed
+    open_t = await tstore.create_task(project_id="prj-1", title="open", element_id=el["id"], created_by="u")
+    await tstore.create_task(project_id="prj-1", title="closed", element_id=el["id"], created_by="u")
+    await tstore.close_task(open_t["id"], closed_by="x")
+
+    items = await estore.list_elements("prj-1")
+    assert len(items) == 1
+    e = items[0]
+    assert e["open_tasks"] == 1
+    assert e["total_tasks"] == 2
+    # canvas_items is 0 in slice 1 (canvas element_id column lands in slice 4).
+    assert e["canvas_items"] == 0
+
+    counts = await estore.count_element_items("prj-1", el["id"])
+    assert counts == {"open_tasks": 1, "total_tasks": 2, "canvas_items": 0}
+
+
+@pytest.mark.asyncio
+async def test_delete_element_strict_and_untag(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    tstore = ProjectTaskStore(tmp_path / "projects.db")
+    await tstore.init()
+
+    el = await estore.create_element(project_id="prj-1", name="Website")
+    t = await tstore.create_task(project_id="prj-1", title="t", element_id=el["id"], created_by="u")
+
+    # Strict delete refuses while items are tagged (caller returns 409).
+    counts = await estore.count_element_items("prj-1", el["id"])
+    assert counts["total_tasks"] == 1
+    tagged = await tstore.get_task(t["id"])
+    assert tagged["element_id"] == el["id"]
+
+    # Untag mode nulls the tags then deletes the row.
+    await estore.delete_element(el["id"], untag=True)
+    cleared = await tstore.get_task(t["id"])
+    assert cleared["element_id"] is None
+    assert await estore.get_element(el["id"]) is None
+    # Untagged task remains.
+    assert (await tstore.get_task(t["id"]))["id"] == t["id"]
+
+
+@pytest.mark.asyncio
+async def test_delete_empty_element(tmp_path):
+    estore = ProjectElementStore(tmp_path / "projects.db")
+    await estore.init()
+    el = await estore.create_element(project_id="prj-1", name="Empty")
+    await estore.delete_element(el["id"])
+    assert await estore.get_element(el["id"]) is None

--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -463,3 +463,241 @@ async def test_task_context_route_shape(client):
 async def test_task_context_route_unknown_task_returns_404(client):
     resp = await client.get("/api/projects/tasks/tsk-nope/context")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Slice 1: project elements + task element tags
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_and_list_elements(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+
+    resp = await client.post(
+        f"/api/projects/{pid}/elements",
+        json={"name": "Website", "type": "website", "description": "the site"},
+    )
+    assert resp.status_code == 200, resp.text
+    el = resp.json()
+    assert el["id"].startswith("elm-")
+    assert el["slug"] == "website"
+    assert el["type"] == "website"
+    assert el["description"] == "the site"
+
+    # default slug from name when omitted
+    resp2 = await client.post(
+        f"/api/projects/{pid}/elements", json={"name": "Designs"}
+    )
+    assert resp2.status_code == 200, resp2.text
+    assert resp2.json()["slug"] == "designs"
+    assert resp2.json()["type"] == "generic"
+
+    listing = await client.get(f"/api/projects/{pid}/elements")
+    assert listing.status_code == 200
+    items = {e["slug"]: e for e in listing.json()["items"]}
+    assert set(items) == {"website", "designs"}
+    # The list endpoint carries counts (open/total tasks, canvas items).
+    assert items["website"]["open_tasks"] == 0
+    assert items["website"]["total_tasks"] == 0
+    assert items["website"]["canvas_items"] == 0
+
+    single = await client.get(f"/api/projects/{pid}/elements/{el['id']}")
+    assert single.status_code == 200
+    assert single.json()["name"] == "Website"
+
+
+@pytest.mark.asyncio
+async def test_element_duplicate_slug_returns_409(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    await client.post(f"/api/projects/{pid}/elements", json={"name": "Website", "slug": "website"})
+    resp = await client.post(
+        f"/api/projects/{pid}/elements", json={"name": "Website Two", "slug": "website"}
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_get_update_archive_delete_element(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    el = (await client.post(
+        f"/api/projects/{pid}/elements", json={"name": "Website", "type": "website"}
+    )).json()
+
+    resp = await client.patch(
+        f"/api/projects/{pid}/elements/{el['id']}",
+        json={"name": "Site", "description": "d"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "Site"
+
+    resp = await client.post(f"/api/projects/{pid}/elements/{el['id']}/archive")
+    assert resp.status_code == 200
+    assert resp.json()["archived_at"] is not None
+
+    resp = await client.delete(f"/api/projects/{pid}/elements/{el['id']}")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert (await client.get(f"/api/projects/{pid}/elements/{el['id']}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_element_assignee_must_be_member(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    resp = await client.post(
+        f"/api/projects/{pid}/elements",
+        json={"name": "Website", "assignee_id": "agent-not-a-member"},
+    )
+    assert resp.status_code == 400
+    await client.post(f"/api/projects/{pid}/members", json={"mode": "native", "agent_id": "agent-1"})
+    resp = await client.post(
+        f"/api/projects/{pid}/elements",
+        json={"name": "Website", "assignee_id": "agent-1"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["assignee_id"] == "agent-1"
+
+
+@pytest.mark.asyncio
+async def test_element_delete_with_tagged_tasks_returns_409(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    el = (await client.post(f"/api/projects/{pid}/elements", json={"name": "Website"})).json()
+    t = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "T", "element_id": el["id"]}
+    )).json()
+
+    resp = await client.delete(f"/api/projects/{pid}/elements/{el['id']}")
+    assert resp.status_code == 409
+    body = resp.json()
+    assert body["total_tasks"] == 1
+    assert body["open_tasks"] == 1
+    # The task (and element) survive the refused delete.
+    assert (await client.get(f"/api/projects/{pid}/tasks/{t['id']}")).status_code == 200
+    assert (await client.get(f"/api/projects/{pid}/elements/{el['id']}")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_element_delete_untag_mode(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    el = (await client.post(f"/api/projects/{pid}/elements", json={"name": "Website"})).json()
+    t = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "T", "element_id": el["id"]}
+    )).json()
+
+    resp = await client.delete(
+        f"/api/projects/{pid}/elements/{el['id']}?mode=untag"
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    # Task stays but its tag is cleared to project-level.
+    cleared = (await client.get(f"/api/projects/{pid}/tasks/{t['id']}")).json()
+    assert cleared["element_id"] is None
+    assert (await client.get(f"/api/projects/{pid}/elements/{el['id']}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_task_with_element_id(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    el = (await client.post(f"/api/projects/{pid}/elements", json={"name": "Website"})).json()
+
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "T", "element_id": el["id"]}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["element_id"] == el["id"]
+
+    listing = await client.get(f"/api/projects/{pid}/elements")
+    assert listing.json()["items"][0]["open_tasks"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_task_with_invalid_element_id_400(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "T", "element_id": "elm-nope"}
+    )
+    assert resp.status_code == 400
+    # An archived element is not a valid tag target either.
+    el = (await client.post(f"/api/projects/{pid}/elements", json={"name": "Website"})).json()
+    await client.post(f"/api/projects/{pid}/elements/{el['id']}/archive")
+    resp = await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "T2", "element_id": el["id"]}
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_filter_by_element_and_none(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    el = (await client.post(f"/api/projects/{pid}/elements", json={"name": "Website"})).json()
+    tagged = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "tagged", "element_id": el["id"]}
+    )).json()
+    untagged = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "general"}
+    )).json()
+
+    all_items = {t["id"] for t in (await client.get(f"/api/projects/{pid}/tasks")).json()["items"]}
+    assert all_items == {tagged["id"], untagged["id"]}
+
+    by_element = (await client.get(
+        f"/api/projects/{pid}/tasks", params={"element_id": el["id"]}
+    )).json()["items"]
+    assert [t["id"] for t in by_element] == [tagged["id"]]
+
+    none_items = (await client.get(
+        f"/api/projects/{pid}/tasks", params={"element_id": "none"}
+    )).json()["items"]
+    assert [t["id"] for t in none_items] == [untagged["id"]]
+
+
+@pytest.mark.asyncio
+async def test_update_task_move_element_and_clear(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    web = (await client.post(f"/api/projects/{pid}/elements", json={"name": "Website"})).json()
+    design = (await client.post(f"/api/projects/{pid}/elements", json={"name": "Designs"})).json()
+    t = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "T", "element_id": web["id"]}
+    )).json()
+
+    # Move to another element.
+    resp = await client.patch(
+        f"/api/projects/{pid}/tasks/{t['id']}",
+        json={"element_id": design["id"]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["element_id"] == design["id"]
+
+    # Clear to project-level via the "none" sentinel.
+    resp = await client.patch(
+        f"/api/projects/{pid}/tasks/{t['id']}", json={"element_id": "none"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["element_id"] is None
+
+    # Omitting element_id leaves the tag untouched.
+    resp = await client.patch(
+        f"/api/projects/{pid}/tasks/{t['id']}", json={"title": "renamed"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["element_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_ready_tasks_filter_by_element(client):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    el = (await client.post(f"/api/projects/{pid}/elements", json={"name": "Website"})).json()
+    tagged = (await client.post(
+        f"/api/projects/{pid}/tasks", json={"title": "tagged", "element_id": el["id"]}
+    )).json()
+    await client.post(f"/api/projects/{pid}/tasks", json={"title": "general"})
+
+    by_element = (await client.get(
+        f"/api/projects/{pid}/tasks/ready", params={"element_id": el["id"]}
+    )).json()["items"]
+    assert [t["id"] for t in by_element] == [tagged["id"]]
+
+    none_items = (await client.get(
+        f"/api/projects/{pid}/tasks/ready", params={"element_id": "none"}
+    )).json()["items"]
+    assert all(t["element_id"] is None for t in none_items)
+    assert len(none_items) == 1

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -386,3 +386,65 @@ class TestSessionRegression:
         async with _bare(ctx.app) as bare:
             resp = await bare.get(f"/api/projects/{pid}/tasks")
         assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestAgentElementFilter:
+    """Slice 1: an agent token filters tasks by element with ZERO auth change.
+
+    The element tag is a view of data the token already reads under
+    project_tasks, so the existing dual-auth gate passes element-filtered
+    reads straight through. No new agent surface, no scope change.
+    """
+
+    async def _new_element(self, ctx, pid, name="Website"):
+        resp = await ctx.client.post(
+            f"/api/projects/{pid}/elements", json={"name": name}
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["id"]
+
+    async def test_agent_filters_by_element(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        eid = await self._new_element(ctx, pid)
+        tagged = await _new_task(ctx, pid)
+        await ctx.client.patch(
+            f"/api/projects/{pid}/tasks/{tagged}", json={"element_id": eid}
+        )
+        await _new_task(ctx, pid)  # untagged task
+
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            by_element = await bare.get(
+                f"/api/projects/{pid}/tasks",
+                params={"element_id": eid},
+                headers=_hdr(token),
+            )
+            assert by_element.status_code == 200
+            assert [t["id"] for t in by_element.json()["items"]] == [tagged]
+
+            none_only = await bare.get(
+                f"/api/projects/{pid}/tasks",
+                params={"element_id": "none"},
+                headers=_hdr(token),
+            )
+            assert none_only.status_code == 200
+            assert all(t["element_id"] is None for t in none_only.json()["items"])
+
+    async def test_agent_ready_filter_by_element(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        eid = await self._new_element(ctx, pid)
+        tagged = await _new_task(ctx, pid)
+        await ctx.client.patch(
+            f"/api/projects/{pid}/tasks/{tagged}", json={"element_id": eid}
+        )
+
+        _cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/ready",
+                params={"element_id": eid},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+        assert [t["id"] for t in resp.json()["items"]] == [tagged]

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -366,6 +366,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     chat_channels = ChatChannelStore(data_dir / "chat.db")
     from tinyagentos.projects.project_store import ProjectStore
     from tinyagentos.projects.task_store import ProjectTaskStore
+    from tinyagentos.projects.element_store import ProjectElementStore
     from tinyagentos.projects.events import ProjectEventBroker
     from tinyagentos.projects.canvas.store import ProjectCanvasStore as ProjectCanvasStoreImpl
     from tinyagentos.projects.canvas.snapshotter import CanvasSnapshotter
@@ -383,6 +384,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         audit=board_audit_store,
         project_store=project_store,
     )
+    project_element_store = ProjectElementStore(data_dir / "projects.db")
     from tinyagentos.projects.routines_store import RoutineStore
     routine_store = RoutineStore(data_dir / "routines.db")
     project_canvas_store = ProjectCanvasStoreImpl(data_dir / "projects.db", broker=project_event_broker)
@@ -511,6 +513,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await receipt_store.init()
         app.state.receipt_store = receipt_store
         await project_task_store.init()
+        await project_element_store.init()
         await routine_store.init()
         app.state.routine_store = routine_store
         await project_canvas_store.init()
@@ -827,6 +830,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.chat_channels = chat_channels
         app.state.project_store = project_store
         app.state.project_task_store = project_task_store
+        app.state.project_element_store = project_element_store
         app.state.project_event_broker = project_event_broker
         app.state.desktop_command_broker = desktop_command_broker
         app.state.project_canvas_store = project_canvas_store
@@ -1412,6 +1416,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 logger.exception("canvas snapshotter stop failed")
         await project_canvas_store.close()
         await project_task_store.close()
+        await project_element_store.close()
         await routine_store.close()
         await project_store.close()
         await chat_channels.close()
@@ -1562,6 +1567,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.board_audit = board_audit_store
     app.state.receipt_store = receipt_store
     app.state.project_task_store = project_task_store
+    app.state.project_element_store = project_element_store
     app.state.routine_store = routine_store
     app.state.project_event_broker = project_event_broker
     app.state.desktop_command_broker = desktop_command_broker

--- a/tinyagentos/projects/beads_format.py
+++ b/tinyagentos/projects/beads_format.py
@@ -51,6 +51,7 @@ def task_to_jsonl_dict(
         "labels": list(task.get("labels") or []),
         "assignee_ids": [assignee_id] if assignee_id else [],
         "parent_id": task.get("parent_task_id"),
+        "element_id": task.get("element_id"),
         "deps": [
             {"task_id": r["to_task_id"], "kind": r["kind"]}
             for r in outbound_relationships

--- a/tinyagentos/projects/element_store.py
+++ b/tinyagentos/projects/element_store.py
@@ -1,0 +1,237 @@
+"""Project element store.
+
+A project element is a first-class, typed, optionally-owned subdivision of a
+project (see docs/design/projects-nested-elements.md). Elements own a tag on
+tasks and canvas items; a NULL tag means project-level. The element record
+itself lives in ``projects.db`` alongside the project and task stores.
+
+This module is slice 1 of the design: schema, CRUD, and the counts query that
+backs the element overview grid. Assignment routing (slice 5) and group/promote
+(slice 6/7) build on top of it.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import time
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+# Element slugs follow the project slug rules.
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+ELEMENT_SCHEMA = """
+CREATE TABLE IF NOT EXISTS project_elements (
+    id          TEXT PRIMARY KEY,
+    project_id  TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    slug        TEXT NOT NULL,
+    type        TEXT NOT NULL DEFAULT 'generic',
+    description TEXT NOT NULL DEFAULT '',
+    assignee_id TEXT,
+    settings    TEXT NOT NULL DEFAULT '{}',
+    created_at  REAL NOT NULL,
+    updated_at  REAL NOT NULL,
+    archived_at REAL,
+    UNIQUE (project_id, slug)
+);
+CREATE INDEX IF NOT EXISTS idx_elements_project ON project_elements(project_id);
+"""
+
+_JSON_FIELDS = ("settings",)
+
+
+def slugify_element_name(name: str) -> str:
+    """Best-effort slug from a human name, matching project slug rules."""
+    s = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+    return s or "element"
+
+
+def validate_element_slug(slug: str) -> str:
+    if not _SLUG_RE.fullmatch(slug):
+        raise ValueError("slug must match ^[a-z0-9][a-z0-9_-]{0,62}$")
+    return slug
+
+
+def _row_to_element(row, description) -> dict:
+    keys = [d[0] for d in description]
+    e = dict(zip(keys, row))
+    for f in _JSON_FIELDS:
+        if f in e and e[f] is not None:
+            e[f] = json.loads(e[f])
+    return e
+
+
+class ProjectElementStore(BaseStore):
+    SCHEMA = ELEMENT_SCHEMA
+
+    async def get_element(self, element_id: str) -> "dict | None":
+        async with self._db.execute(
+            "SELECT * FROM project_elements WHERE id = ?", (element_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_element(row, cur.description)
+
+    async def get_element_by_slug(self, project_id: str, slug: str) -> "dict | None":
+        async with self._db.execute(
+            "SELECT * FROM project_elements WHERE project_id = ? AND slug = ?",
+            (project_id, slug),
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_element(row, cur.description)
+
+    async def create_element(
+        self,
+        project_id: str,
+        name: str,
+        slug: str | None = None,
+        type: str = "generic",
+        description: str = "",
+        assignee_id: "str | None" = None,
+        settings: "dict | None" = None,
+    ) -> dict:
+        if slug is None or slug == "":
+            slug = slugify_element_name(name)
+        validate_element_slug(slug)
+        eid = new_id("elm")
+        now = time.time()
+        try:
+            await self._db.execute(
+                """INSERT INTO project_elements
+                   (id, project_id, name, slug, type, description, assignee_id,
+                    settings, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    eid, project_id, name, slug, type, description, assignee_id,
+                    json.dumps(settings or {}), now, now,
+                ),
+            )
+            await self._db.commit()
+        except sqlite3.IntegrityError as exc:
+            # UNIQUE(project_id, slug) is the only uniqueness a caller can trigger.
+            if "slug" in str(exc).lower() or "unique" in str(exc).lower():
+                await self._db.rollback()
+                raise ValueError(f"element slug already used in project: {slug}") from exc
+            await self._db.rollback()
+            raise
+        return await self.get_element(eid)
+
+    async def update_element(
+        self,
+        element_id: str,
+        name: "str | None" = None,
+        type: "str | None" = None,
+        description: "str | None" = None,
+        assignee_id: "str | None" = None,
+        settings: "dict | None" = None,
+    ) -> "dict | None":
+        candidates = [
+            ("name", name, name),
+            ("type", type, type),
+            ("description", description, description),
+            ("assignee_id", assignee_id, assignee_id),
+            ("settings", settings, json.dumps(settings) if settings is not None else None),
+        ]
+        sets: list[str] = []
+        params: list = []
+        for col, raw, serialised in candidates:
+            if raw is not None:
+                sets.append(f"{col} = ?")
+                params.append(serialised)
+        if not sets:
+            return await self.get_element(element_id)
+        sets.append("updated_at = ?")
+        params.append(time.time())
+        params.append(element_id)
+        await self._db.execute(
+            f"UPDATE project_elements SET {', '.join(sets)} WHERE id = ?", params
+        )
+        await self._db.commit()
+        return await self.get_element(element_id)
+
+    async def archive_element(self, element_id: str) -> bool:
+        now = time.time()
+        cur = await self._db.execute(
+            "UPDATE project_elements SET archived_at = ?, updated_at = ? WHERE id = ?",
+            (now, now, element_id),
+        )
+        await self._db.commit()
+        return cur.rowcount == 1
+
+    async def count_element_items(self, project_id: str, element_id: str) -> dict:
+        """Counts of items currently tagged with this element.
+
+        ``canvas_items`` tolerates the missing column gracefully: the canvas
+        ``element_id`` tag is added in slice 4, so until then the count is 0.
+        Once that column exists, the same query returns the real count with no
+        code change here.
+        """
+        total_tasks = 0
+        open_tasks = 0
+        try:
+            total_tasks = await self._count(
+                "SELECT COUNT(*) FROM project_tasks WHERE project_id = ? AND element_id = ?",
+                (project_id, element_id),
+            )
+            open_tasks = await self._count(
+                "SELECT COUNT(*) FROM project_tasks WHERE project_id = ? AND element_id = ? AND status = 'open'",
+                (project_id, element_id),
+            )
+        except sqlite3.OperationalError:
+            # project_tasks may not be initialized in the shared db yet.
+            total_tasks = 0
+            open_tasks = 0
+        canvas_items = 0
+        try:
+            canvas_items = await self._count(
+                "SELECT COUNT(*) FROM project_canvas_elements WHERE project_id = ? AND element_id = ?",
+                (project_id, element_id),
+            )
+        except sqlite3.OperationalError:
+            # element_id column on project_canvas_elements not yet present (slice 4).
+            canvas_items = 0
+        return {
+            "open_tasks": open_tasks,
+            "total_tasks": total_tasks,
+            "canvas_items": canvas_items,
+        }
+
+    async def list_elements(self, project_id: str) -> list[dict]:
+        async with self._db.execute(
+            "SELECT * FROM project_elements WHERE project_id = ? ORDER BY created_at ASC",
+            (project_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+            desc = cur.description
+        out: list[dict] = []
+        for r in rows:
+            e = _row_to_element(r, desc)
+            counts = await self.count_element_items(project_id, e["id"])
+            e["open_tasks"] = counts["open_tasks"]
+            e["total_tasks"] = counts["total_tasks"]
+            e["canvas_items"] = counts["canvas_items"]
+            out.append(e)
+        return out
+
+    async def delete_element(self, element_id: str, untag: bool = False) -> None:
+        if untag:
+            await self._db.execute(
+                "UPDATE project_tasks SET element_id = NULL WHERE element_id = ?",
+                (element_id,),
+            )
+            # Canvas untag lands with the canvas element_id column (slice 4).
+        await self._db.execute(
+            "DELETE FROM project_elements WHERE id = ?", (element_id,)
+        )
+        await self._db.commit()
+
+    async def _count(self, sql: str, params: tuple) -> int:
+        async with self._db.execute(sql, params) as cur:
+            row = await cur.fetchone()
+        return int(row[0]) if row else 0

--- a/tinyagentos/projects/ids.py
+++ b/tinyagentos/projects/ids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import secrets
 
-ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "rev", "cs", "rtn")
+ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "rev", "cs", "rtn", "elm")
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
 
 

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS project_tasks (
     priority INTEGER NOT NULL DEFAULT 0,
     labels TEXT NOT NULL DEFAULT '[]',
     assignee_id TEXT,
+    element_id TEXT,
     claimed_by TEXT,
     claimed_at REAL,
     closed_at REAL,
@@ -42,6 +43,7 @@ CREATE TABLE IF NOT EXISTS project_tasks (
 );
 CREATE INDEX IF NOT EXISTS idx_tasks_project ON project_tasks(project_id, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_parent ON project_tasks(parent_task_id);
+CREATE INDEX IF NOT EXISTS idx_tasks_element ON project_tasks(project_id, element_id);
 
 CREATE TABLE IF NOT EXISTS task_relationships (
     id TEXT PRIMARY KEY,
@@ -90,6 +92,13 @@ def _row_to_task(row, description) -> dict:
         if f in t and t[f] is not None:
             t[f] = json.loads(t[f])
     return t
+
+
+# Sentinels for update_task's element_id:
+#   _ELEMENT_UNCHANGED -> leave the task's element tag untouched (PATCH omitted)
+#   _ELEMENT_CLEAR     -> explicitly clear the tag to NULL ("none" sentinel)
+_ELEMENT_UNCHANGED: object = object()
+_ELEMENT_CLEAR: object = object()
 
 
 class ProjectTaskStore(BaseStore):
@@ -142,6 +151,20 @@ class ProjectTaskStore(BaseStore):
         except Exception:
             logger.warning("board audit record failed for task %s", task_id, exc_info=True)
 
+    async def _post_init(self) -> None:
+        # Additive column for project elements (slice 1 of
+        # docs/design/projects-nested-elements.md). Existing databases created
+        # before the element tag existed get the column added here; fresh
+        # installs already have it from SCHEMA. Swallow the duplicate-column
+        # error the same way project_store does.
+        try:
+            await self._db.execute(
+                "ALTER TABLE project_tasks ADD COLUMN element_id TEXT"
+            )
+            await self._db.commit()
+        except Exception:
+            pass
+
     async def create_task(
         self,
         project_id: str,
@@ -152,17 +175,18 @@ class ProjectTaskStore(BaseStore):
         labels: list[str] | None = None,
         assignee_id: str | None = None,
         parent_task_id: str | None = None,
+        element_id: str | None = None,
     ) -> dict:
         tid = new_id("tsk")
         now = time.time()
         await self._db.execute(
             """INSERT INTO project_tasks
                (id, project_id, parent_task_id, title, body, status, priority, labels,
-                assignee_id, created_by, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?)""",
+                assignee_id, element_id, created_by, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?)""",
             (
                 tid, project_id, parent_task_id, title, body, priority,
-                json.dumps(labels or []), assignee_id, created_by, now, now,
+                json.dumps(labels or []), assignee_id, element_id, created_by, now, now,
             ),
         )
         await self._db.commit()
@@ -185,6 +209,7 @@ class ProjectTaskStore(BaseStore):
         project_id: str,
         status: str | None = None,
         parent_task_id: str | None = None,
+        element_id: str | None = None,
     ) -> list[dict]:
         conds = ["project_id = ?"]
         params: list = [project_id]
@@ -194,11 +219,22 @@ class ProjectTaskStore(BaseStore):
         if parent_task_id is not None:
             conds.append("parent_task_id = ?")
             params.append(parent_task_id)
+        # element_id convention (mirrors the API surface):
+        #   None      -> no element filter (project-level + every element)
+        #   "none"    -> only untagged (project-level) tasks
+        #   <real id> -> only tasks tagged with that element
+        if element_id is not None:
+            if element_id == "none":
+                conds.append("element_id IS NULL")
+            else:
+                conds.append("element_id = ?")
+                params.append(element_id)
         sql = f"SELECT * FROM project_tasks WHERE {' AND '.join(conds)} ORDER BY created_at ASC"
         async with self._db.execute(sql, params) as cur:
             rows = await cur.fetchall()
             desc = cur.description
         return [_row_to_task(r, desc) for r in rows]
+
 
     async def update_task(
         self,
@@ -209,6 +245,7 @@ class ProjectTaskStore(BaseStore):
         labels: list[str] | None = None,
         assignee_id: str | None = None,
         parent_task_id: str | None = None,
+        element_id: object = _ELEMENT_UNCHANGED,
     ) -> None:
         candidates = [
             ("title", title, title),
@@ -226,6 +263,16 @@ class ProjectTaskStore(BaseStore):
                 sets.append(f"{col} = ?")
                 params.append(serialised)
                 patch[col] = raw
+        # element_id is handled separately so None can mean "unchanged" while an
+        # explicit clear sets the tag to NULL.
+        if element_id is not _ELEMENT_UNCHANGED:
+            sets.append("element_id = ?")
+            if element_id is _ELEMENT_CLEAR:
+                params.append(None)
+                patch["element_id"] = None
+            else:
+                params.append(element_id)
+                patch["element_id"] = element_id
         if not sets:
             return
         sets.append("updated_at = ?"); params.append(time.time())
@@ -404,14 +451,25 @@ class ProjectTaskStore(BaseStore):
             keys = [d[0] for d in cur.description]
         return [dict(zip(keys, r)) for r in rows]
 
-    async def list_ready_tasks(self, project_id: str, limit: int = 50) -> list[dict]:
+    async def list_ready_tasks(
+        self, project_id: str, limit: int = 50, element_id: str | None = None
+    ) -> list[dict]:
         limit = max(1, min(limit, 200))
+        conds = ["project_id = ?"]
+        params: list = [project_id]
+        if element_id is not None:
+            if element_id == "none":
+                conds.append("element_id IS NULL")
+            else:
+                conds.append("element_id = ?")
+                params.append(element_id)
+        params.append(limit)
         async with self._db.execute(
-            """SELECT * FROM ready_tasks
-               WHERE project_id = ?
-               ORDER BY priority DESC, created_at ASC
-               LIMIT ?""",
-            (project_id, limit),
+            f"""SELECT * FROM ready_tasks
+                WHERE {' AND '.join(conds)}
+                ORDER BY priority DESC, created_at ASC
+                LIMIT ?""",
+            params,
         ) as cur:
             rows = await cur.fetchall()
             desc = cur.description

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -17,6 +17,7 @@ from tinyagentos.agent_token_auth import (
 )
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
+from tinyagentos.projects.task_store import _ELEMENT_CLEAR
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -365,6 +366,7 @@ class CreateTaskIn(BaseModel):
     labels: list[str] = Field(default_factory=list)
     assignee_id: str | None = None
     parent_task_id: str | None = None
+    element_id: str | None = None
 
 
 class UpdateTaskIn(BaseModel):
@@ -374,6 +376,9 @@ class UpdateTaskIn(BaseModel):
     labels: list[str] | None = None
     assignee_id: str | None = None
     parent_task_id: str | None = None
+    # Omit to leave the element tag unchanged; send "none" to clear it to
+    # project-level (NULL); send a real element id to move the task.
+    element_id: str | None = None
 
 
 class ClaimIn(BaseModel):
@@ -488,6 +493,23 @@ def _resolve_actor(
     return body_actor
 
 
+async def _require_active_element(
+    estore, project_id: str, element_id: str
+) -> "dict | JSONResponse":
+    """Validate that element_id names a non-archived element of this project.
+
+    Returns the element dict on success, or a 400 JSONResponse when the element
+    is missing, belongs to a different project, or has been archived. Archived
+    elements keep their tags but are no longer valid targets for new tagging.
+    """
+    el = await estore.get_element(element_id)
+    if el is None or el["project_id"] != project_id:
+        return JSONResponse({"error": "element not in project"}, status_code=400)
+    if el.get("archived_at") is not None:
+        return JSONResponse({"error": "element archived"}, status_code=400)
+    return el
+
+
 # ---------------------------------------------------------------------------
 # Task routes — order matters: /tasks/ready before /tasks/{task_id}
 # ---------------------------------------------------------------------------
@@ -501,6 +523,7 @@ async def create_task(
 ):
     store = request.app.state.project_task_store
     pstore = request.app.state.project_store
+    estore = request.app.state.project_element_store
     project_or_err = await _get_owned_project(pstore, project_id, user)
     if isinstance(project_or_err, JSONResponse):
         return project_or_err
@@ -508,6 +531,11 @@ async def create_task(
         parent = await store.get_task(payload.parent_task_id)
         if parent is None or parent["project_id"] != project_id:
             return JSONResponse({"error": "invalid parent_task_id"}, status_code=400)
+    element_id = payload.element_id
+    if element_id is not None:
+        el_check = await _require_active_element(estore, project_id, element_id)
+        if isinstance(el_check, JSONResponse):
+            return el_check
     t = await store.create_task(
         project_id=project_id,
         title=payload.title,
@@ -516,6 +544,7 @@ async def create_task(
         labels=payload.labels,
         assignee_id=payload.assignee_id,
         parent_task_id=payload.parent_task_id,
+        element_id=element_id,
         created_by=user.user_id,
     )
     _beads_mark_dirty(request, project_id)
@@ -528,26 +557,28 @@ async def list_tasks(
     project_id: str,
     request: Request,
     status: str | None = None,
+    element_id: str | None = None,
 ):
     pstore = request.app.state.project_store
     auth = await _authorize_task_actor(request, pstore, project_id)
     if isinstance(auth, JSONResponse):
         return auth
     store = request.app.state.project_task_store
-    return {"items": await store.list_tasks(project_id=project_id, status=status)}
+    return {"items": await store.list_tasks(project_id=project_id, status=status, element_id=element_id)}
 
 
 @router.get("/api/projects/{project_id}/tasks/ready")
 async def ready_tasks(
     project_id: str,
     request: Request,
+    element_id: str | None = None,
 ):
     pstore = request.app.state.project_store
     auth = await _authorize_task_actor(request, pstore, project_id)
     if isinstance(auth, JSONResponse):
         return auth
     store = request.app.state.project_task_store
-    return {"items": await store.list_ready_tasks(project_id=project_id)}
+    return {"items": await store.list_ready_tasks(project_id=project_id, element_id=element_id)}
 
 
 @router.get("/api/projects/{project_id}/tasks/{task_id}")
@@ -603,7 +634,22 @@ async def update_task(
             seen.add(cur["parent_task_id"])
             cur = await store.get_task(cur["parent_task_id"])
 
-    await store.update_task(task_id, **payload.model_dump(exclude_none=True))
+    estore = request.app.state.project_element_store
+    update_fields: dict = {}
+    for f in ("title", "body", "priority", "labels", "assignee_id", "parent_task_id"):
+        v = getattr(payload, f)
+        if v is not None:
+            update_fields[f] = v
+    if payload.element_id is not None:
+        if payload.element_id == "none":
+            update_fields["element_id"] = _ELEMENT_CLEAR
+        else:
+            el_check = await _require_active_element(estore, project_id, payload.element_id)
+            if isinstance(el_check, JSONResponse):
+                return el_check
+            update_fields["element_id"] = payload.element_id
+
+    await store.update_task(task_id, **update_fields)
     _beads_mark_dirty(request, project_id)
     return await store.get_task(task_id)
 
@@ -1013,3 +1059,207 @@ async def beads_export(
     if path is None:
         return JSONResponse({"error": "export failed"}, status_code=500)
     return {"path": str(path)}
+
+
+# ---------------------------------------------------------------------------
+# Element routes (slice 1 of docs/design/projects-nested-elements.md).
+# Owner-gated exactly like the member routes: session owner/admin via
+# _get_owned_project, with existence-hiding 404. External agent tokens get no
+# new mutation surface in v1.
+# ---------------------------------------------------------------------------
+
+class CreateElementIn(BaseModel):
+    name: str
+    slug: str | None = None
+    type: str = "generic"
+    description: str = ""
+    assignee_id: str | None = None
+    settings: dict = Field(default_factory=dict)
+
+
+class UpdateElementIn(BaseModel):
+    name: str | None = None
+    type: str | None = None
+    description: str | None = None
+    assignee_id: str | None = None
+    settings: dict | None = None
+
+
+def _ensure_element_folder(request: Request, project: dict, element: dict) -> None:
+    """Best-effort files subfolder for the element. The DB row is authoritative;
+    a disk failure must never block the element creation."""
+    try:
+        root = request.app.state.projects_root
+        d = root / project["slug"] / "files" / element["slug"]
+        d.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        logger.warning(
+            "element files folder create failed for %s/%s: %s",
+            project.get("slug"), element.get("slug"), exc,
+        )
+
+
+async def _validate_element_assignee(pstore, project_id: str, assignee_id: "str | None") -> "bool":
+    """An element assignee must name a current project member, or be None."""
+    if assignee_id is None:
+        return True
+    members = await pstore.list_members(project_id)
+    return any(m["member_id"] == assignee_id for m in members)
+
+
+@router.post("/api/projects/{project_id}/elements")
+async def create_element(
+    project_id: str,
+    payload: CreateElementIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    estore = request.app.state.project_element_store
+    project = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project, JSONResponse):
+        return project
+    if not await _validate_element_assignee(pstore, project_id, payload.assignee_id):
+        return JSONResponse({"error": "assignee is not a project member"}, status_code=400)
+    try:
+        el = await estore.create_element(
+            project_id=project_id,
+            name=payload.name,
+            slug=payload.slug,
+            type=payload.type,
+            description=payload.description,
+            assignee_id=payload.assignee_id,
+            settings=payload.settings,
+        )
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=409)
+    _ensure_element_folder(request, project, el)
+    await pstore.log_activity(
+        project_id, user.user_id, "element.created",
+        {"element_id": el["id"], "slug": el["slug"], "type": el["type"]},
+    )
+    return el
+
+
+@router.get("/api/projects/{project_id}/elements")
+async def list_elements(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    estore = request.app.state.project_element_store
+    project = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project, JSONResponse):
+        return project
+    return {"items": await estore.list_elements(project_id)}
+
+
+@router.get("/api/projects/{project_id}/elements/{element_id}")
+async def get_element(
+    project_id: str,
+    element_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    estore = request.app.state.project_element_store
+    project = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project, JSONResponse):
+        return project
+    el = await estore.get_element(element_id)
+    if el is None or el["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return el
+
+
+@router.patch("/api/projects/{project_id}/elements/{element_id}")
+async def update_element(
+    project_id: str,
+    element_id: str,
+    payload: UpdateElementIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    estore = request.app.state.project_element_store
+    project = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project, JSONResponse):
+        return project
+    el = await estore.get_element(element_id)
+    if el is None or el["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if payload.assignee_id is not None and not await _validate_element_assignee(
+        pstore, project_id, payload.assignee_id
+    ):
+        return JSONResponse({"error": "assignee is not a project member"}, status_code=400)
+    updated = await estore.update_element(
+        element_id,
+        name=payload.name,
+        type=payload.type,
+        description=payload.description,
+        assignee_id=payload.assignee_id,
+        settings=payload.settings,
+    )
+    await pstore.log_activity(
+        project_id, user.user_id, "element.updated", {"element_id": element_id}
+    )
+    return updated
+
+
+@router.post("/api/projects/{project_id}/elements/{element_id}/archive")
+async def archive_element(
+    project_id: str,
+    element_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    estore = request.app.state.project_element_store
+    project = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project, JSONResponse):
+        return project
+    el = await estore.get_element(element_id)
+    if el is None or el["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await estore.archive_element(element_id)
+    await pstore.log_activity(
+        project_id, user.user_id, "element.archived", {"element_id": element_id}
+    )
+    return await estore.get_element(element_id)
+
+
+@router.delete("/api/projects/{project_id}/elements/{element_id}")
+async def delete_element(
+    project_id: str,
+    element_id: str,
+    request: Request,
+    mode: str = "strict",
+    user: CurrentUser = Depends(current_user),
+):
+    pstore = request.app.state.project_store
+    estore = request.app.state.project_element_store
+    project = await _get_owned_project(pstore, project_id, user)
+    if isinstance(project, JSONResponse):
+        return project
+    el = await estore.get_element(element_id)
+    if el is None or el["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    counts = await estore.count_element_items(project_id, element_id)
+    if (counts["total_tasks"] > 0 or counts["canvas_items"] > 0) and mode != "untag":
+        return JSONResponse(
+            {
+                "error": "element has tagged items",
+                "open_tasks": counts["open_tasks"],
+                "total_tasks": counts["total_tasks"],
+                "canvas_items": counts["canvas_items"],
+            },
+            status_code=409,
+        )
+    await estore.delete_element(element_id, untag=(mode == "untag"))
+    await pstore.log_activity(
+        project_id, user.user_id, "element.deleted",
+        {"element_id": element_id, "mode": mode},
+    )
+    return {"ok": True}
+


### PR DESCRIPTION
Implements Slice 1 of docs/design/projects-nested-elements.md: a project becomes a container of first-class, typed, optionally-owned ELEMENTS with a tag on tasks and canvas items (canvas tagging is slice 4).

Changes
- New tinyagentos/projects/element_store.py: project_elements schema, CRUD, archive, counts query, and delete with strict/untag modes.
- tinyagentos/projects/task_store.py: element_id column (schema + additive ALTER for existing DBs), create/update/list/ready filtering (None = no filter, "none" = untagged, real id = that element).
- tinyagentos/routes/projects.py: owner-gated element CRUD routes, element_id on CreateTaskIn/UpdateTaskIn with non-archived validation, and element_id filtering on list/ready.
- tinyagentos/app.py: element store wiring (init/close/state).
- tinyagentos/projects/beads_format.py: Beads snapshot carries element_id.
- Tests: tests/projects/test_element_store.py (new), plus route coverage for CRUD, tag validation, 409 delete, untag mode, and element_id filtering. An agent-token test proves filtering by element needs zero auth change.

Verification: tests/projects/test_element_store.py, tests/test_routes_projects.py, and tests/test_routes_projects_agent_tasks.py all pass.

Docs-Reviewed: implements the merged design doc docs/design/projects-nested-elements.md slice 1.