### PR TITLE
fix: map violet and red note colors to valid tldraw palette names

### DIFF
--- a/desktop/src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
+++ b/desktop/src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { elementToShape, shapeType } from "../canvas/element-to-shape";
 import { CanvasElement } from "../canvas/canvas-api";
+import { COLOR_MAP } from "../canvas/shapes/NoteShape";
 
 function makeElement(over: Partial<CanvasElement>): CanvasElement {
   return {
@@ -115,5 +116,23 @@ describe("elementToShape", () => {
       const s = elementToShape(makeElement({ kind: "note", author_kind: "system" as unknown as "user", payload: {} }), "slug");
       expect(s.props.taos_author_kind).toBe("user");
     });
+  });
+
+  it("note: preserves violet color in payload (no fallback to yellow)", () => {
+    const s = elementToShape(makeElement({ kind: "note", payload: { text: "hi", color: "violet", font_size: 14 } }), "slug");
+    expect(s.props.taos_payload.color).toBe("violet");
+    expect(COLOR_MAP["violet"]).toBeDefined();
+  });
+
+  it("note: preserves red color in payload (no fallback to yellow)", () => {
+    const s = elementToShape(makeElement({ kind: "note", payload: { text: "hi", color: "red", font_size: 14 } }), "slug");
+    expect(s.props.taos_payload.color).toBe("red");
+    expect(COLOR_MAP["red"]).toBeDefined();
+  });
+
+  it("note: preserves light-blue color in payload", () => {
+    const s = elementToShape(makeElement({ kind: "note", payload: { text: "hi", color: "light-blue", font_size: 14 } }), "slug");
+    expect(s.props.taos_payload.color).toBe("light-blue");
+    expect(COLOR_MAP["light-blue"]).toBeDefined();
   });
 });

--- a/desktop/src/apps/ProjectsApp/canvas/shapes/NoteShape.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/shapes/NoteShape.tsx
@@ -72,5 +72,7 @@ export class TaosNoteShapeUtil extends ShapeUtil<any> {
 
 const COLOR_MAP: Record<string, string> = {
   yellow: "#FFF3A1", blue: "#BEDDFF", green: "#C8F0BE",
+  violet: "#D0BFFF", red: "#FFC9C9", "light-blue": "#C8E0FF",
   pink: "#FFC8E0", grey: "#E0E0E0",
 };
+export { COLOR_MAP };


### PR DESCRIPTION
Canvas notes with payload.color violet or red fell back to yellow because the tldraw COLOR_MAP in NoteShape.tsx was missing those entries.

Changes:
- Added violet, red, and light-blue mappings to COLOR_MAP in NoteShape.tsx
- Added tests to verify the color strings survive element-to-shape coercion and that COLOR_MAP has the expected entries

Test output:
- 16/16 element-to-shape tests pass
- 60/60 ProjectsApp tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added violet, red, and light-blue color options for notes.

* **Bug Fixes**
  * Fixed note color handling so selected non-default colors are preserved instead of reverting to yellow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->