### PR TITLE
feat(projects): kanban element filter bar (slice 2)

### DIFF
--- a/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
@@ -3,12 +3,15 @@ import { createPortal } from "react-dom";
 import styles from "./BoardToolbar.module.css";
 import type { ViewMode, GroupBy, Filters } from "./types";
 import { BoardFilters } from "./BoardFilters";
+import { ElementFilterBar } from "./ElementFilterBar";
+import type { ProjectElement } from "../../../lib/projects";
 import { useIsMobile } from "../../../hooks/use-is-mobile";
 
 export interface BoardToolbarProps {
   viewMode: ViewMode;
   groupBy: GroupBy;
   filters: Filters;
+  elements: ProjectElement[];
   live: boolean;
   onChangeView: (m: ViewMode) => void;
   onChangeGroup: (g: GroupBy) => void;
@@ -93,6 +96,12 @@ export function BoardToolbar(p: BoardToolbarProps) {
 
               <BoardFilters value={p.filters} onChange={p.onChangeFilters} />
 
+              <ElementFilterBar
+                elements={p.elements}
+                value={p.filters.elementId}
+                onChange={(v) => p.onChangeFilters({ ...p.filters, elementId: v })}
+              />
+
               <button
                 type="button"
                 onClick={() => setSheetOpen(false)}
@@ -109,6 +118,7 @@ export function BoardToolbar(p: BoardToolbarProps) {
   }
 
   return (
+    <>
     <div className={styles.bar}>
       <div className={styles.crumb}>Board</div>
       <div className={styles.grow} />
@@ -154,5 +164,11 @@ export function BoardToolbar(p: BoardToolbarProps) {
         <button type="button" className={styles.add} onClick={p.onAddTask}>＋ Task</button>
       )}
     </div>
+    <ElementFilterBar
+      elements={p.elements}
+      value={p.filters.elementId}
+      onChange={(v) => p.onChangeFilters({ ...p.filters, elementId: v })}
+    />
+    </>
   );
 }

--- a/desktop/src/apps/ProjectsApp/board/ElementFilterBar.module.css
+++ b/desktop/src/apps/ProjectsApp/board/ElementFilterBar.module.css
@@ -1,0 +1,28 @@
+.row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 6px 14px;
+  background: rgba(255, 255, 255, 0.02);
+  border-bottom: 1px solid var(--board-hair);
+}
+
+.chip {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--board-hair);
+  border-radius: 999px;
+  padding: 3px 11px;
+  color: #9a9aa1;
+  font: 600 11.5px -apple-system;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.chip:hover { color: #d2d2d7; }
+
+.on {
+  background: rgba(34, 211, 238, 0.18);
+  color: #fff;
+  border-color: rgba(34, 211, 238, 0.4);
+}

--- a/desktop/src/apps/ProjectsApp/board/ElementFilterBar.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ElementFilterBar.tsx
@@ -1,0 +1,45 @@
+import styles from "./ElementFilterBar.module.css";
+import type { ProjectElement } from "../../../lib/projects";
+import type { ElementFilter } from "./types";
+
+export interface ElementFilterBarProps {
+  elements: ProjectElement[];
+  value: ElementFilter;
+  onChange: (v: ElementFilter) => void;
+}
+
+export function ElementFilterBar({ elements, value, onChange }: ElementFilterBarProps) {
+  if (elements.length === 0) return null;
+
+  return (
+    <div className={styles.row} role="group" aria-label="Filter by element">
+      <button
+        type="button"
+        className={`${styles.chip} ${value === null ? styles.on : ""}`}
+        aria-pressed={value === null}
+        onClick={() => onChange(null)}
+      >
+        All
+      </button>
+      {elements.map(el => (
+        <button
+          key={el.id}
+          type="button"
+          className={`${styles.chip} ${value === el.id ? styles.on : ""}`}
+          aria-pressed={value === el.id}
+          onClick={() => onChange(el.id)}
+        >
+          {el.name}
+        </button>
+      ))}
+      <button
+        type="button"
+        className={`${styles.chip} ${value === "none" ? styles.on : ""}`}
+        aria-pressed={value === "none"}
+        onClick={() => onChange("none")}
+      >
+        Project-level
+      </button>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -59,7 +59,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
     localStorage.setItem(PERSIST_KEY(projectId), JSON.stringify({ viewMode, groupBy }));
   }, [projectId, viewMode, groupBy]);
 
-  const { tasks, applyEvent, setTasks } = useBoardData(projectId);
+  const { tasks, elements, applyEvent, setTasks } = useBoardData(projectId);
   const { connected } = useBoardLive(projectId, (e) => {
     if (e.kind === "task.claimed") {
       const id = String((e.payload as { id?: string }).id ?? "");
@@ -92,6 +92,12 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
     claimed: filtered.filter(t => t.status === "claimed").length,
     closed: filtered.filter(t => t.status === "closed").length,
   }), [filtered]);
+
+  const elementNameById = useMemo(
+    () => Object.fromEntries(elements.map(e => [e.id, e.name])),
+    [elements],
+  );
+  const showElementBadge = filters.elementId === null;
 
   const onCardDragStart = (e: DragEvent<HTMLButtonElement>, task: Task) => {
     e.dataTransfer.setData("text/plain", task.id);
@@ -138,6 +144,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
       onMove={(id) => setMovePopover(id)}
       justClaimed={justClaimed === t.id}
       draggable={drag}
+      elementName={showElementBadge && t.element_id ? (elementNameById[t.element_id] ?? null) : null}
       onDragStart={drag ? onCardDragStart : undefined}
     />
   );
@@ -149,6 +156,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
           viewMode={viewMode}
           groupBy={groupBy}
           filters={filters}
+          elements={elements}
           live={connected}
           onChangeView={setViewMode}
           onChangeGroup={setGroupBy}
@@ -171,6 +179,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
         viewMode={viewMode}
         groupBy={groupBy}
         filters={filters}
+        elements={elements}
         live={connected}
         onChangeView={setViewMode}
         onChangeGroup={setGroupBy}

--- a/desktop/src/apps/ProjectsApp/board/TaskCard.module.css
+++ b/desktop/src/apps/ProjectsApp/board/TaskCard.module.css
@@ -14,6 +14,7 @@
 .idRow { display: flex; gap: 6px; font: 9.5px ui-monospace, monospace; color: #86868b; margin-bottom: 5px; }
 .parent { background: rgba(255,255,255,.05); padding: 1px 6px; border-radius: 3px; color: #d2d2d7; }
 .title { font: 600 13px -apple-system; line-height: 1.35; margin-bottom: 8px; letter-spacing: -.01em; }
+.elBadge { display: inline-block; font: 600 9.5px -apple-system; padding: 2px 7px; border-radius: 999px; background: rgba(34,211,238,.16); color: #8be9fd; margin-bottom: 8px; }
 .labels { display: flex; gap: 5px; flex-wrap: wrap; margin-bottom: 9px; }
 .lbl { font: 600 9.5px -apple-system; padding: 2px 7px; border-radius: 4px; }
 .lbl_feature { background: rgba(100,210,255,.16); color: #64d2ff; }

--- a/desktop/src/apps/ProjectsApp/board/TaskCard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/TaskCard.tsx
@@ -9,10 +9,11 @@ export interface TaskCardProps {
   onMove?: (id: string) => void;
   justClaimed?: boolean;
   draggable?: boolean;
+  elementName?: string | null;
   onDragStart?: (e: DragEvent<HTMLButtonElement>, t: Task) => void;
 }
 
-export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, onDragStart }: TaskCardProps) {
+export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, elementName, onDragStart }: TaskCardProps) {
   const cover = inferCoverKind(task);
   const pri = task.priority === 0 ? "p0" : task.priority === 1 ? "p1" : "p2";
   const onKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
@@ -43,6 +44,7 @@ export function TaskCard({ task, onOpen, onMove, justClaimed, draggable, onDragS
           {task.parent_task_id && <span className={styles.parent}>↳</span>}
         </div>
         <div className={styles.title}>{task.title}</div>
+        {elementName && <span className={styles.elBadge}>{elementName}</span>}
         {task.labels.length > 0 && (
           <div className={styles.labels}>
             {task.labels.filter(l => !l.startsWith("cover:")).map(l => (

--- a/desktop/src/apps/ProjectsApp/board/__tests__/BoardToolbar.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/BoardToolbar.test.tsx
@@ -2,6 +2,9 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { BoardToolbar } from "../BoardToolbar";
 import { EMPTY_FILTERS } from "../types";
+import type { ProjectElement } from "../../../../lib/projects";
+
+const elements: ProjectElement[] = [];
 
 describe("BoardToolbar", () => {
   it("hides Group by selector in Kanban mode", () => {
@@ -10,6 +13,7 @@ describe("BoardToolbar", () => {
         viewMode="kanban"
         groupBy="assignee"
         filters={EMPTY_FILTERS}
+        elements={elements}
         live
         onChangeView={() => {}}
         onChangeGroup={() => {}}
@@ -25,6 +29,7 @@ describe("BoardToolbar", () => {
         viewMode="lanes"
         groupBy="assignee"
         filters={EMPTY_FILTERS}
+        elements={elements}
         live
         onChangeView={() => {}}
         onChangeGroup={() => {}}
@@ -41,6 +46,7 @@ describe("BoardToolbar", () => {
         viewMode="lanes"
         groupBy="assignee"
         filters={EMPTY_FILTERS}
+        elements={elements}
         live
         onChangeView={fn}
         onChangeGroup={() => {}}

--- a/desktop/src/apps/ProjectsApp/board/__tests__/ElementFilterBar.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/ElementFilterBar.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ElementFilterBar } from "../ElementFilterBar";
+import type { ProjectElement } from "../../../../lib/projects";
+import type { ElementFilter } from "../types";
+
+const els: ProjectElement[] = [
+  { id: "e1", project_id: "p1", name: "Website", slug: "website", type: "website", description: "", assignee_id: null, settings: {}, created_at: 0, updated_at: 0, archived_at: null },
+  { id: "e2", project_id: "p1", name: "Designs", slug: "designs", type: "design", description: "", assignee_id: null, settings: {}, created_at: 0, updated_at: 0, archived_at: null },
+];
+
+describe("ElementFilterBar", () => {
+  it("returns nothing when there are no elements (back-compat: no filter bar)", () => {
+    const { container } = render(
+      <ElementFilterBar elements={[]} value={null} onChange={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders All, element chips, and Project-level", () => {
+    render(<ElementFilterBar elements={els} value={null} onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Website" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Designs" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Project-level" })).toBeInTheDocument();
+  });
+
+  it("marks the active chip (All = null)", () => {
+    render(<ElementFilterBar elements={els} value={null} onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "All" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("marks the active chip for a specific element", () => {
+    render(<ElementFilterBar elements={els} value="e2" onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "Designs" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("marks the active chip for project-level (none)", () => {
+    render(<ElementFilterBar elements={els} value="none" onChange={() => {}} />);
+    expect(screen.getByRole("button", { name: "Project-level" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("emits null when All is clicked", () => {
+    const fn = vi.fn();
+    render(<ElementFilterBar elements={els} value="e1" onChange={fn} />);
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    expect(fn).toHaveBeenCalledWith(null);
+  });
+
+  it("emits the element id when an element chip is clicked", () => {
+    const fn = vi.fn();
+    render(<ElementFilterBar elements={els} value={null} onChange={fn} />);
+    fireEvent.click(screen.getByRole("button", { name: "Website" }));
+    expect(fn).toHaveBeenCalledWith("e1");
+  });
+
+  it("emits 'none' when Project-level is clicked", () => {
+    const fn = vi.fn();
+    render(<ElementFilterBar elements={els} value={null} onChange={fn} />);
+    fireEvent.click(screen.getByRole("button", { name: "Project-level" }));
+    expect(fn).toHaveBeenCalledWith("none" as ElementFilter);
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/__tests__/ProjectBoard.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/ProjectBoard.test.tsx
@@ -5,6 +5,7 @@ import { projectsApi } from "../../../../lib/projects";
 
 beforeEach(() => {
   vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([]);
+  vi.spyOn(projectsApi.elements, "list").mockResolvedValue([]);
   vi.spyOn(projectsApi, "subscribeEvents").mockReturnValue(() => {});
 });
 

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskCard.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskCard.test.tsx
@@ -7,6 +7,7 @@ const t: Task = {
   id: "t1", project_id: "p1", parent_task_id: null, title: "Wire up auth",
   body: "", status: "claimed", priority: 1, labels: ["feature"], assignee_id: "alice",
   claimed_by: "alice", claimed_at: "2026-04-26T00:00:00Z", closed_at: null, closed_by: null,
+  element_id: null,
   created_by: "u", created_at: "2026-04-26T00:00:00Z", updated_at: "2026-04-26T00:00:00Z",
 };
 

--- a/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/TaskModal.test.tsx
@@ -9,6 +9,7 @@ const sampleTask: ProjectTask = {
   title: "Spec the kanban", body: "Body text",
   status: "open", priority: 0, labels: [], assignee_id: null,
   claimed_by: null, claimed_at: null, closed_at: null, closed_by: null, close_reason: null,
+  element_id: null,
   created_by: "u", created_at: 0, updated_at: 0,
 };
 

--- a/desktop/src/apps/ProjectsApp/board/__tests__/boardDnd.test.ts
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/boardDnd.test.ts
@@ -6,6 +6,7 @@ const t = (over: Partial<Task>): Task => ({
   id: "t1", project_id: "p1", parent_task_id: null, title: "T", body: "",
   status: "open", priority: 2, labels: [], assignee_id: null,
   claimed_by: null, claimed_at: null, closed_at: null, closed_by: null,
+  element_id: null,
   created_by: "u", created_at: "2026-01-01", updated_at: "2026-01-01",
   ...over,
 });

--- a/desktop/src/apps/ProjectsApp/board/__tests__/boardFiltering.test.ts
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/boardFiltering.test.ts
@@ -7,6 +7,7 @@ const t = (over: Partial<Task>): Task => ({
   id: "t1", project_id: "p1", parent_task_id: null, title: "T", body: "",
   status: "open", priority: 2, labels: [], assignee_id: null,
   claimed_by: null, claimed_at: null, closed_at: null, closed_by: null,
+  element_id: null,
   created_by: "u", created_at: "2026-01-01", updated_at: "2026-01-01",
   ...over,
 });
@@ -50,5 +51,32 @@ describe("applyFilters", () => {
   it("AND-combines filters", () => {
     const result = applyFilters(tasks, { ...EMPTY_FILTERS, assignees: ["alice"], labels: ["bug"] });
     expect(result.map(t => t.id)).toEqual(["a"]);
+  });
+
+  it("returns all tasks with elementId null", () => {
+    const elTasks = [
+      t({ id: "e", element_id: "el1" }),
+      t({ id: "f", element_id: null }),
+      t({ id: "g", element_id: "el2" }),
+    ];
+    expect(applyFilters(elTasks, EMPTY_FILTERS).map(t => t.id).sort()).toEqual(["e", "f", "g"]);
+  });
+
+  it("scopes to a single element", () => {
+    const elTasks = [
+      t({ id: "e", element_id: "el1" }),
+      t({ id: "f", element_id: null }),
+      t({ id: "g", element_id: "el2" }),
+    ];
+    expect(applyFilters(elTasks, { ...EMPTY_FILTERS, elementId: "el1" }).map(t => t.id)).toEqual(["e"]);
+  });
+
+  it("'none' returns only untagged (project-level) tasks", () => {
+    const elTasks = [
+      t({ id: "e", element_id: "el1" }),
+      t({ id: "f", element_id: null }),
+      t({ id: "g", element_id: "el2" }),
+    ];
+    expect(applyFilters(elTasks, { ...EMPTY_FILTERS, elementId: "none" }).map(t => t.id)).toEqual(["f"]);
   });
 });

--- a/desktop/src/apps/ProjectsApp/board/__tests__/boardGrouping.test.ts
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/boardGrouping.test.ts
@@ -8,6 +8,7 @@ const t = (over: Partial<Task>): Task => ({
   id: "t1", project_id: "p1", parent_task_id: null, title: "T", body: "",
   status: "open", priority: 2, labels: [], assignee_id: null,
   claimed_by: null, claimed_at: null, closed_at: null, closed_by: null,
+  element_id: null,
   created_by: "u", created_at: "2026-01-01", updated_at: "2026-01-01",
   ...over,
 });

--- a/desktop/src/apps/ProjectsApp/board/__tests__/useBoardData.test.tsx
+++ b/desktop/src/apps/ProjectsApp/board/__tests__/useBoardData.test.tsx
@@ -3,7 +3,10 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { useBoardData } from "../useBoardData";
 import { projectsApi } from "../../../../lib/projects";
 
-beforeEach(() => vi.restoreAllMocks());
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(projectsApi.elements, "list").mockResolvedValue([]);
+});
 
 const seed = (over: Record<string, unknown>) => ({
   id: "t1", title: "T", status: "open", priority: 2, labels: [],
@@ -29,5 +32,14 @@ describe("useBoardData", () => {
     await waitFor(() => expect(result.current.tasks.length).toBe(1));
     act(() => result.current.applyEvent({ kind: "task.updated", payload: { id: "t1", patch: { title: "Renamed" } }, ts: 0 }));
     expect(result.current.tasks[0].title).toBe("Renamed");
+  });
+
+  it("loads the project's elements", async () => {
+    const el = { id: "el1", project_id: "p1", name: "Website", slug: "website", type: "website", description: "", assignee_id: null, settings: {}, created_at: 0, updated_at: 0, archived_at: null };
+    vi.spyOn(projectsApi.tasks, "list").mockResolvedValue([]);
+    vi.spyOn(projectsApi.elements, "list").mockResolvedValue([el as any]);
+    const { result } = renderHook(() => useBoardData("p1"));
+    await waitFor(() => expect(result.current.elements.length).toBe(1));
+    expect(result.current.elements[0].id).toBe("el1");
   });
 });

--- a/desktop/src/apps/ProjectsApp/board/boardFiltering.ts
+++ b/desktop/src/apps/ProjectsApp/board/boardFiltering.ts
@@ -7,6 +7,14 @@ export function applyFilters(tasks: Task[], f: Filters): Task[] {
     if (f.labels.length && !f.labels.some(l => t.labels.includes(l))) return false;
     if (f.priorities.length && !f.priorities.includes(t.priority)) return false;
     if (f.parentTaskId && t.parent_task_id !== f.parentTaskId) return false;
+    if (f.elementId === "none" && t.element_id != null) return false;
+    if (
+      typeof f.elementId === "string" &&
+      f.elementId !== "none" &&
+      t.element_id !== f.elementId
+    ) {
+      return false;
+    }
     if (f.hideClosed && t.status === "closed") return false;
     if (search) {
       const hay = `${t.title} ${t.body} ${t.id}`.toLowerCase();

--- a/desktop/src/apps/ProjectsApp/board/types.ts
+++ b/desktop/src/apps/ProjectsApp/board/types.ts
@@ -14,10 +14,16 @@ export interface Task {
   claimed_at: string | null;
   closed_at: string | null;
   closed_by: string | null;
+  element_id: string | null;
   created_by: string;
   created_at: string;
   updated_at: string;
 }
+
+// Element filter axis. null = no element filter (all tasks, tagged or not).
+// "none" = only untagged (project-level) tasks. A specific element id scopes
+// to that element.
+export type ElementFilter = string | "none" | null;
 
 export type ViewMode = "lanes" | "kanban" | "timeline";
 export type GroupBy = "assignee" | "parent" | "label" | "priority";
@@ -43,9 +49,10 @@ export interface Filters {
   hasAttachments: boolean;
   hideClosed: boolean;
   search: string;
+  elementId: ElementFilter;
 }
 
 export const EMPTY_FILTERS: Filters = {
   assignees: [], labels: [], priorities: [], parentTaskId: null,
-  hasAttachments: false, hideClosed: false, search: "",
+  hasAttachments: false, hideClosed: false, search: "", elementId: null,
 };

--- a/desktop/src/apps/ProjectsApp/board/useBoardData.ts
+++ b/desktop/src/apps/ProjectsApp/board/useBoardData.ts
@@ -1,20 +1,23 @@
 import { useCallback, useEffect, useState } from "react";
 import { projectsApi } from "../../../lib/projects";
+import type { ProjectElement } from "../../../lib/projects";
 import type { Task } from "./types";
 import type { BoardLiveEvent } from "./useBoardLive";
 
 export function useBoardData(projectId: string) {
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [elements, setElements] = useState<ProjectElement[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     (async () => {
-      const [open, claimed, closed] = await Promise.all([
+      const [open, claimed, closed, els] = await Promise.all([
         projectsApi.tasks.list(projectId, "open"),
         projectsApi.tasks.list(projectId, "claimed"),
         projectsApi.tasks.list(projectId, "closed"),
+        projectsApi.elements.list(projectId).catch(() => [] as ProjectElement[]),
       ]);
       if (!cancelled) {
         const seen = new Set<string>();
@@ -24,6 +27,7 @@ export function useBoardData(projectId: string) {
           return true;
         });
         setTasks(all as unknown as Task[]);
+        setElements(els);
         setLoading(false);
       }
     })();
@@ -53,5 +57,5 @@ export function useBoardData(projectId: string) {
     });
   }, []);
 
-  return { tasks, loading, setTasks, applyEvent };
+  return { tasks, elements, loading, setTasks, applyEvent };
 }

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -36,9 +36,37 @@ export type ProjectTask = {
   closed_at: number | null;
   closed_by: string | null;
   close_reason: string | null;
+  element_id: string | null;
   created_by: string;
   created_at: number;
   updated_at: number;
+};
+
+export type ElementType =
+  | "generic"
+  | "code"
+  | "website"
+  | "design"
+  | "docs"
+  | "marketing"
+  | "business"
+  | (string & {});
+
+export type ProjectElement = {
+  id: string;
+  project_id: string;
+  name: string;
+  slug: string;
+  type: ElementType;
+  description: string;
+  assignee_id: string | null;
+  settings: Record<string, unknown>;
+  created_at: number;
+  updated_at: number;
+  archived_at: number | null;
+  open_tasks?: number;
+  total_tasks?: number;
+  canvas_items?: number;
 };
 
 export type ProjectActivity = {
@@ -208,6 +236,50 @@ export const projectsApi = {
       }),
     getContext: (tid: string) =>
       http<TaskContext>(`/api/projects/tasks/${tid}/context`),
+  },
+
+  elements: {
+    list: (pid: string) =>
+      http<{ items: ProjectElement[] }>(`/api/projects/${pid}/elements`).then((r) => r.items),
+    get: (pid: string, eid: string) =>
+      http<ProjectElement>(`/api/projects/${pid}/elements/${eid}`),
+    create: (
+      pid: string,
+      input: {
+        name: string;
+        slug?: string;
+        type?: ElementType;
+        description?: string;
+        assignee_id?: string | null;
+        settings?: Record<string, unknown>;
+      },
+    ) =>
+      http<ProjectElement>(`/api/projects/${pid}/elements`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    update: (
+      pid: string,
+      eid: string,
+      patch: {
+        name?: string;
+        type?: ElementType;
+        description?: string;
+        assignee_id?: string | null;
+        settings?: Record<string, unknown>;
+      },
+    ) =>
+      http<ProjectElement>(`/api/projects/${pid}/elements/${eid}`, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      }),
+    archive: (pid: string, eid: string) =>
+      http<ProjectElement>(`/api/projects/${pid}/elements/${eid}/archive`, { method: "POST" }),
+    remove: (pid: string, eid: string, mode?: "untag") =>
+      http<{ ok: boolean }>(
+        `/api/projects/${pid}/elements/${eid}${mode ? `?mode=${mode}` : ""}`,
+        { method: "DELETE" },
+      ),
   },
 
   routines: {


### PR DESCRIPTION
## Summary

Implements **Slice 2 (Kanban element filter bar)** of `docs/design/projects-nested-elements.md`, building on the merged slice 1 backend.

- `desktop/src/lib/projects.ts`: added `ProjectElement` type, `element_id` to `ProjectTask`, and an `elements` client API (list/get/create/update/archive/remove).
- `desktop/src/apps/ProjectsApp/board/types.ts`: `Filters.elementId` (`string | "none" | null`).
- `desktop/src/apps/ProjectsApp/board/boardFiltering.ts`: pure element filter (`none` = untagged, an id = that element).
- New `desktop/src/apps/ProjectsApp/board/ElementFilterBar.tsx`: persistent chip row `All | <element chips> | Project-level`, rendered from `BoardToolbar` (desktop + mobile). Hidden for zero-element projects (back-compat invariant).
- `TaskCard.tsx`: small element badge when the board is unfiltered.
- `useBoardData.ts` / `ProjectBoard.tsx`: fetch elements and wire the bar + badge.

## Verification

- `npx vitest run src/apps/ProjectsApp/board/__tests__` — all pass (new `ElementFilterBar.test.tsx`, `boardFiltering` element cases, `useBoardData` elements, plus updated existing tests).
- `npx tsc -b` — clean.
- `npx vitest run src/apps/ProjectsApp` — 153 passed.

Docs-Reviewed: implements the merged design doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project element filters for viewing all tasks, tasks assigned to a specific element, or project-level tasks.
  * Task cards now display an element badge when applicable.
  * Project elements are loaded alongside board tasks.
* **Bug Fixes**
  * Improved task filtering to correctly handle tagged and untagged tasks.
* **Tests**
  * Added coverage for element loading, filtering, selection states, and task display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->