### PR TITLE
feat(desktop): add release-channel selector to Updates panel

### DIFF
--- a/desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.test.tsx
@@ -46,25 +46,94 @@ describe("UpdatesPanel -- version display", () => {
   });
 });
 
-describe("UpdatesPanel -- branch selector", () => {
-  it("hides the branch selector until Advanced is expanded", async () => {
+describe("UpdatesPanel -- release channel selector", () => {
+  it("shows Stable and Beta channel radio buttons at the top level", async () => {
     render(<UpdatesPanel />);
-    expect(screen.queryByRole("combobox", { name: /branch/i })).toBeNull();
-    fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
-    await waitFor(() => expect(screen.getByRole("combobox", { name: /branch/i })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("radio", { name: "Stable" })).toBeInTheDocument());
+    expect(screen.getByRole("radio", { name: "Beta" })).toBeInTheDocument();
   });
 
-  it("requires confirm before posting a switch", async () => {
+  it("shows current branch indicator", async () => {
     render(<UpdatesPanel />);
+    // The branch info is fetched when Advanced opens. Current is dev per BASE_FETCH.
+    // Open Advanced first to trigger the branch fetch.
     fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
-    const select = await screen.findByRole("combobox", { name: /branch/i });
-    fireEvent.change(select, { target: { value: "master" } });
-    fireEvent.click(screen.getByRole("button", { name: /switch branch/i }));
+    // "dev" appears in both the top-level Current indicator and the Advanced section
+    await waitFor(() => expect(screen.getAllByText("dev").length).toBeGreaterThanOrEqual(1));
+  });
+
+  it("requires confirm before posting a channel switch", async () => {
+    render(<UpdatesPanel />);
+    // Open Advanced to trigger branch fetch (needed for switch button to enable)
+    fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
+    // Wait for branches to load (dev appears in both Current indicators)
+    await waitFor(() => expect(screen.getAllByText("dev").length).toBeGreaterThanOrEqual(1));
+
+    // Select Stable (master) — it's different from current (dev), so button enables
+    fireEvent.click(screen.getByRole("radio", { name: "Stable" }));
+    fireEvent.click(screen.getByRole("button", { name: /switch channel/i }));
     expect((global.fetch as any).mock.calls.find((c: any[]) => c[0] === "/api/settings/update-channel")).toBeUndefined();
+    // Confirm the dialog
     fireEvent.click(await screen.findByRole("button", { name: /^confirm/i }));
     await waitFor(() =>
       expect((global.fetch as any).mock.calls.find((c: any[]) => c[0] === "/api/settings/update-channel")).toBeTruthy()
     );
+  });
+
+  it("shows confirm dialog with channel label", async () => {
+    render(<UpdatesPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
+    await waitFor(() => expect(screen.getAllByText("dev").length).toBeGreaterThanOrEqual(1));
+
+    fireEvent.click(screen.getByRole("radio", { name: "Stable" }));
+    fireEvent.click(screen.getByRole("button", { name: /switch channel/i }));
+    // Dialog should show "Switch channel?" title
+    await waitFor(() => expect(screen.getByText("Switch channel?")).toBeInTheDocument());
+    // The dialog mentions the selected channel
+    const dialogText = screen.getByRole("dialog").textContent ?? "";
+    expect(dialogText).toContain("Stable");
+    expect(dialogText).toContain("master");
+  });
+
+  it("switch button is disabled when on current channel", async () => {
+    (global.fetch as any) = vi.fn(async (url: string) => {
+      if (url === "/api/preferences/auto-update") return jResp({ check_enabled: true });
+      if (url === "/api/settings/update-check")
+        return jResp({ has_updates: false, current_version: "1.0.0-beta.2", current_commit: "abc x" });
+      if (url === "/api/settings/update-status") return jResp({ current_sha: "abc", pending_restart_sha: null });
+      if (url === "/api/settings/branches") return jResp({ branches: ["master", "dev"], current: "master" });
+      if (url === "/api/apps/optional/catalog") return jResp({ apps: [] });
+      return jResp({});
+    });
+    render(<UpdatesPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
+    await waitFor(() => expect(screen.getAllByText("master").length).toBeGreaterThanOrEqual(1));
+    // Current is master; Stable (master) should be selected and button disabled
+    const btn = screen.getByRole("button", { name: /switch channel/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("custom branch input is behind Advanced disclosure", async () => {
+    render(<UpdatesPanel />);
+    // Custom branch input should not be visible until Advanced is expanded
+    expect(screen.queryByRole("textbox", { name: /custom branch/i })).toBeNull();
+    fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: /custom branch/i })).toBeInTheDocument()
+    );
+  });
+
+  it("custom branch input clears channel selection", async () => {
+    render(<UpdatesPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /advanced/i }));
+    await waitFor(() => expect(screen.getAllByText("dev").length).toBeGreaterThanOrEqual(1));
+
+    // Type a custom branch
+    const input = screen.getByRole("textbox", { name: /custom branch/i });
+    fireEvent.change(input, { target: { value: "feature/test" } });
+    // Stable radio should be unchecked
+    const stableRadio = screen.getByRole("radio", { name: "Stable" }) as HTMLInputElement;
+    expect(stableRadio.checked).toBe(false);
   });
 });
 

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
@@ -45,11 +45,6 @@ const CHANNEL_OPTIONS = [
   { label: "Beta", branch: "dev", description: "Preview upcoming features." },
 ] as const;
 
-function channelForBranch(branch: string): string {
-  const opt = CHANNEL_OPTIONS.find((c) => c.branch === branch);
-  return opt?.branch ?? branch;
-}
-
 // Render a lucide icon by kebab-case name (matches the format used in optional-apps registry).
 function AppIconGlyph({ iconName, size = 16 }: { iconName: string; size?: number }) {
   const pascal = iconName

--- a/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
+++ b/desktop/src/apps/SettingsApp/UpdatesPanel.tsx
@@ -38,6 +38,18 @@ interface OptionalAppCatalogEntry {
   update_available: boolean;
 }
 
+// Release-channel to branch mapping. The label is shown in the UI; the
+// branch is sent to the API and stored as the tracked_branch preference.
+const CHANNEL_OPTIONS = [
+  { label: "Stable", branch: "master", description: "Recommended for most users." },
+  { label: "Beta", branch: "dev", description: "Preview upcoming features." },
+] as const;
+
+function channelForBranch(branch: string): string {
+  const opt = CHANNEL_OPTIONS.find((c) => c.branch === branch);
+  return opt?.branch ?? branch;
+}
+
 // Render a lucide icon by kebab-case name (matches the format used in optional-apps registry).
 function AppIconGlyph({ iconName, size = 16 }: { iconName: string; size?: number }) {
   const pascal = iconName
@@ -114,6 +126,7 @@ export function UpdatesPanel() {
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [branchInfo, setBranchInfo] = useState<BranchInfo | null>(null);
   const [selectedBranch, setSelectedBranch] = useState<string>("");
+  const [customBranch, setCustomBranch] = useState<string>("");
   const [switching, setSwitching] = useState(false);
   const [showSwitchConfirm, setShowSwitchConfirm] = useState(false);
   const branchFetched = useRef(false);
@@ -256,6 +269,9 @@ export function UpdatesPanel() {
           const data: BranchInfo = await r.json();
           setBranchInfo(data);
           setSelectedBranch(data.current);
+          // Pre-select the matching channel option for the top-level selector.
+          const ch = CHANNEL_OPTIONS.find((c) => c.branch === data.current);
+          setCustomBranch(ch ? "" : data.current);
           branchFetched.current = true;
         } else {
           setStatus("Could not load branch list.");
@@ -270,15 +286,19 @@ export function UpdatesPanel() {
     setShowSwitchConfirm(false);
     setSwitching(true);
     setStatus(null);
+    // When a channel option was selected (and custom is blank), use the
+    // channel's branch. Otherwise use the free-text custom branch input.
+    const branch = customBranch.trim() || selectedBranch;
+    if (!branch) { setSwitching(false); return; }
     try {
       const res = await fetch("/api/settings/update-channel", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ branch: selectedBranch }),
+        body: JSON.stringify({ branch }),
       });
       const data = await res.json().catch(() => ({})) as { status?: string; branch?: string; snapshot?: string; recovery_tag?: string; message?: string; error?: string };
       if (res.ok && !data.error) {
-        setStatus(data.message ?? data.snapshot ?? `Switching to ${data.branch ?? selectedBranch}…`);
+        setStatus(data.message ?? data.snapshot ?? `Switching to ${data.branch ?? branch}…`);
         setShowRestartModal(true);
       } else {
         setStatus(data.error ?? "Branch switch failed.");
@@ -423,6 +443,52 @@ export function UpdatesPanel() {
 
         </div>
 
+        {/* Release channel selector */}
+        <div className="border-t border-white/5 pt-4 space-y-3">
+          <Label className="text-sm">Release channel</Label>
+          <div className="space-y-2">
+            {CHANNEL_OPTIONS.map((ch) => (
+              <label
+                key={ch.branch}
+                className={`flex items-start gap-3 rounded-lg border px-3 py-2.5 cursor-pointer transition-colors ${
+                  (selectedBranch === ch.branch && !customBranch.trim())
+                    ? "border-sky-500/40 bg-sky-500/10"
+                    : "border-white/10 hover:border-white/20"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="release-channel"
+                  value={ch.branch}
+                  checked={selectedBranch === ch.branch && !customBranch.trim()}
+                  onChange={() => { setSelectedBranch(ch.branch); setCustomBranch(""); }}
+                  className="mt-0.5 accent-sky-500"
+                  aria-label={ch.label}
+                />
+                <div className="flex-1 min-w-0">
+                  <span className="text-sm font-medium text-shell-text">{ch.label}</span>
+                  <span className="text-[10px] text-shell-text-tertiary ml-1.5 font-mono">({ch.branch})</span>
+                  <p className="text-[11px] text-shell-text-tertiary mt-0.5">{ch.description}</p>
+                </div>
+              </label>
+            ))}
+          </div>
+          {branchInfo && (
+            <p className="text-[11px] text-shell-text-tertiary">
+              Current: <span className="font-mono">{branchInfo.current}</span>
+            </p>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={switching || !selectedBranch || (selectedBranch === branchInfo?.current && !customBranch.trim())}
+            onClick={() => setShowSwitchConfirm(true)}
+            aria-label="Switch channel"
+          >
+            {switching ? "Switching…" : "Switch to " + (CHANNEL_OPTIONS.find((c) => c.branch === selectedBranch)?.label ?? selectedBranch)}
+          </Button>
+        </div>
+
         {/* Advanced disclosure */}
         <div className="border-t border-white/5 pt-4">
           <button
@@ -440,29 +506,27 @@ export function UpdatesPanel() {
             <div className="mt-3 space-y-3">
               <div className="flex flex-col sm:flex-row sm:items-end gap-2">
                 <div className="flex flex-col gap-1 min-w-0 flex-1">
-                  <label htmlFor="branch-select" className="text-[11px] text-shell-text-tertiary">
-                    Branch
+                  <label htmlFor="custom-branch" className="text-[11px] text-shell-text-tertiary">
+                    Custom branch
                   </label>
-                  <select
-                    id="branch-select"
-                    aria-label="Branch"
-                    value={selectedBranch}
-                    onChange={(e) => setSelectedBranch(e.target.value)}
-                    className="w-full min-w-0 max-w-full text-sm bg-white/5 border border-white/10 rounded px-2 py-1 text-shell-text-primary focus:outline-none focus:ring-1 focus:ring-sky-500"
-                  >
-                    {branchInfo?.branches.map((b) => (
-                      <option key={b} value={b}>{b}</option>
-                    ))}
-                  </select>
+                  <input
+                    id="custom-branch"
+                    type="text"
+                    aria-label="Custom branch"
+                    value={customBranch}
+                    onChange={(e) => { setCustomBranch(e.target.value); if (e.target.value.trim()) setSelectedBranch(""); }}
+                    placeholder="e.g. feature/my-branch"
+                    className="w-full min-w-0 max-w-full text-sm bg-white/5 border border-white/10 rounded px-2 py-1 text-shell-text-primary placeholder:text-shell-text-tertiary focus:outline-none focus:ring-1 focus:ring-sky-500"
+                  />
                 </div>
                 <Button
                   size="sm"
                   variant="outline"
-                  disabled={switching || !selectedBranch || selectedBranch === branchInfo?.current}
-                  onClick={() => setShowSwitchConfirm(true)}
-                  aria-label="Switch branch"
+                  disabled={switching || !customBranch.trim() || customBranch.trim() === branchInfo?.current}
+                  onClick={() => { setSelectedBranch(customBranch.trim()); setShowSwitchConfirm(true); }}
+                  aria-label="Switch to custom branch"
                 >
-                  {switching ? "Switching…" : "Switch branch"}
+                  {switching ? "Switching…" : "Switch"}
                 </Button>
               </div>
               {branchInfo && (
@@ -514,9 +578,14 @@ export function UpdatesPanel() {
             className="bg-shell-surface border border-white/10 rounded-xl shadow-2xl p-6 max-w-md w-full mx-4 space-y-4"
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 id="switch-branch-title" className="text-sm font-semibold">Switch branch?</h3>
+            <h3 id="switch-branch-title" className="text-sm font-semibold">Switch channel?</h3>
             <p id="switch-branch-desc" className="text-xs text-shell-text-secondary leading-relaxed">
-              This switches taOS to <span className="font-mono font-semibold">{selectedBranch}</span> and restarts.
+              This switches taOS to{" "}
+              <span className="font-mono font-semibold">
+                {CHANNEL_OPTIONS.find((c) => c.branch === selectedBranch)?.label ?? selectedBranch}
+                {customBranch.trim() ? "" : ` (${selectedBranch})`}
+              </span>{" "}
+              and restarts.
               Your data/ is backed up first (data-backups/).
               Switching to an older branch may leave data written by a newer version unreadable.
             </p>


### PR DESCRIPTION
Task: t_4c8b278a. Fixes #562.

## What
Adds a top-level Release channel selector to Settings → Updates with Stable (master) and Beta (dev) radio buttons. The custom branch input is moved to the Advanced section as a free-text field.

## Changes
- **UpdatesPanel.tsx**: Add CHANNEL_OPTIONS mapping (Stable↔master, Beta↔dev), top-level radio button group, free-text custom branch input in Advanced, confirm dialog with channel labels
- **UpdatesPanel.test.tsx**: 12 tests covering radio buttons, channel labels, confirm flow, custom branch input, disabled state

## Backend
No backend changes — the `POST /api/settings/update-channel` endpoint and `switch_to_branch()` in `update_runner.py` already support branch-agnostic switching (implemented in prior work for #560).

## Tests
- Frontend: 12/12 pass (vitest)
- Backend related: test_auto_update_branch.py (5/5), test_update_runner.py (5/5), test_rollback.py (6/6) all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stable and Beta release channel selection in Updates settings.
  * Added an optional custom branch input under Advanced settings.
  * Added confirmation details showing the selected channel and associated branch before switching.
  * Prevented switching when the selected channel is already active.

* **Bug Fixes**
  * Improved current branch detection and selection when opening Advanced settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->