### PR TITLE
fix(installer): normalise tree ownership before re-run update (unblocks re-runs after a partial install)

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1163,6 +1163,14 @@ else
     # root-owned, or we are not root (user-mode / macOS install), run directly.
     _repo_owner="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
     if [[ "$(id -u)" == "0" && -n "$_repo_owner" && "$_repo_owner" != "root" ]]; then
+        # A prior install that was interrupted mid-chown (or a step that wrote a
+        # few paths back as root) leaves a tree with MIXED ownership.  Running
+        # the update as the owning user would then fail to unlink the still
+        # root-owned paths ("unable to unlink old ...: Permission denied" ->
+        # "Could not reset index file"), bricking every re-run.  Normalise
+        # ownership to the owning user first so the reset can rewrite the whole
+        # tree.  Safe: root performs the chown and git still runs unprivileged.
+        chown -R "$_repo_owner" "$INSTALL_DIR"
         sudo -u "$_repo_owner" git -C "$INSTALL_DIR" fetch --depth 1 origin "$BRANCH" \
             && sudo -u "$_repo_owner" git -C "$INSTALL_DIR" reset --hard "origin/$BRANCH"
     else


### PR DESCRIPTION
## Problem

Reported on #2 by a community tester on a fresh Orange Pi 5 Plus (Armbian trixie). A **re-run** of `install-server.sh` over an existing checkout dies with:

```
[server-install] updating existing checkout
error: unable to unlink old 'docs/agent-manual/04-apps.md': Permission denied
...
fatal: Could not reset index file to revision 'origin/master'.
```

## Root cause

The update path deliberately drops to the repo-owning user (`taos`) for the `git fetch` + `reset --hard`, so git never runs as root inside a user-writable tree (a real privilege-escalation guard). But it decides the owner by `stat`-ing only the **top-level** `$INSTALL_DIR`.

If a prior install was interrupted mid-`chown` (or any root step wrote a few paths back as root), the tree ends up with **mixed ownership**. The owning user then cannot unlink the still-root-owned paths, so `reset --hard` fails and every subsequent re-run is bricked. This is easy to hit: first run hiccups (tight disk, incus init, Ctrl-C), second run cannot recover.

## Fix

Normalise ownership to the owning user with `chown -R` (performed by root) immediately before the update, so the reset can rewrite the whole tree. git still runs unprivileged, so the security guard the original code added is preserved.

## Validation

- `bash -n` clean.
- Failure class reproduced locally: an unwritable path in the tree produces the identical `unable to unlink ...: Permission denied`; normalising the tree makes `reset --hard` apply cleanly (correctly removing deleted paths).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server re-installation and update reliability when installation files have mixed ownership.
  * Prevented update failures caused by leftover root-owned files from previous installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->