### PR TITLE
fix(canvas): bound snapshot render dimensions + offload render + clamp element geometry (audit #1)

### DIFF
--- a/tests/test_routes_project_canvas.py
+++ b/tests/test_routes_project_canvas.py
@@ -1126,3 +1126,72 @@ class TestAgentWriteRateLimit:
             )
             assert resp.status_code == 201, resp.text
 
+
+class TestCanvasGeometryClamping:
+    @pytest.mark.asyncio
+    async def test_extreme_coordinates_are_clamped_on_create(self, ctx):
+        pid = await _new_project(ctx, "geom-clamp")
+        resp = await ctx.client.post(
+            f"/api/projects/{pid}/canvas/elements",
+            json={
+                "kind": "note",
+                "x": 1_000_000_000,
+                "y": -1_000_000_000,
+                "w": 2_000_000_000,
+                "h": -500,
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        el = resp.json()["element"]
+        assert el["x"] == 100_000
+        assert el["y"] == -100_000
+        assert el["w"] == 100_000
+        assert el["h"] == 0
+
+    @pytest.mark.asyncio
+    async def test_extreme_coordinates_are_clamped_on_update(self, ctx):
+        pid = await _new_project(ctx, "geom-clamp-patch")
+        el = await _create_note(ctx.client, pid)
+        resp = await ctx.client.patch(
+            f"/api/projects/{pid}/canvas/elements/{el['id']}",
+            json={"x": 1_000_000_000, "y": -1_000_000_000, "w": 2_000_000_000, "h": -500},
+        )
+        assert resp.status_code == 200, resp.text
+        updated = resp.json()["element"]
+        assert updated["x"] == 100_000
+        assert updated["y"] == -100_000
+        assert updated["w"] == 100_000
+        assert updated["h"] == 0
+
+    @pytest.mark.asyncio
+    async def test_snapshot_render_dimensions_are_clamped(self, ctx):
+        from pathlib import Path
+        from PIL import Image
+
+        pid = await _new_project(ctx, "snap-clamp")
+        await ctx.client.post(
+            f"/api/projects/{pid}/canvas/elements",
+            json={
+                "kind": "note",
+                "x": 1_000_000,
+                "y": 1_000_000,
+                "w": 1_000_000,
+                "h": 1_000_000,
+                "payload": {"text": "extreme"},
+            },
+        )
+        resp = await ctx.client.get(f"/api/projects/{pid}/canvas/snapshot.png")
+        assert resp.status_code == 200, resp.text
+        project = await ctx.app.state.project_store.get_project(pid)
+        target = (
+            Path(ctx.app.state.projects_root)
+            / project["slug"]
+            / "files"
+            / "canvas"
+            / "snapshot.png"
+        )
+        assert target.exists(), f"snapshot not rendered at {target}"
+        with Image.open(target) as img:
+            assert img.width <= 8192
+            assert img.height <= 8192
+

--- a/tinyagentos/projects/canvas/render.py
+++ b/tinyagentos/projects/canvas/render.py
@@ -15,6 +15,7 @@ from PIL import Image, ImageDraw, ImageFont
 _MIN_WIDTH = 800
 _MIN_HEIGHT = 600
 _PADDING = 40
+_MAX_RENDER_DIM = 8192
 
 _KIND_FILL = {
     "note":   (255, 240, 140, 255),
@@ -78,6 +79,8 @@ def render_snapshot_png(*, elements: list[dict], output_path: Path) -> Path:
     min_x, min_y, max_x, max_y = _bounds(elements)
     width = max(_MIN_WIDTH, int(max_x - min_x) + 2 * _PADDING)
     height = max(_MIN_HEIGHT, int(max_y - min_y) + 2 * _PADDING)
+    width = min(width, _MAX_RENDER_DIM)
+    height = min(height, _MAX_RENDER_DIM)
     img = Image.new("RGB", (width, height), color=(255, 255, 255))
     draw = ImageDraw.Draw(img, "RGBA")
     try:

--- a/tinyagentos/routes/project_canvas.py
+++ b/tinyagentos/routes/project_canvas.py
@@ -81,6 +81,21 @@ def _check_payload_size(payload: dict) -> None:
         )
 
 
+_CANVAS_ELEMENT_RANGE = 100_000
+
+
+def _clamp_element_geometry(element: dict) -> dict:
+    if "x" in element:
+        element["x"] = max(-_CANVAS_ELEMENT_RANGE, min(_CANVAS_ELEMENT_RANGE, element["x"]))
+    if "y" in element:
+        element["y"] = max(-_CANVAS_ELEMENT_RANGE, min(_CANVAS_ELEMENT_RANGE, element["y"]))
+    if "w" in element:
+        element["w"] = max(0, min(_CANVAS_ELEMENT_RANGE, element["w"]))
+    if "h" in element:
+        element["h"] = max(0, min(_CANVAS_ELEMENT_RANGE, element["h"]))
+    return element
+
+
 def _user_id(request: Request) -> str:
     uid = getattr(request.state, "user_id", None)
     if uid:
@@ -196,6 +211,7 @@ async def create_canvas_element(
             status_code=429,
         )
     element = payload.model_dump()
+    _clamp_element_geometry(element)
     _check_payload_size(element.get("payload") or {})
     cs = request.app.state.project_canvas_store
     element_id = element.pop("element_id", None)
@@ -243,6 +259,7 @@ async def update_canvas_element(
         )
     cs = request.app.state.project_canvas_store
     patch = {k: v for k, v in payload.model_dump().items() if v is not None}
+    _clamp_element_geometry(patch)
     if "payload" in patch:
         _check_payload_size(patch["payload"])
     try:
@@ -304,7 +321,7 @@ async def get_canvas_png(project_id: str, request: Request):
     )
     out.mkdir(parents=True, exist_ok=True)
     target = out / "snapshot.png"
-    render_snapshot_png(elements=elements, output_path=target)
+    await asyncio.to_thread(render_snapshot_png, elements=elements, output_path=target)
     return FileResponse(target, media_type="image/png")
 
 


### PR DESCRIPTION
Three canvas hardening fixes from an audit of routes exposed to external agent tokens:

1. Bound the canvas snapshot PNG render: added a MAX_RENDER_DIM constant (8192) in render.py and clamp the final width/height so a note placed at an extreme coordinate cannot force a multi-GB Image.new allocation. Normal-sized canvases remain pixel-identical.

2. Run the render off the event loop: wrapped the synchronous render_snapshot_png call in the snapshot.png route with await asyncio.to_thread(...) so a large render cannot block the event loop.

3. Clamp element geometry on write: x/y are clamped to [-100000, 100000] and w/h to [0, 100000] when an element is created or updated. This defends the renderer at the source by preventing bounds from being driven huge via unbounded float inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canvas element coordinates and dimensions are now bounded during creation and updates.
  * Snapshot images are limited to safe maximum dimensions, preventing excessively large renders.
  * Snapshot generation no longer blocks request handling, improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->