### PR TITLE
fix(ci): extend pip-audit scan to proxy and worker extras

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,proxy,worker]"
 
       - name: Check for known vulnerabilities
         # CVE-2026-3219 affects pip itself with no fix released yet; revisit once


### PR DESCRIPTION
## Summary

Part 2/2 of #740. The Python lockfile (uv.lock) was committed in June (PR #40), but pip-audit in security.yml still only scanned `.[dev]` — the heaviest extras (proxy=litellm+prisma, worker=pystray) were never CVE-checked.

## Change

`.github/workflows/security.yml`: install `.[dev,proxy,worker]` instead of `.[dev]` before running pip-audit.

## Why

litellm[proxy] and prisma are complex packages with deep dependency trees; they are the most likely source of CVE-worthy transitive issues. Running pip-audit against only the test-and-dev subset was a blind spot.

Task: t_a842feff. Fixes #740.