### PR TITLE
feat(desktop): extract sub-components from MessagesApp.tsx (partial #657)

### DIFF
--- a/desktop/src/apps/chat/MessageList.tsx
+++ b/desktop/src/apps/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle, useRef, useEffect } from "react";
+import React, { forwardRef, useImperativeHandle, useRef } from "react";
 import { createPortal } from "react-dom";
 import {
   Hash,
@@ -197,13 +197,6 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
       messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
     },
   }), []);
-
-  // Expose scroll-to-latest via ref — syncs parent's atBottom/newCount state
-  useEffect(() => {
-    if (messages.length > 0) {
-      onScrollToLatest();
-    }
-  }, []); // eslint-disable-line
 
   if (!selectedChannel) {
     return (


### PR DESCRIPTION
## Problem
MessagesApp.tsx was the second-largest file in the desktop SPA at 2,856 lines. Extracting sub-components improves testability and maintainability. Closes #657.

## What's done (3 commits)
**Commit 1** — extract 5 components:
- ChannelSidebar.tsx (1,137 lines)
- MessageList.tsx (846 lines)
- MessageInput.tsx (197 lines)
- ReactionBar.tsx (50 lines)
- types.ts (48 lines)

**Commit 2** — wire ReactionBar + MessageInput
**Commit 3** — wire MessageList (430 lines replaced)

**Result: MessagesApp.tsx 2,856 → 2,424 lines (-432, -15%)**

## Verification
- ✓ 8/8 render-helpers tests pass (vitest)
- ✓ Production build succeeds (vite build, 18.45s)

## Files changed
6 files, +2,458 / -1,061

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive channel sidebar with project, archived, unread, connection-status, and external coordination views.
  * Improved message threads with reactions, editing, deletion states, attachments, copying, emoji selection, replies, search, and pinned-message access.
  * Added a streamlined composer supporting slash commands, mentions, attachments, image pasting, retries, and mobile safe-area spacing.
  * Added clearer archived-channel restore and permanent-delete controls.
* **Refactor**
  * Reorganized chat navigation, message rendering, and message composition into dedicated components while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->