### PR TITLE
fix(desktop): gate off dead username-claim onboarding step + mermaid strict (audit #5, #13d)

### DIFF
--- a/desktop/src/apps/ProjectsApp/files/MermaidBlock.tsx
+++ b/desktop/src/apps/ProjectsApp/files/MermaidBlock.tsx
@@ -24,7 +24,7 @@ export default function MermaidBlock({ code, theme = "dark" }: MermaidBlockProps
       try {
         const mermaid = (await import("mermaid")).default as typeof import("mermaid").default;
         if (!initialized) {
-          mermaid.initialize({ startOnLoad: false, theme });
+          mermaid.initialize({ startOnLoad: false, theme, securityLevel: "strict" });
           initialized = true;
         }
         const id = `mermaid-${Math.random().toString(36).slice(2)}`;

--- a/desktop/src/components/OnboardingScreen.test.tsx
+++ b/desktop/src/components/OnboardingScreen.test.tsx
@@ -8,7 +8,7 @@ const okJson = (body: unknown) =>
     headers: { "Content-Type": "application/json" },
   });
 
-/** Fill and submit the first-run account form so we reach the username step. */
+/** Fill and submit the first-run account setup form. */
 async function completeAccountStep() {
   fireEvent.change(screen.getByLabelText(/^Username/), {
     target: { value: "jay" },
@@ -42,13 +42,25 @@ describe("OnboardingScreen username step (slice 5)", () => {
     expect(screen.getByRole("button", { name: "Get started" })).toBeInTheDocument();
   });
 
-  it("advances to the free username step after account creation", async () => {
+  it("finishes onboarding after account creation (username step gated off, #141)", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ ok: true }));
-    render(<OnboardingScreen onDone={() => {}} />);
+    const onDone = vi.fn();
+    render(<OnboardingScreen onDone={onDone} />);
     await completeAccountStep();
-    expect(await screen.findByText("Claim your free taOS username")).toBeInTheDocument();
-    expect(screen.getByLabelText("taOS username")).toBeInTheDocument();
+    // The taos.my username-claim step is gated off until its backend exists, so
+    // account creation completes onboarding directly rather than advancing.
+    await waitFor(() => expect(onDone).toHaveBeenCalledOnce());
+    expect(screen.queryByText("Claim your free taOS username")).not.toBeInTheDocument();
   });
+});
+
+// The free-username-claim step is gated off in OnboardingScreen until its
+// backend route (/api/account/username) lands (#141). The UsernameStep code and
+// these tests are kept as-is so the flow can be re-enabled by restoring
+// setStep("username"); they are skipped meanwhile so CI stays green.
+describe.skip("OnboardingScreen username step (gated off, #141)", () => {
+  afterEach(() => { vi.restoreAllMocks(); });
+  beforeEach(() => { vi.restoreAllMocks(); });
 
   it("labels the username step as free and defers the paid subdomain upsell to Settings", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(okJson({ ok: true }));

--- a/desktop/src/components/OnboardingScreen.tsx
+++ b/desktop/src/components/OnboardingScreen.tsx
@@ -33,7 +33,8 @@ export function OnboardingScreen({
   defaultAutoLogin,
 }: Props) {
   const isInvite = Boolean(invitedUsername && inviteCode);
-  const [step, setStep] = useState<Step>("account");
+  // The username-claim step is gated off (see handleSubmit); step stays "account".
+  const [step] = useState<Step>("account");
 
   const [username, setUsername] = useState(invitedUsername ?? "");
   const [fullName, setFullName] = useState("");
@@ -81,9 +82,11 @@ export function OnboardingScreen({
         setLoading(false);
         return;
       }
-      // Account created: move on to the free username step rather than leaving
-      // onboarding. The username is optional, so this step can never dead-end.
-      setStep("username");
+      // Account created: finish onboarding. The taos.my username-claim step is
+      // gated off until its backend route exists (tracked in #141): advancing to
+      // it would POST to /api/account/username, which is not implemented yet, so
+      // every user would hit an error. Re-enable by restoring setStep("username").
+      onDone();
     } catch {
       setError("Network error — please try again");
       setLoading(false);


### PR DESCRIPTION
Two frontend audit follow-ups. **#5:** onboarding advanced to a username-claim step that POSTs to `/api/account/username`, which does not exist, so every user hit an error; finish onboarding instead until the backend route lands (tracked in #141), re-enabling is one line. **#11 note:** none. **#13d:** MermaidBlock relied on mermaid's implicit `securityLevel` default before `dangerouslySetInnerHTML`; set `'strict'` explicitly. Typechecks clean (tsc --noEmit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter security settings when rendering Mermaid diagrams.

* **Bug Fixes**
  * Updated onboarding to complete immediately after successful account creation.
  * Temporarily gated the free username-claim step until its supporting service is available.
  * Updated onboarding tests to reflect the revised flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->