### PR TITLE
fix(canvas): map text elements to visible taos-text shapes

### DIFF
--- a/desktop/src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
+++ b/desktop/src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
@@ -22,6 +22,7 @@ describe("shapeType", () => {
     expect(shapeType("note")).toBe("taos-note");
     expect(shapeType("link")).toBe("taos-link");
     expect(shapeType("image")).toBe("taos-image");
+    expect(shapeType("text")).toBe("taos-text");
   });
   it("maps unknown kinds to the taos-generic fallback, never built-in geo", () => {
     expect(shapeType("user_shape")).toBe("taos-generic");
@@ -51,6 +52,23 @@ describe("elementToShape", () => {
     const s = elementToShape(makeElement({ kind: "link" }), "slug");
     expect(s.type).toBe("taos-link");
     expect(s.props.taos_kind).toBe("link");
+  });
+
+  it("text: taos_* live in props, payload.text preserved", () => {
+    const s = elementToShape(makeElement({ kind: "text", payload: { text: "hello world" } }), "slug");
+    expect(s.type).toBe("taos-text");
+    expect(s.props.taos_kind).toBe("text");
+    expect(s.props.taos_payload).toEqual({ text: "hello world" });
+  });
+
+  it("text: missing text falls back to empty string", () => {
+    const s = elementToShape(makeElement({ kind: "text", payload: {} }), "slug");
+    expect(s.props.taos_payload).toEqual({ text: "" });
+  });
+
+  it("text: coerces non-string text to string", () => {
+    const s = elementToShape(makeElement({ kind: "text", payload: { text: 42 as unknown as string } }), "slug");
+    expect(s.props.taos_payload.text).toBe("42");
   });
 
   it("fallback: taos_* live in meta, props only carry geometry", () => {

--- a/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
@@ -11,6 +11,7 @@ import { TaosNoteShapeUtil } from "./shapes/NoteShape";
 import { TaosLinkShapeUtil } from "./shapes/LinkShape";
 import { TaosImageShapeUtil } from "./shapes/ImageShape";
 import { TaosGenericShapeUtil } from "./shapes/GenericShape";
+import { TaosTextShapeUtil } from "./shapes/TextShape";
 import { useIsMobile } from "../../../hooks/use-is-mobile";
 
 interface CanvasBoardProps {
@@ -23,6 +24,7 @@ const CUSTOM_SHAPE_UTILS = [
   TaosLinkShapeUtil,
   TaosImageShapeUtil,
   TaosGenericShapeUtil,
+  TaosTextShapeUtil,
 ];
 
 // Self-host tldraw's fonts/translations/icons so they load same-origin.

--- a/desktop/src/apps/ProjectsApp/canvas/element-to-shape.ts
+++ b/desktop/src/apps/ProjectsApp/canvas/element-to-shape.ts
@@ -22,6 +22,7 @@ export function shapeType(kind: string): string {
   if (kind === "note") return "taos-note";
   if (kind === "link") return "taos-link";
   if (kind === "image") return "taos-image";
+  if (kind === "text") return "taos-text";
   return "taos-generic";
 }
 
@@ -77,6 +78,13 @@ function imagePayload(p: any) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+function textPayload(p: any) {
+  return {
+    text: str(p?.text, ""),
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function elementToShape(el: CanvasElement, projectSlug: string): any {
   // Geometry is validated too (T.number), so coerce it as well: a malformed
   // element still places on the board instead of throwing.
@@ -86,7 +94,7 @@ export function elementToShape(el: CanvasElement, projectSlug: string): any {
   const h = num(el.h, 100);
   const rotation = num(el.rotation, 0);
 
-  if (el.kind === "note" || el.kind === "link" || el.kind === "image") {
+  if (el.kind === "note" || el.kind === "link" || el.kind === "image" || el.kind === "text") {
     const taosFields = {
       taos_kind: el.kind,
       taos_payload:
@@ -94,7 +102,9 @@ export function elementToShape(el: CanvasElement, projectSlug: string): any {
           ? notePayload(el.payload)
           : el.kind === "link"
             ? linkPayload(el.payload)
-            : imagePayload(el.payload),
+            : el.kind === "image"
+              ? imagePayload(el.payload)
+              : textPayload(el.payload),
       taos_author_id: str(el.author_id, "user"),
       taos_author_kind: authorKind(el.author_kind),
     };

--- a/desktop/src/apps/ProjectsApp/canvas/shapes/TextShape.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/shapes/TextShape.tsx
@@ -1,0 +1,68 @@
+import {
+  HTMLContainer,
+  ShapeUtil,
+  TLBaseShape,
+  Rectangle2d,
+  T,
+} from "@tldraw/tldraw";
+
+export type TaosTextShape = TLBaseShape<
+  "taos-text",
+  {
+    w: number;
+    h: number;
+    taos_kind: "text";
+    taos_payload: { text: string };
+    taos_author_id: string;
+    taos_author_kind: "user" | "agent";
+  }
+>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class TaosTextShapeUtil extends ShapeUtil<any> {
+  static override type = "taos-text" as const;
+  static override props = {
+    w: T.number, h: T.number,
+    taos_kind: T.literal("text"),
+    taos_payload: T.object({ text: T.string }),
+    taos_author_id: T.string,
+    taos_author_kind: T.literalEnum("user", "agent"),
+  };
+
+  override getDefaultProps(): TaosTextShape["props"] {
+    return {
+      w: 200, h: 100,
+      taos_kind: "text",
+      taos_payload: { text: "" },
+      taos_author_id: "user",
+      taos_author_kind: "user",
+    };
+  }
+  override getGeometry(shape: TaosTextShape) {
+    return new Rectangle2d({ width: shape.props.w, height: shape.props.h, isFilled: true });
+  }
+  override component(shape: TaosTextShape) {
+    const { text } = shape.props.taos_payload;
+    return (
+      <HTMLContainer
+        style={{
+          width: shape.props.w, height: shape.props.h,
+          background: "#ffffff", border: "1px solid rgba(0,0,0,0.15)",
+          padding: 8, borderRadius: 4, fontSize: 14,
+          whiteSpace: "pre-wrap", overflow: "hidden",
+        }}
+      >
+        {shape.props.taos_author_kind === "agent" && (
+          <div style={{ fontSize: 10, opacity: 0.5, marginBottom: 4 }}>
+            by @{shape.props.taos_author_id}
+          </div>
+        )}
+        {text}
+      </HTMLContainer>
+    );
+  }
+  override indicator(shape: TaosTextShape) {
+    return <rect width={shape.props.w} height={shape.props.h} rx={4} />;
+  }
+  override canResize() { return false; }
+}


### PR DESCRIPTION
## Summary
- Maps canvas kind=text to a new taos-text shape util instead of falling through to taos-generic
- Coerces payload.text to string with empty-string default so malformed agent writes still render
- Adds tests for text kind mapping, payload coercion, and missing-field fallback

## Test plan
- cd desktop && npx vitest run src/apps/ProjectsApp/__tests__/element-to-shape.test.ts
- npm run build passes

Fixes #task-tsk-crf3cv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying text elements as dedicated canvas text shapes.
  * Text content now renders with preserved formatting and optional agent author attribution.
  * Text shapes include visual boundaries and automatically size to their content dimensions.

* **Bug Fixes**
  * Text payloads are now normalized consistently, including missing or non-string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->