### PR TITLE
Projects elements slice 4: element-scoped canvas + files

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -332,13 +332,20 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
             )}
           </>
         )}
-        {tab === "canvas" && <CanvasView projectId={project.id} projectSlug={project.slug} />}
+        {tab === "canvas" && (
+          <CanvasView
+            projectId={project.id}
+            projectSlug={project.slug}
+            elementId={scopedElementId}
+          />
+        )}
         {tab === "tasks" && <ProjectTaskList projectId={project.id} />}
         {tab === "files" && (
           <FilesApp
-            key={project.id}
+            key={scopedElement ? `project-files-${project.id}-${scopedElement.slug}` : `project-files-${project.id}`}
             windowId={`project-files-${project.id}`}
             rootPath={`project:${project.slug}`}
+            path={scopedElement?.slug}
           />
         )}
         {tab === "messages" && (

--- a/desktop/src/apps/ProjectsApp/__tests__/canvas-api.test.ts
+++ b/desktop/src/apps/ProjectsApp/__tests__/canvas-api.test.ts
@@ -35,4 +35,38 @@ describe("canvasApi", () => {
     const r = await canvasApi.deleteElement("prj-1", "cve-1");
     expect(r).toBe(true);
   });
+
+  it("listElements appends element_id query when scoped", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ elements: [] }),
+    });
+    await canvasApi.listElements("prj-1", "elm-1");
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/projects/prj-1/canvas/elements?element_id=elm-1",
+    );
+  });
+
+  it("listElements omits the query when not scoped", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ elements: [] }),
+    });
+    await canvasApi.listElements("prj-1");
+    expect(fetch).toHaveBeenCalledWith("/api/projects/prj-1/canvas/elements");
+  });
+
+  it("addElement sends element_id when provided", async () => {
+    (fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => ({ element: { id: "cve-1", kind: "note" } }),
+    });
+    await canvasApi.addElement("prj-1", {
+      kind: "note", x: 1, y: 2, w: 3, h: 4, payload: { text: "x" },
+      element_id: "elm-1",
+    });
+    const call = (fetch as any).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+    expect(body.element_id).toBe("elm-1");
+  });
 });

--- a/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/CanvasBoard.tsx
@@ -17,6 +17,7 @@ import { useIsMobile } from "../../../hooks/use-is-mobile";
 interface CanvasBoardProps {
   projectId: string;
   projectSlug: string;
+  elementId?: string | null;
 }
 
 const CUSTOM_SHAPE_UTILS = [
@@ -33,7 +34,7 @@ const CUSTOM_SHAPE_UTILS = [
 // same-origin URLs that satisfy default-src/connect-src 'self'.
 const ASSET_URLS = getAssetUrlsByMetaUrl();
 
-export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
+export function CanvasBoard({ projectId, projectSlug, elementId }: CanvasBoardProps) {
   const isMobile = useIsMobile();
   const cacheRef = useRef(createCanvasStore());
   const editorRef = useRef<Editor | null>(null);
@@ -55,25 +56,28 @@ export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const elements = await canvasApi.listElements(projectId);
+      const elements = await canvasApi.listElements(projectId, elementId);
       if (cancelled) return;
       cacheRef.current.getState().seed(elements);
-      hydrateEditor(editorRef.current, elements, projectSlug);
+      hydrateEditor(editorRef.current, elements, projectSlug, elementId);
     })();
     const unsub = subscribeCanvasStream(projectId, cacheRef.current);
     return () => {
       cancelled = true;
       unsub();
     };
-  }, [projectId, projectSlug]);
+  }, [projectId, projectSlug, elementId]);
 
-  // Re-hydrate on local cache changes (SSE-driven updates from agents)
+  // Re-hydrate on local cache changes (SSE-driven updates from agents). The
+  // editor only ever renders the items belonging to the active element scope,
+  // so a cross-element SSE event is accepted into the cache but filtered out of
+  // the board until the scope changes.
   useEffect(() => {
     const unsub = cacheRef.current.subscribe((s) => {
-      hydrateEditor(editorRef.current, Object.values(s.elements), projectSlug);
+      hydrateEditor(editorRef.current, Object.values(s.elements), projectSlug, elementId);
     });
     return unsub;
-  }, [projectSlug]);
+  }, [projectSlug, elementId]);
 
   // Keep readonly state in sync if isMobile changes after mount (e.g. window resize)
   useEffect(() => {
@@ -96,7 +100,7 @@ export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
               const added = entry.changes.added as Record<string, TLShape | undefined>;
               for (const shape of Object.values(added)) {
                 if (!shape || !shape.id.startsWith("shape:")) continue;
-                pushAdd(projectId, shape).catch(console.warn);
+                pushAdd(projectId, shape, elementId).catch(console.warn);
               }
               const updated = entry.changes.updated as Record<string, [TLShape, TLShape] | undefined>;
               for (const pair of Object.values(updated)) {
@@ -108,8 +112,8 @@ export function CanvasBoard({ projectId, projectSlug }: CanvasBoardProps) {
               const removed = entry.changes.removed as Record<string, TLShape | undefined>;
               for (const shape of Object.values(removed)) {
                 if (!shape || !shape.id.startsWith("shape:")) continue;
-                const elementId = shape.id.replace(/^shape:/, "");
-                canvasApi.deleteElement(projectId, elementId).catch(console.warn);
+                const removedElementId = shape.id.replace(/^shape:/, "");
+                canvasApi.deleteElement(projectId, removedElementId).catch(console.warn);
               }
             },
             { source: "user", scope: "document" },
@@ -124,15 +128,21 @@ function hydrateEditor(
   editor: Editor | null,
   elements: CanvasElement[],
   projectSlug: string,
+  elementId?: string | null,
 ) {
   if (!editor) return;
+  // When the board is scoped to an element, only that element's items belong on
+  // the canvas. A null/undefined scope shows every item (project-level view).
+  const scoped = elementId == null
+    ? elements
+    : elements.filter((e) => e.element_id === elementId);
   editor.run(() => {
-    const wantedIds = new Set(elements.map((e) => `shape:${e.id}`));
+    const wantedIds = new Set(scoped.map((e) => `shape:${e.id}`));
     const existing = editor.getCurrentPageShapes();
     const toRemove = existing.filter((s) => !wantedIds.has(s.id) && s.id.toString().startsWith("shape:"));
     if (toRemove.length) editor.deleteShapes(toRemove.map((s) => s.id) as any);
 
-    for (const el of elements) {
+    for (const el of scoped) {
       // Isolate each element: a single malformed shape (bad payload, a props
       // shape tldraw's validator rejects, a version-skewed tldraw_shape) must
       // not throw out of editor.run and take down the whole canvas. Skip it and
@@ -164,7 +174,7 @@ function readTaos(shape: TLShape) {
   };
 }
 
-async function pushAdd(projectId: string, shape: TLShape) {
+async function pushAdd(projectId: string, shape: TLShape, elementId?: string | null) {
   if (!shape.id.toString().startsWith("shape:")) return;
   const props: any = shape.props;
   const { kind, payload } = readTaos(shape);
@@ -175,6 +185,7 @@ async function pushAdd(projectId: string, shape: TLShape) {
     w: props.w ?? 100, h: props.h ?? 100,
     rotation: shape.rotation,
     payload: payload ?? { tldraw_shape: shape },
+    element_id: elementId ?? null,
   });
 }
 

--- a/desktop/src/apps/ProjectsApp/canvas/CanvasView.tsx
+++ b/desktop/src/apps/ProjectsApp/canvas/CanvasView.tsx
@@ -2,15 +2,15 @@ import { CanvasBoard } from "./CanvasBoard";
 import { AppErrorBoundary } from "@/components/AppErrorBoundary";
 
 export function CanvasView({
-  projectId, projectSlug,
-}: { projectId: string; projectSlug: string }) {
+  projectId, projectSlug, elementId,
+}: { projectId: string; projectSlug: string; elementId?: string | null }) {
   return (
     <div style={{ height: "100%", padding: 0 }}>
       {/* Contain any canvas/tldraw render crash to a fallback instead of taking
           down the whole Projects app. Keyed by project so switching projects
           gives a fresh boundary. */}
       <AppErrorBoundary key={projectId}>
-        <CanvasBoard projectId={projectId} projectSlug={projectSlug} />
+        <CanvasBoard projectId={projectId} projectSlug={projectSlug} elementId={elementId} />
       </AppErrorBoundary>
     </div>
   );

--- a/desktop/src/apps/ProjectsApp/canvas/canvas-api.ts
+++ b/desktop/src/apps/ProjectsApp/canvas/canvas-api.ts
@@ -22,6 +22,7 @@ export interface CanvasElement {
   rotation: number;
   z_index: number;
   payload: Record<string, unknown>;
+  element_id: string | null;
   created_at: number;
   updated_at: number;
   deleted_at: number | null;
@@ -37,6 +38,7 @@ export interface CanvasElementInput {
   rotation?: number;
   z_index?: number;
   payload: Record<string, unknown>;
+  element_id?: string | null;
 }
 
 async function jsonOrThrow<T>(r: Response): Promise<T> {
@@ -48,8 +50,9 @@ async function jsonOrThrow<T>(r: Response): Promise<T> {
 }
 
 export const canvasApi = {
-  async listElements(projectId: string): Promise<CanvasElement[]> {
-    const r = await fetch(`/api/projects/${projectId}/canvas/elements`);
+  async listElements(projectId: string, elementId?: string | null): Promise<CanvasElement[]> {
+    const qs = elementId != null ? `?element_id=${encodeURIComponent(elementId)}` : "";
+    const r = await fetch(`/api/projects/${projectId}/canvas/elements${qs}`);
     const body = await jsonOrThrow<{ elements: CanvasElement[] }>(r);
     return body.elements;
   },

--- a/tests/projects/test_canvas_store.py
+++ b/tests/projects/test_canvas_store.py
@@ -262,3 +262,88 @@ async def test_update_element_does_not_leak_across_projects(store):
     # Original row is unchanged.
     again = await store.get_element(e["id"])
     assert again["x"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Slice 4: element scoping (element_id tag on canvas items).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_add_element_persists_element_id(store):
+    e = await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "a"}},
+        element_id="elm-1",
+    )
+    assert e["element_id"] == "elm-1"
+
+
+@pytest.mark.asyncio
+async def test_add_element_defaults_element_id_none(store):
+    e = await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "a"}},
+    )
+    assert e["element_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_add_element_upsert_keeps_element_id(store):
+    """Re-sending the same id (the client upsert path) must preserve the tag."""
+    e = await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "a"}},
+        element_id="elm-1",
+    )
+    again = await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"id": e["id"], "kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "a"}},
+        element_id="elm-1",
+    )
+    assert again["element_id"] == "elm-1"
+
+
+@pytest.mark.asyncio
+async def test_list_elements_filters_by_element_id(store):
+    tagged = await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "t"}},
+        element_id="elm-1",
+    )
+    await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "u"}},
+    )
+    rows = await store.list_elements("p", element_id="elm-1")
+    assert [r["id"] for r in rows] == [tagged["id"]]
+
+
+@pytest.mark.asyncio
+async def test_list_elements_none_sentinel_returns_untagged(store):
+    await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "t"}},
+        element_id="elm-1",
+    )
+    untagged = await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "u"}},
+    )
+    rows = await store.list_elements("p", element_id="none")
+    assert [r["id"] for r in rows] == [untagged["id"]]
+
+
+@pytest.mark.asyncio
+async def test_list_elements_without_filter_returns_all(store):
+    await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "t"}},
+        element_id="elm-1",
+    )
+    await store.add_element(
+        project_id="p", author_kind="user", author_id="u",
+        element={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "u"}},
+    )
+    rows = await store.list_elements("p")
+    assert len(rows) == 2

--- a/tests/test_project_folders.py
+++ b/tests/test_project_folders.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import yaml
 
 from tinyagentos.projects.folders import (
+    ensure_element_folder,
     ensure_project_layout,
     project_dir,
     read_project_yaml,
@@ -82,3 +83,34 @@ def test_read_project_yaml_round_trip(tmp_path: Path):
     write_project_yaml(tmp_path, "fox", payload)
 
     assert read_project_yaml(tmp_path, "fox") == payload
+
+
+# ---------------------------------------------------------------------------
+# Element files folder (slice 4)
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_element_folder_creates_subdir(tmp_path: Path):
+    d = ensure_element_folder(tmp_path, "alpha", "website")
+    assert d == tmp_path / "alpha" / "files" / "website"
+    assert d.is_dir()
+
+
+def test_ensure_element_folder_adopts_existing(tmp_path: Path):
+    """An existing user-made folder with the element slug is adopted, not
+    clobbered: pre-existing contents survive element creation."""
+    pre = tmp_path / "alpha" / "files" / "website"
+    pre.mkdir(parents=True, exist_ok=True)
+    (pre / "existing.txt").write_text("keep me")
+
+    d = ensure_element_folder(tmp_path, "alpha", "website")
+
+    assert d == pre
+    assert (d / "existing.txt").read_text() == "keep me"
+
+
+def test_ensure_element_folder_idempotent(tmp_path: Path):
+    first = ensure_element_folder(tmp_path, "alpha", "website")
+    second = ensure_element_folder(tmp_path, "alpha", "website")
+    assert first == second
+    assert first.is_dir()

--- a/tests/test_routes_project_canvas.py
+++ b/tests/test_routes_project_canvas.py
@@ -154,6 +154,74 @@ async def test_create_user_shape_element_returns_201(client):
 
 
 # ---------------------------------------------------------------------------
+# Slice 4: element scoping (element_id tag + list filter).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_note_with_element_id_returns_201(client):
+    body = {
+        "kind": "note",
+        "x": 0, "y": 0, "w": 100, "h": 50,
+        "payload": {"text": "tagged"},
+        "element_id": "elm-1",
+    }
+    resp = await client.post("/api/projects/proj-1/canvas/elements", json=body)
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["element"]["element_id"] == "elm-1"
+
+
+@pytest.mark.asyncio
+async def test_create_note_without_element_id_is_untagged(client):
+    body = {
+        "kind": "note",
+        "x": 0, "y": 0, "w": 100, "h": 50,
+        "payload": {"text": "untagged"},
+    }
+    resp = await client.post("/api/projects/proj-1/canvas/elements", json=body)
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["element"]["element_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_elements_filters_by_element_id(client):
+    tagged = (
+        await client.post(
+            "/api/projects/proj-1/canvas/elements",
+            json={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1,
+                  "payload": {"text": "t"}, "element_id": "elm-1"},
+        )
+    ).json()["element"]
+    await client.post(
+        "/api/projects/proj-1/canvas/elements",
+        json={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "u"}},
+    )
+    data = (
+        await client.get("/api/projects/proj-1/canvas/elements?element_id=elm-1")
+    ).json()
+    assert [e["id"] for e in data["elements"]] == [tagged["id"]]
+
+
+@pytest.mark.asyncio
+async def test_list_elements_none_sentinel_returns_untagged(client):
+    await client.post(
+        "/api/projects/proj-1/canvas/elements",
+        json={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1,
+              "payload": {"text": "t"}, "element_id": "elm-1"},
+    )
+    untagged = (
+        await client.post(
+            "/api/projects/proj-1/canvas/elements",
+            json={"kind": "note", "x": 0, "y": 0, "w": 1, "h": 1, "payload": {"text": "u"}},
+        )
+    ).json()["element"]
+    data = (
+        await client.get("/api/projects/proj-1/canvas/elements?element_id=none")
+    ).json()
+    assert [e["id"] for e in data["elements"]] == [untagged["id"]]
+
+
+# ---------------------------------------------------------------------------
 # Ideas-board kinds (#68): text, mermaid, flowchart, mindmap_edge.
 # Content travels in the free-form payload, so each just needs to round-trip.
 # ---------------------------------------------------------------------------

--- a/tinyagentos/projects/canvas/store.py
+++ b/tinyagentos/projects/canvas/store.py
@@ -27,10 +27,12 @@ CREATE TABLE IF NOT EXISTS project_canvas_elements (
     payload TEXT NOT NULL,
     created_at REAL NOT NULL,
     updated_at REAL NOT NULL,
-    deleted_at REAL
+    deleted_at REAL,
+    element_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_canvas_project ON project_canvas_elements(project_id, deleted_at);
 CREATE INDEX IF NOT EXISTS idx_canvas_updated ON project_canvas_elements(project_id, updated_at);
+CREATE INDEX IF NOT EXISTS idx_canvas_element ON project_canvas_elements(project_id, element_id);
 """
 
 _CANVAS_JSON_FIELDS = ("payload",)
@@ -69,6 +71,20 @@ class ProjectCanvasStore(BaseStore):
         super().__init__(db_path)
         self._broker = broker
 
+    async def _post_init(self) -> None:
+        # Additive column for project elements (slice 4 of
+        # docs/design/projects-nested-elements.md). Existing databases created
+        # before the element tag existed on canvas items get the column added
+        # here; fresh installs already have it from SCHEMA. Swallow the
+        # duplicate-column error the same way the task/element stores do.
+        try:
+            await self._db.execute(
+                "ALTER TABLE project_canvas_elements ADD COLUMN element_id TEXT"
+            )
+            await self._db.commit()
+        except Exception:
+            pass
+
     async def _publish(self, project_id: str, kind: str, payload: dict) -> None:
         if self._broker is not None:
             from tinyagentos.projects.events import ProjectEvent
@@ -99,6 +115,7 @@ class ProjectCanvasStore(BaseStore):
         element: dict,
         author_kind: str,
         author_id: str,
+        element_id: "str | None" = None,
     ) -> dict:
         kind = element.get("kind")
         if kind not in _VALID_KINDS:
@@ -115,13 +132,14 @@ class ProjectCanvasStore(BaseStore):
         await self._db.execute(
             """INSERT INTO project_canvas_elements
                (id, project_id, kind, author_kind, author_id,
-                x, y, w, h, rotation, z_index, payload, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                x, y, w, h, rotation, z_index, payload, element_id, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(id) DO UPDATE SET
                  kind=excluded.kind, author_kind=excluded.author_kind,
                  author_id=excluded.author_id, x=excluded.x, y=excluded.y,
                  w=excluded.w, h=excluded.h, rotation=excluded.rotation,
                  z_index=excluded.z_index, payload=excluded.payload,
+                 element_id=excluded.element_id,
                  updated_at=excluded.updated_at""",
             (
                 eid, project_id, kind, author_kind, author_id,
@@ -130,6 +148,7 @@ class ProjectCanvasStore(BaseStore):
                 float(element.get("rotation", 0)),
                 int(element.get("z_index", 0)),
                 json.dumps(element.get("payload") or {}),
+                element_id,
                 now, now,
             ),
         )
@@ -138,13 +157,30 @@ class ProjectCanvasStore(BaseStore):
         await self._publish(project_id, "canvas.element_added", {"element": new_el})
         return new_el
 
-    async def list_elements(self, project_id: str) -> list[dict]:
-        async with self._db.execute(
-            """SELECT * FROM project_canvas_elements
-               WHERE project_id = ? AND deleted_at IS NULL
-               ORDER BY z_index ASC, created_at ASC""",
-            (project_id,),
-        ) as cur:
+    async def list_elements(
+        self,
+        project_id: str,
+        element_id: "str | None" = None,
+    ) -> list[dict]:
+        """Canvas items for a project, optionally scoped to one element.
+
+        ``element_id`` follows the same conventions as task filtering:
+        ``None`` returns every (non-deleted) item, ``"none"`` returns only
+        untagged items (``element_id IS NULL``), and any other string returns
+        items tagged with that element id.
+        """
+        sql = (
+            "SELECT * FROM project_canvas_elements "
+            "WHERE project_id = ? AND deleted_at IS NULL"
+        )
+        params: list = [project_id]
+        if element_id == "none":
+            sql += " AND element_id IS NULL"
+        elif element_id is not None:
+            sql += " AND element_id = ?"
+            params.append(element_id)
+        sql += " ORDER BY z_index ASC, created_at ASC"
+        async with self._db.execute(sql, params) as cur:
             rows = await cur.fetchall()
             desc = cur.description
         return [_row_to_element(r, desc) for r in rows]

--- a/tinyagentos/projects/element_store.py
+++ b/tinyagentos/projects/element_store.py
@@ -225,7 +225,16 @@ class ProjectElementStore(BaseStore):
                 "UPDATE project_tasks SET element_id = NULL WHERE element_id = ?",
                 (element_id,),
             )
-            # Canvas untag lands with the canvas element_id column (slice 4).
+            # Canvas untag (slice 4). Tolerates a not-yet-initialized canvas
+            # table the same way count_element_items does, so deleting an
+            # element never fails just because the canvas store has not run.
+            try:
+                await self._db.execute(
+                    "UPDATE project_canvas_elements SET element_id = NULL WHERE element_id = ?",
+                    (element_id,),
+                )
+            except sqlite3.OperationalError:
+                pass
         await self._db.execute(
             "DELETE FROM project_elements WHERE id = ?", (element_id,)
         )

--- a/tinyagentos/projects/folders.py
+++ b/tinyagentos/projects/folders.py
@@ -34,3 +34,22 @@ def read_project_yaml(root: Path, slug: str) -> dict | None:
     if not target.exists():
         return None
     return yaml.safe_load(target.read_text())
+
+
+def ensure_element_folder(
+    root: Path, project_slug: str, element_slug: str
+) -> Path:
+    """Best-effort files subfolder for a project element.
+
+    An element owns ``projects_root/<project-slug>/files/<element-slug>/``.
+    If a user already created a folder with that name, the element adopts it
+    rather than erroring: the DB row (the element) is the authority, so the
+    disk path only needs to exist. Returns the element files path.
+
+    A disk failure must never break element creation, so errors are swallowed
+    by the caller; this helper raises nothing on its own for ordinary missing
+    parents.
+    """
+    d = root / project_slug / "files" / element_slug
+    d.mkdir(parents=True, exist_ok=True)
+    return d

--- a/tinyagentos/routes/project_canvas.py
+++ b/tinyagentos/routes/project_canvas.py
@@ -41,12 +41,15 @@ class CreateElementIn(BaseModel):
     z_index: int = 0
     payload: dict = Field(default_factory=dict)
     id: str | None = None
+    element_id: str | None = None
 
 
 @router.get("/api/projects/{project_id}/canvas/elements")
-async def list_canvas_elements(project_id: str, request: Request):
+async def list_canvas_elements(
+    project_id: str, request: Request, element_id: str | None = None,
+):
     cs = request.app.state.project_canvas_store
-    elements = await cs.list_elements(project_id)
+    elements = await cs.list_elements(project_id, element_id=element_id)
     return {"elements": elements}
 
 
@@ -56,6 +59,7 @@ async def create_canvas_element(
 ):
     cs = request.app.state.project_canvas_store
     element = payload.model_dump()
+    element_id = element.pop("element_id", None)
     if element["kind"] == "link":
         url = (element.get("payload") or {}).get("url")
         if not url:
@@ -66,6 +70,7 @@ async def create_canvas_element(
         new_el = await cs.add_element(
             project_id=project_id, element=element,
             author_kind="user", author_id=_user_id(request),
+            element_id=element_id,
         )
     except ValueError as e:
         return JSONResponse({"error": str(e)}, status_code=400)

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -16,7 +16,11 @@ from tinyagentos.agent_token_auth import (
     check_agent_scope_for_project,
 )
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
-from tinyagentos.projects.folders import ensure_project_layout, write_project_yaml
+from tinyagentos.projects.folders import (
+    ensure_element_folder,
+    ensure_project_layout,
+    write_project_yaml,
+)
 from tinyagentos.projects.task_store import _ELEMENT_CLEAR
 
 logger = logging.getLogger(__name__)
@@ -1087,11 +1091,13 @@ class UpdateElementIn(BaseModel):
 
 def _ensure_element_folder(request: Request, project: dict, element: dict) -> None:
     """Best-effort files subfolder for the element. The DB row is authoritative;
-    a disk failure must never block the element creation."""
+    a disk failure must never block the element creation. If a folder with the
+    element's slug already exists (a user-made folder), it is adopted rather
+    than overwritten, matching the design doc's adopt-existing semantics."""
     try:
-        root = request.app.state.projects_root
-        d = root / project["slug"] / "files" / element["slug"]
-        d.mkdir(parents=True, exist_ok=True)
+        ensure_element_folder(
+            request.app.state.projects_root, project["slug"], element["slug"]
+        )
     except Exception as exc:
         logger.warning(
             "element files folder create failed for %s/%s: %s",


### PR DESCRIPTION
## Summary

Implements Slice 4 of `docs/design/projects-nested-elements.md` (element-scoped canvas + files).

- **Backend canvas store** (`tinyagentos/projects/canvas/store.py`): add nullable `element_id` column to `project_canvas_elements` with the additively-ALTERed migration pattern (matches tasks/element stores), plus `element_id` acceptance on `add_element` and a `list_elements` filter supporting the `none` sentinel.
- **Canvas routes** (`tinyagentos/routes/project_canvas.py`): `CreateElementIn` gains `element_id`; the list endpoint accepts `?element_id=` filtering.
- **Folders** (`tinyagentos/projects/folders.py`): new `ensure_element_folder` that adopts an existing user-made folder (it never clobbers) and is used by the element create route.
- **Element store** (`tinyagentos/projects/element_store.py`): `delete_element(untag=True)` now nulls canvas tags too (tolerant of a not-yet-initialized canvas table).
- **Frontend**: `canvas-api` carries `element_id`; `CanvasBoard`/`CanvasView` honor the active element filter (only that element's items render, new shapes are tagged); `ProjectWorkspace` mounts the Files tab at the element's `files/<slug>` subfolder when scoped.

## Verification

- `tests/projects/test_canvas_store.py` (element_id create/persist/upsert/filter/`none`)
- `tests/test_routes_project_canvas.py` (create with `element_id`, list filter + `none` sentinel)
- `tests/test_project_folders.py` (element subfolder + adopt-existing)
- Frontend: `src/apps/ProjectsApp/__tests__/canvas-api.test.ts` extended; `tsc -b` clean.

All required tests pass. PR opened against `dev`; not merged.

Docs-Reviewed: implements the boarded task, frontend/backend change to shipped surface.