### PR TITLE
feat(agents): invite + assign external agents to projects from the Agents app (#1861)

### DIFF
--- a/desktop/src/apps/agents/AssignAgentToProjectDialog.tsx
+++ b/desktop/src/apps/agents/AssignAgentToProjectDialog.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { projectsApi, type Project } from "@/lib/projects";
+import { RegistryEntry } from "./RegistryPanel";
+
+const SCOPE_PRESETS: { value: string; label: string; defaultOn: boolean; disabled?: boolean; hint?: string }[] = [
+  { value: "project_tasks", label: "project_tasks", defaultOn: true, disabled: true, hint: "required" },
+  { value: "canvas_read", label: "canvas_read", defaultOn: true },
+  { value: "canvas_write", label: "canvas_write", defaultOn: true },
+];
+
+export function AssignAgentToProjectDialog({
+  entry,
+  onClose,
+  onAssigned,
+}: {
+  entry: Pick<RegistryEntry, "canonical_id" | "handle" | "status">;
+  onClose: () => void;
+  onAssigned?: () => void;
+}) {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loadingProjects, setLoadingProjects] = useState(true);
+  const [projectErr, setProjectErr] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [scopes, setScopes] = useState<Record<string, boolean>>(() => {
+    const init: Record<string, boolean> = {};
+    for (const s of SCOPE_PRESETS) init[s.value] = s.defaultOn;
+    return init;
+  });
+  const [isLead, setIsLead] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmation, setConfirmation] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoadingProjects(true);
+    setProjectErr(null);
+    projectsApi
+      .list()
+      .then((rows) => {
+        if (!active) return;
+        const list: Project[] = Array.isArray(rows) ? rows : [];
+        setProjects(list);
+        if (list.length > 0) setSelectedProjectId((prev) => prev || list[0]!.id);
+      })
+      .catch((e: unknown) => {
+        if (active) setProjectErr(e instanceof Error ? e.message : "Failed to load projects");
+      })
+      .finally(() => {
+        if (active) setLoadingProjects(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const buildScopes = (): string[] => {
+    const out = new Set<string>();
+    // project_tasks is always granted regardless of its (disabled) checkbox state.
+    out.add("project_tasks");
+    for (const s of SCOPE_PRESETS) {
+      if (s.disabled) continue;
+      if (scopes[s.value]) out.add(s.value);
+    }
+    return [...out];
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting || !selectedProjectId) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const body: {
+        canonical_id: string;
+        scopes: string[];
+        is_lead?: boolean;
+      } = {
+        canonical_id: entry.canonical_id,
+        scopes: buildScopes(),
+      };
+      if (isLead) body.is_lead = true;
+      const r = await fetch(`/api/projects/${selectedProjectId}/members/assign-agent`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!r.ok) {
+        const err = await r.json().catch(() => ({}));
+        throw new Error((err as { error?: string }).error ?? `HTTP ${r.status}`);
+      }
+      const project = projects.find((p) => p.id === selectedProjectId);
+      const label = project?.name || project?.slug || selectedProjectId;
+      setConfirmation(`Assigned ${entry.handle} to ${label}`);
+      onAssigned?.();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Assign agent to project"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4"
+    >
+      <form
+        onSubmit={onSubmit}
+        className="bg-zinc-900 p-4 rounded shadow w-full max-w-md space-y-3"
+      >
+        <h3 className="text-lg font-semibold">Assign {entry.handle} to project</h3>
+
+        {confirmation ? (
+          <section className="space-y-3" aria-label="Assignment result">
+            <p className="text-sm text-emerald-300">{confirmation}</p>
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-3 py-1 bg-zinc-800 rounded hover:bg-zinc-700 text-sm"
+              >
+                Done
+              </button>
+            </div>
+          </section>
+        ) : (
+          <>
+            <label className="block text-sm">
+              <span className="text-zinc-400">Target project</span>
+              {loadingProjects ? (
+                <div className="text-xs text-zinc-500 mt-1">Loading projects…</div>
+              ) : projectErr ? (
+                <p role="alert" className="text-red-400 text-xs mt-1">{projectErr}</p>
+              ) : (
+                <select
+                  value={selectedProjectId}
+                  onChange={(e) => setSelectedProjectId(e.target.value)}
+                  className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+                  aria-label="Target project"
+                >
+                  {projects.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name || p.slug}
+                    </option>
+                  ))}
+                </select>
+              )}
+            </label>
+
+            <fieldset className="border border-zinc-800 p-2 rounded">
+              <legend className="text-xs px-1">Scopes</legend>
+              {SCOPE_PRESETS.map((s) => (
+                <label key={s.value} className="flex items-center gap-2 text-sm py-0.5">
+                  <input
+                    type="checkbox"
+                    checked={scopes[s.value]}
+                    disabled={s.disabled}
+                    onChange={(e) => setScopes((prev) => ({ ...prev, [s.value]: e.target.checked }))}
+                    aria-label={`Scope ${s.label}`}
+                  />
+                  <span>{s.label}</span>
+                  {s.disabled && s.hint && (
+                    <span className="text-[10px] text-zinc-500">({s.hint})</span>
+                  )}
+                </label>
+              ))}
+              <label className="flex items-center gap-2 text-sm py-0.5 mt-1">
+                <input
+                  type="checkbox"
+                  checked={isLead}
+                  onChange={(e) => setIsLead(e.target.checked)}
+                  aria-label="Make this agent the project lead"
+                />
+                <span>Lead</span>
+              </label>
+            </fieldset>
+
+            {error && <div role="alert" className="text-red-400 text-xs">{error}</div>}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={submitting}
+                className="px-3 py-1 text-sm disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !selectedProjectId || loadingProjects}
+                className="px-3 py-1 bg-blue-600 rounded text-sm disabled:opacity-50"
+              >
+                {submitting ? "Assigning…" : "Assign to project"}
+              </button>
+            </div>
+          </>
+        )}
+      </form>
+    </div>,
+    document.body,
+  );
+}

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
 import {
   ChevronRight,
   ShieldCheck,
@@ -10,8 +11,12 @@ import {
   RefreshCw,
   ScrollText,
   ArrowRight,
+  UserPlus,
 } from "lucide-react";
 import { Button, Card } from "@/components/ui";
+import { projectsApi } from "@/lib/projects";
+import { AssignAgentToProjectDialog } from "./AssignAgentToProjectDialog";
+import { InviteAgentDialog } from "@/apps/ProjectsApp/InviteAgentDialog";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                               */
@@ -127,16 +132,19 @@ function RegistryEntryRow({
   isAdmin,
   currentUserId,
   onAction,
+  onAssign,
 }: {
   entry: RegistryEntry;
   isAdmin: boolean;
   currentUserId: string;
   onAction: (id: string, action: "approve" | "reject" | "suspend" | "reactivate" | "revoke") => Promise<void>;
+  onAssign: (entry: RegistryEntry) => void;
 }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const isOwner = entry.user_id === currentUserId;
   const canRevoke = (isAdmin || isOwner) && (entry.status === "active" || entry.status === "suspended");
+  const canAssign = (isAdmin || isOwner) && entry.status === "active";
 
   async function act(action: "approve" | "reject" | "suspend" | "reactivate" | "revoke") {
     setBusy(true);
@@ -248,6 +256,19 @@ function RegistryEntryRow({
               title="Revoke"
             >
               <ShieldOff size={14} />
+            </Button>
+          )}
+          {canAssign && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 hover:bg-blue-500/15 hover:text-blue-400"
+              onClick={() => onAssign(entry)}
+              disabled={busy}
+              aria-label={`Assign ${stripAt(entry.display_name) || entry.canonical_id} to project`}
+              title="Assign to project"
+            >
+              <UserPlus size={14} />
             </Button>
           )}
         </div>
@@ -390,6 +411,103 @@ function GovernanceAuditPanel({ isAdmin }: { isAdmin: boolean }) {
 }
 
 /* ------------------------------------------------------------------ */
+/*  InviteExternalAgentPicker                                           */
+/* ------------------------------------------------------------------ */
+
+function InviteExternalAgentPicker({
+  onCancel,
+  onPick,
+}: {
+  onCancel: () => void;
+  onPick: (projectId: string) => void;
+}) {
+  const [projects, setProjects] = useState<import("@/lib/projects").Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+  const [selected, setSelected] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setErr(null);
+    projectsApi
+      .list()
+      .then((rows) => {
+        if (!active) return;
+        const list: import("@/lib/projects").Project[] = Array.isArray(rows) ? rows : [];
+        setProjects(list);
+        if (list.length > 0) setSelected((prev) => prev || list[0]!.id);
+      })
+      .catch((e: unknown) => {
+        if (active) setErr(e instanceof Error ? e.message : "Failed to load projects");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Invite external agent to project"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4"
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (selected) onPick(selected);
+        }}
+        className="bg-zinc-900 p-4 rounded shadow w-full max-w-md space-y-3"
+      >
+        <h3 className="text-lg font-semibold">Invite external agent</h3>
+        {loading ? (
+          <div className="text-xs text-zinc-500">Loading projects…</div>
+        ) : err ? (
+          <p role="alert" className="text-red-400 text-xs">{err}</p>
+        ) : (
+          <label className="block text-sm">
+            <span className="text-zinc-400">Project</span>
+            <select
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+              className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+              aria-label="Project to invite into"
+            >
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name || p.slug}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1 text-sm"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={loading || !selected}
+            className="px-3 py-1 bg-blue-600 rounded text-sm disabled:opacity-50"
+          >
+            Continue
+          </button>
+        </div>
+      </form>
+    </div>,
+    document.body,
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  RegistryPanel                                                       */
 /* ------------------------------------------------------------------ */
 
@@ -400,6 +518,10 @@ export function RegistryPanel() {
   const [currentUserId, setCurrentUserId] = useState("");
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  // Invite / assign dialogs (Feature: invite + assign external agents to projects).
+  const [inviteProjectId, setInviteProjectId] = useState<string | null>(null);
+  const [invitePickerOpen, setInvitePickerOpen] = useState(false);
+  const [assignEntry, setAssignEntry] = useState<RegistryEntry | null>(null);
   // Monotonic counter, only the latest in-flight response is applied.
   const loadSeq = useRef(0);
 
@@ -548,11 +670,44 @@ export function RegistryPanel() {
               isAdmin={isAdmin}
               currentUserId={currentUserId}
               onAction={handleAction}
+              onAssign={setAssignEntry}
             />
           ))
         )}
         <GovernanceAuditPanel isAdmin={isAdmin} />
       </div>
+
+      {isAdmin && inviteProjectId && (
+        <InviteAgentDialog
+          projectId={inviteProjectId}
+          onClose={() => setInviteProjectId(null)}
+        />
+      )}
+      {isAdmin && invitePickerOpen && (
+        <InviteExternalAgentPicker
+          onCancel={() => setInvitePickerOpen(false)}
+          onPick={(pid) => {
+            setInvitePickerOpen(false);
+            setInviteProjectId(pid);
+          }}
+        />
+      )}
+      {assignEntry && (
+        <AssignAgentToProjectDialog
+          entry={assignEntry}
+          onClose={() => setAssignEntry(null)}
+        />
+      )}
+      {isAdmin && (
+        <button
+          type="button"
+          onClick={() => setInvitePickerOpen(true)}
+          className="mt-2 px-3 py-1 text-xs bg-blue-600 rounded hover:bg-blue-500 transition-colors"
+          aria-label="Invite external agent"
+        >
+          Invite external agent
+        </button>
+      )}
     </section>
   );
 }

--- a/desktop/src/apps/agents/__tests__/AssignAgentToProjectDialog.test.tsx
+++ b/desktop/src/apps/agents/__tests__/AssignAgentToProjectDialog.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AssignAgentToProjectDialog } from "../AssignAgentToProjectDialog";
+import { projectsApi } from "@/lib/projects";
+
+const ENTRY = {
+  canonical_id: "agent:free-builder@taos",
+  handle: "@free-builder",
+  origin: "taos",
+  status: "active" as const,
+};
+
+function ok(data: unknown, status = 200) {
+  return { ok: true, status, json: async () => data };
+}
+
+describe("AssignAgentToProjectDialog", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let assignBody: Record<string, unknown> | null = null;
+  let assignUrl: string | null = null;
+
+  beforeEach(() => {
+    assignBody = null;
+    assignUrl = null;
+    fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (/\/api\/projects\/[^/]+\/members\/assign-agent$/.test(String(url)) && init?.method === "POST") {
+        assignUrl = String(url);
+        const parsed = JSON.parse(String(init.body));
+        assignBody = parsed;
+        return Promise.resolve(
+          ok({
+            member_id: "mem_1",
+            project_id: parsed.project_id,
+            canonical_id: parsed.canonical_id,
+            scopes: parsed.scopes,
+            is_lead: parsed.is_lead ?? 0,
+          }),
+        );
+      }
+      return Promise.resolve(ok({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(projectsApi, "list").mockResolvedValue([
+      { id: "prj_a", name: "Alpha", slug: "alpha", description: "", status: "active", created_by: "u", created_at: 0, updated_at: 0 },
+      { id: "prj_b", name: "Beta", slug: "beta", description: "", status: "active", created_by: "u", created_at: 0, updated_at: 0 },
+    ]);
+  });
+
+  it("loads and renders the project options", async () => {
+    await act(async () => {
+      render(
+        <AssignAgentToProjectDialog
+          entry={ENTRY}
+          onClose={() => {}}
+          onAssigned={() => {}}
+        />,
+      );
+    });
+    await waitFor(() => expect(screen.getByRole("option", { name: /Alpha/ })).toBeInTheDocument());
+    expect(screen.getByRole("option", { name: /Beta/ })).toBeInTheDocument();
+  });
+
+  it("posts to /api/projects/{pid}/members/assign-agent with chosen scopes; project_tasks always present", async () => {
+    await act(async () => {
+      render(
+        <AssignAgentToProjectDialog
+          entry={ENTRY}
+          onClose={() => {}}
+          onAssigned={() => {}}
+        />,
+      );
+    });
+    fireEvent.change(screen.getByLabelText(/target project/i), { target: { value: "prj_a" } });
+    fireEvent.click(screen.getByRole("button", { name: /assign to project/i }));
+
+    await waitFor(() => expect(assignBody).not.toBeNull());
+    expect(assignUrl).toBe("/api/projects/prj_a/members/assign-agent");
+    expect(assignBody!.canonical_id).toBe(ENTRY.canonical_id);
+    const scopes = assignBody!.scopes as string[];
+    expect(scopes).toContain("project_tasks");
+    expect(scopes).toContain("canvas_read");
+    expect(scopes).toContain("canvas_write");
+    // is_lead absent or false when toggle is off.
+    expect(assignBody!.is_lead ?? false).toBeFalsy();
+  });
+
+  it("sends is_lead: true when the Lead toggle is on", async () => {
+    await act(async () => {
+      render(
+        <AssignAgentToProjectDialog
+          entry={ENTRY}
+          onClose={() => {}}
+          onAssigned={() => {}}
+        />,
+      );
+    });
+    fireEvent.change(screen.getByLabelText(/target project/i), { target: { value: "prj_b" } });
+    fireEvent.click(screen.getByLabelText(/make this agent the project lead/i));
+    fireEvent.click(screen.getByRole("button", { name: /assign to project/i }));
+
+    await waitFor(() => expect(assignBody).not.toBeNull());
+    expect(assignUrl).toBe("/api/projects/prj_b/members/assign-agent");
+    expect(assignBody!.is_lead).toBe(true);
+  });
+
+  it("surfaces the error message on a failed POST", async () => {
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (/\/api\/projects\/[^/]+\/members\/assign-agent$/.test(String(url)) && init?.method === "POST") {
+        return Promise.resolve({ ok: false, status: 403, json: async () => ({ error: "not authorized" }) });
+      }
+      return Promise.resolve(ok({}));
+    });
+    vi.spyOn(projectsApi, "list").mockResolvedValue([
+      { id: "prj_a", name: "Alpha", slug: "alpha", description: "", status: "active", created_by: "u", created_at: 0, updated_at: 0 },
+    ]);
+
+    await act(async () => {
+      render(
+        <AssignAgentToProjectDialog
+          entry={ENTRY}
+          onClose={() => {}}
+          onAssigned={() => {}}
+        />,
+      );
+    });
+    fireEvent.change(screen.getByLabelText(/target project/i), { target: { value: "prj_a" } });
+    fireEvent.click(screen.getByRole("button", { name: /assign to project/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent(/not authorized/));
+  });
+});

--- a/desktop/src/apps/agents/__tests__/RegistryPanel.invite-assign.test.tsx
+++ b/desktop/src/apps/agents/__tests__/RegistryPanel.invite-assign.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { RegistryPanel } from "../RegistryPanel";
+import { projectsApi } from "@/lib/projects";
+
+function ok(data: unknown, status = 200) {
+  return { ok: true, status, json: async () => data };
+}
+
+const ACTIVE_ENTRY = {
+  canonical_id: "agent:free-builder@taos",
+  framework: "builder",
+  display_name: "@free-builder",
+  user_id: "u_admin",
+  origin: "taos",
+  handle: "@free-builder",
+  role: null,
+  capabilities: ["build"],
+  status: "active",
+  registered_at: new Date().toISOString(),
+  updated_at: null,
+  revoked_at: null,
+};
+
+describe("RegistryPanel invite + assign wiring", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn((url: string) => {
+      if (url === "/auth/status") {
+        return Promise.resolve(ok({ user: { is_admin: true, id: "u_admin" } }));
+      }
+      if (url === "/api/agents/registry") {
+        return Promise.resolve(ok([ACTIVE_ENTRY]));
+      }
+      return Promise.resolve(ok({}));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(projectsApi, "list").mockResolvedValue([
+      { id: "prj_a", name: "Alpha", slug: "alpha", description: "", status: "active", created_by: "u", created_at: 0, updated_at: 0 },
+    ]);
+  });
+
+  it("renders the 'Invite external agent' button for admins", async () => {
+    await act(async () => {
+      render(<RegistryPanel />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Agent Registry/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Invite external agent/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("renders the 'Assign to project' action for active entries", async () => {
+    await act(async () => {
+      render(<RegistryPanel />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Agent Registry/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Assign free-builder to project/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("opens the assign dialog from the row action", async () => {
+    await act(async () => {
+      render(<RegistryPanel />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Agent Registry/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /Assign free-builder to project/i }),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Assign free-builder to project/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("dialog", { name: /assign agent to project/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("option", { name: /Alpha/ })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Surface two actions in the Agents-app registry panel so one agent identity can be shared across projects (multi-project support shipped in #1862).

Feature 1 - Invite external agent
- Admin-only "Invite external agent" button in the RegistryPanel header.
- Opens a project picker, then the existing InviteAgentDialog for that project (same URL + PIN flow as the Members panel).

Feature 2 - Assign to project
- Per-row "Assign to project" action for active entries where the user is admin or owner.
- New AssignAgentToProjectDialog loads projects, shows scope checkboxes (project_tasks required/disabled, canvas_read/canvas_write default on) and a Lead toggle.
- POSTs /api/projects/{pid}/members/assign-agent with canonical_id, scopes (project_tasks always present), and is_lead when toggled. Shows a confirmation on success or the error message on failure.

Tests (vitest, mock fetch + projectsApi): AssignAgentToProjectDialog covers project loading, scope posting with project_tasks always present, Lead toggle sending is_lead: true, and failed-POST error surfacing. A RegistryPanel wiring test asserts the admin button and active-entry assign action render and open the dialog.

TDD with vitest; tsc --noEmit clean; doc-gate: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options for administrators to invite external agents to projects.
  * Added the ability to assign registered agents to projects.
  * Assignment dialogs support project selection, permission scopes, and project-lead designation.
  * Added loading, error, and success states with confirmation and cancellation actions.

* **Tests**
  * Added coverage for agent invitations, project assignments, permissions, lead designation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->