### PR TITLE
hotfix(installer): normalise tree ownership before re-run update (urgent, unblocks fresh installs)

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1163,6 +1163,14 @@ else
     # root-owned, or we are not root (user-mode / macOS install), run directly.
     _repo_owner="$(stat -c '%U' "$INSTALL_DIR" 2>/dev/null || stat -f '%Su' "$INSTALL_DIR" 2>/dev/null || echo "")"
     if [[ "$(id -u)" == "0" && -n "$_repo_owner" && "$_repo_owner" != "root" ]]; then
+        # A prior install that was interrupted mid-chown (or a step that wrote a
+        # few paths back as root) leaves a tree with MIXED ownership.  Running
+        # the update as the owning user would then fail to unlink the still
+        # root-owned paths ("unable to unlink old ...: Permission denied" ->
+        # "Could not reset index file"), bricking every re-run.  Normalise
+        # ownership to the owning user first so the reset can rewrite the whole
+        # tree.  Safe: root performs the chown and git still runs unprivileged.
+        chown -R "$_repo_owner" "$INSTALL_DIR"
         sudo -u "$_repo_owner" git -C "$INSTALL_DIR" fetch --depth 1 origin "$BRANCH" \
             && sudo -u "$_repo_owner" git -C "$INSTALL_DIR" reset --hard "origin/$BRANCH"
     else


### PR DESCRIPTION
Urgent install-blocker. The installer is fetched from `master`, so this fix must land on master to help anyone installing now.

Cherry-pick of the dev fix (#1839) so only this one-file change reaches master, without pulling unreleased dev work into a release.

## Problem

Reported on #2 (fresh Orange Pi 5 Plus). A **re-run** of `install-server.sh` over an existing checkout dies with `unable to unlink old ...: Permission denied` -> `Could not reset index file to revision origin/master`, bricking every subsequent attempt.

## Root cause

The update path drops to the repo-owning user (`taos`) for the `git reset --hard` (a real privilege-escalation guard), but reads only the top-level dir owner. A prior interrupted install leaves the tree with **mixed ownership**, so the owning user cannot unlink the still-root-owned paths and the reset aborts.

## Fix

`chown -R` the tree to the owning user (as root) immediately before the update, so the reset can rewrite the whole tree. git still runs unprivileged.

## Validation

`bash -n` clean. Failure class reproduced locally (unwritable tree path -> identical unlink-EACCES; normalising the tree makes the reset apply cleanly). Identical change already on the dev PR #1839.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer recovery when a previous installation was interrupted or left files with mixed ownership.
  * Prevented update failures by ensuring the installation directory has the correct ownership before repository updates run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->