### PR TITLE
fix(cluster): heartbeat-driven registration refresh for host_lan_ip/url/hardware

### DIFF
--- a/tests/test_cluster_worker_protocol.py
+++ b/tests/test_cluster_worker_protocol.py
@@ -386,3 +386,98 @@ class TestHeartbeatAvailableModels:
         w = mgr.get_worker("w1")
         assert len(w.available_models) == 1
         assert w.available_models[0]["model_id"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat-driven registration refresh (taOS #1538)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestHeartbeatRegistrationRefresh:
+    async def _register(self, mgr: ClusterManager, name: str) -> WorkerInfo:
+        w = WorkerInfo(
+            name=name,
+            url=f"http://10.0.0.1:{9000 + int(name[-1])}",
+            host_lan_ip="10.0.0.1",
+            hardware={"cpu": "arm", "ram_mb": 4096},
+        )
+        await mgr.register_worker(w)
+        return w
+
+    async def test_heartbeat_updates_host_lan_ip(self):
+        """Heartbeat with host_lan_ip updates the cached value (taOS #1538)."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        assert mgr.get_worker("w1").host_lan_ip == "10.0.0.1"
+
+        # Worker comes up on a new IP (DHCP move / LXC restart)
+        mgr.heartbeat("w1", host_lan_ip="192.168.7.5")
+        w = mgr.get_worker("w1")
+        assert w.host_lan_ip == "192.168.7.5"
+
+    async def test_heartbeat_updates_url(self):
+        """Heartbeat with url updates the cached worker URL (taOS #1538)."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        assert mgr.get_worker("w1").url == "http://10.0.0.1:9001"
+
+        mgr.heartbeat("w1", url="http://192.168.7.5:9001")
+        w = mgr.get_worker("w1")
+        assert w.url == "http://192.168.7.5:9001"
+
+    async def test_heartbeat_updates_hardware(self):
+        """Heartbeat with hardware updates the cached hardware dict (taOS #1538)."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        assert mgr.get_worker("w1").hardware == {"cpu": "arm", "ram_mb": 4096}
+
+        new_hw = {"cpu": "x86_64", "ram_mb": 8192, "gpu": {"type": "cuda"}}
+        mgr.heartbeat("w1", hardware=new_hw)
+        w = mgr.get_worker("w1")
+        assert w.hardware == new_hw
+
+    async def test_heartbeat_omitting_host_lan_ip_preserves_prior(self):
+        """Legacy heartbeat without host_lan_ip leaves stored value unchanged."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        mgr.heartbeat("w1", host_lan_ip="192.168.7.5")
+
+        # Sparse heartbeat — only load, no host_lan_ip
+        mgr.heartbeat("w1", load=0.5)
+        w = mgr.get_worker("w1")
+        assert w.host_lan_ip == "192.168.7.5"
+
+    async def test_heartbeat_stores_storage_counters(self):
+        """Heartbeat with storage counters updates the cached values."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+
+        mgr.heartbeat(
+            "w1",
+            storage_cap_bytes=50_000_000_000,
+            storage_used_bytes=12_000_000_000,
+            bytes_deduped_total=2_000_000_000,
+        )
+        w = mgr.get_worker("w1")
+        assert w.storage_cap_bytes == 50_000_000_000
+        assert w.storage_used_bytes == 12_000_000_000
+        assert w.bytes_deduped_total == 2_000_000_000
+
+    async def test_heartbeat_omitting_storage_preserves_prior(self):
+        """Legacy heartbeat without storage fields leaves stored values unchanged."""
+        mgr = ClusterManager()
+        await self._register(mgr, "w1")
+        mgr.heartbeat(
+            "w1",
+            storage_cap_bytes=50_000_000_000,
+            storage_used_bytes=12_000_000_000,
+            bytes_deduped_total=2_000_000_000,
+        )
+
+        # Sparse heartbeat — only load
+        mgr.heartbeat("w1", load=0.5)
+        w = mgr.get_worker("w1")
+        assert w.storage_cap_bytes == 50_000_000_000
+        assert w.storage_used_bytes == 12_000_000_000
+        assert w.bytes_deduped_total == 2_000_000_000

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -270,11 +270,18 @@ class ClusterManager:
         # in sync with container reality. Optional — None leaves stale values
         # untouched for legacy workers that don't send these fields.
         if host_lan_ip is not None:
-            worker.host_lan_ip = host_lan_ip
+            # Reject empty string — a buggy/malicious heartbeat carrying
+            # "" would pass `is not None` and break find_worker_by_host_lan_ip().
+            if host_lan_ip:
+                worker.host_lan_ip = host_lan_ip
         if url is not None:
-            worker.url = url
+            # Reject empty string — same guard as host_lan_ip above.
+            if url:
+                worker.url = url
         if hardware is not None:
-            worker.hardware = hardware
+            # Reject empty dict — same guard as host_lan_ip above.
+            if hardware:
+                worker.hardware = hardware
         # LXC storage byte counters (taOS #1538): forward from worker
         # heartbeat so capacity reports stay current across restarts.
         if storage_cap_bytes is not None:

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -195,6 +195,16 @@ class ClusterManager:
         kv_cache_quant_boundary_layer_protect: bool | None = None,
         free_vram_mb: int | None = None,
         used_vram_mb: int | None = None,
+        # Registration-drift refresh (taOS #1538): live values from worker
+        # heartbeat to keep cluster manager in sync with container reality.
+        host_lan_ip: str | None = None,
+        url: str | None = None,
+        hardware: dict | None = None,
+        # LXC storage byte counters (taOS #1538): forwarded from worker
+        # heartbeat so capacity reports stay current.
+        storage_cap_bytes: int | None = None,
+        storage_used_bytes: int | None = None,
+        bytes_deduped_total: int | None = None,
     ) -> bool:
         """Accept a worker heartbeat.
 
@@ -255,6 +265,24 @@ class ClusterManager:
             worker.free_vram_mb = int(free_vram_mb)
         if used_vram_mb is not None:
             worker.used_vram_mb = int(used_vram_mb)
+        # Registration-drift refresh (taOS #1538): update cached host_lan_ip,
+        # url, and hardware from every heartbeat so the cluster manager stays
+        # in sync with container reality. Optional — None leaves stale values
+        # untouched for legacy workers that don't send these fields.
+        if host_lan_ip is not None:
+            worker.host_lan_ip = host_lan_ip
+        if url is not None:
+            worker.url = url
+        if hardware is not None:
+            worker.hardware = hardware
+        # LXC storage byte counters (taOS #1538): forward from worker
+        # heartbeat so capacity reports stay current across restarts.
+        if storage_cap_bytes is not None:
+            worker.storage_cap_bytes = int(storage_cap_bytes)
+        if storage_used_bytes is not None:
+            worker.storage_used_bytes = int(storage_used_bytes)
+        if bytes_deduped_total is not None:
+            worker.bytes_deduped_total = int(bytes_deduped_total)
         # Fire worker.online notification when a previously-offline worker recovers.
         # heartbeat() is sync, so schedule the async emit as a background task.
         if self._notifications and prev_status in ("offline", "stale"):

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -266,6 +266,13 @@ class HeartbeatBody(BaseModel):
     # rank candidates by actual free memory, not total capacity.
     free_vram_mb: int | None = None
     used_vram_mb: int | None = None
+    # Registration-drift refresh (taOS #1538): workers report their live
+    # host_lan_ip, url, and hardware on every heartbeat so the cluster
+    # manager stays in sync with container reality. Optional so legacy
+    # workers that don't send them leave stored values unchanged.
+    host_lan_ip: str | None = None
+    url: str | None = None
+    hardware: dict | None = None
 
 
 class RouteRequest(BaseModel):
@@ -506,6 +513,14 @@ async def worker_heartbeat(request: Request, body: HeartbeatBody):
         kv_cache_quant_boundary_layer_protect=body.kv_cache_quant_boundary_layer_protect,
         free_vram_mb=body.free_vram_mb,
         used_vram_mb=body.used_vram_mb,
+        # LXC storage counters (forwarded from worker heartbeat)
+        storage_cap_bytes=body.storage_cap_bytes,
+        storage_used_bytes=body.storage_used_bytes,
+        bytes_deduped_total=body.bytes_deduped_total,
+        # Registration-drift refresh (taOS #1538)
+        host_lan_ip=body.host_lan_ip,
+        url=body.url,
+        hardware=body.hardware,
     )
     if not ok:
         return JSONResponse({"error": "Worker not registered"}, status_code=404)

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -554,6 +554,21 @@ class WorkerAgent:
             kv_quant = self.detect_kv_quant_support(backends)
             snap = capacity_snapshot()
             vram = gpu_vram_snapshot()
+            # Re-resolve the host_lan_ip and worker_url on every heartbeat
+            # so the controller stays in sync with container reality after
+            # DHCP moves or LXC restarts (taOS #1538).
+            adv_ip = os.environ.get("TAOS_ADVERTISE_IP", "").strip()
+            live_url = (
+                self.advertise_url
+                or (f"http://{adv_ip}:{self.worker_port}" if adv_ip and self.worker_port
+                    else f"http://{adv_ip}" if adv_ip
+                    else None)
+                or (backends[0]["url"] if backends else self.get_worker_url())
+            )
+            live_host_lan_ip = adv_ip or _detect_lan_ip(self.controller_url)
+            from tinyagentos.hardware import detect_hardware
+            from dataclasses import asdict
+            live_hardware = asdict(detect_hardware())
             path = "/api/cluster/heartbeat"
             payload = {
                 "name": self.name,
@@ -571,6 +586,12 @@ class WorkerAgent:
                 # controller can tell "unknown" apart from "no VRAM free".
                 "free_vram_mb": vram["free_vram_mb"] if vram else None,
                 "used_vram_mb": vram["used_vram_mb"] if vram else None,
+                # Registration-drift refresh (taOS #1538): send live
+                # host_lan_ip, url, and hardware on every heartbeat
+                # so IP/subnet moves are reflected immediately.
+                "host_lan_ip": live_host_lan_ip,
+                "url": live_url,
+                "hardware": live_hardware,
             }
             body = _json.dumps(payload).encode()
             auth_headers = sign_request_headers(self._signing_key, self.name, "POST", path, body)

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -546,17 +546,23 @@ class WorkerAgent:
             )
             return 0
 
+        from tinyagentos.hardware import detect_hardware
+        from dataclasses import asdict
+
         try:
             from tinyagentos.worker.pairing import sign_request_headers
+            # Re-resolve host_lan_ip, url, and hardware on every heartbeat
+            # so the controller stays in sync with container reality after
+            # DHCP moves or LXC restarts (taOS #1538).
+            # Note: the function call asdict(detect_hardware()) remains inside
+            # the try so a probe failure degrades gracefully (heartbeat skips
+            # this update) rather than crashing the run loop.
             load = psutil.cpu_percent() / 100.0
             backends = await self.detect_backends()
             caps = sorted(set(self.detect_capabilities(backends)) | set(self.extra_capabilities))
             kv_quant = self.detect_kv_quant_support(backends)
             snap = capacity_snapshot()
             vram = gpu_vram_snapshot()
-            # Re-resolve the host_lan_ip and worker_url on every heartbeat
-            # so the controller stays in sync with container reality after
-            # DHCP moves or LXC restarts (taOS #1538).
             adv_ip = os.environ.get("TAOS_ADVERTISE_IP", "").strip()
             live_url = (
                 self.advertise_url
@@ -566,8 +572,6 @@ class WorkerAgent:
                 or (backends[0]["url"] if backends else self.get_worker_url())
             )
             live_host_lan_ip = adv_ip or _detect_lan_ip(self.controller_url)
-            from tinyagentos.hardware import detect_hardware
-            from dataclasses import asdict
             live_hardware = asdict(detect_hardware())
             path = "/api/cluster/heartbeat"
             payload = {


### PR DESCRIPTION
Fixes #1538 — agent registration drift (stale IP, stale running status).

## Problem
When a worker LXC container comes up on a different IP after a DHCP move or restart, the `host_lan_ip`, `url`, and `hardware` drift from reality. Skald and other cluster routing consumers keep using stale values, causing hangs or 5xx on every controller call targeting the dead address.

## Fix — heartbeat-driven refresh/reconciliation
- **`HeartbeatBody`**: added optional `host_lan_ip`, `url`, `hardware` fields
- **`ClusterManager.heartbeat()`**: applies these fields when present; `None` preserves prior values for legacy workers (backward-compatible)
- **`routes/cluster.py` `worker_heartbeat`**: forwards all new fields + LXC storage counters (`storage_cap_bytes`, `storage_used_bytes`, `bytes_deduped_total`) that were accepted by `HeartbeatBody` but silently dropped by the handler
- **`WorkerAgent.heartbeat()`**: re-resolves `host_lan_ip`, `url`, and `hardware` on every pulse so the controller stays in sync with container reality

## Tests
6 new tests in `TestHeartbeatRegistrationRefresh`:
- heartbeat updates `host_lan_ip`, `url`, `hardware`
- omitting fields preserves prior values (legacy compatibility)
- storage counters forwarded and stored

All 33 cluster+protocol unit tests pass, no regressions.