### PR TITLE
feat(invite): project_invites store + mint/list/revoke routes (#1780 S1)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,6 +305,10 @@ async def client(app, tmp_data_dir):
     if project_store._db is not None:
         await project_store.close()
     await project_store.init()
+    project_invites = app.state.project_invites
+    if project_invites._db is not None:
+        await project_invites.close()
+    await project_invites.init()
     board_audit = app.state.board_audit
     if board_audit._db is not None:
         await board_audit.close()
@@ -426,6 +430,7 @@ async def client(app, tmp_data_dir):
     await routine_store.close()
     await board_audit.close()
     await project_store.close()
+    await project_invites.close()
     await chat_channels.close()
     await chat_messages.close()
     await expert_agents.close()

--- a/tests/projects/test_invite_store.py
+++ b/tests/projects/test_invite_store.py
@@ -1,0 +1,332 @@
+import json
+import sqlite3
+import time
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.projects.invite_store import (
+    InviteAlreadyRedeemedError,
+    InviteExpiredError,
+    InvitePendingCapError,
+    InvitePinError,
+    InviteRevokedError,
+    ProjectInviteStore,
+)
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ProjectInviteStore(tmp_path / "project_invites.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+def _make_scopes(*extra):
+    base = ["project_tasks"]
+    return list(dict.fromkeys(list(base) + list(extra)))
+
+
+# ---------------------------------------------------------------------------
+# mint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mint_returns_6_digit_id_and_4_digit_pin(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="user-admin",
+    )
+    assert len(result["record"]["invite_id"]) == 6
+    assert result["record"]["invite_id"].isdigit()
+    assert len(result["pin"]) == 4
+    assert result["pin"].isdigit()
+
+
+@pytest.mark.asyncio
+async def test_mint_forces_project_tasks(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="user-admin",
+    )
+    assert "project_tasks" in result["record"]["scopes"]
+
+
+@pytest.mark.asyncio
+async def test_mint_does_not_duplicate_project_tasks(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=["project_tasks", "a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="user-admin",
+    )
+    assert result["record"]["scopes"].count("project_tasks") == 1
+
+
+@pytest.mark.asyncio
+async def test_mint_enforces_pending_cap(store):
+    for i in range(10):
+        await store.mint(
+            project_id="prj-cap",
+            scopes=[],
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by="u",
+        )
+    with pytest.raises(InvitePendingCapError):
+        await store.mint(
+            project_id="prj-cap",
+            scopes=[],
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by="u",
+        )
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_existing(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    row = await store.get(iid)
+    assert row is not None
+    assert row["invite_id"] == iid
+    assert "pin_hash" in row
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(store):
+    assert await store.get("000000") is None
+
+
+@pytest.mark.asyncio
+async def test_get_sweeps_expired(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    # Manually push expiry into the past
+    await store._db.execute(
+        "UPDATE project_invites SET expires_ts = ? WHERE invite_id = ?",
+        (time.time() - 1, iid),
+    )
+    await store._db.commit()
+    row = await store.get(iid)
+    assert row["status"] == "expired"
+
+
+# ---------------------------------------------------------------------------
+# list_for_project
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_omits_pin_hash(store):
+    result = await store.mint(
+        project_id="prj-list",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    items = await store.list_for_project("prj-list")
+    assert len(items) == 1
+    assert "pin_hash" not in items[0]
+
+
+@pytest.mark.asyncio
+async def test_list_for_project_empty(store):
+    assert await store.list_for_project("no-such") == []
+
+
+# ---------------------------------------------------------------------------
+# revoke
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_pending_invite(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    ok = await store.revoke(iid)
+    assert ok is True
+    row = await store.get(iid)
+    assert row["status"] == "revoked"
+
+
+@pytest.mark.asyncio
+async def test_revoke_nonexistent_returns_false(store):
+    assert await store.revoke("000000") is False
+
+
+# ---------------------------------------------------------------------------
+# redeem
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redeem_wrong_pin_increments_attempts(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    correct_pin = result["pin"]
+    for i in range(4):
+        with pytest.raises(InvitePinError):
+            await store.redeem(iid, "0000")
+        row = await store.get(iid)
+        assert row["redeem_attempts"] == i + 1
+
+
+@pytest.mark.asyncio
+async def test_redeem_5_wrong_pins_invalidates(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    for _ in range(5):
+        with pytest.raises(InvitePinError):
+            await store.redeem(iid, "0000")
+    with pytest.raises(InvitePinError):
+        await store.redeem(iid, "0000")
+    row = await store.get(iid)
+    assert row["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_redeem_correct_pin_single_use(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    pin = result["pin"]
+    record = await store.redeem(iid, pin)
+    assert record["status"] == "redeemed"
+    with pytest.raises(InviteAlreadyRedeemedError):
+        await store.redeem(iid, pin)
+
+
+@pytest.mark.asyncio
+async def test_redeem_expired_invite(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    # Expire it manually
+    await store._db.execute(
+        "UPDATE project_invites SET expires_ts = ? WHERE invite_id = ?",
+        (time.time() - 1, iid),
+    )
+    await store._db.commit()
+    with pytest.raises(InviteExpiredError):
+        await store.redeem(iid, result["pin"])
+
+
+@pytest.mark.asyncio
+async def test_redeem_revoked_invite(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    await store.revoke(iid)
+    with pytest.raises(InviteRevokedError):
+        await store.redeem(iid, result["pin"])
+
+
+# ---------------------------------------------------------------------------
+# boot-migration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_boot_migration_adds_missing_column(tmp_path):
+    db_path = tmp_path / "legacy_invites.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        """
+        CREATE TABLE project_invites (
+            invite_id      TEXT PRIMARY KEY,
+            project_id     TEXT NOT NULL,
+            pin_hash       TEXT NOT NULL,
+            scopes         TEXT NOT NULL,
+            approval_mode  TEXT NOT NULL,
+            check_interval_secs INTEGER,
+            created_by     TEXT NOT NULL,
+            created_ts     REAL NOT NULL,
+            expires_ts     REAL NOT NULL,
+            redeem_attempts INTEGER DEFAULT 0,
+            status         TEXT NOT NULL,
+            redeemed_by    TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO project_invites
+            (invite_id, project_id, pin_hash, scopes, approval_mode,
+             check_interval_secs, created_by, created_ts, expires_ts,
+             redeem_attempts, status, redeemed_by)
+        VALUES ('000001', 'prj-1', 'abc', '[]', 'auto', 1800, 'u', 1.0, ?, 0, 'pending', NULL)
+        """,
+        (time.time() + 900,),
+    )
+    conn.commit()
+    conn.close()
+
+    store = ProjectInviteStore(db_path)
+    await store.init()
+    row = await store.get("000001")
+    assert row is not None
+    assert row["status"] == "pending"
+    assert row.get("redeemed_request_id") is None
+    await store.close()

--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -1,0 +1,115 @@
+import json
+import time
+
+import pytest
+
+from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.projects.invite_store import (
+    InviteAlreadyRedeemedError,
+    InvitePendingCapError,
+    InviteRevokedError,
+    ProjectInviteStore,
+)
+
+
+async def _create_project(client, slug="invite-proj") -> str:
+    resp = await client.post("/api/projects", json={"name": "Invite Proj", "slug": slug})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_mint_returns_invite_id_and_pin(client, app):
+    pid = await _create_project(client)
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": ["a2a_send"], "approval_mode": "auto", "check_interval_secs": 1800},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert len(data["invite_id"]) == 6
+    assert data["invite_id"].isdigit()
+    assert len(data["pin"]) == 4
+    assert data["pin"].isdigit()
+    assert "project_tasks" in data["scopes"]
+    assert data["approval_mode"] == "auto"
+    assert data["check_interval_secs"] == 1800
+
+
+@pytest.mark.asyncio
+async def test_mint_project_tasks_always_present(client, app):
+    pid = await _create_project(client)
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": ["a2a_send"], "approval_mode": "auto"},
+    )
+    assert resp.status_code == 200
+    assert "project_tasks" in resp.json()["scopes"]
+
+
+@pytest.mark.asyncio
+async def test_mint_11th_pending_returns_429(client, app):
+    pid = await _create_project(client, slug="invite-cap-proj")
+    store = app.state.project_invites
+    for i in range(10):
+        await store.mint(
+            project_id=pid,
+            scopes=[],
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by="admin",
+        )
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto"},
+    )
+    assert resp.status_code == 429, resp.text
+
+
+@pytest.mark.asyncio
+async def test_list_invites_excludes_pin_hash(client, app):
+    pid = await _create_project(client)
+    await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto"},
+    )
+    resp = await client.get(f"/api/projects/{pid}/invites")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert "pin_hash" not in items[0]
+
+
+@pytest.mark.asyncio
+async def test_revoke_returns_204(client, app):
+    pid = await _create_project(client)
+    mint_resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto"},
+    )
+    iid = mint_resp.json()["invite_id"]
+    resp = await client.delete(f"/api/projects/{pid}/invites/{iid}")
+    assert resp.status_code == 204, resp.text
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_mint(client, app):
+    pid = await _create_project(client)
+    app.dependency_overrides[current_user] = lambda: CurrentUser(
+        user_id="non-admin-user", is_admin=False
+    )
+    try:
+        resp = await client.post(
+            f"/api/projects/{pid}/invites",
+            json={"scopes": [], "approval_mode": "auto"},
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        app.dependency_overrides.pop(current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_revoke_nonexistent_returns_404(client, app):
+    pid = await _create_project(client)
+    resp = await client.delete(f"/api/projects/{pid}/invites/000000")
+    assert resp.status_code == 404, resp.text

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -375,7 +375,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     from tinyagentos.projects.events import ProjectEventBroker
     from tinyagentos.projects.canvas.store import ProjectCanvasStore as ProjectCanvasStoreImpl
     from tinyagentos.projects.canvas.snapshotter import CanvasSnapshotter
+    from tinyagentos.projects.invite_store import ProjectInviteStore
     project_store = ProjectStore(data_dir / "projects.db")
+    project_invite_store = ProjectInviteStore(data_dir / "project_invites.db")
     project_event_broker = ProjectEventBroker()
     from tinyagentos.desktop_control import DesktopCommandBroker
     desktop_command_broker = DesktopCommandBroker()
@@ -513,6 +515,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await chat_messages.init()
         await chat_channels.init()
         await project_store.init()
+        await project_invite_store.init()
+        app.state.project_invites = project_invite_store
         await board_audit_store.init()
         app.state.board_audit = board_audit_store
         await receipt_store.init()
@@ -1424,6 +1428,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             except Exception:
                 logger.exception("canvas snapshotter stop failed")
         await project_canvas_store.close()
+        await project_invite_store.close()
         await project_task_store.close()
         await project_element_store.close()
         await routine_store.close()
@@ -1573,6 +1578,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.chat_messages = chat_messages
     app.state.chat_channels = chat_channels
     app.state.project_store = project_store
+    app.state.project_invites = project_invite_store
     app.state.board_audit = board_audit_store
     app.state.receipt_store = receipt_store
     app.state.project_task_store = project_task_store

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import time
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+_EXPIRY_SECS = 15 * 60
+_MAX_ATTEMPTS = 5
+_PENDING_CAP = 10
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS project_invites (
+    invite_id            TEXT PRIMARY KEY,
+    project_id           TEXT NOT NULL,
+    pin_hash             TEXT NOT NULL,
+    scopes               TEXT NOT NULL,
+    approval_mode        TEXT NOT NULL,
+    check_interval_secs  INTEGER,
+    created_by           TEXT NOT NULL,
+    created_ts           REAL NOT NULL,
+    expires_ts           REAL NOT NULL,
+    redeem_attempts      INTEGER DEFAULT 0,
+    status               TEXT NOT NULL,
+    redeemed_by          TEXT,
+    redeemed_request_id  TEXT
+);
+"""
+
+MIGRATIONS: list = []
+
+
+class InvitePinError(Exception):
+    pass
+
+
+class InviteExpiredError(Exception):
+    pass
+
+
+class InviteAlreadyRedeemedError(Exception):
+    pass
+
+
+class InvitePendingCapError(Exception):
+    pass
+
+
+class InviteRevokedError(Exception):
+    pass
+
+
+def _now() -> float:
+    return time.time()
+
+
+class ProjectInviteStore(BaseStore):
+    SCHEMA = SCHEMA
+    MIGRATIONS = MIGRATIONS
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    async def _post_init(self) -> None:
+        await super()._post_init()
+        if self._db is None:
+            return
+        existing_cols = {
+            row[1]
+            for row in await (
+                await self._db.execute("PRAGMA table_info(project_invites)")
+            ).fetchall()
+        }
+        if "redeemed_request_id" not in existing_cols:
+            await self._db.execute(
+                "ALTER TABLE project_invites ADD COLUMN redeemed_request_id TEXT"
+            )
+            await self._db.commit()
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_project_invites_project "
+            "ON project_invites(project_id)"
+        )
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_project_invites_status "
+            "ON project_invites(status)"
+        )
+        await self._db.commit()
+
+    def _generate_invite_id(self) -> str:
+        return f"{secrets.randbelow(1_000_000):06d}"
+
+    def _generate_pin(self) -> str:
+        return f"{secrets.randbelow(10_000):04d}"
+
+    async def mint(self, *, project_id, scopes: list[str], approval_mode: str,
+                   check_interval_secs: int, created_by: str) -> dict:
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+
+        cursor = await self._db.execute(
+            "SELECT COUNT(*) FROM project_invites WHERE project_id = ? AND status = 'pending'",
+            (project_id,),
+        )
+        row = await cursor.fetchone()
+        pending_count = row[0] if row else 0
+        if pending_count >= _PENDING_CAP:
+            raise InvitePendingCapError(
+                f"project {project_id} already has {_PENDING_CAP} pending invites"
+            )
+
+        scopes = list(dict.fromkeys(list(scopes) + ["project_tasks"]))
+
+        invite_id = self._generate_invite_id()
+        pin = self._generate_pin()
+        pin_hash = hashlib.sha256(pin.encode()).hexdigest()
+        now = _now()
+        expires_ts = now + _EXPIRY_SECS
+
+        await self._db.execute(
+            """
+            INSERT INTO project_invites
+                (invite_id, project_id, pin_hash, scopes, approval_mode,
+                 check_interval_secs, created_by, created_ts, expires_ts, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')
+            """,
+            (
+                invite_id,
+                project_id,
+                pin_hash,
+                json.dumps(scopes),
+                approval_mode,
+                check_interval_secs,
+                created_by,
+                now,
+                expires_ts,
+            ),
+        )
+        await self._db.commit()
+
+        return {
+            "record": {
+                "invite_id": invite_id,
+                "project_id": project_id,
+                "pin_hash": pin_hash,
+                "scopes": scopes,
+                "approval_mode": approval_mode,
+                "check_interval_secs": check_interval_secs,
+                "created_by": created_by,
+                "created_ts": now,
+                "expires_ts": expires_ts,
+                "redeem_attempts": 0,
+                "status": "pending",
+                "redeemed_by": None,
+                "redeemed_request_id": None,
+            },
+            "pin": pin,
+        }
+
+    async def get(self, invite_id: str) -> dict | None:
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+        row = await self._fetch_row(invite_id)
+        if row is None:
+            return None
+        if row["status"] == "pending" and row["expires_ts"] is not None:
+            if _now() > row["expires_ts"]:
+                await self._db.execute(
+                    "UPDATE project_invites SET status = 'expired' WHERE invite_id = ?",
+                    (invite_id,),
+                )
+                await self._db.commit()
+                row = await self._fetch_row(invite_id)
+        return self._row_to_dict(row)
+
+    async def list_for_project(self, project_id: str) -> list[dict]:
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM project_invites WHERE project_id = ? ORDER BY created_ts DESC",
+            (project_id,),
+        )
+        rows = await cursor.fetchall()
+        result = []
+        for row in rows:
+            d = self._row_to_dict(row)
+            d.pop("pin_hash", None)
+            result.append(d)
+        return result
+
+    async def revoke(self, invite_id: str) -> bool:
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+        cursor = await self._db.execute(
+            "UPDATE project_invites SET status = 'revoked' WHERE invite_id = ? AND status = 'pending'",
+            (invite_id,),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def redeem(self, invite_id: str, pin: str) -> dict:
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+        row = await self._fetch_row(invite_id)
+        if row is None:
+            raise InvitePinError("invalid invite id or pin")
+
+        status = row["status"]
+        if status == "revoked":
+            raise InviteRevokedError("invite has been revoked")
+        if status == "redeemed":
+            raise InviteAlreadyRedeemedError("invite has already been redeemed")
+
+        if row["expires_ts"] is not None and _now() > row["expires_ts"]:
+            await self._db.execute(
+                "UPDATE project_invites SET status = 'expired' WHERE invite_id = ?",
+                (invite_id,),
+            )
+            await self._db.commit()
+            raise InviteExpiredError("invite has expired")
+
+        attempts = row["redeem_attempts"] or 0
+        if attempts >= _MAX_ATTEMPTS:
+            raise InvitePinError("invalid invite id or pin")
+
+        pin_hash = hashlib.sha256(pin.encode()).hexdigest()
+        if not hmac.compare_digest(pin_hash, row["pin_hash"] or ""):
+            await self._db.execute(
+                "UPDATE project_invites SET redeem_attempts = redeem_attempts + 1 WHERE invite_id = ?",
+                (invite_id,),
+            )
+            await self._db.commit()
+            new_attempts = attempts + 1
+            if new_attempts >= _MAX_ATTEMPTS:
+                await self._db.execute(
+                    "UPDATE project_invites SET status = 'expired' WHERE invite_id = ?",
+                    (invite_id,),
+                )
+                await self._db.commit()
+            raise InvitePinError("invalid invite id or pin")
+
+        cursor = await self._db.execute(
+            "UPDATE project_invites SET status = 'redeemed' WHERE invite_id = ? AND status = 'pending'",
+            (invite_id,),
+        )
+        await self._db.commit()
+        if cursor.rowcount != 1:
+            raise InviteAlreadyRedeemedError("invite has already been redeemed")
+
+        updated = await self._fetch_row(invite_id)
+        return self._row_to_dict(updated)
+
+    async def _fetch_row(self, invite_id: str) -> aiosqlite.Row | None:
+        cursor = await self._db.execute(
+            "SELECT * FROM project_invites WHERE invite_id = ?", (invite_id,)
+        )
+        return await cursor.fetchone()
+
+    def _row_to_dict(self, row: aiosqlite.Row) -> dict:
+        if row is None:
+            return {}
+        return dict(row)

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -17,7 +17,7 @@ _PENDING_CAP = 10
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS project_invites (
     invite_id            TEXT PRIMARY KEY,
-    project_id           TEXT NOT NULL,
+    project_id           TEXT,
     pin_hash             TEXT NOT NULL,
     scopes               TEXT NOT NULL,
     approval_mode        TEXT NOT NULL,
@@ -99,7 +99,7 @@ class ProjectInviteStore(BaseStore):
     def _generate_pin(self) -> str:
         return f"{secrets.randbelow(10_000):04d}"
 
-    async def mint(self, *, project_id, scopes: list[str], approval_mode: str,
+    async def mint(self, *, project_id=None, scopes: list[str], approval_mode: str,
                    check_interval_secs: int, created_by: str) -> dict:
         if self._db is None:
             raise RuntimeError("ProjectInviteStore not initialised")

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -55,6 +55,9 @@ def register_all_routers(app):
     from tinyagentos.routes import projects as projects_routes
     app.include_router(projects_routes.router)
 
+    from tinyagentos.routes.project_invites import router as project_invites_router
+    app.include_router(project_invites_router)
+
     from tinyagentos.routes import routines as routines_routes
     app.include_router(routines_routes.router)
 

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
+from tinyagentos.projects.invite_store import InvitePendingCapError
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class MintInviteIn(BaseModel):
+    scopes: list[str] = Field(default_factory=list)
+    approval_mode: str = Field(default="auto", pattern="^(auto|manual)$")
+    check_interval_secs: int = Field(default=1800, ge=60)
+
+
+@router.post("/api/projects/{project_id}/invites")
+async def mint_invite(
+    project_id: str,
+    payload: MintInviteIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = request.app.state.project_invites
+    project_store = request.app.state.project_store
+    project = await project_store.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "project not found"}, status_code=404)
+    require_owner_or_admin(user, project["user_id"])
+    try:
+        result = await store.mint(
+            project_id=project_id,
+            scopes=list(payload.scopes),
+            approval_mode=payload.approval_mode,
+            check_interval_secs=payload.check_interval_secs,
+            created_by=user.user_id,
+        )
+    except InvitePendingCapError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=429)
+    record = result["record"]
+    return {
+        "invite_id": record["invite_id"],
+        "pin": result["pin"],
+        "expires_ts": record["expires_ts"],
+        "scopes": record["scopes"],
+        "approval_mode": record["approval_mode"],
+        "check_interval_secs": record["check_interval_secs"],
+    }
+
+
+@router.get("/api/projects/{project_id}/invites")
+async def list_invites(
+    project_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = request.app.state.project_invites
+    project_store = request.app.state.project_store
+    project = await project_store.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "project not found"}, status_code=404)
+    require_owner_or_admin(user, project["user_id"])
+    items = await store.list_for_project(project_id)
+    return [
+        {
+            "invite_id": i["invite_id"],
+            "scopes": i["scopes"],
+            "status": i["status"],
+            "expires_ts": i["expires_ts"],
+            "redeemed_by": i.get("redeemed_by"),
+        }
+        for i in items
+    ]
+
+
+@router.delete("/api/projects/{project_id}/invites/{invite_id}")
+async def revoke_invite(
+    project_id: str,
+    invite_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    store = request.app.state.project_invites
+    project_store = request.app.state.project_store
+    project = await project_store.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "project not found"}, status_code=404)
+    require_owner_or_admin(user, project["user_id"])
+    row = await store.get(invite_id)
+    if row is None or row.get("project_id") != project_id:
+        return JSONResponse({"error": "invite not found"}, status_code=404)
+    ok = await store.revoke(invite_id)
+    if not ok:
+        return JSONResponse({"error": "invite not found or already redeemed"}, status_code=404)
+    return JSONResponse(content=None, status_code=204)


### PR DESCRIPTION
Slice S1 of the external-agent invite feature.

Implements the ProjectInviteStore with mint/get/list_for_project/revoke/redeem, the admin-gated POST/GET/DELETE routes under /api/projects/{project_id}/invites, and wires the store + router into app.py.

Tests cover: 6-digit invite_id + 4-digit PIN, project_tasks always included, 10-pending cap -> 429, wrong-pin attempts + 5th invalidates, correct-pin single-use (2nd redeem raises), expired invite, revoke, list omits pin_hash, and a boot-migration test (seed a project_invites table missing redeemed_request_id, assert init() boots).