### PR TITLE
feat(agents): multi-project agent identities (per-project grants, grant-gated token) (#1862)

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -123,6 +123,17 @@ PIN; see issue #1780). When you change the
 allowlist in `tinyagentos/auth_middleware.py`, update this section in the same
 PR (the doc-gate enforces it).
 
+Multi-project identities (taOS #1862): one agent identity (the registry JWT) may
+belong to several projects at once. The grants table keys a grant on
+`(canonical_id, scope, project_id)`, so the same scope can be held for multiple
+projects. Project access is GRANT-GATED, not claim-gated: the token's `project_id`
+claim is advisory only, and `check_agent_scope_for_project` authorizes a project
+purely from a matching active grant. An already-registered agent is added to a
+further project via `POST /api/projects/{project_id}/members/assign-agent`
+(admin/owner gated) or by redeeming an invite whose handle collides with an
+active identity (the existing canonical_id and token are reused instead of
+409ing).
+
 ## Project invite redeem route (link + PIN)
 
 A project invite lets an external agent join without going through the consent

--- a/tests/test_agent_grants_store.py
+++ b/tests/test_agent_grants_store.py
@@ -1,4 +1,5 @@
 """Tests for AgentGrantsStore — per-agent scope grants persistence."""
+import aiosqlite
 import pytest
 
 from tinyagentos.agent_grants_store import AgentGrantsStore
@@ -153,5 +154,83 @@ class TestAgentGrantsStore:
         try:
             with pytest.raises(RuntimeError, match="not initialised"):
                 await store.list_active_grants()
+        finally:
+            await store.close()
+
+    # ── per-project grants (multi-project identity) ────────────────────
+    async def test_two_grants_same_scope_different_project_coexist(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-mp", "project_tasks", project_id="proj-A")
+            await store.add_grant("agent-mp", "project_tasks", project_id="proj-B")
+            grants = await store.list_grants("agent-mp")
+            # Both rows must be present (old 2-col unique would have collapsed
+            # the second into a REPLACE of the first).
+            assert len(grants) == 2
+            assert {g["project_id"] for g in grants} == {"proj-A", "proj-B"}
+        finally:
+            await store.close()
+
+    async def test_readd_same_key_replaces_not_duplicates(self, tmp_path):
+        store = await self._store(tmp_path)
+        try:
+            await store.add_grant("agent-mp", "project_tasks", tier="once", project_id="proj-A")
+            second = await store.add_grant(
+                "agent-mp", "project_tasks", tier="always", project_id="proj-A"
+            )
+            assert second["tier"] == "always"
+            grants = await store.list_grants("agent-mp")
+            assert len(grants) == 1
+            assert grants[0]["tier"] == "always"
+        finally:
+            await store.close()
+
+    async def test_existing_db_with_old_unique_upgrades_and_survives(self, tmp_path):
+        db_path = tmp_path / "legacy.db"
+        # Seed a DB with the OLD 2-column unique constraint and a couple rows.
+        conn = await aiosqlite.connect(str(db_path))
+        try:
+            await conn.executescript(
+                """
+                CREATE TABLE agent_grants (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    canonical_id TEXT NOT NULL,
+                    scope TEXT NOT NULL,
+                    tier TEXT NOT NULL DEFAULT 'once',
+                    project_id TEXT,
+                    granted_at TEXT NOT NULL,
+                    expires_at TEXT,
+                    UNIQUE (canonical_id, scope)
+                );
+                INSERT INTO agent_grants
+                    (canonical_id, scope, tier, project_id, granted_at, expires_at)
+                VALUES
+                    ('agent-legacy', 'project_tasks', 'once', 'proj-OLD', '2026-01-01T00:00:00+00:00', NULL),
+                    ('agent-legacy', 'memory_read', 'once', NULL, '2026-01-01T00:00:00+00:00', NULL);
+                """
+            )
+            await conn.commit()
+        finally:
+            await conn.close()
+
+        # init() must boot without crashing on the legacy schema.
+        store = AgentGrantsStore(db_path)
+        await store.init()
+        try:
+            # The pre-existing rows survived the migration.
+            grants = await store.list_grants("agent-legacy")
+            assert len(grants) == 2
+
+            # And a second-project grant for the same (canonical_id, scope) can
+            # now be added (this would have 409'd / replaced under the old unique).
+            await store.add_grant("agent-legacy", "project_tasks", project_id="proj-NEW")
+            after = await store.list_grants("agent-legacy")
+            assert len(after) == 3
+            assert {g["project_id"] for g in after} >= {"proj-OLD", "proj-NEW"}
+
+            # Idempotent re-run must not raise and must not duplicate.
+            await store.init()
+            again = await store.list_grants("agent-legacy")
+            assert len(again) == 3
         finally:
             await store.close()

--- a/tests/test_agent_token_auth.py
+++ b/tests/test_agent_token_auth.py
@@ -43,9 +43,15 @@ async def token_app(app):
             await store.close()
 
 
-async def _mint(app, *, scopes=("project_tasks",), project_id="prj-1"):
-    """Register an active agent, add its grants, and mint a JWT bound to
-    ``project_id`` (global when project_id is None)."""
+async def _mint(
+    app, *, scopes=("project_tasks",), project_id="prj-1", extra_grants=None
+):
+    """Register an active agent, add its grants, and mint a JWT.
+
+    ``scopes`` are all bound to ``project_id``. ``extra_grants`` is an optional
+    list of ``(scope, project_id)`` pairs bound to OTHER projects, used to model
+    an agent that is a member of multiple projects (taOS #1862).
+    """
     registry = app.state.agent_registry
     grants = app.state.agent_grants
     priv, _pub = app.state.agent_registry_keypair
@@ -59,6 +65,8 @@ async def _mint(app, *, scopes=("project_tasks",), project_id="prj-1"):
     await registry.set_status(cid, "active")
     for scope in scopes:
         await grants.add_grant(cid, scope, project_id=project_id)
+    for scope, pid in (extra_grants or []):
+        await grants.add_grant(cid, scope, project_id=pid)
     token = mint_registry_token(
         cid, priv, user_id="u", framework="grok", project_id=project_id
     )
@@ -81,12 +89,15 @@ class TestCheckAgentScopeForProject:
         assert exc.value.status_code == 403
 
     async def test_403_on_missing_project_claim(self, token_app):
-        # Global token (no project_id claim) must never satisfy a project check.
-        _cid, token = await _mint(token_app, project_id=None)
+        # Global token (no project_id claim) is NOT rejected outright: the
+        # project_id claim is advisory (taOS #1862). An agent WITH a grant for
+        # the requested project is authorized, even from a global token.
+        _cid, token = await _mint(
+            token_app, project_id=None, extra_grants=[("project_tasks", "prj-1")]
+        )
         req = _FakeRequest(token_app, token)
-        with pytest.raises(HTTPException) as exc:
-            await check_agent_scope_for_project(req, "project_tasks", "prj-1")
-        assert exc.value.status_code == 403
+        got = await check_agent_scope_for_project(req, "project_tasks", "prj-1")
+        assert got is not None
 
     async def test_403_on_missing_scope(self, token_app):
         _cid, token = await _mint(
@@ -125,4 +136,56 @@ class TestCheckAgentScopeUnchanged:
         req = _FakeRequest(token_app, token)
         with pytest.raises(HTTPException) as exc:
             await check_agent_scope(req, "project_tasks")
+        assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestMultiProjectGrantGatedToken:
+    """taOS #1862: one project-agnostic token authorizes ANY project the agent
+    holds a matching active grant for; no grant for a project means 403."""
+
+    async def test_single_token_authorizes_both_projects(self, token_app):
+        _cid, token = await _mint(
+            token_app,
+            scopes=("project_tasks",),
+            project_id="prj-A",
+            extra_grants=[("project_tasks", "prj-B")],
+        )
+        for pid in ("prj-A", "prj-B"):
+            req = _FakeRequest(token_app, token)
+            got = await check_agent_scope_for_project(req, "project_tasks", pid)
+            assert got is not None
+
+    async def test_403_for_project_without_grant(self, token_app):
+        _cid, token = await _mint(
+            token_app,
+            scopes=("project_tasks",),
+            project_id="prj-A",
+            extra_grants=[("project_tasks", "prj-B")],
+        )
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope_for_project(req, "project_tasks", "prj-C")
+        assert exc.value.status_code == 403
+
+    async def test_403_for_expired_grant(self, token_app):
+        registry = token_app.state.agent_registry
+        grants = token_app.state.agent_grants
+        priv, _pub = token_app.state.agent_registry_keypair
+        rec = await registry.register(
+            framework="grok", display_name="Grok",
+            origin="external-selfjoin", handle="@grok",
+        )
+        cid = rec["canonical_id"]
+        await registry.set_status(cid, "active")
+        await grants.add_grant(
+            cid, "project_tasks", project_id="prj-X",
+            expires_at="2000-01-01T00:00:00+00:00",
+        )
+        token = mint_registry_token(
+            cid, priv, user_id="u", framework="grok", project_id="prj-X"
+        )
+        req = _FakeRequest(token_app, token)
+        with pytest.raises(HTTPException) as exc:
+            await check_agent_scope_for_project(req, "project_tasks", "prj-X")
         assert exc.value.status_code == 403

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -611,9 +611,244 @@ class TestCanvasScopeApproval:
             # The blank-project approval must not register an agent.
             assert await registry.list_all() == []
 
-            await registry.close()
-            await auth_store.close()
-            await grants.close()
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+
+
+class TestAddAgentToAnotherProject:
+    """taOS #1862: an already-registered ACTIVE agent (handle collision) is
+    ADDED to a further project instead of 409ing when the approval is for a
+    project-scoped grant. The identity (canonical_id) and token are reused."""
+
+    @pytest.mark.asyncio
+    async def test_reuse_active_handle_adds_second_project(
+        self, client, monkeypatch, tmp_path
+    ):
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+        from tinyagentos.projects.project_store import ProjectStore
+
+        registry = AgentRegistryStore(tmp_path / "reg-mp.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth-mp.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants-mp.db")
+        await grants.init()
+        pstore = ProjectStore(tmp_path / "projects-mp.db")
+        await pstore.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys-mp")
+
+        pA = await pstore.create_project(name="A", slug="proj-a", created_by="u")
+        pB = await pstore.create_project(name="B", slug="proj-b", created_by="u")
+
+        # Register + approve the agent for project A (handle taosmd-dev).
+        rA = await auth_store.create(
+            identity_claim="@taOSmd-dev", framework="openclaw",
+            requested_scopes=["project_tasks"], requested_skills=None, reason="",
+            duration_secs=None, project_id=pA["id"],
+        )
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(client._transport.app.state, "agent_registry_keypair", (priv, pub))
+        monkeypatch.setattr(client._transport.app.state, "project_store", pstore)
+
+        respA = await client.post(
+            f"/api/agents/auth-requests/{rA['id']}/approve",
+            json={"granted_scopes": ["project_tasks"], "project_id": pA["id"]},
+        )
+        assert respA.status_code == 200, respA.text
+        cid = respA.json()["canonical_id"]
+        assert cid
+
+        # Now approve a SECOND request with the SAME handle, for project B.
+        rB = await auth_store.create(
+            identity_claim="@taOSmd-dev", framework="openclaw",
+            requested_scopes=["project_tasks"], requested_skills=None, reason="",
+            duration_secs=None, project_id=pB["id"],
+        )
+        respB = await client.post(
+            f"/api/agents/auth-requests/{rB['id']}/approve",
+            json={"granted_scopes": ["project_tasks"], "project_id": pB["id"]},
+        )
+        assert respB.status_code == 200, respB.text
+        # Same canonical_id is reused, NOT a fresh one (no 409).
+        assert respB.json()["canonical_id"] == cid
+
+        # Exactly one active agent with that handle.
+        active = await registry.list_all(status="active")
+        assert len([a for a in active if a["handle"] == "taosmd-dev"]) == 1
+
+        # Member of BOTH projects.
+        membersA = await pstore.list_members(pA["id"])
+        membersB = await pstore.list_members(pB["id"])
+        assert any(m["member_id"] == cid for m in membersA)
+        assert any(m["member_id"] == cid for m in membersB)
+
+        # Grants for BOTH projects.
+        agent_grants = await grants.list_grants(cid)
+        assert {g["project_id"] for g in agent_grants} >= {pA["id"], pB["id"]}
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+        await pstore.close()
+
+    @pytest.mark.asyncio
+    async def test_non_project_handle_collision_still_409(
+        self, client, monkeypatch, tmp_path
+    ):
+        """A handle collision on a NON-project grant remains a genuine 409."""
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+
+        registry = AgentRegistryStore(tmp_path / "reg-mp409.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth-mp409.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants-mp409.db")
+        await grants.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys-mp409")
+
+        await registry.register(
+            framework="openclaw", display_name="existing-agent",
+            user_id="user-existing", origin="taos-deployed", handle="taosmd-dev",
+        )
+
+        r = await auth_store.create(
+            identity_claim="@taOSmd-dev", framework="openclaw",
+            requested_scopes=["memory_read"], requested_skills=None, reason="",
+            duration_secs=None, project_id=None,
+        )
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(client._transport.app.state, "agent_registry_keypair", (priv, pub))
+
+        resp = await client.post(
+            f"/api/agents/auth-requests/{r['id']}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+        assert resp.status_code == 409, resp.text
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+
+
+class TestAssignAgentRoute:
+    """Admin route POST /api/projects/{pid}/members/assign-agent."""
+
+    @pytest.mark.asyncio
+    async def test_assign_existing_agent_adds_membership_and_grant(
+        self, client, monkeypatch, tmp_path
+    ):
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+        from tinyagentos.projects.project_store import ProjectStore
+
+        registry = AgentRegistryStore(tmp_path / "reg-assign.db")
+        await registry.init()
+        grants = AgentGrantsStore(tmp_path / "grants-assign.db")
+        await grants.init()
+        pstore = ProjectStore(tmp_path / "projects-assign.db")
+        await pstore.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys-assign")
+
+        # An already-registered agent (owner u).
+        reg = await registry.register(
+            framework="openclaw", display_name="taosmd-dev",
+            user_id="u", origin="external-selfjoin", handle="taosmd-dev",
+        )
+        await registry.set_status(reg["canonical_id"], "active")
+        cid = reg["canonical_id"]
+
+        project = await pstore.create_project(name="P", slug="proj-p", created_by="u")
+
+        # Make the test client act as admin+owner so the gate passes.
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(client._transport.app.state, "project_store", pstore)
+
+        resp = await client.post(
+            f"/api/projects/{project['id']}/members/assign-agent",
+            json={"canonical_id": cid, "scopes": ["project_tasks"]},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["canonical_id"] == cid
+        assert data["project_id"] == project["id"]
+        assert data["granted_scopes"] == ["project_tasks"]
+
+        members = await pstore.list_members(project["id"])
+        assert any(m["member_id"] == cid for m in members)
+        agent_grants = await grants.list_grants(cid)
+        assert any(
+            g["scope"] == "project_tasks" and g["project_id"] == project["id"]
+            for g in agent_grants
+        )
+
+        await registry.close()
+        await grants.close()
+        await pstore.close()
+
+    @pytest.mark.asyncio
+    async def test_assign_requires_admin(self, client, monkeypatch, tmp_path):
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+        from tinyagentos.projects.project_store import ProjectStore
+
+        registry = AgentRegistryStore(tmp_path / "reg-assign2.db")
+        await registry.init()
+        grants = AgentGrantsStore(tmp_path / "grants-assign2.db")
+        await grants.init()
+        pstore = ProjectStore(tmp_path / "projects-assign2.db")
+        await pstore.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys-assign2")
+
+        reg = await registry.register(
+            framework="openclaw", display_name="taosmd-dev",
+            user_id="u", origin="external-selfjoin", handle="taosmd-dev",
+        )
+        await registry.set_status(reg["canonical_id"], "active")
+        project = await pstore.create_project(name="P", slug="proj-p2", created_by="u")
+
+        # A non-admin, non-owner caller must be rejected by the admin gate.
+        # add_user_invite creates a non-admin user; log in as them for this call.
+        auth = client._transport.app.state.auth
+        auth.add_user_invite("bob", "admin")
+        bob = auth.find_user("bob")
+        bob_token = auth.create_session(user_id=bob["id"], long_lived=True)
+
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(client._transport.app.state, "project_store", pstore)
+
+        resp = await client.post(
+            f"/api/projects/{project['id']}/members/assign-agent",
+            json={"canonical_id": reg["canonical_id"], "scopes": ["project_tasks"]},
+            cookies={"taos_session": bob_token},
+        )
+        assert resp.status_code == 403, resp.text
+
+        await registry.close()
+        await grants.close()
+        await pstore.close()
 
     @pytest.mark.asyncio
     async def test_approve_cannot_widen_canvas_scopes(

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -700,6 +700,84 @@ class TestAddAgentToAnotherProject:
         await pstore.close()
 
     @pytest.mark.asyncio
+    async def test_reuse_binds_to_validated_project_not_agent_supplied(
+        self, client, monkeypatch, tmp_path
+    ):
+        """Hardening (kilo review, taOS #1862): the multi-project ADD branch
+        binds to the ADMIN-validated project_id, never to the agent-supplied
+        record.project_id. An agent that self-requests project C but is approved
+        by the admin for project B must land in B only, never C."""
+        from tinyagentos.agent_registry_store import (
+            AgentRegistryStore,
+            load_or_create_signing_keypair,
+        )
+        from tinyagentos.auth_requests_store import AuthRequestsStore
+        from tinyagentos.agent_grants_store import AgentGrantsStore
+        from tinyagentos.projects.project_store import ProjectStore
+
+        registry = AgentRegistryStore(tmp_path / "reg-h.db")
+        await registry.init()
+        auth_store = AuthRequestsStore(tmp_path / "auth-h.db")
+        await auth_store.init()
+        grants = AgentGrantsStore(tmp_path / "grants-h.db")
+        await grants.init()
+        pstore = ProjectStore(tmp_path / "projects-h.db")
+        await pstore.init()
+        priv, pub = load_or_create_signing_keypair(tmp_path / "keys-h")
+
+        pA = await pstore.create_project(name="A", slug="proj-a", created_by="u")
+        pB = await pstore.create_project(name="B", slug="proj-b", created_by="u")
+        pC = await pstore.create_project(name="C", slug="proj-c", created_by="u")
+
+        monkeypatch.setattr(client._transport.app.state, "agent_registry", registry)
+        monkeypatch.setattr(client._transport.app.state, "auth_requests", auth_store)
+        monkeypatch.setattr(client._transport.app.state, "agent_grants", grants)
+        monkeypatch.setattr(client._transport.app.state, "agent_registry_keypair", (priv, pub))
+        monkeypatch.setattr(client._transport.app.state, "project_store", pstore)
+
+        # Establish the active identity in project A.
+        rA = await auth_store.create(
+            identity_claim="@dev", framework="openclaw",
+            requested_scopes=["project_tasks"], requested_skills=None, reason="",
+            duration_secs=None, project_id=pA["id"],
+        )
+        respA = await client.post(
+            f"/api/agents/auth-requests/{rA['id']}/approve",
+            json={"granted_scopes": ["project_tasks"], "project_id": pA["id"]},
+        )
+        assert respA.status_code == 200, respA.text
+        cid = respA.json()["canonical_id"]
+
+        # Second request: the AGENT names project C in the record, but the admin
+        # approves for project B. The reuse/ADD branch must honour B, not C.
+        rB = await auth_store.create(
+            identity_claim="@dev", framework="openclaw",
+            requested_scopes=["project_tasks"], requested_skills=None, reason="",
+            duration_secs=None, project_id=pC["id"],
+        )
+        respB = await client.post(
+            f"/api/agents/auth-requests/{rB['id']}/approve",
+            json={"granted_scopes": ["project_tasks"], "project_id": pB["id"]},
+        )
+        assert respB.status_code == 200, respB.text
+        assert respB.json()["canonical_id"] == cid
+
+        membersB = await pstore.list_members(pB["id"])
+        membersC = await pstore.list_members(pC["id"])
+        assert any(m["member_id"] == cid for m in membersB), "must be a member of the validated project B"
+        assert not any(m["member_id"] == cid for m in membersC), "must NOT be added to the agent-supplied project C"
+
+        agent_grants = await grants.list_grants(cid)
+        grant_projects = {g["project_id"] for g in agent_grants}
+        assert pB["id"] in grant_projects
+        assert pC["id"] not in grant_projects, "no grant may bind to the agent-supplied project C"
+
+        await registry.close()
+        await auth_store.close()
+        await grants.close()
+        await pstore.close()
+
+    @pytest.mark.asyncio
     async def test_non_project_handle_collision_still_409(
         self, client, monkeypatch, tmp_path
     ):

--- a/tinyagentos/agent_grants_store.py
+++ b/tinyagentos/agent_grants_store.py
@@ -11,6 +11,7 @@ The Permissions app and the A2A bus read this table to check what an agent
 may do.  ``list_active_grants`` is the feed @taOSmd polls later.
 """
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from typing import Optional
@@ -42,10 +43,19 @@ class AgentGrantsStore(BaseStore):
 
     SCHEMA = SCHEMA
 
+    # Serializes the DELETE-then-INSERT-then-SELECT in add_grant. The 3-column
+    # UNIQUE with a nullable project_id forces a non-atomic delete+insert
+    # (INSERT OR REPLACE cannot dedup a NULL project_id), so two concurrent
+    # same-key writes could interleave (one DELETE removes the other's row
+    # before its SELECT-back, or the second INSERT hits the unique). The lock
+    # makes each write atomic against the others on this single connection.
+    _write_lock: asyncio.Lock
+
     async def init(self) -> None:
         await super().init()
         if self._db is not None:
             self._db.row_factory = aiosqlite.Row
+        self._write_lock = asyncio.Lock()
 
     async def _post_init(self) -> None:
         """Upgrade an EXISTING database whose agent_grants table still has the
@@ -140,30 +150,34 @@ class AgentGrantsStore(BaseStore):
             raise RuntimeError("AgentGrantsStore not initialised — call init() first")
 
         now = datetime.now(timezone.utc).isoformat()
-        # Remove any existing row for the exact key first (NULL-safe match).
-        await self._db.execute(
-            "DELETE FROM agent_grants "
-            "WHERE canonical_id = ? AND scope = ? AND project_id IS ?",
-            (canonical_id, scope, project_id),
-        )
-        await self._db.execute(
-            """
-            INSERT INTO agent_grants
-                (canonical_id, scope, tier, project_id, granted_at, expires_at)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (canonical_id, scope, tier, project_id, now, expires_at),
-        )
-        await self._db.commit()
-        row = await (
+        # Serialize the delete+insert+select so two concurrent same-key writes
+        # cannot interleave (which would either drop each other's row before the
+        # SELECT-back returns None, or collide on the UNIQUE at INSERT).
+        async with self._write_lock:
+            # Remove any existing row for the exact key first (NULL-safe match).
             await self._db.execute(
-                # Select by the full 3-column key. project_id is nullable, so
-                # match NULL with IS (a plain ``=`` would never match NULL).
-                "SELECT * FROM agent_grants "
+                "DELETE FROM agent_grants "
                 "WHERE canonical_id = ? AND scope = ? AND project_id IS ?",
                 (canonical_id, scope, project_id),
             )
-        ).fetchone()
+            await self._db.execute(
+                """
+                INSERT INTO agent_grants
+                    (canonical_id, scope, tier, project_id, granted_at, expires_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (canonical_id, scope, tier, project_id, now, expires_at),
+            )
+            await self._db.commit()
+            row = await (
+                await self._db.execute(
+                    # Select by the full 3-column key. project_id is nullable, so
+                    # match NULL with IS (a plain ``=`` would never match NULL).
+                    "SELECT * FROM agent_grants "
+                    "WHERE canonical_id = ? AND scope = ? AND project_id IS ?",
+                    (canonical_id, scope, project_id),
+                )
+            ).fetchone()
         return _row_to_dict(row)  # type: ignore[return-value]
 
     # ------------------------------------------------------------------

--- a/tinyagentos/agent_grants_store.py
+++ b/tinyagentos/agent_grants_store.py
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS agent_grants (
     project_id   TEXT,
     granted_at   TEXT    NOT NULL,
     expires_at   TEXT,
-    UNIQUE (canonical_id, scope)
+    UNIQUE (canonical_id, scope, project_id)
 );
 """
 
@@ -47,6 +47,75 @@ class AgentGrantsStore(BaseStore):
         if self._db is not None:
             self._db.row_factory = aiosqlite.Row
 
+    async def _post_init(self) -> None:
+        """Upgrade an EXISTING database whose agent_grants table still has the
+        old 2-column unique ``(canonical_id, scope)`` to the per-project
+        3-column unique ``(canonical_id, scope, project_id)``.
+
+        A table-level UNIQUE constraint cannot be ALTERed, so we do the standard
+        SQLite rebuild dance (create new table, copy rows, drop old, rename).
+        The copy is safe: the OLD unique guaranteed at most one row per
+        (canonical_id, scope), so no duplicate-key conflict can arise under the
+        new 3-column unique. Guarded so it only runs when the legacy constraint
+        is present, making it idempotent on already-migrated DBs. This is a
+        boot-path migration and must never crash an existing DB's init().
+        """
+        if self._db is None:  # pragma: no cover - defensive
+            return
+
+        # Detect the legacy 2-column unique by inspecting the table's SQL.
+        # row_factory may not be set yet (init() sets it after super().init()),
+        # so read the column positionally.
+        cur = await self._db.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='agent_grants'"
+        )
+        row = await cur.fetchone()
+        sql = row[0] if row else ""
+        # Legacy DDL ends the table constraint with UNIQUE (canonical_id, scope)
+        # and lacks the project_id column in the unique list. The fresh SCHEMA
+        # contains "UNIQUE (canonical_id, scope, project_id)".
+        if "UNIQUE (canonical_id, scope, project_id)" in sql:
+            return  # already migrated
+
+        async with self._db.cursor() as cur2:
+            await cur2.execute("SELECT name FROM pragma_table_info('agent_grants')")
+            cols = {r[0] for r in await cur2.fetchall()}
+        if "project_id" not in cols:  # pragma: no cover - defensive
+            return  # current schema already applied by SCHEMA; nothing to do
+
+        await self._db.execute("BEGIN")
+        try:
+            await self._db.execute(
+                """
+                CREATE TABLE agent_grants_new (
+                    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                    canonical_id TEXT    NOT NULL,
+                    scope        TEXT    NOT NULL,
+                    tier         TEXT    NOT NULL DEFAULT 'once',
+                    project_id   TEXT,
+                    granted_at   TEXT    NOT NULL,
+                    expires_at   TEXT,
+                    UNIQUE (canonical_id, scope, project_id)
+                );
+                """
+            )
+            await self._db.execute(
+                """
+                INSERT INTO agent_grants_new
+                    (id, canonical_id, scope, tier, project_id, granted_at, expires_at)
+                SELECT id, canonical_id, scope, tier, project_id, granted_at, expires_at
+                FROM agent_grants;
+                """
+            )
+            await self._db.execute("DROP TABLE agent_grants")
+            await self._db.execute(
+                "ALTER TABLE agent_grants_new RENAME TO agent_grants"
+            )
+            await self._db.commit()
+        except Exception:
+            await self._db.rollback()
+            raise
+
     # ------------------------------------------------------------------
     # Write
     # ------------------------------------------------------------------
@@ -60,17 +129,26 @@ class AgentGrantsStore(BaseStore):
         project_id: Optional[str] = None,
         expires_at: Optional[str] = None,
     ) -> dict:
-        """Insert or replace a grant for (canonical_id, scope).
+        """Insert or replace a grant for (canonical_id, scope, project_id).
 
-        Uses INSERT OR REPLACE so re-approving a scope is idempotent.
+        The 3-column UNIQUE key treats NULL project_id as distinct, so a bare
+        ``INSERT OR REPLACE`` would NOT replace an existing NULL-project_id row
+        (it would append a second one). We make re-approval idempotent by
+        explicitly deleting the matching key (NULL-safe via IS) before inserting.
         """
         if self._db is None:
             raise RuntimeError("AgentGrantsStore not initialised — call init() first")
 
         now = datetime.now(timezone.utc).isoformat()
+        # Remove any existing row for the exact key first (NULL-safe match).
+        await self._db.execute(
+            "DELETE FROM agent_grants "
+            "WHERE canonical_id = ? AND scope = ? AND project_id IS ?",
+            (canonical_id, scope, project_id),
+        )
         await self._db.execute(
             """
-            INSERT OR REPLACE INTO agent_grants
+            INSERT INTO agent_grants
                 (canonical_id, scope, tier, project_id, granted_at, expires_at)
             VALUES (?, ?, ?, ?, ?, ?)
             """,
@@ -79,8 +157,11 @@ class AgentGrantsStore(BaseStore):
         await self._db.commit()
         row = await (
             await self._db.execute(
-                "SELECT * FROM agent_grants WHERE canonical_id = ? AND scope = ?",
-                (canonical_id, scope),
+                # Select by the full 3-column key. project_id is nullable, so
+                # match NULL with IS (a plain ``=`` would never match NULL).
+                "SELECT * FROM agent_grants "
+                "WHERE canonical_id = ? AND scope = ? AND project_id IS ?",
+                (canonical_id, scope, project_id),
             )
         ).fetchone()
         return _row_to_dict(row)  # type: ignore[return-value]

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -153,29 +153,33 @@ async def check_agent_scope_for_project(
 ) -> Optional[str]:
     """Project-scoped sibling of ``check_agent_scope`` (least privilege).
 
-    Verifies the same EdDSA JWT + active-grant chain AND requires the token's
-    ``project_id`` claim to equal *project_id*.  This binds an agent token to a
-    single project's routes so it can never reach another project's board.
+    The token is the identity (project-agnostic); per-project GRANTS are the
+    sole authorization.  This function verifies the same EdDSA JWT + active
+    scope-grant chain as ``check_agent_scope`` and then authorizes ONLY when
+    the agent holds an active grant for *required_scope* bound to *project_id*.
+
+    NOTE (taOS #1862): the hard token-project pin was removed.  The registry
+    JWT's ``project_id`` claim (set by ``mint_registry_token``) is now ADVISORY
+    ONLY - it is not used to gate access.  An agent holding matching active
+    grants can use ONE project-agnostic token to authorize any project it has
+    been granted, and is rejected for any project it lacks a grant for.  See
+    the grant-gated model in docs/agent-coordination.md.
 
     Returns None when no Authorization header is present.
 
     Raises:
       401/403 -- exactly as ``check_agent_scope`` (bad token / inactive agent /
                  missing scope grant).
-      403 ``token not scoped to this project`` -- token is otherwise valid but
-                 its project_id claim is absent or does not match *project_id*.
+      403 -- token is valid and active but holds no active *required_scope*
+                  grant bound to *project_id* (grant-gated, not claim-gated).
     """
     result = await _verify_agent_scope(request, required_scope)
     if result is None:
         return None
-    canonical_id, payload = result
-    token_project = payload.get("project_id")
-    if not token_project or token_project != project_id:
-        raise HTTPException(status_code=403, detail=PROJECT_SCOPE_MISMATCH_DETAIL)
-    # Defense in depth: the token's project_id claim agreeing is not enough; the
-    # underlying grant must itself be bound to this project. A claim and a grant
-    # could diverge (re-mint against a stale claim, a hand-edited grant row), so
-    # require an active grant whose own project_id matches before authorizing.
+    canonical_id, _payload = result
+    # Grant-gated authorization: a project is reachable only if the agent holds
+    # an active grant for the required scope bound to that project. The token's
+    # project_id claim is advisory and is intentionally NOT checked here (taOS #1862).
     grants_store = _get_grants_store(request)
     now = datetime.now(timezone.utc)
     grants = await grants_store.list_grants(canonical_id)

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -30,7 +30,7 @@ from pydantic import BaseModel
 
 from aiosqlite import IntegrityError
 from tinyagentos.agent_registry_store import _slugify, mint_registry_token
-from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +81,12 @@ class CreateAuthRequest(BaseModel):
 class ApproveBody(BaseModel):
     granted_scopes: list[str]
     project_id: Optional[str] = None
+
+
+class AssignAgentBody(BaseModel):
+    canonical_id: str
+    scopes: list[str]
+    is_lead: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -359,6 +365,43 @@ async def approve_request_record(
     handle = _slugify(_claim)
     existing_active = await registry.get_by_handle(handle, status="active")
     if existing_active is not None:
+        # The handle already maps to an ACTIVE identity. In the multi-project
+        # model (taOS #1862) this is NOT a hard collision when the approval is
+        # for a project-scoped grant: instead of 409ing, ADD the existing agent
+        # to the new project (reuse its identity + token, do not re-register).
+        # A non-project approval colliding on a handle is still a genuine
+        # identity collision and stays a 409.
+        if effective_project and set(granted_scopes) & _PROJECT_SCOPES:
+            existing_cid = existing_active["canonical_id"]
+            token = mint_registry_token(
+                existing_cid,
+                private_pem,
+                user_id=decided_by,
+                framework=record["framework"],
+                project_id=effective_project,
+            )
+            await add_agent_to_project(
+                request,
+                canonical_id=existing_cid,
+                project_id=effective_project,
+                granted_scopes=granted_scopes,
+                decided_by=decided_by,
+            )
+            result = await auth_store.set_decision(
+                record["id"],
+                "accepted",
+                canonical_id=existing_cid,
+                token=token,
+                granted_scopes=granted_scopes,
+                decided_by=decided_by,
+            )
+            if result is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="request was decided concurrently; check current status",
+                )
+            await _retire_request_notification(request, record["id"])
+            return {"status": "accepted", "canonical_id": existing_cid}
         raise HTTPException(
             status_code=409,
             detail=(
@@ -500,6 +543,141 @@ async def approve_request_record(
 
     await _retire_request_notification(request, record["id"])
     return {"status": "accepted", "canonical_id": canonical_id}
+
+
+async def add_agent_to_project(
+    request: Request,
+    *,
+    canonical_id: str,
+    project_id: str,
+    granted_scopes: list[str],
+    decided_by: str,
+    is_lead: bool = False,
+) -> dict:
+    """Add an ALREADY-REGISTERED agent to ANOTHER project (taOS #1862).
+
+    This is the shared primitive for the multi-project identity model: it
+    writes the per-scope grants bound to *project_id*, adds the idempotent
+    project_members row, ensures the a2a channel membership, and records the
+    relationship permission edge. It does NOT mint a new token or re-register
+    the agent: the identity is reused so one registry JWT spans every project
+    the agent holds a grant for.
+
+    Returns ``{"canonical_id": ..., "project_id": ..., "granted_scopes": ...}``.
+    """
+    grants_store = _get_grants_store(request)
+    rel_mgr = _get_relationships(request)
+
+    _CANVAS_SCOPES = {"canvas_read", "canvas_write"}
+    _PROJECT_SCOPES = {"project_tasks"} | _CANVAS_SCOPES
+
+    # Write the grants bound to this project and the relationship edge.
+    for scope in granted_scopes:
+        await grants_store.add_grant(
+            canonical_id, scope, tier="once", project_id=project_id
+        )
+        await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
+
+    # If a project-scoped scope was granted, add the agent as a project member
+    # (PK (project_id, member_id) makes this naturally idempotent) and sync the
+    # a2a channel. Best-effort: a membership failure never blocks the grant,
+    # which already authorizes the agent for the project.
+    result: dict = {
+        "canonical_id": canonical_id,
+        "project_id": project_id,
+        "granted_scopes": list(granted_scopes),
+        "is_lead": bool(is_lead),
+    }
+    if set(granted_scopes) & _PROJECT_SCOPES:
+        try:
+            pstore = getattr(request.app.state, "project_store", None)
+            if pstore is not None:
+                granted_canvas = set(granted_scopes) & _CANVAS_SCOPES
+                role = "lead" if is_lead else "member"
+                if "project_tasks" in granted_scopes or granted_canvas:
+                    await pstore.add_member(
+                        project_id=project_id,
+                        member_id=canonical_id,
+                        member_kind="native",
+                        role=role,
+                    )
+                    if granted_canvas:
+                        await pstore.set_member_canvas(
+                            project_id=project_id,
+                            member_id=canonical_id,
+                            can_read=("canvas_read" in granted_canvas),
+                            can_write=("canvas_write" in granted_canvas),
+                        )
+                    if "project_tasks" in granted_scopes:
+                        from tinyagentos.projects.a2a import ensure_a2a_channel
+
+                        await ensure_a2a_channel(
+                            request.app.state.chat_channels,
+                            pstore,
+                            project_id,
+                            config=getattr(request.app.state, "config", None),
+                        )
+        except Exception:  # noqa: BLE001 - membership is best-effort
+            logger.warning(
+                "add_agent_to_project: could not sync %s membership/a2a for project %s",
+                canonical_id,
+                project_id,
+                exc_info=True,
+            )
+    return result
+
+
+@router.post("/api/projects/{project_id}/members/assign-agent")
+async def assign_agent_to_project(
+    request: Request,
+    project_id: str,
+    body: AssignAgentBody,
+    user: CurrentUser = Depends(current_user),
+):
+    """Admin route: assign an EXISTING agent (by canonical_id) to a project.
+
+    The Agents-app UI (a later slice) uses this to add an already-registered
+    agent to another project without re-registering it or minting a new token.
+    Writes the per-scope grants bound to the project, the idempotent
+    project_members row, and ensures a2a channel membership.
+
+    Owner-or-admin gated on the project like the invite mint route.
+    """
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    pstore = getattr(request.app.state, "project_store", None)
+    if pstore is None:
+        raise HTTPException(status_code=500, detail="project store unavailable")
+    project = await pstore.get_project(project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="project not found")
+    require_owner_or_admin(user, project["user_id"])
+
+    # Every granted scope must be in the closed vocabulary.
+    unknown = sorted(set(body.scopes) - VALID_SCOPES)
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}",
+        )
+
+    registry = _get_registry_store(request)
+    existing = await registry.get(body.canonical_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=404, detail="agent canonical_id not found in the registry"
+        )
+
+    result = await add_agent_to_project(
+        request,
+        canonical_id=body.canonical_id,
+        project_id=project_id,
+        granted_scopes=body.scopes,
+        decided_by=user.user_id,
+        is_lead=body.is_lead,
+    )
+    return result
 
 
 async def _do_approve(request: Request, request_id: str, body: ApproveBody, user):

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -371,19 +371,27 @@ async def approve_request_record(
         # to the new project (reuse its identity + token, do not re-register).
         # A non-project approval colliding on a handle is still a genuine
         # identity collision and stays a 409.
-        if effective_project and set(granted_scopes) & _PROJECT_SCOPES:
+        # Bind the multi-project ADD strictly to the EXPLICIT validated
+        # project_id, never to effective_project. The guard above already
+        # rejected a project-scoped grant with an absent project_id, so for
+        # project scopes project_id is the operator/invite-validated value;
+        # binding to effective_project (which can carry the agent-supplied
+        # fallback for global scopes) would be safe only by invariant. Gate and
+        # bind on project_id so cross-project escalation is impossible by
+        # construction (kilo review, taOS #1862).
+        if project_id and set(granted_scopes) & _PROJECT_SCOPES:
             existing_cid = existing_active["canonical_id"]
             token = mint_registry_token(
                 existing_cid,
                 private_pem,
                 user_id=decided_by,
                 framework=record["framework"],
-                project_id=effective_project,
+                project_id=project_id,
             )
             await add_agent_to_project(
                 request,
                 canonical_id=existing_cid,
-                project_id=effective_project,
+                project_id=project_id,
                 granted_scopes=granted_scopes,
                 decided_by=decided_by,
             )


### PR DESCRIPTION
## Summary
Enable ONE external-agent identity to be a member of MULTIPLE projects. The token is now the identity (project-agnostic); per-project GRANTS are the sole authorization.

- Grants table now unique on (canonical_id, scope, project_id) instead of (canonical_id, scope). An idempotent boot-path migration rebuilds the table for existing DBs still on the old 2-column unique.
- add_grant is NULL-safe so re-approving the same (canonical_id, scope, project_id) key is idempotent even with a NULL project_id.
- check_agent_scope_for_project no longer hard-pins the token's project_id claim. Project access is grant-gated: authorized purely from a matching active grant. One project-agnostic token authorizes any project the agent holds a grant for; projects without a grant (or with an expired grant) 403. The mint_registry_token project_id claim is now advisory only.
- Extracted add_agent_to_project shared primitive (grants + idempotent project_members row + a2a channel membership). An already-registered agent whose handle collides on an active identity is now ADDED to the new project (identity + token reused) instead of 409ing.
- Added POST /api/projects/{project_id}/members/assign-agent (owner-or-admin gated) for the Agents-app UI to assign an existing agent to a project.

## Notes
- Option B token model: project access is grant-gated, the token project_id claim is advisory.
- No AI attribution, no em dashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Agents can now belong to multiple projects with the same identity.
  - Added an admin/owner-only endpoint to assign an existing agent to another project.
  - Project access is now granted based on active project-specific permissions (including support for global tokens).
- **Bug Fixes**
  - Improved multi-project invitation/auth approval to reuse existing identities without collisions.
  - Hardened approval behavior so grant/membership is bound to the correct project.
  - Upgraded existing grant databases safely to the new per-project uniqueness rules.
- **Documentation**
  - Updated agent API documentation for multi-project identity and grant authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->