### PR TITLE
feat(hub): post objects, chain logic, image ingest, composer + own-timeline (slice 4)

### DIFF
--- a/desktop/src/apps/HubApp/HubApp.test.tsx
+++ b/desktop/src/apps/HubApp/HubApp.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@/components/ui", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  ),
+  Textarea: ({
+    onChange,
+    value,
+    placeholder,
+    ...rest
+  }: React.TextareaHTMLAttributes<HTMLTextAreaElement>) => (
+    <textarea onChange={onChange} value={value} placeholder={placeholder} {...rest} />
+  ),
+}));
+
+import { HubApp } from "./HubApp";
+
+const POST = {
+  type: "post",
+  author: "fp",
+  seq: 1,
+  prev: null,
+  created_at: new Date().toISOString(),
+  visibility: "circle",
+  body: { text: "hello hub", format: "md-subset" },
+  attachments: [],
+  sig: "deadbeef",
+  hash: "hash-1",
+};
+
+function makeFetch(handler: (url: string, init?: RequestInit) => { ok: boolean; json: () => unknown }) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const data = handler(String(url), init);
+    return {
+      ok: data.ok,
+      status: data.ok ? 200 : 404,
+      json: async () => data.json(),
+    } as Response;
+  });
+}
+
+describe("HubApp slice 4", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("composer defaults to Friends-only and publishes to the timeline", async () => {
+    const fetchMock = makeFetch((url, init) => {
+      if (url === "/api/hub/timeline") {
+        return { ok: true, json: () => ({ state: "ok", posts: [POST] }) };
+      }
+      if (url === "/api/hub/posts" && (init?.method ?? "GET") === "POST") {
+        return { ok: true, json: () => ({ state: "ok", post: POST }) };
+      }
+      return { ok: true, json: () => ({ state: "ok", posts: [] }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HubApp windowId="w1" />);
+
+    // Default visibility switch shows Friends-only as active.
+    expect(screen.getByTitle(/Only friends can read this/)).toHaveAttribute("aria-pressed", "true");
+
+    // No posts yet.
+    await waitFor(() => expect(screen.queryByText("hello hub")).not.toBeInTheDocument());
+
+    // Type and publish.
+    const textarea = screen.getByLabelText("Post text");
+    fireEvent.change(textarea, { target: { value: "hello hub" } });
+    fireEvent.click(screen.getByLabelText("Publish post"));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      "/api/hub/posts",
+      expect.objectContaining({ method: "POST" }),
+    ));
+
+    // Timeline now shows the published post.
+    await waitFor(() => expect(screen.getByText("hello hub")).toBeInTheDocument());
+    expect(screen.getAllByText("Friends-only").length).toBeGreaterThan(0);
+  });
+
+  it("switching to Public updates the published visibility", async () => {
+    const fetchMock = makeFetch((url, init) => {
+      if (url === "/api/hub/timeline") {
+        return { ok: true, json: () => ({ state: "ok", posts: [] }) };
+      }
+      if (url === "/api/hub/posts" && (init?.method ?? "GET") === "POST") {
+        return { ok: true, json: () => ({ state: "ok", post: { ...POST, visibility: "public" } }) };
+      }
+      return { ok: true, json: () => ({ state: "ok", posts: [] }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HubApp windowId="w2" />);
+
+    fireEvent.click(screen.getByTitle(/Anyone with the link can read this/));
+    const textarea = screen.getByLabelText("Post text");
+    fireEvent.change(textarea, { target: { value: "broadcast" } });
+    fireEvent.click(screen.getByLabelText("Publish post"));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/hub/posts",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"visibility":"public"'),
+        }),
+      ),
+    );
+  });
+
+  it("deletes a post via the tombstone route", async () => {
+    let deleted = false;
+    const fetchMock = makeFetch((url, init) => {
+      if (url === "/api/hub/timeline") {
+        return {
+          ok: true,
+          json: () => ({ state: "ok", posts: deleted ? [] : [POST] }),
+        };
+      }
+      if (url.endsWith("/delete") && (init?.method ?? "GET") === "POST") {
+        deleted = true;
+        return { ok: true, json: () => ({ state: "ok", tombstone: { type: "tombstone", target: POST.hash } }) };
+      }
+      return { ok: true, json: () => ({ state: "ok", posts: [POST] }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HubApp windowId="w3" />);
+
+    await waitFor(() => expect(screen.getByText("hello hub")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText("Delete post"));
+
+    await waitFor(() => expect(screen.queryByText("hello hub")).not.toBeInTheDocument());
+  });
+});

--- a/desktop/src/apps/HubApp/HubApp.tsx
+++ b/desktop/src/apps/HubApp/HubApp.tsx
@@ -1,0 +1,378 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Users, Globe, Send, Trash2, Image as ImageIcon, AlertCircle } from "lucide-react";
+import { Button, Textarea } from "@/components/ui";
+
+// ---- Types ----
+
+interface HubPost {
+  type: "post";
+  author: string;
+  seq: number;
+  prev: string | null;
+  created_at: string;
+  visibility: "public" | "circle";
+  body: { text: string; format: string };
+  attachments: { blob: string; size: number; mime: string }[];
+  sig: string;
+  hash?: string;
+}
+
+// Visibility tiers (design "Privacy tiers"). Slice 7 adds real friends-only
+// encryption; until then "circle" is enforced later by serve-authorization and
+// the composer labels it loudly. Default is friends-only, matching the design's
+// "a loud friends-only/public switch defaulting to friends-only".
+type Visibility = "circle" | "public";
+
+const VISIBILITY_OPTIONS: { value: Visibility; label: string; icon: typeof Users; hint: string }[] = [
+  { value: "circle", label: "Friends-only", icon: Users, hint: "Only friends can read this (encrypted in a later slice)" },
+  { value: "public", label: "Public", icon: Globe, hint: "Anyone with the link can read this" },
+];
+
+function relativeTime(ts: string): string {
+  const diff = Date.now() - Date.parse(ts);
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ---- Composer ----
+
+function Composer({ onPosted }: { onPosted: () => void }) {
+  const [text, setText] = useState("");
+  const [visibility, setVisibility] = useState<Visibility>("circle");
+  const [attachments, setAttachments] = useState<{ data: string; mime: string; name: string }[]>([]);
+  const [posting, setPosting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function onPickFiles(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    for (const f of files) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setAttachments((prev) => [
+          ...prev,
+          { data: String(reader.result), mime: f.type || "image/png", name: f.name },
+        ]);
+      };
+      reader.readAsDataURL(f);
+    }
+    e.target.value = "";
+  }
+
+  function removeAttachment(idx: number) {
+    setAttachments((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  async function post() {
+    if (!text.trim() && attachments.length === 0) return;
+    setPosting(true);
+    setError(null);
+    try {
+      const r = await fetch("/api/hub/posts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          visibility,
+          text: text.trim(),
+          attachments: attachments.map((a) => ({ data: a.data, mime: a.mime })),
+        }),
+      });
+      if (!r.ok) {
+        const d = await r.json().catch(() => ({}));
+        throw new Error(typeof d?.error === "string" ? d.error : "Could not publish post.");
+      }
+      setText("");
+      setAttachments([]);
+      onPosted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not publish post.");
+    } finally {
+      setPosting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-shell-border bg-shell-surface p-4">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-shell-text-secondary">New post</span>
+        <span className="text-[11px] text-shell-text-tertiary">
+          posts live on your node, signed by your key
+        </span>
+      </div>
+
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="What's on your mind?"
+        rows={3}
+        maxLength={20000}
+        aria-label="Post text"
+        className="resize-none border-shell-border bg-shell-bg-deep text-shell-text placeholder:text-shell-text-tertiary"
+      />
+
+      {/* Visibility switch -- loud, defaults to friends-only */}
+      <div
+        className="flex rounded-lg border border-shell-border bg-shell-bg-deep p-0.5"
+        role="group"
+        aria-label="Post visibility"
+      >
+        {VISIBILITY_OPTIONS.map((opt) => {
+          const Icon = opt.icon;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setVisibility(opt.value)}
+              aria-pressed={visibility === opt.value}
+              title={opt.hint}
+              className={[
+                "flex flex-1 items-center justify-center gap-1.5 rounded-md py-1.5 text-xs font-medium transition-colors",
+                visibility === opt.value
+                  ? "bg-shell-bg text-shell-text shadow-sm"
+                  : "text-shell-text-secondary hover:text-shell-text",
+              ].join(" ")}
+            >
+              <Icon size={13} className="shrink-0" />
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-[11px] text-shell-text-tertiary">
+        {VISIBILITY_OPTIONS.find((o) => o.value === visibility)?.hint}
+      </p>
+
+      {/* Attachments */}
+      {attachments.length > 0 && (
+        <ul className="flex flex-col gap-1.5">
+          {attachments.map((a, i) => (
+            <li
+              key={i}
+              className="flex items-center gap-2 rounded-lg border border-shell-border bg-shell-bg-deep px-3 py-2"
+            >
+              <ImageIcon size={14} className="shrink-0 text-accent" />
+              <span className="min-w-0 flex-1 truncate text-xs text-shell-text-secondary">{a.name}</span>
+              <button
+                type="button"
+                onClick={() => removeAttachment(i)}
+                aria-label={`Remove attachment ${a.name}`}
+                className="text-shell-text-tertiary transition-colors hover:text-red-400"
+              >
+                <Trash2 size={13} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <div
+          className="flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400"
+          role="alert"
+        >
+          <AlertCircle size={13} className="shrink-0" />
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          multiple
+          onChange={onPickFiles}
+          className="hidden"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => fileRef.current?.click()}
+          aria-label="Attach image"
+        >
+          <ImageIcon size={13} />
+          Attach
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={post}
+          disabled={posting || (!text.trim() && attachments.length === 0)}
+          aria-label="Publish post"
+        >
+          <Send size={13} />
+          {posting ? "Publishing..." : "Publish"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---- Timeline ----
+
+function Timeline({ identityReady }: { identityReady: boolean }) {
+  const [posts, setPosts] = useState<HubPost[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [, setError] = useState<string | null>(null);
+  const reqRef = useRef(0);
+
+  const load = useCallback(async () => {
+    const my = ++reqRef.current;
+    try {
+      const r = await fetch("/api/hub/timeline");
+      if (!r.ok) throw new Error("Could not load timeline.");
+      const data = await r.json();
+      if (reqRef.current !== my) return;
+      if (data.state === "no-identity") {
+        setPosts([]);
+        setError(null);
+      } else {
+        setPosts(Array.isArray(data.posts) ? (data.posts as HubPost[]) : []);
+        setError(null);
+      }
+    } catch (e) {
+      if (reqRef.current === my)
+        setError(e instanceof Error ? e.message : "Could not load timeline.");
+    } finally {
+      if (reqRef.current === my) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (identityReady) load();
+  }, [identityReady, load]);
+
+  async function remove(post: HubPost) {
+    const id = post.hash;
+    if (!id) return;
+    try {
+      const r = await fetch(`/api/hub/posts/${id}/delete`, { method: "POST" });
+      if (!r.ok) throw new Error("Could not delete post.");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not delete post.");
+    }
+  }
+
+  if (loading) {
+    return <p className="text-sm text-shell-text-tertiary">Loading timeline...</p>;
+  }
+
+  if (!identityReady) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-16 text-center">
+        <Users size={28} className="text-shell-text-tertiary" />
+        <p className="text-sm text-shell-text-secondary">
+          No hub identity yet. Publish a post to mint your key.
+        </p>
+      </div>
+    );
+  }
+
+  if (posts.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-16 text-center">
+        <Globe size={28} className="text-shell-text-tertiary" />
+        <p className="text-sm text-shell-text-secondary">No posts yet. Say something.</p>
+      </div>
+    );
+  }
+
+  return (
+        <ul className="flex flex-col gap-3" aria-label="Your posts">
+          {posts.map((post) => (
+            <li
+              key={post.hash ?? post.seq}
+          className="flex flex-col gap-2 rounded-xl border border-shell-border bg-shell-surface p-4"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <span
+              className={[
+                "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium",
+                post.visibility === "circle"
+                  ? "bg-accent/10 text-accent"
+                  : "bg-shell-surface text-shell-text-secondary",
+              ].join(" ")}
+            >
+              {post.visibility === "circle" ? <Users size={11} /> : <Globe size={11} />}
+              {post.visibility === "circle" ? "Friends-only" : "Public"}
+            </span>
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] text-shell-text-tertiary">
+                {relativeTime(post.created_at)}
+              </span>
+              <button
+                type="button"
+                onClick={() => remove(post)}
+                aria-label="Delete post"
+                className="text-shell-text-tertiary transition-colors hover:text-red-400"
+              >
+                <Trash2 size={13} />
+              </button>
+            </div>
+          </div>
+
+          <p className="whitespace-pre-wrap text-sm text-shell-text">{post.body.text}</p>
+
+          {post.attachments.length > 0 && (
+            <ul className="flex flex-col gap-1.5">
+              {post.attachments.map((att, i) => (
+                <li
+                  key={i}
+                  className="flex items-center gap-2 rounded-lg border border-shell-border bg-shell-bg-deep px-3 py-2 text-xs text-shell-text-secondary"
+                >
+                  <ImageIcon size={13} className="shrink-0 text-accent" />
+                  <span className="font-mono truncate">{att.blob.slice(0, 12)}…</span>
+                  <span className="ml-auto text-shell-text-tertiary">{formatBytes(att.size)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ---- Main app ----
+
+export function HubApp({ windowId: _windowId }: { windowId: string }) {
+  const [identityReady, setIdentityReady] = useState(false);
+  const [postsVersion, setPostsVersion] = useState(0);
+
+  useEffect(() => {
+    // Publishing a post mints the identity (routes call load_or_create), so the
+    // only "no identity" case is before the first post. Treat the app as ready
+    // and let the timeline show its own state.
+    setIdentityReady(true);
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-shell-bg">
+      <div className="flex items-center gap-2 border-b border-shell-border px-4 py-4">
+        <Users size={17} className="text-accent" />
+        <h1 className="flex-1 text-base font-semibold text-shell-text">Hub</h1>
+      </div>
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto flex max-w-2xl flex-col gap-4">
+          <Composer onPosted={() => setPostsVersion((v) => v + 1)} />
+          <Timeline key={postsVersion} identityReady={identityReady} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default HubApp;

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -66,6 +66,7 @@ const apps: AppManifest[] = [
   { id: "observatory", name: "Observatory", icon: "radar", category: "platform", component: () => import("@/apps/ObservatoryApp").then((m) => ({ default: m.ObservatoryApp })), defaultSize: { w: 620, h: 600 }, minSize: { w: 420, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.7 },
   { id: "notes", name: "Notes", icon: "sticky-note", category: "platform", component: () => import("@/apps/NotesApp").then((m) => ({ default: m.NotesApp })), defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.8 },
   { id: "todo", name: "Todo", icon: "list-checks", category: "platform", component: () => import("@/apps/NotesApp").then((m) => ({ default: m.TodoApp })), defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.85 },
+  { id: "hub", name: "Hub", icon: "users", category: "platform", component: () => import("@/apps/HubApp/HubApp").then((m) => ({ default: m.HubApp })), defaultSize: { w: 760, h: 640 }, minSize: { w: 480, h: 420 }, singleton: true, pinned: false, launchpadOrder: 16.9 },
 
   // OS apps
   { id: "weather", name: "Weather", icon: "cloud", category: "os", component: () => import("@/apps/WeatherApp").then((m) => ({ default: m.WeatherApp })), defaultSize: { w: 800, h: 600 }, minSize: { w: 400, h: 400 }, singleton: true, pinned: false, launchpadOrder: 19 },

--- a/tests/test_hub_posts.py
+++ b/tests/test_hub_posts.py
@@ -1,0 +1,212 @@
+"""Post objects, chain logic, and image ingest (hub social slice 4).
+
+Covers the things slice 4 in ``docs/design/hub-social-network-foundation.md``
+calls out:
+
+- **chain append/verify**: posts append to a per-author hash chain (``seq`` +
+  ``prev``) and the chain verifies (linkage + signatures) end to end;
+- **tamper detection**: altering a stored post's body, or breaking a chain
+  ``prev`` link, fails verification;
+- **tombstone drops content and keeps the chain verifiable**: deleting a post
+  drops its body and blobs but the chain index survives, so the chain still
+  verifies and the head advances;
+- **EXIF stripped**: image ingest re-encodes and removes EXIF metadata before
+  the bytes are hashed into a blob.
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+import pytest_asyncio
+from PIL import Image
+
+from tinyagentos.hub import identity, posts
+from tinyagentos.hub import store as hub_store
+
+
+@pytest.fixture
+def data_dir(tmp_path, monkeypatch):
+    # Colocate the identity keystore and hub store under an isolated dir, exactly
+    # as production resolves them from TAOS_DATA_DIR.
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+@pytest_asyncio.fixture
+async def store(data_dir):
+    s = hub_store.HubStore(hub_store.default_db_path())
+    await s.init()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+class TestChainAppendVerify:
+    @pytest.mark.asyncio
+    async def test_posts_append_in_chain_order(self, store, data_dir):
+        p1 = await posts.append_post(store, visibility="public", text="first")
+        p2 = await posts.append_post(store, visibility="circle", text="second")
+        p3 = await posts.append_post(store, visibility="public", text="third")
+
+        # seq + prev link the chain; prev of p1 is None.
+        assert p1["seq"] == 1 and p1["prev"] is None
+        assert p2["seq"] == 2 and p2["prev"] == hub_store.object_hash(p1)
+        assert p3["seq"] == 3 and p3["prev"] == hub_store.object_hash(p2)
+
+        # Each is signed by this node and verifies against its own key.
+        pub = identity.public_identity()["signing_pubkey"]
+        for p in (p1, p2, p3):
+            assert hub_store.verify_object(p, pub) is True
+
+    @pytest.mark.asyncio
+    async def test_verify_chain_passes_for_intact_chain(self, store, data_dir):
+        await posts.append_post(store, visibility="public", text="a")
+        await posts.append_post(store, visibility="circle", text="b")
+        await posts.append_post(store, visibility="public", text="c")
+        ok, error = await posts.verify_chain(store, identity.signing_fingerprint())
+        assert ok is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_timeline_lists_own_posts_in_order(self, store, data_dir):
+        await posts.append_post(store, visibility="public", text="a")
+        await posts.append_post(store, visibility="circle", text="b")
+        timeline = await store.list_posts(identity.signing_fingerprint())
+        assert [p["body"]["text"] for p in timeline] == ["a", "b"]
+        # list_posts augments each post with its content-address hash.
+        assert all(p.get("hash") for p in timeline)
+
+
+class TestTamperDetection:
+    @pytest.mark.asyncio
+    async def test_tampered_post_body_fails_object_verify(self, store, data_dir):
+        pub = identity.public_identity()["signing_pubkey"]
+        p = await posts.append_post(store, visibility="public", text="original")
+        assert hub_store.verify_object(p, pub) is True
+        tampered = {**p, "body": {"text": "edited", "format": "md-subset"}}
+        assert hub_store.verify_object(tampered, pub) is False
+
+    @pytest.mark.asyncio
+    async def test_tampered_stored_body_fails_chain_verify(self, store, data_dir):
+        author = identity.signing_fingerprint()
+        p = await posts.append_post(store, visibility="public", text="real")
+        await posts.append_post(store, visibility="circle", text="more")
+
+        # Mutate the stored body in place (same content-address key) so the
+        # signature no longer matches the bytes -> chain verification must fail.
+        tampered_body = hub_store.canonical_json(
+            {**p, "body": {"text": "hacked", "format": "md-subset"}}
+        )
+        await store._db.execute(
+            "UPDATE hub_objects SET body = ? WHERE hash = ?",
+            (tampered_body, hub_store.object_hash(p)),
+        )
+        await store._db.commit()
+
+        ok, error = await posts.verify_chain(store, author)
+        assert ok is False
+        assert error is not None and "tampered" in error
+
+    @pytest.mark.asyncio
+    async def test_broken_prev_link_fails_chain_verify(self, store, data_dir):
+        author = identity.signing_fingerprint()
+        await posts.append_post(store, visibility="public", text="a")
+        await posts.append_post(store, visibility="circle", text="b")
+
+        # Break the chain: point the second entry's prev at the wrong hash.
+        await store._db.execute(
+            "UPDATE hub_chain SET prev_hash = 'deadbeef' WHERE seq = 2 AND author = ?",
+            (author,),
+        )
+        await store._db.commit()
+
+        ok, error = await posts.verify_chain(store, author)
+        assert ok is False
+        assert error is not None and "chain broken" in error
+
+
+class TestTombstone:
+    @pytest.mark.asyncio
+    async def test_delete_drops_content_but_keeps_chain_verifiable(self, store, data_dir):
+        author = identity.signing_fingerprint()
+        await posts.append_post(store, visibility="public", text="keep me")
+        p2 = await posts.append_post(store, visibility="circle", text="delete me")
+
+        tomb = await posts.delete_post(store, hub_store.object_hash(p2))
+
+        # The post body and its blobs are gone from the stores...
+        assert await store.get_object(hub_store.object_hash(p2)) is None
+        # ...but the tombstone is a real chain entry (next seq, prev links head).
+        assert tomb["type"] == "tombstone"
+        assert tomb["seq"] == 3
+        assert tomb["prev"] == hub_store.object_hash(p2)
+        assert tomb["target"] == hub_store.object_hash(p2)
+
+        # The chain still verifies (index survived) and the head advanced to the
+        # tombstone; the deleted post no longer appears in the own-timeline.
+        ok, error = await posts.verify_chain(store, author)
+        assert ok is True
+        assert error is None
+        head = await store.get_chain_head(author)
+        assert head["seq"] == 3 and head["type"] == "tombstone"
+        timeline = await store.list_posts(author)
+        assert [p["body"]["text"] for p in timeline] == ["keep me"]
+
+    @pytest.mark.asyncio
+    async def test_delete_drops_referenced_blobs(self, store, data_dir):
+        # Store a blob, build a post that references it, then delete the post.
+        blob = b"\x89PNG\r\n\x1a\n fake png bytes"
+        h = await store.put_blob(blob, mime="image/png")
+        post = await posts.append_post(
+            store, visibility="public", text="with image",
+            attachments=[{"blob": h, "size": len(blob), "mime": "image/png"}],
+        )
+        assert (await store.get_blob(h)) is not None
+        await posts.delete_post(store, hub_store.object_hash(post))
+        assert await store.get_blob(h) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_post_raises(self, store, data_dir):
+        with pytest.raises(ValueError):
+            await posts.delete_post(store, "nonexistent-hash")
+
+
+class TestImageIngest:
+    def _make_exif_jpeg(self) -> bytes:
+        # Build a JPEG carrying EXIF metadata (a Make tag), so we can prove the
+        # ingest path strips it.
+        img = Image.new("RGB", (16, 16), (120, 60, 200))
+        exif = img.getexif()
+        exif[0x010F] = "LeakyCamera"  # Make
+        buf = io.BytesIO()
+        img.save(buf, "JPEG", exif=exif.tobytes())
+        return buf.getvalue()
+
+    def test_ingest_strips_exif_and_returns_blob(self, data_dir):
+        raw = self._make_exif_jpeg()
+        # The source really carries EXIF.
+        assert "LeakyCamera".encode() in raw or b"Exif" in raw
+
+        out = posts.ingest_image(raw, "image/jpeg")
+
+        assert out["mime"] == "image/webp"
+        assert out["size"] > 0
+        assert out["blob"] == __import__("hashlib").sha256(out["data"]).hexdigest()
+        # The re-encoded output must not carry the source EXIF string.
+        assert b"LeakyCamera" not in out["data"]
+        reopened = Image.open(io.BytesIO(out["data"]))
+        assert "exif" not in reopened.info
+
+    def test_ingest_caps_large_dimensions(self, data_dir):
+        big = Image.new("RGB", (4000, 3000), (10, 20, 30))
+        buf = io.BytesIO()
+        big.save(buf, "PNG")
+        out = posts.ingest_image(buf.getvalue(), "image/png")
+        reopened = Image.open(io.BytesIO(out["data"]))
+        assert max(reopened.size) <= posts.MAX_IMAGE_DIMENSION
+
+    def test_ingest_rejects_non_image(self, data_dir):
+        with pytest.raises(ValueError):
+            posts.ingest_image(b"this is not an image", "text/plain")

--- a/tests/test_routes_hub_slice4.py
+++ b/tests/test_routes_hub_slice4.py
@@ -1,0 +1,108 @@
+"""Local hub post routes (hub social slice 4).
+
+Exercises publishing a signed post (with the default friends-only visibility and
+an inline image attachment that gets EXIF-stripped on ingest), reading the
+own-timeline from the local store, and deleting a post via a signed tombstone
+that drops its content while the chain stays verifiable. The taos.my directory is
+not involved in slice 4 (no peer sync), so no upstream mocking is needed.
+"""
+from __future__ import annotations
+
+import base64
+import io
+
+import pytest
+from PIL import Image
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hub_data(tmp_data_dir, monkeypatch):
+    # Both the identity keystore and the hub store resolve from TAOS_DATA_DIR, so
+    # pointing it at the per-test data dir keeps every request hermetic.
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_data_dir))
+    return tmp_data_dir
+
+
+def _png_data_uri() -> str:
+    img = Image.new("RGB", (8, 8), (200, 100, 50))
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    return "data:image/png;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+class TestHubPostRoutes:
+    @pytest.mark.asyncio
+    async def test_create_post_defaults_to_circle_and_is_signed(self, client):
+        resp = await client.post("/api/hub/posts", json={"text": "hello hub"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "ok"
+        post = body["post"]
+        assert post["visibility"] == "circle"  # loud default
+        assert post["seq"] == 1
+        assert post["prev"] is None
+        assert post["sig"]
+        assert post["body"]["text"] == "hello hub"
+
+    @pytest.mark.asyncio
+    async def test_public_visibility_is_honored(self, client):
+        resp = await client.post(
+            "/api/hub/posts", json={"text": "broadcast", "visibility": "public"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["post"]["visibility"] == "public"
+
+    @pytest.mark.asyncio
+    async def test_invalid_visibility_rejected(self, client):
+        resp = await client.post(
+            "/api/hub/posts", json={"text": "x", "visibility": "secret"}
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_attachment_is_ingested_and_exif_free(self, client):
+        resp = await client.post(
+            "/api/hub/posts",
+            json={"text": "with pic", "attachments": [{"data": _png_data_uri(), "mime": "image/png"}]},
+        )
+        assert resp.status_code == 200
+        post = resp.json()["post"]
+        assert len(post["attachments"]) == 1
+        att = post["attachments"][0]
+        assert att["mime"] == "image/webp"  # re-encoded
+        assert att["blob"]
+
+    @pytest.mark.asyncio
+    async def test_timeline_lists_own_posts(self, client):
+        await client.post("/api/hub/posts", json={"text": "one"})
+        await client.post("/api/hub/posts", json={"text": "two", "visibility": "public"})
+
+        resp = await client.get("/api/hub/timeline")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["state"] == "ok"
+        assert [p["body"]["text"] for p in body["posts"]] == ["one", "two"]
+        assert all(p.get("hash") for p in body["posts"])
+
+    @pytest.mark.asyncio
+    async def test_delete_tombstones_post_and_removes_from_timeline(self, client):
+        await client.post("/api/hub/posts", json={"text": "keep"})
+        created = await client.post("/api/hub/posts", json={"text": "gone"})
+        post_hash = created.json()["post"]["hash"]
+
+        resp = await client.post(f"/api/hub/posts/{post_hash}/delete")
+        assert resp.status_code == 200
+        tomb = resp.json()["tombstone"]
+        assert tomb["type"] == "tombstone"
+        assert tomb["target"] == post_hash
+
+        timeline = await client.get("/api/hub/timeline")
+        texts = [p["body"]["text"] for p in timeline.json()["posts"]]
+        assert texts == ["keep"]
+        # The deleted post body is gone from the store.
+        assert all(p["hash"] != post_hash for p in timeline.json()["posts"])
+
+    @pytest.mark.asyncio
+    async def test_delete_unknown_post_404(self, client):
+        resp = await client.post("/api/hub/posts/nope/delete")
+        assert resp.status_code == 404

--- a/tinyagentos/hub/__init__.py
+++ b/tinyagentos/hub/__init__.py
@@ -2,9 +2,9 @@
 
     See ``docs/design/hub-social-network-foundation.md``. This package holds the
     controller-side node engine: the identity keystore (slice 1), the object
-    store + canonical-JSON/sign helpers (slice 2), and the follow / friend /
-    circle relationship statements (slice 3). Later slices add the chain logic,
-    sync workers, and peer server. Directory calls reach taos.my through
-    ``tinyagentos/routes/account_proxy.py`` additions; the browser never sees the
-    taos.my base URL.
+    store + canonical-JSON/sign helpers (slice 2), the follow / friend /
+    circle relationship statements (slice 3), and the post chain + image ingest
+    (slice 4). Later slices add the sync workers and peer server. Directory calls
+    reach taos.my through ``tinyagentos/routes/account_proxy.py`` additions; the
+    browser never sees the taos.my base URL.
     """

--- a/tinyagentos/hub/posts.py
+++ b/tinyagentos/hub/posts.py
@@ -1,0 +1,258 @@
+"""Post objects + chain logic + image ingest -- hub social slice 4.
+
+See ``docs/design/hub-social-network-foundation.md`` ("Post", "Data model", and
+the slice plan, slice 4). This is the data-model slice that makes posts real:
+the per-author hash *chain* (``seq`` + ``prev``), append, verification, signed
+tombstones, and image ingest (re-encode, strip EXIF, blob store). There is still
+no peer sync (slice 5); this slice only makes the node's own posts correct and
+self-verifying, and surfaces them in the own-timeline.
+
+Chain shape (design "Post")::
+
+    {"type": "post", "author": <fingerprint>, "seq": N, "prev": <hash|null>,
+     "created_at": <iso>, "visibility": "circle"|"public",
+     "body": {"text": ..., "format": "md-subset"},
+     "attachments": [{"blob": <sha256>, "size": int, "mime": str}],
+     "sig": <ed25519 over canonical bytes>}
+
+``seq`` + ``prev`` make each author's posts a hash chain: total order within an
+author (no clock trust needed), tamper evidence (a cacher or a tamperer cannot
+alter or reorder a post without breaking the chain), and cheap gap detection.
+The chain index (``hub_chain`` in the store) records every entry's hash and its
+``prev`` even after a post body is dropped by a tombstone, so the chain stays
+verifiable after deletion (design "Deletion: signed tombstones, honestly").
+
+Privacy tiers (design "Privacy tiers"): two tiers, enforced by encryption in
+slice 7. Until then a ``circle`` (friends-only) post is, per the design's
+explicitly-temporary note, labeled as such and enforced later by
+serve-authorization; the composer makes the choice loud. The body for both tiers
+is plaintext here and slice 7 wraps it.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+from datetime import datetime, timezone
+from typing import Optional
+
+from tinyagentos.hub import identity, store as hub_store
+
+# Post visibility tiers (design "Privacy tiers"). Slice 7 adds real friends-only
+# encryption; until then a "circle" post is enforced by serve-authorization only
+# and the composer labels it accordingly (design, slice 7 note).
+POST_VISIBILITY = ("public", "circle")
+
+# Cap image dimensions on ingest so cached blobs stay small (design open-question
+# 4: images capped per post). Larger inputs are downscaled before re-encoding.
+MAX_IMAGE_DIMENSION = 2048
+
+# Re-encode ingested images to this format. WEBP keeps quality at a small size and
+# (unlike JPEG) does not carry the source EXIF through a re-save, which is exactly
+# the strip we want.
+_INGEST_FORMAT = "WEBP"
+_INGEST_MIME = "image/webp"
+_INGEST_QUALITY = 85
+
+
+def _now_iso() -> str:
+    """UTC ISO-8601 without microseconds, matching the design's ``created_at``."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# --- post object --------------------------------------------------------------
+
+
+def build_post(
+    *,
+    visibility: str,
+    text: str,
+    attachments: Optional[list] = None,
+    author: Optional[str] = None,
+) -> dict:
+    """Build an *unsigned* post object (design "Post").
+
+    ``author`` defaults to this node's signing fingerprint, so the common case
+    (publishing your own post) needs no key handling from the caller. ``seq`` and
+    ``prev`` are left at 0/None here; :func:`append_post` fills them from the
+    chain head before signing. Pass :func:`store.sign_object` over the result to
+    sign it (or just call :func:`append_post`, which does).
+    """
+    if visibility not in POST_VISIBILITY:
+        raise ValueError(
+            f"invalid visibility {visibility!r}; expected one of {POST_VISIBILITY}"
+        )
+    return {
+        "type": "post",
+        "author": author or identity.signing_fingerprint(),
+        "seq": 0,
+        "prev": None,
+        "created_at": _now_iso(),
+        "visibility": visibility,
+        "body": {"text": text, "format": "md-subset"},
+        "attachments": attachments or [],
+    }
+
+
+def build_tombstone(author: str, target_hash: str, seq: int, prev) -> dict:
+    """Build an *unsigned* tombstone for ``target_hash`` (design "Deletion").
+
+    A tombstone is a chain entry in its own right (it carries ``seq``/``prev`` and
+    is signed), so deleting a post extends the chain rather than breaking it.
+    """
+    return {
+        "type": "tombstone",
+        "author": author,
+        "seq": seq,
+        "prev": prev,
+        "created_at": _now_iso(),
+        "target": target_hash,
+    }
+
+
+# --- chain logic --------------------------------------------------------------
+
+
+async def next_chain_position(store: hub_store.HubStore, author: str) -> tuple[int, Optional[str]]:
+    """Return ``(next_seq, prev_hash)`` for appending to ``author``'s chain.
+
+    The first entry is ``seq=1`` with ``prev=None``; every later entry continues
+    from the current head's hash, which is what makes the chain tamper-evident.
+    """
+    head = await store.get_chain_head(author)
+    if head is None:
+        return 1, None
+    return head["seq"] + 1, head["hash"]
+
+
+async def append_post(
+    store: hub_store.HubStore,
+    *,
+    visibility: str,
+    text: str,
+    attachments: Optional[list] = None,
+    author: Optional[str] = None,
+) -> dict:
+    """Build, chain-position, sign, and store a post; return the signed post.
+
+    Fills ``seq``/``prev`` from the live chain head so the new post continues the
+    hash chain, signs it with this node's key, and records it in both the object
+    store and the permanent chain index.
+    """
+    author = author or identity.signing_fingerprint()
+    seq, prev = await next_chain_position(store, author)
+    post = build_post(
+        visibility=visibility, text=text, attachments=attachments, author=author
+    )
+    post["seq"] = seq
+    post["prev"] = prev
+    signed = hub_store.sign_object(post)
+    await store.put_chain_object(signed)
+    return signed
+
+
+async def delete_post(
+    store: hub_store.HubStore,
+    post_hash: str,
+    author: Optional[str] = None,
+) -> dict:
+    """Tombstone a post: append a signed tombstone and drop the post's content.
+
+    Compliant nodes drop the post body and its blobs on receipt (design
+    "Deletion"). The tombstone itself remains in the chain index so the chain
+    stays verifiable. Raises ``ValueError`` if the post is unknown.
+    """
+    author = author or identity.signing_fingerprint()
+    post = await store.get_object(post_hash)
+    if post is None:
+        raise ValueError("post not found")
+    seq, prev = await next_chain_position(store, author)
+    tomb = build_tombstone(author, post_hash, seq, prev)
+    signed_tomb = hub_store.sign_object(tomb)
+    await store.put_chain_object(signed_tomb)
+    # Drop the post body and every blob it referenced. The tombstone's index row
+    # survives, so the chain head advances and stays verifiable.
+    for att in post.get("attachments") or []:
+        blob = att.get("blob") if isinstance(att, dict) else None
+        if blob:
+            await store.drop_blob(blob)
+    await store.drop_object(post_hash)
+    return signed_tomb
+
+
+async def verify_chain(store: hub_store.HubStore, author: str) -> tuple[bool, Optional[str]]:
+    """Walk ``author``'s chain index and verify linkage + signatures.
+
+    Returns ``(ok, error)``. ``ok`` is False (with a human-readable ``error``)
+    when any ``prev`` does not link to the previous entry's hash (chain broken /
+    reordered) or when any entry that still has its body fails signature
+    verification (tampered). Entries whose body was dropped by a tombstone are
+    linkage-checked only, since their signature can no longer be recomputed,
+    which is exactly why the chain index must persist past deletion.
+    """
+    entries = await store.list_chain_entries(author)
+    pub = identity.public_identity()["signing_pubkey"]
+    prev_hash: Optional[str] = None
+    for entry in entries:
+        if entry.get("prev_hash") != prev_hash:
+            return (
+                False,
+                f"seq {entry['seq']}: prev {entry.get('prev_hash')!r} "
+                f"does not link to previous entry {prev_hash!r} (chain broken)",
+            )
+        obj = await store.get_object(entry["hash"])
+        if obj is not None and not hub_store.verify_object(obj, pub):
+            return False, f"seq {entry['seq']}: signature invalid (tampered)"
+        prev_hash = entry["hash"]
+    return True, None
+
+
+# --- image ingest -------------------------------------------------------------
+
+
+def ingest_image(raw: bytes, mime: Optional[str] = None) -> dict:
+    """Re-encode and strip EXIF from an image, returning a blob-ready dict.
+
+    The image is decoded, orientation is applied (so it renders upright), it is
+    flattened to RGB, downscaled if larger than ``MAX_IMAGE_DIMENSION``, and
+    re-encoded to WEBP. Re-encoding to WEBP does not copy the source EXIF, so the
+    output carries no metadata (design: "Images are re-encoded on ingest (strip
+    EXIF, cap dimensions) before hashing"). Returns
+    ``{"blob", "size", "mime", "data"}``; ``data`` is the bytes the caller stores
+    in the blob store and ``blob`` is its SHA-256 content address. Raises
+    ``ValueError`` on non-image input.
+    """
+    try:
+        from PIL import Image, ImageOps
+    except ImportError as exc:  # pragma: no cover - Pillow is a hard dep for ingest
+        raise ValueError("image ingest requires Pillow") from exc
+
+    try:
+        img = Image.open(io.BytesIO(raw))
+        # Apply EXIF orientation, then drop the EXIF: ImageOps.exif_transpose reads
+        # the orientation tag and bakes it into the pixels, so the subsequent
+        # re-save needs no EXIF and writes none.
+        img = ImageOps.exif_transpose(img)
+        img = img.convert("RGB")
+        if max(img.size) > MAX_IMAGE_DIMENSION:
+            img.thumbnail((MAX_IMAGE_DIMENSION, MAX_IMAGE_DIMENSION))
+        buf = io.BytesIO()
+        img.save(buf, format=_INGEST_FORMAT, quality=_INGEST_QUALITY)
+        data = buf.getvalue()
+    except Exception as exc:  # noqa: BLE001 - any decode failure is "not an image"
+        raise ValueError(f"invalid image: {exc}") from exc
+
+    return {
+        "blob": hashlib.sha256(data).hexdigest(),
+        "size": len(data),
+        "mime": _INGEST_MIME,
+        "data": data,
+    }
+
+
+def decode_attachment_data(data: str) -> bytes:
+    """Decode an ``attachment.data`` base64 string (with or without a data: URI
+    prefix) into raw bytes for :func:`ingest_image`."""
+    if "," in data and data.strip().startswith("data:"):
+        data = data.split(",", 1)[1]
+    return base64.b64decode(data)

--- a/tinyagentos/hub/store.py
+++ b/tinyagentos/hub/store.py
@@ -165,6 +165,19 @@ CREATE TABLE IF NOT EXISTS hub_blobs (
     created_at REAL NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS hub_chain (
+    author    TEXT NOT NULL,
+    seq       INTEGER NOT NULL,
+    hash      TEXT NOT NULL,   -- content address of the chain entry (post or tombstone)
+    prev_hash TEXT,           -- previous chain entry hash (NULL for seq 1)
+    type      TEXT NOT NULL,  -- "post" | "tombstone"
+    target    TEXT,           -- tombstone target post hash
+    created_at REAL NOT NULL,
+    PRIMARY KEY (author, seq)
+);
+CREATE INDEX IF NOT EXISTS idx_hub_chain_author_seq
+    ON hub_chain(author, seq);
+
 CREATE TABLE IF NOT EXISTS hub_relationships (
     peer        TEXT NOT NULL,   -- the other party's signing fingerprint
     kind        TEXT NOT NULL,   -- follow_out/follow_in/friend/cache_grant/
@@ -405,6 +418,90 @@ class HubStore(BaseStore):
     async def has_edge(self, peer: str, kind: str) -> bool:
         """True when a relationship row exists for ``(peer, kind)``."""
         return await self.get_relationship(peer, kind) is not None
+
+    # ---------------------------------------------------------------- chain
+    async def put_chain_object(self, obj: dict) -> str:
+        """Store a signed chain entry (post or tombstone) and record it in the
+        per-author chain index.
+
+        The index (``hub_chain``) outlives the object body: when a post is
+        tombstoned its body is dropped but its index row (hash, prev, seq)
+        remains, so the chain stays verifiable after deletion (design "Deletion").
+        """
+        for field in ("author", "type", "sig", "seq"):
+            if obj.get(field) in (None, ""):
+                raise ValueError(f"chain object missing required field {field!r}")
+        h = object_hash(obj)
+        await self.put_object(obj)
+        await self._db.execute(
+            "INSERT OR IGNORE INTO hub_chain "
+            "(author, seq, hash, prev_hash, type, target, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                obj["author"],
+                obj["seq"],
+                h,
+                obj.get("prev"),
+                obj["type"],
+                obj.get("target"),
+                time.time(),
+            ),
+        )
+        await self._db.commit()
+        return h
+
+    async def get_chain_head(self, author: str) -> dict | None:
+        """The last chain entry for ``author`` by seq (None if the chain is empty)."""
+        cur = await self._db.execute(
+            "SELECT author, seq, hash, prev_hash, type, target FROM hub_chain "
+            "WHERE author = ? ORDER BY seq DESC LIMIT 1",
+            (author,),
+        )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        return _row(cur.description, row)
+
+    async def list_chain_entries(self, author: str) -> list[dict]:
+        """All chain entries for ``author`` in seq order (posts and tombstones)."""
+        cur = await self._db.execute(
+            "SELECT author, seq, hash, prev_hash, type, target FROM hub_chain "
+            "WHERE author = ? ORDER BY seq ASC",
+            (author,),
+        )
+        rows = await cur.fetchall()
+        return [_row(cur.description, r) for r in rows]
+
+    async def list_posts(self, author: str) -> list[dict]:
+        """The author's own posts that still have a body, in chain (seq) order.
+
+        Tombstoned posts (body dropped) do not appear here, so this is exactly
+        the own-timeline (design, slice 4). Each returned post is augmented with
+        its content-address ``hash`` (the ``hub_objects`` primary key) so a
+        client can reference it for deletion.
+        """
+        cur = await self._db.execute(
+            "SELECT hash, body FROM hub_objects WHERE author = ? AND type = 'post' "
+            "ORDER BY seq ASC",
+            (author,),
+        )
+        rows = await cur.fetchall()
+        out = []
+        for h, body in rows:
+            post = json.loads(body)
+            post["hash"] = h
+            out.append(post)
+        return out
+
+    async def drop_object(self, obj_hash: str) -> None:
+        """Delete an object body from ``hub_objects`` (tombstone drops content)."""
+        await self._db.execute("DELETE FROM hub_objects WHERE hash = ?", (obj_hash,))
+        await self._db.commit()
+
+    async def drop_blob(self, blob_hash: str) -> None:
+        """Delete a blob from ``hub_blobs`` (tombstone drops cached media)."""
+        await self._db.execute("DELETE FROM hub_blobs WHERE hash = ?", (blob_hash,))
+        await self._db.commit()
 
     # ---------------------------------------------------------------- profiles
     async def get_profile(self, author: str) -> dict | None:

--- a/tinyagentos/routes/hub.py
+++ b/tinyagentos/routes/hub.py
@@ -35,7 +35,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from tinyagentos.auth_context import CurrentUser, current_user
-from tinyagentos.hub import identity, relationships, store as hub_store
+from tinyagentos.hub import identity, posts, relationships, store as hub_store
 from tinyagentos.routes.account_proxy import _forward_to
 
 logger = logging.getLogger(__name__)
@@ -500,3 +500,107 @@ async def lookup_presence(
         status_code=upstream.status_code,
         media_type=upstream.media_type,
     )
+
+
+# --- slice 4: posts, own timeline, tombstone -----------------------------------
+
+
+class PostIn(BaseModel):
+    visibility: str = "circle"  # friends-only by default (design: composer default)
+    text: str = ""
+    # Optional inline attachments, each {"data": <base64|data URI>, "mime": str}.
+    # The server re-encodes (strips EXIF, caps dimensions) and stores the blob.
+    attachments: list | None = None
+
+
+@router.post("/api/hub/posts")
+async def create_post(
+    body: PostIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Publish a signed post to this node's own chain (design "Post", slice 4).
+
+    The visibility switch defaults to ``circle`` (friends-only), the design's
+    loud default. Inline image attachments are re-encoded and their EXIF stripped
+    (``posts.ingest_image``) before the blob is stored and referenced by hash;
+    the post body itself only ever carries the blob hash, never the bytes. The
+    post is chain-positioned and signed before it lands in the store, so it is
+    self-verifying the moment it is created.
+    """
+    identity.load_or_create()
+    store = await _get_store(request)
+    attachments: list[dict] = []
+    if body.attachments:
+        for att in body.attachments:
+            if not isinstance(att, dict) or not att.get("data"):
+                return JSONResponse(
+                    {"error": "each attachment needs base64 'data'"},
+                    status_code=400,
+                )
+            try:
+                raw = posts.decode_attachment_data(str(att["data"]))
+                ingested = posts.ingest_image(raw, att.get("mime"))
+            except ValueError as exc:
+                return JSONResponse({"error": str(exc)}, status_code=400)
+            await store.put_blob(ingested["data"], mime=ingested["mime"])
+            attachments.append(
+                {"blob": ingested["blob"], "size": ingested["size"], "mime": ingested["mime"]}
+            )
+    try:
+        post = await posts.append_post(
+            store,
+            visibility=body.visibility,
+            text=body.text,
+            attachments=attachments or None,
+        )
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    # Include the content address so a client can reference the post (e.g. to
+    # delete it) without recomputing the SHA-256 of the canonical bytes.
+    post = {**post, "hash": hub_store.object_hash(post)}
+    return {"state": "ok", "post": post}
+
+
+@router.get("/api/hub/timeline")
+async def own_timeline(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """The node's own posts, assembled from the local store (design slice 4).
+
+    Slice 4 is single-author only (no peer sync yet): the timeline is every post
+    this node has published that still has a body, in chain (seq) order, with
+    ``created_at`` as the display sort. Degrade states mirror the profile routes:
+    ``no-identity`` before the node has minted a hub identity, else ``ok`` with
+    the posts. The timeline works fully offline from the local store.
+    """
+    if not identity.exists():
+        return {"state": "no-identity"}
+    store = await _get_store(request)
+    fingerprint = identity.signing_fingerprint()
+    posts_list = await store.list_posts(fingerprint)
+    posts_list.sort(key=lambda p: (p.get("created_at", ""), p.get("seq", 0)))
+    return {"state": "ok", "posts": posts_list}
+
+
+@router.post("/api/hub/posts/{post_hash}/delete")
+async def delete_post_route(
+    post_hash: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Delete a post via a signed tombstone (design "Deletion", slice 4).
+
+    Appends a tombstone to the chain (advancing the head) and drops the post body
+    and its blobs from the local store; the tombstone's chain-index row survives
+    so the chain stays verifiable. Best-effort: a peer that later pulls will see
+    the tombstone and drop its copy too. Returns the tombstone statement.
+    """
+    identity.load_or_create()
+    store = await _get_store(request)
+    try:
+        tomb = await posts.delete_post(store, post_hash)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=404)
+    return {"state": "ok", "tombstone": tomb}


### PR DESCRIPTION
## Summary

Implements slice 4 of `docs/design/hub-social-network-foundation.md` (the hub social network "Slice plan"), building on the merged slices 1 to 3 (identity, profile store, follow/friend/circle).

- `tinyagentos/hub/posts.py`: per-author hash chain (`seq`/`prev`), signed append, `verify_chain` (linkage + signatures), signed tombstones, and image ingest (re-encode, strip EXIF, blob store).
- `tinyagentos/hub/store.py`: new `hub_chain` index (survives tombstones so the chain stays verifiable), plus `put_chain_object`, `get_chain_head`, `list_chain_entries`, `drop_object`, `drop_blob`, `list_posts` (own-timeline, augmented with content-address hash).
- `tinyagentos/routes/hub.py`: `POST /api/hub/posts`, `GET /api/hub/timeline`, `POST /api/hub/posts/{hash}/delete`.
- `desktop/src/apps/HubApp/HubApp.tsx`: composer with a loud friends-only-by-default visibility switch and an own-timeline, registered in the app registry.

No peer sync yet (that is slice 5). Friends-only posts are labeled as such and enforced by serve-authorization later (slice 7), per the design's explicitly-temporary note.

## Verification

- `tests/test_hub_posts.py`: chain append/verify, tamper detection, tombstone drops content and keeps the chain verifiable, EXIF stripped (19 hub tests green).
- `tests/test_routes_hub_slice4.py`: create post (default circle, signed), public visibility, EXIF-free attachment ingest, timeline, tombstone delete.
- `desktop/src/apps/HubApp/HubApp.test.tsx`: composer defaults to Friends-only, publish adds to timeline, delete via tombstone route.
- `ruff` clean; `tsc --noEmit` clean for the app.

Docs-Reviewed: implements the merged design doc (doc-gate requires it for scripts/, app-catalog/, tinyagentos/ changes)