### PR TITLE
feat(notifications): scope web-push delivery per-user

### DIFF
--- a/tests/test_notifications_push.py
+++ b/tests/test_notifications_push.py
@@ -283,6 +283,115 @@ class TestAddTriggersPush:
 
 
 # ---------------------------------------------------------------------------
+# Per-user scoping (user_id on add() → per-user push fan-out)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestPerUserScoping:
+    async def test_add_with_user_id_stores_it(self, tmp_path):
+        store = NotificationStore(tmp_path / "notif.db")
+        await store.init()
+        try:
+            await store.add("Hi", "there", user_id="user-1")
+            items = await store.list()
+            assert len(items) == 1
+            assert items[0]["user_id"] == "user-1"
+        finally:
+            await store.close()
+
+    async def test_add_without_user_id_stores_null(self, tmp_path):
+        store = NotificationStore(tmp_path / "notif.db")
+        await store.init()
+        try:
+            await store.add("Broadcast", "to all")
+            items = await store.list()
+            assert len(items) == 1
+            assert items[0]["user_id"] is None
+        finally:
+            await store.close()
+
+    async def test_add_passes_user_id_to_event_emitter(self, tmp_path):
+        store = NotificationStore(tmp_path / "notif.db")
+        await store.init()
+        try:
+            seen: list[dict] = []
+
+            async def emitter(row: dict) -> None:
+                seen.append(row)
+
+            store.set_event_emitter(emitter)
+            await store.add("Scoped", "msg", user_id="user-a")
+            assert len(seen) == 1
+            assert seen[0]["user_id"] == "user-a"
+        finally:
+            await store.close()
+
+    async def test_add_passes_null_user_id_to_event_emitter(self, tmp_path):
+        store = NotificationStore(tmp_path / "notif.db")
+        await store.init()
+        try:
+            seen: list[dict] = []
+
+            async def emitter(row: dict) -> None:
+                seen.append(row)
+
+            store.set_event_emitter(emitter)
+            await store.add("Broadcast", "msg")
+            assert len(seen) == 1
+            assert seen[0]["user_id"] is None
+        finally:
+            await store.close()
+
+    async def test_send_web_push_scoped_to_user(self, push_store):
+        """When row has user_id, only that user's subscriptions are targeted."""
+        import json
+
+        await _seed(push_store, "https://push.example.com/user_a_sub", user_id="user-a")
+        await _seed(push_store, "https://push.example.com/user_b_sub", user_id="user-b")
+
+        row = {**_ROW, "user_id": "user-a"}
+        with patch("pywebpush.webpush") as mock:
+            result = await send_web_push(row, store=push_store, vapid=FAKE_VAPID)
+        assert mock.call_count == 1
+        assert result["sent"] == 1
+        # Verify the targeted endpoint belongs to user-a
+        payload = json.loads(mock.call_args.kwargs["data"])
+        assert payload["title"] == "Access request"
+
+    async def test_send_web_push_broadcast_when_no_user_id(self, push_store):
+        """When row has no user_id (None/absent), fans out to all."""
+        await _seed(push_store, "https://push.example.com/user_a_sub", user_id="user-a")
+        await _seed(push_store, "https://push.example.com/user_b_sub", user_id="user-b")
+
+        row = {**_ROW}  # no user_id
+        with patch("pywebpush.webpush") as mock:
+            result = await send_web_push(row, store=push_store, vapid=FAKE_VAPID)
+        assert mock.call_count == 2
+        assert result["sent"] == 2
+
+    async def test_send_web_push_scoped_no_subscriptions_is_noop(self, push_store):
+        """Scoped send to a user with no subscriptions is a no-op."""
+        await _seed(push_store, "https://push.example.com/user_a_sub", user_id="user-a")
+        row = {**_ROW, "user_id": "user-b"}  # user-b has no subscriptions
+        with patch("pywebpush.webpush") as mock:
+            result = await send_web_push(row, store=push_store, vapid=FAKE_VAPID)
+        mock.assert_not_called()
+        assert result == {"sent": 0, "failed": 0, "removed": 0}
+
+    async def test_send_web_push_broadcast_none_user_id(self, push_store):
+        """When user_id is explicitly None, fans out to all (broadcast)."""
+        await _seed(push_store, "https://push.example.com/user_a_sub", user_id="user-a")
+        await _seed(push_store, "https://push.example.com/user_b_sub", user_id="user-b")
+
+        row = {**_ROW, "user_id": None}
+        with patch("pywebpush.webpush") as mock:
+            result = await send_web_push(row, store=push_store, vapid=FAKE_VAPID)
+        assert mock.call_count == 2
+        assert result["sent"] == 2
+
+
+# ---------------------------------------------------------------------------
 # HTTP routes
 # ---------------------------------------------------------------------------
 

--- a/tinyagentos/notifications.py
+++ b/tinyagentos/notifications.py
@@ -20,7 +20,8 @@ CREATE TABLE IF NOT EXISTS notifications (
     read INTEGER NOT NULL DEFAULT 0,
     source TEXT,
     archived INTEGER NOT NULL DEFAULT 0,
-    data TEXT
+    data TEXT,
+    user_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_notif_ts ON notifications(timestamp DESC);
 CREATE TABLE IF NOT EXISTS notification_prefs (
@@ -37,7 +38,7 @@ def _serialize_row(r) -> dict:
     cannot silently corrupt the mapping. The SELECT queries must select exactly
     these columns in this order.
     """
-    COLS = ("id", "timestamp", "level", "title", "message", "read", "source", "data")
+    COLS = ("id", "timestamp", "level", "title", "message", "read", "source", "data", "user_id")
     row = dict(zip(COLS, r))
     data = None
     if row["data"]:
@@ -48,7 +49,7 @@ def _serialize_row(r) -> dict:
     return {
         "id": row["id"], "timestamp": row["timestamp"], "level": row["level"],
         "title": row["title"], "message": row["message"], "read": bool(row["read"]),
-        "source": row["source"], "data": data,
+        "source": row["source"], "data": data, "user_id": row["user_id"],
     }
 
 
@@ -119,6 +120,20 @@ class NotificationStore(BaseStore):
                 "ALTER TABLE notifications ADD COLUMN data TEXT"
             )
             await self._db.commit()
+        # `user_id` scopes notifications to a specific user. Guarded ALTER so
+        # existing databases gain the column without a destructive migration.
+        # NULL = broadcast (system-wide notice); non-NULL = scoped to that user.
+        if "user_id" not in cols:
+            await self._db.execute(
+                "ALTER TABLE notifications ADD COLUMN user_id TEXT"
+            )
+            await self._db.commit()
+        # Create the per-user index if it doesn't exist yet. Cannot live in
+        # the SCHEMA because the column is added via guarded ALTER after init.
+        await self._db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_notif_user ON notifications(user_id)"
+        )
+        await self._db.commit()
 
     async def add(
         self,
@@ -127,12 +142,22 @@ class NotificationStore(BaseStore):
         level: str = "info",
         source: str = "system",
         data: dict | None = None,
+        user_id: str | None = None,
     ) -> None:
+        """Create a notification row and fan out to emitters + push.
+
+        Args:
+            user_id: Scope the notification to a specific user. When None
+                (default), the notification is a broadcast delivered to every
+                subscribed device (genuinely system-wide notices). When set to a
+                user id, web-push delivery fans out only to that user's
+                subscriptions.
+        """
         ts = int(time.time())
         data_json = json.dumps(data) if data is not None else None
         cursor = await self._db.execute(
-            "INSERT INTO notifications (timestamp, level, title, message, source, data) VALUES (?, ?, ?, ?, ?, ?)",
-            (ts, level, title, message, source, data_json),
+            "INSERT INTO notifications (timestamp, level, title, message, source, data, user_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (ts, level, title, message, source, data_json, user_id),
         )
         await self._db.commit()
         # Fire webhook notifications in the background
@@ -151,6 +176,7 @@ class NotificationStore(BaseStore):
             "read": False,
             "source": source,
             "data": data,
+            "user_id": user_id,
         }
         if self._event_emitter:
             try:
@@ -176,7 +202,7 @@ class NotificationStore(BaseStore):
         if unread_only:
             conds.append("read = 0")
         sql = (
-            "SELECT id, timestamp, level, title, message, read, source, data FROM notifications"
+            "SELECT id, timestamp, level, title, message, read, source, data, user_id FROM notifications"
             f" WHERE {' AND '.join(conds)} ORDER BY timestamp DESC LIMIT ?"
         )
         async with self._db.execute(sql, (limit,)) as cursor:
@@ -187,7 +213,7 @@ class NotificationStore(BaseStore):
         # History view: the dismissed notifications, newest first. Nothing is
         # deleted, so this is the durable record (#62 / append-only #103).
         async with self._db.execute(
-            "SELECT id, timestamp, level, title, message, read, source, data FROM notifications"
+            "SELECT id, timestamp, level, title, message, read, source, data, user_id FROM notifications"
             " WHERE archived = 1 ORDER BY timestamp DESC LIMIT ?",
             (limit,),
         ) as cursor:

--- a/tinyagentos/notifications_push.py
+++ b/tinyagentos/notifications_push.py
@@ -10,9 +10,10 @@ send/subscribe patterns are shared.
 Design notes
 ------------
 * The subscription store is a small SQLite table keyed by the push endpoint.
-  Subscriptions are recorded per user_id, but taOS notifications are currently
-  global (add() has no target user), so the send path fans out to every
-  subscription.
+  Subscriptions are recorded per user_id. When a notification carries a user_id,
+  the send path fans out only to that user's subscriptions; when user_id is None
+  (broadcast), it fans out to every subscription for genuinely system-wide
+  notices.
 * pywebpush.webpush() is synchronous (uses requests). Each send runs in a
   worker thread via asyncio.to_thread so the event loop is never blocked.
 * The whole send path is strictly best-effort: a missing VAPID key, no
@@ -107,6 +108,27 @@ class NotificationPushStore(BaseStore):
         ) as cursor:
             rows = await cursor.fetchall()
         return [{"endpoint": r[0], "created_at": r[1]} for r in rows]
+
+    async def list_all_for_user(self, user_id: str) -> list[dict]:
+        """Full subscription rows (including secrets) for one user.
+
+        Used by the send fan-out when scoping a notification to a specific
+        user. Returns the same shape as list_all() — endpoint, user_id,
+        p256dh, auth, created_at — so _send_one() can use it directly.
+        """
+        if not user_id:
+            raise ValueError("user_id is required")
+        assert self._db is not None
+        async with self._db.execute(
+            "SELECT endpoint, user_id, p256dh, auth, created_at FROM notif_push_subscriptions "
+            "WHERE user_id = ? ORDER BY created_at DESC",
+            (user_id,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [
+            {"endpoint": r[0], "user_id": r[1], "p256dh": r[2], "auth": r[3], "created_at": r[4]}
+            for r in rows
+        ]
 
     async def delete_by_endpoint(self, endpoint: str) -> int:
         """Delete the subscription for this endpoint, ignoring ownership.
@@ -224,6 +246,11 @@ async def _send_one(sub: dict, data_str: str, private_pem: str, store: Notificat
 async def send_web_push(row: dict, *, store: NotificationPushStore, vapid: tuple[str, str] | None) -> dict:
     """Best-effort fan-out of one notification row to every subscription.
 
+    When ``row["user_id"]`` is set, fans out only to that user's subscriptions
+    via ``store.list_all_for_user()``. When ``user_id`` is None (broadcast), fans
+    out to every subscription via ``store.list_all()`` for genuinely
+    system-wide notices.
+
     Returns {"sent", "failed", "removed"} counts (also useful for tests). Never
     raises: a missing VAPID key or no subscriptions is a no-op, and every
     per-subscription error is caught and counted.
@@ -232,7 +259,8 @@ async def send_web_push(row: dict, *, store: NotificationPushStore, vapid: tuple
         return {"sent": 0, "failed": 0, "removed": 0}
     _, private_pem = vapid
     try:
-        subs = await store.list_all()
+        user_id = row.get("user_id")
+        subs = await (store.list_all_for_user(user_id) if user_id else store.list_all())
     except Exception:  # noqa: BLE001 - store read must never break add()
         logger.warning("notif-push: failed to list subscriptions", exc_info=True)
         return {"sent": 0, "failed": 0, "removed": 0}


### PR DESCRIPTION
Task: t_ef276ed5. Fixes #1781.

## Summary

Scopes notification web-push delivery per-user so that when a notification
carries a `user_id`, it fans out only to that user's push subscriptions
instead of every subscription globally.

## Changes

### `tinyagentos/notifications.py`
- Added `user_id TEXT` column to the `notifications` table schema
- Guarded ALTER migration in `_post_init()` — existing databases gain the
  column without destructive re-creation
- Index on `user_id` created in `_post_init()` (after column migration)
  since it can't live in the SCHEMA
- `add()` accepts optional `user_id: str | None = None`: when None
  (default), the notification is broadcast; when set, the notification is
  scoped to that user
- `_serialize_row` includes `user_id` in its COLS tuple and output dict
- `list()` and `list_archived()` SELECT queries include `user_id`

### `tinyagentos/notifications_push.py`
- Added `list_all_for_user(user_id)` — returns full subscription rows
  (including p256dh/auth secrets) for one user, used by the send fan-out
- `send_web_push()` checks `row["user_id"]`: when set, uses
  `list_all_for_user()` to fan out to one user; when None, uses
  `list_all()` for broadcast (backward-compatible)
- Updated module docstring to reflect per-user scoping

### Tests (`tests/test_notifications_push.py`)
- 8 new tests in `TestPerUserScoping` class:
  - `add()` stores `user_id` in DB (with and without)
  - `user_id` passes through to event emitter
  - `send_web_push` scoped to user targets only that user's subscriptions
  - `send_web_push` broadcast (no user_id) fans out to all
  - `send_web_push` scoped to a user with no subscriptions is a no-op
  - `send_web_push` with explicit `user_id=None` is broadcast

## Backward compatibility

All existing callers of `add()` are backward-compatible: `user_id`
defaults to None (broadcast), preserving the current global-notification
model. Future multi-user work can update specific callers to pass a
`user_id` where appropriate.

## Test results

- All 56 targeted store/push tests pass (TestNotificationStore,
  TestNotificationPushStore, TestSendWebPush, TestAddTriggersPush,
  TestPerUserScoping, test_event_stream, test_data_column_migration_on_legacy_db)
- Parallel gate running in background