### PR TITLE
fix(desktop): sync mount-scroll, add missing deps/class in MessageList

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1,12 +1,9 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import { createPortal } from "react-dom";
 import {
   MessageCircle,
   Hash,
   Users,
   Plus,
-  Send,
-  Bot,
   X,
   AtSign,
   ChevronDown,
@@ -34,34 +31,25 @@ import { MobileSplitView } from "@/components/mobile/MobileSplitView";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { useDropTarget } from "@/shell/dnd/use-drop-target";
-import { startDrag, endDrag } from "@/shell/dnd/dnd-bus";
-import { resolveAgentEmoji } from "@/lib/agent-emoji";
-import { MessageAvatar } from "./chat/MessageAvatar";
 import { ChannelSettingsPanel } from "./chat/ChannelSettingsPanel";
 import { AgentContextMenu } from "./chat/AgentContextMenu";
 import { type SlashCommandsBySlug } from "./chat/SlashMenu";
-import { TypingFooter, type AgentTyping } from "./chat/TypingFooter";
+import { type AgentTyping } from "./chat/TypingFooter";
 import { useTypingEmitter } from "@/lib/use-typing-emitter";
-import { MessageHoverActions } from "./chat/MessageHoverActions";
-import { ThreadIndicator } from "./chat/ThreadIndicator";
 import { ThreadPanel } from "./chat/ThreadPanel";
 import { type PendingAttachment } from "./chat/AttachmentsBar";
-import { AttachmentGallery } from "./chat/AttachmentGallery";
 import { uploadDiskFile, attachmentFromPath, type AttachmentRecord } from "@/lib/chat-attachments-api";
 import { useThreadPanel } from "@/lib/use-thread-panel";
 import { openFilePicker } from "@/shell/file-picker-api";
 import { MessageOverflowMenu } from "./chat/MessageOverflowMenu";
 import { BottomSheet } from "@/shell/BottomSheet";
-import { MessageEditor } from "./chat/MessageEditor";
-import { MessageTombstone } from "./chat/MessageTombstone";
 import { PinBadge } from "./chat/PinBadge";
 import { PinnedMessagesPopover, type PinnedMessage } from "./chat/PinnedMessagesPopover";
 import { AllThreadsList } from "./chat/AllThreadsList";
 import { ChannelSwitcher } from "./chat/ChannelSwitcher";
 import { useChatNotifications } from "./chat/useChatNotifications";
-import { PinRequestAffordance } from "./chat/PinRequestAffordance";
-import { ReactionBar } from "./chat/ReactionBar";
 import { MessageInput } from "./chat/MessageInput";
+import { MessageList, type MessageListHandle } from "./chat/MessageList";
 import {
   pinMessage, unpinMessage, listPins,
   editMessage as apiEditMessage, deleteMessage as apiDeleteMessage,
@@ -79,7 +67,6 @@ import {
   computeStallInfo,
   type StallWatch,
 } from "./MessagesApp.stallWatch";
-import { displayAuthor } from "./chat/format-author";
 import { useProcessStore } from "@/stores/process-store";
 import { getApp } from "@/registry/app-registry";
 import { CodeBlock } from "@/components/CodeBlock";
@@ -310,7 +297,6 @@ export function renderInline(text: string, keyPrefix: string) {
   ];
 }
 
-const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", "✅"];
 
 // Best-effort per-channel draft storage. Drafts are user input that may
 // contain sensitive material; they are kept in localStorage (the same
@@ -485,8 +471,7 @@ export function MessagesApp({
   useEffect(() => { channelsRef.current = channels; }, [channels]);
 
   const wsRef = useRef<WebSocket | null>(null);
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const messageListRef = useRef<HTMLDivElement>(null);
+  const messageListHandleRef = useRef<MessageListHandle>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const typingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastTypingSentRef = useRef(0);
@@ -1011,7 +996,7 @@ export function MessagesApp({
     const delta = messages.length - prevMsgCountRef.current;
     prevMsgCountRef.current = messages.length;
     if (autoScrollRef.current) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+      messageListHandleRef.current?.scrollToBottom();
     } else if (delta > 0) {
       setNewCount((c) => c + delta);
     }
@@ -1030,8 +1015,8 @@ export function MessagesApp({
     return () => clearInterval(id);
   }, []);
 
-  const handleScroll = () => {
-    const el = messageListRef.current;
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
     if (!el) return;
     const nowAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
     autoScrollRef.current = nowAtBottom;
@@ -1041,7 +1026,7 @@ export function MessagesApp({
   };
 
   const scrollToLatest = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    messageListHandleRef.current?.scrollToBottom();
     autoScrollRef.current = true;
     setAtBottom(true);
     setNewCount(0);
@@ -1772,362 +1757,80 @@ export function MessagesApp({
             )}
           </div>
 
-          {/* message list — explicitly selectable. Most app shells set
-              `select-none` for the native-OS feel; Messages is the exception
-              where users expect to copy conversation text, so opt back in. */}
-          <div
-            ref={messageListRef}
+          <MessageList
+            ref={messageListHandleRef}
+            messages={messages}
+            fetchedChannel={fetchedChannel}
+            channel={currentChannel}
+            selectedChannel={selectedChannel}
+            isMobile={isMobile}
+            keyboardInset={keyboardInset}
+            nowMs={nowMs}
+            liveAgents={liveAgents}
+            archivedAgents={archivedAgents}
+            currentUserId={currentUserId}
+            currentUserDisplayName={currentUserDisplayName}
+            pinnedMessages={pinnedMessages}
+            pinnedPopoverOpen={pinnedPopoverOpen}
+            onTogglePinnedPopover={() => setPinnedPopoverOpen((o) => !o)}
+            editingMessageId={editingMessageId}
+            onCancelEdit={() => setEditingMessageId(null)}
+            onSaveEdit={handleSaveEdit}
+            onToggleReaction={toggleReaction}
+            showEmoji={showEmoji}
+            onShowEmoji={setShowEmoji}
+            hoveredMessageId={hoveredMessageId}
+            onHoverMessage={setHoveredMessageId}
+            onReplyInThread={handleOpenThreadFor}
+            onOverflow={(e, messageId) => { e.preventDefault(); setOverflowMenu({ messageId, x: e.clientX, y: e.clientY }); }}
+            onOpenThread={handleOpenThreadFor}
+            onApprovePinRequest={handlePinRequest}
+            onViewCanvas={setViewingCanvas}
+            newDividerAtId={newDividerAtId}
+            atBottom={atBottom}
+            newCount={newCount}
+            onScrollToLatest={scrollToLatest}
             onScroll={handleScroll}
-            className={`flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-0.5 select-text message-list-drop-target ${
-              shellFileDropTarget.isOver
-                ? "ring-2 ring-sky-400/60 ring-inset bg-sky-500/5"
-                : shellFileDropTarget.isValidTarget
-                ? "ring-2 ring-sky-400/30 ring-inset"
-                : ""
-            }`}
-            style={isMobile && keyboardInset > 0 ? { paddingBottom: `${keyboardInset + 60}px` } : undefined}
-            onDragEnter={shellFileDropTarget.dropHandlers.onDragEnter}
-            onDragOver={(e) => {
-              shellFileDropTarget.dropHandlers.onDragOver(e);
-              if (!e.defaultPrevented) e.preventDefault();
+            dropTarget={{
+              isOver: shellFileDropTarget.isOver,
+              isValidTarget: shellFileDropTarget.isValidTarget,
+              handlers: {
+                onDragEnter: shellFileDropTarget.dropHandlers.onDragEnter,
+                onDragOver: (e: React.DragEvent) => {
+                  shellFileDropTarget.dropHandlers.onDragOver(e);
+                  if (!e.defaultPrevented) e.preventDefault();
+                },
+                onDragLeave: shellFileDropTarget.dropHandlers.onDragLeave,
+                onDrop: (e: React.DragEvent) => {
+                  if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+                    e.preventDefault();
+                    for (const f of Array.from(e.dataTransfer.files)) {
+                      const id = Math.random().toString(36).slice(2);
+                      setPendingAttachments((p) => [...p, { id, filename: f.name, size: f.size, uploading: true, file: f }]);
+                      uploadDiskFile(f, selectedChannel ?? undefined)
+                        .then((rec) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, record: rec, uploading: false } : x)))
+                        .catch((err) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, uploading: false, error: (err as Error).message } : x)));
+                    }
+                    return;
+                  }
+                  shellFileDropTarget.dropHandlers.onDrop(e);
+                },
+              },
             }}
-            onDragLeave={shellFileDropTarget.dropHandlers.onDragLeave}
-            onDrop={(e) => {
-              // OS-level file drops (finder/explorer) take precedence.
-              if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-                e.preventDefault();
-                for (const f of Array.from(e.dataTransfer.files)) {
-                  const id = Math.random().toString(36).slice(2);
-                  setPendingAttachments((p) => [...p, { id, filename: f.name, size: f.size, uploading: true, file: f }]);
-                  uploadDiskFile(f, selectedChannel ?? undefined)
-                    .then((rec) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, record: rec, uploading: false } : x)))
-                    .catch((err) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, uploading: false, error: (err as Error).message } : x)));
-                }
-                return;
-              }
-              shellFileDropTarget.dropHandlers.onDrop(e);
+            showAllThreads={showAllThreads}
+            onToggleAllThreads={() => {
+              if (showAllThreads) { setShowAllThreads(false); }
+              else { closeThread(); setShowSettings(false); setShowSearch(false); setShowAllThreads(true); }
             }}
-          >
-            {messages.length === 0 && fetchedChannel === selectedChannel && (
-              <div className="flex flex-col items-center justify-center h-full text-white/25 text-center px-6">
-                <MessageCircle size={40} className="mb-3 opacity-30" />
-                <p className="text-sm">
-                  No messages yet. Say hello to{" "}
-                  {currentChannel?.type === "dm"
-                    ? `@${(currentChannel.members ?? []).find((m) => m !== "user") ?? "them"}`
-                    : currentChannel?.name
-                      ? `#${currentChannel.name}`
-                      : "this channel"}
-                  .
-                </p>
-              </div>
-            )}
-            {messages.map((msg, i) => {
-              const isAgent = msg.author_type === "agent";
-              const prev = i > 0 ? messages[i - 1] : undefined;
-              const showAuthor = !prev || prev.author_id !== msg.author_id;
-              const prevDay = prev ? new Date(toMs(prev.created_at)).toDateString() : null;
-              const currDay = new Date(toMs(msg.created_at)).toDateString();
-              const showDaySeparator = !prev || prevDay !== currDay;
-              const authorState = resolveAuthorDisplayState(
-                msg.author_id,
-                msg.author_type,
-                liveAgents,
-                archivedAgents,
-              );
-              const isDeadAgent = isAgent && authorState !== "active";
-              const authorTooltip =
-                authorState === "archived"
-                  ? "Agent no longer active"
-                  : authorState === "removed"
-                    ? "Agent removed"
-                    : undefined;
-              return (
-                <React.Fragment key={msg.id}>
-                {showDaySeparator && (
-                  <div className="flex items-center gap-3 my-4 select-none">
-                    <div className="flex-1 h-px bg-white/10" />
-                    <span className="text-[11px] text-white/40 font-medium">{dayLabel(msg.created_at)}</span>
-                    <div className="flex-1 h-px bg-white/10" />
-                  </div>
-                )}
-                {newDividerAtId === msg.id && (
-                  <div
-                    role="separator"
-                    aria-label="New messages"
-                    className="flex items-center gap-3 my-3 select-none"
-                  >
-                    <div className="flex-1 h-px bg-red-400/40" />
-                    <span className="text-[11px] text-red-400 font-semibold">New</span>
-                    <div className="flex-1 h-px bg-red-400/40" />
-                  </div>
-                )}
-                <div
-                  data-message-id={msg.id}
-                  className={`group relative flex gap-2.5 px-3 py-0.5 rounded-md transition-colors hover:bg-shell-surface ${showAuthor ? (isMobile ? "mt-2" : "mt-3") : ""}`}
-                  onMouseEnter={() => setHoveredMessageId(msg.id)}
-                  onMouseLeave={() => setHoveredMessageId((id) => id === msg.id ? null : id)}
-                >
-                  {/* avatar gutter */}
-                  <div
-                    className="flex-shrink-0 flex justify-end pt-0.5"
-                    style={{ width: isMobile ? 34 : 38 }}
-                    onContextMenu={(e) => {
-                      if (msg.author_type !== "agent") return;
-                      e.preventDefault();
-                      setContextMenu({ slug: msg.author_id, x: e.clientX, y: e.clientY });
-                    }}
-                  >
-                    {showAuthor ? (
-                      (() => {
-                        const agent = isAgent ? liveAgents.find((a) => a.name === msg.author_id) : undefined;
-                        return (
-                          <MessageAvatar
-                            size={isMobile ? 34 : 38}
-                            authorId={msg.author_id}
-                            displayName={displayAuthor(msg, { currentUserId, currentUserDisplayName })}
-                            kind={isAgent ? "agent" : "user"}
-                            dead={isDeadAgent}
-                            emoji={agent ? resolveAgentEmoji(agent.emoji, agent.framework) : isAgent ? resolveAgentEmoji(undefined, undefined) : undefined}
-                          />
-                        );
-                      })()
-                    ) : (
-                      <span
-                        className="text-[10px] leading-none text-shell-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity self-center select-none"
-                        aria-hidden="true"
-                        title={new Date(toMs(msg.created_at)).toLocaleString()}
-                      >
-                        {new Date(toMs(msg.created_at)).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
-                      </span>
-                    )}
-                  </div>
-                  {/* content column */}
-                  <div className="flex-1 min-w-0">
-                  {showAuthor && (
-                    <div
-                      className="flex items-center gap-2 mb-0.5"
-                      onContextMenu={(e) => {
-                        if (msg.author_type !== "agent") return;
-                        e.preventDefault();
-                        setContextMenu({ slug: msg.author_id, x: e.clientX, y: e.clientY });
-                      }}
-                    >
-                      <span
-                        className={`${isMobile ? "text-[14px]" : "text-[15px]"} font-bold tracking-tight ${
-                          isDeadAgent
-                            ? "line-through text-shell-text-tertiary"
-                            : "text-shell-text"
-                        }`}
-                        style={isDeadAgent ? { opacity: 0.55 } : undefined}
-                        title={authorTooltip}
-                      >
-                        {displayAuthor(msg, { currentUserId, currentUserDisplayName })}
-                      </span>
-                      {isAgent && !isDeadAgent && (
-                        <span className="text-[10px] uppercase tracking-wide bg-accent-soft text-accent-strong border border-accent-line px-1.5 py-0.5 rounded font-semibold flex items-center gap-0.5">
-                          <Bot size={10} aria-hidden="true" /> Agent
-                        </span>
-                      )}
-                      {isDeadAgent && (
-                        <span className="text-[10px] uppercase tracking-wide bg-shell-surface-active text-shell-text-tertiary px-1.5 py-0.5 rounded font-semibold flex items-center gap-0.5">
-                          <Bot size={10} aria-hidden="true" />
-                          {authorState === "archived" ? "inactive" : "removed"}
-                        </span>
-                      )}
-                      <span
-                        className="text-[11px] text-shell-text-tertiary"
-                        title={new Date(toMs(msg.created_at)).toLocaleString()}
-                      >{relativeTime(msg.created_at, nowMs)}</span>
-                      {msg.edited_at && <span className="text-[10px] text-shell-text-tertiary">(edited)</span>}
-                    </div>
-                  )}
-                  {msg.deleted_at ? (
-                    <MessageTombstone />
-                  ) : editingMessageId === msg.id ? (
-                    <MessageEditor
-                      initial={msg.content}
-                      onSave={(content) => handleSaveEdit(msg.id, content)}
-                      onCancel={() => setEditingMessageId(null)}
-                    />
-                  ) : (
-                    <div className="relative">
-                      {msg.content && msg.author_type === "agent" && msg.state !== "streaming" && msg.state !== "pending" && (
-                        <CopyButton
-                          content={msg.content}
-                          className="absolute -top-1 right-0 p-1 rounded opacity-0 group-hover:opacity-100 focus:opacity-100 bg-shell-surface border border-white/10 text-shell-text-secondary hover:text-shell-text transition-opacity select-none z-10"
-                        />
-                      )}
-                      <div className={`${isMobile ? "text-[14px]" : "text-[15px]"} leading-[1.46] whitespace-pre-wrap break-words select-text ${isDeadAgent ? "text-shell-text-secondary" : "text-shell-text"}`}>
-                        {renderContent(msg.content)}
-                      {msg.state === "pending" && (
-                        <span className="ml-1 text-shell-text-tertiary">...</span>
-                      )}
-                      {msg.state === "streaming" && (
-                        <span className="ml-1 inline-flex gap-0.5">
-                          <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:0ms]" />
-                          <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:150ms]" />
-                          <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:300ms]" />
-                        </span>
-                      )}
-                      {msg.state === "error" && (
-                        <span className="ml-1 text-red-400 text-[11px]">(error)</span>
-                      )}
-                    </div>
-                    </div>
-                  )}
-                  {msg.metadata?.pin_requested && msg.author_type === "agent" && (
-                    <PinRequestAffordance
-                      authorId={msg.author_id}
-                      onApprove={() => handlePinRequest(msg.id)}
-                    />
-                  )}
-
-                  {/* canvas attachment */}
-                  {msg.content_type === "canvas" && (msg.metadata?.canvas_url || msg.metadata?.canvas_id) && (
-                    <div className="mt-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => {
-                          const url = msg.metadata?.canvas_url ?? `/canvas/${msg.metadata?.canvas_id}`;
-                          setViewingCanvas({ url, title: msg.metadata?.canvas_title as string | undefined });
-                        }}
-                        className="h-7 px-2.5 text-[12px] gap-1.5 bg-shell-surface border-shell-border-strong hover:bg-shell-surface-hover"
-                        aria-label="View canvas"
-                      >
-                        <PanelRight size={13} />
-                        View Canvas{msg.metadata?.canvas_title ? `: ${msg.metadata.canvas_title}` : ""}
-                      </Button>
-                    </div>
-                  )}
-
-                  {/* reactions */}
-                  {msg.reactions && Object.keys(msg.reactions).length > 0 && (
-                    <ReactionBar
-                      reactions={msg.reactions}
-                      messageId={msg.id}
-                      currentUserId={currentUserId}
-                      onToggle={toggleReaction}
-                    />
-                  )}
-
-                  {/* hover actions — always visible on mobile (no hover available), hover-gated on desktop */}
-                  {(isMobile || hoveredMessageId === msg.id) && (() => {
-                    const excerpt = (msg.content || "").slice(0, 80);
-                    const msgChannelId = msg.channel_id ?? selectedChannel ?? "";
-                    return (
-                      <div className="absolute -top-3 right-2 z-10">
-                        <MessageHoverActions
-                          onReact={() => {
-                            if (showEmoji && showEmoji.messageId === msg.id) {
-                              setShowEmoji(null);
-                              return;
-                            }
-                            const row = document.querySelector(`[data-message-id="${msg.id}"]`) as HTMLElement | null;
-                            const rect = row?.getBoundingClientRect();
-                            if (!rect) return;
-                            setShowEmoji({ messageId: msg.id, rect });
-                          }}
-                          onReplyInThread={() => handleOpenThreadFor(msg.channel_id ?? selectedChannel ?? "", msg.id)}
-                          onOverflow={(e) => {
-                            e.preventDefault();
-                            setOverflowMenu({ messageId: msg.id, x: e.clientX, y: e.clientY });
-                          }}
-                          dragHandle={msgChannelId ? (
-                            <span
-                              draggable
-                              onDragStart={(e) => {
-                                e.stopPropagation();
-                                e.dataTransfer.effectAllowed = "copy";
-                                try {
-                                  e.dataTransfer.setData("text/plain", `@${msg.author_id}: ${excerpt}`);
-                                  e.dataTransfer.setData("text/uri-list", `${window.location.origin}/chat/${msgChannelId}?msg=${msg.id}`);
-                                } catch { /* best-effort */ }
-                                startDrag({
-                                  kind: "message",
-                                  channel_id: msgChannelId,
-                                  message_id: msg.id,
-                                  author_id: msg.author_id,
-                                  excerpt,
-                                });
-                              }}
-                              onDragEnd={() => endDrag()}
-                              className="p-1 opacity-40 hover:opacity-100 cursor-grab select-none"
-                              aria-label="Drag message"
-                              title="Drag this message"
-                            >&#8942;&#8942;</span>
-                          ) : undefined}
-                        />
-                      </div>
-                    );
-                  })()}
-                  <AttachmentGallery attachments={(msg.attachments as AttachmentRecord[] | undefined) || []} />
-                  {typeof msg.reply_count === "number" && msg.reply_count > 0 && (
-                    <ThreadIndicator
-                      replyCount={msg.reply_count}
-                      lastReplyAt={msg.last_reply_at ?? null}
-                      onOpen={() => handleOpenThreadFor(msg.channel_id ?? selectedChannel ?? "", msg.id)}
-                    />
-                  )}
-
-                  {/* emoji picker — rendered in a portal to avoid clipping by the scrollable list */}
-                  {showEmoji && showEmoji.messageId === msg.id && createPortal(
-                    (() => {
-                      const POPOVER_W = 300;
-                      const POPOVER_H = 360;
-                      const vw = window.innerWidth;
-                      const vh = window.innerHeight;
-                      const r = showEmoji.rect;
-                      // Upper bounds are clamped to >=8 so a viewport smaller
-                      // than the popover (with margins) cannot produce a
-                      // negative limit and let Math.min return a value < 8.
-                      const top = Math.max(8, Math.min(r.top, Math.max(8, vh - POPOVER_H - 8)));
-                      const left = Math.max(8, Math.min(r.right - POPOVER_W, Math.max(8, vw - POPOVER_W - 8)));
-                      return (
-                    <div
-                      data-emoji-popover="1"
-                      role="dialog"
-                      aria-label="Emoji reactions"
-                      className="fixed z-50 bg-shell-bg border border-shell-border-strong rounded-lg shadow-xl p-2 w-[300px] h-[360px] flex flex-col gap-2 backdrop-blur-xl"
-                      style={{ top, left }}
-                    >
-                      <div className="flex gap-1 shrink-0">
-                        {EMOJI_PICKER.map((em) => (
-                          <button
-                            key={em}
-                            onClick={() => toggleReaction(msg.id, em)}
-                            className="text-lg hover:bg-white/10 rounded p-0.5 transition-colors"
-                          >
-                            {em}
-                          </button>
-                        ))}
-                      </div>
-                      <div className="flex-1 min-h-0">
-                        <Picker
-                          theme={Theme.DARK}
-                          width="100%"
-                          height="100%"
-                          onEmojiClick={(d) => {
-                            toggleReaction(msg.id, d.emoji);
-                          }}
-                        />
-                      </div>
-                    </div>
-                      );
-                    })(),
-                    document.body,
-                  )}
-                  </div>
-                </div>
-                </React.Fragment>
-              );
-            })}
-            <div ref={messagesEndRef} />
-          </div>
-
-          {/* typing footer */}
-          <TypingFooter humans={typingHumans} agents={typingAgents} selfId="user" />
+            showSearch={showSearch}
+            onToggleSearch={() => {
+              if (showSearch) { setShowSearch(false); }
+              else { closeThread(); setShowSettings(false); setShowAllThreads(false); setShowSearch(true); }
+            }}
+            onOpenSettings={handleOpenSettings}
+            typingHumans={typingHumans}
+            typingAgents={typingAgents}
+          />
 
           {/* #1741: stall banner — surfaces only when a response is abnormally
               slow or has gone quiet, so a stalled generation no longer looks
@@ -2717,56 +2420,5 @@ export function MessagesApp({
         )
       )}
     </div>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-/*  CopyButton — hover copy affordance for message bubbles             */
-/*  Matches the CodeBlock + TaosAssistantPanel copy-button pattern.    */
-/* ------------------------------------------------------------------ */
-
-function CopyButton({ content, className }: { content: string; className?: string }) {
-  const [copied, setCopied] = useState(false);
-  const [clipError, setClipError] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  /* Clear any pending timers on unmount so we never setState on a dead component. */
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
-    };
-  }, []);
-
-  const handleCopy = async () => {
-    if (!content) return;
-    try {
-      await navigator.clipboard.writeText(content);
-      setCopied(true);
-      setClipError(false);
-      if (timerRef.current) clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setCopied(false), 1500);
-    } catch {
-      setClipError(true);
-      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
-      errorTimerRef.current = setTimeout(() => setClipError(false), 2500);
-    }
-  };
-
-  return (
-    <button
-      onClick={handleCopy}
-      aria-label={copied ? "Copied" : clipError ? "Copy failed — check clipboard permissions" : "Copy message"}
-      className={className}
-    >
-      {copied ? (
-        <Check size={10} />
-      ) : clipError ? (
-        <X size={10} className="text-red-400" />
-      ) : (
-        <Copy size={10} />
-      )}
-    </button>
   );
 }

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -13,8 +13,6 @@ import {
   PauseCircle,
   MessagesSquare,
   Search,
-  Copy,
-  Check,
   AlertTriangle,
   Loader2,
 } from "lucide-react";
@@ -72,7 +70,7 @@ import { getApp } from "@/registry/app-registry";
 import { CodeBlock } from "@/components/CodeBlock";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import Picker, { Theme } from "emoji-picker-react";
+import { resolveAgentEmoji } from "@/lib/agent-emoji";
 import { SearchPanel } from "./chat/SearchPanel";
 import { ChannelSidebar } from "./chat/ChannelSidebar";
 import { A2aBusMessageView, useBusChannels } from "./chat/A2aBusPanel";

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -6,7 +6,6 @@ import {
   Users,
   Plus,
   Send,
-  Paperclip,
   Bot,
   X,
   AtSign,
@@ -29,7 +28,6 @@ import {
   CardTitle,
   CardContent,
   Input,
-  Textarea,
   Label,
 } from "@/components/ui";
 import { MobileSplitView } from "@/components/mobile/MobileSplitView";
@@ -41,13 +39,13 @@ import { resolveAgentEmoji } from "@/lib/agent-emoji";
 import { MessageAvatar } from "./chat/MessageAvatar";
 import { ChannelSettingsPanel } from "./chat/ChannelSettingsPanel";
 import { AgentContextMenu } from "./chat/AgentContextMenu";
-import { SlashMenu, type SlashCommandsBySlug } from "./chat/SlashMenu";
+import { type SlashCommandsBySlug } from "./chat/SlashMenu";
 import { TypingFooter, type AgentTyping } from "./chat/TypingFooter";
 import { useTypingEmitter } from "@/lib/use-typing-emitter";
 import { MessageHoverActions } from "./chat/MessageHoverActions";
 import { ThreadIndicator } from "./chat/ThreadIndicator";
 import { ThreadPanel } from "./chat/ThreadPanel";
-import { AttachmentsBar, type PendingAttachment } from "./chat/AttachmentsBar";
+import { type PendingAttachment } from "./chat/AttachmentsBar";
 import { AttachmentGallery } from "./chat/AttachmentGallery";
 import { uploadDiskFile, attachmentFromPath, type AttachmentRecord } from "@/lib/chat-attachments-api";
 import { useThreadPanel } from "@/lib/use-thread-panel";
@@ -62,6 +60,8 @@ import { AllThreadsList } from "./chat/AllThreadsList";
 import { ChannelSwitcher } from "./chat/ChannelSwitcher";
 import { useChatNotifications } from "./chat/useChatNotifications";
 import { PinRequestAffordance } from "./chat/PinRequestAffordance";
+import { ReactionBar } from "./chat/ReactionBar";
+import { MessageInput } from "./chat/MessageInput";
 import {
   pinMessage, unpinMessage, listPins,
   editMessage as apiEditMessage, deleteMessage as apiDeleteMessage,
@@ -1265,16 +1265,6 @@ export function MessagesApp({
     emitTyping();
   };
 
-  /* ---- key handler ---- */
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    // The mention popover (when open) owns Enter/Tab via a capture listener
-    // that stops propagation, so this send handler never sees those keys.
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      sendMessage();
-    }
-  };
-
   /* ---- file upload ---- */
   // Re-upload a File-based attachment (used by the retry affordance). Keeps the
   // success/failure state updates identical to a first attempt.
@@ -2014,26 +2004,12 @@ export function MessagesApp({
 
                   {/* reactions */}
                   {msg.reactions && Object.keys(msg.reactions).length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-1.5">
-                      {Object.entries(msg.reactions).map(([emoji, users]) => {
-                        const mine = currentUserId != null && users.includes(currentUserId);
-                        return (
-                          <button
-                            key={emoji}
-                            onClick={() => toggleReaction(msg.id, emoji)}
-                            aria-pressed={mine}
-                            className={`text-[12px] rounded-full px-2 py-0.5 flex items-center gap-1 border transition-colors ${
-                              mine
-                                ? "bg-accent-soft border-accent-line text-accent-strong"
-                                : "bg-shell-surface border-shell-border hover:bg-shell-surface-hover text-shell-text-secondary"
-                            }`}
-                          >
-                            <span>{emoji}</span>
-                            <span className={mine ? "text-accent-strong font-medium" : "text-shell-text-tertiary"}>{users.length}</span>
-                          </button>
-                        );
-                      })}
-                    </div>
+                    <ReactionBar
+                      reactions={msg.reactions}
+                      messageId={msg.id}
+                      currentUserId={currentUserId}
+                      onToggle={toggleReaction}
+                    />
                   )}
 
                   {/* hover actions — always visible on mobile (no hover available), hover-gated on desktop */}
@@ -2233,24 +2209,7 @@ export function MessagesApp({
             </div>
           )}
 
-          {/* pending attachments bar */}
-          <AttachmentsBar
-            items={pendingAttachments}
-            onRemove={(id) => setPendingAttachments((p) => p.filter((x) => x.id !== id))}
-            onRetry={(id) => {
-              const entry = pendingAttachments.find((x) => x.id === id);
-              if (!entry) return;
-              if (!entry.file) {
-                // Path-based attachment (no File kept): can only re-add.
-                setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, error: "Can't retry, remove and re-add" } : x));
-                return;
-              }
-              if ((entry.retries ?? 0) >= 3) return;
-              setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, retries: (x.retries ?? 0) + 1 } : x));
-              uploadFileAttachment(id, entry.file);
-            }}
-          />
-
+          {/* A2A channel note */}
           {currentChannel?.settings?.kind === "a2a" && messages.length === 0 && (
             <div
               role="note"
@@ -2268,97 +2227,54 @@ export function MessagesApp({
             </div>
           )}
 
-          {/* input area */}
-          <div
-            className="px-4 py-3 border-t border-white/[0.06] shrink-0"
-            style={
-              isMobile
-                ? { paddingBottom: `max(env(safe-area-inset-bottom), ${keyboardInset}px)` }
-                : undefined
-            }
-          >
-            <div className="relative">
-              {showSlash && (
-                <SlashMenu
-                  commands={slashCommands}
-                  queryAfterSlash={slashQuery}
-                  members={currentChannel?.members || []}
-                  scopedAgent={slashAgent}
-                  onPick={(slug, cmd) => {
-                    setInput(`@${slug} /${cmd} `);
-                  }}
-                  onClose={() => { /* leave input as-is; user can Esc or delete */ }}
-                />
-              )}
-              {mention && mentionCandidates.length > 0 && !showSlash && (
-                <div
-                  role="listbox"
-                  aria-label="Mention a member"
-                  className="absolute bottom-full left-0 mb-2 w-full max-w-md bg-shell-surface border border-white/10 rounded-lg shadow-xl max-h-60 overflow-y-auto text-sm"
-                >
-                  {mentionCandidates.map((slug, i) => (
-                    <button
-                      key={slug}
-                      role="option"
-                      aria-selected={i === mentionSel}
-                      onMouseEnter={() => setMentionSel(i)}
-                      onMouseDown={(e) => { e.preventDefault(); insertMention(slug); }}
-                      className={`w-full text-left px-3 py-1.5 flex items-center gap-2 ${i === mentionSel ? "bg-white/10" : "hover:bg-white/5"}`}
-                    >
-                      <AtSign size={13} className="text-white/40" aria-hidden="true" />
-                      <span className="font-mono text-[13px]">@{slug}</span>
-                    </button>
-                  ))}
-                </div>
-              )}
-              <div className={`flex items-end gap-2 rounded-2xl border px-2 py-1.5 ${isCurrentArchived ? "bg-white/[0.02] border-white/[0.04] opacity-50" : "bg-shell-surface border-shell-border-strong"}`}>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={handleFileUpload}
-                  className="h-8 w-8 shrink-0 mb-0.5"
-                  aria-label="Upload file"
-                  disabled={isCurrentArchived}
-                >
-                  <Paperclip size={16} />
-                </Button>
-                <Textarea
-                  ref={inputRef}
-                  value={input}
-                  onChange={(e) => !isCurrentArchived && handleInputChange(e.target.value)}
-                  onKeyDown={(e) => !isCurrentArchived && handleKeyDown(e)}
-                  onBlur={() => setMention(null)}
-                  onPaste={(e) => {
-                    if (!e.clipboardData) return;
-                    const files = Array.from(e.clipboardData.files).filter((f) => f.type.startsWith("image/"));
-                    if (files.length === 0) return;
-                    e.preventDefault();
-                    for (const f of files) {
-                      const id = Math.random().toString(36).slice(2);
-                      setPendingAttachments((p) => [...p, { id, filename: f.name || "pasted.png", size: f.size, uploading: true, file: f }]);
-                      uploadDiskFile(f, selectedChannel ?? undefined)
-                        .then((rec) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, record: rec, uploading: false } : x)))
-                        .catch((err) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, uploading: false, error: (err as Error).message } : x)));
-                    }
-                  }}
-                  placeholder={isCurrentArchived ? "This chat is archived" : `Message #${currentChannel?.name ?? ""}...`}
-                  rows={1}
-                  disabled={isCurrentArchived}
-                  className="flex-1 bg-transparent border-0 px-1 py-1.5 min-h-0 text-[13px] focus-visible:ring-0 focus-visible:border-0 max-h-[120px] disabled:cursor-not-allowed"
-                  aria-label="Message input"
-                />
-                <Button
-                  size="icon"
-                  onClick={sendMessage}
-                  disabled={(!input.trim() && pendingAttachments.length === 0) || isCurrentArchived || pendingAttachments.some(a => a.uploading)}
-                  className="h-8 w-8 shrink-0 mb-0.5"
-                  aria-label="Send message"
-                >
-                  <Send size={15} />
-                </Button>
-              </div>
-            </div>
-          </div>
+          <MessageInput
+            value={input}
+            onChange={(v) => !isCurrentArchived && handleInputChange(v)}
+            onSend={sendMessage}
+            channel={currentChannel}
+            isArchived={isCurrentArchived}
+            isMobile={isMobile}
+            keyboardInset={keyboardInset}
+            slashCommands={slashCommands}
+            showSlash={showSlash}
+            slashQuery={slashQuery}
+            slashAgent={slashAgent}
+            mention={mention}
+            mentionCandidates={mentionCandidates}
+            mentionSel={mentionSel}
+            onMentionSelChange={setMentionSel}
+            onInsertMention={insertMention}
+            onDismissMention={() => setMention(null)}
+            pendingAttachments={pendingAttachments}
+            onRemoveAttachment={(id) => setPendingAttachments((p) => p.filter((x) => x.id !== id))}
+            onRetryAttachment={(id) => {
+              const entry = pendingAttachments.find((x) => x.id === id);
+              if (!entry) return;
+              if (!entry.file) {
+                setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, error: "Can't retry, remove and re-add" } : x));
+                return;
+              }
+              if ((entry.retries ?? 0) >= 3) return;
+              setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, retries: (x.retries ?? 0) + 1 } : x));
+              uploadFileAttachment(id, entry.file);
+            }}
+            onFileUpload={handleFileUpload}
+            onSlashPick={(slug, cmd) => setInput(`@${slug} /${cmd} `)}
+            onSlashClose={() => {}}
+            onPaste={(e) => {
+              if (!e.clipboardData) return;
+              const files = Array.from(e.clipboardData.files).filter((f) => f.type.startsWith("image/"));
+              if (files.length === 0) return;
+              e.preventDefault();
+              for (const f of files) {
+                const id = Math.random().toString(36).slice(2);
+                setPendingAttachments((p) => [...p, { id, filename: f.name || "pasted.png", size: f.size, uploading: true, file: f }]);
+                uploadDiskFile(f, selectedChannel ?? undefined)
+                  .then((rec) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, record: rec, uploading: false } : x)))
+                  .catch((err) => setPendingAttachments((p) => p.map((x) => x.id === id ? { ...x, uploading: false, error: (err as Error).message } : x)));
+              }
+            }}
+          />
         </>
       )}
     </div>

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -10,16 +10,11 @@ import {
   Bot,
   X,
   AtSign,
-  Wifi,
-  WifiOff,
-  ChevronRight,
   ChevronDown,
   PanelRight,
   Archive,
   CircleDot,
   PauseCircle,
-  Trash2,
-  RotateCcw,
   MessagesSquare,
   Search,
   Copy,
@@ -92,11 +87,8 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Picker, { Theme } from "emoji-picker-react";
 import { SearchPanel } from "./chat/SearchPanel";
-import {
-  A2aBusSection,
-  A2aBusMessageView,
-  useBusChannels,
-} from "./chat/A2aBusPanel";
+import { ChannelSidebar } from "./chat/ChannelSidebar";
+import { A2aBusMessageView, useBusChannels } from "./chat/A2aBusPanel";
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                              */
@@ -222,7 +214,7 @@ type WsStatus = "connecting" | "connected" | "disconnected";
  * or numeric) to milliseconds suitable for `new Date(...)`. The 1e12
  * threshold safely distinguishes seconds (~1.7e9 today) from ms (~1.7e12).
  */
-function toMs(ts: number | string): number {
+export function toMs(ts: number | string): number {
   if (typeof ts === "number") return ts < 1e12 ? ts * 1000 : ts;
   if (ts === "" || ts == null) return Date.now();
   const n = Number(ts);
@@ -230,7 +222,7 @@ function toMs(ts: number | string): number {
   return new Date(ts).getTime();
 }
 
-function relativeTime(ts: number | string, nowMs: number = Date.now()): string {
+export function relativeTime(ts: number | string, nowMs: number = Date.now()): string {
   const ms = toMs(ts);
   const mins = Math.floor((nowMs - ms) / 60000);
   if (mins < 1) return "now";
@@ -1605,481 +1597,40 @@ export function MessagesApp({
   /*  Channel list — iOS 26 grouped on mobile, flat sidebar on desktop */
   /* ---------------------------------------------------------------- */
 
-  const channelListUI = isMobile ? (
-    /* Mobile: iOS 26 grouped list */
-    <div style={{ padding: "8px 0 16px" }}>
-      {/* connection status */}
-      <div style={{ padding: "0 20px 8px", fontSize: 11, display: "flex", alignItems: "center", gap: 6 }}>
-        {wsStatus === "connected" ? (
-          <><Wifi size={11} style={{ color: "#34d399" }} /><span style={{ color: "rgba(52,211,153,0.8)" }}>Connected</span></>
-        ) : wsStatus === "connecting" ? (
-          <><Wifi size={11} style={{ color: "#fbbf24" }} /><span style={{ color: "rgba(251,191,36,0.8)" }}>Connecting…</span></>
-        ) : (
-          <><WifiOff size={11} style={{ color: "#f87171" }} /><span style={{ color: "rgba(248,113,113,0.8)" }}>Offline</span></>
-        )}
-      </div>
-
-      {allEmpty ? (
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", padding: "48px 24px", textAlign: "center", gap: 12 }}>
-          <MessageCircle size={36} style={{ color: "var(--color-shell-text-tertiary)" }} aria-hidden="true" />
-          <p style={{ fontSize: 15, fontWeight: 600, color: "var(--color-shell-text)", margin: 0 }}>No conversations yet</p>
-          <p style={{ fontSize: 13, color: "var(--color-shell-text-secondary)", margin: 0 }}>Deploy an agent to start chatting</p>
-          <button
-            type="button"
-            onClick={openAgentsApp}
-            style={{ marginTop: 4, fontSize: 13, padding: "8px 16px", borderRadius: 10, background: "var(--color-accent-soft)", border: "1px solid var(--color-accent-line)", color: "var(--color-accent-strong)", cursor: "pointer" }}
-          >
-            Open Agents
-          </button>
-        </div>
-      ) : SECTIONS.map((section) => (
-        <div key={section.label} style={{ marginBottom: 20 }}>
-          <button
-            type="button"
-            onClick={() => toggleSection(section.label)}
-            aria-expanded={!collapsedSections[section.label]}
-            style={{ fontSize: 12, textTransform: "uppercase" as const, letterSpacing: 0.5, color: "var(--color-shell-text-secondary)", padding: "0 20px 6px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", width: "100%" }}
-          >
-            <ChevronRight size={13} aria-hidden="true" style={{ transition: "transform 0.15s", transform: collapsedSections[section.label] ? "none" : "rotate(90deg)" }} />
-            {section.icon} {section.label}
-          </button>
-          {visibleInSection(section.items, section.label).length === 0 ? (
-            collapsedSections[section.label] ? null : (
-              <div style={{ padding: "0 20px", fontSize: 12, color: "var(--color-shell-text-tertiary)", fontStyle: "italic" }}>None yet</div>
-            )
-          ) : (
-            <div
-              style={{
-                margin: "0 12px",
-                borderRadius: 16,
-                background: "var(--color-shell-surface)",
-                border: "1px solid var(--color-shell-border)",
-                overflow: "hidden",
-              }}
-            >
-              {visibleInSection(section.items, section.label).map((ch, idx, arr) => {
-                const isA2A = ch.settings?.kind === "a2a";
-                // Only direct messages get an agent avatar; topics/groups/a2a get
-                // a glyph tile (a topic/group can include agent members too).
-                const agentMember = ch.type === "dm" ? (ch.members ?? []).find((m) => m !== "user") : undefined;
-                const count = unread[ch.id] ?? 0;
-                return (
-                <button
-                  key={ch.id}
-                  type="button"
-                  onClick={() => setSelectedChannel(ch.id)}
-                  aria-label={`Channel ${ch.name}`}
-                  title={isA2A ? "Agent coordination — mention @<slug> to hand off." : undefined}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 12,
-                    width: "100%",
-                    padding: "11px 14px",
-                    background: selectedChannel === ch.id ? "var(--color-shell-surface-active)" : "none",
-                    border: "none",
-                    borderBottom: idx === arr.length - 1 ? "none" : "1px solid var(--color-shell-border)",
-                    cursor: "pointer",
-                    color: "inherit",
-                    textAlign: "left",
-                  }}
-                >
-                  {agentMember ? (
-                    <MessageAvatar size={38} authorId={agentMember} displayName={agentMember} kind="agent" />
-                  ) : isA2A ? (
-                    <div style={{ width: 38, height: 38, borderRadius: 11, display: "flex", alignItems: "center", justifyContent: "center", background: "var(--color-accent-soft)", border: "1px solid var(--color-accent-line)", color: "var(--color-accent-strong)", flexShrink: 0 }}>
-                      <Bot size={18} aria-hidden />
-                    </div>
-                  ) : (
-                    <div style={{ width: 38, height: 38, borderRadius: 11, display: "flex", alignItems: "center", justifyContent: "center", background: "var(--color-shell-surface-active)", color: "var(--color-shell-text-secondary)", flexShrink: 0 }}>
-                      {ch.type === "group" ? <Users size={18} aria-hidden /> : <Hash size={18} aria-hidden />}
-                    </div>
-                  )}
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
-                      <span style={{ flex: 1, fontSize: 15, fontWeight: count > 0 ? 700 : 600, color: "var(--color-shell-text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                        {ch.name}
-                      </span>
-                      {ch.last_message_at && (
-                        <span style={{ fontSize: 11, color: "var(--color-shell-text-tertiary)", flexShrink: 0 }}>
-                          {relativeTime(ch.last_message_at, nowMs)}
-                        </span>
-                      )}
-                    </div>
-                    {ch.lastPreview && (
-                      <div style={{ fontSize: 13, color: "var(--color-shell-text-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", marginTop: 1 }}>
-                        {ch.lastPreview}
-                      </div>
-                    )}
-                  </div>
-                  {count > 0 && (
-                    <span style={{ background: "var(--color-unread)", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 5px", flexShrink: 0 }}>
-                      {count}
-                    </span>
-                  )}
-                </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      ))}
-
-      {/* Projects section — mobile (standalone mode only) */}
-      {!scope?.projectId && projectGroups.length > 0 && (
-        <div style={{ marginBottom: 20 }}>
-          <button
-            type="button"
-            onClick={() => setProjectsExpanded((v) => !v)}
-            aria-expanded={projectsExpanded}
-            aria-controls="projects-section-mobile"
-            style={{ fontSize: 12, textTransform: "uppercase" as const, letterSpacing: 0.5, color: "var(--color-shell-text-secondary)", padding: "0 20px 6px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", width: "100%" }}
-          >
-            <ChevronRight size={12} style={{ transition: "transform 0.15s", transform: projectsExpanded ? "rotate(90deg)" : "none", color: "var(--color-shell-text-tertiary)" }} aria-hidden="true" />
-            Projects ({projectGroups.length})
-          </button>
-          <div id="projects-section-mobile" style={{ display: projectsExpanded ? "block" : "none" }}>
-            {projectGroups.map((g) => {
-              const isOpen = projectChannelExpanded[g.id] !== false;
-              return (
-                <div key={g.id} style={{ marginBottom: 12 }}>
-                  <button
-                    type="button"
-                    onClick={() => setProjectChannelExpanded((prev) => ({ ...prev, [g.id]: !isOpen }))}
-                    aria-expanded={isOpen}
-                    aria-controls={`project-section-mobile-${g.id}`}
-                    style={{ fontSize: 11, color: "var(--color-shell-text-secondary)", padding: "0 20px 4px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", width: "100%" }}
-                  >
-                    <ChevronRight size={10} style={{ transition: "transform 0.15s", transform: isOpen ? "rotate(90deg)" : "none", color: "var(--color-shell-text-tertiary)" }} aria-hidden="true" />
-                    {g.name}
-                  </button>
-                  <div id={`project-section-mobile-${g.id}`} style={{ display: isOpen ? "block" : "none" }}>
-                    <div style={{ margin: "0 12px", borderRadius: 16, background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.08)", overflow: "hidden" }}>
-                      {g.channels.map((ch, idx, arr) => (
-                        <button
-                          key={ch.id}
-                          type="button"
-                          onClick={() => setSelectedChannel(ch.id)}
-                          aria-label={`Channel ${ch.name}`}
-                          title={ch.settings?.kind === "a2a" ? "Agent coordination — mention @<slug> to hand off." : undefined}
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 10,
-                            width: "100%",
-                            padding: "14px 16px",
-                            background: selectedChannel === ch.id ? "var(--color-shell-surface-active)" : "none",
-                            border: "none",
-                            borderBottom: idx === arr.length - 1 ? "none" : "1px solid var(--color-shell-border)",
-                            cursor: "pointer",
-                            color: "inherit",
-                            textAlign: "left",
-                          }}
-                        >
-                          {ch.settings?.kind === "a2a" && (
-                            <Bot
-                              size={14}
-                              aria-hidden
-                              style={{ color: "var(--color-shell-text-secondary)", flexShrink: 0 }}
-                            />
-                          )}
-                          <span style={{ flex: 1, fontSize: 15, fontWeight: 400, color: "var(--color-shell-text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                            {ch.name}
-                          </span>
-                          {(unread[ch.id] ?? 0) > 0 && (
-                            <span style={{ background: "var(--color-unread)", color: "#fff", fontSize: 10, fontWeight: 700, borderRadius: 9999, minWidth: 18, height: 18, display: "flex", alignItems: "center", justifyContent: "center", padding: "0 4px" }}>
-                              {unread[ch.id]}
-                            </span>
-                          )}
-                          <ChevronRight size={16} style={{ color: "var(--color-shell-text-tertiary)", flexShrink: 0 }} />
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* Archived channels section — mobile */}
-      {archivedChannels.length > 0 && (
-        <div style={{ marginBottom: 20 }}>
-          <button
-            type="button"
-            onClick={() => setArchivedExpanded((v) => !v)}
-            aria-expanded={archivedExpanded}
-            aria-controls="archived-channels-mobile"
-            style={{ fontSize: 12, textTransform: "uppercase" as const, letterSpacing: 0.5, color: "var(--color-shell-text-tertiary)", padding: "0 20px 6px", fontWeight: 600, display: "flex", alignItems: "center", gap: 6, background: "none", border: "none", cursor: "pointer", width: "100%" }}
-          >
-            <ChevronRight size={12} style={{ transition: "transform 0.15s", transform: archivedExpanded ? "rotate(90deg)" : "none", color: "var(--color-shell-text-tertiary)" }} aria-hidden="true" />
-            <Archive size={12} aria-hidden="true" />
-            Archived ({archivedChannels.length})
-          </button>
-          <div id="archived-channels-mobile" style={{ display: archivedExpanded ? "block" : "none" }}>
-            <div style={{ margin: "0 12px", borderRadius: 16, background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.06)", overflow: "hidden" }}>
-              {archivedChannels.map((ch, idx, arr) => {
-                const agentId = ch.settings?.archived_agent_id;
-                const hasAgent = agentId ? archivedAgents.some((a) => a.id === agentId) : false;
-                return (
-                  <div
-                    key={ch.id}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      borderBottom: idx === arr.length - 1 ? "none" : "1px solid rgba(255,255,255,0.04)",
-                      opacity: 0.6,
-                    }}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => setSelectedChannel(ch.id)}
-                      aria-label={`Archived channel ${ch.name}`}
-                      style={{ flex: 1, display: "flex", alignItems: "center", gap: 8, padding: "12px 8px 12px 16px", background: selectedChannel === ch.id ? "var(--color-shell-surface-active)" : "none", border: "none", cursor: "pointer", color: "inherit", textAlign: "left" as const, minWidth: 0 }}
-                    >
-                      <Archive size={11} aria-hidden="true" style={{ color: "var(--color-shell-text-tertiary)", flexShrink: 0 }} />
-                      <span style={{ flex: 1, fontSize: 14, color: "var(--color-shell-text-secondary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{ch.name}</span>
-                    </button>
-                    <div style={{ display: "flex", gap: 2, paddingRight: 8 }}>
-                      <button
-                        type="button"
-                        onClick={() => handleRestoreArchivedChannel(ch.id, ch.name)}
-                        disabled={!hasAgent}
-                        aria-label={`Restore archived channel ${ch.name}`}
-                        title={hasAgent ? "Restore agent" : "Agent entry missing — delete only"}
-                        style={{ background: "none", border: "none", cursor: hasAgent ? "pointer" : "not-allowed", color: hasAgent ? "rgba(52,211,153,0.7)" : "rgba(255,255,255,0.2)", padding: "6px" }}
-                      >
-                        <RotateCcw size={13} aria-hidden="true" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteArchivedChannel(ch.id)}
-                        aria-label={`Permanently delete archived channel ${ch.name}`}
-                        title="Delete permanently"
-                        style={{ background: "none", border: "none", cursor: "pointer", color: "rgba(248,113,113,0.7)", padding: "6px" }}
-                      >
-                        <Trash2 size={13} aria-hidden="true" />
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* External taOSmd coordination bus (read-only) */}
-      <A2aBusSection
-        channels={bus.channels}
-        available={bus.available}
-        loaded={bus.loaded}
-        selected={busSelected}
-        onSelect={selectBusChannel}
-      />
-    </div>
-  ) : (
-    /* Desktop: compact sidebar */
-    <div className="w-full flex flex-col h-full">
-      {/* connection status */}
-      <div className="px-3 py-1.5 text-[11px] flex items-center gap-1.5">
-        {wsStatus === "connected" ? (
-          <><Wifi size={11} className="text-emerald-400" /><span className="text-emerald-400/80">Connected</span></>
-        ) : wsStatus === "connecting" ? (
-          <><Wifi size={11} className="text-amber-400 animate-pulse" /><span className="text-amber-400/80">Connecting...</span></>
-        ) : (
-          <><WifiOff size={11} className="text-red-400" /><span className="text-red-400/80">Offline</span></>
-        )}
-      </div>
-
-      {/* channel list */}
-      <div className="flex-1 overflow-y-auto py-1">
-        {allEmpty ? (
-          <div className="flex flex-col items-center justify-center h-full px-4 py-10 text-center gap-2.5">
-            <MessageCircle size={28} className="text-white/15" aria-hidden="true" />
-            <p className="text-[13px] font-medium text-white/60">No conversations yet</p>
-            <p className="text-[11px] text-white/30">Deploy an agent to start chatting</p>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={openAgentsApp}
-              className="mt-1 text-xs"
-            >
-              Open Agents
-            </Button>
-          </div>
-        ) : SECTIONS.map((section) => (
-          <div key={section.label}>
-            <button
-              type="button"
-              onClick={() => toggleSection(section.label)}
-              aria-expanded={!collapsedSections[section.label]}
-              className="w-full px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/30 hover:text-white/50 flex items-center gap-1.5 transition-colors"
-            >
-              <ChevronRight
-                size={11}
-                aria-hidden="true"
-                className={`transition-transform ${collapsedSections[section.label] ? "" : "rotate-90"}`}
-              />
-              {section.icon} {section.label}
-            </button>
-            {!collapsedSections[section.label] && section.items.length === 0 && (
-              <div className="px-3 py-1 text-[11px] text-white/20 italic">None yet</div>
-            )}
-            <div className="px-2 flex flex-col gap-px">
-              {visibleInSection(section.items, section.label).map((ch) => {
-                const isA2A = ch.settings?.kind === "a2a";
-                const agentMember = ch.type === "dm" ? (ch.members ?? []).find((m) => m !== "user") : undefined;
-                const count = unread[ch.id] ?? 0;
-                return (
-                  <button
-                    key={ch.id}
-                    type="button"
-                    onClick={() => setSelectedChannel(ch.id)}
-                    aria-pressed={selectedChannel === ch.id}
-                    className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-left transition-colors ${
-                      selectedChannel === ch.id ? "bg-shell-surface-active" : "hover:bg-shell-surface-hover"
-                    }`}
-                    aria-label={`Channel ${ch.name}`}
-                    title={isA2A ? "Agent coordination — mention @<slug> to hand off." : undefined}
-                  >
-                    {agentMember ? (
-                      <MessageAvatar size={30} authorId={agentMember} displayName={agentMember} kind="agent" />
-                    ) : isA2A ? (
-                      <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
-                        <Bot size={15} aria-hidden />
-                      </span>
-                    ) : (
-                      <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-shell-surface-active text-shell-text-secondary">
-                        {ch.type === "group" ? <Users size={15} aria-hidden /> : <Hash size={15} aria-hidden />}
-                      </span>
-                    )}
-                    <span className={`truncate flex-1 text-[14px] tracking-tight ${count > 0 ? "font-bold text-shell-text" : "font-semibold text-shell-text"}`}>
-                      {ch.name}
-                    </span>
-                    {count > 0 && (
-                      <span className="shrink-0 bg-unread text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 tabular-nums">
-                        {count}
-                      </span>
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        ))}
-
-        {/* Projects section — desktop (standalone mode only) */}
-        {!scope?.projectId && projectGroups.length > 0 && (
-          <details className="px-3 mt-2">
-            <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-wider text-white/30 py-1">
-              Projects
-            </summary>
-            {projectGroups.map((g) => (
-              <details key={g.id} className="ml-2 mt-1">
-                <summary className="cursor-pointer text-xs text-white/60 py-1">{g.name}</summary>
-                <div className="ml-2 mt-0.5">
-                  {g.channels.map((ch) => (
-                    <button
-                      key={ch.id}
-                      type="button"
-                      onClick={() => setSelectedChannel(ch.id)}
-                      aria-pressed={selectedChannel === ch.id}
-                      aria-label={`Channel ${ch.name}`}
-                      title={ch.settings?.kind === "a2a" ? "Agent coordination — mention @<slug> to hand off." : undefined}
-                      className={`w-full text-left text-xs py-1 px-2 rounded flex items-center gap-1.5 ${
-                        selectedChannel === ch.id ? "bg-white/10" : "hover:bg-white/5"
-                      }`}
-                    >
-                      {ch.settings?.kind === "a2a" && (
-                        <Bot
-                          size={12}
-                          aria-hidden
-                          style={{ color: "rgba(255,255,255,0.6)", flexShrink: 0 }}
-                        />
-                      )}
-                      {ch.name}
-                    </button>
-                  ))}
-                </div>
-              </details>
-            ))}
-          </details>
-        )}
-
-        {/* Archived channels section — desktop */}
-        {archivedChannels.length > 0 && (
-          <div className="mt-2">
-            <button
-              type="button"
-              onClick={() => setArchivedExpanded((v) => !v)}
-              className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/25 hover:text-white/40 transition-colors w-full text-left"
-              aria-expanded={archivedExpanded}
-              aria-controls="archived-channels-desktop"
-            >
-              <ChevronRight size={11} className={`transition-transform ${archivedExpanded ? "rotate-90" : ""}`} aria-hidden="true" />
-              <Archive size={11} aria-hidden="true" />
-              Archived ({archivedChannels.length})
-            </button>
-            <div id="archived-channels-desktop" className={archivedExpanded ? "" : "hidden"}>
-              {archivedChannels.map((ch) => {
-                const agentId = ch.settings?.archived_agent_id;
-                const hasAgent = agentId ? archivedAgents.some((a) => a.id === agentId) : false;
-                return (
-                  <div
-                    key={ch.id}
-                    className="group relative flex items-center opacity-60 hover:opacity-80 transition-opacity"
-                  >
-                    <Button
-                      variant={selectedChannel === ch.id ? "secondary" : "ghost"}
-                      onClick={() => setSelectedChannel(ch.id)}
-                      className="flex-1 justify-start h-auto py-1.5 pl-3 pr-1 text-[13px] rounded-none font-normal min-w-0"
-                      aria-label={`Archived channel ${ch.name}`}
-                    >
-                      <Archive size={11} className="shrink-0 mr-1.5 text-white/40" aria-hidden="true" />
-                      <span className="truncate flex-1 text-left">{ch.name}</span>
-                    </Button>
-                    {/* Per-row actions — only visible on hover */}
-                    <div className="hidden group-hover:flex items-center shrink-0 pr-1">
-                      <button
-                        type="button"
-                        onClick={() => handleRestoreArchivedChannel(ch.id, ch.name)}
-                        disabled={!hasAgent}
-                        aria-label={`Restore archived channel ${ch.name}`}
-                        title={hasAgent ? "Restore agent" : "Agent entry missing — delete only"}
-                        className={`p-1 rounded transition-colors ${hasAgent ? "text-white/30 hover:text-emerald-400 hover:bg-emerald-500/10 cursor-pointer" : "text-white/15 cursor-not-allowed"}`}
-                      >
-                        <RotateCcw size={12} aria-hidden="true" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteArchivedChannel(ch.id)}
-                        aria-label={`Permanently delete archived channel ${ch.name}`}
-                        title="Delete permanently"
-                        className="p-1 rounded text-white/30 hover:text-red-400 hover:bg-red-500/10 transition-colors cursor-pointer"
-                      >
-                        <Trash2 size={12} aria-hidden="true" />
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
-
-        {/* External taOSmd coordination bus (read-only) */}
-        <A2aBusSection
-          channels={bus.channels}
-          available={bus.available}
-          loaded={bus.loaded}
-          selected={busSelected}
-          onSelect={selectBusChannel}
-        />
-      </div>
-    </div>
+  const channelListUI = (
+    <ChannelSidebar
+      isMobile={isMobile}
+      wsStatus={wsStatus}
+      allEmpty={allEmpty}
+      sections={SECTIONS}
+      collapsedSections={collapsedSections}
+      onToggleSection={toggleSection}
+      visibleInSection={visibleInSection}
+      selectedChannel={selectedChannel}
+      onSelectChannel={setSelectedChannel}
+      unread={unread}
+      nowMs={nowMs}
+      liveAgents={liveAgents}
+      archivedAgents={archivedAgents}
+      archivedChannels={archivedChannels}
+      archivedExpanded={archivedExpanded}
+      onToggleArchived={() => setArchivedExpanded((v) => !v)}
+      scope={scope}
+      projectGroups={projectGroups}
+      projectsExpanded={projectsExpanded}
+      onToggleProjects={() => setProjectsExpanded((v) => !v)}
+      projectChannelExpanded={projectChannelExpanded}
+      onToggleProjectChannel={(projectId) =>
+        setProjectChannelExpanded((prev) => ({ ...prev, [projectId]: !(prev[projectId] !== false) }))
+      }
+      onOpenAgentsApp={openAgentsApp}
+      onRestoreArchivedChannel={handleRestoreArchivedChannel}
+      onDeleteArchivedChannel={handleDeleteArchivedChannel}
+      bus={bus}
+      busSelected={busSelected}
+      onSelectBusChannel={selectBusChannel}
+      formatRelativeTime={relativeTime}
+    />
   );
 
   /* ---------------------------------------------------------------- */

--- a/desktop/src/apps/chat/ChannelSidebar.tsx
+++ b/desktop/src/apps/chat/ChannelSidebar.tsx
@@ -1,0 +1,1137 @@
+import {
+  MessageCircle,
+  Hash,
+  Users,
+  Wifi,
+  WifiOff,
+  ChevronRight,
+  Bot,
+  Archive,
+  RotateCcw,
+  Trash2,
+} from "lucide-react";
+import { Button } from "@/components/ui";
+import { MessageAvatar } from "./MessageAvatar";
+import { A2aBusSection, type BusChannel } from "./A2aBusPanel";
+import type { Channel, LiveAgent, ArchivedAgentEntry, ProjectGroup, WsStatus } from "./types";
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface SectionDef {
+  label: string;
+  icon: React.ReactNode;
+  items: Channel[];
+}
+
+export interface ChannelSidebarProps {
+  isMobile: boolean;
+  wsStatus: WsStatus;
+  allEmpty: boolean;
+  sections: SectionDef[];
+  collapsedSections: Record<string, boolean>;
+  onToggleSection: (key: string) => void;
+  visibleInSection: (items: Channel[], key: string) => Channel[];
+  selectedChannel: string | null;
+  onSelectChannel: (id: string) => void;
+  unread: Record<string, number>;
+  /** Current time for relative timestamps — pass `Date.now()` or a cached value. */
+  nowMs: number;
+  liveAgents: LiveAgent[];
+  archivedAgents: ArchivedAgentEntry[];
+  archivedChannels: Channel[];
+  archivedExpanded: boolean;
+  onToggleArchived: () => void;
+  scope?: { projectId?: string };
+  projectGroups: ProjectGroup[];
+  projectsExpanded: boolean;
+  onToggleProjects: () => void;
+  projectChannelExpanded: Record<string, boolean>;
+  onToggleProjectChannel: (projectId: string) => void;
+  onOpenAgentsApp: () => void;
+  onRestoreArchivedChannel: (channelId: string, channelName: string) => void;
+  onDeleteArchivedChannel: (channelId: string) => void;
+  bus: {
+    channels: BusChannel[];
+    available: boolean;
+    loaded: boolean;
+  };
+  busSelected: string | null;
+  onSelectBusChannel: (channel: string) => void;
+  /** Relative time formatter. */
+  formatRelativeTime: (ts: number | string, nowMs: number) => string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function ChannelSidebar(props: ChannelSidebarProps) {
+  const {
+    isMobile,
+    wsStatus,
+    allEmpty,
+    sections,
+    collapsedSections,
+    onToggleSection,
+    visibleInSection,
+    selectedChannel,
+    onSelectChannel,
+    unread,
+    nowMs,
+    archivedChannels,
+    archivedExpanded,
+    onToggleArchived,
+    scope,
+    projectGroups,
+    projectsExpanded,
+    onToggleProjects,
+    projectChannelExpanded,
+    onToggleProjectChannel,
+    onOpenAgentsApp,
+    onRestoreArchivedChannel,
+    onDeleteArchivedChannel,
+    bus,
+    busSelected,
+    onSelectBusChannel,
+    formatRelativeTime,
+  } = props;
+
+  if (isMobile) {
+    return (
+      <div style={{ padding: "8px 0 16px" }}>
+        {/* connection status */}
+        <ConnectionStatus wsStatus={wsStatus} />
+
+        {allEmpty ? (
+          <EmptyState onOpenAgentsApp={onOpenAgentsApp} />
+        ) : (
+          sections.map((section) => (
+            <div key={section.label} style={{ marginBottom: 20 }}>
+              <button
+                type="button"
+                onClick={() => onToggleSection(section.label)}
+                aria-expanded={!collapsedSections[section.label]}
+                style={{
+                  fontSize: 12,
+                  textTransform: "uppercase" as const,
+                  letterSpacing: 0.5,
+                  color: "var(--color-shell-text-secondary)",
+                  padding: "0 20px 6px",
+                  fontWeight: 600,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  width: "100%",
+                }}
+              >
+                <ChevronRight
+                  size={13}
+                  aria-hidden="true"
+                  style={{
+                    transition: "transform 0.15s",
+                    transform: collapsedSections[section.label] ? "none" : "rotate(90deg)",
+                  }}
+                />
+                {section.icon} {section.label}
+              </button>
+              {visibleInSection(section.items, section.label).length === 0 ? (
+                collapsedSections[section.label] ? null : (
+                  <div
+                    style={{
+                      padding: "0 20px",
+                      fontSize: 12,
+                      color: "var(--color-shell-text-tertiary)",
+                      fontStyle: "italic",
+                    }}
+                  >
+                    None yet
+                  </div>
+                )
+              ) : (
+                <div
+                  style={{
+                    margin: "0 12px",
+                    borderRadius: 16,
+                    background: "var(--color-shell-surface)",
+                    border: "1px solid var(--color-shell-border)",
+                    overflow: "hidden",
+                  }}
+                >
+                  {visibleInSection(section.items, section.label).map(
+                    (ch, idx, arr) => {
+                      const isA2A = ch.settings?.kind === "a2a";
+                      const agentMember =
+                        ch.type === "dm"
+                          ? (ch.members ?? []).find((m) => m !== "user")
+                          : undefined;
+                      const count = unread[ch.id] ?? 0;
+                      return (
+                        <button
+                          key={ch.id}
+                          type="button"
+                          onClick={() => onSelectChannel(ch.id)}
+                          aria-label={`Channel ${ch.name}`}
+                          title={
+                            isA2A
+                              ? "Agent coordination — mention @<slug> to hand off."
+                              : undefined
+                          }
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 12,
+                            width: "100%",
+                            padding: "11px 14px",
+                            background:
+                              selectedChannel === ch.id
+                                ? "var(--color-shell-surface-active)"
+                                : "none",
+                            border: "none",
+                            borderBottom:
+                              idx === arr.length - 1
+                                ? "none"
+                                : "1px solid var(--color-shell-border)",
+                            cursor: "pointer",
+                            color: "inherit",
+                            textAlign: "left" as const,
+                          }}
+                        >
+                          {agentMember ? (
+                            <MessageAvatar
+                              size={38}
+                              authorId={agentMember}
+                              displayName={agentMember}
+                              kind="agent"
+                            />
+                          ) : isA2A ? (
+                            <div
+                              style={{
+                                width: 38,
+                                height: 38,
+                                borderRadius: 11,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                background: "var(--color-accent-soft)",
+                                border: "1px solid var(--color-accent-line)",
+                                color: "var(--color-accent-strong)",
+                                flexShrink: 0,
+                              }}
+                            >
+                              <Bot size={18} aria-hidden />
+                            </div>
+                          ) : (
+                            <div
+                              style={{
+                                width: 38,
+                                height: 38,
+                                borderRadius: 11,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                background:
+                                  "var(--color-shell-surface-active)",
+                                color: "var(--color-shell-text-secondary)",
+                                flexShrink: 0,
+                              }}
+                            >
+                              {ch.type === "group" ? (
+                                <Users size={18} aria-hidden />
+                              ) : (
+                                <Hash size={18} aria-hidden />
+                              )}
+                            </div>
+                          )}
+                          <div style={{ flex: 1, minWidth: 0 }}>
+                            <div
+                              style={{
+                                display: "flex",
+                                alignItems: "baseline",
+                                gap: 8,
+                              }}
+                            >
+                              <span
+                                style={{
+                                  flex: 1,
+                                  fontSize: 15,
+                                  fontWeight: count > 0 ? 700 : 600,
+                                  color: "var(--color-shell-text)",
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {ch.name}
+                              </span>
+                              {ch.last_message_at && (
+                                <span
+                                  style={{
+                                    fontSize: 11,
+                                    color: "var(--color-shell-text-tertiary)",
+                                    flexShrink: 0,
+                                  }}
+                                >
+                                  {formatRelativeTime(ch.last_message_at, nowMs)}
+                                </span>
+                              )}
+                            </div>
+                            {ch.lastPreview && (
+                              <div
+                                style={{
+                                  fontSize: 13,
+                                  color: "var(--color-shell-text-secondary)",
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                  marginTop: 1,
+                                }}
+                              >
+                                {ch.lastPreview}
+                              </div>
+                            )}
+                          </div>
+                          {count > 0 && (
+                            <span
+                              style={{
+                                background: "var(--color-unread)",
+                                color: "#fff",
+                                fontSize: 10,
+                                fontWeight: 700,
+                                borderRadius: 9999,
+                                minWidth: 18,
+                                height: 18,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                padding: "0 5px",
+                                flexShrink: 0,
+                              }}
+                            >
+                              {count}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    },
+                  )}
+                </div>
+              )}
+            </div>
+          ))
+        )}
+
+        {/* Projects section — mobile */}
+        <ProjectsSectionMobile
+          projectGroups={projectGroups}
+          projectsExpanded={projectsExpanded}
+          onToggleProjects={onToggleProjects}
+          projectChannelExpanded={projectChannelExpanded}
+          onToggleProjectChannel={onToggleProjectChannel}
+          selectedChannel={selectedChannel}
+          onSelectChannel={onSelectChannel}
+          unread={unread}
+          scope={scope}
+        />
+
+        {/* Archived channels — mobile */}
+        <ArchivedSection
+          isMobile={true}
+          archivedChannels={archivedChannels}
+          archivedExpanded={archivedExpanded}
+          onToggleArchived={onToggleArchived}
+          selectedChannel={selectedChannel}
+          onSelectChannel={onSelectChannel}
+          onRestoreArchivedChannel={onRestoreArchivedChannel}
+          onDeleteArchivedChannel={onDeleteArchivedChannel}
+          archivedAgents={props.archivedAgents}
+        />
+
+        {/* External taOSmd coordination bus (read-only) */}
+        <A2aBusSection
+          channels={bus.channels}
+          available={bus.available}
+          loaded={bus.loaded}
+          selected={busSelected}
+          onSelect={onSelectBusChannel}
+        />
+      </div>
+    );
+  }
+
+  /* Desktop: compact sidebar */
+  return (
+    <div className="w-full flex flex-col h-full">
+      {/* connection status */}
+      <div className="px-3 py-1.5 text-[11px] flex items-center gap-1.5">
+        {wsStatus === "connected" ? (
+          <>
+            <Wifi size={11} className="text-emerald-400" />
+            <span className="text-emerald-400/80">Connected</span>
+          </>
+        ) : wsStatus === "connecting" ? (
+          <>
+            <Wifi size={11} className="text-amber-400 animate-pulse" />
+            <span className="text-amber-400/80">Connecting...</span>
+          </>
+        ) : (
+          <>
+            <WifiOff size={11} className="text-red-400" />
+            <span className="text-red-400/80">Offline</span>
+          </>
+        )}
+      </div>
+
+      {/* channel list */}
+      <div className="flex-1 overflow-y-auto py-1">
+        {allEmpty ? (
+          <div className="flex flex-col items-center justify-center h-full px-4 py-10 text-center gap-2.5">
+            <MessageCircle size={28} className="text-white/15" aria-hidden="true" />
+            <p className="text-[13px] font-medium text-white/60">
+              No conversations yet
+            </p>
+            <p className="text-[11px] text-white/30">
+              Deploy an agent to start chatting
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onOpenAgentsApp}
+              className="mt-1 text-xs"
+            >
+              Open Agents
+            </Button>
+          </div>
+        ) : (
+          sections.map((section) => (
+            <div key={section.label}>
+              <button
+                type="button"
+                onClick={() => onToggleSection(section.label)}
+                aria-expanded={!collapsedSections[section.label]}
+                className="w-full px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/30 hover:text-white/50 flex items-center gap-1.5 transition-colors"
+              >
+                <ChevronRight
+                  size={11}
+                  aria-hidden="true"
+                  className={`transition-transform ${
+                    collapsedSections[section.label] ? "" : "rotate-90"
+                  }`}
+                />
+                {section.icon} {section.label}
+              </button>
+              {!collapsedSections[section.label] &&
+                section.items.length === 0 && (
+                  <div className="px-3 py-1 text-[11px] text-white/20 italic">
+                    None yet
+                  </div>
+                )}
+              <div className="px-2 flex flex-col gap-px">
+                {visibleInSection(section.items, section.label).map((ch) => {
+                  const isA2A = ch.settings?.kind === "a2a";
+                  const agentMember =
+                    ch.type === "dm"
+                      ? (ch.members ?? []).find((m) => m !== "user")
+                      : undefined;
+                  const count = unread[ch.id] ?? 0;
+                  return (
+                    <button
+                      key={ch.id}
+                      type="button"
+                      onClick={() => onSelectChannel(ch.id)}
+                      aria-pressed={selectedChannel === ch.id}
+                      className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-[10px] text-left transition-colors ${
+                        selectedChannel === ch.id
+                          ? "bg-shell-surface-active"
+                          : "hover:bg-shell-surface-hover"
+                      }`}
+                      aria-label={`Channel ${ch.name}`}
+                      title={
+                        isA2A
+                          ? "Agent coordination — mention @<slug> to hand off."
+                          : undefined
+                      }
+                    >
+                      {agentMember ? (
+                        <MessageAvatar
+                          size={30}
+                          authorId={agentMember}
+                          displayName={agentMember}
+                          kind="agent"
+                        />
+                      ) : isA2A ? (
+                        <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-accent-soft border border-accent-line text-accent-strong">
+                          <Bot size={15} aria-hidden />
+                        </span>
+                      ) : (
+                        <span className="shrink-0 grid place-items-center w-[30px] h-[30px] rounded-[9px] bg-shell-surface-active text-shell-text-secondary">
+                          {ch.type === "group" ? (
+                            <Users size={15} aria-hidden />
+                          ) : (
+                            <Hash size={15} aria-hidden />
+                          )}
+                        </span>
+                      )}
+                      <span
+                        className={`truncate flex-1 text-[14px] tracking-tight ${
+                          count > 0
+                            ? "font-bold text-shell-text"
+                            : "font-semibold text-shell-text"
+                        }`}
+                      >
+                        {ch.name}
+                      </span>
+                      {count > 0 && (
+                        <span className="shrink-0 bg-unread text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 tabular-nums">
+                          {count}
+                        </span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))
+        )}
+
+        {/* Projects section — desktop */}
+        {!scope?.projectId && projectGroups.length > 0 && (
+          <details className="px-3 mt-2">
+            <summary className="cursor-pointer text-[10px] font-semibold uppercase tracking-wider text-white/30 py-1">
+              Projects
+            </summary>
+            {projectGroups.map((g) => (
+              <details key={g.id} className="ml-2 mt-1">
+                <summary className="cursor-pointer text-xs text-white/60 py-1">
+                  {g.name}
+                </summary>
+                <div className="ml-2 mt-0.5">
+                  {g.channels.map((ch) => (
+                    <button
+                      key={ch.id}
+                      type="button"
+                      onClick={() => onSelectChannel(ch.id)}
+                      aria-pressed={selectedChannel === ch.id}
+                      aria-label={`Channel ${ch.name}`}
+                      title={
+                        ch.settings?.kind === "a2a"
+                          ? "Agent coordination — mention @<slug> to hand off."
+                          : undefined
+                      }
+                      className={`w-full text-left text-xs py-1 px-2 rounded flex items-center gap-1.5 ${
+                        selectedChannel === ch.id
+                          ? "bg-white/10"
+                          : "hover:bg-white/5"
+                      }`}
+                    >
+                      {ch.settings?.kind === "a2a" && (
+                        <Bot
+                          size={12}
+                          aria-hidden
+                          style={{
+                            color: "rgba(255,255,255,0.6)",
+                            flexShrink: 0,
+                          }}
+                        />
+                      )}
+                      {ch.name}
+                    </button>
+                  ))}
+                </div>
+              </details>
+            ))}
+          </details>
+        )}
+
+        {/* Archived channels section — desktop */}
+        <ArchivedSection
+          isMobile={false}
+          archivedChannels={archivedChannels}
+          archivedExpanded={archivedExpanded}
+          onToggleArchived={onToggleArchived}
+          selectedChannel={selectedChannel}
+          onSelectChannel={onSelectChannel}
+          onRestoreArchivedChannel={onRestoreArchivedChannel}
+          onDeleteArchivedChannel={onDeleteArchivedChannel}
+          archivedAgents={props.archivedAgents}
+        />
+
+        {/* External taOSmd coordination bus (read-only) */}
+        <A2aBusSection
+          channels={bus.channels}
+          available={bus.available}
+          loaded={bus.loaded}
+          selected={busSelected}
+          onSelect={onSelectBusChannel}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Internal sub-components                                            */
+/* ------------------------------------------------------------------ */
+
+function ConnectionStatus({ wsStatus }: { wsStatus: WsStatus }) {
+  return (
+    <div
+      style={{
+        padding: "0 20px 8px",
+        fontSize: 11,
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+      }}
+    >
+      {wsStatus === "connected" ? (
+        <>
+          <Wifi size={11} style={{ color: "#34d399" }} />
+          <span style={{ color: "rgba(52,211,153,0.8)" }}>Connected</span>
+        </>
+      ) : wsStatus === "connecting" ? (
+        <>
+          <Wifi size={11} style={{ color: "#fbbf24" }} />
+          <span style={{ color: "rgba(251,191,36,0.8)" }}>Connecting…</span>
+        </>
+      ) : (
+        <>
+          <WifiOff size={11} style={{ color: "#f87171" }} />
+          <span style={{ color: "rgba(248,113,113,0.8)" }}>Offline</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ onOpenAgentsApp }: { onOpenAgentsApp: () => void }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "48px 24px",
+        textAlign: "center",
+        gap: 12,
+      }}
+    >
+      <MessageCircle
+        size={36}
+        style={{ color: "var(--color-shell-text-tertiary)" }}
+        aria-hidden="true"
+      />
+      <p
+        style={{
+          fontSize: 15,
+          fontWeight: 600,
+          color: "var(--color-shell-text)",
+          margin: 0,
+        }}
+      >
+        No conversations yet
+      </p>
+      <p
+        style={{
+          fontSize: 13,
+          color: "var(--color-shell-text-secondary)",
+          margin: 0,
+        }}
+      >
+        Deploy an agent to start chatting
+      </p>
+      <button
+        type="button"
+        onClick={onOpenAgentsApp}
+        style={{
+          marginTop: 4,
+          fontSize: 13,
+          padding: "8px 16px",
+          borderRadius: 10,
+          background: "var(--color-accent-soft)",
+          border: "1px solid var(--color-accent-line)",
+          color: "var(--color-accent-strong)",
+          cursor: "pointer",
+        }}
+      >
+        Open Agents
+      </button>
+    </div>
+  );
+}
+
+function ProjectsSectionMobile({
+  projectGroups,
+  projectsExpanded,
+  onToggleProjects,
+  projectChannelExpanded,
+  onToggleProjectChannel,
+  selectedChannel,
+  onSelectChannel,
+  unread,
+  scope,
+}: {
+  projectGroups: ProjectGroup[];
+  projectsExpanded: boolean;
+  onToggleProjects: () => void;
+  projectChannelExpanded: Record<string, boolean>;
+  onToggleProjectChannel: (projectId: string) => void;
+  selectedChannel: string | null;
+  onSelectChannel: (id: string) => void;
+  unread: Record<string, number>;
+  scope?: { projectId?: string };
+}) {
+  if (scope?.projectId || projectGroups.length === 0) return null;
+
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <button
+        type="button"
+        onClick={onToggleProjects}
+        aria-expanded={projectsExpanded}
+        aria-controls="projects-section-mobile"
+        style={{
+          fontSize: 12,
+          textTransform: "uppercase" as const,
+          letterSpacing: 0.5,
+          color: "var(--color-shell-text-secondary)",
+          padding: "0 20px 6px",
+          fontWeight: 600,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          width: "100%",
+        }}
+      >
+        <ChevronRight
+          size={12}
+          style={{
+            transition: "transform 0.15s",
+            transform: projectsExpanded ? "rotate(90deg)" : "none",
+            color: "var(--color-shell-text-tertiary)",
+          }}
+          aria-hidden="true"
+        />
+        Projects ({projectGroups.length})
+      </button>
+      <div
+        id="projects-section-mobile"
+        style={{ display: projectsExpanded ? "block" : "none" }}
+      >
+        {projectGroups.map((g) => {
+          const isOpen = projectChannelExpanded[g.id] !== false;
+          return (
+            <div key={g.id} style={{ marginBottom: 12 }}>
+              <button
+                type="button"
+                onClick={() => onToggleProjectChannel(g.id)}
+                aria-expanded={isOpen}
+                aria-controls={`project-section-mobile-${g.id}`}
+                style={{
+                  fontSize: 11,
+                  color: "var(--color-shell-text-secondary)",
+                  padding: "0 20px 4px",
+                  fontWeight: 600,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  background: "none",
+                  border: "none",
+                  cursor: "pointer",
+                  width: "100%",
+                }}
+              >
+                <ChevronRight
+                  size={10}
+                  style={{
+                    transition: "transform 0.15s",
+                    transform: isOpen ? "rotate(90deg)" : "none",
+                    color: "var(--color-shell-text-tertiary)",
+                  }}
+                  aria-hidden="true"
+                />
+                {g.name}
+              </button>
+              <div
+                id={`project-section-mobile-${g.id}`}
+                style={{ display: isOpen ? "block" : "none" }}
+              >
+                <div
+                  style={{
+                    margin: "0 12px",
+                    borderRadius: 16,
+                    background: "rgba(255,255,255,0.05)",
+                    border: "1px solid rgba(255,255,255,0.08)",
+                    overflow: "hidden",
+                  }}
+                >
+                  {g.channels.map((ch, idx, arr) => (
+                    <button
+                      key={ch.id}
+                      type="button"
+                      onClick={() => onSelectChannel(ch.id)}
+                      aria-label={`Channel ${ch.name}`}
+                      title={
+                        ch.settings?.kind === "a2a"
+                          ? "Agent coordination — mention @<slug> to hand off."
+                          : undefined
+                      }
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 10,
+                        width: "100%",
+                        padding: "14px 16px",
+                        background:
+                          selectedChannel === ch.id
+                            ? "var(--color-shell-surface-active)"
+                            : "none",
+                        border: "none",
+                        borderBottom:
+                          idx === arr.length - 1
+                            ? "none"
+                            : "1px solid var(--color-shell-border)",
+                        cursor: "pointer",
+                        color: "inherit",
+                        textAlign: "left" as const,
+                      }}
+                    >
+                      {ch.settings?.kind === "a2a" && (
+                        <Bot
+                          size={14}
+                          aria-hidden
+                          style={{
+                            color: "var(--color-shell-text-secondary)",
+                            flexShrink: 0,
+                          }}
+                        />
+                      )}
+                      <span
+                        style={{
+                          flex: 1,
+                          fontSize: 15,
+                          fontWeight: 400,
+                          color: "var(--color-shell-text)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {ch.name}
+                      </span>
+                      {(unread[ch.id] ?? 0) > 0 && (
+                        <span
+                          style={{
+                            background: "var(--color-unread)",
+                            color: "#fff",
+                            fontSize: 10,
+                            fontWeight: 700,
+                            borderRadius: 9999,
+                            minWidth: 18,
+                            height: 18,
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            padding: "0 4px",
+                          }}
+                        >
+                          {unread[ch.id]}
+                        </span>
+                      )}
+                      <ChevronRight
+                        size={16}
+                        style={{
+                          color: "var(--color-shell-text-tertiary)",
+                          flexShrink: 0,
+                        }}
+                      />
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ArchivedSection({
+  isMobile,
+  archivedChannels,
+  archivedExpanded,
+  onToggleArchived,
+  selectedChannel,
+  onSelectChannel,
+  onRestoreArchivedChannel,
+  onDeleteArchivedChannel,
+  archivedAgents,
+}: {
+  isMobile: boolean;
+  archivedChannels: Channel[];
+  archivedExpanded: boolean;
+  onToggleArchived: () => void;
+  selectedChannel: string | null;
+  onSelectChannel: (id: string) => void;
+  onRestoreArchivedChannel: (channelId: string, name: string) => void;
+  onDeleteArchivedChannel: (channelId: string) => void;
+  archivedAgents: ArchivedAgentEntry[];
+}) {
+  if (archivedChannels.length === 0) return null;
+
+  if (isMobile) {
+    return (
+      <div style={{ marginBottom: 20 }}>
+        <button
+          type="button"
+          onClick={onToggleArchived}
+          aria-expanded={archivedExpanded}
+          aria-controls="archived-channels-mobile"
+          style={{
+            fontSize: 12,
+            textTransform: "uppercase" as const,
+            letterSpacing: 0.5,
+            color: "var(--color-shell-text-tertiary)",
+            padding: "0 20px 6px",
+            fontWeight: 600,
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            background: "none",
+            border: "none",
+            cursor: "pointer",
+            width: "100%",
+          }}
+        >
+          <ChevronRight
+            size={12}
+            style={{
+              transition: "transform 0.15s",
+              transform: archivedExpanded ? "rotate(90deg)" : "none",
+              color: "var(--color-shell-text-tertiary)",
+            }}
+            aria-hidden="true"
+          />
+          <Archive size={12} aria-hidden="true" />
+          Archived ({archivedChannels.length})
+        </button>
+        <div
+          id="archived-channels-mobile"
+          style={{ display: archivedExpanded ? "block" : "none" }}
+        >
+          <div
+            style={{
+              margin: "0 12px",
+              borderRadius: 16,
+              background: "rgba(255,255,255,0.03)",
+              border: "1px solid rgba(255,255,255,0.06)",
+              overflow: "hidden",
+            }}
+          >
+            {archivedChannels.map((ch, idx, arr) => {
+              const agentId = ch.settings?.archived_agent_id;
+              const hasAgent = agentId
+                ? archivedAgents.some((a) => a.id === agentId)
+                : false;
+              return (
+                <div
+                  key={ch.id}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    borderBottom:
+                      idx === arr.length - 1
+                        ? "none"
+                        : "1px solid rgba(255,255,255,0.04)",
+                    opacity: 0.6,
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => onSelectChannel(ch.id)}
+                    aria-label={`Archived channel ${ch.name}`}
+                    style={{
+                      flex: 1,
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "12px 8px 12px 16px",
+                      background:
+                        selectedChannel === ch.id
+                          ? "var(--color-shell-surface-active)"
+                          : "none",
+                      border: "none",
+                      cursor: "pointer",
+                      color: "inherit",
+                      textAlign: "left" as const,
+                      minWidth: 0,
+                    }}
+                  >
+                    <Archive
+                      size={11}
+                      aria-hidden="true"
+                      style={{
+                        color: "var(--color-shell-text-tertiary)",
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span
+                      style={{
+                        flex: 1,
+                        fontSize: 14,
+                        color: "var(--color-shell-text-secondary)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {ch.name}
+                    </span>
+                  </button>
+                  <div style={{ display: "flex", gap: 2, paddingRight: 8 }}>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        onRestoreArchivedChannel(ch.id, ch.name)
+                      }
+                      disabled={!hasAgent}
+                      aria-label={`Restore archived channel ${ch.name}`}
+                      title={
+                        hasAgent
+                          ? "Restore agent"
+                          : "Agent entry missing — delete only"
+                      }
+                      style={{
+                        background: "none",
+                        border: "none",
+                        cursor: hasAgent ? "pointer" : "not-allowed",
+                        color: hasAgent
+                          ? "rgba(52,211,153,0.7)"
+                          : "rgba(255,255,255,0.2)",
+                        padding: "6px",
+                      }}
+                    >
+                      <RotateCcw size={13} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDeleteArchivedChannel(ch.id)}
+                      aria-label={`Permanently delete archived channel ${ch.name}`}
+                      title="Delete permanently"
+                      style={{
+                        background: "none",
+                        border: "none",
+                        cursor: "pointer",
+                        color: "rgba(248,113,113,0.7)",
+                        padding: "6px",
+                      }}
+                    >
+                      <Trash2 size={13} aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  /* Desktop archived section */
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={onToggleArchived}
+        className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-white/25 hover:text-white/40 transition-colors w-full text-left"
+        aria-expanded={archivedExpanded}
+        aria-controls="archived-channels-desktop"
+      >
+        <ChevronRight
+          size={11}
+          className={`transition-transform ${
+            archivedExpanded ? "rotate-90" : ""
+          }`}
+          aria-hidden="true"
+        />
+        <Archive size={11} aria-hidden="true" />
+        Archived ({archivedChannels.length})
+      </button>
+      <div
+        id="archived-channels-desktop"
+        className={archivedExpanded ? "" : "hidden"}
+      >
+        {archivedChannels.map((ch) => {
+          const agentId = ch.settings?.archived_agent_id;
+          const hasAgent = agentId
+            ? archivedAgents.some((a) => a.id === agentId)
+            : false;
+          return (
+            <div
+              key={ch.id}
+              className="group relative flex items-center opacity-60 hover:opacity-80 transition-opacity"
+            >
+              <Button
+                variant={
+                  selectedChannel === ch.id ? "secondary" : "ghost"
+                }
+                onClick={() => onSelectChannel(ch.id)}
+                className="flex-1 justify-start h-auto py-1.5 pl-3 pr-1 text-[13px] rounded-none font-normal min-w-0"
+                aria-label={`Archived channel ${ch.name}`}
+              >
+                <Archive
+                  size={11}
+                  className="shrink-0 mr-1.5 text-white/40"
+                  aria-hidden="true"
+                />
+                <span className="truncate flex-1 text-left">{ch.name}</span>
+              </Button>
+              <div className="hidden group-hover:flex items-center shrink-0 pr-1">
+                <button
+                  type="button"
+                  onClick={() =>
+                    onRestoreArchivedChannel(ch.id, ch.name)
+                  }
+                  disabled={!hasAgent}
+                  aria-label={`Restore archived channel ${ch.name}`}
+                  title={
+                    hasAgent
+                      ? "Restore agent"
+                      : "Agent entry missing — delete only"
+                  }
+                  className={`p-1 rounded transition-colors ${
+                    hasAgent
+                      ? "text-white/30 hover:text-emerald-400 hover:bg-emerald-500/10 cursor-pointer"
+                      : "text-white/15 cursor-not-allowed"
+                  }`}
+                >
+                  <RotateCcw size={12} aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDeleteArchivedChannel(ch.id)}
+                  aria-label={`Permanently delete archived channel ${ch.name}`}
+                  title="Delete permanently"
+                  className="p-1 rounded text-white/30 hover:text-red-400 hover:bg-red-500/10 transition-colors cursor-pointer"
+                >
+                  <Trash2 size={12} aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/chat/MessageInput.tsx
+++ b/desktop/src/apps/chat/MessageInput.tsx
@@ -1,0 +1,193 @@
+import { useRef, useCallback } from "react";
+import { Send, Paperclip, AtSign } from "lucide-react";
+import { Button, Textarea } from "@/components/ui";
+import { SlashMenu, type SlashCommandsBySlug } from "./SlashMenu";
+import { AttachmentsBar, type PendingAttachment } from "./AttachmentsBar";
+import type { Channel } from "./types";
+
+export interface MessageInputProps {
+  /** Current input text. */
+  value: string;
+  /** Called when the user types. */
+  onChange: (value: string) => void;
+  /** Called on Enter (no shift). */
+  onSend: () => void;
+  /** The active channel. */
+  channel: Channel | undefined;
+  /** Whether the current channel is archived. */
+  isArchived: boolean;
+  /** Whether mobile layout is active. */
+  isMobile: boolean;
+  /** Keyboard inset for mobile safe-area handling. */
+  keyboardInset: number;
+  /** Slash commands by slug. */
+  slashCommands: SlashCommandsBySlug;
+
+  /* ---- slash menu derived state (computed by parent) ---- */
+  showSlash: boolean;
+  slashQuery: string;
+  slashAgent: string | undefined;
+
+  /* ---- @mention state (computed by parent) ---- */
+  mention: { partial: string; atIndex: number } | null;
+  mentionCandidates: string[];
+  mentionSel: number;
+  onMentionSelChange: (sel: number) => void;
+  onInsertMention: (slug: string | undefined) => void;
+  onDismissMention: () => void;
+
+  /* ---- attachments ---- */
+  pendingAttachments: PendingAttachment[];
+  onRemoveAttachment: (id: string) => void;
+  onRetryAttachment: (id: string) => void;
+
+  /* ---- callbacks ---- */
+  onFileUpload: () => void;
+  onSlashPick: (slug: string, cmd: string) => void;
+  onSlashClose: () => void;
+}
+
+export function MessageInput({
+  value,
+  onChange,
+  onSend,
+  channel,
+  isArchived,
+  isMobile,
+  keyboardInset,
+  slashCommands,
+  showSlash,
+  slashQuery,
+  slashAgent,
+  mention,
+  mentionCandidates,
+  mentionSel,
+  onMentionSelChange,
+  onInsertMention,
+  onDismissMention,
+  pendingAttachments,
+  onRemoveAttachment,
+  onRetryAttachment,
+  onFileUpload,
+  onSlashPick,
+  onSlashClose,
+}: MessageInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        onSend();
+      }
+    },
+    [onSend],
+  );
+
+  return (
+    <>
+      {/* pending attachments bar */}
+      <AttachmentsBar
+        items={pendingAttachments}
+        onRemove={onRemoveAttachment}
+        onRetry={onRetryAttachment}
+      />
+
+      {/* input area */}
+      <div
+        className="px-4 py-3 border-t border-white/[0.06] shrink-0"
+        style={
+          isMobile
+            ? { paddingBottom: `max(env(safe-area-inset-bottom), ${keyboardInset}px)` }
+            : undefined
+        }
+      >
+        <div className="relative">
+          {showSlash && (
+            <SlashMenu
+              commands={slashCommands}
+              queryAfterSlash={slashQuery}
+              members={channel?.members || []}
+              scopedAgent={slashAgent}
+              onPick={onSlashPick}
+              onClose={onSlashClose}
+            />
+          )}
+          {mention && mentionCandidates.length > 0 && !showSlash && (
+            <div
+              role="listbox"
+              aria-label="Mention a member"
+              className="absolute bottom-full left-0 mb-2 w-full max-w-md bg-shell-surface border border-white/10 rounded-lg shadow-xl max-h-60 overflow-y-auto text-sm"
+            >
+              {mentionCandidates.map((slug, i) => (
+                <button
+                  key={slug}
+                  role="option"
+                  aria-selected={i === mentionSel}
+                  onMouseEnter={() => onMentionSelChange(i)}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    onInsertMention(slug);
+                  }}
+                  className={`w-full text-left px-3 py-1.5 flex items-center gap-2 ${
+                    i === mentionSel ? "bg-white/10" : "hover:bg-white/5"
+                  }`}
+                >
+                  <AtSign size={13} className="text-white/40" aria-hidden="true" />
+                  <span className="font-mono text-[13px]">@{slug}</span>
+                </button>
+              ))}
+            </div>
+          )}
+          <div
+            className={`flex items-end gap-2 rounded-2xl border px-2 py-1.5 ${
+              isArchived
+                ? "bg-white/[0.02] border-white/[0.04] opacity-50"
+                : "bg-shell-surface border-shell-border-strong"
+            }`}
+          >
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onFileUpload}
+              className="h-8 w-8 shrink-0 mb-0.5"
+              aria-label="Upload file"
+              disabled={isArchived}
+            >
+              <Paperclip size={16} />
+            </Button>
+            <Textarea
+              ref={textareaRef}
+              value={value}
+              onChange={(e) => !isArchived && onChange(e.target.value)}
+              onKeyDown={(e) => !isArchived && handleKeyDown(e)}
+              onBlur={() => onDismissMention()}
+              placeholder={
+                isArchived
+                  ? "This chat is archived"
+                  : `Message #${channel?.name ?? ""}...`
+              }
+              rows={1}
+              disabled={isArchived}
+              className="flex-1 bg-transparent border-0 px-1 py-1.5 min-h-0 text-[13px] focus-visible:ring-0 focus-visible:border-0 max-h-[120px] disabled:cursor-not-allowed"
+              aria-label="Message input"
+            />
+            <Button
+              size="icon"
+              onClick={onSend}
+              disabled={
+                (!value.trim() && pendingAttachments.length === 0) ||
+                isArchived ||
+                pendingAttachments.some((a) => a.uploading)
+              }
+              className="h-8 w-8 shrink-0 mb-0.5"
+              aria-label="Send message"
+            >
+              <Send size={15} />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/desktop/src/apps/chat/MessageInput.tsx
+++ b/desktop/src/apps/chat/MessageInput.tsx
@@ -45,6 +45,8 @@ export interface MessageInputProps {
   onFileUpload: () => void;
   onSlashPick: (slug: string, cmd: string) => void;
   onSlashClose: () => void;
+  /** Optional paste handler (e.g. image upload from clipboard). */
+  onPaste?: (e: React.ClipboardEvent) => void;
 }
 
 export function MessageInput({
@@ -71,6 +73,7 @@ export function MessageInput({
   onFileUpload,
   onSlashPick,
   onSlashClose,
+  onPaste,
 }: MessageInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -162,6 +165,7 @@ export function MessageInput({
               onChange={(e) => !isArchived && onChange(e.target.value)}
               onKeyDown={(e) => !isArchived && handleKeyDown(e)}
               onBlur={() => onDismissMention()}
+              onPaste={onPaste}
               placeholder={
                 isArchived
                   ? "This chat is archived"

--- a/desktop/src/apps/chat/MessageList.tsx
+++ b/desktop/src/apps/chat/MessageList.tsx
@@ -1,0 +1,836 @@
+import React, { useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+import {
+  Hash,
+  Users,
+  AtSign,
+  Bot,
+  MessageCircle,
+  ChevronDown,
+  MessagesSquare,
+  Search,
+  PanelRight,
+} from "lucide-react";
+import Picker, { Theme } from "emoji-picker-react";
+import { Button } from "@/components/ui";
+import { MessageAvatar } from "./MessageAvatar";
+import { MessageHoverActions } from "./MessageHoverActions";
+import { MessageEditor } from "./MessageEditor";
+import { MessageTombstone } from "./MessageTombstone";
+import { ThreadIndicator } from "./ThreadIndicator";
+import { AttachmentGallery } from "./AttachmentGallery";
+import { PinBadge } from "./PinBadge";
+import { PinnedMessagesPopover, type PinnedMessage } from "./PinnedMessagesPopover";
+import { TypingFooter, type AgentTyping } from "./TypingFooter";
+import { PinRequestAffordance } from "./PinRequestAffordance";
+import { ReactionBar } from "./ReactionBar";
+import { resolveAgentEmoji } from "@/lib/agent-emoji";
+import { startDrag, endDrag } from "@/shell/dnd/dnd-bus";
+import { renderContent, dayLabel, relativeTime, toMs, resolveAuthorDisplayState } from "../MessagesApp";
+import type { AttachmentRecord } from "@/lib/chat-attachments-api";
+import { displayAuthor } from "./format-author";
+import type { LiveAgent, ArchivedAgentEntry, Channel } from "./types";
+
+const EMOJI_PICKER = ["👍", "❤️", "😂", "🎉", "🤔", "👀", "🚀", "✅"];
+
+export interface MessageRow {
+  id: string;
+  channel_id: string;
+  author_id: string;
+  author_type: "user" | "agent";
+  content: string;
+  thread_id?: string;
+  content_type?: "text" | "canvas" | string;
+  metadata?: {
+    canvas_id?: string;
+    canvas_url?: string;
+    canvas_title?: string;
+    pin_requested?: boolean;
+    [key: string]: unknown;
+  };
+  state?: "pending" | "streaming" | "complete" | "error";
+  created_at: number | string;
+  reactions?: Record<string, string[]>;
+  edited_at?: number | string;
+  deleted_at?: number | null;
+  attachments?: AttachmentRecord[];
+  reply_count?: number;
+  last_reply_at?: number | null;
+}
+
+export interface MessageListProps {
+  /** Messages to render. */
+  messages: MessageRow[];
+  /** ID of the channel whose messages were last fetched. */
+  fetchedChannel: string | null;
+  /** Current channel. */
+  channel: Channel | undefined;
+  /** Current selected channel id. */
+  selectedChannel: string | null;
+  /** Whether mobile layout is active. */
+  isMobile: boolean;
+  /** Keyboard inset for mobile safe-area handling. */
+  keyboardInset: number;
+  /** Current time for relative timestamps. */
+  nowMs: number;
+
+  /* ---- author resolution ---- */
+  liveAgents: LiveAgent[];
+  archivedAgents: ArchivedAgentEntry[];
+  currentUserId: string | null;
+  currentUserDisplayName: string | null;
+
+  /* ---- pinned messages ---- */
+  pinnedMessages: PinnedMessage[];
+  pinnedPopoverOpen: boolean;
+  onTogglePinnedPopover: () => void;
+
+  /* ---- editing ---- */
+  editingMessageId: string | null;
+  onCancelEdit: () => void;
+  onSaveEdit: (msgId: string, content: string) => void;
+
+  /* ---- reactions ---- */
+  onToggleReaction: (messageId: string, emoji: string) => void;
+  showEmoji: { messageId: string; rect: DOMRect } | null;
+  onShowEmoji: (v: { messageId: string; rect: DOMRect } | null) => void;
+
+  /* ---- hover / overflow ---- */
+  hoveredMessageId: string | null;
+  onHoverMessage: (id: string | null) => void;
+  onReplyInThread: (channelId: string, parentId: string) => void;
+  onOverflow: (e: React.MouseEvent, messageId: string) => void;
+
+  /* ---- thread indicator ---- */
+  onOpenThread: (channelId: string, parentId: string) => void;
+
+  /* ---- pin request ---- */
+  onApprovePinRequest: (messageId: string) => void;
+
+  /* ---- canvas ---- */
+  onViewCanvas: (v: { url: string; title?: string } | null) => void;
+
+  /* ---- new divider ---- */
+  newDividerAtId: string | null;
+
+  /* ---- scroll-to-bottom ---- */
+  atBottom: boolean;
+  newCount: number;
+  onScrollToLatest: () => void;
+  onScroll: () => void;
+
+  /* ---- drop target ---- */
+  dropTarget: {
+    isOver: boolean;
+    isValidTarget: boolean;
+    handlers: {
+      onDragEnter: (e: React.DragEvent) => void;
+      onDragOver: (e: React.DragEvent) => void;
+      onDragLeave: (e: React.DragEvent) => void;
+      onDrop: (e: React.DragEvent) => void;
+    };
+  };
+
+  /* ---- thread/view toggles ---- */
+  showAllThreads: boolean;
+  onToggleAllThreads: () => void;
+  showSearch: boolean;
+  onToggleSearch: () => void;
+  onOpenSettings: () => void;
+
+  /* ---- typing ---- */
+  typingHumans: string[];
+  typingAgents: AgentTyping[];
+}
+
+export function MessageList({
+  messages,
+  fetchedChannel,
+  channel,
+  selectedChannel,
+  isMobile,
+  keyboardInset,
+  nowMs,
+  liveAgents,
+  archivedAgents,
+  currentUserId,
+  currentUserDisplayName,
+  pinnedMessages,
+  pinnedPopoverOpen,
+  onTogglePinnedPopover,
+  editingMessageId,
+  onCancelEdit,
+  onSaveEdit,
+  onToggleReaction,
+  showEmoji,
+  onShowEmoji,
+  hoveredMessageId,
+  onHoverMessage,
+  onReplyInThread,
+  onOverflow,
+  onOpenThread,
+  onApprovePinRequest,
+  onViewCanvas,
+  newDividerAtId,
+  atBottom,
+  newCount,
+  onScrollToLatest,
+  onScroll,
+  dropTarget,
+  showAllThreads,
+  onToggleAllThreads,
+  showSearch,
+  onToggleSearch,
+  onOpenSettings,
+  typingHumans,
+  typingAgents,
+}: MessageListProps) {
+  const messageListRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Expose scroll-to-latest via ref
+  useEffect(() => {
+    if (messagesEndRef.current && messages.length > 0) {
+      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, []); // eslint-disable-line
+
+  if (!selectedChannel) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-white/20">
+        <div className="text-center px-6">
+          <MessageCircle size={48} className="mx-auto mb-3 opacity-30" />
+          <p className="text-sm mb-3">Pick a channel or start a DM</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* channel header */}
+      <div className="px-4 py-2.5 border-b border-white/[0.06] flex items-center gap-3 shrink-0">
+        {channel?.type === "topic" ? (
+          <Hash size={16} className="text-white/40" />
+        ) : channel?.type === "group" ? (
+          <Users size={16} className="text-white/40" />
+        ) : (
+          <AtSign size={16} className="text-white/40" />
+        )}
+        {/* DM agent emoji */}
+        {channel?.type === "dm" &&
+          (() => {
+            const agentName = (channel.members ?? []).find((m) => m !== "user");
+            if (!agentName) return null;
+            const agent = liveAgents.find((a) => a.name === agentName);
+            if (!agent) return null;
+            return (
+              <span className="text-base leading-none shrink-0" aria-hidden="true">
+                {resolveAgentEmoji(agent.emoji, agent.framework)}
+              </span>
+            );
+          })()}
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium truncate flex items-center gap-1">
+            {channel?.name ?? "Unknown"}
+            {channel && channel.type !== "dm" && (
+              <button
+                aria-label="Channel settings"
+                onClick={onOpenSettings}
+                className="ml-1 opacity-60 hover:opacity-100"
+              >
+                ⓘ
+              </button>
+            )}
+            <a
+              aria-label="Open chat guide"
+              href="https://github.com/jaylfc/tinyagentos/blob/master/docs/chat-guide.md"
+              target="_blank"
+              rel="noreferrer"
+              className="ml-1 opacity-60 hover:opacity-100 text-[12px]"
+            >
+              ?
+            </a>
+            <div className="relative">
+              <PinBadge
+                count={pinnedMessages.length}
+                onClick={onTogglePinnedPopover}
+              />
+              {pinnedPopoverOpen && (
+                <PinnedMessagesPopover
+                  pins={pinnedMessages}
+                  authorCtx={{ currentUserId, currentUserDisplayName }}
+                  onJumpTo={(id) => {
+                    onTogglePinnedPopover();
+                    const el = document.querySelector(
+                      `[data-message-id="${id}"]`,
+                    ) as HTMLElement | null;
+                    if (el) {
+                      el.scrollIntoView({ behavior: "smooth", block: "center" });
+                      el.classList.add("data-highlight");
+                      setTimeout(() => el.classList.remove("data-highlight"), 2000);
+                    }
+                  }}
+                  onClose={onTogglePinnedPopover}
+                />
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={onToggleAllThreads}
+              className="ml-2 p-1 rounded hover:bg-white/10 text-white/60 hover:text-white"
+              aria-label={showAllThreads ? "Hide all threads" : "Show all threads"}
+              aria-expanded={showAllThreads}
+              aria-controls="all-threads-panel"
+              title="All threads"
+            >
+              <MessagesSquare size={14} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={onToggleSearch}
+              className="ml-2 p-1 rounded hover:bg-white/10 text-white/60 hover:text-white"
+              aria-label={showSearch ? "Hide search" : "Search messages"}
+              aria-expanded={showSearch}
+              aria-controls="search-panel"
+              title="Search"
+            >
+              <Search size={14} aria-hidden="true" />
+            </button>
+          </div>
+          {channel?.description && (
+            <div className="text-[11px] text-white/35 truncate">
+              {channel.description}
+            </div>
+          )}
+        </div>
+        {channel?.members && (
+          <div className="text-[11px] text-white/30 flex items-center gap-1">
+            <Users size={12} /> {channel.members.length}
+          </div>
+        )}
+      </div>
+
+      {/* message list */}
+      <div
+        ref={messageListRef}
+        onScroll={onScroll}
+        className={`flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-0.5 select-text ${
+          dropTarget.isOver
+            ? "ring-2 ring-sky-400/60 ring-inset bg-sky-500/5"
+            : dropTarget.isValidTarget
+              ? "ring-2 ring-sky-400/30 ring-inset"
+              : ""
+        }`}
+        style={
+          isMobile && keyboardInset > 0
+            ? { paddingBottom: `${keyboardInset + 60}px` }
+            : undefined
+        }
+        onDragEnter={dropTarget.handlers.onDragEnter}
+        onDragOver={(e) => {
+          dropTarget.handlers.onDragOver(e);
+          if (!e.defaultPrevented) e.preventDefault();
+        }}
+        onDragLeave={dropTarget.handlers.onDragLeave}
+        onDrop={dropTarget.handlers.onDrop}
+      >
+        {/* scroll-to-bottom affordance */}
+        {selectedChannel && !atBottom && (
+          <button
+            type="button"
+            onClick={onScrollToLatest}
+            aria-label="Jump to latest"
+            className="absolute right-4 bottom-24 z-20 flex items-center gap-1.5 px-3 h-9 rounded-full bg-shell-surface-active border border-shell-border-strong text-shell-text/80 hover:text-shell-text shadow-lg hover:bg-shell-surface-hover backdrop-blur-xl transition-colors"
+          >
+            <ChevronDown size={16} aria-hidden="true" />
+            {newCount > 0 && (
+              <span className="text-[11px] font-semibold">{newCount} new</span>
+            )}
+          </button>
+        )}
+
+        {messages.length === 0 && fetchedChannel === selectedChannel && (
+          <div className="flex flex-col items-center justify-center h-full text-white/25 text-center px-6">
+            <MessageCircle size={40} className="mb-3 opacity-30" />
+            <p className="text-sm">
+              No messages yet. Say hello to{" "}
+              {channel?.type === "dm"
+                ? `@${(channel.members ?? []).find((m) => m !== "user") ?? "them"}`
+                : channel?.name
+                  ? `#${channel.name}`
+                  : "this channel"}
+              .
+            </p>
+          </div>
+        )}
+
+        {messages.map((msg, i) => {
+          const isAgent = msg.author_type === "agent";
+          const prev = i > 0 ? messages[i - 1] : undefined;
+          const showAuthor = !prev || prev.author_id !== msg.author_id;
+          const prevDay = prev
+            ? new Date(toMs(prev.created_at)).toDateString()
+            : null;
+          const currDay = new Date(toMs(msg.created_at)).toDateString();
+          const showDaySeparator = !prev || prevDay !== currDay;
+          const authorState = resolveAuthorDisplayState(
+            msg.author_id,
+            msg.author_type,
+            liveAgents,
+            archivedAgents,
+          );
+          const isDeadAgent = isAgent && authorState !== "active";
+          const authorTooltip =
+            authorState === "archived"
+              ? "Agent no longer active"
+              : authorState === "removed"
+                ? "Agent removed"
+                : undefined;
+
+          return (
+            <React.Fragment key={msg.id}>
+              {showDaySeparator && (
+                <div className="flex items-center gap-3 my-4 select-none">
+                  <div className="flex-1 h-px bg-white/10" />
+                  <span className="text-[11px] text-white/40 font-medium">
+                    {dayLabel(msg.created_at)}
+                  </span>
+                  <div className="flex-1 h-px bg-white/10" />
+                </div>
+              )}
+              {newDividerAtId === msg.id && (
+                <div
+                  role="separator"
+                  aria-label="New messages"
+                  className="flex items-center gap-3 my-3 select-none"
+                >
+                  <div className="flex-1 h-px bg-red-400/40" />
+                  <span className="text-[11px] text-red-400 font-semibold">
+                    New
+                  </span>
+                  <div className="flex-1 h-px bg-red-400/40" />
+                </div>
+              )}
+              <div
+                data-message-id={msg.id}
+                className={`group relative flex gap-2.5 px-3 py-0.5 rounded-md transition-colors hover:bg-shell-surface ${
+                  showAuthor ? (isMobile ? "mt-2" : "mt-3") : ""
+                }`}
+                onMouseEnter={() => onHoverMessage(msg.id)}
+                onMouseLeave={() => onHoverMessage(null)}
+              >
+                {/* avatar gutter */}
+                <div
+                  className="flex-shrink-0 flex justify-end pt-0.5"
+                  style={{ width: isMobile ? 34 : 38 }}
+                >
+                  {showAuthor ? (
+                    (() => {
+                      const agent = isAgent
+                        ? liveAgents.find((a) => a.name === msg.author_id)
+                        : undefined;
+                      return (
+                        <MessageAvatar
+                          size={isMobile ? 34 : 38}
+                          authorId={msg.author_id}
+                          displayName={displayAuthor(msg, {
+                            currentUserId,
+                            currentUserDisplayName,
+                          })}
+                          kind={isAgent ? "agent" : "user"}
+                          dead={isDeadAgent}
+                          emoji={
+                            agent
+                              ? resolveAgentEmoji(agent.emoji, agent.framework)
+                              : isAgent
+                                ? resolveAgentEmoji(undefined, undefined)
+                                : undefined
+                          }
+                        />
+                      );
+                    })()
+                  ) : (
+                    <span
+                      className="text-[10px] leading-none text-shell-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity self-center select-none"
+                      aria-hidden="true"
+                      title={new Date(toMs(msg.created_at)).toLocaleString()}
+                    >
+                      {new Date(toMs(msg.created_at)).toLocaleTimeString(
+                        undefined,
+                        { hour: "2-digit", minute: "2-digit" },
+                      )}
+                    </span>
+                  )}
+                </div>
+                {/* content column */}
+                <div className="flex-1 min-w-0">
+                  {showAuthor && (
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <span
+                        className={`${isMobile ? "text-[14px]" : "text-[15px]"} font-bold tracking-tight ${
+                          isDeadAgent
+                            ? "line-through text-shell-text-tertiary"
+                            : "text-shell-text"
+                        }`}
+                        style={isDeadAgent ? { opacity: 0.55 } : undefined}
+                        title={authorTooltip}
+                      >
+                        {displayAuthor(msg, {
+                          currentUserId,
+                          currentUserDisplayName,
+                        })}
+                      </span>
+                      {isAgent && !isDeadAgent && (
+                        <span className="text-[10px] uppercase tracking-wide bg-accent-soft text-accent-strong border border-accent-line px-1.5 py-0.5 rounded font-semibold flex items-center gap-0.5">
+                          <Bot size={10} aria-hidden="true" /> Agent
+                        </span>
+                      )}
+                      {isDeadAgent && (
+                        <span className="text-[10px] uppercase tracking-wide bg-shell-surface-active text-shell-text-tertiary px-1.5 py-0.5 rounded font-semibold flex items-center gap-0.5">
+                          <Bot size={10} aria-hidden="true" />
+                          {authorState === "archived"
+                            ? "inactive"
+                            : "removed"}
+                        </span>
+                      )}
+                      <span
+                        className="text-[11px] text-shell-text-tertiary"
+                        title={new Date(
+                          toMs(msg.created_at),
+                        ).toLocaleString()}
+                      >
+                        {relativeTime(msg.created_at, nowMs)}
+                      </span>
+                      {msg.edited_at && (
+                        <span className="text-[10px] text-shell-text-tertiary">
+                          (edited)
+                        </span>
+                      )}
+                    </div>
+                  )}
+                  {msg.deleted_at ? (
+                    <MessageTombstone />
+                  ) : editingMessageId === msg.id ? (
+                    <MessageEditor
+                      initial={msg.content}
+                      onSave={(content) => onSaveEdit(msg.id, content)}
+                      onCancel={onCancelEdit}
+                    />
+                  ) : (
+                    <div className="relative">
+                      {msg.content &&
+                        msg.author_type === "agent" &&
+                        msg.state !== "streaming" &&
+                        msg.state !== "pending" && (
+                          <CopyButton
+                            content={msg.content}
+                            className="absolute -top-1 right-0 p-1 rounded opacity-0 group-hover:opacity-100 focus:opacity-100 bg-shell-surface border border-white/10 text-shell-text-secondary hover:text-shell-text transition-opacity select-none z-10"
+                          />
+                        )}
+                      <div
+                        className={`${isMobile ? "text-[14px]" : "text-[15px]"} leading-[1.46] whitespace-pre-wrap break-words select-text ${
+                          isDeadAgent
+                            ? "text-shell-text-secondary"
+                            : "text-shell-text"
+                        }`}
+                      >
+                        {renderContent(msg.content)}
+                        {msg.state === "pending" && (
+                          <span className="ml-1 text-shell-text-tertiary">
+                            ...
+                          </span>
+                        )}
+                        {msg.state === "streaming" && (
+                          <span className="ml-1 inline-flex gap-0.5">
+                            <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:0ms]" />
+                            <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:150ms]" />
+                            <span className="w-1 h-1 bg-accent rounded-full animate-bounce [animation-delay:300ms]" />
+                          </span>
+                        )}
+                        {msg.state === "error" && (
+                          <span className="ml-1 text-red-400 text-[11px]">
+                            (error)
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                  {msg.metadata?.pin_requested &&
+                    msg.author_type === "agent" && (
+                      <PinRequestAffordance
+                        authorId={msg.author_id}
+                        onApprove={() => onApprovePinRequest(msg.id)}
+                      />
+                    )}
+
+                  {/* canvas attachment */}
+                  {msg.content_type === "canvas" &&
+                    (msg.metadata?.canvas_url || msg.metadata?.canvas_id) && (
+                      <div className="mt-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            const url =
+                              msg.metadata?.canvas_url ??
+                              `/canvas/${msg.metadata?.canvas_id}`;
+                            onViewCanvas({
+                              url,
+                              title: msg.metadata
+                                ?.canvas_title as string | undefined,
+                            });
+                          }}
+                          className="h-7 px-2.5 text-[12px] gap-1.5 bg-shell-surface border-shell-border-strong hover:bg-shell-surface-hover"
+                          aria-label="View canvas"
+                        >
+                          <PanelRight size={13} />
+                          View Canvas
+                          {msg.metadata?.canvas_title
+                            ? `: ${msg.metadata.canvas_title}`
+                            : ""}
+                        </Button>
+                      </div>
+                    )}
+
+                  {/* reactions */}
+                  {msg.reactions &&
+                    Object.keys(msg.reactions).length > 0 && (
+                      <ReactionBar
+                        reactions={msg.reactions}
+                        messageId={msg.id}
+                        currentUserId={currentUserId}
+                        onToggle={onToggleReaction}
+                      />
+                    )}
+
+                  {/* hover actions */}
+                  {(isMobile || hoveredMessageId === msg.id) &&
+                    (() => {
+                      const excerpt = (msg.content || "").slice(0, 80);
+                      const msgChannelId =
+                        msg.channel_id ?? selectedChannel ?? "";
+                      return (
+                        <div className="absolute -top-3 right-2 z-10">
+                          <MessageHoverActions
+                            onReact={() => {
+                              if (
+                                showEmoji &&
+                                showEmoji.messageId === msg.id
+                              ) {
+                                onShowEmoji(null);
+                                return;
+                              }
+                              const row = document.querySelector(
+                                `[data-message-id="${msg.id}"]`,
+                              ) as HTMLElement | null;
+                              const rect = row?.getBoundingClientRect();
+                              if (!rect) return;
+                              onShowEmoji({
+                                messageId: msg.id,
+                                rect,
+                              });
+                            }}
+                            onReplyInThread={() =>
+                              onReplyInThread(
+                                msg.channel_id ?? selectedChannel ?? "",
+                                msg.id,
+                              )
+                            }
+                            onOverflow={(e) => {
+                              e.preventDefault();
+                              onOverflow(e, msg.id);
+                            }}
+                            dragHandle={
+                              msgChannelId ? (
+                                <span
+                                  draggable
+                                  onDragStart={(e) => {
+                                    e.stopPropagation();
+                                    e.dataTransfer.effectAllowed =
+                                      "copy";
+                                    try {
+                                      e.dataTransfer.setData(
+                                        "text/plain",
+                                        `@${msg.author_id}: ${excerpt}`,
+                                      );
+                                      e.dataTransfer.setData(
+                                        "text/uri-list",
+                                        `${window.location.origin}/chat/${msgChannelId}?msg=${msg.id}`,
+                                      );
+                                    } catch {
+                                      /* best-effort */
+                                    }
+                                    startDrag({
+                                      kind: "message",
+                                      channel_id: msgChannelId,
+                                      message_id: msg.id,
+                                      author_id: msg.author_id,
+                                      excerpt,
+                                    });
+                                  }}
+                                  onDragEnd={() => endDrag()}
+                                  className="p-1 opacity-40 hover:opacity-100 cursor-grab select-none"
+                                  aria-label="Drag message"
+                                  title="Drag this message"
+                                >
+                                  &#8942;&#8942;
+                                </span>
+                              ) : undefined
+                            }
+                          />
+                        </div>
+                      );
+                    })()}
+                  <AttachmentGallery attachments={msg.attachments || []} />
+                  {typeof msg.reply_count === "number" &&
+                    msg.reply_count > 0 && (
+                      <ThreadIndicator
+                        replyCount={msg.reply_count}
+                        lastReplyAt={msg.last_reply_at ?? null}
+                        onOpen={() =>
+                          onOpenThread(
+                            msg.channel_id ?? selectedChannel ?? "",
+                            msg.id,
+                          )
+                        }
+                      />
+                    )}
+
+                  {/* emoji picker portal */}
+                  {showEmoji &&
+                    showEmoji.messageId === msg.id &&
+                    createPortal(
+                      (() => {
+                        const POPOVER_W = 300;
+                        const POPOVER_H = 360;
+                        const vw = window.innerWidth;
+                        const vh = window.innerHeight;
+                        const r = showEmoji.rect;
+                        const top = Math.max(
+                          8,
+                          Math.min(r.top, Math.max(8, vh - POPOVER_H - 8)),
+                        );
+                        const left = Math.max(
+                          8,
+                          Math.min(
+                            r.right - POPOVER_W,
+                            Math.max(8, vw - POPOVER_W - 8),
+                          ),
+                        );
+                        return (
+                          <div
+                            data-emoji-popover="1"
+                            role="dialog"
+                            aria-label="Emoji reactions"
+                            className="fixed z-50 bg-shell-bg border border-shell-border-strong rounded-lg shadow-xl p-2 w-[300px] h-[360px] flex flex-col gap-2 backdrop-blur-xl"
+                            style={{ top, left }}
+                          >
+                            <div className="flex gap-1 shrink-0">
+                              {EMOJI_PICKER.map((em) => (
+                                <button
+                                  key={em}
+                                  onClick={() =>
+                                    onToggleReaction(msg.id, em)
+                                  }
+                                  className="text-lg hover:bg-white/10 rounded p-0.5 transition-colors"
+                                >
+                                  {em}
+                                </button>
+                              ))}
+                            </div>
+                            <div className="flex-1 min-h-0">
+                              <Picker
+                                theme={Theme.DARK}
+                                width="100%"
+                                height="100%"
+                                onEmojiClick={(d) => {
+                                  onToggleReaction(msg.id, d.emoji);
+                                }}
+                              />
+                            </div>
+                          </div>
+                        );
+                      })(),
+                      document.body,
+                    )}
+                </div>
+              </div>
+            </React.Fragment>
+          );
+        })}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* typing footer */}
+      <TypingFooter
+        humans={typingHumans}
+        agents={typingAgents}
+        selfId="user"
+      />
+    </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  CopyButton (hover copy affordance)                                 */
+/* ------------------------------------------------------------------ */
+
+function CopyButton({
+  content,
+  className,
+}: {
+  content: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = React.useState(false);
+  const [clipError, setClipError] = React.useState(false);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const errorTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  React.useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    if (!content) return;
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      setClipError(false);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setClipError(true);
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+      errorTimerRef.current = setTimeout(() => setClipError(false), 2500);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      aria-label={
+        copied
+          ? "Copied"
+          : clipError
+            ? "Copy failed — check clipboard permissions"
+            : "Copy message"
+      }
+      className={className}
+    >
+      {copied ? (
+        <span>✓</span>
+      ) : clipError ? (
+        <span className="text-red-400">✕</span>
+      ) : (
+        <span>📋</span>
+      )}
+    </button>
+  );
+}

--- a/desktop/src/apps/chat/MessageList.tsx
+++ b/desktop/src/apps/chat/MessageList.tsx
@@ -196,12 +196,12 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
     scrollToBottom: () => {
       messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
     },
-  }));
+  }), []);
 
-  // Expose scroll-to-latest via ref
+  // Expose scroll-to-latest via ref — syncs parent's atBottom/newCount state
   useEffect(() => {
-    if (messagesEndRef.current && messages.length > 0) {
-      messagesEndRef.current.scrollIntoView({ behavior: "smooth" });
+    if (messages.length > 0) {
+      onScrollToLatest();
     }
   }, []); // eslint-disable-line
 
@@ -325,7 +325,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
       <div
         ref={messageListRef}
         onScroll={onScroll}
-        className={`flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-0.5 select-text ${
+        className={`flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-0.5 select-text message-list-drop-target ${
           dropTarget.isOver
             ? "ring-2 ring-sky-400/60 ring-inset bg-sky-500/5"
             : dropTarget.isValidTarget

--- a/desktop/src/apps/chat/MessageList.tsx
+++ b/desktop/src/apps/chat/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from "react";
+import React, { forwardRef, useImperativeHandle, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
 import {
   Hash,
@@ -117,7 +117,7 @@ export interface MessageListProps {
   atBottom: boolean;
   newCount: number;
   onScrollToLatest: () => void;
-  onScroll: () => void;
+  onScroll: (e: React.UIEvent<HTMLDivElement>) => void;
 
   /* ---- drop target ---- */
   dropTarget: {
@@ -143,7 +143,11 @@ export interface MessageListProps {
   typingAgents: AgentTyping[];
 }
 
-export function MessageList({
+export interface MessageListHandle {
+  scrollToBottom: () => void;
+}
+
+export const MessageList = forwardRef<MessageListHandle, MessageListProps>(function MessageList({
   messages,
   fetchedChannel,
   channel,
@@ -184,9 +188,15 @@ export function MessageList({
   onOpenSettings,
   typingHumans,
   typingAgents,
-}: MessageListProps) {
+}: MessageListProps, ref: React.Ref<MessageListHandle>) {
   const messageListRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    scrollToBottom: () => {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    },
+  }));
 
   // Expose scroll-to-latest via ref
   useEffect(() => {
@@ -770,7 +780,7 @@ export function MessageList({
       />
     </>
   );
-}
+});
 
 /* ------------------------------------------------------------------ */
 /*  CopyButton (hover copy affordance)                                 */

--- a/desktop/src/apps/chat/ReactionBar.tsx
+++ b/desktop/src/apps/chat/ReactionBar.tsx
@@ -1,0 +1,50 @@
+export interface ReactionBarProps {
+  /** Emoji → list of user ids who reacted. */
+  reactions: Record<string, string[]>;
+  /** The message these reactions belong to. */
+  messageId: string;
+  /** Current user id for the "mine" highlight. */
+  currentUserId: string | null;
+  /** Called when a reaction button is clicked. */
+  onToggle: (messageId: string, emoji: string) => void;
+}
+
+/**
+ * Renders the reaction buttons row for a single message.
+ * Pure presentational — no picker, no portal.
+ */
+export function ReactionBar({
+  reactions,
+  messageId,
+  currentUserId,
+  onToggle,
+}: ReactionBarProps) {
+  return (
+    <div className="flex flex-wrap gap-1 mt-1.5">
+      {Object.entries(reactions).map(([emoji, users]) => {
+        const mine = currentUserId != null && users.includes(currentUserId);
+        return (
+          <button
+            key={emoji}
+            onClick={() => onToggle(messageId, emoji)}
+            aria-pressed={mine}
+            className={`text-[12px] rounded-full px-2 py-0.5 flex items-center gap-1 border transition-colors ${
+              mine
+                ? "bg-accent-soft border-accent-line text-accent-strong"
+                : "bg-shell-surface border-shell-border hover:bg-shell-surface-hover text-shell-text-secondary"
+            }`}
+          >
+            <span>{emoji}</span>
+            <span
+              className={
+                mine ? "text-accent-strong font-medium" : "text-shell-text-tertiary"
+              }
+            >
+              {users.length}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/desktop/src/apps/chat/types.ts
+++ b/desktop/src/apps/chat/types.ts
@@ -1,0 +1,48 @@
+/** Shared channel/message types used by MessagesApp sub-components. */
+
+export interface Channel {
+  id: string;
+  name: string;
+  type: "dm" | "topic" | "group";
+  description?: string;
+  topic?: string;
+  members?: string[];
+  created_at?: string;
+  last_message_at?: string;
+  lastPreview?: string;
+  project_id?: string;
+  settings?: {
+    archived?: boolean;
+    archived_at?: string;
+    archived_agent_id?: string;
+    archived_agent_slug?: string;
+    muted?: string[];
+    kind?: string;
+  };
+}
+
+export interface LiveAgent {
+  name: string;
+  display_name?: string;
+  emoji?: string;
+  framework?: string;
+  model?: string;
+  status?: string;
+}
+
+export interface ArchivedAgentEntry {
+  id: string;
+  archived_slug: string;
+  original?: {
+    name?: string;
+    display_name?: string;
+  };
+}
+
+export interface ProjectGroup {
+  id: string;
+  name: string;
+  channels: Channel[];
+}
+
+export type WsStatus = "connecting" | "connected" | "disconnected";


### PR DESCRIPTION
Fixes 3 Kilo bot findings from PR #1877 in `desktop/src/apps/chat/MessageList.tsx`:

1. **WARNING (L202):** Replaced direct `scrollIntoView` with `onScrollToLatest()` in the mount-time effect so the parent's `atBottom`/`newCount` state stays in sync — prevents the phantom "X new" badge when viewport is already at the latest message.

2. **SUGGESTION (L195):** Added missing `[]` dependency array to `useImperativeHandle` — stops re-creating the scroll handle on every render.

3. **SUGGESTION (~L329):** Restored `message-list-drop-target` CSS class on the scroll container (used by E2E test `test_cross_app_dnd.py`).

TypeScript (`tsc --noEmit`) passes for the changed file. CI will run vitest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated channel sidebar with unread counters, relative timestamps, connection status, projects, and archived channels (with mobile/desktop layouts).
  - Introduced a new message composer supporting attachments (upload/paste), slash commands, and `@mentions`, with archived/disabled send behavior.
  - Added a full-featured message list with channel header, jump-to-latest, typing indicator, threads/pins/canvas, reactions, and improved drag-and-drop file handling.
  - Added clickable reaction buttons with per-user highlighting and counts.

- **Improvements**
  - Refreshed chat UI to use reusable, component-based views for better responsiveness and interaction consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->