### PR TITLE
feat(desktop): add wallpaper picker entry to Settings > Desktop & Dock

### DIFF
--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -29,6 +29,7 @@ import { useThemeStore } from "@/stores/theme-store";
 import { useDockStore } from "@/stores/dock-store";
 import { ThemesPanel } from "@/apps/SettingsApp/ThemesPanel";
 import { safeFetch, ProgressBar, RestartProgressModal } from "@/apps/SettingsApp/_shared";
+import { WallpaperPicker } from "@/components/WallpaperPicker";
 import { UpdatesSection } from "@/apps/SettingsApp/UpdatesPanel";
 import { UsersSection } from "@/apps/SettingsApp/UsersPanel";
 import { AccountSection } from "@/apps/SettingsApp/AccountPanel";
@@ -692,11 +693,59 @@ export function DesktopDockSection() {
   const applyDockSize = useDockStore((s) => s.setIconSize);
   const applyDockPosition = useDockStore((s) => s.setPosition);
 
+  const wallpaperId = useThemeStore((s) => s.wallpaperId);
+  const wallpaperImage = useThemeStore((s) => s.wallpaperImage);
+  const wallpaperFallback = useThemeStore((s) => s.wallpaperFallback);
+  const wallpaperLightImage = useThemeStore((s) => s.wallpaperLightImage);
+  const wallpaperLightFallback = useThemeStore((s) => s.wallpaperLightFallback);
+  const scheme = useThemeStore((s) => s.scheme);
+  const getWallpapers = useThemeStore((s) => s.getWallpapers);
+  const [showPicker, setShowPicker] = useState(false);
+
+  const wallpapers = getWallpapers();
+  const currentWallpaper = wallpapers.find((w) => w.id === wallpaperId);
+  const wallpaperLabel = currentWallpaper?.label ?? "Unknown";
+
+  const isLight = scheme === "light";
+  const thumbImage = isLight && wallpaperLightImage ? wallpaperLightImage : wallpaperImage;
+  const thumbFallback = isLight && wallpaperLightFallback ? wallpaperLightFallback : wallpaperFallback;
+
+  const thumbnailStyle: React.CSSProperties =
+    currentWallpaper && currentWallpaper.kind === "animated"
+      ? { background: "radial-gradient(120% 120% at 50% 46%, #2a2a2e 0%, #1d1d1f 45%, #101011 100%)" }
+      : {
+          backgroundImage: thumbImage,
+          backgroundSize: "cover",
+          backgroundPosition: "center",
+          backgroundColor: thumbFallback,
+        };
+
   return (
     <section aria-label="Desktop and dock settings">
       <h2 className="text-lg font-semibold mb-5">Desktop & Dock</h2>
 
       <div className="space-y-3">
+        <Card className="p-4">
+          <p className="text-sm font-medium mb-3">Wallpaper</p>
+          <div className="flex items-center gap-3">
+            <div
+              className="w-12 h-8 rounded-md shrink-0 border border-white/10"
+              style={thumbnailStyle}
+              aria-hidden="true"
+            />
+            <span className="text-sm text-shell-text-secondary flex-1 min-w-0 truncate">
+              {wallpaperLabel}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowPicker(true)}
+            >
+              Change…
+            </Button>
+          </div>
+        </Card>
+
         <Card className="p-4">
           <p className="text-sm font-medium mb-3">Dock icon size</p>
           <div className="flex gap-2" role="group" aria-label="Dock icon size">
@@ -736,6 +785,13 @@ export function DesktopDockSection() {
           </div>
         </Card>
       </div>
+
+      {showPicker && (
+        <WallpaperPicker
+          open={showPicker}
+          onClose={() => setShowPicker(false)}
+        />
+      )}
     </section>
   );
 }

--- a/desktop/src/apps/__tests__/SettingsApp.test.tsx
+++ b/desktop/src/apps/__tests__/SettingsApp.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
-import { SettingsApp } from "../SettingsApp";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, waitFor, within, fireEvent, act } from "@testing-library/react";
+import { SettingsApp, DesktopDockSection } from "../SettingsApp";
+import { useThemeStore } from "@/stores/theme-store";
 
 function mockAuthStatus(isAdmin: boolean) {
   return vi.spyOn(globalThis, "fetch").mockImplementation((input) => {
@@ -57,5 +58,72 @@ describe("SettingsApp admin-only sections", () => {
 
     expect(within(nav).getByText("Themes")).toBeInTheDocument();
     expect(within(nav).getByText("Account")).toBeInTheDocument();
+  });
+});
+
+describe("DesktopDockSection wallpaper entry", () => {
+  beforeEach(() => {
+    useThemeStore.setState({
+      wallpaperId: "graphite",
+      wallpaperImage: "url('/static/wallpaper-graphite.png')",
+      wallpaperFallback: "#141415",
+      wallpaperKind: "image",
+      wallpaperOverlayText: null,
+      showOverlayText: true,
+      wallpaperParams: { density: 200, speed: 0.5, glow: 6 },
+    });
+  });
+
+  it("shows the current wallpaper label", () => {
+    render(<DesktopDockSection />);
+    expect(screen.getByText("Graphite")).toBeInTheDocument();
+  });
+
+  it("shows a \"Change…\" button", () => {
+    render(<DesktopDockSection />);
+    expect(
+      screen.getByRole("button", { name: /change…/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the WallpaperPicker when \"Change…\" is clicked", () => {
+    render(<DesktopDockSection />);
+    fireEvent.click(screen.getByRole("button", { name: /change…/i }));
+    expect(
+      screen.getByRole("dialog", { name: /change wallpaper/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the WallpaperPicker when its close button is clicked", () => {
+    render(<DesktopDockSection />);
+    fireEvent.click(screen.getByRole("button", { name: /change…/i }));
+    const dialog = screen.getByRole("dialog", { name: /change wallpaper/i });
+    expect(dialog).toBeInTheDocument();
+    fireEvent.click(within(dialog).getByRole("button", { name: /close/i }));
+    expect(
+      screen.queryByRole("dialog", { name: /change wallpaper/i }),
+    ).toBeNull();
+  });
+
+  it("updates the wallpaper label when the store wallpaperId changes", () => {
+    const { rerender } = render(<DesktopDockSection />);
+    expect(screen.getByText("Graphite")).toBeInTheDocument();
+    act(() => {
+      useThemeStore.setState({ wallpaperId: "aurora" });
+    });
+    rerender(<DesktopDockSection />);
+    expect(screen.getByText("Aurora")).toBeInTheDocument();
+  });
+
+  it("retains dock icon size and position controls", () => {
+    render(<DesktopDockSection />);
+    expect(screen.getByText("Dock icon size")).toBeInTheDocument();
+    expect(screen.getByText("Dock position")).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Dock icon size" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "Dock position" }),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Adds a wallpaper picker entry to the Settings app under **Desktop & Dock**, giving users a second discovery path alongside the right-click desktop menu.

## Changes

- **`desktop/src/apps/SettingsApp.tsx`**: Updated `DesktopDockSection` to include a Wallpaper subsection with:
  - A small rounded thumbnail preview of the current wallpaper
  - The current wallpaper label  
  - A "Change…" button that opens the `WallpaperPicker` modal inline
- **`desktop/src/apps/__tests__/SettingsApp.test.tsx`**: Added 6 new tests covering:
  - Wallpaper label visibility
  - "Change…" button presence
  - WallpaperPicker opens on click
  - WallpaperPicker closes via close button
  - Label updates when store wallpaperId changes
  - Dock controls retained

## Testing

```
npx vitest run src/apps/__tests__/SettingsApp.test.tsx src/components/WallpaperPicker.test.tsx
# 22 tests passed (8 SettingsApp + 14 WallpaperPicker)
```

## Issue

Task t_1b021d07 (C2 of #864)