### PR TITLE
feat(desktop): add categorized wallpaper sections with theme-default first

### DIFF
--- a/desktop/src/components/WallpaperPicker.test.tsx
+++ b/desktop/src/components/WallpaperPicker.test.tsx
@@ -11,6 +11,8 @@ describe("WallpaperPicker", () => {
       wallpaperOverlayText: null,
       showOverlayText: true,
       wallpaperParams: { density: 200, speed: 0.5, glow: 6 },
+      activeThemeId: "default",
+      themeDefaultWallpaperId: {},
     });
   });
 
@@ -25,12 +27,39 @@ describe("WallpaperPicker", () => {
     expect(screen.getByText("Change Wallpaper")).toBeInTheDocument();
   });
 
-  it("renders all wallpaper buttons with labels", () => {
+  it("renders section headings for all four sections", () => {
     render(<WallpaperPicker open={true} onClose={vi.fn()} />);
-    expect(screen.getByRole("button", { name: /graphite/i })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /neural \(live\)/i })).toBeInTheDocument();
+    // Section headings render as h4 elements — use getAllByText to disambiguate
+    // from the badge that shares the text "Theme default" inside the wallpaper tile.
+    const themeDefaultHeadings = screen.getAllByText("Theme default");
+    expect(themeDefaultHeadings.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Built-in")).toBeInTheDocument();
+    expect(screen.getByText("Your wallpapers")).toBeInTheDocument();
+    expect(screen.getByText("Browse online")).toBeInTheDocument();
+  });
+
+  it("shows the theme default wallpaper in its own section with a badge when it matches", () => {
+    useThemeStore.setState({ wallpaperId: "graphite" });
+    render(<WallpaperPicker open={true} onClose={vi.fn()} />);
+    // The graphite wallpaper is in the themeDefault section and is pre-selected
+    const graphiteBtn = screen.getByRole("button", { name: /graphite/i });
+    expect(graphiteBtn).toHaveAttribute("aria-pressed", "true");
+    // The badge text "Theme default" appears inside the wallpaper tile
+    const badges = screen.getAllByText("Theme default");
+    // At least one is the badge (inside a span), plus the section heading (h4)
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders all built-in wallpaper buttons in the builtin section", () => {
+    useThemeStore.setState({
+      wallpaperId: "default",
+      themeDefaultWallpaperId: { default: "graphite" },
+    });
+    render(<WallpaperPicker open={true} onClose={vi.fn()} />);
     expect(screen.getByRole("button", { name: /classic/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /neural \(live\)/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /aurora/i })).toBeInTheDocument();
+    // "default" = Classic, which is in the builtin section
   });
 
   it("marks the active wallpaper with aria-pressed and a check indicator", () => {
@@ -42,7 +71,7 @@ describe("WallpaperPicker", () => {
     expect(inactiveBtn).toHaveAttribute("aria-pressed", "false");
   });
 
-  it("updates wallpaperId when a wallpaper button is clicked", () => {
+  it("updates wallpaperId when a built-in wallpaper button is clicked", () => {
     render(<WallpaperPicker open={true} onClose={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: /midnight blue/i }));
     expect(useThemeStore.getState().wallpaperId).toBe("midnight");
@@ -116,5 +145,11 @@ describe("WallpaperPicker", () => {
     const densitySlider = screen.getByLabelText("Density");
     fireEvent.change(densitySlider, { target: { value: "300" } });
     expect(useThemeStore.getState().wallpaperParams.density).toBe(300);
+  });
+
+  it("renders empty states for user and online sections", () => {
+    render(<WallpaperPicker open={true} onClose={vi.fn()} />);
+    expect(screen.getByText("Upload an image")).toBeInTheDocument();
+    expect(screen.getByText("Search Wallhaven")).toBeInTheDocument();
   });
 });

--- a/desktop/src/components/WallpaperPicker.tsx
+++ b/desktop/src/components/WallpaperPicker.tsx
@@ -1,4 +1,5 @@
 import { useThemeStore } from "@/stores/theme-store";
+import type { Wallpaper } from "@/stores/theme-store";
 import { Check } from "lucide-react";
 
 interface Props {
@@ -12,19 +13,98 @@ const SLIDERS: { key: "density" | "speed" | "glow"; label: string; min: number; 
   { key: "glow", label: "Glow", min: 0, max: 16, step: 1 },
 ];
 
+function WallpaperTile({
+  wp,
+  isSelected,
+  onClick,
+  showBadge,
+}: {
+  wp: Wallpaper;
+  isSelected: boolean;
+  onClick: () => void;
+  showBadge?: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={wp.label}
+      aria-pressed={isSelected}
+      className={`relative rounded-lg overflow-hidden border-2 transition-all ${
+        isSelected
+          ? "border-accent ring-1 ring-accent/30"
+          : "border-shell-border hover:border-shell-border-strong"
+      }`}
+    >
+      <div
+        className="relative h-24 w-full"
+        style={
+          wp.kind === "animated"
+            ? { background: "radial-gradient(120% 120% at 50% 46%, #2a2a2e 0%, #1d1d1f 45%, #101011 100%)" }
+            : {
+                backgroundImage: wp.image,
+                backgroundColor: wp.fallback,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat",
+              }
+        }
+      >
+        {wp.overlayText && (
+          <span className="absolute inset-0 grid place-items-center text-[13px] font-semibold tracking-tight text-white/85">
+            {wp.overlayText}
+          </span>
+        )}
+      </div>
+      <div className="px-2 py-1.5 text-xs text-shell-text-secondary text-left flex items-center gap-1.5">
+        {wp.label}
+        {showBadge && (
+          <span className="text-[10px] px-1 py-px rounded bg-accent/15 text-accent font-medium">
+            {showBadge}
+          </span>
+        )}
+      </div>
+      {isSelected && (
+        <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-accent flex items-center justify-center">
+          <Check size={12} className="text-white" />
+        </div>
+      )}
+    </button>
+  );
+}
+
+function SectionHeading({ label }: { label: string }) {
+  return (
+    <h4 className="text-[11px] font-medium uppercase tracking-wider text-shell-text-tertiary px-1 pt-2 pb-1">
+      {label}
+    </h4>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-shell-border px-3 py-4 text-center">
+      <span className="text-xs text-shell-text-tertiary">{message}</span>
+    </div>
+  );
+}
+
 export function WallpaperPicker({ open, onClose }: Props) {
   const {
     wallpaperId,
     setWallpaper,
-    getWallpapers,
+    getWallpapersBySection,
     wallpaperOverlayText,
     showOverlayText,
     toggleOverlayText,
     wallpaperKind,
     wallpaperParams,
     setWallpaperParam,
+    themeDefaultWallpaperId,
+    activeThemeId,
   } = useThemeStore();
-  const wallpapers = getWallpapers();
+  const sections = getWallpapersBySection();
+  const themeDefaultId = themeDefaultWallpaperId[activeThemeId] || "graphite";
+  const isThemeDefault = wallpaperId === themeDefaultId;
 
   if (!open) return null;
 
@@ -55,50 +135,44 @@ export function WallpaperPicker({ open, onClose }: Props) {
             ×
           </button>
         </div>
-        <div className="p-4 grid grid-cols-2 gap-3 overflow-y-auto flex-1">
-          {wallpapers.map((wp) => (
-            <button
-              key={wp.id}
-              onClick={() => {
-                setWallpaper(wp.id);
-              }}
-              aria-label={wp.label}
-              aria-pressed={wallpaperId === wp.id}
-              className={`relative rounded-lg overflow-hidden border-2 transition-all ${
-                wallpaperId === wp.id
-                  ? "border-accent ring-1 ring-accent/30"
-                  : "border-shell-border hover:border-shell-border-strong"
-              }`}
-            >
-              <div
-                className="relative h-24 w-full"
-                style={
-                  wp.kind === "animated"
-                    ? { background: "radial-gradient(120% 120% at 50% 46%, #2a2a2e 0%, #1d1d1f 45%, #101011 100%)" }
-                    : {
-                        backgroundImage: wp.image,
-                        backgroundColor: wp.fallback,
-                        backgroundSize: "cover",
-                        backgroundPosition: "center",
-                        backgroundRepeat: "no-repeat",
+        <div className="p-4 flex flex-col gap-1 overflow-y-auto flex-1">
+          {sections.map((section) => (
+            <div key={section.id}>
+              <SectionHeading label={section.label} />
+              {section.items.length > 0 ? (
+                <div
+                  className={
+                    section.id === "themeDefault"
+                      ? "grid grid-cols-1 gap-3"
+                      : "grid grid-cols-2 gap-3"
+                  }
+                >
+                  {section.items.map((wp) => (
+                    <WallpaperTile
+                      key={wp.id}
+                      wp={wp}
+                      isSelected={wallpaperId === wp.id}
+                      onClick={() => setWallpaper(wp.id)}
+                      showBadge={
+                        section.id === "themeDefault" && isThemeDefault
+                          ? "Theme default"
+                          : undefined
                       }
-                }
-              >
-                {wp.overlayText && (
-                  <span className="absolute inset-0 grid place-items-center text-[13px] font-semibold tracking-tight text-white/85">
-                    {wp.overlayText}
-                  </span>
-                )}
-              </div>
-              <div className="px-2 py-1.5 text-xs text-shell-text-secondary text-left">
-                {wp.label}
-              </div>
-              {wallpaperId === wp.id && (
-                <div className="absolute top-2 right-2 w-5 h-5 rounded-full bg-accent flex items-center justify-center">
-                  <Check size={12} className="text-white" />
+                    />
+                  ))}
                 </div>
+              ) : (
+                <EmptyState
+                  message={
+                    section.id === "user"
+                      ? "Upload an image"
+                      : section.id === "online"
+                        ? "Search Wallhaven"
+                        : "No wallpapers"
+                  }
+                />
               )}
-            </button>
+            </div>
           ))}
         </div>
         {wallpaperKind === "animated" && (

--- a/desktop/src/stores/__tests__/wallpaper.test.ts
+++ b/desktop/src/stores/__tests__/wallpaper.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useThemeStore, setWallpaperForActiveTheme, resolveWallpaper } from "../theme-store";
 
-beforeEach(() => useThemeStore.setState({ activeThemeId: "matrix", wallpaperByTheme: {}, themeDefaultWallpaper: { matrix: "linear-gradient(#000,#020)" } } as never));
+beforeEach(() => useThemeStore.setState({ activeThemeId: "matrix", wallpaperByTheme: {}, themeDefaultWallpaper: { matrix: "linear-gradient(#000,#020)" }, themeDefaultWallpaperId: {} } as never));
 
 describe("wallpaper (decoupled, per-theme)", () => {
   it("resolves to the theme default when the user hasn't chosen", () => {
@@ -13,5 +13,64 @@ describe("wallpaper (decoupled, per-theme)", () => {
     useThemeStore.setState({ activeThemeId: "default" } as never);
     useThemeStore.setState({ activeThemeId: "matrix" } as never); // switch away + back
     expect(resolveWallpaper()).toBe("url('/x.png')");
+  });
+});
+
+describe("getWallpapersBySection", () => {
+  beforeEach(() => {
+    useThemeStore.setState({
+      activeThemeId: "default",
+      themeDefaultWallpaperId: {},
+    } as never);
+  });
+
+  it("returns 4 sections with correct ids and labels", () => {
+    const sections = useThemeStore.getState().getWallpapersBySection();
+    expect(sections).toHaveLength(4);
+    expect(sections[0].id).toBe("themeDefault");
+    expect(sections[0].label).toBe("Theme default");
+    expect(sections[1].id).toBe("builtin");
+    expect(sections[1].label).toBe("Built-in");
+    expect(sections[2].id).toBe("user");
+    expect(sections[2].label).toBe("Your wallpapers");
+    expect(sections[3].id).toBe("online");
+    expect(sections[3].label).toBe("Browse online");
+  });
+
+  it("falls back to graphite for themeDefault when no theme declares a default wallpaper id", () => {
+    const sections = useThemeStore.getState().getWallpapersBySection();
+    expect(sections[0].items).toHaveLength(1);
+    expect(sections[0].items[0].id).toBe("graphite");
+  });
+
+  it("deduplicates the theme-default wallpaper from the builtin section", () => {
+    // Use indigo theme which declares neural-live as its default
+    useThemeStore.setState({
+      activeThemeId: "indigo",
+      themeDefaultWallpaperId: { indigo: "neural-live" },
+    } as never);
+    const sections = useThemeStore.getState().getWallpapersBySection();
+    expect(sections[0].items[0].id).toBe("neural-live");
+    const builtinIds = sections[1].items.map((w) => w.id);
+    expect(builtinIds).not.toContain("neural-live");
+    // All builtins except neural-live should be present
+    expect(builtinIds).toContain("graphite");
+    expect(builtinIds).toContain("default");
+  });
+
+  it("user and online sections are empty placeholders", () => {
+    const sections = useThemeStore.getState().getWallpapersBySection();
+    expect(sections[2].items).toHaveLength(0);
+    expect(sections[3].items).toHaveLength(0);
+  });
+
+  it("still returns all wallpapers in builtin when themeDefault wallpaper is not found", () => {
+    useThemeStore.setState({
+      activeThemeId: "custom",
+      themeDefaultWallpaperId: { custom: "nonexistent" },
+    } as never);
+    const sections = useThemeStore.getState().getWallpapersBySection();
+    // Falls back to graphite since "nonexistent" is not in WALLPAPERS
+    expect(sections[0].items[0].id).toBe("graphite");
   });
 });

--- a/desktop/src/stores/theme-store.test.ts
+++ b/desktop/src/stores/theme-store.test.ts
@@ -22,6 +22,7 @@ const reset = () => {
     activeThemeId: "default",
     wallpaperByTheme: {},
     themeDefaultWallpaper: {},
+    themeDefaultWallpaperId: {},
     wallpaperIdByTheme: {},
   });
 };
@@ -108,6 +109,50 @@ describe("theme-store", () => {
     expect(ids).toContain("neural-live");
     expect(ids).toContain("default");
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("getWallpapersBySection returns structured sections with theme-default first", () => {
+    const sections = useThemeStore.getState().getWallpapersBySection();
+    expect(sections.length).toBe(4);
+
+    // themeDefault section
+    expect(sections[0].id).toBe("themeDefault");
+    expect(sections[0].label).toBe("Theme default");
+    // Falls back to graphite when no theme is set
+    expect(sections[0].items[0].id).toBe("graphite");
+
+    // builtin section
+    expect(sections[1].id).toBe("builtin");
+    expect(sections[1].label).toBe("Built-in");
+    // All 11 wallpapers minus the theme default (graphite) = 10
+    expect(sections[1].items.length).toBe(10);
+    const builtinIds = sections[1].items.map((w) => w.id);
+    expect(builtinIds).not.toContain("graphite"); // deduplicated
+
+    // user and online are empty placeholders
+    expect(sections[2].id).toBe("user");
+    expect(sections[2].items).toHaveLength(0);
+    expect(sections[3].id).toBe("online");
+    expect(sections[3].items).toHaveLength(0);
+  });
+
+  it("getWallpapersBySection uses the active theme's declared default wallpaper id", () => {
+    useThemeStore.setState({
+      activeThemeId: "indigo",
+      themeDefaultWallpaperId: { indigo: "neural-live" },
+    });
+    const sections = useThemeStore.getState().getWallpapersBySection();
+    expect(sections[0].items[0].id).toBe("neural-live");
+    expect(sections[1].items.map((w) => w.id)).not.toContain("neural-live");
+  });
+
+  it("getWallpapersBySection falls back to graphite when themeDefaultWallpaperId is not set", () => {
+    useThemeStore.setState({
+      activeThemeId: "custom-theme",
+      themeDefaultWallpaperId: {},
+    });
+    const sections = useThemeStore.getState().getWallpapersBySection();
+    expect(sections[0].items[0].id).toBe("graphite");
   });
 
   it("reset: showDesktopIcons defaults to true after explicit false then reset", () => {

--- a/desktop/src/stores/theme-store.ts
+++ b/desktop/src/stores/theme-store.ts
@@ -8,7 +8,7 @@ import { BUILTIN_THEMES } from "@/theme/builtin-themes";
 // per viewport (cover on desktop, contain on mobile so the full image is
 // visible instead of cropped at the edges).
 
-interface Wallpaper {
+export interface Wallpaper {
   id: string;
   label: string;
   image: string; // desktop background-image (empty for animated wallpapers)
@@ -30,6 +30,13 @@ interface Wallpaper {
   lightImage?: string;
   lightMobileImage?: string;
   lightFallback?: string;
+}
+
+// Section of wallpaper items shown in the picker, grouped by source.
+export interface WallpaperSection {
+  id: string;
+  label: string;
+  items: Wallpaper[];
 }
 
 const WALLPAPERS: Wallpaper[] = [
@@ -204,6 +211,7 @@ interface ThemeStore {
   activeThemeId: string;
   wallpaperByTheme: Record<string, string>;
   themeDefaultWallpaper: Record<string, string>;
+  themeDefaultWallpaperId: Record<string, string>;
   // Per-theme memory of the wallpaper id the user last picked while that theme
   // was active. Lets a theme switch restore the wallpaper that was in use for
   // the target theme rather than inheriting the previous theme's wallpaper.
@@ -215,6 +223,7 @@ interface ThemeStore {
   toggleDesktopIcons: () => void;
   setReduceEffects: (on: boolean) => void;
   getWallpapers: () => Wallpaper[];
+  getWallpapersBySection: () => WallpaperSection[];
 }
 
 export const useThemeStore = create<ThemeStore>((set) => ({
@@ -239,6 +248,7 @@ export const useThemeStore = create<ThemeStore>((set) => ({
   activeThemeId: "default",
   wallpaperByTheme: {},
   themeDefaultWallpaper: {},
+  themeDefaultWallpaperId: {},
   wallpaperIdByTheme: {},
 
   setWallpaper(id) {
@@ -291,6 +301,43 @@ export const useThemeStore = create<ThemeStore>((set) => ({
   },
 
   getWallpapers: () => WALLPAPERS,
+
+  getWallpapersBySection: () => {
+    const state = useThemeStore.getState();
+    // The theme's declared default wallpaper id, or the global fallback.
+    const themeDefaultId =
+      state.themeDefaultWallpaperId[state.activeThemeId] || "graphite";
+    const themeDefaultWp =
+      WALLPAPERS.find((w) => w.id === themeDefaultId) ??
+      WALLPAPERS.find((w) => w.id === "graphite");
+
+    const sections: WallpaperSection[] = [
+      {
+        id: "themeDefault",
+        label: "Theme default",
+        items: themeDefaultWp ? [themeDefaultWp] : [],
+      },
+      {
+        id: "builtin",
+        label: "Built-in",
+        // Deduplicate: if the theme-default is a builtin, don't show it twice.
+        items: WALLPAPERS.filter(
+          (w) => !themeDefaultWp || w.id !== themeDefaultWp.id
+        ),
+      },
+      {
+        id: "user",
+        label: "Your wallpapers",
+        items: [], // C3 fills this in
+      },
+      {
+        id: "online",
+        label: "Browse online",
+        items: [], // C4 fills this in
+      },
+    ];
+    return sections;
+  },
 }));
 
 let _applied: string[] = []; // token keys currently set, for revert
@@ -483,6 +530,12 @@ export async function restoreActiveTheme(): Promise<void> {
         ...useThemeStore.getState().themeDefaultWallpaper,
         ...(cfg.wallpaper ? { [themeId]: cfg.wallpaper } : {}),
       },
+      themeDefaultWallpaperId: {
+        ...useThemeStore.getState().themeDefaultWallpaperId,
+        ...(cfg.defaultWallpaperId
+          ? { [themeId]: cfg.defaultWallpaperId }
+          : {}),
+      },
     });
     // Do NOT apply the theme's default wallpaper here: useSessionPersistence
     // restores the user's persisted wallpaper, which is authoritative (#1603).
@@ -499,6 +552,12 @@ export function keepTheme(themeId: string, cfg: ThemeConfig) {
     themeDefaultWallpaper: {
       ...useThemeStore.getState().themeDefaultWallpaper,
       ...(cfg.wallpaper ? { [themeId]: cfg.wallpaper } : {}),
+    },
+    themeDefaultWallpaperId: {
+      ...useThemeStore.getState().themeDefaultWallpaperId,
+      ...(cfg.defaultWallpaperId
+        ? { [themeId]: cfg.defaultWallpaperId }
+        : {}),
     },
   });
   applyThemeDefaultWallpaper(themeId, cfg);


### PR DESCRIPTION
## Summary
Refactors the WallpaperPicker to show categorized sections, with the active theme's default wallpaper pre-selected and shown first.

## Changes
- **theme-store.ts**: Added `WallpaperSection` type, exported `Wallpaper` interface, added `themeDefaultWallpaperId` store field (populated in `keepTheme`/`restoreActiveTheme`), added `getWallpapersBySection()` returning four sections: Theme default, Built-in, Your wallpapers (placeholder), Browse online (placeholder)
- **WallpaperPicker.tsx**: Rebuilt with sectioned layout — each section has a heading, theme-default shows a badge when it matches the current wallpaper, built-in grid preserved, empty states for user/online sections. Animated slider controls and overlay toggle unchanged.
- **Tests**: 36 tests pass (12 theme-store + 7 wallpaper + 17 picker) covering sections, deduplication, theme-default pre-selection, fallback behavior, and empty states.

Fixes #864 C1
Tasks: t_0d30f061 (kanban)
Tests: 36/36 pass (`npx vitest run`)