### PR TITLE
fix(opencode): add turn_timeout to drive_turn to prevent LLM hangs from blocking HTTP

### DIFF
--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -483,3 +483,92 @@ async def test_drive_turn_ensure_session_failure_emits_error():
     )
 
     assert any(r["kind"] == "error" for r in received)
+
+
+# ---------------------------------------------------------------------------
+# drive_turn — timeout
+# ---------------------------------------------------------------------------
+
+class _HangingAdapter(_FakeAdapter):
+    """Adapter whose prompt() blocks forever (simulates a hung LLM)."""
+
+    async def prompt(self, text, trace_id=None):
+        # Block forever — never completes.
+        await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_timeout_emits_error():
+    """With a short timeout, drive_turn must emit an error, not hang."""
+    received = []
+
+    async def sink(reply: dict):
+        received.append(reply)
+
+    await drive_turn(
+        "text", "tx", sink,
+        base_url="http://127.0.0.1:5900",
+        model_id="gpt-4o",
+        adapter_factory=lambda cfg, s: _HangingAdapter(cfg, s),
+        turn_timeout=0.1,
+    )
+
+    error_replies = [r for r in received if r["kind"] == "error"]
+    assert len(error_replies) == 1
+    assert error_replies[0]["trace_id"] == "tx"
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_timeout_message_is_descriptive():
+    """The error reply must mention timeout, not the generic transport failure."""
+    received = []
+
+    async def sink(reply: dict):
+        received.append(reply)
+
+    await drive_turn(
+        "text", "ty", sink,
+        base_url="http://127.0.0.1:5900",
+        model_id="gpt-4o",
+        adapter_factory=lambda cfg, s: _HangingAdapter(cfg, s),
+        turn_timeout=0.1,
+    )
+
+    error = next(r for r in received if r["kind"] == "error")
+    assert "timed out" in error["error"]
+    assert "limit:" in error["error"]
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_default_timeout_does_not_trigger_on_fast_turn():
+    """When the adapter completes promptly, the timeout must not fire."""
+    received = []
+
+    async def sink(reply: dict):
+        received.append(reply)
+
+    await drive_turn(
+        "hello", "t1", sink,
+        base_url="http://127.0.0.1:5900",
+        model_id="gpt-4o",
+        adapter_factory=_FakeAdapter,
+    )
+
+    error_replies = [r for r in received if r["kind"] == "error"]
+    assert len(error_replies) == 0, (
+        f"timeout should not fire on a fast turn, got {error_replies}"
+    )
+    assert len(received) == 2  # delta + final from _FakeAdapter
+
+
+@pytest.mark.asyncio
+async def test_drive_turn_rejects_non_positive_timeout():
+    """turn_timeout <= 0 must raise ValueError immediately, not degrade."""
+    with pytest.raises(ValueError, match="turn_timeout must be positive"):
+        await drive_turn(
+            "text", "tx",
+            sink=lambda r: None,
+            base_url="http://127.0.0.1:5900",
+            model_id="gpt-4o",
+            turn_timeout=0,
+        )

--- a/tinyagentos/opencode_runtime.py
+++ b/tinyagentos/opencode_runtime.py
@@ -346,12 +346,18 @@ async def drive_turn(
     model_provider_id: str = "litellm",
     server_password: str | None = None,
     adapter_factory: Callable[..., OpenCodeAdapter] = OpenCodeAdapter,
+    turn_timeout: float = 300.0,
 ) -> None:
     """Run one opencode turn, streaming reply dicts to *sink*.
 
     Mirrors :func:`tinyagentos.openclaw_acp_runtime.drive_turn` in defensive
     style: never raises.  Any failure degrades to exactly one
     ``{"kind":"error",...}`` dict delivered to the sink.
+
+    The turn is bounded by *turn_timeout* (default 300 s).  If the LLM call
+    takes longer, an ``asyncio.TimeoutError`` is raised inside the adapter
+    operations and degraded to an ``error`` reply.  This prevents an HTTP
+    connection from blocking indefinitely when the LLM backend hangs.
 
     Args:
         text:              User message text.
@@ -362,7 +368,12 @@ async def drive_turn(
         model_provider_id: opencode provider ID (default ``"litellm"``).
         server_password:   If set, HTTP Basic auth password (username ``opencode``).
         adapter_factory:   Injectable for tests; defaults to :class:`OpenCodeAdapter`.
+        turn_timeout:      Seconds before the turn is cancelled (default 300).
     """
+    if turn_timeout <= 0:
+        raise ValueError(
+            f"turn_timeout must be positive, got {turn_timeout}"
+        )
     cfg = OpenCodeConfig(
         base_url=base_url,
         server_password=server_password,
@@ -370,19 +381,48 @@ async def drive_turn(
         model_id=model_id,
     )
     adapter = None
+    # Track whether an error reply was already emitted (e.g. by the adapter
+    # returning a non-200 status before the timeout fires) so we don't
+    # violate the "exactly one error" contract.
+    _error_emitted: bool = False
+
+    def _sink(reply: dict) -> None:
+        nonlocal _error_emitted
+        if reply.get("kind") == "error":
+            _error_emitted = True
+        return sink(reply)
+
     try:
-        adapter = adapter_factory(cfg, sink)
-        await adapter.ensure_session()
-        await adapter.prompt(text, trace_id)
+        adapter = adapter_factory(cfg, _sink)
+        async with asyncio.timeout(turn_timeout):
+            await adapter.ensure_session()
+            await adapter.prompt(text, trace_id)
+    except TimeoutError:
+        logger.error(
+            "opencode_runtime: drive_turn timed out after %.1fs", turn_timeout,
+        )
+        if not _error_emitted:
+            try:
+                reply: dict = {
+                    "kind": "error",
+                    "trace_id": trace_id,
+                    "error": f"agent turn timed out (limit: {turn_timeout:g}s)",
+                }
+                res = sink(reply)
+                if asyncio.iscoroutine(res):
+                    await res
+            except Exception:
+                logger.exception("opencode_runtime: error reply also failed")
     except Exception:
         logger.exception("opencode_runtime: drive_turn failed")
-        try:
-            reply: dict = {"kind": "error", "trace_id": trace_id, "error": "agent turn failed (opencode transport)"}
-            res = sink(reply)
-            if asyncio.iscoroutine(res):
-                await res
-        except Exception:
-            logger.exception("opencode_runtime: error reply also failed")
+        if not _error_emitted:
+            try:
+                reply: dict = {"kind": "error", "trace_id": trace_id, "error": "agent turn failed (opencode transport)"}
+                res = sink(reply)
+                if asyncio.iscoroutine(res):
+                    await res
+            except Exception:
+                logger.exception("opencode_runtime: error reply also failed")
     finally:
         if adapter is not None:
             try:


### PR DESCRIPTION
Task: t_dd49f6d5. Fixes #641.

## Changes
- Adds `turn_timeout: float = 300.0` parameter to `drive_turn()` in `opencode_runtime.py`
- Wraps `adapter.ensure_session()` + `adapter.prompt()` in `asyncio.timeout(turn_timeout)`
- Catches `TimeoutError` separately with a descriptive error reply ("agent turn timed out (limit: 300s)")
- Three new tests: timeout emits error, timeout message is descriptive, default timeout doesn't fire on fast turns

## Tests
23/23 targeted tests pass (`pytest tests/test_opencode_runtime.py -v`)