### PR TITLE
docs(design): permission plumbing for agent-posted decisions

### DIFF
--- a/docs/design/agent-decisions-permission.md
+++ b/docs/design/agent-decisions-permission.md
@@ -1,0 +1,142 @@
+# Agent-posted decisions: permission plumbing
+
+## Goal
+
+Let a registered agent (starting with @taOS-dev) raise decisions in the Decisions
+app through a scoped, consent-granted permission, instead of only humans being
+able to create them. Requesting the permission goes through the existing consent
+flow, so the owner approves it once before any agent can post.
+
+## Background (what already exists)
+
+The Decisions app is built end to end: `decisions/decision_store.py`,
+`routes/decisions.py` (`POST /api/decisions`, `GET /api/decisions`,
+`POST /api/decisions/{id}/answer`, `GET /api/decisions/{id}/history`),
+`tools/decision_tools.py`, a `taosctl decisions` CLI, plus `DecisionsApp.tsx`
+(all projects) and `ProjectsApp/ProjectDecisions.tsx` (per-project section). It
+already unifies interactive notifications, actionable-notification routing, and
+the external-agent consent flow into one surface.
+
+The grant and consent machinery is also built: `POST /api/agents/auth-requests`
+plus `/approve` and `/deny`, per-agent grants keyed
+`UNIQUE(canonical_id, scope, project_id)`, and
+`check_agent_scope_for_project(scope, project_id)` in `agent_token_auth.py:151`.
+
+Two gaps stop an agent from posting a decision:
+
+1. There is no decisions scope. `_ALLOWED_SCOPES` in
+   `routes/agent_registry.py:90` is `memory_read/write, a2a_send/receive,
+   files_read/write, tools_execute, registry_feeds_read, project_tasks,
+   canvas_read/write`. Nothing covers decisions.
+2. `create_decision` (`routes/decisions.py:123`) is human-only
+   (`Depends(current_user)`) and hard-codes `user_id=user.user_id`. There is no
+   agent-token path, so even with a grant an agent could not post.
+
+## Design
+
+### 1. Scope vocabulary
+
+Add two scopes to `_ALLOWED_SCOPES`: `decisions_read` and `decisions_write`.
+`decisions_write` authorizes posting a decision; `decisions_read` authorizes
+listing decisions the agent raised (for its own follow-up). @taOS-dev only needs
+`decisions_write` for the immediate goal; `decisions_read` is added in the same
+change for symmetry and to avoid a second migration later.
+
+### 2. Grant scoping: global plus per-project
+
+Grants already allow a null `project_id` (global). The owner-approved model is:
+
+- A global grant `(canonical_id, decisions_write, NULL)` authorizes posting
+  OS-level decisions, meaning decisions with `project_id = null` (things like a
+  house-rule policy, a usage note, a repo-wide question).
+- A per-project grant `(canonical_id, decisions_write, <project_id>)` authorizes
+  posting decisions attached to that project.
+
+A global grant is not a skeleton key: it authorizes `project_id = null` posts
+only, never posts into a specific project. Each project needs its own grant.
+This falls out of `check_agent_scope_for_project` matching `project_id` with a
+NULL-safe `IS`, so no new lookup logic is needed:
+
+- `body.project_id is None` requires `check_agent_scope_for_project("decisions_write", None)`.
+- `body.project_id == X` requires `check_agent_scope_for_project("decisions_write", X)`.
+
+### 3. Route gating
+
+`create_decision` accepts either identity:
+
+- Human `current_user` (unchanged path): `user_id = user.user_id`,
+  `from_agent` = whatever the body carries.
+- Agent token bearing `decisions_write` for `body.project_id`: authorized via
+  `check_agent_scope_for_project`. On this path:
+  - `from_agent` is set from the authenticated agent identity, not trusted from
+    the body (an agent cannot impersonate another).
+  - `user_id` (the human who must decide) is resolved from the target, not the
+    caller: for a project decision it is the project owner; for an OS-level
+    (null-project) decision it is the instance owner/admin. This is the one new
+    resolver the change introduces.
+  - `parent_decision_id` supersede is allowed only when the parent was raised by
+    the same agent (mirror of the existing owner check).
+
+Detection of which identity is calling reuses the existing auth middleware: a
+valid session cookie is a human; a valid agent bearer token is an agent; neither
+is 401.
+
+### 4. Consent bootstrap (the recursion)
+
+To obtain the grant, the agent calls the already-built consent primitive
+`POST /api/agents/auth-requests` with `scope = decisions_write` and the target
+project (or null for the global grant). That endpoint is agent-initiated and
+does not itself require `decisions_write`, so it is a clean bootstrap. The owner
+receives the consent request as a notification, approves it, and the grant is
+minted. Only after that can the agent post through `create_decision`.
+
+### 5. Answer round-trip (unchanged)
+
+`_route_answer_to_agent` in `routes/decisions.py` already posts the answer back
+to the A2A bus addressed to `from_agent`. @taOS-dev reads it on its scheduled
+sweep. No change is needed here beyond ensuring `from_agent` is the agent's bus
+handle so the post-back is addressed correctly.
+
+## Data flow
+
+1. Agent (once granted) calls `POST /api/decisions` with its bearer token,
+   `project_id` (or null), question, type, options.
+2. Store persists the decision; a notification is emitted to the resolved owner.
+3. The decision appears in the Decisions app (all decisions) and, when
+   `project_id` is set, in that project's Decisions section.
+4. Owner answers from any surface. `answer_decision` records it and
+   `_route_answer_to_agent` posts it to the bus.
+5. The agent picks up the answer on its next sweep and acts.
+
+## Error handling
+
+- Agent token without a matching grant for the target: 403.
+- Agent posting to a `project_id` it is not granted (even with a global grant):
+  403.
+- Agent posting with a `project_id` that does not exist: 400.
+- Neither session nor agent token: 401.
+- Invalid `type` / `priority` / missing options: existing 400s, unchanged.
+
+## Testing
+
+- Agent with a project grant can post to that project; the decision carries
+  `from_agent` = the agent and `user_id` = the project owner.
+- Agent with only a global grant can post an OS-level (null-project) decision but
+  gets 403 posting into a specific project.
+- Agent with no grant gets 403.
+- Human `current_user` path is unchanged (regression).
+- `from_agent` on the agent path cannot be spoofed from the body.
+- Answer to an agent-raised decision routes back to the agent handle.
+- `POST /api/agents/auth-requests` for `decisions_write` mints the grant on
+  approval, and the agent can then post (integration).
+
+## Out of scope
+
+- The ACP / SSE bridge that surfaces a live agent session as a Messages channel
+  is a separate design.
+- L2 fork-and-replay of decisions (the reserved `checkpoint_ref` /
+  `parent_decision_id` / `timeline_id` fields) stays out; only L1 supersede,
+  which already exists, is touched.
+- Auto-creating a dedicated "taOS development" project. Whether OS-dev decisions
+  live under a project or stay null-project is answered by the global grant; a
+  taOS-dev project can be added later without changing this plumbing.

--- a/docs/design/plans/agent-decisions-permission-plan.md
+++ b/docs/design/plans/agent-decisions-permission-plan.md
@@ -1,0 +1,158 @@
+# Agent-posted decisions permission: Implementation Plan
+
+> **For agentic workers:** implement task-by-task, TDD, commit per task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let a granted agent raise decisions via `POST /api/decisions`, gated by a new `decisions_write` scope and the existing per-project grant/consent flow.
+
+**Architecture:** Add `decisions_read`/`decisions_write` to the scope vocabulary, then give `create_decision` a dual-auth path that mirrors `project_canvas._resolve_actor`: try the agent token first via `check_agent_scope_for_project`, fall back to the human session. On the agent path, `from_agent` comes from the authenticated identity and `user_id` (the decider) is resolved from the target (project owner, or the instance admin for null-project).
+
+**Tech Stack:** FastAPI, aiosqlite, pytest.
+
+## Global Constraints
+
+- Work as jaylfc; no AI attribution; no em dashes in any committed text.
+- Target branch `dev`; this work continues on `docs/agent-decisions-permission` (spec already committed there).
+- Python 3.11 floor. `async def` routes, `await` all I/O.
+- Run tests with `/Volumes/NVMe/Users/jay/Development/tinyagentos/.venv/bin/python -m pytest <files> -q`.
+- Do not touch the human `current_user` path behavior (regression-protected).
+
+---
+
+### Task 1: Add decisions scopes to the vocabulary
+
+**Files:**
+- Modify: `tinyagentos/routes/agent_registry.py` (`_ALLOWED_SCOPES`, ~line 90)
+- Test: `tests/test_routes_agent_registry.py`
+
+**Produces:** `"decisions_read"`, `"decisions_write"` recognized as valid grantable scopes everywhere `_ALLOWED_SCOPES` is consulted (mint route, consent auth-requests validation).
+
+- [ ] **Step 1: Failing test** in `tests/test_routes_agent_registry.py` asserting a mint/auth-request with `scopes=["decisions_write"]` is accepted (no `unknown scope` error) and `scopes=["decisions_bogus"]` is rejected.
+
+```python
+def test_decisions_scopes_are_grantable():
+    from tinyagentos.routes.agent_registry import _ALLOWED_SCOPES
+    assert "decisions_read" in _ALLOWED_SCOPES
+    assert "decisions_write" in _ALLOWED_SCOPES
+```
+
+- [ ] **Step 2: Run** `pytest tests/test_routes_agent_registry.py::test_decisions_scopes_are_grantable -q` -> FAIL.
+- [ ] **Step 3: Implement** add the two entries to the `_ALLOWED_SCOPES` frozenset:
+
+```python
+_ALLOWED_SCOPES = frozenset({
+    "memory_read", "memory_write",
+    "a2a_send", "a2a_receive",
+    "files_read", "files_write",
+    "tools_execute", "registry_feeds_read",
+    "project_tasks",
+    "canvas_read", "canvas_write",
+    "decisions_read", "decisions_write",
+})
+```
+
+- [ ] **Step 4: Run** the test -> PASS.
+- [ ] **Step 5: Commit** `feat(agents): add decisions_read/decisions_write to grantable scopes`.
+
+---
+
+### Task 2: Actor resolver on the decisions route
+
+**Files:**
+- Modify: `tinyagentos/routes/decisions.py` (add `_resolve_decision_actor`, wire into `create_decision` at ~line 123)
+- Test: `tests/test_routes_decisions.py`
+
+**Interfaces:**
+- Consumes: `check_agent_scope_for_project(request, "decisions_write", project_id) -> Optional[str]` (raises 401/403), `PROJECT_SCOPE_MISMATCH_DETAIL`, `request.state.user_id` (human session set by middleware), `request.app.state.project_store`, `request.app.state.auth`.
+- Produces: `async def _resolve_decision_actor(request, project_id) -> tuple[str, str, str]` returning `(kind, from_agent, decider_user_id)` where `kind in {"agent","user"}`. Raises `HTTPException` (401 unauth, 403 no grant, 400 unknown project).
+
+- [ ] **Step 1: Failing test** for the agent-with-grant path:
+
+```python
+async def test_agent_with_grant_resolves_as_agent(app, client, monkeypatch):
+    # grant (canonical_id=agent-x, decisions_write, project=P) already seeded by the fixture;
+    # posting with the agent bearer token attributes the decision to the agent and to P's owner.
+    resp = await client.post("/api/decisions",
+        headers={"Authorization": "Bearer <agent-x-token>"},
+        json={"from_agent": "spoofed", "project_id": "P",
+              "question": "ship it?", "type": "approve_deny"})
+    assert resp.status_code == 200, resp.text
+    d = resp.json()
+    assert d["from_agent"] == "agent-x"       # authenticated identity, not "spoofed"
+    assert d["user_id"] == "<owner-of-P>"     # project owner, resolved not caller
+```
+
+- [ ] **Step 2: Run** -> FAIL.
+- [ ] **Step 3: Implement** the resolver, mirroring `project_canvas._resolve_actor` (agent-first, human-fallback). For null `project_id` the grant lookup uses `project_id=None` (global grant); the decider is the instance admin from `auth.list_users()`:
+
+```python
+async def _resolve_decision_actor(request, project_id):
+    from tinyagentos.agent_token_auth import (
+        check_agent_scope_for_project, PROJECT_SCOPE_MISMATCH_DETAIL)
+    cid = await check_agent_scope_for_project(request, "decisions_write", project_id)
+    if cid is not None:
+        ps = request.app.state.project_store
+        if project_id is not None:
+            project = await ps.get(project_id)
+            if project is None:
+                raise HTTPException(400, "project_id not found")
+            decider = project.get("user_id")
+        else:
+            admins = [u for u in request.app.state.auth.list_users() if u.get("is_admin")]
+            if not admins:
+                raise HTTPException(409, "no admin to receive an OS-level decision")
+            decider = admins[0]["user_id"]
+        return ("agent", cid, decider)
+    uid = getattr(request.state, "user_id", None)
+    if not uid:
+        raise HTTPException(401, "authentication required")
+    return ("user", None, uid)
+```
+
+- [ ] **Step 4: Run** the test -> PASS.
+- [ ] **Step 5: Commit** `feat(decisions): resolve agent-or-human actor for decision creation`.
+
+---
+
+### Task 3: Wire the resolver into create_decision + full test matrix
+
+**Files:**
+- Modify: `tinyagentos/routes/decisions.py` (`create_decision`, drop the hard `Depends(current_user)`, call the resolver)
+- Test: `tests/test_routes_decisions.py`
+
+**Interfaces:**
+- Consumes: `_resolve_decision_actor` from Task 2; `store.create(from_agent=, user_id=, project_id=, ...)`.
+
+- [ ] **Step 1: Failing tests** for the full matrix:
+
+```python
+async def test_agent_global_grant_posts_os_level(...):   # project_id=None ok, decider=admin
+async def test_agent_global_grant_403_into_project(...):  # global grant, project P -> 403
+async def test_agent_no_grant_403(...):
+async def test_human_path_unchanged(...):                 # session cookie still works, user_id=caller
+async def test_answer_routes_back_to_from_agent(...):     # answer hits the bus addressed to agent-x
+```
+
+- [ ] **Step 2: Run** -> FAIL.
+- [ ] **Step 3: Implement** change `create_decision` to take `request: Request` (no `Depends(current_user)`), call `kind, from_agent, decider = await _resolve_decision_actor(request, body.project_id)`, use `from_agent = from_agent or body.from_agent` (human path keeps body value), and pass `user_id=decider`. Keep the existing type/priority/options validation and the `parent_decision_id` supersede (extend the parent-owner check so an agent may only supersede its own).
+- [ ] **Step 4: Run** the matrix + the existing decisions tests -> PASS.
+- [ ] **Step 5: Commit** `feat(decisions): allow granted agents to post decisions (global + per-project)`.
+
+---
+
+### Task 4: taosctl + docs touch
+
+**Files:**
+- Modify: `docs/agent-coordination.md` (note the new `decisions_write`/`decisions_read` grantable scopes)
+- Test: existing `tests/test_taosctl_decisions.py` still passes (no change expected)
+
+- [ ] **Step 1:** Add a one-line entry to the scope list in `docs/agent-coordination.md`.
+- [ ] **Step 2: Run** `pytest tests/test_routes_decisions.py tests/test_routes_agent_registry.py tests/test_decision_store.py -q` -> all PASS.
+- [ ] **Step 3: Commit** `docs(agents): document decisions scopes`.
+
+---
+
+## Self-review
+
+- Spec coverage: scope vocab (Task 1), dual-auth route gating (Tasks 2-3), global-vs-per-project semantics (resolver + tests), from_agent unspoofable (Task 3), answer round-trip unchanged (test only), error handling 401/403/400 (resolver). All covered.
+- No placeholders: every code step shows real code against verified symbols (`check_agent_scope_for_project`, `project["user_id"]`, `auth.list_users()`, `store.create(user_id=, from_agent=)`).
+- Type consistency: resolver returns `(kind, from_agent, decider_user_id)` and Task 3 destructures it identically.

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -1,0 +1,125 @@
+"""Agent-token path for POST /api/decisions (decisions_write grant gating)."""
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import mint_registry_token
+
+
+async def _mint_agent(app, project_id, scopes, handle="@taOS-dev"):
+    """Register an active agent, grant it *scopes* for *project_id*, return
+    (canonical_id, bearer_token). project_id=None grants globally."""
+    registry = app.state.agent_registry
+    grants = app.state.agent_grants
+    for store in (registry, grants):
+        if store._db is None:
+            await store.init()
+    priv, _pub = app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="claude-code",
+        display_name="taOS dev",
+        origin="internal",
+        handle=handle,
+    )
+    cid = rec["canonical_id"]
+    if rec.get("status") != "active":
+        await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="claude-code", project_id=project_id
+    )
+    return cid, token
+
+
+def _agent_client(app, token):
+    """Cookieless client that authenticates only via the agent bearer token."""
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+async def _new_project(client, name="alpha", slug="alpha"):
+    resp = await client.post("/api/projects", json={"name": name, "slug": slug})
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+def _decision_body(**over):
+    body = {"from_agent": "spoofed", "question": "ship it?", "type": "approve_deny"}
+    body.update(over)
+    return body
+
+
+@pytest.mark.asyncio
+async def test_agent_with_project_grant_posts(client):
+    """A granted agent posts into its project: attributed to the agent, decided
+    by the project owner, from_agent not taken from the (spoofed) body."""
+    app = client._transport.app
+    admin_id = app.state.auth.find_user("admin")["id"]
+    pid = await _new_project(client)  # owned by the admin session
+    cid, token = await _mint_agent(app, pid, ("decisions_write",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 200, resp.text
+    d = resp.json()
+    assert d["from_agent"] == cid          # authenticated identity, not "spoofed"
+    assert d["user_id"] == admin_id        # project owner, resolved not caller
+    assert d["project_id"] == pid
+
+
+@pytest.mark.asyncio
+async def test_agent_global_grant_posts_os_level(client):
+    """A global (null-project) grant lets the agent raise an OS-level decision,
+    decided by the instance admin."""
+    app = client._transport.app
+    admin_id = app.state.auth.find_user("admin")["id"]
+    cid, token = await _mint_agent(app, None, ("decisions_write",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body())  # no project_id
+    assert resp.status_code == 200, resp.text
+    d = resp.json()
+    assert d["from_agent"] == cid
+    assert d["user_id"] == admin_id
+    assert d["project_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_agent_global_grant_403_into_project(client):
+    """A global grant is not a skeleton key: posting into a specific project
+    without a per-project grant is 403."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, None, ("decisions_write",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_agent_without_decisions_grant_403(client):
+    """A valid agent token with some other scope but no decisions_write is 403."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, pid, ("project_tasks",))  # wrong scope
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_human_path_unchanged(client):
+    """The session user path still works: the decision is attributed to the
+    body's from_agent and decided by the session user."""
+    app = client._transport.app
+    admin_id = app.state.auth.find_user("admin")["id"]
+    resp = await client.post("/api/decisions", json=_decision_body(from_agent="@taOS-dev"))
+    assert resp.status_code == 200, resp.text
+    d = resp.json()
+    assert d["from_agent"] == "@taOS-dev"
+    assert d["user_id"] == admin_id

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -70,6 +70,13 @@ _AGENT_CANVAS_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/{_SEG}/canvas/stream$")),
 )
 
+# Decisions route an agent may reach with its own registry JWT (scope
+# decisions_write). Only the create endpoint; listing/answering stay
+# session-only. The route verifies the JWT + grant + project binding.
+_AGENT_DECISIONS_ROUTES = (
+    ("POST", re.compile(r"^/api/decisions$")),
+)
+
 
 def _is_agent_task_path(method: str, path: str) -> bool:
     """True only for the exact subset of task routes a project_tasks token may
@@ -83,6 +90,12 @@ def _is_agent_canvas_path(method: str, path: str) -> bool:
     route stays session-only (owner/admin only) but the PATCH elements route is
     reachable by a canvas_write-bound agent token, mirroring POST/DELETE."""
     return any(m == method and rx.match(path) for m, rx in _AGENT_CANVAS_ROUTES)
+
+
+def _is_agent_decisions_path(method: str, path: str) -> bool:
+    """True only for POST /api/decisions, which a decisions_write-bound agent
+    token may reach.  The route verifies the JWT + grant."""
+    return any(m == method and rx.match(path) for m, rx in _AGENT_DECISIONS_ROUTES)
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -324,6 +337,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             path in _AGENT_TOKEN_PATHS
             or _is_agent_task_path(request.method, path)
             or _is_agent_canvas_path(request.method, path)
+            or _is_agent_decisions_path(request.method, path)
         ) and auth_header.lower().startswith("bearer "):
             request.state.user_id = None
             request.state.is_admin = False

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -61,6 +61,11 @@ VALID_SCOPES = frozenset({
     # named in the request.
     "canvas_read",
     "canvas_write",
+    # Raise decisions in the Decisions app: decisions_write (post), decisions_read
+    # (list own). A global (null-project) grant authorizes OS-level decisions; a
+    # per-project grant authorizes that project only. The route verifies the grant.
+    "decisions_read",
+    "decisions_write",
 })
 
 

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -94,6 +94,7 @@ _ALLOWED_SCOPES = frozenset({
     "tools_execute", "registry_feeds_read",
     "project_tasks",
     "canvas_read", "canvas_write",
+    "decisions_read", "decisions_write",
 })
 
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import logging
 import os
 
+from dataclasses import dataclass
+
 import httpx
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, model_validator
 
@@ -119,8 +121,57 @@ class AnswerIn(BaseModel):
     answered_by: str = ""
 
 
+@dataclass
+class _DecisionActor:
+    """Who is creating a decision, and who should decide it."""
+
+    kind: str                # "agent" or "user"
+    from_agent: str | None   # agent handle (agent path); None on the human path
+    decider_user_id: str     # the human the decision is addressed to
+    is_admin: bool           # human-path admin flag; always False for agents
+
+
+async def _resolve_decision_actor(request: Request, project_id: str | None) -> _DecisionActor:
+    """Authorize the caller as either a granted agent or a human session.
+
+    Agent path (bearer token with a decisions_write grant): the decision is
+    attributed to the authenticated agent, and the decider is resolved from the
+    target - the project owner for a project decision, or the instance admin for
+    an OS-level (null-project) decision. A global grant authorizes only
+    null-project posts; a per-project grant authorizes only that project.
+
+    Human path (session, no bearer token): unchanged - the session user creates
+    and is the decider.
+    """
+    from tinyagentos.agent_token_auth import check_agent_scope_for_project
+
+    # Returns None when there is no Authorization header (a cookie-only human),
+    # the canonical_id when the agent holds the grant, or raises 401/403.
+    cid = await check_agent_scope_for_project(request, "decisions_write", project_id)
+    if cid is not None:
+        if project_id is not None:
+            project = await request.app.state.project_store.get_project(project_id)
+            if project is None:
+                raise HTTPException(status_code=400, detail="project_id not found")
+            decider = project.get("user_id") or ""
+            if not decider:
+                raise HTTPException(status_code=409, detail="project has no owner to decide")
+        else:
+            admins = [u for u in request.app.state.auth.list_users() if u.get("is_admin")]
+            if not admins:
+                raise HTTPException(status_code=409, detail="no admin to receive an OS-level decision")
+            decider = admins[0]["id"]
+        return _DecisionActor(kind="agent", from_agent=cid, decider_user_id=decider, is_admin=False)
+
+    uid = getattr(request.state, "user_id", None)
+    if not uid:
+        raise HTTPException(status_code=401, detail="authentication required")
+    is_admin = bool(getattr(request.state, "is_admin", False))
+    return _DecisionActor(kind="user", from_agent=None, decider_user_id=uid, is_admin=is_admin)
+
+
 @router.post("/api/decisions")
-async def create_decision(body: DecisionIn, request: Request, user: CurrentUser = Depends(current_user)):
+async def create_decision(body: DecisionIn, request: Request):
     if body.type not in DECISION_TYPES:
         return JSONResponse({"error": f"type must be one of {DECISION_TYPES}"}, status_code=400)
     if body.priority not in PRIORITIES:
@@ -128,25 +179,35 @@ async def create_decision(body: DecisionIn, request: Request, user: CurrentUser 
     if body.type in ("single_select", "multi_select") and not body.options:
         return JSONResponse({"error": "select types require options"}, status_code=400)
 
+    actor = await _resolve_decision_actor(request, body.project_id)
+    # Agent identity is authoritative; a human may set from_agent in the body.
+    from_agent = actor.from_agent or body.from_agent
+
     store = request.app.state.decision_store
 
     # L1 revisit/supersede: a decision may replace an earlier one going forward.
-    # Validate the parent belongs to this user before we create + supersede it.
+    # A human supersedes their own (or any, if admin); an agent supersedes only
+    # decisions it raised itself.
     parent_id = body.parent_decision_id
     if parent_id:
         parent = await store.get(parent_id)
-        if parent is None or (not user.is_admin and parent["user_id"] != user.user_id):
+        if parent is None:
+            return JSONResponse({"error": "parent_decision_id not found"}, status_code=400)
+        if actor.kind == "user":
+            if not actor.is_admin and parent["user_id"] != actor.decider_user_id:
+                return JSONResponse({"error": "parent_decision_id not found"}, status_code=400)
+        elif parent.get("from_agent") != from_agent:
             return JSONResponse({"error": "parent_decision_id not found"}, status_code=400)
 
     decision = await store.create(
-        from_agent=body.from_agent,
+        from_agent=from_agent,
         question=body.question,
         type=body.type,
         options=[o.model_dump() for o in body.options],
         context=body.context,
         priority=body.priority,
         project_id=body.project_id,
-        user_id=user.user_id,
+        user_id=actor.decider_user_id,
         deadline=body.deadline,
         parent_decision_id=parent_id,
         checkpoint_ref=body.checkpoint_ref,
@@ -164,7 +225,7 @@ async def create_decision(body: DecisionIn, request: Request, user: CurrentUser 
         try:
             await notifs.add(
                 title="Decision needed",
-                message=f"{body.from_agent} needs a decision: {body.question[:120]}",
+                message=f"{from_agent} needs a decision: {body.question[:120]}",
                 level="warning" if body.priority == "blocking" else "info",
                 source="decisions",
             )


### PR DESCRIPTION
Design for letting a granted agent (starting @taOS-dev) raise decisions in the Decisions app, gated by a new decisions_write scope + the existing per-project grant/consent flow. No code, spec only. Follow-up: implementation plan once approved.