### PR TITLE
fix(scheduling): enable WAL mode + fix sync-in-async in SQLite stores

### DIFF
--- a/tinyagentos/db_migrations.py
+++ b/tinyagentos/db_migrations.py
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 
 def apply_wal_pragmas(conn: sqlite3.Connection) -> None:
     """Enable WAL journal mode and NORMAL synchronous on *conn*."""
+    conn.execute("PRAGMA busy_timeout = 5000")
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA synchronous = NORMAL")
 

--- a/tinyagentos/scheduling/job_queue.py
+++ b/tinyagentos/scheduling/job_queue.py
@@ -101,6 +101,7 @@ class JobQueue:
         self._db_path = str(db_path)
         self._conn: sqlite3.Connection | None = None
         self._limits: dict[str, int] = dict(DEFAULT_LIMITS)
+        self._lock = asyncio.Lock()
 
     def _sync_init(self) -> None:
         self._conn = sqlite3.connect(self._db_path, isolation_level=None, check_same_thread=False)
@@ -133,7 +134,8 @@ class JobQueue:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(self._sync_init)
+        async with self._lock:
+            await asyncio.to_thread(self._sync_init)
 
     async def close(self) -> None:
         if self._conn:
@@ -174,10 +176,11 @@ class JobQueue:
         estimated_seconds: int = 0,
     ) -> str:
         """Add a job to the queue. Returns job ID."""
-        return await asyncio.to_thread(
-            self._sync_enqueue,
-            job_type, payload, agent_name, priority, resource_type, estimated_seconds,
-        )
+        async with self._lock:
+            return await asyncio.to_thread(
+                self._sync_enqueue,
+                job_type, payload, agent_name, priority, resource_type, estimated_seconds,
+            )
 
     # ------------------------------------------------------------------
     # Dequeue (pull-based)
@@ -236,7 +239,8 @@ class JobQueue:
 
         Returns the job dict or None if nothing is eligible.
         """
-        return await asyncio.to_thread(self._sync_dequeue, resource_types)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_dequeue, resource_types)
 
     # ------------------------------------------------------------------
     # Complete / fail
@@ -252,7 +256,8 @@ class JobQueue:
 
     async def complete(self, job_id: str, result: dict | None = None) -> bool:
         """Mark a job as completed."""
-        return await asyncio.to_thread(self._sync_complete, job_id, result)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_complete, job_id, result)
 
     def _sync_fail(self, job_id: str, error: str) -> bool:
         now = time.time()
@@ -264,7 +269,8 @@ class JobQueue:
 
     async def fail(self, job_id: str, error: str) -> bool:
         """Mark a job as failed."""
-        return await asyncio.to_thread(self._sync_fail, job_id, error)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_fail, job_id, error)
 
     def _sync_cancel(self, job_id: str) -> bool:
         cursor = self._conn.execute(
@@ -275,7 +281,8 @@ class JobQueue:
 
     async def cancel(self, job_id: str) -> bool:
         """Cancel a pending job."""
-        return await asyncio.to_thread(self._sync_cancel, job_id)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_cancel, job_id)
 
     # ------------------------------------------------------------------
     # Queries
@@ -286,7 +293,8 @@ class JobQueue:
         return dict(row) if row else None
 
     async def get_job(self, job_id: str) -> dict | None:
-        return await asyncio.to_thread(self._sync_get_job, job_id)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_get_job, job_id)
 
     def _sync_pending_count(self, agent_name: str | None) -> int:
         if agent_name:
@@ -299,7 +307,8 @@ class JobQueue:
         return row["n"]
 
     async def pending_count(self, agent_name: str | None = None) -> int:
-        return await asyncio.to_thread(self._sync_pending_count, agent_name)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_pending_count, agent_name)
 
     def _sync_running_jobs(self) -> list[dict]:
         rows = self._conn.execute(
@@ -308,7 +317,8 @@ class JobQueue:
         return [dict(r) for r in rows]
 
     async def running_jobs(self) -> list[dict]:
-        return await asyncio.to_thread(self._sync_running_jobs)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_running_jobs)
 
     def _sync_recent(self, limit: int, status: str | None) -> list[dict]:
         if status:
@@ -323,7 +333,8 @@ class JobQueue:
         return [dict(r) for r in rows]
 
     async def recent(self, limit: int = 20, status: str | None = None) -> list[dict]:
-        return await asyncio.to_thread(self._sync_recent, limit, status)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_recent, limit, status)
 
     def _sync_agent_jobs(self, agent_name: str, limit: int) -> list[dict]:
         rows = self._conn.execute(
@@ -333,7 +344,8 @@ class JobQueue:
         return [dict(r) for r in rows]
 
     async def agent_jobs(self, agent_name: str, limit: int = 20) -> list[dict]:
-        return await asyncio.to_thread(self._sync_agent_jobs, agent_name, limit)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_agent_jobs, agent_name, limit)
 
     # ------------------------------------------------------------------
     # Config
@@ -348,7 +360,8 @@ class JobQueue:
 
     async def set_limit(self, resource_type: str, max_concurrent: int) -> None:
         """Set the concurrency limit for a resource type."""
-        await asyncio.to_thread(self._sync_set_limit, resource_type, max_concurrent)
+        async with self._lock:
+            await asyncio.to_thread(self._sync_set_limit, resource_type, max_concurrent)
 
     async def get_limits(self) -> dict[str, int]:
         return dict(self._limits)
@@ -367,7 +380,8 @@ class JobQueue:
 
     async def cleanup(self, older_than_days: int = 7) -> int:
         """Remove completed/failed/cancelled jobs older than N days."""
-        return await asyncio.to_thread(self._sync_cleanup, older_than_days)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_cleanup, older_than_days)
 
     # ------------------------------------------------------------------
     # Stats
@@ -396,4 +410,5 @@ class JobQueue:
 
     async def stats(self) -> dict:
         """Queue statistics."""
-        return await asyncio.to_thread(self._sync_stats)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_stats)

--- a/tinyagentos/scheduling/job_queue.py
+++ b/tinyagentos/scheduling/job_queue.py
@@ -17,6 +17,7 @@ controller. For cluster-level job distribution, use taOS's worker dispatch.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sqlite3
@@ -25,6 +26,8 @@ import uuid
 from datetime import datetime, timezone
 from enum import IntEnum
 from pathlib import Path
+
+from tinyagentos.db_migrations import apply_wal_pragmas
 
 logger = logging.getLogger(__name__)
 
@@ -88,19 +91,21 @@ DEFAULT_LIMITS = {
 
 
 class JobQueue:
-    """SQLite-backed job queue for serialising heavy memory tasks."""
+    """SQLite-backed job queue for serialising heavy memory tasks.
+
+    All public methods are async.  Blocking sqlite3 calls are dispatched to a
+    thread via asyncio.to_thread so they never stall the event loop.
+    """
 
     def __init__(self, db_path: str | Path = "data/job-queue.db"):
         self._db_path = str(db_path)
         self._conn: sqlite3.Connection | None = None
         self._limits: dict[str, int] = dict(DEFAULT_LIMITS)
 
-    async def init(self) -> None:
-        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        # isolation_level=None puts the connection in autocommit mode so we
-        # can issue BEGIN IMMEDIATE manually for atomic read-check-write.
-        self._conn = sqlite3.connect(self._db_path, isolation_level=None)
+    def _sync_init(self) -> None:
+        self._conn = sqlite3.connect(self._db_path, isolation_level=None, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
+        apply_wal_pragmas(self._conn)
         self._conn.executescript(SCHEMA)
 
         # Load custom limits from config
@@ -126,6 +131,10 @@ class JobQueue:
         if stale.rowcount > 0:
             logger.info("Marked %d stale running jobs as failed", stale.rowcount)
 
+    async def init(self) -> None:
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._sync_init)
+
     async def close(self) -> None:
         if self._conn:
             self._conn.close()
@@ -135,16 +144,15 @@ class JobQueue:
     # Enqueue
     # ------------------------------------------------------------------
 
-    async def enqueue(
+    def _sync_enqueue(
         self,
         job_type: str,
-        payload: dict | None = None,
-        agent_name: str | None = None,
-        priority: int = Priority.NORMAL,
-        resource_type: str = RESOURCE_CPU,
-        estimated_seconds: int = 0,
+        payload: dict | None,
+        agent_name: str | None,
+        priority: int,
+        resource_type: str,
+        estimated_seconds: int,
     ) -> str:
-        """Add a job to the queue. Returns job ID."""
         job_id = uuid.uuid4().hex[:12]
         now = time.time()
         self._conn.execute(
@@ -156,18 +164,29 @@ class JobQueue:
         )
         return job_id
 
+    async def enqueue(
+        self,
+        job_type: str,
+        payload: dict | None = None,
+        agent_name: str | None = None,
+        priority: int = Priority.NORMAL,
+        resource_type: str = RESOURCE_CPU,
+        estimated_seconds: int = 0,
+    ) -> str:
+        """Add a job to the queue. Returns job ID."""
+        return await asyncio.to_thread(
+            self._sync_enqueue,
+            job_type, payload, agent_name, priority, resource_type, estimated_seconds,
+        )
+
     # ------------------------------------------------------------------
     # Dequeue (pull-based)
     # ------------------------------------------------------------------
 
-    async def dequeue(self, resource_types: list[str] | None = None) -> dict | None:
-        """Get the next eligible job to run, atomically.
-
-        Uses BEGIN IMMEDIATE to acquire a write lock before the read-check-update
-        sequence so two concurrent callers cannot both claim the same job.
-
-        Returns the job dict or None if nothing is eligible.
-        """
+    def _sync_dequeue(
+        self,
+        resource_types: list[str] | None,
+    ) -> dict | None:
         query = "SELECT * FROM jobs WHERE status = 'pending'"
         params: list = []
         if resource_types:
@@ -209,12 +228,21 @@ class JobQueue:
 
         return None
 
+    async def dequeue(self, resource_types: list[str] | None = None) -> dict | None:
+        """Get the next eligible job to run, atomically.
+
+        Uses BEGIN IMMEDIATE to acquire a write lock before the read-check-update
+        sequence so two concurrent callers cannot both claim the same job.
+
+        Returns the job dict or None if nothing is eligible.
+        """
+        return await asyncio.to_thread(self._sync_dequeue, resource_types)
+
     # ------------------------------------------------------------------
     # Complete / fail
     # ------------------------------------------------------------------
 
-    async def complete(self, job_id: str, result: dict | None = None) -> bool:
-        """Mark a job as completed."""
+    def _sync_complete(self, job_id: str, result: dict | None) -> bool:
         now = time.time()
         cursor = self._conn.execute(
             "UPDATE jobs SET status = 'completed', completed_at = ?, result_json = ? WHERE id = ? AND status = 'running'",
@@ -222,8 +250,11 @@ class JobQueue:
         )
         return cursor.rowcount > 0
 
-    async def fail(self, job_id: str, error: str) -> bool:
-        """Mark a job as failed."""
+    async def complete(self, job_id: str, result: dict | None = None) -> bool:
+        """Mark a job as completed."""
+        return await asyncio.to_thread(self._sync_complete, job_id, result)
+
+    def _sync_fail(self, job_id: str, error: str) -> bool:
         now = time.time()
         cursor = self._conn.execute(
             "UPDATE jobs SET status = 'failed', completed_at = ?, error = ? WHERE id = ? AND status = 'running'",
@@ -231,23 +262,33 @@ class JobQueue:
         )
         return cursor.rowcount > 0
 
-    async def cancel(self, job_id: str) -> bool:
-        """Cancel a pending job."""
+    async def fail(self, job_id: str, error: str) -> bool:
+        """Mark a job as failed."""
+        return await asyncio.to_thread(self._sync_fail, job_id, error)
+
+    def _sync_cancel(self, job_id: str) -> bool:
         cursor = self._conn.execute(
             "UPDATE jobs SET status = 'cancelled' WHERE id = ? AND status = 'pending'",
             (job_id,),
         )
         return cursor.rowcount > 0
 
+    async def cancel(self, job_id: str) -> bool:
+        """Cancel a pending job."""
+        return await asyncio.to_thread(self._sync_cancel, job_id)
+
     # ------------------------------------------------------------------
     # Queries
     # ------------------------------------------------------------------
 
-    async def get_job(self, job_id: str) -> dict | None:
+    def _sync_get_job(self, job_id: str) -> dict | None:
         row = self._conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
         return dict(row) if row else None
 
-    async def pending_count(self, agent_name: str | None = None) -> int:
+    async def get_job(self, job_id: str) -> dict | None:
+        return await asyncio.to_thread(self._sync_get_job, job_id)
+
+    def _sync_pending_count(self, agent_name: str | None) -> int:
         if agent_name:
             row = self._conn.execute(
                 "SELECT COUNT(*) as n FROM jobs WHERE status = 'pending' AND agent_name = ?",
@@ -257,13 +298,19 @@ class JobQueue:
             row = self._conn.execute("SELECT COUNT(*) as n FROM jobs WHERE status = 'pending'").fetchone()
         return row["n"]
 
-    async def running_jobs(self) -> list[dict]:
+    async def pending_count(self, agent_name: str | None = None) -> int:
+        return await asyncio.to_thread(self._sync_pending_count, agent_name)
+
+    def _sync_running_jobs(self) -> list[dict]:
         rows = self._conn.execute(
             "SELECT * FROM jobs WHERE status = 'running' ORDER BY started_at"
         ).fetchall()
         return [dict(r) for r in rows]
 
-    async def recent(self, limit: int = 20, status: str | None = None) -> list[dict]:
+    async def running_jobs(self) -> list[dict]:
+        return await asyncio.to_thread(self._sync_running_jobs)
+
+    def _sync_recent(self, limit: int, status: str | None) -> list[dict]:
         if status:
             rows = self._conn.execute(
                 "SELECT * FROM jobs WHERE status = ? ORDER BY created_at DESC LIMIT ?",
@@ -275,24 +322,33 @@ class JobQueue:
             ).fetchall()
         return [dict(r) for r in rows]
 
-    async def agent_jobs(self, agent_name: str, limit: int = 20) -> list[dict]:
+    async def recent(self, limit: int = 20, status: str | None = None) -> list[dict]:
+        return await asyncio.to_thread(self._sync_recent, limit, status)
+
+    def _sync_agent_jobs(self, agent_name: str, limit: int) -> list[dict]:
         rows = self._conn.execute(
             "SELECT * FROM jobs WHERE agent_name = ? ORDER BY created_at DESC LIMIT ?",
             (agent_name, limit),
         ).fetchall()
         return [dict(r) for r in rows]
 
+    async def agent_jobs(self, agent_name: str, limit: int = 20) -> list[dict]:
+        return await asyncio.to_thread(self._sync_agent_jobs, agent_name, limit)
+
     # ------------------------------------------------------------------
     # Config
     # ------------------------------------------------------------------
 
-    async def set_limit(self, resource_type: str, max_concurrent: int) -> None:
-        """Set the concurrency limit for a resource type."""
+    def _sync_set_limit(self, resource_type: str, max_concurrent: int) -> None:
         self._limits[resource_type] = max_concurrent
         self._conn.execute(
             "INSERT INTO queue_config (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
             (f"limit_{resource_type}", str(max_concurrent)),
         )
+
+    async def set_limit(self, resource_type: str, max_concurrent: int) -> None:
+        """Set the concurrency limit for a resource type."""
+        await asyncio.to_thread(self._sync_set_limit, resource_type, max_concurrent)
 
     async def get_limits(self) -> dict[str, int]:
         return dict(self._limits)
@@ -301,8 +357,7 @@ class JobQueue:
     # Cleanup
     # ------------------------------------------------------------------
 
-    async def cleanup(self, older_than_days: int = 7) -> int:
-        """Remove completed/failed/cancelled jobs older than N days."""
+    def _sync_cleanup(self, older_than_days: int) -> int:
         cutoff = time.time() - (older_than_days * 86400)
         cursor = self._conn.execute(
             "DELETE FROM jobs WHERE status IN ('completed', 'failed', 'cancelled') AND created_at < ?",
@@ -310,12 +365,15 @@ class JobQueue:
         )
         return cursor.rowcount
 
+    async def cleanup(self, older_than_days: int = 7) -> int:
+        """Remove completed/failed/cancelled jobs older than N days."""
+        return await asyncio.to_thread(self._sync_cleanup, older_than_days)
+
     # ------------------------------------------------------------------
     # Stats
     # ------------------------------------------------------------------
 
-    async def stats(self) -> dict:
-        """Queue statistics."""
+    def _sync_stats(self) -> dict:
         counts = {}
         for row in self._conn.execute(
             "SELECT status, COUNT(*) as n FROM jobs GROUP BY status"
@@ -335,3 +393,7 @@ class JobQueue:
             "total_pending": counts.get("pending", 0),
             "total_running": counts.get("running", 0),
         }
+
+    async def stats(self) -> dict:
+        """Queue statistics."""
+        return await asyncio.to_thread(self._sync_stats)

--- a/tinyagentos/scheduling/leases.py
+++ b/tinyagentos/scheduling/leases.py
@@ -14,10 +14,13 @@ Lease model:
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 import time
 import uuid
 from pathlib import Path
+
+from tinyagentos.db_migrations import apply_wal_pragmas
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS leases (
@@ -39,24 +42,34 @@ MAX_RENEW_COUNT = 5    # Prevent infinite lease hogging
 
 
 class LeaseManager:
-    """SQLite-backed lease manager for multi-agent coordination."""
+    """SQLite-backed lease manager for multi-agent coordination.
+
+    All public methods are async.  Blocking sqlite3 calls are dispatched to a
+    thread via asyncio.to_thread so they never stall the event loop.
+    """
 
     def __init__(self, db_path: str | Path = "data/leases.db"):
         self._db_path = str(db_path)
         self._conn: sqlite3.Connection | None = None
 
+    def _sync_init(self) -> None:
+        self._conn = sqlite3.connect(self._db_path, isolation_level=None, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        apply_wal_pragmas(self._conn)
+        self._conn.executescript(SCHEMA)
+
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        # isolation_level=None puts the connection in autocommit mode so we
-        # can issue BEGIN IMMEDIATE manually for atomic read-check-write.
-        self._conn = sqlite3.connect(self._db_path, isolation_level=None)
-        self._conn.row_factory = sqlite3.Row
-        self._conn.executescript(SCHEMA)
+        await asyncio.to_thread(self._sync_init)
 
     async def close(self) -> None:
         if self._conn:
             self._conn.close()
             self._conn = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers (thread-safe, called via asyncio.to_thread)
+    # ------------------------------------------------------------------
 
     def _cleanup_expired(self) -> int:
         """Remove expired leases. Returns count removed."""
@@ -84,21 +97,13 @@ class LeaseManager:
             "renewed_count": existing["renewed_count"] + 1,
         }
 
-    async def acquire(
-        self,
-        resource_key: str,
-        agent_name: str,
-        ttl: float = DEFAULT_TTL,
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def _sync_acquire(
+        self, resource_key: str, agent_name: str, ttl: float
     ) -> dict | None:
-        """Acquire an exclusive lease on a resource, atomically.
-
-        Uses BEGIN IMMEDIATE so the cleanup + check + insert sequence is
-        serialised: two concurrent callers cannot both observe the lease as
-        absent and then both succeed.
-
-        Returns lease dict on success, None if resource is already held
-        by another agent.
-        """
         ttl = min(ttl, MAX_TTL)
 
         self._conn.execute("BEGIN IMMEDIATE")
@@ -142,18 +147,28 @@ class LeaseManager:
             "renewed_count": 0,
         }
 
-    async def renew(
+    async def acquire(
         self,
         resource_key: str,
         agent_name: str,
         ttl: float = DEFAULT_TTL,
     ) -> dict | None:
-        """Renew an existing lease, atomically. Only the holder can renew.
+        """Acquire an exclusive lease on a resource, atomically.
 
-        Uses BEGIN IMMEDIATE so the read-check-update sequence is serialised:
-        two concurrent renewals from the same agent cannot both pass the
-        renewed_count cap.
+        Uses BEGIN IMMEDIATE so the cleanup + check + insert sequence is
+        serialised: two concurrent callers cannot both observe the lease as
+        absent and then both succeed.
+
+        Returns lease dict on success, None if resource is already held
+        by another agent.
         """
+        return await asyncio.to_thread(
+            self._sync_acquire, resource_key, agent_name, ttl
+        )
+
+    def _sync_renew(
+        self, resource_key: str, agent_name: str, ttl: float
+    ) -> dict | None:
         ttl = min(ttl, MAX_TTL)
 
         self._conn.execute("BEGIN IMMEDIATE")
@@ -175,16 +190,31 @@ class LeaseManager:
             self._conn.execute("ROLLBACK")
             raise
 
-    async def release(self, resource_key: str, agent_name: str) -> bool:
-        """Release a lease. Only the holder can release."""
+    async def renew(
+        self,
+        resource_key: str,
+        agent_name: str,
+        ttl: float = DEFAULT_TTL,
+    ) -> dict | None:
+        """Renew an existing lease. Only the holder can renew."""
+        return await asyncio.to_thread(
+            self._sync_renew, resource_key, agent_name, ttl
+        )
+
+    def _sync_release(self, resource_key: str, agent_name: str) -> bool:
         cursor = self._conn.execute(
             "DELETE FROM leases WHERE resource_key = ? AND agent_name = ?",
             (resource_key, agent_name),
         )
         return cursor.rowcount > 0
 
-    async def check(self, resource_key: str) -> dict | None:
-        """Check who holds a lease on a resource. Returns lease dict or None."""
+    async def release(self, resource_key: str, agent_name: str) -> bool:
+        """Release a lease. Only the holder can release."""
+        return await asyncio.to_thread(
+            self._sync_release, resource_key, agent_name
+        )
+
+    def _sync_check(self, resource_key: str) -> dict | None:
         self._cleanup_expired()
         row = self._conn.execute(
             "SELECT * FROM leases WHERE resource_key = ?",
@@ -192,8 +222,11 @@ class LeaseManager:
         ).fetchone()
         return dict(row) if row else None
 
-    async def is_held_by(self, resource_key: str, agent_name: str) -> bool:
-        """Check if a specific agent holds the lease."""
+    async def check(self, resource_key: str) -> dict | None:
+        """Check who holds a lease on a resource. Returns lease dict or None."""
+        return await asyncio.to_thread(self._sync_check, resource_key)
+
+    def _sync_is_held_by(self, resource_key: str, agent_name: str) -> bool:
         self._cleanup_expired()
         row = self._conn.execute(
             "SELECT 1 FROM leases WHERE resource_key = ? AND agent_name = ?",
@@ -201,8 +234,13 @@ class LeaseManager:
         ).fetchone()
         return row is not None
 
-    async def agent_leases(self, agent_name: str) -> list[dict]:
-        """List all active leases held by an agent."""
+    async def is_held_by(self, resource_key: str, agent_name: str) -> bool:
+        """Check if a specific agent holds the lease."""
+        return await asyncio.to_thread(
+            self._sync_is_held_by, resource_key, agent_name
+        )
+
+    def _sync_agent_leases(self, agent_name: str) -> list[dict]:
         self._cleanup_expired()
         rows = self._conn.execute(
             "SELECT * FROM leases WHERE agent_name = ? ORDER BY acquired_at",
@@ -210,17 +248,27 @@ class LeaseManager:
         ).fetchall()
         return [dict(r) for r in rows]
 
-    async def release_all(self, agent_name: str) -> int:
-        """Release all leases held by an agent (e.g., on agent shutdown)."""
+    async def agent_leases(self, agent_name: str) -> list[dict]:
+        """List all active leases held by an agent."""
+        return await asyncio.to_thread(self._sync_agent_leases, agent_name)
+
+    def _sync_release_all(self, agent_name: str) -> int:
         cursor = self._conn.execute(
             "DELETE FROM leases WHERE agent_name = ?",
             (agent_name,),
         )
         return cursor.rowcount
 
-    async def stats(self) -> dict:
-        """Lease statistics."""
+    async def release_all(self, agent_name: str) -> int:
+        """Release all leases held by an agent (e.g., on agent shutdown)."""
+        return await asyncio.to_thread(self._sync_release_all, agent_name)
+
+    def _sync_stats(self) -> dict:
         self._cleanup_expired()
         total = self._conn.execute("SELECT COUNT(*) as n FROM leases").fetchone()["n"]
         agents = self._conn.execute("SELECT COUNT(DISTINCT agent_name) as n FROM leases").fetchone()["n"]
         return {"active_leases": total, "agents_with_leases": agents}
+
+    async def stats(self) -> dict:
+        """Lease statistics."""
+        return await asyncio.to_thread(self._sync_stats)

--- a/tinyagentos/scheduling/leases.py
+++ b/tinyagentos/scheduling/leases.py
@@ -51,6 +51,7 @@ class LeaseManager:
     def __init__(self, db_path: str | Path = "data/leases.db"):
         self._db_path = str(db_path)
         self._conn: sqlite3.Connection | None = None
+        self._lock = asyncio.Lock()
 
     def _sync_init(self) -> None:
         self._conn = sqlite3.connect(self._db_path, isolation_level=None, check_same_thread=False)
@@ -60,7 +61,8 @@ class LeaseManager:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(self._sync_init)
+        async with self._lock:
+            await asyncio.to_thread(self._sync_init)
 
     async def close(self) -> None:
         if self._conn:
@@ -162,9 +164,10 @@ class LeaseManager:
         Returns lease dict on success, None if resource is already held
         by another agent.
         """
-        return await asyncio.to_thread(
-            self._sync_acquire, resource_key, agent_name, ttl
-        )
+        async with self._lock:
+            return await asyncio.to_thread(
+                self._sync_acquire, resource_key, agent_name, ttl
+            )
 
     def _sync_renew(
         self, resource_key: str, agent_name: str, ttl: float
@@ -197,9 +200,10 @@ class LeaseManager:
         ttl: float = DEFAULT_TTL,
     ) -> dict | None:
         """Renew an existing lease. Only the holder can renew."""
-        return await asyncio.to_thread(
-            self._sync_renew, resource_key, agent_name, ttl
-        )
+        async with self._lock:
+            return await asyncio.to_thread(
+                self._sync_renew, resource_key, agent_name, ttl
+            )
 
     def _sync_release(self, resource_key: str, agent_name: str) -> bool:
         cursor = self._conn.execute(
@@ -210,9 +214,10 @@ class LeaseManager:
 
     async def release(self, resource_key: str, agent_name: str) -> bool:
         """Release a lease. Only the holder can release."""
-        return await asyncio.to_thread(
-            self._sync_release, resource_key, agent_name
-        )
+        async with self._lock:
+            return await asyncio.to_thread(
+                self._sync_release, resource_key, agent_name
+            )
 
     def _sync_check(self, resource_key: str) -> dict | None:
         self._cleanup_expired()
@@ -224,7 +229,8 @@ class LeaseManager:
 
     async def check(self, resource_key: str) -> dict | None:
         """Check who holds a lease on a resource. Returns lease dict or None."""
-        return await asyncio.to_thread(self._sync_check, resource_key)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_check, resource_key)
 
     def _sync_is_held_by(self, resource_key: str, agent_name: str) -> bool:
         self._cleanup_expired()
@@ -236,9 +242,10 @@ class LeaseManager:
 
     async def is_held_by(self, resource_key: str, agent_name: str) -> bool:
         """Check if a specific agent holds the lease."""
-        return await asyncio.to_thread(
-            self._sync_is_held_by, resource_key, agent_name
-        )
+        async with self._lock:
+            return await asyncio.to_thread(
+                self._sync_is_held_by, resource_key, agent_name
+            )
 
     def _sync_agent_leases(self, agent_name: str) -> list[dict]:
         self._cleanup_expired()
@@ -250,7 +257,8 @@ class LeaseManager:
 
     async def agent_leases(self, agent_name: str) -> list[dict]:
         """List all active leases held by an agent."""
-        return await asyncio.to_thread(self._sync_agent_leases, agent_name)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_agent_leases, agent_name)
 
     def _sync_release_all(self, agent_name: str) -> int:
         cursor = self._conn.execute(
@@ -261,7 +269,8 @@ class LeaseManager:
 
     async def release_all(self, agent_name: str) -> int:
         """Release all leases held by an agent (e.g., on agent shutdown)."""
-        return await asyncio.to_thread(self._sync_release_all, agent_name)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_release_all, agent_name)
 
     def _sync_stats(self) -> dict:
         self._cleanup_expired()
@@ -271,4 +280,5 @@ class LeaseManager:
 
     async def stats(self) -> dict:
         """Lease statistics."""
-        return await asyncio.to_thread(self._sync_stats)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_stats)

--- a/tinyagentos/scheduling/mesh_sync.py
+++ b/tinyagentos/scheduling/mesh_sync.py
@@ -15,6 +15,7 @@ Syncs: KG triples, vector memories, archive index entries, crystals, insights.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import ipaddress
 import json
@@ -158,7 +159,15 @@ def is_safe_url(url: str, allow_private: bool = False) -> bool:
 
 
 class MeshSync:
-    """Memory mesh synchronization manager."""
+    """Memory mesh synchronization manager.
+
+    All public methods are async.  Blocking sqlite3 calls on self._conn are
+    dispatched to a thread via asyncio.to_thread so they never stall the
+    event loop.  Methods that operate on caller-supplied connections
+    (export_delta, import_delta, prepare_agent_bundle) perform synchronous
+    I/O on the *caller's* connections — the caller is responsible for thread
+    safety of those handles.
+    """
 
     def __init__(
         self,
@@ -171,12 +180,15 @@ class MeshSync:
         self._is_controller = is_controller
         self._conn: sqlite3.Connection | None = None
 
-    async def init(self) -> None:
-        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+    def _sync_init(self) -> None:
         self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
         self._conn.row_factory = sqlite3.Row
         apply_wal_pragmas(self._conn)
         run_migrations(self._conn, MIGRATIONS, namespace="MeshSync")
+
+    async def init(self) -> None:
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(self._sync_init)
 
     async def close(self) -> None:
         if self._conn:
@@ -187,8 +199,7 @@ class MeshSync:
     # Peer management
     # ------------------------------------------------------------------
 
-    async def add_peer(self, peer_id: str, url: str) -> dict:
-        """Register a sync peer (worker or controller)."""
+    def _sync_add_peer(self, peer_id: str, url: str) -> dict:
         now = time.time()
         self._conn.execute(
             """INSERT INTO sync_peers (peer_id, url, created_at) VALUES (?, ?, ?)
@@ -198,14 +209,24 @@ class MeshSync:
         self._conn.commit()
         return {"peer_id": peer_id, "url": url}
 
-    async def remove_peer(self, peer_id: str) -> bool:
+    async def add_peer(self, peer_id: str, url: str) -> dict:
+        """Register a sync peer (worker or controller)."""
+        return await asyncio.to_thread(self._sync_add_peer, peer_id, url)
+
+    def _sync_remove_peer(self, peer_id: str) -> bool:
         cursor = self._conn.execute("DELETE FROM sync_peers WHERE peer_id = ?", (peer_id,))
         self._conn.commit()
         return cursor.rowcount > 0
 
-    async def list_peers(self) -> list[dict]:
+    async def remove_peer(self, peer_id: str) -> bool:
+        return await asyncio.to_thread(self._sync_remove_peer, peer_id)
+
+    def _sync_list_peers(self) -> list[dict]:
         rows = self._conn.execute("SELECT * FROM sync_peers ORDER BY created_at").fetchall()
         return [dict(r) for r in rows]
+
+    async def list_peers(self) -> list[dict]:
+        return await asyncio.to_thread(self._sync_list_peers)
 
     # ------------------------------------------------------------------
     # Delta export (controller → worker)
@@ -312,24 +333,13 @@ class MeshSync:
     # Full sync cycle
     # ------------------------------------------------------------------
 
-    async def pull_from_peer(
+    def _sync_pull_from_peer(
         self,
         peer_id: str,
         source_dbs: dict[str, sqlite3.Connection],
         target_dbs: dict[str, sqlite3.Connection],
-        allow_private: bool = True,
+        allow_private: bool,
     ) -> dict:
-        """Pull deltas from a peer for all syncable tables.
-
-        Args:
-            peer_id: The peer to pull from.
-            source_dbs: Map of table_name → source connection (on peer).
-            target_dbs: Map of table_name → target connection (local).
-            allow_private: Allow private IPs (True for LAN workers).
-
-        Returns:
-            {tables_synced, total_records, errors}.
-        """
         peer = self._conn.execute(
             "SELECT * FROM sync_peers WHERE peer_id = ?", (peer_id,)
         ).fetchone()
@@ -347,9 +357,9 @@ class MeshSync:
             if table not in source_dbs or table not in target_dbs:
                 continue
             try:
-                delta = await self.export_delta(source_dbs[table], table, last_sync)
+                delta = _export_delta_sync(source_dbs[table], table, last_sync)
                 if delta:
-                    imported = await self.import_delta(target_dbs[table], table, delta)
+                    imported = _import_delta_sync(target_dbs[table], table, delta)
                     results["tables_synced"] += 1
                     results["total_records"] += imported
 
@@ -369,6 +379,29 @@ class MeshSync:
         self._conn.commit()
 
         return results
+
+    async def pull_from_peer(
+        self,
+        peer_id: str,
+        source_dbs: dict[str, sqlite3.Connection],
+        target_dbs: dict[str, sqlite3.Connection],
+        allow_private: bool = True,
+    ) -> dict:
+        """Pull deltas from a peer for all syncable tables.
+
+        Args:
+            peer_id: The peer to pull from.
+            source_dbs: Map of table_name → source connection (on peer).
+            target_dbs: Map of table_name → target connection (local).
+            allow_private: Allow private IPs (True for LAN workers).
+
+        Returns:
+            {tables_synced, total_records, errors}.
+        """
+        return await asyncio.to_thread(
+            self._sync_pull_from_peer,
+            peer_id, source_dbs, target_dbs, allow_private,
+        )
 
     async def push_to_peer(
         self,
@@ -438,7 +471,7 @@ class MeshSync:
     # Stats
     # ------------------------------------------------------------------
 
-    async def stats(self) -> dict:
+    def _sync_stats(self) -> dict:
         peers = self._conn.execute("SELECT COUNT(*) as n FROM sync_peers").fetchone()["n"]
         syncs = self._conn.execute("SELECT COUNT(*) as n FROM sync_log").fetchone()["n"]
         last = self._conn.execute("SELECT MAX(timestamp) as ts FROM sync_log").fetchone()["ts"]
@@ -449,3 +482,61 @@ class MeshSync:
             "total_syncs": syncs,
             "last_sync": last,
         }
+
+    async def stats(self) -> dict:
+        return await asyncio.to_thread(self._sync_stats)
+
+
+# ---------------------------------------------------------------------------
+# Standalone sync helpers (used by _sync_pull_from_peer inside a thread)
+# ---------------------------------------------------------------------------
+
+def _export_delta_sync(
+    source_db: sqlite3.Connection,
+    table: str,
+    since: float,
+) -> list[dict]:
+    """Sync version of export_delta for use inside asyncio.to_thread."""
+    if table not in SYNCABLE_TABLES:
+        return []
+    ts_col = SYNCABLE_TABLES[table]
+    rows = source_db.execute(
+        f"SELECT * FROM {table} WHERE {ts_col} > ? ORDER BY {ts_col}",
+        (since,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _import_delta_sync(
+    target_db: sqlite3.Connection,
+    table: str,
+    records: list[dict],
+) -> int:
+    """Sync version of import_delta for use inside asyncio.to_thread."""
+    if not records or table not in SYNCABLE_TABLES:
+        return 0
+
+    rows = target_db.execute(f"PRAGMA table_info({table})").fetchall()
+    known_columns = frozenset(r[1] for r in rows)
+    if not known_columns:
+        return 0
+
+    imported = 0
+    for record in records:
+        peer_cols = list(record.keys())
+        if not all(col in known_columns for col in peer_cols):
+            continue
+        placeholders = ", ".join(["?"] * len(peer_cols))
+        col_names = ", ".join(peer_cols)
+        try:
+            target_db.execute(
+                f"INSERT OR REPLACE INTO {table} ({col_names}) VALUES ({placeholders})",
+                tuple(record[c] for c in peer_cols),
+            )
+            imported += 1
+        except Exception:
+            pass
+
+    if imported:
+        target_db.commit()
+    return imported

--- a/tinyagentos/scheduling/mesh_sync.py
+++ b/tinyagentos/scheduling/mesh_sync.py
@@ -179,6 +179,7 @@ class MeshSync:
         self._node_id = node_id or hashlib.sha256(str(time.time()).encode()).hexdigest()[:12]
         self._is_controller = is_controller
         self._conn: sqlite3.Connection | None = None
+        self._lock = asyncio.Lock()
 
     def _sync_init(self) -> None:
         self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
@@ -188,7 +189,8 @@ class MeshSync:
 
     async def init(self) -> None:
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
-        await asyncio.to_thread(self._sync_init)
+        async with self._lock:
+            await asyncio.to_thread(self._sync_init)
 
     async def close(self) -> None:
         if self._conn:
@@ -211,7 +213,8 @@ class MeshSync:
 
     async def add_peer(self, peer_id: str, url: str) -> dict:
         """Register a sync peer (worker or controller)."""
-        return await asyncio.to_thread(self._sync_add_peer, peer_id, url)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_add_peer, peer_id, url)
 
     def _sync_remove_peer(self, peer_id: str) -> bool:
         cursor = self._conn.execute("DELETE FROM sync_peers WHERE peer_id = ?", (peer_id,))
@@ -219,14 +222,16 @@ class MeshSync:
         return cursor.rowcount > 0
 
     async def remove_peer(self, peer_id: str) -> bool:
-        return await asyncio.to_thread(self._sync_remove_peer, peer_id)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_remove_peer, peer_id)
 
     def _sync_list_peers(self) -> list[dict]:
         rows = self._conn.execute("SELECT * FROM sync_peers ORDER BY created_at").fetchall()
         return [dict(r) for r in rows]
 
     async def list_peers(self) -> list[dict]:
-        return await asyncio.to_thread(self._sync_list_peers)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_list_peers)
 
     # ------------------------------------------------------------------
     # Delta export (controller → worker)
@@ -398,10 +403,11 @@ class MeshSync:
         Returns:
             {tables_synced, total_records, errors}.
         """
-        return await asyncio.to_thread(
-            self._sync_pull_from_peer,
-            peer_id, source_dbs, target_dbs, allow_private,
-        )
+        async with self._lock:
+            return await asyncio.to_thread(
+                self._sync_pull_from_peer,
+                peer_id, source_dbs, target_dbs, allow_private,
+            )
 
     async def push_to_peer(
         self,
@@ -484,7 +490,8 @@ class MeshSync:
         }
 
     async def stats(self) -> dict:
-        return await asyncio.to_thread(self._sync_stats)
+        async with self._lock:
+            return await asyncio.to_thread(self._sync_stats)
 
 
 # ---------------------------------------------------------------------------
@@ -534,8 +541,8 @@ def _import_delta_sync(
                 tuple(record[c] for c in peer_cols),
             )
             imported += 1
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning("Import failed for %s record: %s", table, e)
 
     if imported:
         target_db.commit()


### PR DESCRIPTION
Fixes #653.

Three related SQLite fixes across the scheduling subsystem:

**1. WAL mode** — `job_queue.py` and `leases.py` now call `apply_wal_pragmas()` on init (WAL + NORMAL synchronous + busy_timeout=5000). `mesh_sync.py` and `worker_heartbeat.py` already had this. Together with `base_store.py`, all SQLite stores in taOS now use WAL mode.

**2. Sync-in-async** — All three files (`job_queue.py`, `leases.py`, `mesh_sync.py`) now dispatch blocking `sqlite3` calls through `asyncio.to_thread()` following the pattern already established by `worker_heartbeat.py`. Public async API is unchanged.

**3. Concurrency safety (review fix)** — Added `asyncio.Lock` to `JobQueue`, `LeaseManager`, and `MeshSync` to guard the shared `sqlite3.Connection` against concurrent `asyncio.to_thread` workers. This prevents interleaved `BEGIN IMMEDIATE … COMMIT` transactions when multiple callers operate on the same singleton instance (e.g., `app.state.job_queue` reused across concurrent requests).

**4. Migration system** — Verified robust. `db_migrations.py` has version-tracked migrations with `schema_migrations` table, baseline-at-latest semantics for pre-existing DBs, and both sync/async variants. Tests cover fresh DB, existing DB baseline, idempotent re-run, callable migrations, and WAL pragma assertions.

**Also:**
- `apply_wal_pragmas` now sets `busy_timeout=5000` to match every other store (litellm_keystore/agent_budget_store/broker).
- `_import_delta_sync` no longer swallows insert failures with bare `except: pass` — logs a warning instead.

**Tests: 60/60 pass** (`test_db_migrations.py` + `tests/scheduling/`).