### PR TITLE
fix(notifications): persist archive to the backend so it survives reload

### DIFF
--- a/desktop/src/lib/server-notifications.test.ts
+++ b/desktop/src/lib/server-notifications.test.ts
@@ -3,6 +3,7 @@ import {
   fetchServerNotifications,
   markServerRead,
   markAllServerRead,
+  archiveServerNotification,
   sourceToTarget,
 } from "./server-notifications";
 
@@ -169,6 +170,27 @@ describe("server-notifications", () => {
     it("swallows fetch failures", async () => {
       fetchMock.mockRejectedValue(new Error("boom"));
       await expect(markServerRead("srv-1")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("archiveServerNotification", () => {
+    it("POSTs the numeric id to the archive endpoint for srv- ids", async () => {
+      fetchMock.mockResolvedValue({ ok: true });
+      await archiveServerNotification("srv-42");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/notifications/42/archive");
+      expect(init?.method).toBe("POST");
+    });
+
+    it("is a no-op for client (notif-) ids", async () => {
+      await archiveServerNotification("notif-3");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("swallows fetch failures", async () => {
+      fetchMock.mockRejectedValue(new Error("boom"));
+      await expect(archiveServerNotification("srv-1")).resolves.toBeUndefined();
     });
   });
 

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -179,6 +179,17 @@ export async function markServerRead(id: string): Promise<void> {
   }
 }
 
+/** Archive a single server-origin notification on the backend. No-op for client ids. */
+export async function archiveServerNotification(id: string): Promise<void> {
+  const n = serverId(id);
+  if (n == null) return;
+  try {
+    await fetch(`/api/notifications/${n}/archive`, withCsrf({ method: "POST" }));
+  } catch {
+    // best-effort; the optimistic local update already happened
+  }
+}
+
 /** Mark all server-origin notifications read on the backend. */
 export async function markAllServerRead(): Promise<void> {
   try {

--- a/desktop/src/stores/notification-store.test.ts
+++ b/desktop/src/stores/notification-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useNotificationStore, type Notification } from "./notification-store";
 
 function srv(id: number, ts: number, read = false): Notification {
@@ -13,8 +13,18 @@ function srv(id: number, ts: number, read = false): Notification {
   };
 }
 
+const originalFetch = global.fetch;
+let fetchMock: ReturnType<typeof vi.fn>;
+
 beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue({ ok: true });
+  global.fetch = fetchMock as unknown as typeof fetch;
   useNotificationStore.setState({ notifications: [], centreOpen: false });
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  vi.restoreAllMocks();
 });
 
 describe("mergeServerNotifications", () => {
@@ -168,6 +178,53 @@ describe("dismiss archives instead of removing", () => {
     store.clearArchived();
 
     expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  it("dismiss persists to the backend for a srv- item", () => {
+    const store = useNotificationStore.getState();
+    store.mergeServerNotifications([srv(42, 100)]);
+
+    store.dismiss("srv-42");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/notifications/42/archive");
+    expect(init?.method).toBe("POST");
+  });
+
+  it("archiveRead persists to the backend for a srv- item", () => {
+    const store = useNotificationStore.getState();
+    store.mergeServerNotifications([srv(7, 100)]);
+
+    store.archiveRead("srv-7");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/notifications/7/archive",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("does NOT persist for a client-origin (notif-) item", () => {
+    const store = useNotificationStore.getState();
+    const id = store.addNotification({ source: "system", title: "t", body: "b", level: "info" });
+
+    store.dismiss(id);
+    store.archiveRead(id);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("clearAll persists archive for every server item, none for client items", () => {
+    const store = useNotificationStore.getState();
+    store.addNotification({ source: "system", title: "c", body: "b", level: "info" });
+    store.mergeServerNotifications([srv(11, 100), srv(12, 200)]);
+
+    store.clearAll();
+
+    const urls = fetchMock.mock.calls.map((c) => c[0]);
+    expect(urls).toContain("/api/notifications/11/archive");
+    expect(urls).toContain("/api/notifications/12/archive");
+    expect(urls).toHaveLength(2);
   });
 
   it("unreadCount excludes archived items", () => {

--- a/desktop/src/stores/notification-store.ts
+++ b/desktop/src/stores/notification-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { archiveServerNotification } from "@/lib/server-notifications";
 
 export interface Notification {
   id: string;
@@ -39,10 +40,11 @@ interface NotificationStore {
 
 let counter = 0;
 
-// Server items dismissed this session. The backend has no "dismiss" concept
-// (only read), so without this a dismissed server notification would be
-// re-added by the very next poll. Session-scoped: a hard reload re-shows
-// items that are still unread on the server, which is the intended behaviour.
+// Server items archived this session. Archiving POSTs to the backend
+// (archiveServerNotification), which is the durable source of truth: once the
+// write lands, GET /api/notifications no longer returns the row. This Set is an
+// optimistic guard covering the window between the POST and the next poll, so a
+// just-archived item is not briefly re-shown as active.
 const dismissedServerIds = new Set<string>();
 
 export const useNotificationStore = create<NotificationStore>((set, get) => ({
@@ -95,7 +97,10 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
   },
 
   dismiss(id) {
-    if (id.startsWith("srv-")) dismissedServerIds.add(id);
+    if (id.startsWith("srv-")) {
+      dismissedServerIds.add(id);
+      void archiveServerNotification(id);
+    }
     set((s) => ({
       notifications: s.notifications.map((n) =>
         n.id === id ? { ...n, archived: true } : n,
@@ -107,7 +112,10 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
     // Resolving a notification (e.g. answering an agent access-request) both
     // reads and archives it: it leaves the active Inbox and lands in History
     // rather than being marked read in place or silently removed (#62).
-    if (id.startsWith("srv-")) dismissedServerIds.add(id);
+    if (id.startsWith("srv-")) {
+      dismissedServerIds.add(id);
+      void archiveServerNotification(id);
+    }
     set((s) => ({
       notifications: s.notifications.map((n) =>
         n.id === id ? { ...n, archived: true, read: true } : n,
@@ -118,7 +126,10 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
   clearAll() {
     set((s) => {
       for (const n of s.notifications) {
-        if (n.id.startsWith("srv-")) dismissedServerIds.add(n.id);
+        if (n.id.startsWith("srv-")) {
+          dismissedServerIds.add(n.id);
+          void archiveServerNotification(n.id);
+        }
       }
       return {
         notifications: s.notifications.map((n) => ({ ...n, archived: true })),


### PR DESCRIPTION
Closes #1916.

## Problem

Archiving or dismissing a server-origin notification in the desktop PWA did not persist. After closing and reopening the app (or a hard reload), archived notifications reappeared in the active inbox.

## Root cause

`desktop/src/stores/notification-store.ts`: the archive actions `dismiss`, `archiveRead` and `clearAll` only set a local `archived: true` flag and recorded the server id in a module-scoped in-memory `Set` (`dismissedServerIds`). They never called the backend. On reload the Set was gone and the store re-fetched `GET /api/notifications` (the active list), which still returned those rows because the server was never told, so archived items came back.

The backend already exposes `POST /api/notifications/{notif_id}/archive`, which persists the archive and drops the row from the active feed (covered by `test_notification_api_archive`). The client simply never called it.

## Fix

- Add `archiveServerNotification(id)` in `desktop/src/lib/server-notifications.ts`, mirroring the existing `markServerRead`: it maps a `srv-<int>` id to the numeric backend id and POSTs `/api/notifications/<int>/archive` with the CSRF header, and is a no-op for client (`notif-`) ids.
- Call it (fire and forget) from `dismiss`, `archiveRead` and `clearAll` for every server item. The UI still updates optimistically; the backend is now the durable source of truth.
- `dismissedServerIds` stays as an optimistic guard for the window between the POST and the next poll, but is no longer the only mechanism.
- Client-origin `notif-` items keep local-only archiving, since they have no server row to persist (documented in the store comment).

After a reload, `GET /api/notifications` no longer returns the archived server items and they show under History (`GET /api/notifications/archived`).

## Tests

- `desktop/src/stores/notification-store.test.ts`: assert `dismiss`, `archiveRead` and `clearAll` POST `/api/notifications/<int>/archive` for `srv-` items, and that client-origin items do NOT POST.
- `desktop/src/lib/server-notifications.test.ts`: unit tests for `archiveServerNotification` (POST url/method, no-op for client ids, swallows failures).
- Backend persistence across a fresh `GET /api/notifications` is already covered by `test_notification_api_archive` / `test_notification_api_archived_history`.

## Verification

- `npx tsc -b` clean
- `npx vitest run` on the two store/lib suites: 40 passed; NotificationCentre + NotificationToast: 13 passed
- `pytest tests/test_notifications.py`: 21 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server notifications are now archived when dismissed, resolved, or cleared.
  * Archived notifications are immediately hidden to prevent them from reappearing during refreshes.

* **Bug Fixes**
  * Archive requests now persist server notification changes reliably while avoiding unnecessary requests for local notifications.
  * Archive request failures no longer interrupt notification actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->