### PR TITLE
docs(gate): document agent-JWT API surface + gate auth_middleware drift

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -95,6 +95,34 @@ POST <controller>/api/a2a/bus/send   (Authorization: Bearer <registry JWT, scope
 An admin session may also call it and set an explicit `from`. On a bus failure
 the proxy returns 502 (the read proxies degrade to an empty 200 instead).
 
+## Agent API surface (scoped registry JWT)
+
+A registered external agent authenticates with its registry JWT
+(`Authorization: Bearer`) and reaches exactly the routes its granted SCOPES
+allow, nothing else: the middleware allowlist is a closed set, no skeleton key.
+The surface, by scope:
+
+- **project_tasks** (the kanban board): `GET /api/projects/{pid}/tasks`,
+  `.../tasks/ready`, `.../tasks/{id}`, `.../tasks/{id}/comments` (GET + POST),
+  `POST .../tasks/{id}/(claim|release|close|reopen)`, and
+  `GET /api/projects/tasks/{id}/context`. Granting project_tasks also makes the
+  agent a project member.
+- **canvas_read**: `GET .../canvas/elements`, `.../canvas/snapshot.png|.tldr`,
+  `.../canvas/stream`. **canvas_write**: `POST .../canvas/elements`,
+  `PATCH|DELETE .../canvas/elements/{id}`.
+- **project_doc_review**: `GET .../doc-reviews`, `GET|PUT .../doc-review/{path}`.
+- **a2a_send / a2a_receive**: the authenticated bus proxy above
+  (`/api/a2a/bus/send|messages|channels|stream`), which forces `from` to the
+  agent's own handle.
+
+Access is per-project: a token is authorized for a project only when the agent
+holds an active grant + membership there; a request for a project it has no
+grant on returns an existence-hiding 404. External agents onboard via the
+consent flow (`POST /api/agents/auth-requests`) or a project invite (link +
+PIN, see `docs/design/external-agent-project-invite.md`). When you change the
+allowlist in `tinyagentos/auth_middleware.py`, update this section in the same
+PR (the doc-gate enforces it).
+
 These rules are deliberately lightweight. The goal is not process for its own
 sake; it is to let many hands move quickly on the same codebase without undoing
 each other's work.

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -119,7 +119,7 @@ Access is per-project: a token is authorized for a project only when the agent
 holds an active grant + membership there; a request for a project it has no
 grant on returns an existence-hiding 404. External agents onboard via the
 consent flow (`POST /api/agents/auth-requests`) or a project invite (link +
-PIN, see `docs/design/external-agent-project-invite.md`). When you change the
+PIN; see issue #1780). When you change the
 allowlist in `tinyagentos/auth_middleware.py`, update this section in the same
 PR (the doc-gate enforces it).
 

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -13,7 +13,7 @@
 trailer = "Docs-Reviewed:"
 
 [invariants]
-referenced_paths_scan = ["README.md", "docs/agent-coordination.md"]
+referenced_paths_scan = ["README.md", "docs/agent-coordination.md", "docs/agent-manual/index.md"]
 
 [[rules]]
 name = "apps"
@@ -41,3 +41,9 @@ name = "catalog"
 when_changed = ["app-catalog/**"]
 require_doc = ["README.md"]
 hint = "a catalog manifest was added or removed"
+
+[[rules]]
+name = "agent-api"
+when_changed = ["tinyagentos/auth_middleware.py"]
+require_doc = ["docs/agent-coordination.md"]
+hint = "the agent-token route allowlist changed; update the agent-facing API surface (or add a Docs-Reviewed trailer explaining why not)"


### PR DESCRIPTION
The doc-gate is structural (app/route/installer/catalog file add-or-remove + dead-link invariants). It does NOT catch behavior/content drift inside existing files, so the identity epic's new agent scopes (canvas, doc-review, per-project grant access) drifted `agent-coordination.md` while the gate kept passing.

- **agent-coordination.md**: adds an 'Agent API surface' section documenting the full scoped agent-JWT route set (project_tasks / canvas_read+write / project_doc_review / a2a) + the per-project grant model + onboarding (consent / invite).
- **doc-gate.toml**: new `agent-api` rule so future changes to `auth_middleware.py` (the agent-token allowlist) require touching that doc or a `Docs-Reviewed:` trailer; adds `docs/agent-manual/index.md` to the dead-link scan.

The remaining gap (a dedicated agent-manual Projects/Canvas page the invite onboarding kit links to) is folded into invite slice S2.