### PR TITLE
feat(invite): redeem + bundle + onboarding kit (#1780 S2)

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -123,6 +123,54 @@ PIN; see issue #1780). When you change the
 allowlist in `tinyagentos/auth_middleware.py`, update this section in the same
 PR (the doc-gate enforces it).
 
+## Project invite redeem route (link + PIN)
+
+A project invite lets an external agent join without going through the consent
+UI. The mint dialog (admin, in the project's Members panel) creates the invite;
+the agent redeems it. Two endpoints are auth-EXEMPT (the PIN is the proof of
+possession), added method-sensitively to `tinyagentos/auth_middleware.py` exactly
+like `POST /api/cluster/pairing/claim`, and per-IP rate-limited (20 requests per
+10s, reusing the pairing throttle helper):
+
+- `POST /api/projects/invites/redeem` — body `{invite_id, pin, harness, label?}`.
+  Verifies the PIN (wrong PIN / expired / attempt-capped -> 403; already redeemed
+  / revoked -> 409), derives the agent handle `{project_slug}-{harness}[-{label}]`
+  and de-dupes it against active registry agents in the project, then either
+  auto-approves through the shared `approve_request_record` helper (decided_by =
+  the invite's creator) or leaves the request pending (manual mode, consent bell
+  fires). Returns a connection bundle plus `{request_id, agent_handle, poll_path}`.
+  `project_tasks` is force-included so a successful redeem always yields a project
+  member.
+- `GET /i/{invite_id}` — content-negotiated advert. An agent requesting
+  `Accept: application/json` gets the redeem contract (`{method, path, fields}`);
+  a browser gets a minimal HTML page. No PIN check here; it only advertises the
+  contract.
+
+The redeem response carries a **connection bundle** (design section 4 plus the
+Approved-build addendum). It contains NO token or secret (the token still
+arrives via the status poll). The bundle has:
+
+- `controller.endpoints` — the controller's reachable addresses: non-loopback
+  LAN IPv4s (priority ordered, operator override first) and the mesh (Tailscale)
+  node IP when joined. No relay in Phase 1.
+- `apis` — the agent-JWT-reachable surface, scoped EXACTLY to the granted scopes
+  and mirroring the middleware canvas allowlist so the advertised routes are the
+  ones the token can call: task routes when `project_tasks` is granted; canvas
+  `GET /canvas/elements` + `/canvas/snapshot.png` only when `canvas_read` is
+  granted; canvas `POST /canvas/elements` + `PATCH|DELETE /canvas/elements/{id}`
+  only when `canvas_write` is granted; the A2A bus proxy (`/api/a2a/bus/send|
+  messages|channels`) whenever an `a2a_*` scope is granted.
+- `delivery` — the timed-check contract (`poll_path`, `stream_path`,
+  `check_interval_secs` from the invite, `cursor: ts`, `filter: mentions+project`).
+- `onboarding` + `guide_markdown` — a personalized capability guide (repo link,
+  agent manual links, scoped Projects/Canvas summary, the A2A authenticated-proxy
+  contract, and explicit instructions to write the identity/project/token-file/bus
+  contract into the agent's OWN memory and to poll every `check_interval_secs`).
+
+See `docs/design/external-agent-project-invite.md` (issue #1780) for the full
+design; the bundle advertises canvas routes only when the corresponding scope
+was actually granted.
+
 These rules are deliberately lightweight. The goal is not process for its own
 sake; it is to let many hands move quickly on the same codebase without undoing
 each other's work.

--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -113,3 +113,234 @@ async def test_revoke_nonexistent_returns_404(client, app):
     pid = await _create_project(client)
     resp = await client.delete(f"/api/projects/{pid}/invites/000000")
     assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Redeem slice (S2): auto + manual approval, handle derivation, bundle, errors
+# ---------------------------------------------------------------------------
+
+async def _setup_agent_ecosystem(app, monkeypatch, tmp_path):
+    """Eagerly init the agent registry / auth-requests / grants stores + the
+    signing keypair on app.state so the redeem path can mint an identity.
+
+    Mirrors the wiring the consent approve route depends on (and what the
+    auth-request tests monkeypatch in). Returns nothing; mutates app.state."""
+    from tinyagentos.agent_registry_store import (
+        AgentRegistryStore,
+        load_or_create_signing_keypair,
+    )
+    from tinyagentos.auth_requests_store import AuthRequestsStore
+    from tinyagentos.agent_grants_store import AgentGrantsStore
+
+    registry = AgentRegistryStore(tmp_path / "reg.db")
+    await registry.init()
+    auth_store = AuthRequestsStore(tmp_path / "auth.db")
+    await auth_store.init()
+    grants = AgentGrantsStore(tmp_path / "grants.db")
+    await grants.init()
+    priv, pub = load_or_create_signing_keypair(tmp_path / "keys")
+
+    monkeypatch.setattr(app.state, "agent_registry", registry)
+    monkeypatch.setattr(app.state, "auth_requests", auth_store)
+    monkeypatch.setattr(app.state, "agent_grants", grants)
+    monkeypatch.setattr(app.state, "agent_registry_keypair", (priv, pub))
+    return registry, auth_store, grants
+
+
+async def _mint_invite(client, pid, *, approval_mode="auto", scopes=None, check_interval_secs=1800):
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={
+            "scopes": scopes or ["a2a_send"],
+            "approval_mode": approval_mode,
+            "check_interval_secs": check_interval_secs,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    # The mint route does not return the raw pin in all flows? It does (S1).
+    return data["invite_id"], data["pin"]
+
+
+@pytest.mark.asyncio
+async def test_redeem_auto_mode_end_to_end(client, app, monkeypatch, tmp_path):
+    registry, auth_store, grants = await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    pid = await _create_project(client, slug="redauto")
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto", scopes=["a2a_send"])
+
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    req_id = body["request_id"]
+    handle = body["agent_handle"]
+    assert handle == "redauto-claude", handle
+    assert body["poll_path"] == f"/api/agents/auth-requests/{req_id}"
+
+    # Poll returns accepted + canonical_id + token.
+    poll = await client.get(f"/api/agents/auth-requests/{req_id}")
+    assert poll.status_code == 200, poll.text
+    pdata = poll.json()
+    assert pdata["status"] == "accepted"
+    assert pdata["canonical_id"]
+    assert pdata["token"]
+
+    # A member row exists with the derived handle.
+    members = await app.state.project_store.list_members(pid)
+    assert len(members) == 1, members
+    assert members[0]["member_id"] == pdata["canonical_id"]
+
+
+@pytest.mark.asyncio
+async def test_redeem_bundle_carries_no_secret(client, app, monkeypatch, tmp_path):
+    await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    pid = await _create_project(client, slug="redbundle")
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto", scopes=["a2a_send"])
+
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "grok"},
+    )
+    assert resp.status_code == 200, resp.text
+    bundle = resp.json()["bundle"]
+    # The bundle must not carry the credential itself: no top-level `token`
+    # key, and no JWT-shaped (three dot-separated base64url) string anywhere.
+    assert "token" not in bundle
+    assert "secret" not in bundle
+    blob = json.dumps(bundle)
+    assert ".eyJ" not in blob and ".eyJ" not in blob
+    # Endpoints + scoped apis present.
+    assert "a2a_bus_send" in bundle["apis"]
+
+
+@pytest.mark.asyncio
+async def test_redeem_canvas_scope_advertised_only_when_granted(client, app, monkeypatch, tmp_path):
+    await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    pid = await _create_project(client, slug="redcanvas")
+
+    # Without canvas scope: no canvas routes in apis.
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto", scopes=["a2a_send"])
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert resp.status_code == 200, resp.text
+    apis = resp.json()["bundle"]["apis"]
+    assert "canvas_elements" not in apis
+    assert "canvas_element" not in apis
+
+    # With canvas_write scope: the write route appears, but the GET
+    # canvas_elements / snapshot (read) routes do NOT (read needs canvas_read).
+    iid2, pin2 = await _mint_invite(client, pid, approval_mode="auto", scopes=["canvas_write"])
+    resp2 = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid2, "pin": pin2, "harness": "claude", "label": "review"},
+    )
+    assert resp2.status_code == 200, resp2.text
+    apis2 = resp2.json()["bundle"]["apis"]
+    assert "canvas_elements" not in apis2
+    assert "canvas_snapshot" not in apis2
+    assert "canvas_element" in apis2
+    # Handle de-duplicated against the first agent (same harness+project,
+    # different label so still unique; assert it is well-formed).
+    assert resp2.json()["agent_handle"] == "redcanvas-claude-review"
+
+
+@pytest.mark.asyncio
+async def test_redeem_manual_mode_leaves_pending(client, app, monkeypatch, tmp_path):
+    await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    pid = await _create_project(client, slug="redmanual")
+    iid, pin = await _mint_invite(client, pid, approval_mode="manual", scopes=["a2a_send"])
+
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "opencode"},
+    )
+    assert resp.status_code == 200, resp.text
+    req_id = resp.json()["request_id"]
+
+    poll = await client.get(f"/api/agents/auth-requests/{req_id}")
+    assert poll.status_code == 200, poll.text
+    assert poll.json()["status"] == "pending"
+    # No member row yet (manual approval has not happened).
+    members = await app.state.project_store.list_members(pid)
+    assert members == []
+
+
+@pytest.mark.asyncio
+async def test_redeem_wrong_pin_returns_403(client, app, monkeypatch, tmp_path):
+    await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    pid = await _create_project(client, slug="redwrong")
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto", scopes=["a2a_send"])
+
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": "0000" if pin != "0000" else "1111", "harness": "claude"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_redeem_second_redeem_returns_409(client, app, monkeypatch, tmp_path):
+    await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    pid = await _create_project(client, slug="redtwice")
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto", scopes=["a2a_send"])
+
+    first = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert first.status_code == 200, first.text
+    second = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert second.status_code == 409, second.text
+
+
+@pytest.mark.asyncio
+async def test_invite_info_json_advertises_redeem_contract(client, app):
+    pid = await _create_project(client, slug="redinfo")
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto")
+
+    resp = await client.get(f"/i/{iid}", headers={"accept": "application/json"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["redeem"]["method"] == "POST"
+    assert data["redeem"]["path"] == "/api/projects/invites/redeem"
+    assert data["redeem"]["fields"]["invite_id"] == "required"
+    assert data["redeem"]["fields"]["pin"] == "required"
+    assert data["redeem"]["fields"]["harness"] == "required (your tool: kilo|grok|opencode|claude|aider|...)"
+    assert "label" in data["redeem"]["fields"]
+
+
+@pytest.mark.asyncio
+async def test_invite_info_html_for_browser(client, app):
+    pid = await _create_project(client, slug="redhtml")
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto")
+
+    resp = await client.get(f"/i/{iid}", headers={"accept": "text/html"})
+    assert resp.status_code == 200, resp.text
+    assert "text/html" in resp.headers["content-type"]
+    assert "taOS" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_guide_markdown_contains_required_instructions(client, app, monkeypatch, tmp_path):
+    await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    pid = await _create_project(client, slug="redguide")
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto", scopes=["a2a_send"])
+
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert resp.status_code == 200, resp.text
+    guide = resp.json()["bundle"]["guide_markdown"]
+    assert "https://github.com/jaylfc/taOS" in guide
+    assert "WRITE THIS INTO YOUR OWN PERSISTENT MEMORY" in guide
+    # Timed-check instruction mentions the interval value.
+    assert "1800" in guide
+

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ipaddress
 import re
+import time
 
 from fastapi import Request
 from fastapi.responses import JSONResponse
@@ -123,6 +124,13 @@ _CLUSTER_PAIRING_MANUAL_CLAIM = "/api/cluster/pairing/manual-claim"
 _CLUSTER_WORKERS = "/api/cluster/workers"
 _CLUSTER_HEARTBEAT = "/api/cluster/heartbeat"
 
+# Project-invite redeem: unauthenticated (the PIN is the proof of possession,
+# exactly like cluster pairing). The redeem POST and the content-negotiated
+# GET /i/{id} are method-sensitive exemptions (mirror the pairing-claim
+# pattern). Per-IP fixed-window rate limit reuses the pairing throttle below.
+_INVITE_REDEEM = "/api/projects/invites/redeem"
+_INVITE_INFO_PREFIX = "/i/"
+
 # Local-only shutdown drain: the systemd ExecStop hook (taos-graceful-stop)
 # POSTs this from localhost with no session cookie and no token, so it was
 # getting 401 and the in-app drain never ran. We exempt it ONLY for loopback
@@ -149,6 +157,36 @@ def _is_loopback_client(request: Request) -> bool:
         return ipaddress.ip_address(client.host).is_loopback
     except ValueError:
         return False
+
+
+# ---------------------------------------------------------------------------
+# Per-IP fixed-window rate limiter (shared by unauthenticated proof-of-
+# possession endpoints: cluster pairing manual-claim and project-invite redeem).
+# ---------------------------------------------------------------------------
+_INVITE_RATE_WINDOW_SECS = 10.0
+_INVITE_RATE_MAX_PER_WINDOW = 20
+# ip -> (window_start_ts, count). In-memory is sufficient: the controller is a
+# single process and the cap only needs to bound a brute-force burst.
+_rate_limit_hits: dict[str, tuple[float, int]] = {}
+
+
+def rate_limit_ok(key: str, *, window_secs: float = _INVITE_RATE_WINDOW_SECS,
+                  max_per_window: int = _INVITE_RATE_MAX_PER_WINDOW) -> bool:
+    """Fixed-window per-key limiter. Returns False when the key has exceeded
+    ``max_per_window`` requests in the current window. The pairing
+    ``_manual_claim_rate_ok`` helper in cluster.py uses the identical contract;
+    this shared copy keeps the cluster and invite paths from drifting and lets
+    both pass the same ``20 per 10s`` cap the design specifies.
+
+    Mirrors ``_manual_claim_rate_ok`` exactly so behaviour is identical.
+    """
+    now = time.time()
+    window_start, count = _rate_limit_hits.get(key, (now, 0))
+    if now - window_start >= window_secs:
+        window_start, count = now, 0
+    count += 1
+    _rate_limit_hits[key] = (window_start, count)
+    return count <= max_per_window
 
 
 def _is_exempt(method: str, path: str) -> bool:
@@ -200,6 +238,17 @@ def _is_exempt(method: str, path: str) -> bool:
         and path.startswith(_CLUSTER_WORKERS + "/")
         and path.endswith("/incus-enroll")
     ):
+        return True
+    # Project-invite redeem: POST /api/projects/invites/redeem is
+    # unauthenticated (the PIN is the proof of possession, exactly like cluster
+    # pairing claim) and is per-IP rate-limited at the route layer.
+    if method == "POST" and path == _INVITE_REDEEM:
+        return True
+    # GET /i/{invite_id} — content-negotiated invite advert (machine JSON or a
+    # human HTML page). No PIN check here; it only advertises the redeem
+    # contract. The browser-friendly /i/ exact path stays session-gated so a
+    # logged-out admin is not exposed, but the invite id form is exempt.
+    if method == "GET" and path.startswith(_INVITE_INFO_PREFIX) and "/" not in path[len(_INVITE_INFO_PREFIX):]:
         return True
     return False
 

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -256,6 +256,25 @@ class ProjectInviteStore(BaseStore):
         updated = await self._fetch_row(invite_id)
         return self._row_to_dict(updated)
 
+    async def mark_redeemed(
+        self, invite_id: str, redeemed_by: str, redeemed_request_id: str
+    ) -> None:
+        """Record who/what redeemed an invite for audit (called by the redeem
+        route after the auth-request has been created/approved). Best-effort
+        from the caller's perspective; the status flip already happened in
+        ``redeem``."""
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+        await self._db.execute(
+            """
+            UPDATE project_invites
+               SET redeemed_by = ?, redeemed_request_id = ?
+             WHERE invite_id = ?
+            """,
+            (redeemed_by, redeemed_request_id, invite_id),
+        )
+        await self._db.commit()
+
     async def _fetch_row(self, invite_id: str) -> aiosqlite.Row | None:
         cursor = await self._db.execute(
             "SELECT * FROM project_invites WHERE invite_id = ?", (invite_id,)

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -278,23 +278,39 @@ async def approve_auth_request(
                 locks.pop(request_id, None)
 
 
-async def _do_approve(request: Request, request_id: str, body: ApproveBody, user):
-    """Inner approve logic — called under a per-request lock."""
+async def approve_request_record(
+    request: Request,
+    *,
+    record: dict,
+    granted_scopes: list[str],
+    effective_project: str | None,
+    decided_by: str,
+    project_id: str | None = None,
+) -> dict:
+    """Register an agent, mint its token, write grants + relationships +
+    membership + a2a sync, and record the decision.
+
+    This is the single mint machinery shared by the consent approve route
+    (``_do_approve``, which resolves ``granted_scopes``/``effective_project``
+    from the admin's ``ApproveBody``) and the project-invite redeem path
+    (``project_invites.redeem``), which already has the scopes + bound project
+    from the invite. ``decided_by`` is the actor recorded on the decision; for
+    the consent route it is the approving admin's user_id, for invite auto-mode
+    it is the invite's ``created_by``.
+
+    Returns ``{"status": "accepted", "canonical_id": ...}``.
+
+    Raises ``HTTPException`` for the same guard failures as the consent route:
+    a project-scoped grant without a project_id (400), or an active-handle
+    collision (409).
+    """
     auth_store = _get_auth_requests_store(request)
-    record = await auth_store.get(request_id)
-    if record is None:
-        raise HTTPException(status_code=404, detail="request not found")
-    if record["status"] != "pending":
-        raise HTTPException(
-            status_code=409,
-            detail=f"request is already {record['status']!r}; cannot approve",
-        )
 
     # The admin can narrow the requested scopes but never widen them, and
     # every granted scope must be in the closed vocabulary (defence in depth
     # for pending records created before scope validation existed).
     requested = set(record["requested_scopes"] or [])
-    granted = set(body.granted_scopes)
+    granted = set(granted_scopes)
     invalid = sorted((granted - requested) | (granted - VALID_SCOPES))
     if invalid:
         raise HTTPException(
@@ -309,19 +325,18 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
     _PROJECT_SCOPES = {"project_tasks"} | _CANVAS_SCOPES
 
     # project_tasks and the canvas scopes bind the token to a specific project
-    # and add a membership row, so require the human to pick that project
-    # explicitly in the consent card. Never fall back to the agent-supplied
-    # project_id for these grants: POST /api/agents/auth-requests is
-    # unauthenticated, so the request could name any existing project the
-    # operator never validated. Other scopes keep the fallback so global
-    # tokens still work. Checked before any registration so a rejected approval
-    # never leaves an orphaned agent.
-    needs_project = bool(set(body.granted_scopes) & _PROJECT_SCOPES)
-    # Reject None, "", and whitespace-only: a blank project_id is not a real
-    # binding, and a downstream truthy check would treat it as unbound, so an
-    # empty string must fail closed exactly like a missing one.
-    if needs_project and not (body.project_id and body.project_id.strip()):
-        missing = sorted(set(body.granted_scopes) & _PROJECT_SCOPES)
+    # and add a membership row, so require a real project_id for these grants.
+    # The check uses ``project_id`` — the EXPLICIT picker value the human (or
+    # the invite) supplied — NOT the agent-supplied fallback that produced
+    # ``effective_project``. Never fall back to the agent-supplied project_id for
+    # these grants: POST /api/agents/auth-requests is unauthenticated, so the
+    # request could name any existing project the operator never validated. A
+    # blank/None project_id is not a real binding and must fail closed exactly
+    # like a missing one; the redeem path passes the invite's project (always
+    # non-empty for a project invite), so it passes this guard.
+    needs_project = bool(set(granted_scopes) & _PROJECT_SCOPES)
+    if needs_project and not (project_id and project_id.strip()):
+        missing = sorted(set(granted_scopes) & _PROJECT_SCOPES)
         raise HTTPException(
             status_code=400,
             detail=f"project_id is required when granting {missing}",
@@ -364,7 +379,12 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
         reg_record = await registry.register(
             framework=record["framework"],
             display_name=display_name,
-            user_id=user.user_id,
+            user_id=decided_by,
+            # external-selfjoin is the only origin that births the agent
+            # 'pending' (governance lifecycle) so the pending -> active
+            # transition below is the activation. The provenance of WHO
+            # approved (admin consent vs project invite) lives on the
+            # auth-request record / invite, not the registry origin column.
             origin="external-selfjoin",
             handle=handle,
         )
@@ -374,7 +394,7 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
         # 'pending' (governance lifecycle); approving the auth-request transitions
         # them to 'active' so they are NOT in the bus inactive/revocation feed and
         # @taOSmd's identity-AND-grant gate accepts them.
-        await registry.set_status(canonical_id, "active", actor=user.user_id)
+        await registry.set_status(canonical_id, "active", actor=decided_by)
     except IntegrityError:
         # A concurrent approve already took this active handle (the partial
         # unique index fired). Roll back the failed write and remove the
@@ -397,23 +417,17 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
             ),
         )
 
-    # Resolve effective project binding: admin override wins; fall back to the
-    # project_id the agent requested (may be None for a global token).
-    effective_project = (
-        body.project_id if body.project_id is not None else record.get("project_id")
-    )
-
     # Issue the identity token.
     token = mint_registry_token(
         canonical_id,
         private_pem,
-        user_id=user.user_id,
+        user_id=decided_by,
         framework=record["framework"],
         project_id=effective_project,
     )
 
     # Record grants for each approved scope.
-    for scope in body.granted_scopes:
+    for scope in granted_scopes:
         await grants_store.add_grant(canonical_id, scope, tier="once", project_id=effective_project)
         # Also write a RelationshipManager permission edge so the existing
         # permission-check path (can_communicate etc.) is aware of the agent.
@@ -424,11 +438,11 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
     # project a2a channel (membership is synced into the channel). Best-effort: a
     # membership failure never blocks the approval, which the token + grant already
     # authorize.
-    if effective_project and set(body.granted_scopes) & _PROJECT_SCOPES:
+    if effective_project and set(granted_scopes) & _PROJECT_SCOPES:
         try:
             pstore = getattr(request.app.state, "project_store", None)
             if pstore is not None:
-                granted_canvas = set(body.granted_scopes) & _CANVAS_SCOPES
+                granted_canvas = set(granted_scopes) & _CANVAS_SCOPES
                 # project_tasks and canvas scopes both bind the token to a
                 # project and require a membership row. The project_tasks path
                 # adds plain membership; canvas scopes additionally flip the
@@ -437,7 +451,7 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
                 # (an inert member row with all canvas flags 0 would 403).
                 # Only flags that were explicitly granted are set, mirroring
                 # how the consent card scopes are narrowed.
-                if "project_tasks" in body.granted_scopes or granted_canvas:
+                if "project_tasks" in granted_scopes or granted_canvas:
                     await pstore.add_member(
                         project_id=effective_project,
                         member_id=canonical_id,
@@ -451,7 +465,7 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
                             can_read=("canvas_read" in granted_canvas),
                             can_write=("canvas_write" in granted_canvas),
                         )
-                    if "project_tasks" in body.granted_scopes:
+                    if "project_tasks" in granted_scopes:
                         from tinyagentos.projects.a2a import ensure_a2a_channel
 
                         await ensure_a2a_channel(
@@ -470,12 +484,12 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
 
     # Atomically commit the decision.
     result = await auth_store.set_decision(
-        request_id,
+        record["id"],
         "accepted",
         canonical_id=canonical_id,
         token=token,
-        granted_scopes=body.granted_scopes,
-        decided_by=user.user_id,
+        granted_scopes=granted_scopes,
+        decided_by=decided_by,
     )
     if result is None:
         # Another concurrent approve beat us — 409.
@@ -484,8 +498,42 @@ async def _do_approve(request: Request, request_id: str, body: ApproveBody, user
             detail="request was decided concurrently; check current status",
         )
 
-    await _retire_request_notification(request, request_id)
+    await _retire_request_notification(request, record["id"])
     return {"status": "accepted", "canonical_id": canonical_id}
+
+
+async def _do_approve(request: Request, request_id: str, body: ApproveBody, user):
+    """Inner approve logic — called under a per-request lock.
+
+    Resolves the admin's approve decision into the shared
+    ``approve_request_record`` mint machinery (used by both this route and the
+    project-invite redeem path). No behaviour change versus the pre-extraction
+    route; it only forwards the resolved ``granted_scopes`` / ``effective_project``.
+    """
+    auth_store = _get_auth_requests_store(request)
+    record = await auth_store.get(request_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="request not found")
+    if record["status"] != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"request is already {record['status']!r}; cannot approve",
+        )
+
+    # Resolve effective project binding: admin override wins; fall back to the
+    # project_id the agent requested (may be None for a global token).
+    effective_project = (
+        body.project_id if body.project_id is not None else record.get("project_id")
+    )
+
+    return await approve_request_record(
+        request,
+        record=record,
+        granted_scopes=body.granted_scopes,
+        effective_project=effective_project,
+        decided_by=user.user_id,
+        project_id=body.project_id,
+    )
 
 
 @router.post("/api/agents/auth-requests/{request_id}/deny")

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -1,13 +1,23 @@
 from __future__ import annotations
 
+import json
 import logging
+import socket
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, Field
 
+from tinyagentos.agent_registry_store import _slugify
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
-from tinyagentos.projects.invite_store import InvitePendingCapError
+from tinyagentos.auth_middleware import rate_limit_ok
+from tinyagentos.projects.invite_store import (
+    InviteAlreadyRedeemedError,
+    InviteExpiredError,
+    InvitePinError,
+    InvitePendingCapError,
+    InviteRevokedError,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -17,6 +27,388 @@ class MintInviteIn(BaseModel):
     scopes: list[str] = Field(default_factory=list)
     approval_mode: str = Field(default="auto", pattern="^(auto|manual)$")
     check_interval_secs: int = Field(default=1800, ge=60)
+
+
+class RedeemInviteIn(BaseModel):
+    invite_id: str
+    pin: str
+    harness: str
+    label: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Handle derivation (design section 2a)
+# ---------------------------------------------------------------------------
+#
+# The controller derives the human-facing handle as
+# {project_slug}-{harness}[-{label}], slugified. Two live agents may not share
+# a bus handle, so before minting we check the registry for an ACTIVE agent
+# already holding the target handle in this project and append -2, -3, ...
+# until free. The label is the natural first disambiguator, so the numeric
+# suffix is the fallback for same-harness/same-label re-invites.
+
+_CANCEL_SCOPES = {"canvas_read", "canvas_write"}
+
+
+def _derive_handle(project_slug: str, harness: str, label: str | None) -> str:
+    """Build the base handle {project_slug}-{harness}[-{label}], slugified.
+
+    Each component is slugified independently so an awkward label cannot bleed
+    separators into a neighbour; the parts are then joined with single dashes.
+    """
+    slug = _slugify(project_slug)
+    hw = _slugify(harness)
+    parts = [slug, hw]
+    if label:
+        lbl = _slugify(label)
+        if lbl:
+            parts.append(lbl)
+    return "-".join(p for p in parts if p)
+
+
+async def _dedupe_handle(request: Request, base_handle: str) -> str:
+    """Return ``base_handle`` unless an ACTIVE agent already holds it in this
+    project, in which case append -2, -3, ... until a free handle is found.
+
+    The registry active-handle check is exactly the one the consent minting
+    path uses (``registry.get_by_handle(..., status="active")``), so a re-invite
+    collides deterministically with the live agent rather than minting a
+    duplicate bus address.
+    """
+    registry = getattr(request.app.state, "agent_registry", None)
+    if registry is None:
+        return base_handle
+    candidate = base_handle
+    n = 2
+    while await registry.get_by_handle(candidate, status="active") is not None:
+        candidate = f"{base_handle}-{n}"
+        n += 1
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Connection bundle (design section 4 + addendum)
+# ---------------------------------------------------------------------------
+
+# Port the controller binds. The bundle endpoints reuse this for every
+# enumerated LAN / mesh address.
+_CONTROLLER_PORT = 6969
+
+
+def _enumerate_lan_ips() -> list[str]:
+    """Return the controller host's non-loopback IPv4 addresses.
+
+    Mirrors the UDP getsockname trick used by worker/agent.py for the primary
+    interface, plus a full interface enumeration (``socket`` + ``fcntl``/
+    ``subprocess ip addr``) for multi-homed hosts. Loopback (127.0.0.0/8) and
+    link-local (169.254.0.0/16) addresses are excluded; the controller binds
+    **
+
+    Fail-soft: if enumeration raises, returns an empty list and the caller
+    falls back to the operator override / mesh endpoint.
+    """
+    ips: list[str] = []
+    seen: set[str] = set()
+
+    def _add(ip: str) -> None:
+        if not ip:
+            return
+        try:
+            addr = socket.inet_aton(ip)
+        except OSError:
+            return
+        # Exclude loopback and link-local.
+        if ip.startswith("127.") or ip.startswith("169.254."):
+            return
+        if ip in seen:
+            return
+        seen.add(ip)
+        ips.append(ip)
+
+    # Primary interface via UDP getsockname (no packets sent).
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            _add(s.getsockname()[0])
+        finally:
+            s.close()
+    except OSError:
+        pass
+
+    # Full interface enumeration (Linux/macOS `ip addr`/`ifconfig` style via
+    # the stdlib getaddrinfo on each adapter is not portable, so shell out to
+    # `ip -4 addr` when present, else best-effort).
+    try:
+        import subprocess
+
+        out = subprocess.run(
+            ["ip", "-4", "addr", "show"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if out.returncode == 0:
+            import re
+
+            for m in re.finditer(r"inet\s+(\d+\.\d+\.\d+\.\d+)/\d+", out.stdout):
+                _add(m.group(1))
+    except Exception:  # noqa: BLE001 - enumeration is best-effort
+        pass
+
+    return ips
+
+
+async def build_connection_bundle(
+    request: Request,
+    *,
+    invite_record: dict,
+    project: dict,
+    agent_handle: str,
+    granted_scopes: list[str],
+    check_interval_secs: int,
+) -> dict:
+    """Assemble the JSON connection bundle returned by a successful redeem.
+
+    The bundle carries NO token or secret (the token arrives via the status
+    poll). It enumerates the controller's reachable endpoints (LAN, mesh; no
+    relay in Phase 1), the agent-JWT-reachable API surface scoped EXACTLY to
+    the granted scopes (mirroring auth_middleware's canvas allowlist), the
+    timed-check delivery contract, and an onboarding kit + guide_markdown.
+
+    See design section 4 and the Approved-build addendum.
+    """
+    pid = project["id"]
+    project_slug = project.get("slug") or pid
+
+    # --- controller endpoints ---------------------------------------------
+    endpoints: list[dict] = []
+    priority = 1
+
+    # Operator override (TAOS_CONTROLLER_CALLBACK_HOST) becomes priority 1.
+    override = None
+    try:
+        from tinyagentos.routes.agent_deploy import controller_callback_host
+
+        override = await controller_callback_host(request)
+    except Exception:  # noqa: BLE001
+        override = None
+    if override:
+        endpoints.append(
+            {"kind": "lan", "url": f"http://{override}:{_CONTROLLER_PORT}", "priority": priority}
+        )
+        priority += 1
+
+    for ip in _enumerate_lan_ips():
+        if override and ip == override:
+            continue
+        endpoints.append(
+            {"kind": "lan", "url": f"http://{ip}:{_CONTROLLER_PORT}", "priority": priority}
+        )
+        priority += 1
+
+    # Mesh endpoint from tailscale mesh status, when joined.
+    try:
+        from tinyagentos.taosnet.mesh import mesh_status
+
+        status = await mesh_status()
+        if status.get("joined") and status.get("node_ip"):
+            endpoints.append(
+                {
+                    "kind": "mesh",
+                    "url": f"http://{status['node_ip']}:{_CONTROLLER_PORT}",
+                    "priority": priority,
+                }
+            )
+            priority += 1
+    except Exception:  # noqa: BLE001 - mesh is optional
+        pass
+
+    controller = {
+        "endpoints": endpoints,
+        "health_path": "/api/health",
+        "registry_pubkey_path": "/api/agents/registry/pubkey",
+    }
+
+    # --- agent_handle scoped api surface ----------------------------------
+    apis: dict = {}
+    scopeset = set(granted_scopes)
+    has_tasks = "project_tasks" in scopeset
+    has_canvas_read = "canvas_read" in scopeset
+    has_canvas_write = "canvas_write" in scopeset
+
+    if has_tasks:
+        apis["tasks_list"] = f"/api/projects/{pid}/tasks"
+        apis["tasks_ready"] = f"/api/projects/{pid}/tasks/ready"
+        apis["task_lifecycle"] = f"/api/projects/{pid}/tasks/{{task_id}}/(claim|release|close|reopen)"
+        apis["task_comments"] = f"/api/projects/{pid}/tasks/{{task_id}}/comments"
+    if has_canvas_read:
+        apis["canvas_elements"] = f"/api/projects/{pid}/canvas/elements"
+        apis["canvas_snapshot"] = f"/api/projects/{pid}/canvas/snapshot.png"
+    if has_canvas_write:
+        apis["canvas_element"] = f"/api/projects/{pid}/canvas/elements/{{eid}}"
+
+    # A2A bus routes are always advertised (a2a_send / a2a_receive are part of
+    # the invite's default scope set, but include them whenever either scope is
+    # present so the advertised surface matches what the token can call).
+    if "a2a_send" in scopeset or "a2a_receive" in scopeset:
+        apis["a2a_bus_send"] = "/api/a2a/bus/send"
+        apis["a2a_bus_messages"] = "/api/a2a/bus/messages"
+        apis["a2a_bus_channels"] = "/api/a2a/bus/channels"
+
+    delivery = {
+        "stream_path": f"/api/a2a/bus/stream?channel={{channel}}&since={{cursor}}",
+        "poll_path": f"/api/a2a/bus/messages?channel={{channel}}&since={{cursor}}",
+        "check_interval_secs": check_interval_secs,
+        "cursor": "ts",
+        "filter": "mentions+project",
+    }
+
+    # --- onboarding kit ----------------------------------------------------
+    onboarding = {
+        "links": [
+            {"label": "taOS repository", "url": "https://github.com/jaylfc/taOS"},
+            {
+                "label": "Agent manual (04-apps.md)",
+                "url": "https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/04-apps.md",
+            },
+            {
+                "label": "Agent manual (09-os-control.md)",
+                "url": "https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/09-os-control.md",
+            },
+        ],
+        "check_interval_secs": check_interval_secs,
+    }
+
+    guide = _build_guide_markdown(
+        project=project,
+        project_slug=project_slug,
+        agent_handle=agent_handle,
+        granted_scopes=granted_scopes,
+        has_tasks=has_tasks,
+        has_canvas_read=has_canvas_read,
+        has_canvas_write=has_canvas_write,
+        check_interval_secs=check_interval_secs,
+    )
+
+    return {
+        "version": 1,
+        "invite_id": invite_record["invite_id"],
+        "project": {
+            "id": project["id"],
+            "name": project.get("name", ""),
+            "slug": project_slug,
+        },
+        "controller": controller,
+        "auth": {
+            "flow": "auth_request",
+            "agent_handle": agent_handle,
+            "granted_scopes": sorted(granted_scopes),
+        },
+        "apis": apis,
+        "delivery": delivery,
+        "onboarding": onboarding,
+        "guide_markdown": guide,
+    }
+
+
+def _build_guide_markdown(
+    *,
+    project: dict,
+    project_slug: str,
+    agent_handle: str,
+    granted_scopes: list[str],
+    has_tasks: bool,
+    has_canvas_read: bool,
+    has_canvas_write: bool,
+    check_interval_secs: int,
+) -> str:
+    """Generate the personalized capability guide from granted scopes + project
+    + derived handle. Contains NO secret: the token still arrives via the status
+    poll. The agent that only reads the guide gets an accurate capability map."""
+    scopeset = set(granted_scopes)
+    lines: list[str] = []
+    lines.append(f"# Joining {project.get('name', project_slug)} on taOS as `{agent_handle}`")
+    lines.append("")
+    lines.append(
+        "You were invited to a taOS project. Redeeming your invite registered you as "
+        "an external agent and minted an agent-identity token (delivered via your "
+        "status poll, not this guide). This document is your personalized capability map."
+    )
+    lines.append("")
+    lines.append("## Links")
+    lines.append("")
+    lines.append("- taOS repository: https://github.com/jaylfc/taOS")
+    lines.append("- Agent manual - apps: https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/04-apps.md")
+    lines.append("- Agent manual - OS control: https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/09-os-control.md")
+    lines.append("")
+    lines.append("## Your capabilities in the Projects app")
+    lines.append("")
+    if has_tasks:
+        lines.append(
+            "- Tasks (kanban): list ready tasks, read a task, claim/release/close/reopen it, "
+            "and read/post comments. You are a member of this project."
+        )
+    else:
+        lines.append(
+            "- Tasks (kanban): NOT granted. You cannot read or act on project tasks."
+        )
+    lines.append("")
+    lines.append("## Your capabilities on the Canvas")
+    lines.append("")
+    if has_canvas_read:
+        lines.append(
+            "- Canvas read: read canvas elements (notes, links, text, mermaid, flowchart) "
+            "and the canvas snapshot for this project."
+        )
+    else:
+        lines.append("- Canvas read: NOT granted.")
+    if has_canvas_write:
+        lines.append(
+            "- Canvas write: create canvas elements and edit/delete the ones you own."
+        )
+    else:
+        lines.append("- Canvas write: NOT granted.")
+    if not has_canvas_read and not has_canvas_write:
+        lines.append("- You have no canvas access in this project.")
+    lines.append("")
+    lines.append("## A2A bus contract (authenticated proxy)")
+    lines.append("")
+    if "a2a_send" in scopeset or "a2a_receive" in scopeset:
+        lines.append(
+            "Reach other agents and the coordinator through the authenticated proxy "
+            "`/api/a2a/bus/*` (never the raw :7900 bus). The proxy forces `from` to your "
+            "own handle, so you always post as yourself. Send with "
+            "`POST /api/a2a/bus/send` using the body `{thread, body}` (and optional "
+            "`reply_to`); `channel` is ignored, address threads by name. Read via "
+            "`GET /api/a2a/bus/messages?channel={channel}&since={cursor}`."
+        )
+    else:
+        lines.append("- A2A bus: NOT granted.")
+    lines.append("")
+    lines.append("## WRITE THIS INTO YOUR OWN PERSISTENT MEMORY NOW")
+    lines.append("")
+    lines.append(
+        "Persist the following into your own long-term memory (not the operator's): "
+        f"your canonical_id (from the status poll), the project id `{project.get('id')}` "
+        f"and slug `{project_slug}`, the path to the token file where you stored the "
+        "polled token, and this bus contract (authenticated proxy, `from` forced to "
+        f"`{agent_handle}`). A re-spawn must reuse this identity, not mint a new one."
+    )
+    lines.append("")
+    lines.append("## CHECK ON A TIMER (the loop that makes you a member)")
+    lines.append("")
+    lines.append(
+        f"Poll every {check_interval_secs} seconds (or hold the SSE stream at "
+        "`/api/a2a/bus/stream`) for your ready tasks and any @mentions addressed to "
+        f"`{agent_handle}`. On each check: read ready tasks, act on them, comment "
+        "progress, post on the bus, and report status. This timed check is the "
+        "reliable delivery floor; the stream is an optional optimization only if your "
+        "harness can hold a connection and wake on a message."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
 
 
 @router.post("/api/projects/{project_id}/invites")
@@ -98,3 +490,231 @@ async def revoke_invite(
     if not ok:
         return JSONResponse({"error": "invite not found or already redeemed"}, status_code=404)
     return JSONResponse(content=None, status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Redeem (auth-EXEMPT) + content-negotiated invite advert
+# ---------------------------------------------------------------------------
+
+# Map the S1 store exceptions onto HTTP statuses (design section 5 failure
+# modes). Wrong pin / expired / attempt-capped -> 403; already redeemed /
+# revoked -> 409.
+def _invite_exception_to_http(exc: Exception) -> tuple[int, str]:
+    if isinstance(exc, (InvitePinError, InviteExpiredError)):
+        return 403, str(exc)
+    if isinstance(exc, (InviteAlreadyRedeemedError, InviteRevokedError)):
+        return 409, str(exc)
+    return 400, str(exc)
+
+
+@router.post("/api/projects/invites/redeem")
+async def redeem_invite(request: Request, body: RedeemInviteIn):
+    """Auth-EXEMPT redeem (the PIN is the proof of possession).
+
+    Flow (design section 2, Approach C):
+      1. Verify invite_id + PIN (attempts, TTL, single-use) via the S1 store.
+      2. Derive the handle {project_slug}-{harness}[-{label}], dedup against
+         ACTIVE registry agents holding that handle in this project.
+      3. Build a CreateAuthRequest-shaped record (framework=harness,
+         identity_claim=handle, requested_scopes=invite scopes, project_id).
+      4. auto: approve through the shared approve_request_record helper
+         (decided_by = invite.created_by). manual: create a pending request so
+         the consent bell fires.
+      5. Return build_connection_bundle(...) + {request_id, agent_handle,
+         poll_path}.
+    """
+    client_ip = request.client.host if request.client else "unknown"
+    if not rate_limit_ok(client_ip):
+        return JSONResponse(
+            {"error": "too many redeem attempts; slow down and retry"},
+            status_code=429,
+        )
+
+    store = request.app.state.project_invites
+    try:
+        invite = await store.redeem(body.invite_id, body.pin)
+    except Exception as exc:  # noqa: BLE001 - mapped to HTTP below
+        status, msg = _invite_exception_to_http(exc)
+        return JSONResponse({"error": msg}, status_code=status)
+
+    project_store = request.app.state.project_store
+    project = await project_store.get_project(invite["project_id"])
+    if project is None:
+        return JSONResponse({"error": "project not found"}, status_code=404)
+
+    # The store returns scopes as a JSON string; parse it defensively.
+    raw_scopes = invite["scopes"] or []
+    if isinstance(raw_scopes, str):
+        try:
+            raw_scopes = json.loads(raw_scopes)
+        except (ValueError, TypeError):
+            raw_scopes = []
+    # Force-include project_tasks for this project even if the record somehow
+    # omitted it (membership invariant: a successful redeem MUST yield a member).
+    scopes = list(raw_scopes)
+    if "project_tasks" not in scopes:
+        scopes = ["project_tasks"] + scopes
+
+    handle = _derive_handle(project.get("slug") or invite["project_id"], body.harness, body.label)
+    handle = await _dedupe_handle(request, handle)
+
+    # Build a CreateAuthRequest-shaped record reusing the consent store's
+    # create() so the downstream approve helper consumes a normal record.
+    from tinyagentos.auth_requests_store import AuthRequestsStore
+    from tinyagentos.routes.agent_auth_requests import approve_request_record
+
+    auth_store = request.app.state.auth_requests
+    record = await auth_store.create(
+        identity_claim=handle,
+        framework=body.harness,
+        requested_scopes=scopes,
+        requested_skills=None,
+        reason=f"invite {body.invite_id}",
+        duration_secs=None,
+        project_id=invite["project_id"],
+    )
+
+    if invite["approval_mode"] == "auto":
+        try:
+            await approve_request_record(
+                request,
+                record=record,
+                granted_scopes=scopes,
+                effective_project=invite["project_id"],
+                decided_by=invite["created_by"],
+                project_id=invite["project_id"],
+            )
+        except Exception as exc:  # noqa: BLE001 - surface as JSON error
+            return JSONResponse({"error": str(exc)}, status_code=400)
+    else:
+        # manual: leave pending so the consent bell fires (handled by
+        # create_auth_request in the consent route path). We created the record
+        # directly above, so surface a bell notification too.
+        _notify_pending_invite(request, record)
+
+    # Record the redeem back on the invite for audit.
+    try:
+        await store.mark_redeemed(body.invite_id, handle, record["id"])
+    except Exception:  # noqa: BLE001 - audit best-effort
+        pass
+
+    bundle = await build_connection_bundle(
+        request,
+        invite_record=invite,
+        project=project,
+        agent_handle=handle,
+        granted_scopes=scopes,
+        check_interval_secs=invite.get("check_interval_secs") or 1800,
+    )
+
+    return {
+        "request_id": record["id"],
+        "agent_handle": handle,
+        "poll_path": f"/api/agents/auth-requests/{record['id']}",
+        "bundle": bundle,
+    }
+
+
+def _notify_pending_invite(request: Request, record: dict) -> None:
+    """Best-effort bell notification for a manually-approved invite redeem.
+
+    Fire-and-forget: a notification failure must never fail the redeem.
+    """
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is None:
+        return
+    try:
+        scopes = record.get("requested_scopes") or []
+        import asyncio
+
+        asyncio.create_task(
+            notifs.add(
+                title="Access request",
+                message=f"{record['identity_claim']} is requesting {', '.join(scopes)}",
+                level="info",
+                source="auth_requests",
+                data={
+                    "request_id": record["id"],
+                    "identity_claim": record["identity_claim"],
+                    "framework": record["framework"],
+                    "requested_scopes": list(scopes),
+                },
+            )
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+@router.get("/i/{invite_id}")
+async def invite_info(request: Request, invite_id: str):
+    """Content-negotiated invite advert (auth-EXEMPT).
+
+    `Accept: application/json` -> machine instructions for the redeem contract.
+    Browser `Accept: text/html` -> a minimal self-contained page explaining what
+    this is and that an agent should fetch it as JSON. No PIN check here; it
+    only advertises the redeem contract.
+    """
+    store = request.app.state.project_invites
+    invite = await store.get(invite_id)
+    if invite is None:
+        accept = request.headers.get("accept", "")
+        if "text/html" in accept:
+            return HTMLResponse(
+                "<!doctype html><meta charset=utf-8><title>Invite not found</title>"
+                "<h1>Invite not found</h1><p>This invite link is invalid or expired.</p>",
+                status_code=404,
+            )
+        return JSONResponse({"error": "invite not found"}, status_code=404)
+
+    project_store = request.app.state.project_store
+    project = await project_store.get_project(invite["project_id"]) or {}
+
+    accept = request.headers.get("accept", "")
+    if "text/html" in accept and "application/json" not in accept:
+        return HTMLResponse(_invite_html(invite, project), status_code=200)
+
+    return {
+        "redeem": {
+            "method": "POST",
+            "path": "/api/projects/invites/redeem",
+            "fields": {
+                "invite_id": "required",
+                "pin": "required",
+                "harness": "required (your tool: kilo|grok|opencode|claude|aider|...)",
+                "label": "optional (short role hint, e.g. frontend)",
+            },
+        },
+        "project": {
+            "id": project.get("id"),
+            "name": project.get("name"),
+            "slug": project.get("slug"),
+        },
+        "onboarding": {
+            "links": [
+                {"label": "taOS repository", "url": "https://github.com/jaylfc/taOS"},
+                {
+                    "label": "Agent manual (04-apps.md)",
+                    "url": "https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/04-apps.md",
+                },
+                {
+                    "label": "Agent manual (09-os-control.md)",
+                    "url": "https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/09-os-control.md",
+                },
+            ],
+        },
+    }
+
+
+def _invite_html(invite: dict, project: dict) -> str:
+    """Minimal self-contained HTML page for a human who opens the invite link."""
+    name = (project.get("name") or invite.get("project_id") or "a taOS project")
+    return (
+        "<!doctype html><meta charset=utf-8><title>taOS project invite</title>"
+        "<h1>You have been invited to a taOS project</h1>"
+        f"<p>This link is an invite to join <strong>{name}</strong> as an external agent.</p>"
+        "<p>Hand the URL to your agent (Claude Code, grok, opencode, kilo, aider, ...). "
+        "It should fetch this URL as JSON and then POST a redeem with the PIN it was "
+        "given. The JSON advertises the exact redeem contract.</p>"
+        "<p>If you are the agent: request <code>Accept: application/json</code> and follow "
+        "the returned <code>redeem</code> instructions.</p>"
+    )


### PR DESCRIPTION
## Summary

Implements the S2 slice of the external-agent project invite (issue #1780): redeem + the extracted approve helper + connection bundle + onboarding kit.

- **Refactor (no behavior change):** extracted the mint machinery out of `_do_approve` into a shared `approve_request_record(request, *, record, granted_scopes, effective_project, decided_by, project_id)` helper. The consent route still passes `decided_by=user.user_id`; all existing `tests/test_routes_agent_auth_requests.py` tests stay green.
- **Redeem route (auth-EXEMPT):** `POST /api/projects/invites/redeem` verifies the PIN via the S1 store (wrong pin/expired/attempts -> 403; already redeemed/revoked -> 409), derives the `{project_slug}-{harness}[-{label}]` handle and de-dupes it against ACTIVE registry agents in the project, then either auto-approves (decided_by = invite creator, origin forced to include project_tasks) or leaves a pending request (manual mode, consent bell fires). `GET /i/{invite_id}` is content-negotiated (JSON redeem contract for agents, HTML page for browsers).
- **Middleware:** added method-sensitive exemptions for both new routes and a shared per-IP fixed-window rate limiter (20 per 10s) mirroring the cluster pairing throttle.
- **Connection bundle:** `build_connection_bundle` returns LAN/mesh controller endpoints, the scope-exact `apis` map (canvas routes only when the granted scope allows, mirroring the middleware canvas allowlist), the timed-check `delivery` contract, and an `onboarding` block + `guide_markdown`. The bundle carries NO token or secret (the token arrives via the status poll).
- **Docs:** extended `docs/agent-coordination.md` with the invite redeem surface; doc-gate passes (`doc-gate: clean`).

## Test plan

`tests/test_routes_project_invites.py` + `tests/test_routes_agent_auth_requests.py`: 39 passed. Covers auto end-to-end (redeem -> poll accepted -> member row), canvas scoping, manual pending, wrong-pin 403, double-redeem 409, bundle-no-secret, and guide requirements.