### PR TITLE
fix(app): remove redundant app.state assignments from lifespan

### DIFF
--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -479,22 +479,13 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # Arm the startup guard: block non-exempt requests until init completes.
         app.state._startup_complete = False
         await agent_registry_store.init()
-        app.state.agent_registry = agent_registry_store
-        app.state.agent_registry_keypair = agent_registry_keypair
         await auth_requests_store.init()
-        app.state.auth_requests = auth_requests_store
         await agent_grants_store.init()
-        app.state.agent_grants = agent_grants_store
         await app_grants_store.init()
-        app.state.app_grants = app_grants_store
         await license_acceptances_store.init()
-        app.state.license_acceptances = license_acceptances_store
         await agent_model_key_store.init()
-        app.state.agent_model_keys = agent_model_key_store
         await cluster_pairing_store.init()
-        app.state.cluster_pairing = cluster_pairing_store
         await capability_map_store.init()
-        app.state.capability_map = capability_map_store
         await metrics_store.init()
         await notif_store.init()
         await notif_push_store.init()
@@ -517,24 +508,16 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await chat_channels.init()
         await project_store.init()
         await project_invite_store.init()
-        app.state.project_invites = project_invite_store
         await board_audit_store.init()
-        app.state.board_audit = board_audit_store
         await receipt_store.init()
-        app.state.receipt_store = receipt_store
         await project_task_store.init()
         await project_element_store.init()
         await routine_store.init()
-        app.state.routine_store = routine_store
         await project_canvas_store.init()
         await decision_store.init()
-        app.state.decision_store = decision_store
         await execution_policy_store.init()
-        app.state.execution_policies = execution_policy_store
         await shared_docs_store.init()
-        app.state.shared_docs_store = shared_docs_store
         await coding_session_store.init()
-        app.state.coding_session_store = coding_session_store
         app.state.coding_launcher = coding_launcher
         projects_root.mkdir(parents=True, exist_ok=True)
         await canvas_store.init()
@@ -543,27 +526,16 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await user_memory.init()
         await installed_apps.init()
         await feedback_store.init()
-        app.state.feedback_store = feedback_store
         await client_log_store.init()
-        app.state.client_log_store = client_log_store
         await userspace_apps.init()
-        app.state.userspace_apps = userspace_apps
         await userspace_data.init()
-        app.state.userspace_data = userspace_data
         await office_docs.init()
-        app.state.office_docs = office_docs
         await web_sites.init()
-        app.state.web_sites = web_sites
         await song_store.init()
-        app.state.song_store = song_store
         await design_docs.init()
-        app.state.design_docs = design_docs
         await coding_workspaces_store.init()
-        app.state.coding_workspaces = coding_workspaces_store
         await install_registry_store.init()
-        app.state.install_registry = install_registry_store
         await store_submissions.init()
-        app.state.store_submissions = store_submissions
         try:
             from tinyagentos.userspace.seed import seed_bundled_apps
             await seed_bundled_apps(userspace_apps, data_dir / "apps")
@@ -571,15 +543,10 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             logger.warning("bundled app seeding failed", exc_info=True)
         await skills.init()
         await themes.init()
-        app.state.themes = themes
         await knowledge_store.init()
         await mcp_store.init()
         mcp_supervisor = MCPSupervisor(mcp_store, catalog=registry, notif_store=notif_store, secrets_store=secrets_store)
-        app.state.mcp_store = mcp_store
         app.state.mcp_supervisor = mcp_supervisor
-        app.state.knowledge_store = knowledge_store
-        app.state.ingest_pipeline = knowledge_ingest
-        app.state.knowledge_monitor = knowledge_monitor
         await knowledge_monitor.start()
         await agent_browsers.init()
         app.state.agent_browsers = agent_browsers
@@ -643,9 +610,6 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await scheduler_history_store.init()
         await council_role_registry.init()
         await council_member_store.init()
-        app.state.config = config
-        app.state.config_path = config_path
-        app.state.data_dir = data_dir
 
         # Backfill all agents to the v2 persona shape and register each with
         # taosmd.  Idempotent — safe to run on every startup.
@@ -784,8 +748,6 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
         # Per-agent state lives on the host and is mounted into containers.
         # See docs/design/framework-agnostic-runtime.md.
-        app.state.agent_workspaces_dir = data_dir / "agent-workspaces"
-        app.state.agent_memory_dir = data_dir / "agent-memory"
         app.state.agent_workspaces_dir.mkdir(parents=True, exist_ok=True)
         app.state.agent_memory_dir.mkdir(parents=True, exist_ok=True)
         app.state.models_dir = data_dir / "models"
@@ -797,60 +759,15 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         from tinyagentos.installers.model_paths import models_root
         app.state.models_root = models_root()
         app.state.models_root.mkdir(parents=True, exist_ok=True)
-        app.state.metrics = metrics_store
-        app.state.notifications = notif_store
-        app.state.notif_push_store = notif_push_store
-        app.state.qmd_client = qmd_client
-        app.state.http_client = http_client
-        app.state.download_manager = download_manager
         app.state.torrent_settings_store = torrent_settings_store
-        app.state.secrets = secrets_store
-        app.state.broker = broker_service
-        app.state.broker_store = broker_store
-        app.state.github_identities = github_identities_store
-        app.state.relationships = relationship_mgr
-        app.state.channels = channel_store
-        app.state.fallback = fallback
-        app.state.scheduler = scheduler
-        app.state.cluster_manager = cluster_manager
-        app.state.task_router = task_router
-        app.state.capabilities = cap_checker
-        app.state.training = training_manager
-        app.state.conversion = conversion_manager
-        app.state.agent_messages = agent_messages
-        app.state.shared_folders = shared_folders
-        app.state.streaming_sessions = streaming_sessions
-        app.state.expert_agents = expert_agents
-        app.state.app_orchestrator = app_orchestrator
-        app.state.computer_use = computer_use
-        app.state.auth = auth_manager
         # Ensure the local token file exists before any request can arrive.
         # Logs the path at INFO so the user can find it.
         _local_token_path = auth_manager.local_token_path()
         auth_manager.get_local_token()
         logger.info("local auth token path: %s", _local_token_path)
-        app.state.webhook_notifier = webhook_notifier
-        app.state.llm_proxy = llm_proxy
-        app.state.channel_hub_router = channel_hub_router
         channel_hub_router.set_archive(archive)  # Wire archive for zero-loss channel message capture
-        app.state.adapter_manager = adapter_manager
-        app.state.channel_hub_connectors = {}
-        app.state.deploy_tasks = {}
-        from tinyagentos.routes.agents import IdempotencyCache
-        app.state.idempotency_cache = IdempotencyCache()
-        app.state.chat_messages = chat_messages
-        app.state.chat_channels = chat_channels
-        app.state.project_store = project_store
-        app.state.project_task_store = project_task_store
-        app.state.project_element_store = project_element_store
-        app.state.project_event_broker = project_event_broker
-        app.state.desktop_command_broker = desktop_command_broker
-        app.state.project_canvas_store = project_canvas_store
-        app.state.decision_store = decision_store
-        app.state.shared_docs_store = shared_docs_store
-        app.state.coding_session_store = coding_session_store
-        app.state.projects_root = projects_root
-        app.state.chat_hub = chat_hub
+        # channel_hub_connectors, deploy_tasks, and idempotency_cache are
+        # already set by the eager section; do not create new instances here.
         from tinyagentos.chat.group_policy import GroupPolicy
         app.state.group_policy = GroupPolicy()
         from tinyagentos.chat.reactions import WantsReplyRegistry
@@ -859,28 +776,9 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.typing = TypingRegistry()
         from tinyagentos.agent_chat_router import AgentChatRouter
         app.state.agent_chat_router = AgentChatRouter(app.state)
-        app.state.canvas_store = canvas_store
-        app.state.desktop_settings = desktop_settings
-        app.state.device_store = device_store
-        app.state.apns_sender = apns_sender
-        app.state.user_memory = user_memory
-        app.state.user_personas = user_personas
-        app.state.installed_apps = installed_apps
-        app.state.userspace_apps = userspace_apps
-        app.state.userspace_data = userspace_data
-        app.state.office_docs = office_docs
-        app.state.web_sites = web_sites
-        app.state.song_store = song_store
-        app.state.design_docs = design_docs
-        app.state.coding_workspaces = coding_workspaces_store
-        app.state.install_registry = install_registry_store
-        app.state.store_submissions = store_submissions
-        app.state.skills = skills
         app.state.benchmark_store = benchmark_store
         app.state.score_cache = score_cache
         app.state.scheduler_history_store = scheduler_history_store
-        app.state.council_roles = council_role_registry
-        app.state.council_members = council_member_store
         orchestrator = RestartOrchestrator(app.state)
         app.state.orchestrator = orchestrator
         # Boot-time: check if a pending restart was applied successfully
@@ -941,8 +839,6 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         # Start background health monitor
         from tinyagentos.health import HealthMonitor
         monitor = HealthMonitor(config, metrics_store, qmd_client, http_client, notif_store)
-        app.state.registry = registry
-        app.state.hardware_profile = hardware_profile
         app.state.health_monitor = monitor
         await monitor.start()
 


### PR DESCRIPTION
## Summary
Removes ~100 redundant `app.state.X = local_X` reassignments from the lifespan that were already set by the eager section in `create_app()`.

## Problem (closes #642)
`create_app()` set ~100+ app.state attributes twice — once eagerly (after app creation, for test compatibility) and again in the lifespan. The lifespan also created duplicate instances of `IdempotencyCache`, shadowing the eager one.

## Fix
- Removed redundant `app.state.X = local_X` lines from the lifespan (106 lines removed)
- Preserved all `.init()` calls — stores are still initialized in the correct order
- Removed duplicate `IdempotencyCache`/channel_hub_connectors/deploy_tasks creation in lifespan
- Lifespan-only objects (MCPSupervisor, TraceStoreRegistry, browser stores, etc.) keep their assignments — the eager section correctly sets them to None
- Eager section is unchanged — tests that use `create_app()` without running the lifespan continue to work

## Testing
- All config tests pass (34/34)
- Router registration tests pass (4/4)
- Agent DB/heartbeat/activity/a2a/admin tests pass
- `create_app()` smoke test: all attributes correctly populated
- Syntax check: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application startup initialization so core services and configuration are available earlier.
  * Streamlined startup sequencing for authentication, agents, storage, monitoring, and background services.
  * Preserved health monitoring and service startup behavior while reducing redundant initialization work.
* **Bug Fixes**
  * Improved reliability for components accessed before full application startup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->