### PR TITLE
fix(agents): z-index on invite/assign dialogs so they show above windows

### DIFF
--- a/desktop/src/apps/ProjectsApp/InviteAgentDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/InviteAgentDialog.tsx
@@ -173,7 +173,7 @@ export function InviteAgentDialog({
       role="dialog"
       aria-modal="true"
       aria-label="Invite external agent"
-      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-[10001] bg-black/50 flex items-center justify-center p-4"
     >
       <form
         onSubmit={onSubmit}

--- a/desktop/src/apps/agents/AssignAgentToProjectDialog.tsx
+++ b/desktop/src/apps/agents/AssignAgentToProjectDialog.tsx
@@ -107,7 +107,7 @@ export function AssignAgentToProjectDialog({
       role="dialog"
       aria-modal="true"
       aria-label="Assign agent to project"
-      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-[10001] bg-black/50 flex items-center justify-center p-4"
     >
       <form
         onSubmit={onSubmit}

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -454,7 +454,7 @@ function InviteExternalAgentPicker({
       role="dialog"
       aria-modal="true"
       aria-label="Invite external agent to project"
-      className="fixed inset-0 bg-black/50 flex items-center justify-center p-4"
+      className="fixed inset-0 z-[10001] bg-black/50 flex items-center justify-center p-4"
     >
       <form
         onSubmit={(e) => {


### PR DESCRIPTION
The Invite external agent picker + InviteAgentDialog + AssignAgentToProjectDialog portal to body with fixed inset-0 but no z-index, so they render behind the app window and the button looks like it does nothing. Adds z-[10001] (matching CreateProjectDialog). Reported live by testing the Agents app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog layering so invitation and agent-selection modals appear correctly above other interface elements.
  * Updated the assignment dialog overlay with a semi-transparent backdrop and centered modal positioning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->