### PR TITLE
fix(llm_proxy): restore EMBEDDING_ALIAS + CLOUD_BACKEND_TYPES re-exports

### DIFF
--- a/tinyagentos/llm_proxy.py
+++ b/tinyagentos/llm_proxy.py
@@ -18,14 +18,16 @@ from pathlib import Path
 
 import httpx
 
-from tinyagentos.providers import CLOUD_TYPES as CLOUD_BACKEND_TYPES
+from tinyagentos.providers import CLOUD_TYPES as CLOUD_BACKEND_TYPES  # noqa: F401  (public re-export)
 from tinyagentos.litellm_config import (
-    EMBEDDING_ALIAS,
+    EMBEDDING_ALIAS,  # noqa: F401  (public re-export)
     _is_embedding_model,
     _discover_ollama_backends_concurrent,
     generate_litellm_config,
     get_litellm_master_key,
 )
+
+__all__ = ["EMBEDDING_ALIAS", "CLOUD_BACKEND_TYPES"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Restores two intentional public re-exports in `tinyagentos/llm_proxy.py` that were removed during a ruff lint pass (PR #1875).

## Changes

- Add `# noqa: F401  (public re-export)` to `EMBEDDING_ALIAS` and `CLOUD_BACKEND_TYPES` imports
- Add `__all__ = [EMBEDDING_ALIAS, CLOUD_BACKEND_TYPES]` so static analysers/IDEs treat them as public API

## Why

Both are consumed externally:
- `EMBEDDING_ALIAS` is imported by `tinyagentos/deployer.py`
- `CLOUD_BACKEND_TYPES` is imported by `tests/test_llm_proxy_config.py`

Without `# noqa: F401`, ruff (and any F401-aware linter) flags them as unused imports, defeating the purpose of the re-export pattern.

## Tests

```
pytest tests/test_llm_proxy.py tests/test_llm_proxy_config.py -v --timeout=120
51 passed in 9.84s
```

Refs: #1875