### PR TITLE
fix(systemd): move desktop rebuild out of ExecStartPre into separate oneshot service

### DIFF
--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1839,9 +1839,10 @@ install_linux_systemd_system() {
     fi
 
     $sudo_cmd systemctl daemon-reload
-    $sudo_cmd systemctl enable --now tinyagentos
-    # Enable the desktop rebuild service (runs async after controller start; taOS #807)
+    # Enable the desktop rebuild service before starting the controller so
+    # systemd installs the WantedBy= symlink atomically (taOS #807).
     $sudo_cmd systemctl enable tinyagentos-rebuild-desktop.service
+    $sudo_cmd systemctl enable --now tinyagentos
     if [[ -f /etc/systemd/system/taos-pre-shutdown.service ]]; then
         $sudo_cmd systemctl enable taos-pre-shutdown.service
     fi
@@ -1892,6 +1893,8 @@ install_linux_systemd_user() {
         -e "s|TAOS_GROUP|$(id -gn)|g" \
         -e "s|TAOS_INSTALL_DIR|$INSTALL_DIR|g" \
         -e "s|/usr/local/bin/taos-rebuild-desktop|$HOME/.local/bin/taos-rebuild-desktop|g" \
+        -e "/^User=/d" \
+        -e "/^Group=/d" \
         "$INSTALL_DIR/scripts/systemd/tinyagentos-rebuild-desktop.service" \
         > "$rebuild_unit"
     log "installed $rebuild_unit (user unit fallback)"
@@ -1916,9 +1919,10 @@ install_linux_systemd_user() {
         warn "to start manually: systemctl --user daemon-reload && systemctl --user enable --now tinyagentos tinyagentos-rebuild-desktop"
         return 0
     fi
-    systemctl --user enable --now tinyagentos
-    # Enable the desktop rebuild service (runs async after controller start; taOS #807)
+    # Enable the desktop rebuild service before starting the controller so
+    # systemd --user installs the WantedBy= symlink atomically (taOS #807).
     systemctl --user enable tinyagentos-rebuild-desktop.service
+    systemctl --user enable --now tinyagentos
     log "controller running as user systemd service"
     log "check: systemctl --user status tinyagentos"
     log "logs:  journalctl --user -u tinyagentos -f"

--- a/scripts/install-server.sh
+++ b/scripts/install-server.sh
@@ -1796,6 +1796,10 @@ install_linux_systemd_system() {
     $sudo_cmd install -m 0755 "$INSTALL_DIR/scripts/taos-graceful-stop.sh" /usr/local/bin/taos-graceful-stop
     log "installed /usr/local/bin/taos-graceful-stop"
 
+    # Install desktop rebuild script (runs async after controller start; taOS #807)
+    $sudo_cmd install -m 0755 "$INSTALL_DIR/scripts/rebuild-desktop.sh" /usr/local/bin/taos-rebuild-desktop
+    log "installed /usr/local/bin/taos-rebuild-desktop"
+
     # Stamp the template from the repo, substituting install-time variables.
     # The service runs as the dedicated 'taos' system user, not the installer's
     # $USER.  The installer itself still runs as root.
@@ -1815,6 +1819,16 @@ install_linux_systemd_system() {
     $sudo_cmd sed -i "s|^Environment=PYTHONUNBUFFERED=1|Environment=PYTHONUNBUFFERED=1\nEnvironment=TAOS_HOST=0.0.0.0\nEnvironment=TAOS_PORT=$TAOS_PORT\nEnvironment=TAOS_BROWSER_PROXY_PORT=$TAOS_BROWSER_PROXY_PORT|" "$unit"
     log "installed $unit (system unit, runs as 'taos')"
 
+    # Install desktop-rebuild service (runs async after controller starts; taOS #807)
+    local rebuild_unit="/etc/systemd/system/tinyagentos-rebuild-desktop.service"
+    sed \
+        -e "s|TAOS_USER|taos|g" \
+        -e "s|TAOS_GROUP|taos|g" \
+        -e "s|TAOS_INSTALL_DIR|$INSTALL_DIR|g" \
+        "$INSTALL_DIR/scripts/systemd/tinyagentos-rebuild-desktop.service" \
+        | $sudo_cmd tee "$rebuild_unit" > /dev/null
+    log "installed $rebuild_unit"
+
     # Hand the data directory to the service user before the unit first starts.
     set_data_dir_ownership
 
@@ -1826,6 +1840,8 @@ install_linux_systemd_system() {
 
     $sudo_cmd systemctl daemon-reload
     $sudo_cmd systemctl enable --now tinyagentos
+    # Enable the desktop rebuild service (runs async after controller start; taOS #807)
+    $sudo_cmd systemctl enable tinyagentos-rebuild-desktop.service
     if [[ -f /etc/systemd/system/taos-pre-shutdown.service ]]; then
         $sudo_cmd systemctl enable taos-pre-shutdown.service
     fi
@@ -1841,6 +1857,9 @@ install_linux_systemd_user() {
     # Install graceful-stop script to user-local bin if possible
     mkdir -p "$HOME/.local/bin"
     install -m 0755 "$INSTALL_DIR/scripts/taos-graceful-stop.sh" "$HOME/.local/bin/taos-graceful-stop"
+    # Install desktop rebuild script (runs async after controller start; taOS #807)
+    install -m 0755 "$INSTALL_DIR/scripts/rebuild-desktop.sh" "$HOME/.local/bin/taos-rebuild-desktop"
+    log "installed $HOME/.local/bin/taos-rebuild-desktop"
 
     local taos_prefetch="${TAOS_PREFETCH_BASE_IMAGE:-0}"
 
@@ -1866,6 +1885,17 @@ install_linux_systemd_user() {
     sed -i "s|^Environment=PYTHONUNBUFFERED=1|Environment=PYTHONUNBUFFERED=1\nEnvironment=TAOS_HOST=0.0.0.0\nEnvironment=TAOS_PORT=$TAOS_PORT\nEnvironment=TAOS_BROWSER_PROXY_PORT=$TAOS_BROWSER_PROXY_PORT|" "$unit"
     log "installed $unit (user unit fallback — sudo unavailable)"
 
+    # Install desktop-rebuild service (runs async after controller starts; taOS #807)
+    local rebuild_unit="$unit_dir/tinyagentos-rebuild-desktop.service"
+    sed \
+        -e "s|TAOS_USER|$USER|g" \
+        -e "s|TAOS_GROUP|$(id -gn)|g" \
+        -e "s|TAOS_INSTALL_DIR|$INSTALL_DIR|g" \
+        -e "s|/usr/local/bin/taos-rebuild-desktop|$HOME/.local/bin/taos-rebuild-desktop|g" \
+        "$INSTALL_DIR/scripts/systemd/tinyagentos-rebuild-desktop.service" \
+        > "$rebuild_unit"
+    log "installed $rebuild_unit (user unit fallback)"
+
     # Make the user manager start on boot without an active login. Must
     # happen BEFORE the systemctl --user calls so the user bus is up.
     loginctl enable-linger "$USER" 2>/dev/null || true
@@ -1882,11 +1912,13 @@ install_linux_systemd_user() {
     done
 
     if ! systemctl --user daemon-reload 2>/dev/null; then
-        warn "user systemd not reachable — leaving the unit on disk so it activates on next login"
-        warn "to start manually: systemctl --user daemon-reload && systemctl --user enable --now tinyagentos"
+        warn "user systemd not reachable — leaving the units on disk so they activate on next login"
+        warn "to start manually: systemctl --user daemon-reload && systemctl --user enable --now tinyagentos tinyagentos-rebuild-desktop"
         return 0
     fi
     systemctl --user enable --now tinyagentos
+    # Enable the desktop rebuild service (runs async after controller start; taOS #807)
+    systemctl --user enable tinyagentos-rebuild-desktop.service
     log "controller running as user systemd service"
     log "check: systemctl --user status tinyagentos"
     log "logs:  journalctl --user -u tinyagentos -f"

--- a/scripts/rebuild-desktop.sh
+++ b/scripts/rebuild-desktop.sh
@@ -30,7 +30,7 @@ fi
 #
 # Using -print -quit so find stops at the first hit (no need to scan everything).
 if [ -f static/desktop/index.html ]; then
-    _stale_src="$(find desktop/src -type f -newer static/desktop/index.html -print -quit 2>/dev/null)"
+    _stale_src="$(find desktop/src -type f -not -path '*/node_modules/*' -newer static/desktop/index.html -print -quit 2>/dev/null)"
     _stale_cfg="$(find desktop \( -name 'package.json' -o -name '*-lock.*' -o -name 'vite.config.*' -o -name 'tsconfig*.json' \) -type f -newer static/desktop/index.html -print -quit 2>/dev/null)"
     if [ -z "$_stale_src" ] && [ -z "$_stale_cfg" ]; then
         echo "[taos-rebuild-desktop] desktop bundle is current — skipping rebuild"
@@ -48,7 +48,7 @@ if [ ! -f desktop/package.json ]; then
     exit 0
 fi
 
-if (cd desktop && npm install --silent && npm run build); then
+if (cd desktop && npm install && npm run build); then
     echo "[taos-rebuild-desktop] desktop rebuild succeeded"
 elif [ -f static/desktop/index.html ]; then
     echo "[taos-rebuild-desktop] desktop rebuild FAILED -- keeping the existing bundle (see journalctl -u tinyagentos-rebuild-desktop)"

--- a/scripts/rebuild-desktop.sh
+++ b/scripts/rebuild-desktop.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Rebuild the TinyAgentOS desktop SPA when the source is newer than the bundle.
+#
+# Launched by tinyagentos-rebuild-desktop.service AFTER the controller is already
+# running, so a stale (or missing) bundle never blocks service startup.  Previously
+# this was an ExecStartPre in tinyagentos.service, which added ~50 s to every
+# restart after a git pull, and the mtime check could fire spuriously after a
+# checkout/rebase even when nothing changed (taOS #807).
+#
+# The script is designed to be run from the install directory (WorkingDirectory=),
+# matching the paths the old ExecStartPre used.
+
+set -euo pipefail
+
+# The service unit sets WorkingDirectory to the install root, so relative
+# paths resolve correctly without needing a parameter.
+if [ ! -d desktop ]; then
+    echo "[taos-rebuild-desktop] no desktop/ directory found — nothing to rebuild"
+    exit 0
+fi
+
+# Check whether any desktop build source is newer than the bundle.
+# The bundle is considered stale if ANY of these are newer than
+# static/desktop/index.html:
+#   • desktop/src/**           — the React/TypeScript source
+#   • desktop/package.json     — dependency declarations
+#   • desktop/*-lock.*         — dependency lock-files (package-lock.json, pnpm-lock.yaml, etc.)
+#   • desktop/vite.config.*    — Vite build config
+#   • desktop/tsconfig*.json   — TypeScript compiler config
+#
+# Using -print -quit so find stops at the first hit (no need to scan everything).
+if [ -f static/desktop/index.html ]; then
+    _stale_src="$(find desktop/src -type f -newer static/desktop/index.html -print -quit 2>/dev/null)"
+    _stale_cfg="$(find desktop \( -name 'package.json' -o -name '*-lock.*' -o -name 'vite.config.*' -o -name 'tsconfig*.json' \) -type f -newer static/desktop/index.html -print -quit 2>/dev/null)"
+    if [ -z "$_stale_src" ] && [ -z "$_stale_cfg" ]; then
+        echo "[taos-rebuild-desktop] desktop bundle is current — skipping rebuild"
+        exit 0
+    fi
+fi
+
+echo "[taos-rebuild-desktop] desktop source newer than bundle (or no bundle) — rebuilding..."
+
+# Guard: without package.json, npm install will fail with a confusing error.
+# Exit cleanly so the service doesn't look broken when this is a bare install
+# that hasn't checked out the desktop subdirectory yet.
+if [ ! -f desktop/package.json ]; then
+    echo "[taos-rebuild-desktop] desktop/package.json not found — skipping rebuild (desktop source not checked out?)"
+    exit 0
+fi
+
+if (cd desktop && npm install --silent && npm run build); then
+    echo "[taos-rebuild-desktop] desktop rebuild succeeded"
+elif [ -f static/desktop/index.html ]; then
+    echo "[taos-rebuild-desktop] desktop rebuild FAILED -- keeping the existing bundle (see journalctl -u tinyagentos-rebuild-desktop)"
+else
+    echo "[taos-rebuild-desktop] desktop rebuild FAILED and no existing bundle — UI may be unavailable until a successful rebuild"
+    exit 1
+fi

--- a/scripts/systemd/tinyagentos-rebuild-desktop.service
+++ b/scripts/systemd/tinyagentos-rebuild-desktop.service
@@ -15,6 +15,10 @@ ExecStart=/usr/local/bin/taos-rebuild-desktop
 # Slow builds on low-end SBCs can take a while.  Give plenty of headroom
 # but not infinite — a hung npm install shouldn't linger forever.
 TimeoutStartSec=300
+# Oneshot services don't get automatic retry — failures are surfaced via
+# systemctl status and journalctl.  To check the last-run outcome:
+#   systemctl status tinyagentos-rebuild-desktop
+#   journalctl -u tinyagentos-rebuild-desktop
 
 [Install]
 WantedBy=tinyagentos.service

--- a/scripts/systemd/tinyagentos-rebuild-desktop.service
+++ b/scripts/systemd/tinyagentos-rebuild-desktop.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Rebuild TinyAgentOS desktop SPA when source is newer than bundle
+After=tinyagentos.service
+PartOf=tinyagentos.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# User/Group/WorkingDirectory/ExecStart are rewritten by install-server.sh at
+# install time, matching the controller unit.
+User=TAOS_USER
+Group=TAOS_GROUP
+WorkingDirectory=TAOS_INSTALL_DIR
+ExecStart=/usr/local/bin/taos-rebuild-desktop
+# Slow builds on low-end SBCs can take a while.  Give plenty of headroom
+# but not infinite — a hung npm install shouldn't linger forever.
+TimeoutStartSec=300
+
+[Install]
+WantedBy=tinyagentos.service

--- a/scripts/systemd/tinyagentos.service
+++ b/scripts/systemd/tinyagentos.service
@@ -21,22 +21,12 @@ ExecStartPre=+/bin/sh -c '\
   chmod o+r /sys/kernel/debug/rkrga/load 2>/dev/null || true; \
   chmod o+rx /sys/kernel/debug/mali0 2>/dev/null || true; \
   chmod o+r /sys/kernel/debug/mali0/dvfs_utilization 2>/dev/null || true'
-# Rebuild the desktop bundle if desktop/src is newer than the last build output.
-# Catches the case where `git pull` landed new frontend source but `npm run build`
-# was not run before restarting the service. ~0s when current, ~50s when stale.
-ExecStartPre=/bin/sh -c '\
-  cd TAOS_INSTALL_DIR && \
-  if [ -d desktop ] && { [ ! -f static/desktop/index.html ] || [ -n "$(find desktop/src -type f -newer static/desktop/index.html -print -quit 2>/dev/null)" ]; }; then \
-    echo "[taos] desktop source newer than bundle — rebuilding..."; \
-    if (cd desktop && npm install --silent && npm run build); then \
-      echo "[taos] desktop rebuild succeeded"; \
-    elif [ -f static/desktop/index.html ]; then \
-      echo "[taos] desktop rebuild FAILED -- starting with the existing (stale) bundle (see journalctl -u tinyagentos)"; \
-    else \
-      echo "[taos] desktop rebuild FAILED and no existing bundle -- cannot start"; \
-      exit 1; \
-    fi; \
-  fi'
+# Desktop bundle rebuild moved to tinyagentos-rebuild-desktop.service (taOS #807)
+# to avoid blocking service startup with a ~50s npm install + vite build.
+#
+# If you git-pull new desktop source and restart the controller, the rebuild
+# runs asynchronously — the UI stays responsive while the build completes.
+
 # Launch via the module entrypoint (not uvicorn directly) so the dual-port
 # browser-proxy origin starts. __main__.main() reads TAOS_HOST/TAOS_PORT and
 # TAOS_BROWSER_PROXY_PORT from the Environment block injected by install-server.sh.


### PR DESCRIPTION
## Summary

Moves the desktop SPA rebuild (npm install + npm run build) out of the blocking ExecStartPre in tinyagentos.service and into a separate oneshot service that runs asynchronously after the controller starts.

Fixes #807

## Changes

- **New:** `scripts/rebuild-desktop.sh` — standalone rebuild script with the same conditional logic (check mtime, rebuild if needed, graceful fallback)
- **New:** `scripts/systemd/tinyagentos-rebuild-desktop.service` — oneshot service (Type=oneshot, PartOf=tinyagentos.service, After=tinyagentos.service) that runs the rebuild script after the controller is already up
- **Modified:** `scripts/systemd/tinyagentos.service` — removed the ~50s desktop rebuild ExecStartPre block, replaced with a comment pointing to the new service
- **Modified:** `scripts/install-server.sh` — installs the rebuild script to /usr/local/bin/, stamps and installs the rebuild service unit, and enables it alongside the main service

## Behavior

- Controller starts immediately — no more ~50s delay on restarts after git pull
- Desktop rebuild happens in the background via the oneshot service
- If rebuild fails, the existing bundle is preserved (no regression)
- If no bundle exists and rebuild fails, the service exits 1 and journalctl shows the error
- Mtime false positives (after checkout/rebase) no longer block service startup

## Testing

- All tests in `tests/test_agent_image_prefetch.py` pass (includes service template validation)
- All tests in `tests/test_install_server.sh` pass
- Fast gate `pytest tests/ --ignore=tests/e2e -n auto` running (partial pass so far, no failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic background rebuilding of the desktop interface when source files are newer than the current bundle.
  * Added support for both system-wide and user-level installations.
  * Desktop rebuild failures preserve an existing working bundle when possible.

* **Improvements**
  * Controller startup is no longer blocked by desktop rebuilding.
  * Installations provide clearer manual-start guidance when automatic service activation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->