### PR TITLE
fix(security): account proxy stops forwarding local session cookie + hub binds author to signing key (audit #7, #8)

### DIFF
--- a/tests/test_hub_posts.py
+++ b/tests/test_hub_posts.py
@@ -62,10 +62,15 @@ class TestChainAppendVerify:
 
     @pytest.mark.asyncio
     async def test_verify_chain_passes_for_intact_chain(self, store, data_dir):
+        author = identity.signing_fingerprint()
+        pub = identity.public_identity()["signing_pubkey"]
+        # The chain verifier resolves each entry's key from its declared author,
+        # so the author -> signing key mapping must be registered.
+        await store.upsert_author(author, signing_pubkey=pub)
         await posts.append_post(store, visibility="public", text="a")
         await posts.append_post(store, visibility="circle", text="b")
         await posts.append_post(store, visibility="public", text="c")
-        ok, error = await posts.verify_chain(store, identity.signing_fingerprint())
+        ok, error = await posts.verify_chain(store, author)
         assert ok is True
         assert error is None
 
@@ -91,6 +96,8 @@ class TestTamperDetection:
     @pytest.mark.asyncio
     async def test_tampered_stored_body_fails_chain_verify(self, store, data_dir):
         author = identity.signing_fingerprint()
+        pub = identity.public_identity()["signing_pubkey"]
+        await store.upsert_author(author, signing_pubkey=pub)
         p = await posts.append_post(store, visibility="public", text="real")
         await posts.append_post(store, visibility="circle", text="more")
 
@@ -112,6 +119,8 @@ class TestTamperDetection:
     @pytest.mark.asyncio
     async def test_broken_prev_link_fails_chain_verify(self, store, data_dir):
         author = identity.signing_fingerprint()
+        pub = identity.public_identity()["signing_pubkey"]
+        await store.upsert_author(author, signing_pubkey=pub)
         await posts.append_post(store, visibility="public", text="a")
         await posts.append_post(store, visibility="circle", text="b")
 
@@ -131,6 +140,8 @@ class TestTombstone:
     @pytest.mark.asyncio
     async def test_delete_drops_content_but_keeps_chain_verifiable(self, store, data_dir):
         author = identity.signing_fingerprint()
+        pub = identity.public_identity()["signing_pubkey"]
+        await store.upsert_author(author, signing_pubkey=pub)
         await posts.append_post(store, visibility="public", text="keep me")
         p2 = await posts.append_post(store, visibility="circle", text="delete me")
 

--- a/tests/test_hub_store.py
+++ b/tests/test_hub_store.py
@@ -93,6 +93,34 @@ class TestSignVerify:
         assert hub_store.verify_object({"type": "x"}, pub) is False
         assert hub_store.verify_object({"type": "x", "sig": 123}, pub) is False
 
+    def test_verify_accepts_object_whose_author_matches_signing_key(self, data_dir):
+        # A correctly bound object (author == fingerprint of the signing key)
+        # verifies True.
+        pub = identity.public_identity()["signing_pubkey"]
+        signed = hub_store.sign_object(
+            {"type": "profile", "author": identity.signing_fingerprint(), "version": 1}
+        )
+        assert hub_store.verify_object(signed, pub) is True
+
+    def test_verify_rejects_object_with_wrong_author(self, data_dir, tmp_path, monkeypatch):
+        # A valid signature from key A must NOT verify as authored by peer B:
+        # verify_object binds author to the signing key's fingerprint and rejects
+        # a mismatched author (the peer-impersonation vector).
+        signed = hub_store.sign_object(
+            {"type": "profile", "author": identity.signing_fingerprint(), "version": 1}
+        )
+        # Capture the original signing pubkey before switching identities.
+        orig_pub = identity.public_identity()["signing_pubkey"]
+        # Mint a different identity in an isolated dir to be the "wrong author".
+        monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path / "other"))
+        other_fp = identity.signing_fingerprint()
+        # Present the object as authored by the OTHER peer's fingerprint.
+        impersonated = {**signed, "author": other_fp}
+        assert hub_store.verify_object(impersonated, orig_pub) is False
+        # And with a completely foreign (non-fingerprint) author string.
+        foreign = {**signed, "author": "deadbeef" * 8}
+        assert hub_store.verify_object(foreign, orig_pub) is False
+
 
 class TestStoreRoundTrip:
     @pytest.mark.asyncio

--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -176,9 +176,8 @@ async def test_cluster_join_request_forwards(client, monkeypatch):
         )
 
     _patch_upstream(monkeypatch, handler)
-    # Do NOT override the cookie header: the `client` fixture carries the taOS
-    # controller session that the /api/account/* proxy (rightly) requires, and
-    # that session cookie is what gets forwarded upstream.
+    # The `client` fixture carries the taOS controller (local admin) session
+    # cookie. It must NOT be relayed upstream: the forwarded Cookie is empty.
     r = await client.post(
         "/api/account/cluster/join/request",
         json={"device_name": "Mac", "ttl": "10m"},
@@ -187,7 +186,8 @@ async def test_cluster_join_request_forwards(client, monkeypatch):
     assert r.json()["request_id"] == "r1"
     assert captured["url"] == "https://taos.my/api/cluster/join/request"
     assert captured["method"] == "POST"
-    assert captured["cookie"]  # the session cookie was passed through
+    assert "taos_session" not in captured["cookie"]
+    assert captured["cookie"] == ""
 
 
 @pytest.mark.asyncio
@@ -258,7 +258,8 @@ async def test_subdomains_check_forwards_name(client, monkeypatch):
     assert r.json()["available"] is True
     assert captured["url"] == "https://taos.my/api/subdomains/check?name=mybiz"
     assert captured["method"] == "GET"
-    assert captured["cookie"]  # session cookie passed through
+    assert "taos_session" not in captured["cookie"]
+    assert captured["cookie"] == ""
 
 
 @pytest.mark.asyncio
@@ -279,12 +280,16 @@ async def test_subdomains_claim_forwards_body(client, monkeypatch):
         )
 
     _patch_upstream(monkeypatch, handler)
-    r = await client.post("/api/account/subdomains/claim", json={"name": "mybiz"})
+    r = await client.post(
+        "/api/account/subdomains/claim",
+        json={"name": "mybiz"},
+    )
     assert r.status_code == 200
     assert r.json()["name"] == "mybiz"
     assert captured["url"] == "https://taos.my/api/subdomains/claim"
     assert captured["method"] == "POST"
-    assert captured["cookie"]
+    assert "taos_session" not in captured["cookie"]
+    assert captured["cookie"] == ""
     assert "mybiz" in captured["body"]
 
 
@@ -437,7 +442,8 @@ async def test_hub_identity_register_forwards_body(client, monkeypatch):
     assert r.json()["status"] == "registered"
     assert captured["url"] == "https://taos.my/api/hub/identity/register"
     assert captured["method"] == "POST"
-    assert captured["cookie"]  # session cookie passed through
+    assert "taos_session" not in captured["cookie"]
+    assert captured["cookie"] == ""
     assert "signing_pubkey" in captured["body"]
 
 
@@ -555,3 +561,63 @@ async def test_hub_identity_register_503_when_upstream_unreachable(client, monke
     )
     assert r.status_code == 503
     assert "unreachable" in r.json().get("error", "")
+
+
+@pytest.mark.asyncio
+async def test_forward_to_strips_local_session_cookie(client, monkeypatch):
+    """The proxy must NOT relay the local ``taos_session`` admin cookie upstream:
+    a taos.my log leak would otherwise expose valid local admin session tokens.
+    An upstream (taos.my) cookie in the same Cookie header IS forwarded."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
+        return _FakeResp(
+            content=b'{"username":"alice","status":"registered"}',
+            headers={"content-type": "application/json"},
+        )
+
+    # Build a Cookie header with the (valid) local admin session plus an upstream
+    # taos.my session cookie. The proxy receives this from the browser. We keep
+    # the real session token so the request is authenticated; the fix must strip
+    # it from what is relayed upstream while forwarding the upstream cookie.
+    session = client.cookies.get("taos_session", "")
+    cookie_header = "taos_session=" + session + "; taosgo_session=upstream-value"
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post(
+        "/api/account/hub/identity/register",
+        json={"signing_pubkey": "aa", "encryption_pubkey": "bb", "proof": "cc"},
+        headers={"cookie": cookie_header},
+    )
+    assert r.status_code == 200
+    forwarded = captured.get("cookie", "")
+    # The local session cookie must never reach the upstream.
+    assert "taos_session" not in forwarded
+    # The upstream cookie is forwarded as-is.
+    assert "taosgo_session=upstream-value" in forwarded
+
+
+@pytest.mark.asyncio
+async def test_forward_to_sends_no_cookie_when_only_local_session(client, monkeypatch):
+    """When the only cookie present is the local session cookie, the relayed
+    request must send no Cookie header at all (not an empty one)."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
+        return _FakeResp(
+            content=b'{"username":"alice","status":"registered"}',
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post(
+        "/api/account/hub/identity/register",
+        json={"signing_pubkey": "aa", "encryption_pubkey": "bb", "proof": "cc"},
+        headers={"cookie": "taos_session=" + client.cookies.get("taos_session", "")},
+    )
+    assert r.status_code == 200
+    assert "taos_session" not in captured.get("cookie", "")
+    assert captured.get("cookie", "") == ""

--- a/tests/test_routes_account_proxy_hub_slice3.py
+++ b/tests/test_routes_account_proxy_hub_slice3.py
@@ -55,7 +55,8 @@ async def test_hub_requests_post_forwards_signed_intro(client, monkeypatch):
     assert r.json()["request_id"] == "r1"
     assert captured["url"] == "https://taos.my/api/hub/requests"
     assert captured["method"] == "POST"
-    assert captured["cookie"]
+    assert "taos_session" not in captured["cookie"]
+    assert captured["cookie"] == ""
     assert "peerFP" in captured["body"]
 
 

--- a/tinyagentos/hub/posts.py
+++ b/tinyagentos/hub/posts.py
@@ -208,7 +208,6 @@ async def verify_chain(store: hub_store.HubStore, author: str) -> tuple[bool, Op
     which is exactly why the chain index must persist past deletion.
     """
     entries = await store.list_chain_entries(author)
-    pub = identity.public_identity()["signing_pubkey"]
     prev_hash: Optional[str] = None
     for entry in entries:
         if entry.get("prev_hash") != prev_hash:
@@ -218,8 +217,16 @@ async def verify_chain(store: hub_store.HubStore, author: str) -> tuple[bool, Op
                 f"does not link to previous entry {prev_hash!r} (chain broken)",
             )
         obj = await store.get_object(entry["hash"])
-        if obj is not None and not hub_store.verify_object(obj, pub):
-            return False, f"seq {entry['seq']}: signature invalid (tampered)"
+        if obj is not None:
+            # Verify each entry against the public key resolved from that entry's
+            # declared author (its signing fingerprint), not one assumed key. A
+            # directory/network mishap that pairs an entry with the wrong author
+            # fails the author-to-key binding in verify_object.
+            resolved = await store.get_author(entry["author"])
+            if resolved is None or not resolved.get("signing_pubkey"):
+                return False, f"seq {entry['seq']}: unknown author {entry['author']!r}"
+            if not hub_store.verify_object(obj, resolved["signing_pubkey"]):
+                return False, f"seq {entry['seq']}: signature invalid (tampered)"
         prev_hash = entry["hash"]
     return True, None
 

--- a/tinyagentos/hub/store.py
+++ b/tinyagentos/hub/store.py
@@ -91,9 +91,20 @@ def verify_object(obj: dict, signing_pubkey_hex: str) -> bool:
     Returns False (never raises) on a missing or malformed signature so callers
     verifying arbitrary peer objects degrade cleanly. Tampering with any signed
     field changes the canonical bytes and fails the check.
+
+    The declared ``author`` MUST be the fingerprint (SHA-256) of the public key
+    that signed the object, so a valid signature from key A cannot be presented
+    as authored by peer B. This closes the peer-impersonation gap that opens once
+    peer ingest lands (today the routes force the local fingerprint, so it is not
+    yet exploitable). The check is rejected unless ``author`` equals that
+    fingerprint.
     """
     sig = obj.get("sig")
     if not isinstance(sig, str) or not sig:
+        return False
+    author = obj.get("author")
+    expected_author = identity.fingerprint(signing_pubkey_hex)
+    if not isinstance(author, str) or author != expected_author:
         return False
     return identity.verify_signature(signing_pubkey_hex, canonical_bytes(obj), sig)
 

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -125,6 +125,36 @@ def _rewrite_set_cookie(value: str, secure_ok: bool) -> str:
     return "; ".join(kept)
 
 
+# The local admin session cookie. The browser presents it on every same-origin
+# /api/account/* call, but it must never be relayed to the upstream taos.my: a
+# taos.my log leak or compromise would otherwise expose valid local admin
+# session tokens. Only the cookies that belong upstream are forwarded.
+_LOCAL_SESSION_COOKIE = "taos_session"
+
+
+def _strip_local_session_cookie(cookie_header: str) -> str | None:
+    """Return ``cookie_header`` with the local ``taos_session`` cookie removed.
+
+    Parses the incoming Cookie header and drops only the local session cookie,
+    preserving every other cookie (the upstream taos.my session cookie, etc.).
+    Returns ``None`` when no cookies remain, so the relayed request sends no
+    Cookie header at all. A malformed Cookie header is returned untouched rather
+    than dropping unrelated cookies.
+    """
+    kept: list[str] = []
+    for part in cookie_header.split(";"):
+        p = part.strip()
+        if not p:
+            continue
+        name = p.split("=", 1)[0].strip().lower()
+        if name == _LOCAL_SESSION_COOKIE:
+            continue
+        kept.append(p)
+    if not kept:
+        return None
+    return "; ".join(kept)
+
+
 async def _forward_to(
     request: Request, method: str, path: str, *, body: bytes | None = None
 ) -> Response:
@@ -136,7 +166,9 @@ async def _forward_to(
     headers: dict[str, str] = {}
     cookie = request.headers.get("cookie")
     if cookie:
-        headers["Cookie"] = cookie
+        relayed = _strip_local_session_cookie(cookie)
+        if relayed:
+            headers["Cookie"] = relayed
     if body is None and method == "POST":
         # Default: relay the incoming request body verbatim (slice 1/2 actions).
         body = await request.body()


### PR DESCRIPTION
Two security-hardening fixes from the audit.

1. Account proxy leaked the local admin cookie to taos.my (audit #7).
   _forward_to previously relayed the browser's entire Cookie header upstream,
   including the local ``taos_session`` admin cookie. A taos.my log leak or
   compromise would then expose valid local admin session tokens. The proxy now
   parses the incoming Cookie header and strips the local session cookie,
   forwarding only upstream cookies. When nothing remains, no Cookie header is
   sent at all.

2. Hub verify_object did not bind author to the signing key (audit #8).
   verify_object verified the Ed25519 signature but never asserted that
   obj["author"] equals the fingerprint (SHA-256) of the verifying public key,
   so a valid signature from key A could be presented as authored by peer B once
   peer ingest lands. It now computes the fingerprint from the verifying key and
   rejects the object unless it matches the declared author. verify_chain now
   resolves each entry's public key from that entry's declared author (via the
   resolved author table) instead of assuming one key, keeping the existing
   signature check.

Tests added:
- verify_object accepts a correctly-bound object and rejects one whose author
  does not match the signing key fingerprint.
- _forward_to omits the local session cookie from the request sent upstream
  (asserts the forwarded Cookie header omits taos_session).

All hub and account_proxy route tests pass.