### PR TITLE
feat(catalog): Gemma 4 E4B/E2B uncensored GGUF models (#1836)

### DIFF
--- a/app-catalog/models/gemma-4-e2b-uncensored-gguf/manifest.yaml
+++ b/app-catalog/models/gemma-4-e2b-uncensored-gguf/manifest.yaml
@@ -1,0 +1,54 @@
+id: gemma-4-e2b-uncensored-gguf
+name: Gemma 4 E2B Uncensored (GGUF)
+type: model
+version: 4.0.0
+description: "Google Gemma 4 E2B (~5B raw / 2.3B effective via PLE), abliterated/uncensored GGUF (no refusals, original Google behaviour). Natively multimodal: text, image, video and audio in one model (mmproj needed for vision/audio). CPU/llama.cpp + Ollama path only; does NOT run on the Hailo NPU."
+homepage: https://huggingface.co/mradermacher/gemma-4-E2B-it-uncensored-GGUF
+license: "Gemma Terms of Use"
+capabilities: [chat, tool-calling, vision, audio]
+context_window: 131072
+
+variants:
+  - id: q4_k_m
+    name: "Q4_K_M GGUF (3.4GB)"
+    format: gguf
+    size_mb: 3512
+    download_url: https://huggingface.co/mradermacher/gemma-4-E2B-it-uncensored-GGUF/resolve/main/gemma-4-E2B-it-uncensored.Q4_K_M.gguf
+    # TODO: sha256 not yet resolved (xet-backed repo, no LFS pointer). Fill in before release.
+    sha256: ''
+    requires:
+      backends:
+        - id: ollama
+          targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 4096
+        - id: llama-cpp
+          targets: [x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 4096
+
+  - id: q3_k_m
+    name: "Q3_K_M GGUF (3.2GB)"
+    format: gguf
+    size_mb: 3277
+    download_url: https://huggingface.co/mradermacher/gemma-4-E2B-it-uncensored-GGUF/resolve/main/gemma-4-E2B-it-uncensored.Q3_K_M.gguf
+    # TODO: sha256 not yet resolved (xet-backed repo, no LFS pointer). Fill in before release.
+    sha256: ''
+    requires:
+      backends:
+        - id: ollama
+          targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 4096
+        - id: llama-cpp
+          targets: [x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 4096
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: q4_k_m}
+  arm-npu-32gb: {recommended: q4_k_m}
+  apple-silicon: {recommended: q4_k_m}
+  x86-cuda-12gb: {recommended: q4_k_m}
+  x86-vulkan-8gb: {recommended: q4_k_m}
+  x86-vulkan-16gb: {recommended: q4_k_m}
+  cpu-only: {recommended: q3_k_m}
+  arm-npu-4gb: {recommended: q3_k_m}
+  x86-cuda-4gb: {recommended: q3_k_m}
+  x86-vulkan-4gb: {recommended: q3_k_m}

--- a/app-catalog/models/gemma-4-e4b-uncensored-gguf/manifest.yaml
+++ b/app-catalog/models/gemma-4-e4b-uncensored-gguf/manifest.yaml
@@ -1,0 +1,54 @@
+id: gemma-4-e4b-uncensored-gguf
+name: Gemma 4 E4B Uncensored (GGUF)
+type: model
+version: 4.0.0
+description: "Google Gemma 4 E4B (~7.5B raw / 4B effective via PLE), abliterated/uncensored GGUF (no refusals, original Google behaviour). Natively multimodal: text, image, video and audio in one model (mmproj needed for vision/audio). CPU/llama.cpp + Ollama path only; does NOT run on the Hailo NPU."
+homepage: https://huggingface.co/mradermacher/gemma-4-E4B-it-uncensored-GGUF
+license: "Gemma Terms of Use"
+capabilities: [chat, tool-calling, vision, audio]
+context_window: 131072
+
+variants:
+  - id: q4_k_m
+    name: "Q4_K_M GGUF (5.3GB)"
+    format: gguf
+    size_mb: 5470
+    download_url: https://huggingface.co/mradermacher/gemma-4-E4B-it-uncensored-GGUF/resolve/main/gemma-4-E4B-it-uncensored.Q4_K_M.gguf
+    # TODO: sha256 not yet resolved (xet-backed repo, no LFS pointer). Fill in before release.
+    sha256: ''
+    requires:
+      backends:
+        - id: ollama
+          targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 6144
+        - id: llama-cpp
+          targets: [x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 6144
+
+  - id: q3_k_m
+    name: "Q3_K_M GGUF (4.9GB)"
+    format: gguf
+    size_mb: 4966
+    download_url: https://huggingface.co/mradermacher/gemma-4-E4B-it-uncensored-GGUF/resolve/main/gemma-4-E4B-it-uncensored.Q3_K_M.gguf
+    # TODO: sha256 not yet resolved (xet-backed repo, no LFS pointer). Fill in before release.
+    sha256: ''
+    requires:
+      backends:
+        - id: ollama
+          targets: [apple-silicon, x86-cuda, x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 6144
+        - id: llama-cpp
+          targets: [x86-vulkan, arm-vulkan, cpu]
+          min_ram_mb: 6144
+
+hardware_tiers:
+  arm-npu-16gb: {recommended: q4_k_m}
+  arm-npu-32gb: {recommended: q4_k_m}
+  apple-silicon: {recommended: q4_k_m}
+  x86-cuda-12gb: {recommended: q4_k_m}
+  x86-vulkan-8gb: {recommended: q4_k_m}
+  x86-vulkan-16gb: {recommended: q4_k_m}
+  cpu-only: {recommended: q3_k_m}
+  arm-npu-6gb: {recommended: q3_k_m}
+  x86-cuda-6gb: {recommended: q3_k_m}
+  x86-vulkan-6gb: {recommended: q3_k_m}


### PR DESCRIPTION
## Summary
- Adds two new CPU/llama.cpp + Ollama GGUF catalog entries per community request #1836:
  - `gemma-4-e4b-uncensored-gguf` (Q4_K_M + Q3_K_M)
  - `gemma-4-e2b-uncensored-gguf` (Q4_K_M + Q3_K_M)
- Sourced from reputable mradermacher uploads of the abliterated/uncensored Gemma 4 variants.
- These are GGUF models and deliberately target only `llama-cpp` and `ollama` (CPU path). They do NOT run on the Hailo NPU, so `rk-llama` / `hailo` backends are intentionally excluded.
- Descriptions note these are UNCENSORED variants and natively multimodal (text/image/video/audio; mmproj needed for vision/audio).

## Notes
- `sha256` is left as an empty `''` with a clear TODO comment: the source repos are xet-backed and expose no LFS pointer, so a real sha256 could not be resolved without downloading multi-GB blobs. No fake values were inserted.
- `python3 scripts/check_manifests.py managed-lint` passes.

Docs-Reviewed: add Gemma 4 E4B/E2B uncensored GGUF catalog entries (CPU path) per #1836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemma 4 E2B Uncensored GGUF model support.
  * Added Gemma 4 E4B Uncensored GGUF model support.
  * Provided Q4 and Q3 model variants with download details.
  * Added hardware recommendations for Apple Silicon, CUDA, Vulkan, ARM NPU, and CPU-only systems.
  * Documented support for chat, tool-calling, vision, and audio capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->