### PR TITLE
feat(taos-agent): allow editing agent message before sending reply

### DIFF
--- a/desktop/src/components/TaosAssistantPanel.test.tsx
+++ b/desktop/src/components/TaosAssistantPanel.test.tsx
@@ -91,4 +91,97 @@ describe("TaosAssistantPanel", () => {
     fireEvent.click(cogBtn);
     expect(screen.getByTestId("settings-modal")).toBeInTheDocument();
   });
+
+  it("last assistant message shows edit hint when not streaming", () => {
+    useTaosAgentStore.setState({
+      model: "qwen3",
+      streaming: false,
+      messages: [
+        { role: "user", content: "Hello", ts: 1 },
+        { role: "assistant", content: "Hi! How can I help?", ts: 2 },
+      ],
+    });
+    render(<TaosAssistantPanel />);
+    expect(screen.getByText("click to edit")).toBeInTheDocument();
+  });
+
+  it("no edit hint while streaming the last assistant message", () => {
+    useTaosAgentStore.setState({
+      model: "qwen3",
+      streaming: true,
+      messages: [
+        { role: "user", content: "Hello", ts: 1 },
+        { role: "assistant", content: "Thinking...", ts: 2 },
+      ],
+    });
+    render(<TaosAssistantPanel />);
+    expect(screen.queryByText("click to edit")).not.toBeInTheDocument();
+  });
+
+  it("clicking last assistant bubble enters edit mode", () => {
+    useTaosAgentStore.setState({
+      model: "qwen3",
+      streaming: false,
+      messages: [
+        { role: "user", content: "Hello", ts: 1 },
+        { role: "assistant", content: "Old response", ts: 2 },
+      ],
+    });
+    render(<TaosAssistantPanel />);
+    const bubble = screen.getByText("Old response").closest('[class*="cursor-pointer"]');
+    expect(bubble).not.toBeNull();
+    fireEvent.click(bubble!);
+    expect(screen.getByRole("textbox", { name: /edit agent message/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save edit/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel edit/i })).toBeInTheDocument();
+  });
+
+  it("saving edit updates the store", () => {
+    useTaosAgentStore.setState({
+      model: "qwen3",
+      streaming: false,
+      messages: [
+        { role: "user", content: "Hello", ts: 1 },
+        { role: "assistant", content: "Old response", ts: 2 },
+      ],
+    });
+    render(<TaosAssistantPanel />);
+    const bubble = screen.getByText("Old response").closest('[class*="cursor-pointer"]');
+    fireEvent.click(bubble!);
+    const textarea = screen.getByRole("textbox", { name: /edit agent message/i });
+    fireEvent.change(textarea, { target: { value: "Corrected!" } });
+    fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
+    expect(useTaosAgentStore.getState().messages[1].content).toBe("Corrected!");
+  });
+
+  it("cancel edit reverts without changing store", () => {
+    useTaosAgentStore.setState({
+      model: "qwen3",
+      streaming: false,
+      messages: [
+        { role: "user", content: "Hello", ts: 1 },
+        { role: "assistant", content: "Original", ts: 2 },
+      ],
+    });
+    render(<TaosAssistantPanel />);
+    fireEvent.click(screen.getByText("Original").closest('[class*="cursor-pointer"]')!);
+    fireEvent.click(screen.getByRole("button", { name: /cancel edit/i }));
+    expect(useTaosAgentStore.getState().messages[1].content).toBe("Original");
+  });
+
+  it("Escape key cancels edit", () => {
+    useTaosAgentStore.setState({
+      model: "qwen3",
+      streaming: false,
+      messages: [
+        { role: "user", content: "Hello", ts: 1 },
+        { role: "assistant", content: "Original", ts: 2 },
+      ],
+    });
+    render(<TaosAssistantPanel />);
+    fireEvent.click(screen.getByText("Original").closest('[class*="cursor-pointer"]')!);
+    const textarea = screen.getByRole("textbox", { name: /edit agent message/i });
+    fireEvent.keyDown(textarea, { key: "Escape" });
+    expect(useTaosAgentStore.getState().messages[1].content).toBe("Original");
+  });
 });

--- a/desktop/src/components/TaosAssistantPanel.test.tsx
+++ b/desktop/src/components/TaosAssistantPanel.test.tsx
@@ -92,7 +92,7 @@ describe("TaosAssistantPanel", () => {
     expect(screen.getByTestId("settings-modal")).toBeInTheDocument();
   });
 
-  it("last assistant message shows edit hint when not streaming", () => {
+  it("last assistant message shows edit button when not streaming", () => {
     useTaosAgentStore.setState({
       model: "qwen3",
       streaming: false,
@@ -102,10 +102,10 @@ describe("TaosAssistantPanel", () => {
       ],
     });
     render(<TaosAssistantPanel />);
-    expect(screen.getByText("click to edit")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /edit message/i })).toBeInTheDocument();
   });
 
-  it("no edit hint while streaming the last assistant message", () => {
+  it("no edit button while streaming the last assistant message", () => {
     useTaosAgentStore.setState({
       model: "qwen3",
       streaming: true,
@@ -115,10 +115,10 @@ describe("TaosAssistantPanel", () => {
       ],
     });
     render(<TaosAssistantPanel />);
-    expect(screen.queryByText("click to edit")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /edit message/i })).not.toBeInTheDocument();
   });
 
-  it("clicking last assistant bubble enters edit mode", () => {
+  it("clicking edit button enters edit mode", () => {
     useTaosAgentStore.setState({
       model: "qwen3",
       streaming: false,
@@ -128,9 +128,7 @@ describe("TaosAssistantPanel", () => {
       ],
     });
     render(<TaosAssistantPanel />);
-    const bubble = screen.getByText("Old response").closest('[class*="cursor-pointer"]');
-    expect(bubble).not.toBeNull();
-    fireEvent.click(bubble!);
+    fireEvent.click(screen.getByRole("button", { name: /edit message/i }));
     expect(screen.getByRole("textbox", { name: /edit agent message/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /save edit/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /cancel edit/i })).toBeInTheDocument();
@@ -146,8 +144,7 @@ describe("TaosAssistantPanel", () => {
       ],
     });
     render(<TaosAssistantPanel />);
-    const bubble = screen.getByText("Old response").closest('[class*="cursor-pointer"]');
-    fireEvent.click(bubble!);
+    fireEvent.click(screen.getByRole("button", { name: /edit message/i }));
     const textarea = screen.getByRole("textbox", { name: /edit agent message/i });
     fireEvent.change(textarea, { target: { value: "Corrected!" } });
     fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
@@ -164,7 +161,7 @@ describe("TaosAssistantPanel", () => {
       ],
     });
     render(<TaosAssistantPanel />);
-    fireEvent.click(screen.getByText("Original").closest('[class*="cursor-pointer"]')!);
+    fireEvent.click(screen.getByRole("button", { name: /edit message/i }));
     fireEvent.click(screen.getByRole("button", { name: /cancel edit/i }));
     expect(useTaosAgentStore.getState().messages[1].content).toBe("Original");
   });
@@ -179,9 +176,25 @@ describe("TaosAssistantPanel", () => {
       ],
     });
     render(<TaosAssistantPanel />);
-    fireEvent.click(screen.getByText("Original").closest('[class*="cursor-pointer"]')!);
+    fireEvent.click(screen.getByRole("button", { name: /edit message/i }));
     const textarea = screen.getByRole("textbox", { name: /edit agent message/i });
     fireEvent.keyDown(textarea, { key: "Escape" });
     expect(useTaosAgentStore.getState().messages[1].content).toBe("Original");
+  });
+
+  it("save is disabled when textarea is emptied", () => {
+    useTaosAgentStore.setState({
+      model: "qwen3",
+      streaming: false,
+      messages: [
+        { role: "user", content: "Hello", ts: 1 },
+        { role: "assistant", content: "Original", ts: 2 },
+      ],
+    });
+    render(<TaosAssistantPanel />);
+    fireEvent.click(screen.getByRole("button", { name: /edit message/i }));
+    const textarea = screen.getByRole("textbox", { name: /edit agent message/i });
+    fireEvent.change(textarea, { target: { value: "   " } });
+    expect(screen.getByRole("button", { name: /save edit/i })).toBeDisabled();
   });
 });

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -43,6 +43,7 @@ export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boole
     messages,
     appendMessage,
     appendDelta,
+    updateMessage,
     model,
     setModel,
     streaming,
@@ -288,6 +289,13 @@ export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boole
             role={msg.role}
             content={msg.content}
             streaming={streaming && i === messages.length - 1 && msg.role === "assistant"}
+            editable={
+              !streaming
+              && msg.role === "assistant"
+              && msg.content
+              && i === messages.length - 1
+            }
+            onSave={(newContent) => updateMessage(i, newContent)}
           />
         ))}
         <div ref={messagesEndRef} />
@@ -578,16 +586,22 @@ function MessageBubble({
   role,
   content,
   streaming,
+  onSave,
+  editable,
 }: {
   role: "user" | "assistant" | "system";
   content: string;
   streaming?: boolean;
+  onSave?: (content: string) => void;
+  editable?: boolean;
 }) {
   const [copied, setCopied] = useState(false);
+  const [editing, setEditing] = useState(false);
 
   if (role === "system") return null;
 
   const isUser = role === "user";
+  const canEdit = editable && !streaming && content && onSave;
 
   const handleCopy = async () => {
     try {
@@ -599,12 +613,74 @@ function MessageBubble({
     }
   };
 
+  const startEdit = () => {
+    if (canEdit) setEditing(true);
+  };
+
+  const saveEdit = (newContent: string) => {
+    const trimmed = newContent.trim();
+    if (trimmed && onSave) onSave(trimmed);
+    setEditing(false);
+  };
+
+  const cancelEdit = () => {
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+        <div className={`max-w-[85%] rounded-xl px-3 py-2 text-sm ${
+          isUser ? "bg-accent text-white" : "bg-shell-surface-hover text-shell-text"
+        }`}>
+          <textarea
+            autoFocus
+            defaultValue={content}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") { e.preventDefault(); cancelEdit(); }
+              else if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                saveEdit((e.target as HTMLTextAreaElement).value);
+              }
+            }}
+            aria-label="Edit agent message"
+            rows={3}
+            className="w-full bg-white/5 border border-white/10 rounded px-2 py-1 text-sm resize-none focus:outline-none focus:border-accent/50"
+          />
+          <div className="flex gap-1 mt-1 justify-end">
+            <button
+              onClick={cancelEdit}
+              className="px-2 py-0.5 text-xs rounded text-shell-text-tertiary hover:text-shell-text"
+              aria-label="Cancel edit"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => {
+                const ta = document.querySelector<HTMLTextAreaElement>(
+                  '[aria-label="Edit agent message"]'
+                );
+                if (ta) saveEdit(ta.value);
+              }}
+              className="px-2 py-0.5 text-xs rounded bg-accent text-white"
+              aria-label="Save edit"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"} group`}>
       <div
         className={`relative max-w-[85%] rounded-xl px-3 py-2 text-sm break-words select-text ${
           isUser ? "bg-accent text-white" : "bg-shell-surface-hover text-shell-text"
-        }`}
+        }${canEdit ? " cursor-pointer hover:ring-1 hover:ring-accent/40" : ""}`}
+        onClick={startEdit}
+        title={canEdit ? "Click to edit this message" : undefined}
       >
         <div className="whitespace-pre-wrap">
           {renderBubbleContent(content)}
@@ -615,9 +691,14 @@ function MessageBubble({
         {streaming && content && (
           <span className="inline-block w-1.5 h-3 bg-current opacity-60 animate-pulse ml-0.5 rounded-sm" />
         )}
-        {!streaming && content && (
+        {!streaming && content && canEdit && (
+          <span className="ml-1 text-[10px] text-shell-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity select-none">
+            click to edit
+          </span>
+        )}
+        {!streaming && content && !canEdit && (
           <button
-            onClick={handleCopy}
+            onClick={(e) => { e.stopPropagation(); handleCopy(); }}
             aria-label={copied ? "Copied" : "Copy message"}
             className="absolute -top-2 -right-2 p-1 rounded opacity-0 group-hover:opacity-100 focus:opacity-100 bg-shell-surface border border-white/10 text-shell-text-secondary hover:text-shell-text transition-opacity select-none"
           >

--- a/desktop/src/components/TaosAssistantPanel.tsx
+++ b/desktop/src/components/TaosAssistantPanel.tsx
@@ -10,6 +10,7 @@ import {
   ExternalLink,
   Copy,
   Check,
+  Pencil,
 } from "lucide-react";
 import { CodeBlock } from "@/components/CodeBlock";
 import { useTaosAgentStore } from "@/stores/taos-agent-store";
@@ -288,11 +289,11 @@ export function TaosAssistantPanelInner({ embedded = false }: { embedded?: boole
             key={i}
             role={msg.role}
             content={msg.content}
-            streaming={streaming && i === messages.length - 1 && msg.role === "assistant"}
+            streaming={!!(streaming && i === messages.length - 1 && msg.role === "assistant")}
             editable={
               !streaming
               && msg.role === "assistant"
-              && msg.content
+              && !!msg.content
               && i === messages.length - 1
             }
             onSave={(newContent) => updateMessage(i, newContent)}
@@ -597,6 +598,16 @@ function MessageBubble({
 }) {
   const [copied, setCopied] = useState(false);
   const [editing, setEditing] = useState(false);
+  const [draftValue, setDraftValue] = useState("");
+
+  // Reset editing state when the bubble stops being editable (e.g. new message
+  // appended mid-edit, or streaming restarts).  Without this the editor stays
+  // open on a now-stale message.
+  useEffect(() => {
+    if (!editable || streaming) {
+      setEditing(false);
+    }
+  }, [editable, streaming]);
 
   if (role === "system") return null;
 
@@ -614,11 +625,13 @@ function MessageBubble({
   };
 
   const startEdit = () => {
-    if (canEdit) setEditing(true);
+    if (!canEdit) return;
+    setDraftValue(content);
+    setEditing(true);
   };
 
-  const saveEdit = (newContent: string) => {
-    const trimmed = newContent.trim();
+  const saveEdit = () => {
+    const trimmed = draftValue.trim();
     if (trimmed && onSave) onSave(trimmed);
     setEditing(false);
   };
@@ -635,12 +648,13 @@ function MessageBubble({
         }`}>
           <textarea
             autoFocus
-            defaultValue={content}
+            value={draftValue}
+            onChange={(e) => setDraftValue(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Escape") { e.preventDefault(); cancelEdit(); }
               else if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
-                saveEdit((e.target as HTMLTextAreaElement).value);
+                saveEdit();
               }
             }}
             aria-label="Edit agent message"
@@ -656,13 +670,9 @@ function MessageBubble({
               Cancel
             </button>
             <button
-              onClick={() => {
-                const ta = document.querySelector<HTMLTextAreaElement>(
-                  '[aria-label="Edit agent message"]'
-                );
-                if (ta) saveEdit(ta.value);
-              }}
-              className="px-2 py-0.5 text-xs rounded bg-accent text-white"
+              onClick={saveEdit}
+              disabled={!draftValue.trim()}
+              className="px-2 py-0.5 text-xs rounded bg-accent text-white disabled:opacity-30"
               aria-label="Save edit"
             >
               Save
@@ -673,14 +683,14 @@ function MessageBubble({
     );
   }
 
+  // Edit affordance: show an explicit Edit button on hover instead of making
+  // the whole bubble click-to-edit (avoids accidental entry while copying).
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"} group`}>
       <div
         className={`relative max-w-[85%] rounded-xl px-3 py-2 text-sm break-words select-text ${
           isUser ? "bg-accent text-white" : "bg-shell-surface-hover text-shell-text"
-        }${canEdit ? " cursor-pointer hover:ring-1 hover:ring-accent/40" : ""}`}
-        onClick={startEdit}
-        title={canEdit ? "Click to edit this message" : undefined}
+        }`}
       >
         <div className="whitespace-pre-wrap">
           {renderBubbleContent(content)}
@@ -691,19 +701,25 @@ function MessageBubble({
         {streaming && content && (
           <span className="inline-block w-1.5 h-3 bg-current opacity-60 animate-pulse ml-0.5 rounded-sm" />
         )}
-        {!streaming && content && canEdit && (
-          <span className="ml-1 text-[10px] text-shell-text-tertiary opacity-0 group-hover:opacity-100 transition-opacity select-none">
-            click to edit
-          </span>
-        )}
-        {!streaming && content && !canEdit && (
-          <button
-            onClick={(e) => { e.stopPropagation(); handleCopy(); }}
-            aria-label={copied ? "Copied" : "Copy message"}
-            className="absolute -top-2 -right-2 p-1 rounded opacity-0 group-hover:opacity-100 focus:opacity-100 bg-shell-surface border border-white/10 text-shell-text-secondary hover:text-shell-text transition-opacity select-none"
-          >
-            {copied ? <Check size={10} /> : <Copy size={10} />}
-          </button>
+        {!streaming && content && (
+          <div className="absolute -top-2 -right-2 flex gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity select-none">
+            {canEdit && (
+              <button
+                onClick={startEdit}
+                aria-label="Edit message"
+                className="p-1 rounded bg-shell-surface border border-white/10 text-shell-text-secondary hover:text-shell-text"
+              >
+                <Pencil size={10} />
+              </button>
+            )}
+            <button
+              onClick={handleCopy}
+              aria-label={copied ? "Copied" : "Copy message"}
+              className="p-1 rounded bg-shell-surface border border-white/10 text-shell-text-secondary hover:text-shell-text"
+            >
+              {copied ? <Check size={10} /> : <Copy size={10} />}
+            </button>
+          </div>
         )}
       </div>
     </div>

--- a/desktop/src/stores/taos-agent-store.test.ts
+++ b/desktop/src/stores/taos-agent-store.test.ts
@@ -69,4 +69,24 @@ describe("taos-agent-store", () => {
     useTaosAgentStore.getState().setStreaming(false);
     expect(useTaosAgentStore.getState().streaming).toBe(false);
   });
+
+  it("updateMessage replaces content at index", () => {
+    const { appendMessage, updateMessage } = useTaosAgentStore.getState();
+    appendMessage({ role: "user", content: "Hello", ts: 1 });
+    appendMessage({ role: "assistant", content: "Hi there", ts: 2 });
+    updateMessage(1, "Corrected response");
+    const msgs = useTaosAgentStore.getState().messages;
+    expect(msgs[1].content).toBe("Corrected response");
+    // Does not touch other fields
+    expect(msgs[1].role).toBe("assistant");
+    expect(msgs[1].ts).toBe(2);
+  });
+
+  it("updateMessage with out-of-range index is a no-op", () => {
+    const { appendMessage, updateMessage } = useTaosAgentStore.getState();
+    appendMessage({ role: "assistant", content: "ok", ts: 1 });
+    updateMessage(-1, "x");
+    updateMessage(99, "x");
+    expect(useTaosAgentStore.getState().messages[0].content).toBe("ok");
+  });
 });

--- a/desktop/src/stores/taos-agent-store.ts
+++ b/desktop/src/stores/taos-agent-store.ts
@@ -28,6 +28,7 @@ interface TaosAgentActions {
   setMessages: (messages: AssistantMessage[]) => void;
   appendMessage: (msg: AssistantMessage) => void;
   appendDelta: (delta: string) => void;
+  updateMessage: (index: number, content: string) => void;
   setModel: (model: string | null) => void;
   setStreaming: (streaming: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
@@ -59,6 +60,14 @@ export const useTaosAgentStore = create<TaosAgentStore>((set) => ({
       if (last && last.role === "assistant") {
         msgs[msgs.length - 1] = { ...last, content: last.content + delta };
       }
+      return { messages: msgs };
+    }),
+
+  updateMessage: (index, content) =>
+    set((s) => {
+      if (index < 0 || index >= s.messages.length) return s;
+      const msgs = [...s.messages];
+      msgs[index] = { ...msgs[index], content };
       return { messages: msgs };
     }),
 

--- a/desktop/src/stores/taos-agent-store.ts
+++ b/desktop/src/stores/taos-agent-store.ts
@@ -65,9 +65,10 @@ export const useTaosAgentStore = create<TaosAgentStore>((set) => ({
 
   updateMessage: (index, content) =>
     set((s) => {
-      if (index < 0 || index >= s.messages.length) return s;
+      const existing = s.messages[index];
+      if (!existing) return s;
       const msgs = [...s.messages];
-      msgs[index] = { ...msgs[index], content };
+      msgs[index] = { ...existing, content };
       return { messages: msgs };
     }),
 


### PR DESCRIPTION
## Summary
Adds an inline edit step for the last assistant message in the TaOS Agent Panel. After the agent finishes streaming, the user can click the response bubble to edit the content inline. The edited text replaces the original in the Zustand store, so the corrected context flows into subsequent turns — exactly the pattern described in #834.