### PR TITLE
fix(installer): re-run chown warns instead of aborting on partial failure

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1170,7 +1170,11 @@ else
         # "Could not reset index file"), bricking every re-run.  Normalise
         # ownership to the owning user first so the reset can rewrite the whole
         # tree.  Safe: root performs the chown and git still runs unprivileged.
-        chown -R "$_repo_owner" "$INSTALL_DIR"
+        # Do not let a partial chown failure (immutable file, read-only mount)
+        # abort the whole installer under set -euo pipefail; warn and proceed,
+        # since the reset below will surface any real ownership problem.
+        chown -R "$_repo_owner" "$INSTALL_DIR" \
+            || warn "chown -R $_repo_owner $INSTALL_DIR partially failed; the update may not apply cleanly"
         sudo -u "$_repo_owner" git -C "$INSTALL_DIR" fetch --depth 1 origin "$BRANCH" \
             && sudo -u "$_repo_owner" git -C "$INSTALL_DIR" reset --hard "origin/$BRANCH"
     else


### PR DESCRIPTION
Audit follow-up to #1839. The re-run ownership `chown -R` runs under `set -euo pipefail`, so a partial failure (immutable file, read-only mount) aborts the whole installer. Wrap it in a `warn` like the sibling `set_data_dir_ownership` does, and let the subsequent git reset surface any real ownership problem. bash -n clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability when updating an existing repository.
  * Partial ownership-adjustment failures now generate a warning while allowing the update process to continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->