### PR TITLE
fix(cluster): restore local-worker guard + correct worker-update restart handling (#1690)

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -103,6 +103,33 @@ class TestClusterManager:
 
         assert mgr.get_worker("gpu-box").status == "offline"
 
+    async def test_monitor_loop_never_offlines_local_worker(self):
+        """The controller's own 'local' worker is kept alive by
+        local_heartbeat_loop, not remote heartbeats. The monitor loop must
+        skip it so a heartbeat gap never marks the controller offline (which
+        would drop its own leases and remove local backends from routing).
+        A regular stale worker in the same pass is still marked offline
+        (taOS #1690)."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("local"))
+        await mgr.register_worker(_make_worker("gpu-box"))
+        stale = time.time() - HEARTBEAT_TIMEOUT - 5
+        mgr.get_worker("local").last_heartbeat = stale
+        mgr.get_worker("gpu-box").last_heartbeat = stale
+
+        task = asyncio.create_task(mgr._monitor_loop())
+        try:
+            await asyncio.sleep(0.05)  # let one iteration run
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        assert mgr.get_worker("local").status == "online"    # guard held
+        assert mgr.get_worker("gpu-box").status == "offline"  # normal path
+
     async def test_get_workers_for_capability_filters_and_sorts(self):
         mgr = ClusterManager()
         await mgr.register_worker(_make_worker("fast-gpu", capabilities=["chat", "embed"], load=0.2))

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -520,3 +520,72 @@ async def test_install_targets_matches_remote_to_worker_by_url_host(app, client,
     assert fedora is not None
     assert fedora["hardware_known"] is True, fedora
     assert fedora["tier_id"] not in ("", "unknown"), fedora
+
+
+# ---------------------------------------------------------------------------
+# Worker auto-update: deploy-connection classification (taOS #1690)
+# ---------------------------------------------------------------------------
+
+async def _register_online_worker(app, name="gpu-box", url="http://gpu-box:9000"):
+    from tinyagentos.cluster.worker_protocol import WorkerInfo
+    await app.state.cluster_manager.register_worker(
+        WorkerInfo(name=name, url=url, capabilities=["chat"],
+                   load=0.0, status="online", platform="linux")
+    )
+
+
+def _client_raising(exc):
+    """An httpx.AsyncClient stand-in whose .post always raises *exc*."""
+    class _Raising:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, *a, **k):
+            raise exc
+
+    return _Raising
+
+
+@pytest.mark.asyncio
+async def test_update_worker_restart_disconnect_reports_updating(client, app, monkeypatch):
+    """The deploy request blocks until update-worker restarts the worker, which
+    drops the connection (RemoteProtocolError). That is the happy path: the
+    update was accepted, so the route must return 200 status='updating' and
+    keep the worker draining, not cancel the drain and return 502."""
+    import httpx as _httpx
+    await _register_online_worker(app)
+    monkeypatch.setattr(
+        _httpx, "AsyncClient",
+        _client_raising(_httpx.RemoteProtocolError("server disconnected during restart")),
+    )
+
+    resp = await client.post("/api/cluster/workers/gpu-box/update")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "updating"
+    # Drain must remain active so the monitor loop completes it on re-register.
+    assert app.state.cluster_manager.get_worker("gpu-box").status == "draining"
+
+
+@pytest.mark.asyncio
+async def test_update_worker_connect_error_cancels_drain(client, app, monkeypatch):
+    """Connection refused means the worker is unreachable and the update was
+    never delivered: the route must cancel the drain (worker keeps serving)
+    and return 502, not silently leave it draining."""
+    import httpx as _httpx
+    await _register_online_worker(app)
+    monkeypatch.setattr(
+        _httpx, "AsyncClient",
+        _client_raising(_httpx.ConnectError("connection refused")),
+    )
+
+    resp = await client.post("/api/cluster/workers/gpu-box/update")
+    assert resp.status_code == 502, resp.text
+    assert resp.json().get("drain_cancelled") is True
+    # Drain was cancelled, so the worker is back online and still routable.
+    assert app.state.cluster_manager.get_worker("gpu-box").status == "online"

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -517,7 +517,7 @@ class ClusterManager:
                 f"{'Tasks will complete before detach.' if graceful else 'All leases released immediately.'}"
             )
             try:
-                asyncio.get_running_loop().create_task(
+                task = asyncio.get_running_loop().create_task(
                     self._notifications.emit_event(
                         "worker.drain",
                         f"Worker '{name}' draining",
@@ -525,6 +525,8 @@ class ClusterManager:
                         level="info",
                     )
                 )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
             except RuntimeError:
                 pass
 
@@ -551,7 +553,7 @@ class ClusterManager:
 
         if self._notifications:
             try:
-                asyncio.get_running_loop().create_task(
+                task = asyncio.get_running_loop().create_task(
                     self._notifications.emit_event(
                         "worker.online",
                         f"Worker '{name}' drain cancelled",
@@ -559,6 +561,8 @@ class ClusterManager:
                         level="info",
                     )
                 )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
             except RuntimeError:
                 pass
 
@@ -664,6 +668,13 @@ class ClusterManager:
         while True:
             now = time.time()
             for worker in list(self._workers.values()):
+                # The 'local' worker is the controller itself, kept alive by
+                # local_heartbeat_loop (15s) rather than remote heartbeats. It
+                # must never be marked offline or drained here: doing so would
+                # drop the controller's own leases and remove local backends
+                # from routing and the aggregate catalog (taOS #1690).
+                if worker.name == "local":
+                    continue
                 # Handle online workers that haven't heartbeated
                 if worker.status == "online" and (now - worker.last_heartbeat) > HEARTBEAT_TIMEOUT:
                     worker.status = "offline"

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -1233,8 +1233,37 @@ async def update_worker(request: Request, name: str):
             # reporting status:"updating" with the error body as deploy_result.
             resp.raise_for_status()
             deploy_result = resp.json()
+    except (httpx.RemoteProtocolError, httpx.ReadError, httpx.ReadTimeout):
+        # The deploy request blocks until update-worker restarts the worker
+        # service, which drops the connection mid-response. This is the
+        # EXPECTED happy path: the update was accepted and is running. Keep
+        # the worker draining; the monitor loop auto-completes the drain once
+        # the restarted worker re-registers and heartbeats. Reporting this as
+        # a failure (and cancelling the drain) was a regression — the update
+        # actually succeeds and self-heals on re-register.
+        return {
+            "worker": name,
+            "status": "updating",
+            "previous_status": drain_result["previous_status"],
+            "drain": drain_result,
+            "deploy": None,
+            "message": (
+                "Worker accepted the update and is restarting. The connection "
+                "dropped as expected during the restart; the monitor loop will "
+                "auto-complete the drain once it re-registers and heartbeats."
+            ),
+        }
+    except httpx.ConnectError as exc:
+        # Connection refused / DNS failure: the worker is unreachable and the
+        # update was never delivered. Cancel the drain so it keeps serving.
+        await cluster.cancel_drain(name)
+        return JSONResponse(
+            {"error": f"Worker unreachable for update: {exc}", "drain_cancelled": True},
+            status_code=502,
+        )
     except Exception as exc:
-        # Deploy failed — cancel drain so worker can still serve traffic
+        # Non-2xx worker response (raise_for_status) or any other unexpected
+        # error: real failure, cancel drain so worker can still serve traffic.
         await cluster.cancel_drain(name)
         return JSONResponse(
             {"error": f"Worker update deploy failed: {exc}", "drain_cancelled": True},


### PR DESCRIPTION
## What

Two regressions that came in when the worker-drain feature landed via the GPU arbiter convergence (#1859). Both were correctly identified by @hognek's review rounds on #1690, which is superseded by #1859 and cannot merge cleanly (rebasing it would fight the arbiter wiring).

### 1. `local` worker guard dropped from `_monitor_loop`
`#1859` removed the `if worker.name == "local": continue` guard. The `local` worker is the controller registering itself, kept alive by `local_heartbeat_loop` (15s) rather than remote heartbeats. Without the guard, a >30s stall marks the controller's own worker offline, drops its leases, and removes local backends from routing and the aggregate catalog. Restored.

### 2. `update_worker` reports failure on a successful update
The route used a broad `except Exception` that always cancelled the drain and returned 502. But `/api/worker/deploy` blocks until `update-worker` restarts the worker and the connection drops, so the happy path was caught as an error, the drain cancelled, and 502 returned even though the update succeeded. Split the handling:
- disconnect (`RemoteProtocolError` / `ReadError` / `ReadTimeout`) = accepted, keep draining, `200 status=updating`
- `ConnectError` = worker unreachable, cancel drain, `502`
- non-2xx (`raise_for_status`) / unexpected = cancel drain, `502`

Also retains the drain / cancel-drain notification tasks in `_background_tasks` so they are not GC'd mid-flight.

## Tests
- `test_monitor_loop_never_offlines_local_worker`
- `test_update_worker_restart_disconnect_reports_updating`
- `test_update_worker_connect_error_cancels_drain`

Full `tests/test_cluster.py` + `tests/test_routes_cluster.py`: 49 passed.

Design and both fixes spotted by @hognek in #1690.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local workers now remain online during heartbeat monitoring, preventing interruptions to local workloads and routing.
  * Worker updates now correctly distinguish expected restart disconnects from genuine connection failures.
  * Failed worker updates provide clearer error responses and restore affected workers to an available state when appropriate.
  * Background notifications during worker draining and cancellation are delivered more reliably.
* **Tests**
  * Added coverage for worker monitoring and update behavior across successful, restarting, and failed connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->