### PR TITLE
feat(projects): markdown doc reader (#1802 slice 1)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -51,6 +51,7 @@
         "konva": "^10.3.0",
         "lucide-react": "^0.577.0",
         "mathjs": "^15.2.0",
+        "mermaid": "^11.16.0",
         "modern-screenshot": "^4.7.0",
         "motion": "^12.42.2",
         "plyr": "^3.8.4",
@@ -10537,26 +10538,26 @@
       "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
-      "version": "11.15.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
       "license": "MIT",
       "dependencies": {
-        "@braintree/sanitize-url": "^7.1.1",
+        "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.1.1",
+        "@mermaid-js/parser": "^1.2.0",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.1",
+        "cytoscape": "^3.33.3",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.19",
-        "dompurify": "^3.3.1",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.25",
+        "katex": "^0.16.45",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -10578,12 +10579,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/mermaid/node_modules/@mermaid-js/parser": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
       "license": "MIT",
       "dependencies": {
-        "@chevrotain/types": "~11.1.1"
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/mermaid/node_modules/katex": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -55,6 +55,7 @@
     "konva": "^10.3.0",
     "lucide-react": "^0.577.0",
     "mathjs": "^15.2.0",
+    "mermaid": "^11.16.0",
     "modern-screenshot": "^4.7.0",
     "motion": "^12.42.2",
     "plyr": "^3.8.4",

--- a/desktop/src/apps/FilesApp.tsx
+++ b/desktop/src/apps/FilesApp.tsx
@@ -35,6 +35,7 @@ import { MobileSplitView } from "@/components/mobile/MobileSplitView";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { resolveAgentEmoji } from "@/lib/agent-emoji";
 import { useDragSource } from "@/shell/dnd/use-drag-source";
+import { DocViewer } from "@/apps/ProjectsApp/files/DocViewer";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -490,6 +491,11 @@ export function FilesApp({
   >(null);
   // Context menu anchor + payload. file === null targets the empty list area.
   const [menu, setMenu] = useState<{ x: number; y: number; file: FileEntry | null } | null>(null);
+
+  // In-app markdown reader: set when a .md/.markdown file is opened from a
+  // project: location, replacing the window.open download behaviour. Cleared
+  // by DocViewer's Close affordance.
+  const [docViewer, setDocViewer] = useState<{ url: string; title: string } | null>(null);
 
   // Recycle bin (per-agent container trash-cli)
   const [recycleItems, setRecycleItems] = useState<RecycleItem[]>([]);
@@ -1691,7 +1697,15 @@ export function FilesApp({
   const openFile = useCallback((f: FileEntry) => {
     if (f.is_dir) {
       navigateTo(f.path || (currentPath ? `${currentPath}/${f.name}` : f.name));
-    } else if (isWritable) {
+      return;
+    }
+    const lowerName = f.name.toLowerCase();
+    const isMarkdown = lowerName.endsWith(".md") || lowerName.endsWith(".markdown");
+    if (isMarkdown && isProjectLocation(location)) {
+      setDocViewer({ url: fileUrl(location, f.path || f.name), title: f.name });
+      return;
+    }
+    if (isWritable) {
       window.open(fileUrl(location, f.path || f.name), "_blank");
     }
   }, [navigateTo, currentPath, isWritable, location]);
@@ -1761,6 +1775,16 @@ export function FilesApp({
   };
 
   /* ---- Root layout ---- */
+  if (docViewer) {
+    return (
+      <DocViewer
+        url={docViewer.url}
+        title={docViewer.title}
+        onClose={() => setDocViewer(null)}
+      />
+    );
+  }
+
   return (
     <div className="flex h-full bg-shell-bg text-shell-text text-sm overflow-hidden">
       <MobileSplitView

--- a/desktop/src/apps/ProjectsApp/__tests__/DocViewer.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/DocViewer.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+// Mermaid is lazy-loaded and pulls a heavy lib; stub it so the suite stays
+// fast and deterministic (no real mermaid chunk / dynamic import in jsdom).
+vi.mock("../files/MermaidBlock", () => ({
+  default: ({ code }: { code: string }) => <div data-testid="mermaid-block">{code}</div>,
+}));
+
+import { DocViewer } from "../files/DocViewer";
+
+const SAMPLE = `# Title
+
+Some intro paragraph with a [link](https://example.com).
+
+## Section A
+
+- one
+- two
+- three
+
+### Subsection
+
+> a blockquote line
+
+\`\`\`js
+const x = 1;
+\`\`\`
+
+| Name | Value |
+| ---- | ----- |
+| alpha | 1 |
+| beta | 2 |
+
+## Section B
+
+\`\`\`mermaid
+graph TD; A-->B;
+\`\`\`
+`;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    text: async () => SAMPLE,
+  })) as unknown as typeof fetch;
+});
+
+describe("DocViewer — slice 1 markdown reader", () => {
+  it("fetches the document from the provided url", async () => {
+    render(<DocViewer url="/api/projects/p1/files/doc.md" title="doc.md" />);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { level: 1, name: "Title" })).toBeInTheDocument(),
+    );
+
+
+    // list
+    expect(screen.getByText("one")).toBeInTheDocument();
+    expect(screen.getByText("three")).toBeInTheDocument();
+
+    // blockquote
+    expect(screen.getByText("a blockquote line")).toBeInTheDocument();
+
+    // table
+    const table = screen.getByRole("table");
+    expect(within(table).getByText("Name")).toBeInTheDocument();
+    expect(within(table).getByText("beta")).toBeInTheDocument();
+
+    // link (relative to full href)
+    const link = screen.getByRole("link", { name: "link" });
+    expect(link).toHaveAttribute("href", "https://example.com");
+
+    // fenced code block (rehype-highlight tokenises it into spans, so assert
+    // on the rendered <pre> text content rather than a single text node)
+    const codeBlock = await waitFor(() => {
+      const el = document.querySelector("pre");
+      if (!el) throw new Error("no pre yet");
+      return el;
+    });
+    expect(codeBlock.textContent).toContain("const x = 1;");
+  });
+
+  it("renders a lazily-loaded mermaid block", async () => {
+    render(<DocViewer url="/api/projects/p1/files/doc.md" title="doc.md" />);
+    await waitFor(() => expect(screen.getByTestId("mermaid-block")).toBeInTheDocument());
+    expect(screen.getByTestId("mermaid-block")).toHaveTextContent("graph TD; A-->B;");
+  });
+
+  it("clicking an outline item scrolls to the heading", async () => {
+    const scrollSpy = vi.spyOn(HTMLElement.prototype, "scrollIntoView");
+    render(<DocViewer url="/api/projects/p1/files/doc.md" title="doc.md" />);
+    const outline = await waitFor(() => screen.findByLabelText("Document outline"));
+
+    fireEvent.click(within(outline).getByText("Section B"));
+
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  it("shows an error when the fetch fails", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      text: async () => "",
+    })) as unknown as typeof fetch;
+
+    render(<DocViewer url="/api/projects/p1/files/missing.md" title="missing.md" />);
+    await waitFor(() =>
+      expect(screen.getByText(/Failed to load document \(404\)/)).toBeInTheDocument(),
+    );
+  });
+
+  it("invokes onClose when Close is pressed", async () => {
+    const onClose = vi.fn();
+    render(<DocViewer url="/api/projects/p1/files/doc.md" title="doc.md" onClose={onClose} />);
+    await waitFor(() => expect(screen.getByText("Title")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText("Close document"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/desktop/src/apps/ProjectsApp/files/DocViewer.module.css
+++ b/desktop/src/apps/ProjectsApp/files/DocViewer.module.css
@@ -1,0 +1,307 @@
+/* Markdown doc reader (document-review-surface slice 1). */
+
+.viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  background: var(--color-shell-bg, #0e0f13);
+  color: var(--color-shell-text, #e7e9ee);
+  overflow: hidden;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--color-shell-border, rgba(255, 255, 255, 0.08));
+  flex: none;
+}
+
+.toolbarTitle {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.toolbarActions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+}
+
+.outlineToggle {
+  display: none;
+}
+
+.layout {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.outline {
+  width: 240px;
+  flex: none;
+  border-right: 1px solid var(--color-shell-border, rgba(255, 255, 255, 0.08));
+  overflow: auto;
+  padding: 12px 8px;
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+  overflow: auto;
+  padding: 24px;
+}
+
+.status {
+  color: var(--color-shell-text-secondary, #9aa0ad);
+  padding: 24px;
+}
+
+.statusError {
+  color: #f87171;
+  padding: 24px;
+}
+
+/* ---- outline pane ---- */
+.outline-pane {
+  width: 100%;
+}
+
+.outline-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  padding: 0 4px;
+}
+
+.outline-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-shell-text-secondary, #9aa0ad);
+}
+
+.outline-close {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--color-shell-text-secondary, #9aa0ad);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.outline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.outline-item {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--color-shell-text-secondary, #9aa0ad);
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.outline-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--color-shell-text, #e7e9ee);
+}
+
+.outline-item-active {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-shell-text, #e7e9ee);
+}
+
+/* ---- rendered markdown ---- */
+.markdown {
+  max-width: 860px;
+  margin: 0 auto;
+  line-height: 1.65;
+  font-size: 15px;
+}
+
+.markdown h1,
+.markdown h2,
+.markdown h3,
+.markdown h4,
+.markdown h5,
+.markdown h6 {
+  scroll-margin-top: 16px;
+  line-height: 1.25;
+  margin: 1.4em 0 0.6em;
+  font-weight: 650;
+}
+
+.markdown h1 {
+  font-size: 1.9em;
+}
+.markdown h2 {
+  font-size: 1.5em;
+}
+.markdown h3 {
+  font-size: 1.25em;
+}
+.markdown h4 {
+  font-size: 1.05em;
+}
+
+.markdown p {
+  margin: 0.8em 0;
+}
+
+.markdown a {
+  color: var(--accent, #6ea8fe);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+
+.markdown ul,
+.markdown ol {
+  margin: 0.8em 0;
+  padding-left: 1.5em;
+}
+
+.markdown li {
+  margin: 0.3em 0;
+}
+
+.markdown blockquote {
+  margin: 1em 0;
+  padding: 0.4em 1em;
+  border-left: 3px solid var(--accent, #6ea8fe);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-shell-text-secondary, #c3c8d4);
+}
+
+.markdown code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88em;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.15em 0.4em;
+  border-radius: 5px;
+}
+
+.markdown pre {
+  margin: 1em 0;
+  padding: 14px 16px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--color-shell-border, rgba(255, 255, 255, 0.08));
+  border-radius: 10px;
+  overflow: auto;
+}
+
+.markdown pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85em;
+}
+
+.markdown table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1em 0;
+  font-size: 0.92em;
+  display: block;
+  overflow-x: auto;
+}
+
+.markdown th,
+.markdown td {
+  border: 1px solid var(--color-shell-border, rgba(255, 255, 255, 0.12));
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.markdown th {
+  background: rgba(255, 255, 255, 0.05);
+  font-weight: 600;
+}
+
+.markdown img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.markdown hr {
+  border: none;
+  border-top: 1px solid var(--color-shell-border, rgba(255, 255, 255, 0.1));
+  margin: 1.5em 0;
+}
+
+.mermaid-block {
+  margin: 1em 0;
+  padding: 16px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--color-shell-border, rgba(255, 255, 255, 0.08));
+  border-radius: 10px;
+  overflow: auto;
+  text-align: center;
+}
+
+.mermaidFallback {
+  color: var(--color-shell-text-secondary, #9aa0ad);
+  padding: 16px;
+}
+
+/* ---- mobile ---- */
+@media (max-width: 720px) {
+  .body {
+    padding: 16px;
+  }
+
+  .outlineToggle {
+    display: inline-flex;
+  }
+
+  .outline {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 20;
+    width: 78%;
+    max-width: 300px;
+    background: var(--color-shell-bg-deep, #0b0c10);
+    box-shadow: 0 0 24px rgba(0, 0, 0, 0.5);
+    transform: translateX(-100%);
+    transition: transform 0.18s ease;
+  }
+
+  .outlineOpen {
+    transform: translateX(0);
+  }
+
+  .outline-close {
+    display: block;
+  }
+
+  .layout {
+    position: relative;
+  }
+}

--- a/desktop/src/apps/ProjectsApp/files/DocViewer.tsx
+++ b/desktop/src/apps/ProjectsApp/files/DocViewer.tsx
@@ -1,0 +1,200 @@
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSlug from "rehype-slug";
+import rehypeHighlight from "rehype-highlight";
+import { Button } from "@/components/ui";
+import { OutlinePane, type Heading } from "./OutlinePane";
+import styles from "./DocViewer.module.css";
+
+// Lazy-loaded so the (heavy) mermaid diagram renderer stays out of the entry
+// chunk for every document that does not contain a diagram.
+const MermaidBlock = lazy(() => import("./MermaidBlock"));
+
+interface DocViewerProps {
+  url: string;
+  title?: string;
+  onClose?: () => void;
+}
+
+function codeToString(children: React.ReactNode): string {
+  if (children == null) return "";
+  if (typeof children === "string") return children;
+  if (Array.isArray(children)) {
+    return children.map((c) => (typeof c === "string" ? c : "")).join("");
+  }
+  return "";
+}
+
+export function DocViewer({ url, title, onClose }: DocViewerProps) {
+  const [markdown, setMarkdown] = useState<string>("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [headings, setHeadings] = useState<Heading[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [showOutline, setShowOutline] = useState(false);
+
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setMarkdown("");
+    (async () => {
+      try {
+        const res = await fetch(url, { credentials: "include" });
+        if (!res.ok) throw new Error(`Failed to load document (${res.status})`);
+        const text = await res.text();
+        if (!cancelled) setMarkdown(text);
+      } catch (e: unknown) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load document");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  // Build the outline from the rendered headings so the ids match exactly what
+  // rehype-slug assigned (no slug algorithm duplication needed).
+  useEffect(() => {
+    const root = bodyRef.current;
+    if (!root) return;
+    const nodes = root.querySelectorAll<HTMLHeadingElement>("h1, h2, h3, h4, h5, h6");
+    const found: Heading[] = [];
+    nodes.forEach((node) => {
+      const id = node.id;
+      const text = node.textContent ?? "";
+      if (!id) return;
+      const level = Number(node.tagName.charAt(1));
+      found.push({ id, text, level });
+    });
+    setHeadings(found);
+    setActiveId(found[0]?.id ?? null);
+  }, [markdown]);
+
+  const scrollToHeading = useCallback(
+    (id: string) => {
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "start" });
+        setActiveId(id);
+      }
+      setShowOutline(false);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const root = bodyRef.current;
+    if (!root) return;
+    const onScroll = () => {
+      const nodes = root.querySelectorAll<HTMLHeadingElement>("h1, h2, h3, h4, h5, h6");
+      let current: string | null = null;
+      nodes.forEach((node) => {
+        if (node.getBoundingClientRect().top <= 120) current = node.id;
+      });
+      if (current) setActiveId(current);
+    };
+    root.addEventListener("scroll", onScroll, { passive: true });
+    return () => root.removeEventListener("scroll", onScroll);
+  }, [markdown]);
+
+  const components: Components = {
+    // Keep the real <pre> for normal code, but unwrap it for mermaid so the
+    // diagram block (a <div>) is not nested inside an invalid <pre>.
+    pre({ children }) {
+      const child = Array.isArray(children) ? children[0] : children;
+      const childClassName =
+        child && typeof child === "object" && "props" in child
+          ? ((child as React.ReactElement<{ className?: string }>).props.className ?? "")
+          : "";
+      if (typeof childClassName === "string" && childClassName.includes("language-mermaid")) {
+        return <>{children}</>;
+      }
+      return <pre>{children}</pre>;
+    },
+    code({ className, children, ...props }) {
+      const match = /language-(\w+)/.exec(className ?? "");
+      const lang = match?.[1];
+      const text = codeToString(children);
+      if (lang === "mermaid") {
+        return (
+          <Suspense fallback={<div className={styles.mermaidFallback}>Loading diagram…</div>}>
+            <MermaidBlock code={text.replace(/\n+$/, "")} />
+          </Suspense>
+        );
+      }
+      return (
+        <code className={className} {...props}>
+          {children}
+        </code>
+      );
+    },
+  };
+
+  return (
+    <div className={styles.viewer} role="dialog" aria-label={title ?? "Document viewer"}>
+      <div className={styles.toolbar}>
+        <div className={styles.toolbarTitle} title={title}>
+          {title ?? "Document"}
+        </div>
+        <div className={styles.toolbarActions}>
+          {headings.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className={styles.outlineToggle}
+              onClick={() => setShowOutline((v) => !v)}
+            >
+              Outline
+            </Button>
+          )}
+          {onClose && (
+            <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close document">
+              Close
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.layout}>
+        <aside
+          className={
+            styles.outline +
+            (showOutline ? " " + styles.outlineOpen : "")
+          }
+        >
+          <OutlinePane
+            headings={headings}
+            activeId={activeId}
+            onSelect={scrollToHeading}
+            onClose={() => setShowOutline(false)}
+          />
+        </aside>
+
+        <div className={styles.body} ref={bodyRef}>
+          {loading && <div className={styles.status}>Loading…</div>}
+          {error && <div className={styles.statusError}>{error}</div>}
+          {!loading && !error && markdown.length === 0 && (
+            <div className={styles.status}>This document is empty.</div>
+          )}
+          {!loading && !error && markdown.length > 0 && (
+            <article className={styles.markdown}>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeSlug, rehypeHighlight]}
+                components={components}
+              >
+                {markdown}
+              </ReactMarkdown>
+            </article>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/ProjectsApp/files/MermaidBlock.tsx
+++ b/desktop/src/apps/ProjectsApp/files/MermaidBlock.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef, useState } from "react";
+
+interface MermaidBlockProps {
+  code: string;
+  theme?: "default" | "dark" | "forest" | "neutral";
+}
+
+// Mermaid is heavy (~600 kB). Load it lazily via a dynamic `import()` so it
+// never lands in the DocViewer entry chunk; it is only fetched the first time
+// a diagram is actually rendered. DocViewer imports this module through
+// `React.lazy`, keeping the wrapper itself out of the entry chunk too.
+let initialized = false;
+
+export default function MermaidBlock({ code, theme = "dark" }: MermaidBlockProps) {
+  const [svg, setSvg] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const source = code.replace(/\n+$/, "");
+
+    (async () => {
+      try {
+        const mermaid = (await import("mermaid")).default as typeof import("mermaid").default;
+        if (!initialized) {
+          mermaid.initialize({ startOnLoad: false, theme });
+          initialized = true;
+        }
+        const id = `mermaid-${Math.random().toString(36).slice(2)}`;
+        const { svg: rendered } = await mermaid.render(id, source);
+        if (!cancelled) setSvg(rendered);
+      } catch (e: unknown) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : "Failed to render diagram");
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [code, theme]);
+
+  if (error) {
+    return (
+      <pre data-mermaid-error="true" className="mermaid-error">
+        {error}
+      </pre>
+    );
+  }
+
+  return (
+    <div ref={ref} className="mermaid-block" data-mermaid="true" dangerouslySetInnerHTML={{ __html: svg }} />
+  );
+}

--- a/desktop/src/apps/ProjectsApp/files/OutlinePane.tsx
+++ b/desktop/src/apps/ProjectsApp/files/OutlinePane.tsx
@@ -1,0 +1,47 @@
+interface Heading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface OutlinePaneProps {
+  headings: Heading[];
+  activeId: string | null;
+  onSelect: (id: string) => void;
+  onClose?: () => void;
+}
+
+export function OutlinePane({ headings, activeId, onSelect, onClose }: OutlinePaneProps) {
+  if (headings.length === 0) return null;
+
+  return (
+    <nav className="outline-pane" aria-label="Document outline">
+      <div className="outline-header">
+        <span className="outline-title">On this page</span>
+        {onClose && (
+          <button type="button" className="outline-close" onClick={onClose} aria-label="Close outline">
+            ×
+          </button>
+        )}
+      </div>
+      <ul className="outline-list">
+        {headings.map((h) => (
+          <li key={h.id}>
+            <button
+              type="button"
+              className={
+                "outline-item" + (activeId === h.id ? " outline-item-active" : "")
+              }
+              style={{ paddingLeft: `${(h.level - 1) * 12 + 8}px` }}
+              onClick={() => onSelect(h.id)}
+            >
+              {h.text}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+export type { Heading };


### PR DESCRIPTION
## Summary
Implements Slice 1 (Markdown reader) of the document-review-surface feature (#1802).

- New `DocViewer` renders project markdown (`.md`/`.markdown`) in-app with headings, GFM tables, fenced code (highlight.js), links, blockquotes, and lists.
- `OutlinePane` builds an in-page outline from the rendered headings and supports click-to-scroll; collapsible on mobile.
- `MermaidBlock` is a lazy-loaded wrapper that dynamically imports `mermaid`, so mermaid is excluded from the entry chunk.
- `FilesApp.openFile` now opens the `DocViewer` for `.md`/`.markdown` files under `project:` locations only, preserving the existing `window.open` behaviour for everything else.
- Unit tests cover rendering, outline building, mermaid lazy load, scroll, error, and close.

## Verification
- `npx vitest run src/apps/ProjectsApp` (187 tests pass, including the new `DocViewer.test.tsx`)
- `npm run build` succeeds; mermaid is emitted as separate lazy chunks, not in the entry/main chunk.

Docs-Reviewed: markdown reader slice per document-review-surface.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app Markdown viewer for project files.
  * Supports headings, lists, tables, links, code blocks, images, and blockquotes.
  * Added an “On this page” outline with heading navigation and active-section tracking.
  * Added Mermaid diagram rendering with error handling.
  * Added responsive layout support for desktop and mobile screens.
* **Bug Fixes**
  * Markdown project files now open within the app instead of an external window.
* **Tests**
  * Added coverage for rendering, navigation, Mermaid diagrams, loading errors, and closing the viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->