### PR TITLE
fix(install): pin git clone to known-good commit hash for installation integrity

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,12 @@ INSTALL_DIR="/opt/tinyagentos"
 DATA_DIR="/opt/tinyagentos/data"
 CATALOG_REPO="https://github.com/jaylfc/tinyagentos.git"
 
+# Pinned commit hash for installation integrity.
+# Each release this script is updated with the current master HEAD so that
+# `git clone` + `git checkout` always fetches a known-good revision.
+# To update: git ls-remote https://github.com/jaylfc/tinyagentos.git HEAD | awk '{print $1}'
+TAOS_INSTALL_COMMIT="${TAOS_INSTALL_COMMIT:-66accad8bb725e3c86ab92db1fbde553040364fc}"
+
 echo "======================================"
 echo "  TinyAgentOS Installer"
 echo "======================================"
@@ -87,6 +93,7 @@ if [ -d "$INSTALL_DIR/.git" ]; then
 else
     echo "Installing TinyAgentOS to $INSTALL_DIR..."
     git clone "$CATALOG_REPO" "$INSTALL_DIR"
+    git -C "$INSTALL_DIR" checkout "$TAOS_INSTALL_COMMIT"
 fi
 
 cd "$INSTALL_DIR"

--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,14 @@ if [ -d "$INSTALL_DIR/.git" ]; then
 else
     echo "Installing TinyAgentOS to $INSTALL_DIR..."
     git clone "$CATALOG_REPO" "$INSTALL_DIR"
-    git -C "$INSTALL_DIR" checkout "$TAOS_INSTALL_COMMIT"
+    echo "Checking out pinned commit $TAOS_INSTALL_COMMIT..."
+    if ! git -C "$INSTALL_DIR" checkout "$TAOS_INSTALL_COMMIT"; then
+        echo "ERROR: Failed to checkout pinned commit $TAOS_INSTALL_COMMIT" >&2
+        echo "  The commit may have been garbage-collected or the hash is incorrect." >&2
+        echo "  Override with TAOS_INSTALL_COMMIT=<valid-hash> or set TAOS_INSTALL_COMMIT=HEAD" >&2
+        rm -rf "$INSTALL_DIR"
+        exit 1
+    fi
 fi
 
 cd "$INSTALL_DIR"


### PR DESCRIPTION
## Summary

Pins the `git clone` in `install.sh` to a known-good commit hash so arbitrary code on master HEAD can't be injected into a fresh install.

## What changed

- **install.sh**: Added `TAOS_INSTALL_COMMIT` variable (default: `66accad8`, current master HEAD). After `git clone`, the script now runs `git checkout $TAOS_INSTALL_COMMIT` to verify the revision.
- **os-build/userpatches/customize-image.sh**: No changes needed — this file was already fixed. NodeSource uses GPG-verified key import (not curl-pipe-bash), and taOS is cloned at a pinned `TAOS_COMMIT`.

## Verification

- `bash -n install.sh` — no syntax errors
- All 4 router registration tests pass
- No Python test surface affected by the shell script change

Fixes #658