### PR TITLE
feat(desktop): clamp off-screen windows on viewport resize

### DIFF
--- a/desktop/src/components/Desktop.tsx
+++ b/desktop/src/components/Desktop.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { FolderPlus, Image, Monitor, Settings, LayoutGrid, Layers, BookmarkPlus } from "lucide-react";
 import { useProcessStore } from "@/stores/process-store";
 import { useThemeStore } from "@/stores/theme-store";
@@ -25,7 +25,7 @@ type ContextMenuState = {
 
 export function Desktop() {
   const windows = useProcessStore((s) => s.windows);
-  const { openWindow } = useProcessStore();
+  const { openWindow, reclampAllWindows } = useProcessStore();
   const wallpaperImage = useThemeStore((s) => s.wallpaperImage);
   const wallpaperMobileImage = useThemeStore((s) => s.wallpaperMobileImage);
   const wallpaperFallback = useThemeStore((s) => s.wallpaperFallback);
@@ -78,6 +78,23 @@ export function Desktop() {
   // (open apps, move/arrange windows) by pushing commands the controller streams
   // here. Re-dispatches to the taos:open-app / taos:window receivers above.
   useDesktopCommandStream();
+
+  // When the viewport shrinks (e.g. moving the browser from an ultrawide
+  // monitor to a 16:9 laptop), windows with absolute positions can end up
+  // off-screen and unreachable.  Re-clamp every visible window after each
+  // resize, debounced so we don't thrash during a drag-resize.
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    const onResize = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => reclampAllWindows(), 150);
+    };
+    window.addEventListener("resize", onResize);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("resize", onResize);
+    };
+  }, [reclampAllWindows]);
 
   const menuItems: MenuItem[] = [
     {

--- a/desktop/src/stores/process-store.test.ts
+++ b/desktop/src/stores/process-store.test.ts
@@ -89,3 +89,105 @@ describe("process-store openWindow", () => {
     ).toHaveLength(1);
   });
 });
+
+describe("process-store reclampAllWindows", () => {
+  beforeEach(() => {
+    reset();
+    // Set a known viewport size so safeBounds clamping is deterministic.
+    Object.defineProperty(window, "innerWidth", { value: 1024, writable: true, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: 768, writable: true, configurable: true });
+  });
+
+  it("clamps an off-screen window back into the viewport", () => {
+    // Open a window at a position that would be reachable on a big monitor
+    // but simulate it being far outside the current viewport.
+    useProcessStore.getState().openWindow("files", { w: 600, h: 400 });
+    // Directly set a position way off-screen to the right.
+    const winId = useProcessStore.getState().windows[0].id;
+    useProcessStore.setState((s) => ({
+      windows: s.windows.map((w) =>
+        w.id === winId ? { ...w, position: { x: 2000, y: 100 } } : w
+      ),
+    }));
+    // Before clamping: window is unreachable.
+    const before = useProcessStore.getState().windows[0];
+    expect(before.position.x).toBe(2000);
+
+    useProcessStore.getState().reclampAllWindows();
+
+    const after = useProcessStore.getState().windows[0];
+    // After clamping: x should be within the viewport (clamped to right edge).
+    expect(after.position.x).toBeLessThan(1024);
+    expect(after.position.x).toBeGreaterThan(0);
+  });
+
+  it("leaves a window already on-screen unchanged", () => {
+    useProcessStore.getState().openWindow("files", { w: 600, h: 400 });
+    const winId = useProcessStore.getState().windows[0].id;
+    useProcessStore.setState((s) => ({
+      windows: s.windows.map((w) =>
+        w.id === winId ? { ...w, position: { x: 200, y: 150 } } : w
+      ),
+    }));
+
+    useProcessStore.getState().reclampAllWindows();
+
+    const after = useProcessStore.getState().windows[0];
+    expect(after.position.x).toBe(200);
+    expect(after.position.y).toBe(150);
+  });
+
+  it("skips minimized windows", () => {
+    useProcessStore.getState().openWindow("files", { w: 600, h: 400 });
+    const winId = useProcessStore.getState().windows[0].id;
+    useProcessStore.getState().minimizeWindow(winId);
+    useProcessStore.setState((s) => ({
+      windows: s.windows.map((w) =>
+        w.id === winId ? { ...w, position: { x: 2000, y: 100 } } : w
+      ),
+    }));
+
+    useProcessStore.getState().reclampAllWindows();
+
+    // Minimized window should stay at its stored position (off-screen).
+    const after = useProcessStore.getState().windows[0];
+    expect(after.position.x).toBe(2000);
+    expect(after.minimized).toBe(true);
+  });
+
+  it("skips maximized windows", () => {
+    useProcessStore.getState().openWindow("files", { w: 600, h: 400 });
+    const winId = useProcessStore.getState().windows[0].id;
+    useProcessStore.getState().maximizeWindow(winId);
+    useProcessStore.setState((s) => ({
+      windows: s.windows.map((w) =>
+        w.id === winId ? { ...w, position: { x: 2000, y: 100 } } : w
+      ),
+    }));
+
+    useProcessStore.getState().reclampAllWindows();
+
+    // Maximized window keeps its stored position (viewport handles display).
+    const after = useProcessStore.getState().windows[0];
+    expect(after.position.x).toBe(2000);
+    expect(after.maximized).toBe(true);
+  });
+
+  it("skips snapped windows", () => {
+    useProcessStore.getState().openWindow("files", { w: 600, h: 400 });
+    const winId = useProcessStore.getState().windows[0].id;
+    useProcessStore.getState().snapWindow(winId, "left");
+    useProcessStore.setState((s) => ({
+      windows: s.windows.map((w) =>
+        w.id === winId ? { ...w, position: { x: 2000, y: 100 } } : w
+      ),
+    }));
+
+    useProcessStore.getState().reclampAllWindows();
+
+    // Snapped window keeps stored position; display is handled reactively.
+    const after = useProcessStore.getState().windows[0];
+    expect(after.position.x).toBe(2000);
+    expect(after.snapped).toBe("left");
+  });
+});

--- a/desktop/src/stores/process-store.ts
+++ b/desktop/src/stores/process-store.ts
@@ -255,7 +255,7 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
       windows: s.windows.map((w) => {
         if (w.minimized || w.maximized || w.snapped) return w;
         const safe = safeBounds(w.position, w.size);
-        // safeBounds is idempotent — if the window is already on-screen it
+        // safeBounds is idempotent -- if the window is already on-screen it
         // returns the same position and size.
         if (safe.position.x === w.position.x && safe.position.y === w.position.y && safe.size.w === w.size.w && safe.size.h === w.size.h) {
           return w;

--- a/desktop/src/stores/process-store.ts
+++ b/desktop/src/stores/process-store.ts
@@ -40,6 +40,7 @@ interface ProcessStore {
   updateSize: (id: string, w: number, h: number) => void;
   updateBounds: (id: string, x: number, y: number, w: number, h: number) => void;
   snapWindow: (id: string, snap: SnapPosition) => void;
+  reclampAllWindows: () => void;
   runningAppIds: () => string[];
 }
 
@@ -241,6 +242,26 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
       windows: s.windows.map((w) =>
         w.id === id ? { ...w, snapped: snap } : w
       ),
+    }));
+  },
+
+  // Re-clamp every visible, non-maximized, non-snapped window after a viewport
+  // resize (e.g. moving the browser window from an ultrawide monitor to a
+  // 16:9 laptop screen).  Maximized windows already fill the available area
+  // and snapped windows are recomputed reactively; this only adjusts windows
+  // with stored absolute positions that may now be off-screen.
+  reclampAllWindows() {
+    set((s) => ({
+      windows: s.windows.map((w) => {
+        if (w.minimized || w.maximized || w.snapped) return w;
+        const safe = safeBounds(w.position, w.size);
+        // safeBounds is idempotent — if the window is already on-screen it
+        // returns the same position and size.
+        if (safe.position.x === w.position.x && safe.position.y === w.position.y && safe.size.w === w.size.w && safe.size.h === w.size.h) {
+          return w;
+        }
+        return { ...w, ...safe };
+      }),
     }));
   },
 


### PR DESCRIPTION
## Summary
Adds viewport-resize clamping so windows don't become unreachable when the browser moves from an ultrawide monitor to a 16:9 screen.

The dock right-click context menu (minimise/maximise/close) was already present in DockIcon.tsx — this PR completes the remaining piece of \#866.

## Changes

### `desktop/src/stores/process-store.ts`
- Added `reclampAllWindows()` — iterates visible, non-maximized, non-snapped windows and re-clamps them into the viewport using the existing `safeBounds()` helper. Skips minimized/maximized/snapped windows.

### `desktop/src/components/Desktop.tsx`
- Added a `useEffect` resize listener with 150ms debounce that calls `reclampAllWindows()` on viewport resize.

### `desktop/src/stores/process-store.test.ts`
- 5 new test cases: off-screen clamp, on-screen unchanged, skip minimized, skip maximized, skip snapped.

## Testing
```
npx vitest run --run \
  src/stores/process-store.test.ts \
  src/components/__tests__/DockIcon.context-menu.test.tsx \
  src/components/Dock.test.tsx \
  src/components/DockIcon.test.tsx \
  src/stores/dock-store.test.ts \
  src/components/dock/__tests__/DockVariants.test.tsx
```
**Result:** 6 files, 41 tests — all pass.

Closes \#866