### PR TITLE
feat(projects): element overview grid, creation flow, and drill-in navigation (slice 3)

### DIFF
--- a/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/CreateProjectDialog.tsx
@@ -1,9 +1,15 @@
 import { useState } from "react";
 import { createPortal } from "react-dom";
-import { projectsApi } from "@/lib/projects";
+import { projectsApi, type ElementType } from "@/lib/projects";
+import { ELEMENT_TYPES, ELEMENT_TYPE_ORDER } from "./elements/types";
 
 const slugify = (s: string) =>
   s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+interface ElementDraft {
+  name: string;
+  type: string;
+}
 
 export function CreateProjectDialog({
   onClose,
@@ -12,29 +18,65 @@ export function CreateProjectDialog({
   onClose: () => void;
   onCreated: () => void;
 }) {
+  const [step, setStep] = useState<1 | 2>(1);
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
   const [slugTouched, setSlugTouched] = useState(false);
   const [description, setDescription] = useState("");
+  const [elements, setElements] = useState<ElementDraft[]>([{ name: "", type: "generic" }]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const onSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (submitting) return;
+  const createProject = async () => {
     const trimmedName = name.trim();
     if (!trimmedName) {
       setError("Name is required.");
-      return;
+      return null;
     }
+    return projectsApi.create({
+      name: trimmedName,
+      slug: slug.trim() || slugify(trimmedName),
+      description: description.trim(),
+    });
+  };
+
+  // Step 1 submit: create the project only (skip elements). Enter-to-submit and
+  // the primary "Create" button both take this path, so a project with no
+  // elements is byte-for-byte today's behaviour.
+  const onSubmitStep1 = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
     setSubmitting(true);
     setError(null);
     try {
-      await projectsApi.create({
-        name: trimmedName,
-        slug: slug.trim() || slugify(trimmedName),
-        description: description.trim(),
-      });
+      await createProject();
+      onCreated();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  // Step 2 submit: create the project, then each named element in parallel.
+  const onSubmitStep2 = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    const named = elements.filter((el) => el.name.trim());
+    setSubmitting(true);
+    setError(null);
+    try {
+      const project = await createProject();
+      if (!project) return;
+      await Promise.all(
+        named.map((el) =>
+          projectsApi.elements.create(project.id, {
+            name: el.name.trim(),
+            slug: slugify(el.name.trim()),
+            type: (el.type || "generic") as ElementType,
+          }),
+        ),
+      );
       onCreated();
     } catch (err) {
       setError(String(err));
@@ -51,57 +93,150 @@ export function CreateProjectDialog({
       className="fixed inset-0 z-[10001] bg-black/50 flex items-center justify-center p-4"
     >
       <form
-        onSubmit={onSubmit}
+        onSubmit={step === 1 ? onSubmitStep1 : onSubmitStep2}
         className="bg-zinc-900 text-zinc-200 p-4 rounded shadow w-full max-w-sm space-y-3"
       >
-        <h3 className="text-lg font-semibold text-zinc-200">New Project</h3>
-        <label className="block text-sm text-zinc-400">
-          Name
-          <input
-            value={name}
-            onChange={(e) => {
-              setName(e.target.value);
-              if (!slugTouched) setSlug(slugify(e.target.value));
-            }}
-            required
-            autoFocus
-            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
-          />
-        </label>
-        <label className="block text-sm text-zinc-400">
-          Slug
-          <input
-            value={slug}
-            onChange={(e) => {
-              setSlug(e.target.value);
-              setSlugTouched(true);
-            }}
-            pattern="[a-z0-9-]+"
-            required
-            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
-          />
-        </label>
-        <label className="block text-sm text-zinc-400">
-          Description
-          <textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            rows={3}
-            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
-          />
-        </label>
+        <h3 className="text-lg font-semibold text-zinc-200">
+          {step === 1 ? "New Project" : "Add elements"}
+        </h3>
+
+        {step === 1 && (
+          <>
+            <label className="block text-sm text-zinc-400">
+              Name
+              <input
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  if (!slugTouched) setSlug(slugify(e.target.value));
+                }}
+                required
+                autoFocus
+                className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+              />
+            </label>
+            <label className="block text-sm text-zinc-400">
+              Slug
+              <input
+                value={slug}
+                onChange={(e) => {
+                  setSlug(e.target.value);
+                  setSlugTouched(true);
+                }}
+                pattern="[a-z0-9-]+"
+                required
+                className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+              />
+            </label>
+            <label className="block text-sm text-zinc-400">
+              Description
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={3}
+                className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+              />
+            </label>
+          </>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-2">
+            <p className="text-xs text-zinc-500">
+              Optional. Give the project a few nested elements. Leave blank to skip.
+            </p>
+            {elements.map((el, i) => (
+              <div key={i} className="flex gap-2 items-center">
+                <input
+                  value={el.name}
+                  onChange={(e) => {
+                    const next = [...elements];
+                    next[i] = { ...next[i]!, name: e.target.value };
+                    setElements(next);
+                  }}
+                  placeholder="Element name"
+                  aria-label={`Element ${i + 1} name`}
+                  className="flex-1 min-w-0 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+                />
+                <select
+                  value={el.type}
+                  onChange={(e) => {
+                    const next = [...elements];
+                    next[i] = { ...next[i]!, type: e.target.value };
+                    setElements(next);
+                  }}
+                  aria-label={`Element ${i + 1} type`}
+                  className="px-2 py-1 bg-zinc-800 text-zinc-100 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+                >
+                  {ELEMENT_TYPE_ORDER.map((t) => (
+                    <option key={t} value={t}>
+                      {ELEMENT_TYPES[t]!.label}
+                      {t === "generic" ? " (default)" : ""}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  aria-label={`Remove element ${i + 1}`}
+                  onClick={() => setElements(elements.filter((_, j) => j !== i))}
+                  className="px-2 py-1 text-zinc-400 hover:text-zinc-200"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => setElements([...elements, { name: "", type: "generic" }])}
+              className="text-sm text-blue-400 hover:text-blue-300"
+            >
+              + Add another element
+            </button>
+          </div>
+        )}
+
         {error && <div role="alert" className="mt-2 text-sm text-red-400">{error}</div>}
+
         <div className="flex justify-end gap-2">
           <button type="button" onClick={onClose} className="px-3 py-1 text-sm text-zinc-300 hover:text-zinc-100 disabled:opacity-50">
             Cancel
           </button>
-          <button
-            type="submit"
-            disabled={submitting}
-            className="px-3 py-1 bg-blue-600 hover:bg-blue-500 rounded text-sm font-medium text-white disabled:opacity-50"
-          >
-            {submitting ? "Creating…" : "Create"}
-          </button>
+          {step === 1 ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setStep(2)}
+                className="px-3 py-1 text-sm text-blue-300 hover:text-blue-200"
+              >
+                Add elements
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="px-3 py-1 bg-blue-600 hover:bg-blue-500 rounded text-sm font-medium text-white disabled:opacity-50"
+              >
+                {submitting ? "Creating…" : "Create"}
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => setStep(1)}
+                disabled={submitting}
+                className="px-3 py-1 text-sm text-zinc-300 hover:text-zinc-100 disabled:opacity-50"
+              >
+                Back
+              </button>
+              <button
+                type="submit"
+                disabled={submitting}
+                className="px-3 py-1 bg-blue-600 hover:bg-blue-500 rounded text-sm font-medium text-white disabled:opacity-50"
+              >
+                {submitting ? "Creating…" : "Create project & elements"}
+              </button>
+            </>
+          )}
         </div>
       </form>
     </div>,

--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { projectsApi, type Project, type ProjectMember } from "@/lib/projects";
+import { projectsApi, type Project, type ProjectMember, type ProjectElement } from "@/lib/projects";
 import { ProjectTaskList } from "./ProjectTaskList";
 import { ProjectMembers } from "./ProjectMembers";
 import { ProjectActivity } from "./ProjectActivity";
@@ -16,9 +16,12 @@ import { useIsMobile } from "../../hooks/use-is-mobile";
 import { WorkspaceTabPills } from "../../components/mobile/WorkspaceTabPills";
 import { ProjectFab } from "./mobile/ProjectFab";
 import { TaskCreateSheet } from "./mobile/TaskCreateSheet";
+import { defaultTabForType } from "./elements/types";
+import { ElementGrid } from "./elements/ElementGrid";
+import { ElementCreateDialog } from "./elements/ElementCreateDialog";
 import styles from "./ProjectsApp.module.css";
 
-type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity" | "decisions" | "routines";
+export type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity" | "decisions" | "routines";
 const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity", "decisions", "routines"];
 
 interface AgentSummary {
@@ -40,6 +43,21 @@ function setTaskParam(taskId: string | null) {
   window.history.pushState({}, "", url);
 }
 
+// The drilled-in element id rides the URL next to `task` so deep links and
+// open-in-new-window work per element (per design doc slice 3).
+function readElementParam(): string | null {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get("element");
+}
+
+function setElementParam(elementId: string | null) {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (elementId) url.searchParams.set("element", elementId);
+  else url.searchParams.delete("element");
+  window.history.pushState({}, "", url);
+}
+
 export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
   const isMobile = useIsMobile();
   const [tab, setTab] = useState<Tab>("workspace");
@@ -49,6 +67,9 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
   const [createSheetOpen, setCreateSheetOpen] = useState(false);
   const [members, setMembers] = useState<ProjectMember[]>([]);
   const [agents, setAgents] = useState<AgentSummary[]>([]);
+  const [elements, setElements] = useState<ProjectElement[]>([]);
+  const [activeElementId, setActiveElementId] = useState<string | null>(() => readElementParam());
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   const handleCreateTask = async ({ title }: { title: string }) => {
     await projectsApi.tasks.create(project.id, { title });
@@ -95,11 +116,41 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
     return () => { cancelled = true; };
   }, []);
 
+  // Elements drive the overview grid and the drill-in navigation. Failure here
+  // must never break the rest of the workspace: fall back to an empty list.
   useEffect(() => {
-    const onPop = () => setOpenTaskId(readTaskParam());
+    let cancelled = false;
+    projectsApi.elements
+      .list(project.id)
+      .then((rows) => {
+        if (cancelled) return;
+        const items = Array.isArray(rows) ? rows : [];
+        setElements(items);
+        // Honour a deep-linked element param once we know the valid ids.
+        const deep = readElementParam();
+        if (deep && items.some((e) => e.id === deep)) {
+          setActiveElementId(deep);
+          const el = items.find((e) => e.id === deep);
+          if (el) setTab(defaultTabForType(el.type));
+        }
+      })
+      .catch(() => { if (!cancelled) setElements([]); });
+    return () => { cancelled = true; };
+  }, [project.id]);
+
+  useEffect(() => {
+    const onPop = () => {
+      setOpenTaskId(readTaskParam());
+      const el = readElementParam();
+      setActiveElementId(el);
+      if (el) {
+        const found = elements.find((e) => e.id === el);
+        if (found) setTab(defaultTabForType(found.type));
+      }
+    };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
-  }, []);
+  }, [elements]);
 
   const agentName = useMemo(() => {
     const byId = new Map<string, AgentSummary>();
@@ -110,6 +161,20 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
     };
   }, [agents]);
 
+  // Resolve a member/agent id to a friendly label for the element card owner
+  // chip. Members are agents, so fall back to the agent roster, then the id.
+  const memberLabel = useMemo(() => {
+    const byId = new Map<string, string>();
+    for (const m of members) byId.set(m.member_id, agentName(m.member_id));
+    for (const a of agents) byId.set(a.id, a.display_name || a.name);
+    return (id: string) => byId.get(id) ?? id;
+  }, [members, agents, agentName]);
+
+  const memberOptions = useMemo(
+    () => members.map((m) => ({ id: m.member_id, label: memberLabel(m.member_id) })),
+    [members, memberLabel],
+  );
+
   const presence = useMemo(
     () => derivePresence({ ownerInitial: "Y", members, agentName }),
     [members, agentName],
@@ -117,6 +182,45 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
 
   const openTask = (id: string) => { setTaskParam(id); setOpenTaskId(id); };
   const closeTask = () => { setTaskParam(null); setOpenTaskId(null); };
+
+  // Element drill-in: scope the board/canvas/files to the element and land on
+  // its type's preferred tab. The id rides the URL for deep links.
+  const openElement = (id: string) => {
+    const el = elements.find((e) => e.id === id);
+    if (!el) return;
+    setElementParam(id);
+    setActiveElementId(id);
+    setTab(defaultTabForType(el.type));
+  };
+  const openProjectView = () => {
+    setElementParam(null);
+    setActiveElementId(null);
+    setTab("workspace");
+  };
+  const refreshElements = () => {
+    projectsApi.elements
+      .list(project.id)
+      .then((rows) => setElements(Array.isArray(rows) ? rows : []))
+      .catch(() => {});
+  };
+
+  // Selecting the workspace tab returns to the element overview grid (clears
+  // any drilled-in element). This is the breadcrumb's "project" home too.
+  const selectTab = (t: Tab) => {
+    if (t === "workspace") {
+      setElementParam(null);
+      setActiveElementId(null);
+    }
+    setTab(t);
+  };
+
+  // The element we are currently scoped to, validated against the live list so
+  // a stale/removed id never silently scopes the board.
+  const scopedElement =
+    activeElementId && elements.some((e) => e.id === activeElementId)
+      ? elements.find((e) => e.id === activeElementId)!
+      : null;
+  const scopedElementId = scopedElement ? scopedElement.id : null;
 
   return (
     <div className="flex flex-col h-full min-h-0">
@@ -150,7 +254,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
           <WorkspaceTabPills
             tabs={tabPills}
             active={tab}
-            onSelect={(id) => setTab(id as Tab)}
+            onSelect={(id) => selectTab(id as Tab)}
           />
         ) : (
           <nav className={styles.tabs} role="tablist">
@@ -162,7 +266,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
                 id={`workspace-tab-${t}`}
                 aria-selected={tab === t}
                 aria-controls={`workspace-tabpanel-${t}`}
-                onClick={() => setTab(t)}
+                onClick={() => selectTab(t)}
                 className={`${styles.tab} ${tab === t ? styles.tabOn : ""}`}
               >
                 {t}
@@ -172,13 +276,38 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         )}
       </header>
 
+      {scopedElement && (
+        <nav className={styles.breadcrumb} aria-label="Breadcrumb">
+          <button type="button" className={styles.crumb} onClick={openProjectView}>
+            {project.name}
+          </button>
+          <span className={styles.crumbSep} aria-hidden>/</span>
+          <span className={`${styles.crumb} ${styles.crumbOn}`} aria-current="page">
+            {scopedElement.name}
+          </span>
+        </nav>
+      )}
+
       <div
         className={tab === "workspace" ? styles.panel : styles.panelPad}
         role="tabpanel"
         id={`workspace-tabpanel-${tab}`}
         aria-labelledby={`workspace-tab-${tab}`}
       >
-        {tab === "workspace" && <ProjectWorkspacePane project={project} />}
+        {tab === "workspace" && (
+          elements.length > 0 ? (
+            <ElementGrid
+              project={project}
+              elements={elements}
+              assigneeName={memberLabel}
+              onOpenElement={openElement}
+              onAddElement={() => setCreateDialogOpen(true)}
+              onOpenProject={openProjectView}
+            />
+          ) : (
+            <ProjectWorkspacePane project={project} />
+          )
+        )}
         {tab === "board" && (
           <>
             {!authResolved ? (
@@ -187,6 +316,7 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
               <ProjectBoard
                 projectId={project.id}
                 currentUserId={currentUserId}
+                elementId={scopedElementId}
                 onOpenTask={openTask}
               />
             ) : (
@@ -233,6 +363,18 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
             onSubmit={handleCreateTask}
           />
         </>
+      )}
+
+      {createDialogOpen && (
+        <ElementCreateDialog
+          projectId={project.id}
+          memberOptions={memberOptions}
+          onClose={() => setCreateDialogOpen(false)}
+          onCreated={() => {
+            setCreateDialogOpen(false);
+            refreshElements();
+          }}
+        />
       )}
     </div>
   );

--- a/desktop/src/apps/ProjectsApp/ProjectsApp.module.css
+++ b/desktop/src/apps/ProjectsApp/ProjectsApp.module.css
@@ -384,6 +384,35 @@
   background: var(--color-accent-strong);
 }
 
+/* breadcrumb (element drill-in) */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 22px 0;
+  font-size: 12.5px;
+  color: var(--color-shell-text-tertiary);
+}
+.crumb {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-shell-text-secondary);
+  font: inherit;
+  padding: 0;
+}
+.crumb:hover {
+  color: var(--color-shell-text);
+}
+.crumbOn {
+  color: var(--color-shell-text);
+  font-weight: 600;
+  cursor: default;
+}
+.crumbSep {
+  color: var(--color-shell-text-tertiary);
+}
+
 /* panel host */
 .panel {
   flex: 1;

--- a/desktop/src/apps/ProjectsApp/__tests__/CreateProjectDialog.elements.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/CreateProjectDialog.elements.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CreateProjectDialog } from "../CreateProjectDialog";
+
+vi.mock("@/lib/projects", () => ({
+  projectsApi: {
+    create: vi.fn().mockResolvedValue({ id: "p1", slug: "p1" }),
+    elements: { create: vi.fn().mockResolvedValue({ id: "e1" }) },
+  },
+}));
+
+import { projectsApi } from "@/lib/projects";
+
+describe("CreateProjectDialog step two (elements)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("skips elements when the primary Create button is used (today's behaviour)", async () => {
+    const onCreated = vi.fn();
+    render(<CreateProjectDialog onClose={() => {}} onCreated={onCreated} />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: /name/i }), {
+      target: { value: "T-Shirt Business" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(projectsApi.create).toHaveBeenCalledTimes(1);
+    expect(projectsApi.elements.create).not.toHaveBeenCalled();
+  });
+
+  it("creates the project and each named element on the second step", async () => {
+    const onCreated = vi.fn();
+    render(<CreateProjectDialog onClose={() => {}} onCreated={onCreated} />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: /name/i }), {
+      target: { value: "T-Shirt Business" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add elements" }));
+
+    // Step two renders an element row.
+    fireEvent.change(screen.getByRole("textbox", { name: /Element 1 name/i }), {
+      target: { value: "Designs" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: /Element 1 type/i }), {
+      target: { value: "design" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create project & elements" }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(projectsApi.create).toHaveBeenCalledTimes(1);
+    expect(projectsApi.elements.create).toHaveBeenCalledWith("p1", {
+      name: "Designs",
+      slug: "designs",
+      type: "design",
+    });
+  });
+
+  it("only creates elements whose name is non-blank", async () => {
+    const onCreated = vi.fn();
+    render(<CreateProjectDialog onClose={() => {}} onCreated={onCreated} />);
+
+    fireEvent.change(screen.getByRole("textbox", { name: /name/i }), {
+      target: { value: "T-Shirt Business" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add elements" }));
+    // Leave the first row blank, add a second row with a name.
+    fireEvent.click(screen.getByRole("button", { name: /Add another element/ }));
+    const nameInputs = screen.getAllByRole("textbox", { name: /Element .* name/ });
+    fireEvent.change(nameInputs[1]!, { target: { value: "Website" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create project & elements" }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(projectsApi.elements.create).toHaveBeenCalledTimes(1);
+    expect(projectsApi.elements.create).toHaveBeenCalledWith("p1", {
+      name: "Website",
+      slug: "website",
+      type: "generic",
+    });
+  });
+});

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectWorkspace.elements.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectWorkspace.elements.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { Project, ProjectElement } from "@/lib/projects";
+import { ProjectWorkspace } from "../ProjectWorkspace";
+
+const h = vi.hoisted(() => ({ current: [] as ProjectElement[] }));
+
+vi.mock("@/lib/projects", () => ({
+  projectsApi: {
+    elements: { list: () => Promise.resolve(h.current) },
+    members: { list: vi.fn().mockResolvedValue([]) },
+    tasks: { create: vi.fn() },
+  },
+}));
+
+vi.mock("../../../hooks/use-is-mobile", () => ({ useIsMobile: () => false }));
+vi.mock("../ProjectWorkspacePane", () => ({ ProjectWorkspacePane: () => <div data-testid="workspace-pane" /> }));
+vi.mock("../board/ProjectBoard", () => ({
+  ProjectBoard: (props: { elementId?: string | null }) => (
+    <div data-testid="board" data-element={props.elementId ?? ""} />
+  ),
+}));
+vi.mock("../board/TaskModal", () => ({ TaskModal: () => <div /> }));
+vi.mock("../canvas/CanvasView", () => ({ CanvasView: () => <div /> }));
+vi.mock("../ProjectTaskList", () => ({ ProjectTaskList: () => <div /> }));
+vi.mock("../ProjectMembers", () => ({ ProjectMembers: () => <div /> }));
+vi.mock("../ProjectActivity", () => ({ ProjectActivity: () => <div /> }));
+vi.mock("../ProjectDecisions", () => ({ ProjectDecisions: () => <div /> }));
+vi.mock("../ProjectRoutines", () => ({ ProjectRoutines: () => <div /> }));
+vi.mock("@/apps/FilesApp", () => ({ FilesApp: () => <div /> }));
+vi.mock("@/apps/MessagesApp", () => ({ MessagesApp: () => <div /> }));
+vi.mock("../elements/ElementCreateDialog", () => ({
+  ElementCreateDialog: () => <div data-testid="create-el-dialog" />,
+}));
+
+const fakeProject: Project = {
+  id: "p1",
+  slug: "p1",
+  name: "T-Shirt Business",
+  description: "",
+  status: "active",
+  created_by: "u1",
+  created_at: 0,
+  updated_at: 0,
+};
+
+const elements: ProjectElement[] = [
+  {
+    id: "e1", project_id: "p1", name: "Designs", slug: "designs", type: "design",
+    description: "", assignee_id: null, settings: {}, created_at: 0, updated_at: 0, archived_at: null,
+    open_tasks: 2, total_tasks: 4,
+  },
+  {
+    id: "e2", project_id: "p1", name: "Website", slug: "website", type: "website",
+    description: "", assignee_id: null, settings: {}, created_at: 0, updated_at: 0, archived_at: null,
+    open_tasks: 1, total_tasks: 3,
+  },
+];
+
+describe("ProjectWorkspace element overview (slice 3)", () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    // The element id rides the URL; jsdom persists location across tests, so
+    // clear any query string left by a prior test's drill-in.
+    window.history.replaceState({}, "", "/");
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn((url: unknown) => {
+      if (String(url).includes("/auth/me")) {
+        return Promise.resolve({ ok: true, json: async () => ({ user: { id: "u1" } }) });
+      }
+      if (String(url).includes("/api/agents")) {
+        return Promise.resolve({ ok: true, json: async () => [] });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    }) as unknown as typeof fetch;
+    h.current = elements;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("shows the element overview grid when the project has elements", async () => {
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    expect(await screen.findByText("Elements")).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Open element Designs/ })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: /Open element Website/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open project-level view" })).toBeInTheDocument();
+    expect(screen.queryByTestId("workspace-pane")).not.toBeInTheDocument();
+  });
+
+  it("regresses to today's workspace pane when there are no elements", async () => {
+    h.current = [];
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    expect(await screen.findByTestId("workspace-pane")).toBeInTheDocument();
+    expect(screen.queryByText("Elements")).not.toBeInTheDocument();
+  });
+
+  it("drills into an element: scopes the board and shows a breadcrumb", async () => {
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    const card = await screen.findByRole("button", { name: /Open element Website/ });
+    await act(async () => {
+      fireEvent.click(card);
+    });
+    expect(screen.getByTestId("board").getAttribute("data-element")).toBe("e2");
+    expect(screen.getByRole("button", { name: "T-Shirt Business" })).toBeInTheDocument();
+    expect(screen.getByText("Website")).toBeInTheDocument();
+  });
+
+  it("returns to the grid via the breadcrumb project link", async () => {
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    const card = await screen.findByRole("button", { name: /Open element Website/ });
+    await act(async () => {
+      fireEvent.click(card);
+    });
+    const crumb = await screen.findByRole("button", { name: "T-Shirt Business" });
+    await act(async () => {
+      fireEvent.click(crumb);
+    });
+    expect(await screen.findByText("Elements")).toBeInTheDocument();
+    expect(screen.queryByTestId("board")).not.toBeInTheDocument();
+  });
+
+  it("opens the element create dialog from the grid", async () => {
+    await act(async () => {
+      render(<ProjectWorkspace project={fakeProject} onChanged={() => {}} />);
+    });
+    const add = await screen.findByRole("button", { name: "+ Add element" });
+    await act(async () => {
+      fireEvent.click(add);
+    });
+    expect(await screen.findByTestId("create-el-dialog")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
+++ b/desktop/src/apps/ProjectsApp/board/BoardToolbar.tsx
@@ -17,6 +17,9 @@ export interface BoardToolbarProps {
   onChangeGroup: (g: GroupBy) => void;
   onChangeFilters: (f: Filters) => void;
   onAddTask?: () => void;
+  /** When scoped to a single element (element drill-in), the filter bar is
+   *  hidden because the element is already the active filter. */
+  hideElementFilter?: boolean;
 }
 
 const VIEWS: ViewMode[] = ["lanes", "kanban", "timeline"];
@@ -96,11 +99,13 @@ export function BoardToolbar(p: BoardToolbarProps) {
 
               <BoardFilters value={p.filters} onChange={p.onChangeFilters} />
 
-              <ElementFilterBar
-                elements={p.elements}
-                value={p.filters.elementId}
-                onChange={(v) => p.onChangeFilters({ ...p.filters, elementId: v })}
-              />
+              {!p.hideElementFilter && (
+                <ElementFilterBar
+                  elements={p.elements}
+                  value={p.filters.elementId}
+                  onChange={(v) => p.onChangeFilters({ ...p.filters, elementId: v })}
+                />
+              )}
 
               <button
                 type="button"
@@ -159,16 +164,25 @@ export function BoardToolbar(p: BoardToolbarProps) {
         aria-label="Search tasks"
       />
       <BoardFilters value={p.filters} onChange={p.onChangeFilters} />
+      {!p.hideElementFilter && (
+        <ElementFilterBar
+          elements={p.elements}
+          value={p.filters.elementId}
+          onChange={(v) => p.onChangeFilters({ ...p.filters, elementId: v })}
+        />
+      )}
       <span className={`${styles.pill} ${p.live ? styles.live : styles.dead}`}>● Live</span>
       {p.onAddTask && (
         <button type="button" className={styles.add} onClick={p.onAddTask}>＋ Task</button>
       )}
     </div>
-    <ElementFilterBar
-      elements={p.elements}
-      value={p.filters.elementId}
-      onChange={(v) => p.onChangeFilters({ ...p.filters, elementId: v })}
-    />
+    {!p.hideElementFilter && (
+      <ElementFilterBar
+        elements={p.elements}
+        value={p.filters.elementId}
+        onChange={(v) => p.onChangeFilters({ ...p.filters, elementId: v })}
+      />
+    )}
     </>
   );
 }

--- a/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/board/ProjectBoard.tsx
@@ -22,6 +22,9 @@ export interface ProjectBoardProps {
   projectId: string;
   currentUserId: string;
   onOpenTask?: (id: string) => void;
+  /** When set, the board is scoped to this element and the element filter bar
+   *  is hidden (the element is the active filter). Used by element drill-in. */
+  elementId?: string | null;
 }
 
 const PERSIST_KEY = (pid: string) => `taos.projects.${pid}.board`;
@@ -36,13 +39,18 @@ const MOBILE_COLUMNS: ReadonlyArray<MobileBoardColumn> = [
 ];
 type ColStatus = "ready" | "claimed" | "closed";
 
-export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBoardProps) {
+export function ProjectBoard({ projectId, currentUserId, onOpenTask, elementId }: ProjectBoardProps) {
   const [viewMode, setViewMode] = useState<ViewMode>("lanes");
   const [groupBy, setGroupBy] = useState<GroupBy>("assignee");
-  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+  const [filters, setFilters] = useState<Filters>({ ...EMPTY_FILTERS, elementId: elementId ?? null });
   const [justClaimed, setJustClaimed] = useState<string | null>(null);
   const [movePopover, setMovePopover] = useState<string | null>(null);
   const [announcement, setAnnouncement] = useState("");
+
+  // Keep the board scoped to the drilled-in element when the prop changes.
+  useEffect(() => {
+    setFilters((f) => (f.elementId === (elementId ?? null) ? f : { ...f, elementId: elementId ?? null }));
+  }, [elementId]);
 
   useEffect(() => {
     try {
@@ -128,7 +136,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
       } catch (err) {
         console.error("DnD call failed", err);
         setTasks(snapshot);
-        window.alert("Could not move card — reverted.");
+        window.alert("Could not move card: reverted.");
         return;
       }
     }
@@ -161,6 +169,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
           onChangeView={setViewMode}
           onChangeGroup={setGroupBy}
           onChangeFilters={setFilters}
+          hideElementFilter={elementId != null}
         />
         <MobileBoardCarousel
           columns={MOBILE_COLUMNS}
@@ -184,6 +193,7 @@ export function ProjectBoard({ projectId, currentUserId, onOpenTask }: ProjectBo
         onChangeView={setViewMode}
         onChangeGroup={setGroupBy}
         onChangeFilters={setFilters}
+        hideElementFilter={elementId != null}
       />
       {viewMode === "kanban" ? (
         <div className={styles.cols}>

--- a/desktop/src/apps/ProjectsApp/elements/ElementCard.tsx
+++ b/desktop/src/apps/ProjectsApp/elements/ElementCard.tsx
@@ -1,0 +1,43 @@
+import type { ProjectElement } from "../../../lib/projects";
+import { elementType } from "./types";
+import styles from "./Elements.module.css";
+
+function timeAgo(ts: number): string {
+  if (!ts) return "recently";
+  const diff = Date.now() / 1000 - ts;
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export interface ElementCardProps {
+  element: ProjectElement;
+  assigneeName?: string | null;
+  onOpen: (id: string) => void;
+}
+
+export function ElementCard({ element, assigneeName, onOpen }: ElementCardProps) {
+  const def = elementType(element.type);
+  return (
+    <button
+      type="button"
+      className={styles.card}
+      onClick={() => onOpen(element.id)}
+      aria-label={`Open element ${element.name}`}
+    >
+      <span className={styles.cardIcon} aria-hidden>{def.icon}</span>
+      <span className={styles.cardBody}>
+        <span className={styles.cardName}>{element.name}</span>
+        <span className={styles.cardType}>{def.label}</span>
+        {element.assignee_id && assigneeName ? (
+          <span className={styles.cardAssignee}>Owner: {assigneeName}</span>
+        ) : null}
+        <span className={styles.cardMeta}>
+          {element.open_tasks ?? 0} open · {element.total_tasks ?? 0} total
+        </span>
+        <span className={styles.cardActivity}>Updated {timeAgo(element.updated_at)}</span>
+      </span>
+    </button>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/elements/ElementCreateDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/elements/ElementCreateDialog.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { projectsApi, type ElementType } from "@/lib/projects";
+import { ELEMENT_TYPES, ELEMENT_TYPE_ORDER } from "./types";
+
+const slugify = (s: string) =>
+  s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+export interface ElementCreateDialogProps {
+  projectId: string;
+  /** Member/agent options for the optional owner picker. */
+  memberOptions: { id: string; label: string }[];
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+export function ElementCreateDialog({
+  projectId,
+  memberOptions,
+  onClose,
+  onCreated,
+}: ElementCreateDialogProps) {
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugTouched, setSlugTouched] = useState(false);
+  const [type, setType] = useState<string>("generic");
+  const [assigneeId, setAssigneeId] = useState<string>("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Name is required.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await projectsApi.elements.create(projectId, {
+        name: trimmedName,
+        slug: slug.trim() || slugify(trimmedName),
+        type: (type || "generic") as ElementType,
+        assignee_id: assigneeId || null,
+        description: description.trim(),
+      });
+      onCreated();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Create element"
+      className="fixed inset-0 z-[10001] bg-black/50 flex items-center justify-center p-4"
+    >
+      <form
+        onSubmit={onSubmit}
+        className="bg-zinc-900 text-zinc-200 p-4 rounded shadow w-full max-w-sm space-y-3"
+      >
+        <h3 className="text-lg font-semibold text-zinc-200">New element</h3>
+        <label className="block text-sm text-zinc-400">
+          Name
+          <input
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              if (!slugTouched) setSlug(slugify(e.target.value));
+            }}
+            autoFocus
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+          />
+        </label>
+        <label className="block text-sm text-zinc-400">
+          Slug
+          <input
+            value={slug}
+            onChange={(e) => {
+              setSlug(e.target.value);
+              setSlugTouched(true);
+            }}
+            pattern="[a-z0-9-]+"
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+          />
+        </label>
+        <label className="block text-sm text-zinc-400">
+          Type
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+          >
+                  {ELEMENT_TYPE_ORDER.map((t) => (
+                    <option key={t} value={t}>
+                      {ELEMENT_TYPES[t]!.label}
+                      {t === "generic" ? " (default)" : ""}
+                    </option>
+                  ))}
+          </select>
+        </label>
+        <label className="block text-sm text-zinc-400">
+          Owner (optional)
+          <select
+            value={assigneeId}
+            onChange={(e) => setAssigneeId(e.target.value)}
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+          >
+            <option value="">None</option>
+            {memberOptions.map((m) => (
+              <option key={m.id} value={m.id}>{m.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-sm text-zinc-400">
+          Description
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full mt-1 px-2 py-1 bg-zinc-800 text-zinc-100 placeholder-zinc-500 rounded outline-none focus:ring-2 focus:ring-zinc-600"
+          />
+        </label>
+        {error && <div role="alert" className="mt-2 text-sm text-red-400">{error}</div>}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 text-sm text-zinc-300 hover:text-zinc-100 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-3 py-1 bg-blue-600 hover:bg-blue-500 rounded text-sm font-medium text-white disabled:opacity-50"
+          >
+            {submitting ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </form>
+    </div>,
+    document.body,
+  );
+}

--- a/desktop/src/apps/ProjectsApp/elements/ElementGrid.tsx
+++ b/desktop/src/apps/ProjectsApp/elements/ElementGrid.tsx
@@ -1,0 +1,75 @@
+import type { Project, ProjectElement } from "../../../lib/projects";
+import { ElementCard } from "./ElementCard";
+import styles from "./Elements.module.css";
+
+export interface ElementGridProps {
+  project: Project;
+  elements: ProjectElement[];
+  /** Resolve a member/agent id to a display name, or null if unknown. */
+  assigneeName: (id: string) => string | null;
+  onOpenElement: (id: string) => void;
+  onAddElement: () => void;
+  onOpenProject: () => void;
+}
+
+export function ElementGrid({
+  project,
+  elements,
+  assigneeName,
+  onOpenElement,
+  onAddElement,
+  onOpenProject,
+}: ElementGridProps) {
+  return (
+    <div className={styles.gridWrap}>
+      <div className={styles.gridHead}>
+        <h2 className={styles.gridTitle}>Elements</h2>
+        <button type="button" className={styles.addBtn} onClick={onAddElement}>
+          + Add element
+        </button>
+      </div>
+      <div className={styles.grid} role="list">
+        <div role="listitem">
+          <button
+            type="button"
+            className={`${styles.card} ${styles.projectCard}`}
+            onClick={onOpenProject}
+            aria-label="Open project-level view"
+          >
+            <span className={styles.cardIcon} aria-hidden>🗂️</span>
+            <span className={styles.cardBody}>
+              <span className={styles.cardName}>{project.name}</span>
+              <span className={styles.cardType}>Project</span>
+              <span className={styles.cardActivity}>All project-level items</span>
+            </span>
+          </button>
+        </div>
+
+        {elements.map((el) => (
+          <div role="listitem" key={el.id}>
+            <ElementCard
+              element={el}
+              assigneeName={assigneeName(el.assignee_id ?? "")}
+              onOpen={onOpenElement}
+            />
+          </div>
+        ))}
+
+        <div role="listitem">
+          <button
+            type="button"
+            className={`${styles.card} ${styles.addTile}`}
+            onClick={onAddElement}
+            aria-label="Add element"
+          >
+            <span className={styles.cardIcon} aria-hidden>+</span>
+            <span className={styles.cardBody}>
+              <span className={styles.cardName}>Add element</span>
+              <span className={styles.cardType}>Create a nested element</span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/elements/Elements.module.css
+++ b/desktop/src/apps/ProjectsApp/elements/Elements.module.css
@@ -1,0 +1,117 @@
+.gridWrap {
+  padding: 16px 22px;
+}
+
+.gridHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.gridTitle {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-shell-text);
+}
+
+.addBtn {
+  background: var(--color-accent-strong);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.addBtn:hover {
+  filter: brightness(1.08);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.card {
+  display: flex;
+  gap: 12px;
+  text-align: left;
+  align-items: flex-start;
+  background: var(--color-shell-surface, #1c1d22);
+  border: 1px solid var(--color-shell-border);
+  border-radius: 12px;
+  padding: 14px;
+  cursor: pointer;
+  color: var(--color-shell-text);
+  font: inherit;
+}
+
+.card:hover {
+  border-color: var(--color-accent-strong);
+}
+
+.cardIcon {
+  flex: none;
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.cardName {
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--color-shell-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cardType {
+  font-size: 11.5px;
+  color: var(--color-shell-text-tertiary);
+  font-weight: 600;
+}
+
+.cardAssignee {
+  font-size: 11.5px;
+  color: var(--color-shell-text-secondary);
+}
+
+.cardMeta {
+  font-size: 12px;
+  color: var(--color-shell-text-secondary);
+}
+
+.cardActivity {
+  font-size: 11px;
+  color: var(--color-shell-text-tertiary);
+}
+
+.projectCard {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.addTile {
+  border-style: dashed;
+  align-items: center;
+}
+
+.addTile .cardName {
+  color: var(--color-accent-strong);
+}

--- a/desktop/src/apps/ProjectsApp/elements/__tests__/ElementCard.test.tsx
+++ b/desktop/src/apps/ProjectsApp/elements/__tests__/ElementCard.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ElementCard } from "../ElementCard";
+import type { ProjectElement } from "../../../../lib/projects";
+
+const base: ProjectElement = {
+  id: "e1",
+  project_id: "p1",
+  name: "My Site",
+  slug: "my-site",
+  type: "website",
+  description: "",
+  assignee_id: null,
+  settings: {},
+  created_at: 0,
+  updated_at: 0,
+  archived_at: null,
+  open_tasks: 3,
+  total_tasks: 5,
+  canvas_items: 2,
+};
+
+describe("ElementCard", () => {
+  it("renders the name, type label, and task counts", () => {
+    render(<ElementCard element={base} onOpen={() => {}} />);
+    expect(screen.getByText("My Site")).toBeInTheDocument();
+    expect(screen.getByText("Website")).toBeInTheDocument();
+    expect(screen.getByText("3 open · 5 total")).toBeInTheDocument();
+  });
+
+  it("shows the owner chip when an assignee is given a name", () => {
+    render(<ElementCard element={{ ...base, assignee_id: "a1" }} assigneeName="Web Agent" onOpen={() => {}} />);
+    expect(screen.getByText("Owner: Web Agent")).toBeInTheDocument();
+  });
+
+  it("hides the owner chip when there is no assignee", () => {
+    render(<ElementCard element={base} assigneeName="Web Agent" onOpen={() => {}} />);
+    expect(screen.queryByText(/Owner:/)).not.toBeInTheDocument();
+  });
+
+  it("calls onOpen with the element id when clicked", () => {
+    const onOpen = vi.fn();
+    render(<ElementCard element={base} onOpen={onOpen} />);
+    fireEvent.click(screen.getByRole("button", { name: /Open element My Site/ }));
+    expect(onOpen).toHaveBeenCalledWith("e1");
+  });
+});

--- a/desktop/src/apps/ProjectsApp/elements/__tests__/ElementCreateDialog.test.tsx
+++ b/desktop/src/apps/ProjectsApp/elements/__tests__/ElementCreateDialog.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ElementCreateDialog } from "../ElementCreateDialog";
+
+vi.mock("@/lib/projects", () => ({
+  projectsApi: {
+    elements: { create: vi.fn().mockResolvedValue({ id: "e1" }) },
+  },
+}));
+
+import { projectsApi } from "@/lib/projects";
+
+describe("ElementCreateDialog", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates an element with the typed name and default generic type", async () => {
+    const onCreated = vi.fn();
+    render(
+      <ElementCreateDialog
+        projectId="p1"
+        memberOptions={[]}
+        onClose={() => {}}
+        onCreated={onCreated}
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: /name/i }), {
+      target: { value: "Designs" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(projectsApi.elements.create).toHaveBeenCalledWith("p1", {
+      name: "Designs",
+      slug: "designs",
+      type: "generic",
+      assignee_id: null,
+      description: "",
+    });
+  });
+
+  it("includes the chosen type and owner", async () => {
+    const onCreated = vi.fn();
+    render(
+      <ElementCreateDialog
+        projectId="p1"
+        memberOptions={[{ id: "a1", label: "Web Agent" }]}
+        onClose={() => {}}
+        onCreated={onCreated}
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: /name/i }), {
+      target: { value: "Site" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: /type/i }), {
+      target: { value: "website" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: /owner/i }), {
+      target: { value: "a1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(projectsApi.elements.create).toHaveBeenCalledWith("p1", {
+      name: "Site",
+      slug: "site",
+      type: "website",
+      assignee_id: "a1",
+      description: "",
+    });
+  });
+
+  it("shows an error and does not create when the name is blank", async () => {
+    const onCreated = vi.fn();
+    render(
+      <ElementCreateDialog
+        projectId="p1"
+        memberOptions={[]}
+        onClose={() => {}}
+        onCreated={onCreated}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Name is required.");
+    expect(projectsApi.elements.create).not.toHaveBeenCalled();
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/elements/__tests__/ElementGrid.test.tsx
+++ b/desktop/src/apps/ProjectsApp/elements/__tests__/ElementGrid.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ElementGrid } from "../ElementGrid";
+import type { Project, ProjectElement } from "../../../../lib/projects";
+
+const project: Project = {
+  id: "p1",
+  slug: "p1",
+  name: "T-Shirt Business",
+  description: "",
+  status: "active",
+  created_by: "u1",
+  created_at: 0,
+  updated_at: 0,
+};
+
+const els: ProjectElement[] = [
+  {
+    id: "e1", project_id: "p1", name: "Designs", slug: "designs", type: "design",
+    description: "", assignee_id: null, settings: {}, created_at: 0, updated_at: 0, archived_at: null,
+    open_tasks: 2, total_tasks: 4,
+  },
+  {
+    id: "e2", project_id: "p1", name: "Website", slug: "website", type: "website",
+    description: "", assignee_id: "a1", settings: {}, created_at: 0, updated_at: 0, archived_at: null,
+    open_tasks: 1, total_tasks: 3,
+  },
+];
+
+describe("ElementGrid", () => {
+  it("renders the overview header, the Project card, and element cards", () => {
+    render(
+      <ElementGrid
+        project={project}
+        elements={els}
+        assigneeName={() => "Web Agent"}
+        onOpenElement={() => {}}
+        onAddElement={() => {}}
+        onOpenProject={() => {}}
+      />,
+    );
+    expect(screen.getByText("Elements")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open project-level view" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open element Designs/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Open element Website/ })).toBeInTheDocument();
+  });
+
+  it("resolves the assignee name for the owner chip", () => {
+    render(
+      <ElementGrid
+        project={project}
+        elements={els}
+        assigneeName={(id) => (id === "a1" ? "Web Agent" : null)}
+        onOpenElement={() => {}}
+        onAddElement={() => {}}
+        onOpenProject={() => {}}
+      />,
+    );
+    expect(screen.getByText("Owner: Web Agent")).toBeInTheDocument();
+  });
+
+  it("opens an element when its card is clicked", () => {
+    const onOpenElement = vi.fn();
+    render(
+      <ElementGrid
+        project={project}
+        elements={els}
+        assigneeName={() => null}
+        onOpenElement={onOpenElement}
+        onAddElement={() => {}}
+        onOpenProject={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Open element Website/ }));
+    expect(onOpenElement).toHaveBeenCalledWith("e2");
+  });
+
+  it("fires onAddElement from both the header button and the add tile", () => {
+    const onAddElement = vi.fn();
+    render(
+      <ElementGrid
+        project={project}
+        elements={els}
+        assigneeName={() => null}
+        onOpenElement={() => {}}
+        onAddElement={onAddElement}
+        onOpenProject={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Add element" }));
+    fireEvent.click(screen.getByRole("button", { name: "+ Add element" }));
+    expect(onAddElement).toHaveBeenCalledTimes(2);
+  });
+
+  it("fires onOpenProject from the Project card", () => {
+    const onOpenProject = vi.fn();
+    render(
+      <ElementGrid
+        project={project}
+        elements={els}
+        assigneeName={() => null}
+        onOpenElement={() => {}}
+        onAddElement={() => {}}
+        onOpenProject={onOpenProject}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open project-level view" }));
+    expect(onOpenProject).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/elements/types.ts
+++ b/desktop/src/apps/ProjectsApp/elements/types.ts
@@ -1,0 +1,83 @@
+import type { Tab } from "../ProjectWorkspace";
+
+export interface ElementTypeDef {
+  /** Human label for the type, shown on the element card and picker. */
+  label: string;
+  /** Short glyph rendered in the card icon badge. */
+  icon: string;
+  /** Ordered tabs; the first is the landing tab when an element is opened. */
+  defaultTabs: Tab[];
+  /** Free-form hints for future view/template wiring (per design doc). */
+  appHints: Record<string, unknown>;
+}
+
+// The registry is code-level metadata only. The server stores `type` as a
+// free string and does not validate against this map, so a newer client can
+// introduce a type without a server change. Any unknown type renders as
+// generic (see elementType).
+export const ELEMENT_TYPES: Record<string, ElementTypeDef> = {
+  generic: {
+    label: "Element",
+    icon: "📦",
+    defaultTabs: ["board", "canvas", "files", "tasks", "messages", "members", "activity", "decisions", "routines"],
+    appHints: {},
+  },
+  code: {
+    label: "Code repo",
+    icon: "💻",
+    defaultTabs: ["board", "canvas", "files", "tasks", "messages", "members", "activity", "decisions", "routines"],
+    appHints: { repo_url: "" },
+  },
+  website: {
+    label: "Website",
+    icon: "🌐",
+    defaultTabs: ["board", "canvas", "files", "tasks", "messages", "members", "activity", "decisions", "routines"],
+    appHints: { url: "" },
+  },
+  design: {
+    label: "Design collection",
+    icon: "🎨",
+    defaultTabs: ["canvas", "board", "files", "tasks", "messages", "members", "activity", "decisions", "routines"],
+    appHints: {},
+  },
+  docs: {
+    label: "Docs",
+    icon: "📄",
+    defaultTabs: ["files", "board", "canvas", "tasks", "messages", "members", "activity", "decisions", "routines"],
+    appHints: {},
+  },
+  marketing: {
+    label: "Marketing",
+    icon: "📣",
+    defaultTabs: ["canvas", "files", "board", "tasks", "messages", "members", "activity", "decisions", "routines"],
+    appHints: {},
+  },
+  business: {
+    label: "Business planning",
+    icon: "📊",
+    defaultTabs: ["files", "board", "canvas", "tasks", "messages", "members", "activity", "decisions", "routines"],
+    appHints: {},
+  },
+};
+
+export const ELEMENT_TYPE_ORDER: string[] = [
+  "generic",
+  "code",
+  "website",
+  "design",
+  "docs",
+  "marketing",
+  "business",
+];
+
+export function elementType(type: string): ElementTypeDef {
+  return ELEMENT_TYPES[type] ?? ELEMENT_TYPES.generic!;
+}
+
+export function elementTypeLabel(type: string): string {
+  return elementType(type).label;
+}
+
+export function defaultTabForType(type: string): Tab {
+  return elementType(type).defaultTabs[0] ?? "board";
+}


### PR DESCRIPTION
## Summary

Implements slice 3 of `docs/design/projects-nested-elements.md` (frontend only, builds on the merged slice 1 element store + slice 2 filter bar).

- New `elements/` registry (`types.ts`) for the seven known element types with icons and type-driven landing-tab order.
- `ElementGrid`: overview grid when a project has elements (fixed Project card + Add element tile). Zero-element projects keep today's workspace pane untouched (back-compat invariant).
- `ElementCard`: icon, name, type label, open/total counts, owner chip, recent-activity line.
- `ElementCreateDialog`: create one nested element inside an existing project (name, slug, type, optional owner).
- `CreateProjectDialog`: optional second step to seed nested elements; skipping yields a project identical to today's.
- `ProjectWorkspace`: element drill-in scopes the board to the element and lands on the type's preferred tab, with a breadcrumb and the element id carried on the URL for deep links.
- `ProjectBoard`/`BoardToolbar`: accept a scoped element id and hide the element filter bar while scoped.

## Verification

`cd desktop && npx vitest run src/apps/ProjectsApp/elements/__tests__ src/apps/ProjectsApp/__tests__/ProjectWorkspace.elements.test.tsx src/apps/ProjectsApp/__tests__/CreateProjectDialog.elements.test.tsx` is green (20 tests). The full `src/apps/ProjectsApp` suite is green (176 tests), including a zero-element regression test asserting today's workspace is untouched.

Slices 5 to 7 are maintainer-held and were not touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project elements, including element types, owners, descriptions, and task summaries.
  * Projects can now be created with multiple elements in a guided two-step flow.
  * Added an Elements grid with options to open, create, and manage elements.
  * Added element-specific views with breadcrumbs, deep links, and browser navigation support.
  * Boards now focus on the selected element and hide irrelevant filters.
* **Tests**
  * Added coverage for element creation, display, navigation, validation, and project workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->