### PR TITLE
feat(cluster): worker-initiated graceful pause + drain protocol (taOS #890 C2)

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -420,3 +420,151 @@ class TestWorkerDrain:
             ttl_seconds=30,
         )
         assert lease is None
+
+    # ── Worker-initiated drain (taOS #890 C2) ──────────────────────────
+
+    async def test_heartbeat_status_draining_triggers_worker_self_drain(self):
+        """When a worker heartbeats with status='draining', it enters
+        draining state — identical to a controller-initiated drain."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
+
+        ok = mgr.heartbeat("gpu-box", load=0.1, status="draining", drain_reason="update")
+        assert ok is True
+        worker = mgr.get_worker("gpu-box")
+        assert worker.status == "draining"
+
+    async def test_heartbeat_status_update_available_sets_status(self):
+        """Worker reports an update is available but stays routable."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
+
+        ok = mgr.heartbeat("gpu-box", load=0.1, status="update-available", drain_reason="update")
+        assert ok is True
+        worker = mgr.get_worker("gpu-box")
+        assert worker.status == "update-available"
+
+    async def test_update_available_workers_still_routable(self):
+        """Workers in update-available status should still receive tasks."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("update-gpu", capabilities=["chat"], load=0.1))
+        await mgr.register_worker(_make_worker("draining-gpu", capabilities=["chat"], load=0.0))
+
+        # Transition via heartbeat
+        mgr.heartbeat("update-gpu", status="update-available")
+        await mgr.drain_worker("draining-gpu", graceful=True)
+
+        result = mgr.get_workers_for_capability("chat")
+        assert len(result) == 1
+        assert result[0].name == "update-gpu"
+
+    async def test_update_available_workers_in_catalog(self):
+        """Update-available workers are included in the aggregate catalog."""
+        mgr = ClusterManager()
+        online = _make_worker("online", capabilities=["chat"])
+        online.backends = [{"name": "b1", "type": "ollama", "url": "u", "capabilities": ["chat"], "models": [{"name": "m1"}]}]
+        updating = _make_worker("updating", capabilities=["chat"])
+        updating.backends = [{"name": "b2", "type": "ollama", "url": "u", "capabilities": ["chat"], "models": [{"name": "m2"}]}]
+        await mgr.register_worker(online)
+        await mgr.register_worker(updating)
+        mgr.heartbeat("updating", status="update-available")
+
+        out = mgr.aggregate_catalog()
+        worker_names = [w["name"] for w in out["workers"]]
+        assert "online" in worker_names
+        assert "updating" in worker_names
+        model_names = [m["name"] for m in out["models"]]
+        assert "m1" in model_names
+        assert "m2" in model_names
+
+    async def test_update_available_can_claim_leases(self):
+        """Update-available workers still allow lease claims."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("update-gpu", url="http://update:9000"))
+        worker = mgr.get_worker("update-gpu")
+        worker.free_vram_mb = 8000
+        mgr.heartbeat("update-gpu", status="update-available")
+
+        lease = await mgr.claim_lease(
+            resource_id="update-gpu:gpu-cuda-0",
+            caller="test",
+            ttl_seconds=30,
+        )
+        assert lease is not None
+        assert lease.resource_id == "update-gpu:gpu-cuda-0"
+
+    async def test_state_transition_online_to_update_available_to_draining(self):
+        """Full state transition: online → update-available → draining."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
+
+        # online → update-available
+        mgr.heartbeat("gpu-box", status="update-available", drain_reason="new version v2")
+        assert mgr.get_worker("gpu-box").status == "update-available"
+
+        # update-available → draining (worker initiates drain)
+        mgr.heartbeat("gpu-box", status="draining", drain_reason="new version v2")
+        assert mgr.get_worker("gpu-box").status == "draining"
+
+    async def test_drain_preserved_on_subsequent_heartbeats(self):
+        """Once draining, subsequent heartbeats without status preserve drain."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
+
+        # Initiate self-drain
+        mgr.heartbeat("gpu-box", status="draining", drain_reason="update")
+        assert mgr.get_worker("gpu-box").status == "draining"
+
+        # Normal heartbeat (no status field) — should stay draining
+        mgr.heartbeat("gpu-box", load=0.5)
+        assert mgr.get_worker("gpu-box").status == "draining"
+        assert mgr.get_worker("gpu-box").load == 0.5
+
+    async def test_heartbeat_without_status_reonlines_update_available(self):
+        """A normal heartbeat without status should transition
+        update-available back to online (it's not a drain)."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
+
+        mgr.heartbeat("gpu-box", status="update-available")
+        assert mgr.get_worker("gpu-box").status == "update-available"
+
+        # Normal heartbeat without explicit status
+        mgr.heartbeat("gpu-box", load=0.2)
+        # Should go back to online because update-available is not draining
+        assert mgr.get_worker("gpu-box").status == "online"
+
+    async def test_monitor_loop_offlines_stale_update_available_worker(self):
+        """An update-available worker that stops heartbeating is marked offline."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("gpu-box"))
+        mgr.heartbeat("gpu-box", status="update-available")
+        # Simulate stale heartbeat
+        mgr.get_worker("gpu-box").last_heartbeat = time.time() - HEARTBEAT_TIMEOUT - 5
+
+        now = time.time()
+        for worker in mgr._workers.values():
+            if worker.status in ("online", "update-available") and (now - worker.last_heartbeat) > HEARTBEAT_TIMEOUT:
+                worker.status = "offline"
+
+        assert mgr.get_worker("gpu-box").status == "offline"
+
+    async def test_heartbeat_status_updating_sets_status(self):
+        """Worker reports it is actively applying an update."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
+
+        ok = mgr.heartbeat("gpu-box", status="updating", drain_reason="update")
+        assert ok is True
+        assert mgr.get_worker("gpu-box").status == "updating"
+
+    async def test_updating_workers_excluded_from_routing(self):
+        """Updating workers should not receive new tasks."""
+        mgr = ClusterManager()
+        await mgr.register_worker(_make_worker("online-gpu", capabilities=["chat"], load=0.1))
+        await mgr.register_worker(_make_worker("updating-gpu", capabilities=["chat"], load=0.0))
+        mgr.heartbeat("updating-gpu", status="updating")
+
+        result = mgr.get_workers_for_capability("chat")
+        assert len(result) == 1
+        assert result[0].name == "online-gpu"

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -520,19 +520,29 @@ class TestWorkerDrain:
         assert mgr.get_worker("gpu-box").status == "draining"
         assert mgr.get_worker("gpu-box").load == 0.5
 
-    async def test_heartbeat_without_status_reonlines_update_available(self):
-        """A normal heartbeat without status should transition
-        update-available back to online (it's not a drain)."""
+    async def test_heartbeat_without_status_preserves_update_available(self):
+        """A status-less heartbeat preserves update-available (taOS #890 C2).
+
+        The periodic ~15s heartbeat carries no status; when combined with the
+        old manager.py:226-231 logic that flipped any non-draining worker back
+        to "online", this silently cancelled the update signal before the
+        worker could initiate its drain.  Now "update-available" is protected
+        in the same way "draining" is: only an explicit status transition
+        (e.g. "draining" or "updating") changes it."""
         mgr = ClusterManager()
         await mgr.register_worker(_make_worker("gpu-box", capabilities=["chat"]))
 
         mgr.heartbeat("gpu-box", status="update-available")
         assert mgr.get_worker("gpu-box").status == "update-available"
 
-        # Normal heartbeat without explicit status
+        # Normal heartbeat without explicit status — should stay update-available
         mgr.heartbeat("gpu-box", load=0.2)
-        # Should go back to online because update-available is not draining
-        assert mgr.get_worker("gpu-box").status == "online"
+        assert mgr.get_worker("gpu-box").status == "update-available"
+        assert mgr.get_worker("gpu-box").load == 0.2
+
+        # Explicit transition to draining still works
+        mgr.heartbeat("gpu-box", status="draining", drain_reason="update")
+        assert mgr.get_worker("gpu-box").status == "draining"
 
     async def test_monitor_loop_offlines_stale_update_available_worker(self):
         """An update-available worker that stops heartbeating is marked offline."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -485,7 +485,7 @@ class TestRunLoopRepairState:
             agent._registered = True
             return True
 
-        async def fake_heartbeat() -> int:
+        async def fake_heartbeat(**kwargs) -> int:
             heartbeat_called.append(1)
             agent._running = False  # stop after first successful heartbeat
             return 200
@@ -517,7 +517,7 @@ class TestRunLoopRepairState:
             if sleep_count >= 2:
                 agent._running = False
 
-        async def fake_heartbeat() -> int:
+        async def fake_heartbeat(**kwargs) -> int:
             nonlocal hb_count
             hb_count += 1
             return 404
@@ -552,7 +552,7 @@ class TestRunLoopRepairState:
         async def fake_sleep(n: float) -> None:
             agent._running = call_count >= 2
 
-        async def fake_heartbeat() -> int:
+        async def fake_heartbeat(**kwargs) -> int:
             nonlocal call_count
             call_count += 1
             return 0

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -236,7 +236,7 @@ class ClusterManager:
         # update signal before the worker can initiate the drain.
         # Only block status-less heartbeats; explicit status transitions
         # (e.g. "update-available" → "draining") are still honoured.
-        if worker.status not in ("draining", "update-available") or status is not None:
+        if worker.status not in ("draining", "update-available", "updating") or status is not None:
             # Honour worker-initiated status transitions (taOS #890 C2).
             if status in ("draining", "update-available", "updating"):
                 worker.status = status
@@ -854,6 +854,18 @@ class ClusterManager:
                             ]
                             for lid in update_lids:
                                 self._leases.pop(lid, None)
+                        # Cancel any running GPU arbiter tasks for the
+                        # released leases (taOS cross-cutting wiring).
+                        if update_lids and self._gpu_arbiter is not None:
+                            try:
+                                cancelled, already_done = await self._gpu_arbiter.cancel_running_for_leases(set(update_lids))
+                                logger.info(
+                                    "Worker '%s' stale-update: arbiter cancelled %d tasks, %d already done",
+                                    worker.name, cancelled, already_done)
+                            except Exception:
+                                logger.exception(
+                                    "gpu-arbiter: cancel for stale-update of '%s' failed",
+                                    worker.name)
             async with self._lease_lock:
                 self._sweep_expired_leases()
             await asyncio.sleep(5)

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -231,9 +231,12 @@ class ClusterManager:
         # A worker mid graceful-drain keeps heartbeating while it finishes
         # inflight work. Do NOT flip it back to "online" — that would re-enter
         # it into routing/catalog/lease-claims before its leases drain and
-        # defeat the drain (taOS #890). Leave the drain to complete or be
-        # cancelled explicitly; every other status re-onlines as before.
-        if worker.status != "draining":
+        # defeat the drain (taOS #890). Similarly, protect "update-available"
+        # so a periodic status-less heartbeat doesn't silently cancel the
+        # update signal before the worker can initiate the drain.
+        # Only block status-less heartbeats; explicit status transitions
+        # (e.g. "update-available" → "draining") are still honoured.
+        if worker.status not in ("draining", "update-available") or status is not None:
             # Honour worker-initiated status transitions (taOS #890 C2).
             if status in ("draining", "update-available", "updating"):
                 worker.status = status
@@ -306,8 +309,11 @@ class ClusterManager:
         # Worker-initiated drain notification (taOS #890 C2).
         # Emit when the worker transitions into draining/update-available on
         # its own initiative, so the operator sees it in the activity feed.
-        if self._notifications and status in ("draining", "update-available", "updating") and prev_status not in (status,):
-            reason = drain_reason or "unspecified"
+        # Validate: only trusted status values; sanitize drain_reason to
+        # prevent injection into notification UI.
+        _VALID_STATUSES = frozenset({"draining", "update-available", "updating"})
+        if self._notifications and status in _VALID_STATUSES and prev_status not in (status,):
+            reason = (drain_reason or "unspecified").replace("'", "\\'").replace("\\", "\\\\")[:200]
             event_type = f"worker.{status}" if status != "draining" else "worker.drain"
             title_map = {
                 "draining": f"Worker '{worker.name}' self-initiated drain",
@@ -824,6 +830,30 @@ class ClusterManager:
                                 logger.exception(
                                     "gpu-arbiter: cancel for stale-drain of '%s' failed",
                                     worker.name)
+                # Handle updating workers: if they stop heartbeating they're
+                # stuck in a bad state — force-offline them so they can re-onboard.
+                elif worker.status == "updating":
+                    if (now - worker.last_heartbeat) > HEARTBEAT_TIMEOUT:
+                        worker.status = "offline"
+                        logger.warning(
+                            "Worker '%s' stuck in 'updating' (no heartbeat for %ds) — marked offline",
+                            worker.name, HEARTBEAT_TIMEOUT,
+                        )
+                        if self._notifications:
+                            await self._notifications.emit_event(
+                                "worker.leave",
+                                f"Worker '{worker.name}' timed out during update",
+                                f"Worker was stuck in 'updating' state. Forced offline to allow re-onboarding.",
+                                level="warning",
+                            )
+                        async with self._lease_lock:
+                            update_lids = [
+                                lid for lid, lease in self._leases.items()
+                                if (parsed := self._parse_resource_id(lease.resource_id))
+                                and parsed[0] == worker.name
+                            ]
+                            for lid in update_lids:
+                                self._leases.pop(lid, None)
             async with self._lease_lock:
                 self._sweep_expired_leases()
             await asyncio.sleep(5)

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -205,6 +205,8 @@ class ClusterManager:
         storage_cap_bytes: int | None = None,
         storage_used_bytes: int | None = None,
         bytes_deduped_total: int | None = None,
+        status: str | None = None,
+        drain_reason: str | None = None,
     ) -> bool:
         """Accept a worker heartbeat.
 
@@ -212,6 +214,13 @@ class ClusterManager:
         (worker agent v2+), overwrite the worker's cached view so the
         cluster-wide catalog stays fresh. Old-style heartbeats that only
         carry load/models still work.
+
+        Worker-initiated state transitions (taOS #890 C2): the worker can
+        report ``status="update-available"`` or ``status="draining"`` to
+        initiate a self-drain. When the worker reports ``"draining"``, the
+        controller treats it identically to a controller-initiated drain:
+        no new tasks are routed, existing leases complete, and the monitor
+        loop auto-completes the drain when all leases are released.
         """
         worker = self._workers.get(name)
         if not worker:
@@ -225,7 +234,11 @@ class ClusterManager:
         # defeat the drain (taOS #890). Leave the drain to complete or be
         # cancelled explicitly; every other status re-onlines as before.
         if worker.status != "draining":
-            worker.status = "online"
+            # Honour worker-initiated status transitions (taOS #890 C2).
+            if status in ("draining", "update-available", "updating"):
+                worker.status = status
+            else:
+                worker.status = "online"
         if models is not None:
             worker.models = models
         if backends is not None:
@@ -290,6 +303,33 @@ class ClusterManager:
             worker.storage_used_bytes = int(storage_used_bytes)
         if bytes_deduped_total is not None:
             worker.bytes_deduped_total = int(bytes_deduped_total)
+        # Worker-initiated drain notification (taOS #890 C2).
+        # Emit when the worker transitions into draining/update-available on
+        # its own initiative, so the operator sees it in the activity feed.
+        if self._notifications and status in ("draining", "update-available", "updating") and prev_status not in (status,):
+            reason = drain_reason or "unspecified"
+            event_type = f"worker.{status}" if status != "draining" else "worker.drain"
+            title_map = {
+                "draining": f"Worker '{worker.name}' self-initiated drain",
+                "update-available": f"Worker '{worker.name}' has an update available",
+                "updating": f"Worker '{worker.name}' is updating",
+            }
+            detail_map = {
+                "draining": f"Worker '{worker.name}' is draining for {reason}. Tasks will complete before the update.",
+                "update-available": f"Worker '{worker.name}' reports an update is available (reason: {reason}). It will drain when ready.",
+                "updating": f"Worker '{worker.name}' is applying an update (reason: {reason}). It will restart when done.",
+            }
+            try:
+                asyncio.get_running_loop().create_task(
+                    self._notifications.emit_event(
+                        event_type,
+                        title_map.get(status, f"Worker '{worker.name}' {status}"),
+                        detail_map.get(status, f"Worker '{worker.name}' self-reported {status}: {reason}"),
+                        level="info",
+                    )
+                )
+            except RuntimeError:
+                pass
         # Fire worker.online notification when a previously-offline worker recovers.
         # heartbeat() is sync, so schedule the async emit as a background task.
         if self._notifications and prev_status in ("offline", "stale"):
@@ -372,7 +412,7 @@ class ClusterManager:
             return None
         worker_name, _ = parsed
         worker = self._workers.get(worker_name)
-        if worker is None or worker.status not in ("online",):
+        if worker is None or worker.status not in ("online", "update-available"):
             return None
         return worker
 
@@ -611,7 +651,7 @@ class ClusterManager:
         Draining workers are excluded (taOS #890)."""
         eligible = [
             w for w in self._workers.values()
-            if w.status == "online" and capability in w.capabilities
+            if w.status in ("online", "update-available") and capability in w.capabilities
         ]
         return sorted(eligible, key=lambda w: w.load)
 
@@ -654,8 +694,8 @@ class ClusterManager:
         all_capabilities: set[str] = set()
 
         for worker in self._workers.values():
-            if worker.status != "online":
-                continue  # skip offline and draining workers (taOS #890)
+            if worker.status not in ("online", "update-available"):
+                continue  # skip offline, draining, and updating workers (taOS #890)
 
             worker_caps = set(worker.capabilities or [])
             all_capabilities |= worker_caps
@@ -710,8 +750,8 @@ class ClusterManager:
                 # from routing and the aggregate catalog (taOS #1690).
                 if worker.name == "local":
                     continue
-                # Handle online workers that haven't heartbeated
-                if worker.status == "online" and (now - worker.last_heartbeat) > HEARTBEAT_TIMEOUT:
+                # Handle online / update-available workers that haven't heartbeated
+                if worker.status in ("online", "update-available") and (now - worker.last_heartbeat) > HEARTBEAT_TIMEOUT:
                     worker.status = "offline"
                     logger.warning(f"Worker '{worker.name}' marked offline (no heartbeat for {HEARTBEAT_TIMEOUT}s)")
                     if self._notifications:

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -342,7 +342,10 @@ class ClusterManager:
                 pass
         # Fire worker.online notification when a previously-offline worker recovers.
         # heartbeat() is sync, so schedule the async emit as a background task.
-        if self._notifications and prev_status in ("offline", "stale"):
+        # Only fire for workers that are genuinely "online" — a worker recovering
+        # from a controller restart into "draining" or "updating" should NOT
+        # trigger a false "back online" event (taOS #890 C2).
+        if self._notifications and prev_status in ("offline", "stale") and worker.status == "online":
             try:
                 asyncio.get_running_loop().create_task(
                     self._notifications.emit_event(
@@ -783,6 +786,21 @@ class ClusterManager:
                         for lid in offline_lids:
                             self._leases.pop(lid, None)
                             logger.debug("Lease %s released — worker %s went offline", lid, worker.name)
+                    # Cancel any running GPU arbiter tasks for the
+                    # released leases (taOS #890 C2 — cross-cutting wiring).
+                    # This mirrors the cancellation done for stale-drain and
+                    # stale-update workers; the update-available path was
+                    # previously missing it, leaving orphaned arbiter tasks.
+                    if offline_lids and self._gpu_arbiter is not None:
+                        try:
+                            cancelled, already_done = await self._gpu_arbiter.cancel_running_for_leases(set(offline_lids))
+                            logger.info(
+                                "Worker '%s' stale-update-available: arbiter cancelled %d tasks, %d already done",
+                                worker.name, cancelled, already_done)
+                        except Exception:
+                            logger.exception(
+                                "gpu-arbiter: cancel for stale-update-available of '%s' failed",
+                                worker.name)
 
                 # Handle draining workers: auto-complete if no active leases (taOS #890)
                 elif worker.status == "draining":

--- a/tinyagentos/cluster/manager.py
+++ b/tinyagentos/cluster/manager.py
@@ -14,6 +14,10 @@ logger = logging.getLogger(__name__)
 
 HEARTBEAT_TIMEOUT = 30  # seconds before marking worker offline
 
+# Valid worker-initiated status values that gate drain/update protection.
+# Keep in sync with the notification block below and the heartbeat guard.
+_VALID_STATUSES: frozenset[str] = frozenset({"draining", "update-available", "updating"})
+
 
 def _format_hw(hw) -> str:
     """Format hardware info for notification messages."""
@@ -234,11 +238,12 @@ class ClusterManager:
         # defeat the drain (taOS #890). Similarly, protect "update-available"
         # so a periodic status-less heartbeat doesn't silently cancel the
         # update signal before the worker can initiate the drain.
-        # Only block status-less heartbeats; explicit status transitions
-        # (e.g. "update-available" → "draining") are still honoured.
-        if worker.status not in ("draining", "update-available", "updating") or status is not None:
+        # Block status-less heartbeats AND invalid status values for protected
+        # workers. Explicit valid-status transitions (e.g. "update-available"
+        # → "draining") are still honoured.
+        if worker.status not in _VALID_STATUSES or (status is not None and status in _VALID_STATUSES):
             # Honour worker-initiated status transitions (taOS #890 C2).
-            if status in ("draining", "update-available", "updating"):
+            if status in _VALID_STATUSES:
                 worker.status = status
             else:
                 worker.status = "online"
@@ -311,7 +316,6 @@ class ClusterManager:
         # its own initiative, so the operator sees it in the activity feed.
         # Validate: only trusted status values; sanitize drain_reason to
         # prevent injection into notification UI.
-        _VALID_STATUSES = frozenset({"draining", "update-available", "updating"})
         if self._notifications and status in _VALID_STATUSES and prev_status not in (status,):
             reason = (drain_reason or "unspecified").replace("'", "\\'").replace("\\", "\\\\")[:200]
             event_type = f"worker.{status}" if status != "draining" else "worker.drain"

--- a/tinyagentos/routes/cluster.py
+++ b/tinyagentos/routes/cluster.py
@@ -273,6 +273,12 @@ class HeartbeatBody(BaseModel):
     host_lan_ip: str | None = None
     url: str | None = None
     hardware: dict | None = None
+    # Worker-initiated state transitions (taOS #890 C2).
+    # When the worker reports status="draining", the controller initiates
+    # a graceful drain. status="update-available" signals an update is
+    # ready but the worker is still accepting tasks.
+    status: str | None = None
+    drain_reason: str | None = None
 
 
 class RouteRequest(BaseModel):
@@ -521,6 +527,8 @@ async def worker_heartbeat(request: Request, body: HeartbeatBody):
         host_lan_ip=body.host_lan_ip,
         url=body.url,
         hardware=body.hardware,
+        status=body.status,
+        drain_reason=body.drain_reason,
     )
     if not ok:
         return JSONResponse({"error": "Worker not registered"}, status_code=404)

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -717,13 +717,14 @@ class WorkerAgent:
         """Notify the controller that the worker's drain is complete.
 
         After in-flight work finishes, the worker sends one final
-        heartbeat to confirm readiness for the update. The controller
-        can then proceed with the update deploy.
+        heartbeat with status="updating" to signal readiness for
+        the update. The controller can then proceed with the update
+        deploy.
 
         Returns the HTTP status code from the controller.
         """
         logger.info("worker '%s': drain complete, ready for update", self.name)
-        return await self.heartbeat()
+        return await self.heartbeat(status="updating")
 
     def _log_repair_instruction(self) -> None:
         logger.error(

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -104,6 +104,11 @@ class WorkerAgent:
         self.advertise_url = advertise_url
         self._running = False
         self._registered = False
+        # Worker-initiated lifecycle status (taOS #890 C2).  Persisted across
+        # controller restarts so that periodic status-less heartbeats don't
+        # silently revert a draining/updating worker back to "online".
+        self._lifecycle_status: str | None = None
+        self._lifecycle_reason: str | None = None
 
         from tinyagentos.worker.pairing import default_state_dir, load_signing_key
         self._state_dir = state_dir or default_state_dir()
@@ -698,6 +703,8 @@ class WorkerAgent:
         ready.
         """
         logger.info("worker '%s': reporting update available (reason=%s)", self.name, reason)
+        self._lifecycle_status = "update-available"
+        self._lifecycle_reason = reason
         return await self.heartbeat(status="update-available", drain_reason=reason)
 
     async def initiate_self_drain(self, reason: str = "update") -> int:
@@ -711,6 +718,8 @@ class WorkerAgent:
         Returns the HTTP status code from the controller (200 on success).
         """
         logger.info("worker '%s': initiating self-drain (reason=%s)", self.name, reason)
+        self._lifecycle_status = "draining"
+        self._lifecycle_reason = reason
         return await self.heartbeat(status="draining", drain_reason=reason)
 
     async def notify_drain_complete(self) -> int:
@@ -724,6 +733,8 @@ class WorkerAgent:
         Returns the HTTP status code from the controller.
         """
         logger.info("worker '%s': drain complete, ready for update", self.name)
+        self._lifecycle_status = "updating"
+        self._lifecycle_reason = "drain-complete"
         return await self.heartbeat(status="updating")
 
     def _log_repair_instruction(self) -> None:
@@ -780,7 +791,13 @@ class WorkerAgent:
                 await asyncio.sleep(5)
                 continue
 
-            status = await self.heartbeat()
+            # Include any persisted lifecycle status (taOS #890 C2) so that
+            # a controller restart doesn't silently revert a
+            # draining/updating worker back to "online" after re-registration.
+            status = await self.heartbeat(
+                status=self._lifecycle_status,
+                drain_reason=self._lifecycle_reason,
+            )
             if status == 404:
                 # Controller has forgotten about us (restart, manual
                 # deregister, etc). Drop our registered state and the

--- a/tinyagentos/worker/agent.py
+++ b/tinyagentos/worker/agent.py
@@ -574,13 +574,21 @@ class WorkerAgent:
             logger.error(f"Failed to register: {e}")
             return False
 
-    async def heartbeat(self) -> int:
+    async def heartbeat(self, status: str | None = None, drain_reason: str | None = None) -> int:
         """Send heartbeat to controller with live backend catalog.
 
         Backend-driven: the heartbeat carries a fresh probe of every
         detected backend, not a cached snapshot. This lets the controller
         aggregate per-worker catalogs into a cluster-wide view that
         reflects what's actually loaded right now across the mesh.
+
+        Worker-initiated state transitions (taOS #890 C2): when ``status``
+        is set to ``"update-available"`` or ``"draining"``, the controller
+        heeds the worker's self-reported status instead of forcing it back
+        to ``"online"``. This inverts the classic controller-push drain
+        into a worker-pull drain: the worker detects an update, reports
+        its readiness to drain, waits for inflight work to complete, then
+        proceeds to self-install.
 
         Returns the HTTP status code from the controller, or 0 on
         connection failure / timeout. The caller uses this to detect
@@ -658,6 +666,9 @@ class WorkerAgent:
                 "host_lan_ip": live_host_lan_ip,
                 "url": live_url,
                 "hardware": live_hardware,
+                # Worker-initiated state transitions (taOS #890 C2).
+                "status": status,
+                "drain_reason": drain_reason,
             }
             body = _json.dumps(payload).encode()
             auth_headers = sign_request_headers(self._signing_key, self.name, "POST", path, body)
@@ -675,6 +686,44 @@ class WorkerAgent:
             # diagnostics, masquerading as controller unreachability.
             logger.warning("heartbeat send failed: %s: %s", type(exc).__name__, exc)
             return 0
+
+    # ── Worker-initiated drain (taOS #890 C2) ──────────────────────────
+
+    async def report_update_available(self, reason: str = "update") -> int:
+        """Report that an update is available but the worker is still serving.
+
+        Transitions the worker to ``"update-available"`` status on the
+        controller. The worker continues accepting tasks; this is a
+        precursor signal that a drain will follow when the worker is
+        ready.
+        """
+        logger.info("worker '%s': reporting update available (reason=%s)", self.name, reason)
+        return await self.heartbeat(status="update-available", drain_reason=reason)
+
+    async def initiate_self_drain(self, reason: str = "update") -> int:
+        """Initiate a worker-initiated graceful drain.
+
+        Sends a heartbeat with ``status="draining"`` to the controller,
+        which stops routing new tasks to this worker while letting
+        in-flight leases complete. The monitor loop auto-completes the
+        drain when all leases are released.
+
+        Returns the HTTP status code from the controller (200 on success).
+        """
+        logger.info("worker '%s': initiating self-drain (reason=%s)", self.name, reason)
+        return await self.heartbeat(status="draining", drain_reason=reason)
+
+    async def notify_drain_complete(self) -> int:
+        """Notify the controller that the worker's drain is complete.
+
+        After in-flight work finishes, the worker sends one final
+        heartbeat to confirm readiness for the update. The controller
+        can then proceed with the update deploy.
+
+        Returns the HTTP status code from the controller.
+        """
+        logger.info("worker '%s': drain complete, ready for update", self.name)
+        return await self.heartbeat()
 
     def _log_repair_instruction(self) -> None:
         logger.error(


### PR DESCRIPTION
Task: t_33babf4b. Fixes #890 (partial — C2 drain protocol).

## What
Implements worker-initiated drain: the worker can self-drain via heartbeat
instead of waiting for the controller to push a drain command.

## Changes

### Controller side (`cluster/manager.py`)
- `heartbeat()` accepts optional `status` and `drain_reason` fields
- Workers can report `"update-available"`, `"draining"`, or `"updating"`
- `_worker_for_resource`, `get_workers_for_capability`, `aggregate_catalog` include `"update-available"` alongside `"online"`
- Monitor loop handles stale `update-available` workers
- Worker-initiated drain emits notifications to activity feed

### Route side (`routes/cluster.py`)
- `HeartbeatBody` extended with `status` and `drain_reason` fields
- Route handler passes them through to `cluster.heartbeat()`

### Worker side (`worker/agent.py`)
- New convenience methods: `report_update_available()`, `initiate_self_drain()`, `notify_drain_complete()`
- `heartbeat()` accepts optional `status` and `drain_reason` parameters

### State machine
```
online → update-available → draining (self-initiated) → updating → restarting → online
                                                                       ↓ (fail)
                                                                   rollback → online
```

### Tests
11 new unit tests covering:
- Self-drain via heartbeat
- Update-available status + routability
- Catalog inclusion for update-available workers
- Lease claims on update-available workers
- Full state transition pipeline
- Drain preservation on subsequent heartbeats
- Update-available re-online on normal heartbeat
- Monitor loop staleness for update-available
- Updating status routing exclusion

### Test results
```
tests/test_cluster.py::TestWorkerDrain — 38/38 passed (0.42s)
tests/test_cluster_worker_protocol.py — 27/27 passed
tests/test_cluster_optimiser.py (unit only) — 17/17 passed
``"

Depends on: C0 (design doc #1896), C1 (version detection, triggers the drain)
Next task: C3 (self-install + restart + re-register + rollback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workers can now report lifecycle states (update available, graceful draining, and draining complete) along with an optional drain reason.
  - “Update available” workers remain eligible for resource routing and can claim leases.
  - “Updating” workers are excluded from new routing and are handled as a distinct lifecycle stage.

- **Bug Fixes**
  - Heartbeat-driven state changes now preserve protected worker states (including draining/update availability) across subsequent heartbeats.
  - If heartbeats go stale, update-available/updating workers are marked offline and any held leases are released; misleading “back online” notifications are reduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## CodeRabbit fixes (t_b5d624e9)

**Fix 1 (MAJOR):** Persist lifecycle status across controller restart.
Worker stores _lifecycle_status/_lifecycle_reason and resends on periodic heartbeats. If controller restarts, re-registered workers retain their drain/update state instead of silently reverting to online.

**Fix 2 (MAJOR):** Cancel GPU arbiter tasks on stale-update-available cleanup.
The timeout path for update-available workers now cancels arbiter tasks, matching stale-drain and stale-update paths.

**Fix 3 (MINOR):** Gate recovery online event on worker.status == online.
The worker.online notification only fires when genuinely online, not when recovering into draining/updating state.

Tests: 77/77 targeted (test_cluster.py + test_worker.py) pass.