### PR TITLE
fix(projects): stop cleared Lead re-promotion + approve canvas scope adds membership (audit #4, #11)

### DIFF
--- a/tests/projects/test_project_store.py
+++ b/tests/projects/test_project_store.py
@@ -94,3 +94,74 @@ async def test_log_activity(store):
     rows = await store.list_activity(p["id"])
     assert [r["kind"] for r in rows] == ["member.added", "project.created"]
     assert rows[0]["payload"] == {"member_id": "agent-1"}
+
+
+@pytest.mark.asyncio
+async def test_backfill_clear_lead_does_not_repromote_on_restart(tmp_path):
+    """A Lead the owner deliberately cleared (lead_member_id set NULL, legacy
+    is_lead still set) must not be re-promoted by the one-shot backfill when the
+    store is re-initialized. The backfill clears is_lead after migrating, so a
+    second init sees nothing to promote."""
+    from tinyagentos.projects.project_store import ProjectStore
+
+    db_path = tmp_path / "proj-repromote.db"
+    s = ProjectStore(db_path)
+    await s.init()
+    try:
+        project = await s.create_project(name="A", slug="a", created_by="u")
+        pid = project["id"]
+        await s.add_member(pid, member_id="agent-old-lead", member_kind="native")
+        # Simulate the legacy is_lead flag being set (the pre-epic state).
+        await s._db.execute(
+            "UPDATE project_members SET is_lead = 1 WHERE project_id = ? AND member_id = ?",
+            (pid, "agent-old-lead"),
+        )
+        await s._db.commit()
+        # Re-run init so the backfill sees the legacy is_lead flag and migrates it.
+        await s.init()
+        again = await s.get_project(pid)
+        assert again["lead_member_id"] == "agent-old-lead"
+
+        # Owner clears the Lead.
+        await s.set_lead(pid, None)
+    finally:
+        await s.close()
+
+    # Second store init (a restart): the legacy flag must have been cleared by
+    # the first backfill, so nothing promotes a Lead.
+    s2 = ProjectStore(db_path)
+    await s2.init()
+    try:
+        restarted = await s2.get_project(pid)
+        assert restarted["lead_member_id"] is None
+        members = await s2.list_members(pid)
+        assert members[0]["is_lead"] == 0
+    finally:
+        await s2.close()
+
+
+@pytest.mark.asyncio
+async def test_backfill_only_runs_for_null_lead(tmp_path):
+    """Projects that already have a Lead (lead_member_id set) are untouched by the
+    backfill, and projects with no is_lead flag are never promoted."""
+    from tinyagentos.projects.project_store import ProjectStore
+
+    s = ProjectStore(tmp_path / "proj-no-reprompt.db")
+    await s.init()
+    try:
+        # Project with a proper lead already set, no legacy flag.
+        p1 = await s.create_project(name="A", slug="a", created_by="u")
+        await s.add_member(p1["id"], member_id="agent-a", member_kind="native")
+        await s.set_lead(p1["id"], "agent-a")
+
+        # Project with no lead and no flag: must stay NULL.
+        p2 = await s.create_project(name="B", slug="b", created_by="u")
+        await s.add_member(p2["id"], member_id="agent-b", member_kind="native")
+
+        # Re-init to force a backfill pass.
+        await s.init()
+
+        assert (await s.get_project(p1["id"]))["lead_member_id"] == "agent-a"
+        assert (await s.get_project(p2["id"]))["lead_member_id"] is None
+    finally:
+        await s.close()

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -379,6 +379,138 @@ class TestCanvasScopeApproval:
         await grants.close()
 
     @pytest.mark.asyncio
+    async def test_approve_canvas_write_adds_member_with_write_flag(
+        self, client, monkeypatch, tmp_path
+    ):
+        """Approving a canvas_write grant bound to a project must add the agent as
+        a project member with can_edit_canvas=1 (and not can_read_canvas unless
+        granted), so the approved token is actually authorized to write the
+        canvas instead of 403ing on every call."""
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+        from tinyagentos.projects.project_store import ProjectStore
+
+        registry = AgentRegistryStore(tmp_path / "reg-canvas-mem.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth-canvas-mem.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants-canvas-mem.db")
+        await grants.init()
+        pstore = ProjectStore(tmp_path / "projects-canvas-mem.db")
+        await pstore.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys-canvas-mem")
+
+        project = await pstore.create_project(
+            name="Canvas Proj", slug="canvas-proj", created_by="u"
+        )
+        pid = project["id"]
+
+        record = await auth_store.create(
+            identity_claim="canvas-bot",
+            framework="canvas-cli",
+            requested_scopes=["canvas_write"],
+            requested_skills=None,
+            reason="",
+            duration_secs=None,
+            project_id=pid,
+        )
+
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(
+            client._transport.app.state, "agent_registry_keypair", (priv, pub)
+        )
+        monkeypatch.setattr(client._transport.app.state, "project_store", pstore)
+
+        resp = await client.post(
+            f"/api/agents/auth-requests/{record['id']}/approve",
+            json={"granted_scopes": ["canvas_write"], "project_id": pid},
+        )
+        assert resp.status_code == 200, resp.text
+
+        members = await pstore.list_members(pid)
+        assert len(members) == 1
+        member = members[0]
+        assert member["can_edit_canvas"] == 1
+        # canvas_write alone must NOT grant read.
+        assert member["can_read_canvas"] == 0
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+        await pstore.close()
+
+    @pytest.mark.asyncio
+    async def test_approve_canvas_read_and_write_sets_both_flags(
+        self, client, monkeypatch, tmp_path
+    ):
+        """Both canvas scopes granted bound to a project flip both member flags."""
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+        from tinyagentos.projects.project_store import ProjectStore
+
+        registry = AgentRegistryStore(tmp_path / "reg-canvas-both.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth-canvas-both.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants-canvas-both.db")
+        await grants.init()
+        pstore = ProjectStore(tmp_path / "projects-canvas-both.db")
+        await pstore.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys-canvas-both")
+
+        project = await pstore.create_project(
+            name="Canvas Proj", slug="canvas-proj-both", created_by="u"
+        )
+        pid = project["id"]
+
+        record = await auth_store.create(
+            identity_claim="canvas-bot",
+            framework="canvas-cli",
+            requested_scopes=["canvas_read", "canvas_write"],
+            requested_skills=None,
+            reason="",
+            duration_secs=None,
+            project_id=pid,
+        )
+
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(
+            client._transport.app.state, "agent_registry_keypair", (priv, pub)
+        )
+        monkeypatch.setattr(client._transport.app.state, "project_store", pstore)
+
+        resp = await client.post(
+            f"/api/agents/auth-requests/{record['id']}/approve",
+            json={
+                "granted_scopes": ["canvas_read", "canvas_write"],
+                "project_id": pid,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        members = await pstore.list_members(pid)
+        assert len(members) == 1
+        assert members[0]["can_read_canvas"] == 1
+        assert members[0]["can_edit_canvas"] == 1
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+        await pstore.close()
+
+    @pytest.mark.asyncio
     async def test_approve_canvas_scopes_without_project_is_rejected(
         self, client, monkeypatch, tmp_path
     ):

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -101,6 +101,14 @@ class ProjectStore(BaseStore):
                     "UPDATE projects SET lead_member_id = ? WHERE id = ?",
                     (flagged[0], pid),
                 )
+                # Clear the legacy per-member is_lead flag so this backfill
+                # runs once. The epic removed the only writer of is_lead, so
+                # without this a Lead the owner deliberately cleared (lead_member_id
+                # set NULL) would be re-promoted from the stale flag on restart.
+                await self._db.execute(
+                    "UPDATE project_members SET is_lead = 0 WHERE project_id = ?",
+                    (pid,),
+                )
         await self._db.commit()
 
     async def set_lead(self, project_id: str, member_id: "str | None") -> None:
@@ -276,6 +284,35 @@ class ProjectStore(BaseStore):
             "UPDATE projects SET lead_member_id = NULL "
             "WHERE id = ? AND lead_member_id = ?",
             (project_id, member_id),
+        )
+        await self._db.commit()
+
+    async def set_member_canvas(
+        self,
+        project_id: str,
+        member_id: str,
+        can_read: bool = False,
+        can_write: bool = False,
+    ) -> None:
+        """Set a member's per-project canvas flags (best-effort, additive OR).
+
+        Only the flags explicitly passed as True are flipped on; a flag not
+        requested is left untouched, so a partial approval (e.g. canvas_read
+        only) never clears a flag the member already held.
+        """
+        sets: list[str] = []
+        params: list = []
+        if can_read:
+            sets.append("can_read_canvas = 1")
+        if can_write:
+            sets.append("can_edit_canvas = 1")
+        if not sets:
+            return
+        params.extend([project_id, member_id])
+        await self._db.execute(
+            f"UPDATE project_members SET {', '.join(sets)} "
+            "WHERE project_id = ? AND member_id = ?",
+            params,
         )
         await self._db.commit()
 

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -424,24 +424,42 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
     # project a2a channel (membership is synced into the channel). Best-effort: a
     # membership failure never blocks the approval, which the token + grant already
     # authorize.
-    if effective_project and "project_tasks" in body.granted_scopes:
+    if effective_project and set(body.granted_scopes) & _PROJECT_SCOPES:
         try:
             pstore = getattr(request.app.state, "project_store", None)
             if pstore is not None:
-                await pstore.add_member(
-                    project_id=effective_project,
-                    member_id=canonical_id,
-                    member_kind="native",
-                    role="member",
-                )
-                from tinyagentos.projects.a2a import ensure_a2a_channel
+                granted_canvas = set(body.granted_scopes) & _CANVAS_SCOPES
+                # project_tasks and canvas scopes both bind the token to a
+                # project and require a membership row. The project_tasks path
+                # adds plain membership; canvas scopes additionally flip the
+                # per-member can_read_canvas / can_edit_canvas flags so the
+                # approved token is actually authorized for canvas calls
+                # (an inert member row with all canvas flags 0 would 403).
+                # Only flags that were explicitly granted are set, mirroring
+                # how the consent card scopes are narrowed.
+                if "project_tasks" in body.granted_scopes or granted_canvas:
+                    await pstore.add_member(
+                        project_id=effective_project,
+                        member_id=canonical_id,
+                        member_kind="native",
+                        role="member",
+                    )
+                    if granted_canvas:
+                        await pstore.set_member_canvas(
+                            project_id=effective_project,
+                            member_id=canonical_id,
+                            can_read=("canvas_read" in granted_canvas),
+                            can_write=("canvas_write" in granted_canvas),
+                        )
+                    if "project_tasks" in body.granted_scopes:
+                        from tinyagentos.projects.a2a import ensure_a2a_channel
 
-                await ensure_a2a_channel(
-                    request.app.state.chat_channels,
-                    pstore,
-                    effective_project,
-                    config=getattr(request.app.state, "config", None),
-                )
+                        await ensure_a2a_channel(
+                            request.app.state.chat_channels,
+                            pstore,
+                            effective_project,
+                            config=getattr(request.app.state, "config", None),
+                        )
         except Exception:  # noqa: BLE001 - membership is best-effort, never blocks approval
             logger.warning(
                 "auth-approve: could not sync %s membership/a2a channel for project %s",


### PR DESCRIPTION
Two follow-ups from the lead-agent identity + canvas epic audit.

Fix 1: Cleared project Lead re-promotes itself on restart
- In `project_store._backfill_lead_member_id`, the legacy `is_lead` flag was never cleared after migrating to `lead_member_id`. Because nothing else writes `is_lead` anymore, a Lead the owner cleared (lead_member_id set NULL) was re-promoted from the stale flag on the next restart.
- Now the backfill clears `is_lead=0` for the project once it migrates the Lead, making the backfill one-shot. Projects that never had a Lead are unaffected.

Fix 2: Approving a canvas-only scope mints an inert token
- In the auth-request approve path, membership was added only for `project_tasks`. A grant of `canvas_read` and/or `canvas_write` bound to a project created no membership row and left the canvas flags at 0, so the approved token 403ed on every canvas call.
- Now canvas grants also add the agent as a project member (mirroring the project_tasks path) and flip `can_read_canvas` / `can_edit_canvas` per the exact scopes approved. Flags not granted are never set.

Tests:
- A Lead cleared by the owner does not re-promote after a second store init.
- Approving a `canvas_write` grant bound to a project yields a member row with `can_edit_canvas=1` (and `can_read_canvas` only when `canvas_read` was also granted).