### PR TITLE
fix(scheduling): add BEGIN IMMEDIATE to renew(), close #654

### DIFF
--- a/tests/scheduling/test_toctou_atomicity.py
+++ b/tests/scheduling/test_toctou_atomicity.py
@@ -332,3 +332,64 @@ async def test_concurrent_acquire_different_resources(lease_pair):
     assert r2 is not None
     assert r1["resource_key"] == "kg:a"
     assert r2["resource_key"] == "kg:b"
+
+
+# ---------------------------------------------------------------------------
+# LeaseManager — renew atomicity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_concurrent_renew_both_succeed(lease_pair: tuple[LeaseManager, LeaseManager]) -> None:
+    """Two managers renewing a lease held by the same agent — both should succeed
+    and the renewed_count must reflect exactly two increments."""
+    m1, m2 = lease_pair
+
+    # Acquire the lease via m1
+    lease = await m1.acquire("kg:shared", "agent-a")
+    assert lease is not None
+    assert lease["renewed_count"] == 0
+
+    # Both renew concurrently (same agent, same resource)
+    r1, r2 = await asyncio.gather(
+        m1.renew("kg:shared", "agent-a"),
+        m2.renew("kg:shared", "agent-a"),
+    )
+
+    assert r1 is not None
+    assert r2 is not None
+    # renewed_count must have been incremented exactly twice
+    assert {r1["renewed_count"], r2["renewed_count"]} == {1, 2}, (
+        f"Expected renewed_count in {{1, 2}} but got {r1['renewed_count']} and {r2['renewed_count']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_renew_respects_cap(lease_pair: tuple[LeaseManager, LeaseManager]) -> None:
+    """With renewed_count at MAX-1, two concurrent renews must not both
+    bypass the MAX_RENEW_COUNT cap."""
+    from tinyagentos.scheduling.leases import MAX_RENEW_COUNT
+
+    m1, m2 = lease_pair
+
+    # Acquire and renew until we're one short of the cap
+    await m1.acquire("kg:shared", "agent-a")
+    for _ in range(MAX_RENEW_COUNT - 1):
+        result = await m1.acquire("kg:shared", "agent-a")
+        assert result is not None
+
+    # At this point renewed_count == MAX_RENEW_COUNT - 1
+    lease_check = await m1.check("kg:shared")
+    assert lease_check is not None
+    assert lease_check["renewed_count"] == MAX_RENEW_COUNT - 1
+
+    # Both renew concurrently — at most one should succeed
+    r1, r2 = await asyncio.gather(
+        m1.renew("kg:shared", "agent-a"),
+        m2.renew("kg:shared", "agent-a"),
+    )
+
+    granted = [r for r in (r1, r2) if r is not None]
+    # At most one renewal succeeds because the cap is hit
+    assert len(granted) <= 1, (
+        f"Expected at most 1 renewal at cap {MAX_RENEW_COUNT}, got {len(granted)}: {granted}"
+    )

--- a/tinyagentos/scheduling/leases.py
+++ b/tinyagentos/scheduling/leases.py
@@ -148,34 +148,32 @@ class LeaseManager:
         agent_name: str,
         ttl: float = DEFAULT_TTL,
     ) -> dict | None:
-        """Renew an existing lease. Only the holder can renew."""
+        """Renew an existing lease, atomically. Only the holder can renew.
+
+        Uses BEGIN IMMEDIATE so the read-check-update sequence is serialised:
+        two concurrent renewals from the same agent cannot both pass the
+        renewed_count cap.
+        """
         ttl = min(ttl, MAX_TTL)
-        now = time.time()
 
-        existing = self._conn.execute(
-            "SELECT * FROM leases WHERE resource_key = ? AND agent_name = ?",
-            (resource_key, agent_name),
-        ).fetchone()
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            now = time.time()
+            existing = self._conn.execute(
+                "SELECT * FROM leases WHERE resource_key = ? AND agent_name = ?",
+                (resource_key, agent_name),
+            ).fetchone()
 
-        if not existing:
-            return None
+            if not existing:
+                self._conn.execute("COMMIT")
+                return None
 
-        if existing["renewed_count"] >= MAX_RENEW_COUNT:
-            return None  # Force release — prevent lease hogging
-
-        self._conn.execute(
-            "UPDATE leases SET expires_at = ?, renewed_count = renewed_count + 1 WHERE id = ?",
-            (now + ttl, existing["id"]),
-        )
-
-        return {
-            "id": existing["id"],
-            "resource_key": resource_key,
-            "agent_name": agent_name,
-            "acquired_at": existing["acquired_at"],
-            "expires_at": now + ttl,
-            "renewed_count": existing["renewed_count"] + 1,
-        }
+            result = self._renew_locked(existing, ttl, now)
+            self._conn.execute("COMMIT")
+            return result
+        except Exception:
+            self._conn.execute("ROLLBACK")
+            raise
 
     async def release(self, resource_key: str, agent_name: str) -> bool:
         """Release a lease. Only the holder can release."""


### PR DESCRIPTION
## Summary

Fixes the last remaining TOCTOU gap in `scheduling/leases.py`: the `renew()` method was missing its `BEGIN IMMEDIATE` transaction wrapper, unlike `acquire()` and `dequeue()`.

## What changed

**`tinyagentos/scheduling/leases.py`** — Wrapped `renew()` in `BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK`:
- The read-check-update sequence (SELECT → check renewed_count → UPDATE) is now atomic
- Delegates to existing `_renew_locked()` helper to avoid code duplication
- Matches the same pattern already present in `acquire()` and `dequeue()`

**`tests/scheduling/test_toctou_atomicity.py`** — +2 tests (21 total):
- `test_concurrent_renew_both_succeed`: two concurrent renewals both succeed, renewed_count increments exactly twice
- `test_concurrent_renew_respects_cap`: at MAX_RENEW_COUNT boundary, at most one concurrent renewal succeeds

## Context

Issue #654 reported two races (dequeue double-claim + lease acquire). Both were fixed in commit 707a960f. This PR closes the third related gap — `renew()` had the same read-then-write pattern without a transaction guard.

**Tests:** 21/21 pass (tests/scheduling/test_toctou_atomicity.py)