### PR TITLE
fix(agents): self-heal duplicate active handles so the new unique index cannot brick boot (#2, #10)

### DIFF
--- a/tests/test_registry_governance_lifecycle.py
+++ b/tests/test_registry_governance_lifecycle.py
@@ -261,6 +261,67 @@ class TestSetStatus:
         finally:
             await store.close()
 
+    async def test_init_heals_duplicate_active_handles(self, tmp_path):
+        """A pre-invariant DB with two active rows sharing a handle must still
+        boot: init() blanks the duplicate, keeps the oldest, and builds the
+        index (regression for the boot-brick audit finding)."""
+        import aiosqlite
+        from tinyagentos.db_migrations import apply_wal_pragmas_async
+
+        db_path = tmp_path / "dup.db"
+        async with aiosqlite.connect(str(db_path)) as conn:
+            await apply_wal_pragmas_async(conn)
+            # Full current columns, NO unique index (a pre-invariant DB).
+            await conn.executescript("""
+                CREATE TABLE IF NOT EXISTS agent_registry (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    canonical_id TEXT NOT NULL UNIQUE,
+                    display_name TEXT NOT NULL DEFAULT '',
+                    framework    TEXT NOT NULL DEFAULT '',
+                    user_id      TEXT NOT NULL DEFAULT '',
+                    origin       TEXT NOT NULL DEFAULT 'taos-deployed',
+                    handle       TEXT NOT NULL DEFAULT '',
+                    role         TEXT,
+                    capabilities TEXT NOT NULL DEFAULT '[]',
+                    created_ts   TEXT NOT NULL,
+                    revoked_at   TEXT,
+                    status       TEXT NOT NULL DEFAULT 'active'
+                );
+            """)
+            for cid in ("first", "second"):
+                await conn.execute(
+                    "INSERT INTO agent_registry (canonical_id, framework, handle, created_ts, status) "
+                    "VALUES (?, 'f', 'hermes', '2026-01-01T00:00:00', 'active')",
+                    (cid,),
+                )
+            await conn.commit()
+
+        # Must NOT raise IntegrityError (would brick boot before the fix).
+        store = AgentRegistryStore(db_path)
+        await store.init()
+        try:
+            first = await store.get("first")   # oldest keeps the handle
+            second = await store.get("second")  # duplicate blanked
+            assert first["handle"] == "hermes"
+            assert second["handle"] == ""
+            assert first["status"] == "active" and second["status"] == "active"
+            # Index now exists and is enforced: 'first' still owns 'hermes', so a
+            # new active agent taking it is rejected.
+            with pytest.raises(Exception):
+                await store.register(framework="f", handle="hermes")
+        finally:
+            await store.close()
+
+    async def test_register_duplicate_active_handle_rejected(self, tmp_path):
+        """Write-time enforcement: a second active agent cannot take a live handle."""
+        store = await self._make_store(tmp_path / "reg.db")
+        try:
+            await store.register(framework="f", handle="solo")
+            with pytest.raises(Exception):
+                await store.register(framework="f", handle="solo")
+        finally:
+            await store.close()
+
     # -- list_inactive + list_all(status=) ----------------------------------
 
     async def test_list_inactive_returns_non_active(self, tmp_path):

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -157,6 +157,54 @@ async def _migration_v3_add_org_fields(conn) -> None:
         await conn.execute("ALTER TABLE agent_registry ADD COLUMN reports_to TEXT")
     await conn.commit()
 
+
+async def _migration_v4_dedupe_active_handles(conn) -> None:
+    """Blank duplicate active handles so ux_agent_active_handle can be created.
+
+    Handle uniqueness among active agents is a NEW invariant (the consent flow
+    added it).  Databases created before it can legally hold two active rows
+    with the same non-empty handle.  Creating the partial unique index over
+    such a DB raises IntegrityError, and since this runs in lifespan the whole
+    controller would fail to boot on every restart until manual DB surgery --
+    unacceptable for a no-terminal appliance.
+
+    Heal it non-destructively: keep the handle on the OLDEST active row (lowest
+    id, the most likely original owner) and blank it on the rest.  The rows
+    survive as active agents; empty handles are excluded from the index, so a
+    freed handle can be reclaimed later.  Every change is logged so an operator
+    can reconcile.  Idempotent: a clean DB has no duplicates and is untouched.
+    """
+    rows = await (
+        await conn.execute(
+            "SELECT id, canonical_id, handle FROM agent_registry "
+            "WHERE status = 'active' AND handle != '' ORDER BY handle, id"
+        )
+    ).fetchall()
+
+    seen_handles: set[str] = set()
+    demoted: list[tuple[str, str]] = []  # (canonical_id, handle)
+    for row in rows:
+        handle = row[2]
+        if handle in seen_handles:
+            demoted.append((row[1], handle))
+        else:
+            seen_handles.add(handle)
+
+    for canonical_id, handle in demoted:
+        await conn.execute(
+            "UPDATE agent_registry SET handle = '' WHERE canonical_id = ?",
+            (canonical_id,),
+        )
+        logger.warning(
+            "registry heal: blanked duplicate active handle %r on agent %s so the "
+            "active-handle unique index can be created; reassign a handle if needed",
+            handle,
+            canonical_id,
+        )
+    if demoted:
+        await conn.commit()
+
+
 # ---------------------------------------------------------------------------
 # Signing-key helpers (Ed25519, persisted to disk)
 # ---------------------------------------------------------------------------
@@ -366,9 +414,22 @@ class AgentRegistryStore(BaseStore):
         await _migration_v1_add_status(self._db)
         await _migration_v2_strip_at_display_name(self._db)
         await _migration_v3_add_org_fields(self._db)
+        # Dedupe BEFORE the index so a pre-invariant DB with duplicate active
+        # handles cannot make the CREATE UNIQUE INDEX (hence boot) fail.
+        await _migration_v4_dedupe_active_handles(self._db)
         # Created after the status migration so the partial index's WHERE clause
         # can reference the status column on the pre-status migration path.
-        await self._db.executescript(ACTIVE_HANDLE_INDEX)
+        # Guard the index creation too: if some path we did not anticipate still
+        # leaves a duplicate, warn and continue rather than bricking boot -- the
+        # uniqueness is also enforced at write time (register/activation).
+        try:
+            await self._db.executescript(ACTIVE_HANDLE_INDEX)
+        except aiosqlite.IntegrityError:
+            logger.error(
+                "registry: could not create ux_agent_active_handle (duplicate "
+                "active handles remain); continuing without it -- write-time "
+                "uniqueness still applies. Reconcile duplicate handles manually."
+            )
 
     # ------------------------------------------------------------------
     # Registration

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -24,6 +24,7 @@ import asyncio
 import logging
 from typing import Optional
 
+import aiosqlite
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
@@ -235,15 +236,23 @@ async def register_agent(
     store = _get_store(request)
     private_pem, _public_pem = _get_keypair(request)
 
-    record = await store.register(
-        framework=body.framework,
-        display_name=body.display_name or "",
-        user_id=user.user_id,
-        origin=body.origin or "taos-deployed",
-        handle=body.handle or "",
-        role=body.role,
-        capabilities=body.capabilities or [],
-    )
+    try:
+        record = await store.register(
+            framework=body.framework,
+            display_name=body.display_name or "",
+            user_id=user.user_id,
+            origin=body.origin or "taos-deployed",
+            handle=body.handle or "",
+            role=body.role,
+            capabilities=body.capabilities or [],
+        )
+    except aiosqlite.IntegrityError:
+        # The active-handle unique index rejected a handle another active agent
+        # already owns. That is a client conflict, not a server error.
+        raise HTTPException(
+            status_code=409,
+            detail="handle is already owned by another active agent",
+        )
 
     token = mint_registry_token(
         record["canonical_id"],
@@ -574,13 +583,20 @@ async def patch_registry_entry(
         return JSONResponse({"error": "not found"}, status_code=404)
     require_owner_or_admin(user, record["user_id"])
     old_name = record.get("display_name") or ""
-    updated = await store.update(
-        canonical_id,
-        display_name=body.display_name,
-        handle=body.handle,
-        role=body.role,
-        capabilities=body.capabilities,
-    )
+    try:
+        updated = await store.update(
+            canonical_id,
+            display_name=body.display_name,
+            handle=body.handle,
+            role=body.role,
+            capabilities=body.capabilities,
+        )
+    except aiosqlite.IntegrityError:
+        # Renaming this entry's handle onto one another active agent owns.
+        return JSONResponse(
+            {"error": "handle is already owned by another active agent"},
+            status_code=409,
+        )
     if updated is None:
         # The entry was revoked/removed between the get and the update; do not
         # emit a rename notification for a row that no longer exists.


### PR DESCRIPTION
Folds two findings from the multi-day audit of the identity epic.

**#2 (boot-brick, the important one):** `ux_agent_active_handle` is created in `_post_init` (runs in lifespan). Handle uniqueness among active agents is a NEW invariant, so a DB created before it can hold two active rows with the same handle; `CREATE UNIQUE INDEX` then raises `IntegrityError` and the controller fails to boot on every restart until manual DB surgery. This directly gates deploying the epic to any existing install.

Fix: `_migration_v4_dedupe_active_handles` blanks the handle on all but the oldest active row per handle (rows stay active; blanked handles are excluded from the partial index and reclaimable), logging each change; then the index creation is itself guarded (catch `IntegrityError`, warn, continue) so nothing unanticipated can brick boot. Write-time uniqueness still applies.

**#10:** `register` / `PATCH` returned an unhandled 500 on a duplicate handle; now 409.

Regression tests added: a DB seeded with two active `hermes` rows boots, keeps the oldest, blanks the duplicate, and enforces uniqueness afterward. Full registry + mint + auth-requests suite: 227 passed.