### PR TITLE
feat(cluster): rolling 'update all workers' — drain one-at-a-time fleet orchestration

### DIFF
--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -613,14 +613,50 @@ async def _register_workers(app, *names):
         )
 
 
+async def _fake_sleep(seconds):
+    """No-op sleep for tests — makes re-registration polling instant."""
+    pass
+
+
 @pytest.mark.asyncio
 async def test_update_all_workers_happy_path(client, app, monkeypatch):
-    """Two online workers: both restart-disconnect, both succeed."""
-    import httpx as _httpx
+    """Two online workers: both succeed via restart-disconnect, re-registration wait passes."""
+    import asyncio as _asyncio
     await _register_workers(app, "w1", "w2")
+
+    from tinyagentos.routes.cluster import _do_single_worker_update as _original_do
+
+    call_order: list[str] = []
+
+    async def _mock_do(cluster, worker):
+        call_order.append(worker.name)
+        # Simulate the drain→deploy step: set worker to draining, then return success.
+        # The re-registration loop will poll and break once status is "online".
+        # In the real helper, drain_worker sets draining; we simulate that here.
+        worker.status = "draining"
+        return {
+            "success": True,
+            "worker": worker.name,
+            "status": "updating",
+            "previous_status": "online",
+            "drain_cancelled": False,
+        }
+
+    # Simulate re-registration: after the first poll, the worker comes back online.
+    original_get_worker = app.state.cluster_manager.get_worker
+
+    def _get_worker(name):
+        w = original_get_worker(name)
+        if w is not None and w.status == "draining":
+            # Simulate re-registration: worker comes back online
+            w.status = "online"
+        return w
+
+    monkeypatch.setattr(app.state.cluster_manager, "get_worker", _get_worker)
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
     monkeypatch.setattr(
-        _httpx, "AsyncClient",
-        _client_raising(_httpx.RemoteProtocolError("server disconnected during restart")),
+        "tinyagentos.routes.cluster._do_single_worker_update",
+        _mock_do,
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
@@ -629,25 +665,47 @@ async def test_update_all_workers_happy_path(client, app, monkeypatch):
     assert sorted(data["updated"]) == ["w1", "w2"]
     assert data["failed"] == []
     assert data["total_targets"] == 2
+    # Verify sequential: w1 must be processed before w2
+    assert call_order == ["w1", "w2"]
 
 
 @pytest.mark.asyncio
 async def test_update_all_workers_one_fails_others_continue(client, app, monkeypatch):
     """w1 fails with ConnectError, w2 succeeds — roll continues."""
-    import httpx as _httpx
+    import asyncio as _asyncio
     await _register_workers(app, "w1", "w2")
 
-    from tinyagentos.routes.cluster import _do_single_worker_update as _original_do
+    call_order: list[str] = []
 
     async def _mock_do(cluster, worker):
+        call_order.append(worker.name)
         if worker.name == "w1":
-            return {"success": False, "worker": "w1", "error": "Worker unreachable for update: test"}
-        return await _original_do(cluster, worker)
+            return {
+                "success": False,
+                "worker": "w1",
+                "error": "Worker unreachable for update: test",
+                "drain_cancelled": False,
+            }
+        worker.status = "draining"
+        return {
+            "success": True,
+            "worker": worker.name,
+            "status": "updating",
+            "previous_status": "online",
+            "drain_cancelled": False,
+        }
 
-    monkeypatch.setattr(
-        _httpx, "AsyncClient",
-        _client_raising(_httpx.RemoteProtocolError("server disconnected")),
-    )
+    # Simulate re-registration for w2
+    original_get_worker = app.state.cluster_manager.get_worker
+
+    def _get_worker(name):
+        w = original_get_worker(name)
+        if w is not None and w.status == "draining":
+            w.status = "online"
+        return w
+
+    monkeypatch.setattr(app.state.cluster_manager, "get_worker", _get_worker)
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
     monkeypatch.setattr(
         "tinyagentos.routes.cluster._do_single_worker_update",
         _mock_do,
@@ -661,21 +719,39 @@ async def test_update_all_workers_one_fails_others_continue(client, app, monkeyp
     assert data["failed"][0]["name"] == "w1"
     assert "unreachable" in data["failed"][0]["error"]
     assert data["total_targets"] == 2
+    # w1 must be processed before w2
+    assert call_order == ["w1", "w2"]
 
 
 @pytest.mark.asyncio
 async def test_update_all_workers_skips_local(client, app, monkeypatch):
     """The 'local' worker is never targeted for update."""
-    import httpx as _httpx
+    import asyncio as _asyncio
     await _register_workers(app, "r1", "r2")
     from tinyagentos.cluster.worker_protocol import WorkerInfo
     app.state.cluster_manager._workers["local"] = WorkerInfo(  # noqa: SLF001
         name="local", url="http://localhost:9000",
         capabilities=["chat"], load=0.0, status="online", platform="linux",
     )
+
+    async def _mock_do(cluster, worker):
+        worker.status = "draining"
+        return {"success": True, "worker": worker.name, "drain_cancelled": False}
+
+    # Simulate re-registration
+    original_get_worker = app.state.cluster_manager.get_worker
+
+    def _get_worker(name):
+        w = original_get_worker(name)
+        if w is not None and w.status == "draining":
+            w.status = "online"
+        return w
+
+    monkeypatch.setattr(app.state.cluster_manager, "get_worker", _get_worker)
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
     monkeypatch.setattr(
-        _httpx, "AsyncClient",
-        _client_raising(_httpx.RemoteProtocolError("server disconnected")),
+        "tinyagentos.routes.cluster._do_single_worker_update",
+        _mock_do,
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
@@ -690,12 +766,28 @@ async def test_update_all_workers_skips_local(client, app, monkeypatch):
 @pytest.mark.asyncio
 async def test_update_all_workers_skips_offline(client, app, monkeypatch):
     """Offline workers are skipped, online workers are updated."""
-    import httpx as _httpx
+    import asyncio as _asyncio
     await _register_workers(app, "online-1", "online-2")
     app.state.cluster_manager._workers["online-2"].status = "offline"  # noqa: SLF001
+
+    async def _mock_do(cluster, worker):
+        worker.status = "draining"
+        return {"success": True, "worker": worker.name, "drain_cancelled": False}
+
+    # Simulate re-registration
+    original_get_worker = app.state.cluster_manager.get_worker
+
+    def _get_worker(name):
+        w = original_get_worker(name)
+        if w is not None and w.status == "draining":
+            w.status = "online"
+        return w
+
+    monkeypatch.setattr(app.state.cluster_manager, "get_worker", _get_worker)
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
     monkeypatch.setattr(
-        _httpx, "AsyncClient",
-        _client_raising(_httpx.RemoteProtocolError("server disconnected")),
+        "tinyagentos.routes.cluster._do_single_worker_update",
+        _mock_do,
     )
 
     resp = await client.post("/api/cluster/workers/update-all")
@@ -713,7 +805,128 @@ async def test_update_all_workers_no_online_workers(client, app):
     data = resp.json()
     assert data["updated"] == []
     assert data["failed"] == []
+    assert data["skipped"] == []
+    assert data["total_targets"] == 0
     assert "no online" in data.get("message", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_draining_excluded_from_skipped(client, app, monkeypatch):
+    """Draining workers are not counted as skipped — they are mid-update."""
+    import asyncio as _asyncio
+    await _register_workers(app, "w1", "w2")
+    # Set w2 to draining — it should NOT appear in skipped
+    app.state.cluster_manager._workers["w2"].status = "draining"  # noqa: SLF001
+
+    async def _mock_do(cluster, worker):
+        worker.status = "draining"
+        return {"success": True, "worker": worker.name, "drain_cancelled": False}
+
+    original_get_worker = app.state.cluster_manager.get_worker
+
+    def _get_worker(name):
+        w = original_get_worker(name)
+        if w is not None and w.status == "draining" and name != "w2":
+            w.status = "online"
+        return w
+
+    monkeypatch.setattr(app.state.cluster_manager, "get_worker", _get_worker)
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(
+        "tinyagentos.routes.cluster._do_single_worker_update",
+        _mock_do,
+    )
+
+    resp = await client.post("/api/cluster/workers/update-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["updated"] == ["w1"]
+    # w2 is draining — NOT skipped
+    assert "w2" not in data["skipped"]
+    assert data["total_targets"] == 1  # only w1 was online
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_helper_exception_isolated(client, app, monkeypatch):
+    """If _do_single_worker_update raises unexpectedly, roll continues."""
+    import asyncio as _asyncio
+    await _register_workers(app, "w1", "w2")
+
+    call_order: list[str] = []
+
+    async def _mock_do(cluster, worker):
+        call_order.append(worker.name)
+        if worker.name == "w1":
+            raise RuntimeError("drain_worker exploded!")
+        worker.status = "draining"
+        return {
+            "success": True,
+            "worker": worker.name,
+            "status": "updating",
+            "previous_status": "online",
+            "drain_cancelled": False,
+        }
+
+    original_get_worker = app.state.cluster_manager.get_worker
+
+    def _get_worker(name):
+        w = original_get_worker(name)
+        if w is not None and w.status == "draining":
+            w.status = "online"
+        return w
+
+    monkeypatch.setattr(app.state.cluster_manager, "get_worker", _get_worker)
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(
+        "tinyagentos.routes.cluster._do_single_worker_update",
+        _mock_do,
+    )
+
+    resp = await client.post("/api/cluster/workers/update-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["updated"] == ["w2"]
+    assert len(data["failed"]) == 1
+    assert data["failed"][0]["name"] == "w1"
+    assert "RuntimeError" in data["failed"][0]["error"]
+    assert data["total_targets"] == 2
+    assert call_order == ["w1", "w2"]
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_re_register_timeout(client, app, monkeypatch):
+    """When a worker never comes back online, the roll continues after timeout."""
+    import asyncio as _asyncio
+    await _register_workers(app, "w1", "w2")
+
+    call_order: list[str] = []
+
+    async def _mock_do(cluster, worker):
+        call_order.append(worker.name)
+        worker.status = "draining"
+        return {
+            "success": True,
+            "worker": worker.name,
+            "status": "updating",
+            "previous_status": "online",
+            "drain_cancelled": False,
+        }
+
+    # get_worker always returns "draining" — simulates worker never coming back
+    monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(
+        "tinyagentos.routes.cluster._do_single_worker_update",
+        _mock_do,
+    )
+
+    resp = await client.post("/api/cluster/workers/update-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    # Both workers should still be listed as updated — the timeout just logs a warning
+    assert sorted(data["updated"]) == ["w1", "w2"]
+    assert data["failed"] == []
+    assert data["total_targets"] == 2
+    assert call_order == ["w1", "w2"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -614,7 +614,7 @@ async def _register_workers(app, *names):
 
 
 async def _fake_sleep(seconds):
-    """No-op sleep for tests — makes re-registration polling instant."""
+    """No-op sleep for tests -- makes re-registration polling instant."""
     pass
 
 
@@ -671,7 +671,7 @@ async def test_update_all_workers_happy_path(client, app, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_update_all_workers_one_fails_others_continue(client, app, monkeypatch):
-    """w1 fails with ConnectError, w2 succeeds — roll continues."""
+    """w1 fails with ConnectError, w2 succeeds -- roll continues."""
     import asyncio as _asyncio
     await _register_workers(app, "w1", "w2")
 
@@ -812,10 +812,10 @@ async def test_update_all_workers_no_online_workers(client, app):
 
 @pytest.mark.asyncio
 async def test_update_all_workers_draining_excluded_from_skipped(client, app, monkeypatch):
-    """Draining workers are not counted as skipped — they are mid-update."""
+    """Draining workers are not counted as skipped -- they are mid-update."""
     import asyncio as _asyncio
     await _register_workers(app, "w1", "w2")
-    # Set w2 to draining — it should NOT appear in skipped
+    # Set w2 to draining -- it should NOT appear in skipped
     app.state.cluster_manager._workers["w2"].status = "draining"  # noqa: SLF001
 
     async def _mock_do(cluster, worker):
@@ -841,7 +841,7 @@ async def test_update_all_workers_draining_excluded_from_skipped(client, app, mo
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["updated"] == ["w1"]
-    # w2 is draining — NOT skipped
+    # w2 is draining -- NOT skipped
     assert "w2" not in data["skipped"]
     assert data["total_targets"] == 1  # only w1 was online
 
@@ -912,7 +912,7 @@ async def test_update_all_workers_re_register_timeout(client, app, monkeypatch):
             "drain_cancelled": False,
         }
 
-    # get_worker always returns "draining" — simulates worker never coming back
+    # get_worker always returns "draining" -- simulates worker never coming back
     monkeypatch.setattr(_asyncio, "sleep", _fake_sleep)
     monkeypatch.setattr(
         "tinyagentos.routes.cluster._do_single_worker_update",
@@ -922,7 +922,7 @@ async def test_update_all_workers_re_register_timeout(client, app, monkeypatch):
     resp = await client.post("/api/cluster/workers/update-all")
     assert resp.status_code == 200, resp.text
     data = resp.json()
-    # Both workers should still be listed as updated — the timeout just logs a warning
+    # Both workers should still be listed as updated -- the timeout just logs a warning
     assert sorted(data["updated"]) == ["w1", "w2"]
     assert data["failed"] == []
     assert data["total_targets"] == 2

--- a/tests/test_routes_cluster.py
+++ b/tests/test_routes_cluster.py
@@ -589,3 +589,141 @@ async def test_update_worker_connect_error_cancels_drain(client, app, monkeypatc
     assert resp.json().get("drain_cancelled") is True
     # Drain was cancelled, so the worker is back online and still routable.
     assert app.state.cluster_manager.get_worker("gpu-box").status == "online"
+
+
+# ---------------------------------------------------------------------------
+# Rolling "update all workers" orchestration (taOS #1876)
+# ---------------------------------------------------------------------------
+
+
+async def _register_workers(app, *names):
+    """Register multiple online workers for testing update-all.
+
+    Adds workers directly to the cluster manager's internal dict to avoid
+    spawning background model-promotion tasks that can accumulate across
+    concurrent async tests and cause event-loop deadlocks.
+    """
+    from tinyagentos.cluster.worker_protocol import WorkerInfo
+    cluster = app.state.cluster_manager
+    for i, name in enumerate(names):
+        cluster._workers[name] = WorkerInfo(  # noqa: SLF001
+            name=name, url=f"http://{name}:9000",
+            capabilities=["chat"],
+            load=0.0, status="online", platform="linux",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_happy_path(client, app, monkeypatch):
+    """Two online workers: both restart-disconnect, both succeed."""
+    import httpx as _httpx
+    await _register_workers(app, "w1", "w2")
+    monkeypatch.setattr(
+        _httpx, "AsyncClient",
+        _client_raising(_httpx.RemoteProtocolError("server disconnected during restart")),
+    )
+
+    resp = await client.post("/api/cluster/workers/update-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert sorted(data["updated"]) == ["w1", "w2"]
+    assert data["failed"] == []
+    assert data["total_targets"] == 2
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_one_fails_others_continue(client, app, monkeypatch):
+    """w1 fails with ConnectError, w2 succeeds — roll continues."""
+    import httpx as _httpx
+    await _register_workers(app, "w1", "w2")
+
+    from tinyagentos.routes.cluster import _do_single_worker_update as _original_do
+
+    async def _mock_do(cluster, worker):
+        if worker.name == "w1":
+            return {"success": False, "worker": "w1", "error": "Worker unreachable for update: test"}
+        return await _original_do(cluster, worker)
+
+    monkeypatch.setattr(
+        _httpx, "AsyncClient",
+        _client_raising(_httpx.RemoteProtocolError("server disconnected")),
+    )
+    monkeypatch.setattr(
+        "tinyagentos.routes.cluster._do_single_worker_update",
+        _mock_do,
+    )
+
+    resp = await client.post("/api/cluster/workers/update-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["updated"] == ["w2"]
+    assert len(data["failed"]) == 1
+    assert data["failed"][0]["name"] == "w1"
+    assert "unreachable" in data["failed"][0]["error"]
+    assert data["total_targets"] == 2
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_skips_local(client, app, monkeypatch):
+    """The 'local' worker is never targeted for update."""
+    import httpx as _httpx
+    await _register_workers(app, "r1", "r2")
+    from tinyagentos.cluster.worker_protocol import WorkerInfo
+    app.state.cluster_manager._workers["local"] = WorkerInfo(  # noqa: SLF001
+        name="local", url="http://localhost:9000",
+        capabilities=["chat"], load=0.0, status="online", platform="linux",
+    )
+    monkeypatch.setattr(
+        _httpx, "AsyncClient",
+        _client_raising(_httpx.RemoteProtocolError("server disconnected")),
+    )
+
+    resp = await client.post("/api/cluster/workers/update-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert sorted(data["updated"]) == ["r1", "r2"]
+    # local must appear in skipped, not updated
+    assert "local" in data["skipped"]
+    assert "local" not in data["updated"]
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_skips_offline(client, app, monkeypatch):
+    """Offline workers are skipped, online workers are updated."""
+    import httpx as _httpx
+    await _register_workers(app, "online-1", "online-2")
+    app.state.cluster_manager._workers["online-2"].status = "offline"  # noqa: SLF001
+    monkeypatch.setattr(
+        _httpx, "AsyncClient",
+        _client_raising(_httpx.RemoteProtocolError("server disconnected")),
+    )
+
+    resp = await client.post("/api/cluster/workers/update-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["updated"] == ["online-1"]
+    assert "online-2" in data["skipped"]
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_no_online_workers(client, app):
+    """When no online remote workers exist, return empty with a message."""
+    resp = await client.post("/api/cluster/workers/update-all")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["updated"] == []
+    assert data["failed"] == []
+    assert "no online" in data.get("message", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_update_all_workers_admin_gate_rejected(app, tmp_data_dir):
+    """Unauthenticated callers are rejected with 401/403."""
+    from httpx import ASGITransport, AsyncClient
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/api/cluster/workers/update-all",
+            headers={"content-type": "application/json"},
+        )
+        assert resp.status_code in (401, 403)

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -1201,11 +1201,11 @@ async def _do_single_worker_update(cluster, worker) -> dict:
     ``"drain_cancelled": bool`` (whether ``cancel_drain`` was actually called).
     On success: ``{"success": True, "worker": ..., "status": "updating", ...}``.
     On failure: ``{"success": False, "worker": ..., "error": "..."}``.
-    Never raises — all exceptions are caught and converted into error dicts.
+    Never raises -- all exceptions are caught and converted into error dicts.
     """
     name = worker.name
 
-    # Step 1: Begin draining (with exception isolation — drain_worker
+    # Step 1: Begin draining (with exception isolation -- drain_worker
     # may raise from notification or background-task failures).
     try:
         drain_result = await cluster.drain_worker(name, graceful=True)
@@ -1338,12 +1338,12 @@ async def update_worker(request: Request, name: str):
 
 @router.post("/api/cluster/workers/update-all")
 async def update_all_workers(request: Request):
-    """Rolling update of the entire worker fleet — one at a time (taOS #1876).
+    """Rolling update of the entire worker fleet -- one at a time (taOS #1876).
 
     Updates every online worker sequentially, draining and updating at most
     one worker at any moment so the fleet never fully drains. Skips the
     ``local`` worker (the controller itself) and any worker that is not
-    ``online``. Workers already ``draining`` are not counted as skipped — they
+    ``online``. Workers already ``draining`` are not counted as skipped -- they
     are likely mid-update from a prior action.
 
     If one worker's update fails, the roll continues to the remaining workers.
@@ -1408,7 +1408,7 @@ async def update_all_workers(request: Request):
                     break
             else:
                 # Timeout: worker didn't come back online in time. Log it but
-                # continue the roll — the worker's status will resolve on its own.
+                # continue the roll -- the worker's status will resolve on its own.
                 logger.warning(
                     "update-all: worker '%s' did not re-register within %ds timeout; "
                     "continuing roll",

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -1197,16 +1197,33 @@ async def _do_single_worker_update(cluster, worker) -> dict:
     Shared helper called by both the single-worker ``update_worker`` route
     and the rolling ``update_all_workers`` route (taOS #1876).
 
-    Returns a dict with at least ``"success": bool`` and ``"worker"``.
+    Returns a dict with at least ``"success": bool``, ``"worker"``, and
+    ``"drain_cancelled": bool`` (whether ``cancel_drain`` was actually called).
     On success: ``{"success": True, "worker": ..., "status": "updating", ...}``.
     On failure: ``{"success": False, "worker": ..., "error": "..."}``.
     Never raises — all exceptions are caught and converted into error dicts.
     """
     name = worker.name
-    # Step 1: Begin draining
-    drain_result = await cluster.drain_worker(name, graceful=True)
+
+    # Step 1: Begin draining (with exception isolation — drain_worker
+    # may raise from notification or background-task failures).
+    try:
+        drain_result = await cluster.drain_worker(name, graceful=True)
+    except Exception as exc:
+        logger.exception("drain_worker('%s') raised during update", name)
+        return {
+            "success": False,
+            "worker": name,
+            "error": f"Worker drain failed: {exc}",
+            "drain_cancelled": False,
+        }
     if "error" in drain_result:
-        return {"success": False, "worker": name, "error": drain_result["error"]}
+        return {
+            "success": False,
+            "worker": name,
+            "error": drain_result["error"],
+            "drain_cancelled": False,
+        }
 
     # Step 2: Trigger the update-worker deploy command on the worker
     import httpx
@@ -1232,6 +1249,7 @@ async def _do_single_worker_update(cluster, worker) -> dict:
             "previous_status": drain_result["previous_status"],
             "drain": drain_result,
             "deploy": None,
+            "drain_cancelled": False,
             "message": (
                 "Worker accepted the update and is restarting. The connection "
                 "dropped as expected during the restart; the monitor loop will "
@@ -1241,20 +1259,32 @@ async def _do_single_worker_update(cluster, worker) -> dict:
     except httpx.ConnectError as exc:
         # Connection refused / DNS failure: the worker is unreachable and the
         # update was never delivered. Cancel the drain so it keeps serving.
-        await cluster.cancel_drain(name)
+        drain_cancelled = False
+        try:
+            await cluster.cancel_drain(name)
+            drain_cancelled = True
+        except Exception:
+            logger.exception("cancel_drain('%s') raised after ConnectError", name)
         return {
             "success": False,
             "worker": name,
             "error": f"Worker unreachable for update: {exc}",
+            "drain_cancelled": drain_cancelled,
         }
     except Exception as exc:
         # Non-2xx worker response (raise_for_status) or any other unexpected
         # error: real failure, cancel drain so worker can still serve traffic.
-        await cluster.cancel_drain(name)
+        drain_cancelled = False
+        try:
+            await cluster.cancel_drain(name)
+            drain_cancelled = True
+        except Exception:
+            logger.exception("cancel_drain('%s') raised after deploy failure", name)
         return {
             "success": False,
             "worker": name,
             "error": f"Worker update deploy failed: {exc}",
+            "drain_cancelled": drain_cancelled,
         }
 
     return {
@@ -1264,6 +1294,7 @@ async def _do_single_worker_update(cluster, worker) -> dict:
         "previous_status": drain_result["previous_status"],
         "drain": drain_result,
         "deploy": deploy_result,
+        "drain_cancelled": False,
         "message": (
             "Worker is draining and updating. It will restart and re-register. "
             "The controller monitor loop will auto-complete the drain once "
@@ -1299,7 +1330,7 @@ async def update_worker(request: Request, name: str):
     result = await _do_single_worker_update(cluster, worker)
     if not result["success"]:
         return JSONResponse(
-            {**result, "drain_cancelled": True},
+            {**result, "drain_cancelled": result.get("drain_cancelled", False)},
             status_code=502,
         )
     return result
@@ -1311,8 +1342,13 @@ async def update_all_workers(request: Request):
 
     Updates every online worker sequentially, draining and updating at most
     one worker at any moment so the fleet never fully drains. Skips the
-    ``local`` worker (the controller itself). If one worker's update fails,
-    the roll continues to the remaining workers.
+    ``local`` worker (the controller itself) and any worker that is not
+    ``online``. Workers already ``draining`` are not counted as skipped — they
+    are likely mid-update from a prior action.
+
+    If one worker's update fails, the roll continues to the remaining workers.
+    After a successful update, the route waits (with a timeout) for the worker
+    to re-register as ``online`` before proceeding to the next target.
 
     Returns an aggregate ``{updated: [...], failed: [{name, error}], skipped: [...]}``
     so the admin can see exactly which workers were touched and which failed.
@@ -1324,20 +1360,60 @@ async def update_all_workers(request: Request):
 
     workers = cluster.get_workers()
     targets = [w for w in workers if w.status == "online" and w.name != "local"]
+    skipped: list[str] = [
+        w.name for w in workers
+        if w.name == "local" or w.status not in ("online", "draining")
+    ]
     if not targets:
-        return {"updated": [], "failed": [], "skipped": [], "message": "No online remote workers to update"}
+        return {
+            "updated": [],
+            "failed": [],
+            "skipped": skipped,
+            "total_targets": 0,
+            "message": "No online remote workers to update",
+        }
 
     updated: list[str] = []
     failed: list[dict] = []
-    skipped: list[str] = [
-        w.name for w in workers
-        if w.name == "local" or (w.status != "online" and w.name != "local")
-    ]
+
+    RE_REGISTER_TIMEOUT = 300  # seconds to wait for worker to come back online
+    RE_REGISTER_POLL = 5       # seconds between status checks
 
     for worker in targets:
-        result = await _do_single_worker_update(cluster, worker)
+        try:
+            result = await _do_single_worker_update(cluster, worker)
+        except Exception as exc:
+            logger.exception(
+                "update-all: unexpected exception for worker '%s' (continuing roll)",
+                worker.name,
+            )
+            failed.append({"name": worker.name, "error": f"Unexpected error: {type(exc).__name__}: {exc}"})
+            continue
+
         if result["success"]:
             updated.append(worker.name)
+            # Wait for the worker to re-register as "online" before proceeding
+            # to the next target. This guarantees at most one worker is actively
+            # updating at any moment (never more than one draining concurrently).
+            waited = 0
+            while waited < RE_REGISTER_TIMEOUT:
+                await asyncio.sleep(RE_REGISTER_POLL)
+                waited += RE_REGISTER_POLL
+                w = cluster.get_worker(worker.name)
+                if w is not None and w.status == "online":
+                    logger.info(
+                        "update-all: worker '%s' re-registered online after %ds",
+                        worker.name, waited,
+                    )
+                    break
+            else:
+                # Timeout: worker didn't come back online in time. Log it but
+                # continue the roll — the worker's status will resolve on its own.
+                logger.warning(
+                    "update-all: worker '%s' did not re-register within %ds timeout; "
+                    "continuing roll",
+                    worker.name, RE_REGISTER_TIMEOUT,
+                )
         else:
             failed.append({"name": worker.name, "error": result.get("error", "unknown")})
             logger.warning(
@@ -1345,10 +1421,6 @@ async def update_all_workers(request: Request):
                 worker.name, result.get("error", "unknown"),
             )
 
-    # Re-read latest statuses after the roll for accurate skipped count
-    # (workers that went offline during the roll are not "skipped" — they
-    # were either updated or failed; skipped is only for workers that were
-    # never online to begin with from the admin's perspective).
     return {
         "updated": updated,
         "failed": failed,

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -1191,6 +1191,87 @@ async def cancel_drain(request: Request, name: str):
     return result
 
 
+async def _do_single_worker_update(cluster, worker) -> dict:
+    """Run one worker through the drain→deploy update sequence.
+
+    Shared helper called by both the single-worker ``update_worker`` route
+    and the rolling ``update_all_workers`` route (taOS #1876).
+
+    Returns a dict with at least ``"success": bool`` and ``"worker"``.
+    On success: ``{"success": True, "worker": ..., "status": "updating", ...}``.
+    On failure: ``{"success": False, "worker": ..., "error": "..."}``.
+    Never raises — all exceptions are caught and converted into error dicts.
+    """
+    name = worker.name
+    # Step 1: Begin draining
+    drain_result = await cluster.drain_worker(name, graceful=True)
+    if "error" in drain_result:
+        return {"success": False, "worker": name, "error": drain_result["error"]}
+
+    # Step 2: Trigger the update-worker deploy command on the worker
+    import httpx
+    deploy_result = None
+    try:
+        async with httpx.AsyncClient(timeout=620) as htx_client:
+            resp = await htx_client.post(
+                f"{worker.url}/api/worker/deploy",
+                json={"command": "update-worker"},
+            )
+            resp.raise_for_status()
+            deploy_result = resp.json()
+    except (httpx.RemoteProtocolError, httpx.ReadError, httpx.ReadTimeout):
+        # The deploy request blocks until update-worker restarts the worker
+        # service, which drops the connection mid-response. This is the
+        # EXPECTED happy path: the update was accepted and is running. Keep
+        # the worker draining; the monitor loop auto-completes the drain once
+        # the restarted worker re-registers and heartbeats.
+        return {
+            "success": True,
+            "worker": name,
+            "status": "updating",
+            "previous_status": drain_result["previous_status"],
+            "drain": drain_result,
+            "deploy": None,
+            "message": (
+                "Worker accepted the update and is restarting. The connection "
+                "dropped as expected during the restart; the monitor loop will "
+                "auto-complete the drain once it re-registers and heartbeats."
+            ),
+        }
+    except httpx.ConnectError as exc:
+        # Connection refused / DNS failure: the worker is unreachable and the
+        # update was never delivered. Cancel the drain so it keeps serving.
+        await cluster.cancel_drain(name)
+        return {
+            "success": False,
+            "worker": name,
+            "error": f"Worker unreachable for update: {exc}",
+        }
+    except Exception as exc:
+        # Non-2xx worker response (raise_for_status) or any other unexpected
+        # error: real failure, cancel drain so worker can still serve traffic.
+        await cluster.cancel_drain(name)
+        return {
+            "success": False,
+            "worker": name,
+            "error": f"Worker update deploy failed: {exc}",
+        }
+
+    return {
+        "success": True,
+        "worker": name,
+        "status": "updating",
+        "previous_status": drain_result["previous_status"],
+        "drain": drain_result,
+        "deploy": deploy_result,
+        "message": (
+            "Worker is draining and updating. It will restart and re-register. "
+            "The controller monitor loop will auto-complete the drain once "
+            "all leases are released and the new worker process heartbeats."
+        ),
+    }
+
+
 @router.post("/api/cluster/workers/{name}/update")
 async def update_worker(request: Request, name: str):
     """Trigger a full auto-update sequence on a worker.
@@ -1215,70 +1296,62 @@ async def update_worker(request: Request, name: str):
             status_code=400,
         )
 
-    # Step 1: Begin draining
-    drain_result = await cluster.drain_worker(name, graceful=True)
-    if "error" in drain_result:
-        return JSONResponse(drain_result, status_code=404)
+    result = await _do_single_worker_update(cluster, worker)
+    if not result["success"]:
+        return JSONResponse(
+            {**result, "drain_cancelled": True},
+            status_code=502,
+        )
+    return result
 
-    # Step 2: Trigger the update-worker deploy command on the worker
-    import httpx
-    deploy_result = None
-    try:
-        async with httpx.AsyncClient(timeout=620) as client:
-            resp = await client.post(
-                f"{worker.url}/api/worker/deploy",
-                json={"command": "update-worker"},
+
+@router.post("/api/cluster/workers/update-all")
+async def update_all_workers(request: Request):
+    """Rolling update of the entire worker fleet — one at a time (taOS #1876).
+
+    Updates every online worker sequentially, draining and updating at most
+    one worker at any moment so the fleet never fully drains. Skips the
+    ``local`` worker (the controller itself). If one worker's update fails,
+    the roll continues to the remaining workers.
+
+    Returns an aggregate ``{updated: [...], failed: [{name, error}], skipped: [...]}``
+    so the admin can see exactly which workers were touched and which failed.
+    """
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
+    cluster = request.app.state.cluster_manager
+
+    workers = cluster.get_workers()
+    targets = [w for w in workers if w.status == "online" and w.name != "local"]
+    if not targets:
+        return {"updated": [], "failed": [], "skipped": [], "message": "No online remote workers to update"}
+
+    updated: list[str] = []
+    failed: list[dict] = []
+    skipped: list[str] = [
+        w.name for w in workers
+        if w.name == "local" or (w.status != "online" and w.name != "local")
+    ]
+
+    for worker in targets:
+        result = await _do_single_worker_update(cluster, worker)
+        if result["success"]:
+            updated.append(worker.name)
+        else:
+            failed.append({"name": worker.name, "error": result.get("error", "unknown")})
+            logger.warning(
+                "update-all: worker '%s' update failed (continuing roll): %s",
+                worker.name, result.get("error", "unknown"),
             )
-            # Surface a non-2xx worker response as a failure instead of
-            # reporting status:"updating" with the error body as deploy_result.
-            resp.raise_for_status()
-            deploy_result = resp.json()
-    except (httpx.RemoteProtocolError, httpx.ReadError, httpx.ReadTimeout):
-        # The deploy request blocks until update-worker restarts the worker
-        # service, which drops the connection mid-response. This is the
-        # EXPECTED happy path: the update was accepted and is running. Keep
-        # the worker draining; the monitor loop auto-completes the drain once
-        # the restarted worker re-registers and heartbeats. Reporting this as
-        # a failure (and cancelling the drain) was a regression — the update
-        # actually succeeds and self-heals on re-register.
-        return {
-            "worker": name,
-            "status": "updating",
-            "previous_status": drain_result["previous_status"],
-            "drain": drain_result,
-            "deploy": None,
-            "message": (
-                "Worker accepted the update and is restarting. The connection "
-                "dropped as expected during the restart; the monitor loop will "
-                "auto-complete the drain once it re-registers and heartbeats."
-            ),
-        }
-    except httpx.ConnectError as exc:
-        # Connection refused / DNS failure: the worker is unreachable and the
-        # update was never delivered. Cancel the drain so it keeps serving.
-        await cluster.cancel_drain(name)
-        return JSONResponse(
-            {"error": f"Worker unreachable for update: {exc}", "drain_cancelled": True},
-            status_code=502,
-        )
-    except Exception as exc:
-        # Non-2xx worker response (raise_for_status) or any other unexpected
-        # error: real failure, cancel drain so worker can still serve traffic.
-        await cluster.cancel_drain(name)
-        return JSONResponse(
-            {"error": f"Worker update deploy failed: {exc}", "drain_cancelled": True},
-            status_code=502,
-        )
 
+    # Re-read latest statuses after the roll for accurate skipped count
+    # (workers that went offline during the roll are not "skipped" — they
+    # were either updated or failed; skipped is only for workers that were
+    # never online to begin with from the admin's perspective).
     return {
-        "worker": name,
-        "status": "updating",
-        "previous_status": drain_result["previous_status"],
-        "drain": drain_result,
-        "deploy": deploy_result,
-        "message": (
-            "Worker is draining and updating. It will restart and re-register. "
-            "The controller monitor loop will auto-complete the drain once "
-            "all leases are released and the new worker process heartbeats."
-        ),
+        "updated": updated,
+        "failed": failed,
+        "skipped": skipped,
+        "total_targets": len(targets),
     }


### PR DESCRIPTION
Closes #1876.

## What
Adds `POST /api/cluster/workers/update-all` — one admin action to update the entire worker fleet without taking the cluster down. Updates every online remote worker sequentially, draining and updating at most one worker at any moment (Umbrel-style 'update all').

## How
- Refactors `update_worker` into shared `_do_single_worker_update(cluster, worker)` helper
- New route: `POST /api/cluster/workers/update-all` (admin-gated, same `_require_admin` gate)
- Skips `local` worker, only targets `online` remote workers
- Fault-tolerant: one worker's failure continues the roll
- Returns `{updated: [...], failed: [{name, error}], skipped: [...]}`
- Reuses existing drain→deploy→restart semantics (RemoteProtocolError = success, ConnectError = cancel)

## Tests (9/9 pass local, Python 3.11)
- Happy path: 2 workers, both succeed
- One fails (ConnectError), others continue
- Local worker skipped  
- Offline workers skipped
- Empty cluster returns message
- Admin gate rejects unauthenticated callers
- Existing update_worker tests still pass (restart-disconnect + connect-error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only `POST /api/cluster/workers/update-all` to perform a sequential rolling update of eligible workers.
  * Updates aggregate into `updated`, `failed`, and `skipped` outcomes, excluding `local` and offline workers.
* **Bug Fixes**
  * Improved `POST /api/cluster/workers/{name}/update` to use the full drain/deploy flow and return consistent failure details.
  * Connection-drop-style deploy issues are handled as successful, allowing restart-based recovery; drain is cancelled on failures.
* **Tests**
  * Added comprehensive coverage for happy path, partial failures, skipping rules, empty eligibility, drain/timeout behavior, and auth enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->