### PR TITLE
feat(projects): deep-link target registry (#1802 slice 2)

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectWorkspace.tsx
@@ -24,6 +24,17 @@ import styles from "./ProjectsApp.module.css";
 export type Tab = "workspace" | "board" | "canvas" | "tasks" | "files" | "messages" | "members" | "activity" | "decisions" | "routines";
 const TABS: Tab[] = ["workspace", "board", "canvas", "tasks", "files", "messages", "members", "activity", "decisions", "routines"];
 
+function isTab(value: string | undefined): value is Tab {
+  return value != null && (TABS as string[]).includes(value);
+}
+
+// The directory a deep-linked file lives in, used to open the Files tab in the
+// right folder. "docs/plan.md" -> "docs"; a root-level file -> "".
+function dirOf(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i === -1 ? "" : path.slice(0, i);
+}
+
 interface AgentSummary {
   id: string;
   name: string;
@@ -58,9 +69,9 @@ function setElementParam(elementId: string | null) {
   window.history.pushState({}, "", url);
 }
 
-export function ProjectWorkspace({ project, onChanged }: { project: Project; onChanged: () => void }) {
+export function ProjectWorkspace({ project, onChanged, initialTab, filePath }: { project: Project; onChanged: () => void; initialTab?: string; filePath?: string }) {
   const isMobile = useIsMobile();
-  const [tab, setTab] = useState<Tab>("workspace");
+  const [tab, setTab] = useState<Tab>(() => (isTab(initialTab) ? initialTab : "workspace"));
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [authResolved, setAuthResolved] = useState(false);
   const [openTaskId, setOpenTaskId] = useState<string | null>(() => readTaskParam());
@@ -70,6 +81,17 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
   const [elements, setElements] = useState<ProjectElement[]>([]);
   const [activeElementId, setActiveElementId] = useState<string | null>(() => readElementParam());
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  // The deep-linked document (from a notification target). Threaded into the
+  // Files tab so a review link lands on the right document.
+  const [deepFilePath, setDeepFilePath] = useState<string | null>(filePath ?? null);
+
+  // Deep-link launch props arrive both on first mount and, for an already-open
+  // Projects window, on a prop merge that bumps the window launchNonce. React to
+  // the merged props so a notification click navigates the workspace in place.
+  useEffect(() => {
+    if (isTab(initialTab)) setTab(initialTab);
+    if (filePath) setDeepFilePath(filePath);
+  }, [initialTab, filePath]);
 
   const handleCreateTask = async ({ title }: { title: string }) => {
     await projectsApi.tasks.create(project.id, { title });
@@ -342,10 +364,16 @@ export function ProjectWorkspace({ project, onChanged }: { project: Project; onC
         {tab === "tasks" && <ProjectTaskList projectId={project.id} />}
         {tab === "files" && (
           <FilesApp
-            key={scopedElement ? `project-files-${project.id}-${scopedElement.slug}` : `project-files-${project.id}`}
+            key={
+              scopedElement
+                ? `project-files-${project.id}-${scopedElement.slug}`
+                : deepFilePath
+                  ? `project-files-${project.id}-${deepFilePath}`
+                  : `project-files-${project.id}`
+            }
             windowId={`project-files-${project.id}`}
             rootPath={`project:${project.slug}`}
-            path={scopedElement?.slug}
+            path={scopedElement?.slug ?? (deepFilePath ? dirOf(deepFilePath) : undefined)}
           />
         )}
         {tab === "messages" && (

--- a/desktop/src/apps/ProjectsApp/index.tsx
+++ b/desktop/src/apps/ProjectsApp/index.tsx
@@ -10,7 +10,20 @@ import { ProjectWorkspace } from "./ProjectWorkspace";
 // `projectId` is a per-window prop: each Projects window can be pinned to a
 // different project (opened via the project list's "open in new window"), so
 // the user can view two projects side by side. Omitted for the first window.
-export function ProjectsApp({ windowId: _windowId, projectId }: { windowId: string; projectId?: string }) {
+// `tab` and `filePath` are deep-link launch props: a notification target can
+// open a specific project on a specific tab (and, for the Files tab, a specific
+// document). They ride the same prop-merge/launchNonce path as `projectId`.
+export function ProjectsApp({
+  windowId: _windowId,
+  projectId,
+  tab,
+  filePath,
+}: {
+  windowId: string;
+  projectId?: string;
+  tab?: string;
+  filePath?: string;
+}) {
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(projectId ?? null);
   const openWindow = useProcessStore((s) => s.openWindow);
@@ -76,7 +89,7 @@ export function ProjectsApp({ windowId: _windowId, projectId }: { windowId: stri
     <>
       {error && <div role="alert" className="p-3 text-red-400">{error}</div>}
       {selected ? (
-        <ProjectWorkspace project={selected} onChanged={refresh} />
+        <ProjectWorkspace project={selected} onChanged={refresh} initialTab={tab} filePath={filePath} />
       ) : (
         <div className="p-6 text-shell-text-secondary">Select or create a project.</div>
       )}

--- a/desktop/src/lib/__tests__/server-notifications.test.ts
+++ b/desktop/src/lib/__tests__/server-notifications.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapRow,
+  sourceToTarget,
+  targetToAction,
+  type ServerNotificationRow,
+} from "../server-notifications";
+
+function row(overrides: Partial<ServerNotificationRow> = {}): ServerNotificationRow {
+  return {
+    id: 7,
+    timestamp: 1_700_000_000,
+    level: "info",
+    title: "Review requested",
+    message: "plan.md is ready for review",
+    read: false,
+    source: "doc_review",
+    data: null,
+    ...overrides,
+  };
+}
+
+describe("targetToAction", () => {
+  it("routes a project_file target to the projects app Files tab", () => {
+    const out = targetToAction({
+      kind: "project_file",
+      project_id: "prj-1",
+      path: "docs/plan.md",
+    });
+    expect(out.action).toBe("projects");
+    expect(out.meta).toEqual({
+      projectId: "prj-1",
+      tab: "files",
+      filePath: "docs/plan.md",
+    });
+  });
+
+  it("returns an empty object for an unknown kind", () => {
+    expect(targetToAction({ kind: "not_a_real_kind", project_id: "prj-1" })).toEqual({});
+  });
+
+  it("returns an empty object when the target is missing or malformed", () => {
+    expect(targetToAction(undefined)).toEqual({});
+    expect(targetToAction(null)).toEqual({});
+    expect(targetToAction("project_file")).toEqual({});
+    expect(targetToAction({})).toEqual({});
+    expect(targetToAction({ kind: 42 })).toEqual({});
+  });
+
+  it("tolerates a project_file target with missing fields", () => {
+    const out = targetToAction({ kind: "project_file" });
+    expect(out.action).toBe("projects");
+    expect(out.meta).toEqual({ projectId: "", tab: "files", filePath: "" });
+  });
+});
+
+describe("mapRow target precedence", () => {
+  it("prefers a typed data.target over the source switch", () => {
+    // The source alone would route to the Decisions app, but the typed target
+    // wins and points at the project file.
+    const n = mapRow(
+      row({
+        source: "decisions",
+        data: { target: { kind: "project_file", project_id: "prj-9", path: "docs/audit.md" } },
+      }),
+    );
+    expect(n.action).toBe("projects");
+    expect(n.meta).toEqual({ projectId: "prj-9", tab: "files", filePath: "docs/audit.md" });
+  });
+
+  it("falls back to sourceToTarget when there is no target", () => {
+    const n = mapRow(row({ source: "disk_quota", data: null }));
+    expect(n.action).toBe("settings");
+    expect(n.meta).toEqual({ section: "storage" });
+    // Consistent with the standalone source mapping.
+    expect(sourceToTarget("disk_quota")).toEqual({ action: "settings", meta: { section: "storage" } });
+  });
+
+  it("falls back to sourceToTarget when the target kind is unknown", () => {
+    const n = mapRow(
+      row({ source: "decisions", data: { target: { kind: "canvas_element", id: "el-1" } } }),
+    );
+    expect(n.action).toBe("decisions");
+  });
+
+  it("leaves a row non-navigable when neither target nor source routes", () => {
+    const n = mapRow(row({ source: "mystery", data: null }));
+    expect(n.action).toBeUndefined();
+    expect(n.meta).toBeUndefined();
+  });
+});
+
+describe("mapRow base mapping", () => {
+  it("prefixes the id, scales the timestamp, and passes data through", () => {
+    const data = { target: { kind: "project_file", project_id: "prj-1", path: "a.md" } };
+    const n = mapRow(row({ id: 12, timestamp: 1_700_000_000, data }));
+    expect(n.id).toBe("srv-12");
+    expect(n.timestamp).toBe(1_700_000_000 * 1000);
+    expect(n.data).toEqual(data);
+  });
+
+  it("clamps an unknown level to info", () => {
+    expect(mapRow(row({ level: "bogus" })).level).toBe("info");
+    expect(mapRow(row({ level: "error" })).level).toBe("error");
+  });
+});

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -30,6 +30,55 @@ const VALID_LEVELS: ReadonlySet<Notification["level"]> = new Set([
 ]);
 
 /**
+ * A typed deep-link target carried on a notification's JSON `data.target`.
+ * `kind` selects a route builder from TARGET_ROUTES; the remaining fields are
+ * kind-specific (e.g. a `project_file` carries `project_id` and `path`).
+ */
+export interface NotificationTarget {
+  kind: string;
+  project_id?: string;
+  path?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Registry mapping a target `kind` to the app route a click should open. Keyed
+ * by kind rather than a hardcoded switch so new kinds (`project_task`,
+ * `canvas_element`, ...) are purely additive: one entry each, no change to the
+ * click handler. `action` is an app id understood by the process store; `meta`
+ * carries the launch props the target app reads.
+ */
+const TARGET_ROUTES: Record<
+  string,
+  (t: NotificationTarget) => { action: string; meta: Record<string, string> }
+> = {
+  project_file: (t) => ({
+    action: "projects",
+    meta: {
+      projectId: String(t.project_id ?? ""),
+      tab: "files",
+      filePath: String(t.path ?? ""),
+    },
+  }),
+};
+
+/**
+ * Resolve a typed notification `target` to an app route via TARGET_ROUTES.
+ * Returns an empty object when there is no target or its kind is unknown, so
+ * the caller can fall back to the source-keyed switch.
+ */
+export function targetToAction(
+  target: unknown,
+): { action?: string; meta?: Record<string, string> } {
+  if (!target || typeof target !== "object") return {};
+  const kind = (target as { kind?: unknown }).kind;
+  if (typeof kind !== "string") return {};
+  const build = TARGET_ROUTES[kind];
+  if (!build) return {};
+  return build(target as NotificationTarget);
+}
+
+/**
  * Map a backend event `source` to the app a click on the notification should
  * open. Sources that have no relevant destination return an empty object, which
  * leaves the notification non-navigable. `action` is an app id understood by the
@@ -70,7 +119,14 @@ export function mapRow(row: ServerNotificationRow): Notification {
   const level = VALID_LEVELS.has(row.level as Notification["level"])
     ? (row.level as Notification["level"])
     : "info";
-  const { action, meta } = sourceToTarget(row.source);
+  // A typed `data.target` takes precedence over the source-keyed switch, so a
+  // row can point at a specific destination (e.g. a project file opens the doc
+  // viewer) regardless of its source. Source routing stays as the fallback for
+  // rows that only carry a source.
+  const targetRoute = targetToAction(row.data?.target);
+  const { action, meta } = targetRoute.action
+    ? targetRoute
+    : sourceToTarget(row.source);
   return {
     id: `srv-${row.id}`,
     source: row.source || "system",


### PR DESCRIPTION
## Summary

Slice 2 (Deep-link target registry) of the document-review-surface feature (#1802). Wires notification `data.target` deep links through to the Projects app so pressing a review notification lands on the right project, tab, and document.

- `desktop/src/lib/server-notifications.ts`: add a `TARGET_ROUTES` registry keyed by target `kind` and a `targetToAction` step in `mapRow` that takes precedence over the source-keyed switch. A `project_file` target routes to the projects app Files tab; unknown kinds fall through to the existing `sourceToTarget` fallback. New kinds are purely additive (one registry entry each, no click-handler change).
- `desktop/src/apps/ProjectsApp/index.tsx` and `ProjectWorkspace.tsx`: accept `tab` and `filePath` launch props, seed the active tab and deep-linked document, and react to `launchNonce` prop merges so a click navigates an already-open Projects window in place. The Files tab opens in the target document's folder.
- `desktop/src/lib/__tests__/server-notifications.test.ts`: new tests for `targetToAction`, target-over-source precedence, source fallback, and base `mapRow` mapping.

## Verify

`cd desktop && npx vitest run src/lib` (825 passed). `tsc --noEmit` clean; `npx vitest run src/apps/ProjectsApp` (182 passed).

## Notes

DO NOT MERGE.

Docs-Reviewed: deep-link target registry slice per document-review-surface.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications can now open directly to a specific project file and its containing folder.
  * Project links support opening a selected tab and file location automatically.
  * Typed notification targets provide more accurate navigation than source-based routing.

* **Bug Fixes**
  * Improved handling of missing, malformed, or unknown notification targets.

* **Tests**
  * Added coverage for notification routing, fallback behavior, and notification data mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->