### PR TITLE
feat(agents): invite external agent with no project + name/alias (#1913)

### DIFF
--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -414,6 +414,16 @@ function GovernanceAuditPanel({ isAdmin }: { isAdmin: boolean }) {
 /*  InviteExternalAgentPicker                                           */
 /* ------------------------------------------------------------------ */
 
+/** OS-level (project-less) mint result: the redeemable URL + PIN. */
+interface OsInviteResult {
+  invite_id: string;
+  pin: string;
+}
+
+function osInviteUrl(inviteId: string): string {
+  return `${window.location.origin}/i/${inviteId}`;
+}
+
 function InviteExternalAgentPicker({
   onCancel,
   onPick,
@@ -424,7 +434,11 @@ function InviteExternalAgentPicker({
   const [projects, setProjects] = useState<import("@/lib/projects").Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
+  const [alias, setAlias] = useState("");
+  // "" is the default "None" option: available in chat, assign to projects later.
   const [selected, setSelected] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<OsInviteResult | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -436,7 +450,6 @@ function InviteExternalAgentPicker({
         if (!active) return;
         const list: import("@/lib/projects").Project[] = Array.isArray(rows) ? rows : [];
         setProjects(list);
-        if (list.length > 0) setSelected((prev) => prev || list[0]!.id);
       })
       .catch((e: unknown) => {
         if (active) setErr(e instanceof Error ? e.message : "Failed to load projects");
@@ -449,59 +462,181 @@ function InviteExternalAgentPicker({
     };
   }, []);
 
+  const copy = (text: string) => {
+    navigator.clipboard?.writeText(text).catch(() => {});
+  };
+
+  const mintOsInvite = async () => {
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const r = await fetch("/api/agents/invites", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scopes: ["a2a_send", "a2a_receive"],
+          approval_mode: "auto",
+          check_interval_secs: 1800,
+          display_name: alias.trim() || null,
+        }),
+      });
+      if (!r.ok) {
+        const text = await r.text().catch(() => r.statusText);
+        throw new Error(`${r.status}: ${text}`);
+      }
+      const data = (await r.json()) as OsInviteResult;
+      setResult(data);
+    } catch (e) {
+      setErr(String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting) return;
+    if (selected) {
+      // A project was chosen: chain to the existing project-scoped mint UI.
+      onPick(selected);
+      return;
+    }
+    void mintOsInvite();
+  };
+
+  const instruction = result
+    ? `Fetch ${osInviteUrl(result.invite_id)} and redeem with PIN ${result.pin}; follow the returned JSON instructions to join taOS as an external agent.`
+    : "";
+
   return createPortal(
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Invite external agent to project"
+      aria-label="Invite external agent"
       className="fixed inset-0 z-[10001] bg-black/50 flex items-center justify-center p-4"
     >
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          if (selected) onPick(selected);
-        }}
-        className="bg-zinc-900 p-4 rounded shadow w-full max-w-md space-y-3"
-      >
-        <h3 className="text-lg font-semibold">Invite external agent</h3>
-        {loading ? (
-          <div className="text-xs text-zinc-500">Loading projects…</div>
-        ) : err ? (
-          <p role="alert" className="text-red-400 text-xs">{err}</p>
-        ) : (
-          <label className="block text-sm">
-            <span className="text-zinc-400">Project</span>
-            <select
-              value={selected}
-              onChange={(e) => setSelected(e.target.value)}
-              className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
-              aria-label="Project to invite into"
-            >
-              {projects.map((p) => (
-                <option key={p.id} value={p.id}>
-                  {p.name || p.slug}
-                </option>
-              ))}
-            </select>
-          </label>
-        )}
-        <div className="flex justify-end gap-2">
+      {result ? (
+        <section
+          className="bg-zinc-900 p-4 rounded shadow w-full max-w-lg space-y-3"
+          aria-label="Invite result"
+        >
+          <h3 className="text-lg font-semibold">Invite external agent</h3>
+          <div className="space-y-1">
+            <div className="text-xs text-zinc-400">Invite URL</div>
+            <div className="flex items-center gap-2">
+              <code className="text-sm break-all bg-zinc-800 rounded px-2 py-1 flex-1">
+                {osInviteUrl(result.invite_id)}
+              </code>
+              <button
+                type="button"
+                onClick={() => copy(osInviteUrl(result.invite_id))}
+                className="text-xs px-2 py-1 bg-zinc-800 rounded hover:bg-zinc-700"
+                aria-label="Copy invite URL"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-xs text-zinc-400">PIN (shown once)</div>
+            <div className="flex items-center gap-2">
+              <div className="text-4xl font-bold tracking-widest tabular-nums">{result.pin}</div>
+              <button
+                type="button"
+                onClick={() => copy(result.pin)}
+                className="text-xs px-2 py-1 bg-zinc-800 rounded hover:bg-zinc-700"
+                aria-label="Copy PIN"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-xs text-zinc-400">Agent instruction</div>
+            <div className="flex items-start gap-2">
+              <code className="text-xs break-all bg-zinc-800 rounded px-2 py-1 flex-1">{instruction}</code>
+              <button
+                type="button"
+                onClick={() => copy(instruction)}
+                className="text-xs px-2 py-1 bg-zinc-800 rounded hover:bg-zinc-700 whitespace-nowrap"
+                aria-label="Copy instruction"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <p className="text-xs text-zinc-500">
+            This agent has no project yet. Assign it to projects later from its
+            row in the registry.
+          </p>
           <button
             type="button"
             onClick={onCancel}
-            className="px-3 py-1 text-sm"
+            className="px-3 py-1 text-sm bg-zinc-800 rounded hover:bg-zinc-700"
           >
-            Cancel
+            Done
           </button>
-          <button
-            type="submit"
-            disabled={loading || !selected}
-            className="px-3 py-1 bg-blue-600 rounded text-sm disabled:opacity-50"
-          >
-            Continue
-          </button>
-        </div>
-      </form>
+        </section>
+      ) : (
+        <form
+          onSubmit={onSubmit}
+          className="bg-zinc-900 p-4 rounded shadow w-full max-w-md space-y-3"
+        >
+          <h3 className="text-lg font-semibold">Invite external agent</h3>
+          <label className="block text-sm">
+            <span className="text-zinc-400">Name / alias</span>
+            <input
+              type="text"
+              value={alias}
+              onChange={(e) => setAlias(e.target.value)}
+              placeholder="e.g. Scout"
+              className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+              aria-label="Agent name or alias"
+            />
+          </label>
+          {loading ? (
+            <div className="text-xs text-zinc-500">Loading projects…</div>
+          ) : (
+            <label className="block text-sm">
+              <span className="text-zinc-400">Project</span>
+              <select
+                value={selected}
+                onChange={(e) => setSelected(e.target.value)}
+                className="w-full mt-1 px-2 py-1 bg-zinc-800 rounded"
+                aria-label="Project to invite into"
+              >
+                <option value="">None — available in chat, assign to projects later</option>
+                {projects.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name || p.slug}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          {err && (
+            <p role="alert" className="text-red-400 text-xs">{err}</p>
+          )}
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={submitting}
+              className="px-3 py-1 text-sm disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={submitting}
+              className="px-3 py-1 bg-blue-600 rounded text-sm disabled:opacity-50"
+            >
+              {selected ? "Continue" : submitting ? "Minting…" : "Mint invite"}
+            </button>
+          </div>
+        </form>
+      )}
     </div>,
     document.body,
   );

--- a/desktop/src/apps/agents/__tests__/RegistryPanel.invite-assign.test.tsx
+++ b/desktop/src/apps/agents/__tests__/RegistryPanel.invite-assign.test.tsx
@@ -33,6 +33,12 @@ describe("RegistryPanel invite + assign wiring", () => {
       if (url === "/api/agents/registry") {
         return Promise.resolve(ok([ACTIVE_ENTRY]));
       }
+      if (url === "/api/agents/invites") {
+        return Promise.resolve(ok({ invite_id: "482913", pin: "7788" }));
+      }
+      if (url === "/api/projects/prj_a/invites") {
+        return Promise.resolve(ok([]));
+      }
       return Promise.resolve(ok({}));
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -82,5 +88,66 @@ describe("RegistryPanel invite + assign wiring", () => {
       expect(screen.getByRole("dialog", { name: /assign agent to project/i })).toBeInTheDocument(),
     );
     expect(screen.getByRole("option", { name: /Alpha/ })).toBeInTheDocument();
+  });
+
+  it("mints an OS-level invite (no project) with the entered alias and shows URL + PIN", async () => {
+    await act(async () => {
+      render(<RegistryPanel />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Agent Registry/ }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Invite external agent/i }),
+    );
+
+    // The project select defaults to the "None" option.
+    const projectSelect = await screen.findByRole("combobox", { name: /Project to invite into/i });
+    expect((projectSelect as HTMLSelectElement).value).toBe("");
+    expect(screen.getByRole("option", { name: /None — available in chat/i })).toBeInTheDocument();
+
+    // Enter an alias.
+    fireEvent.change(screen.getByRole("textbox", { name: /Agent name or alias/i }), {
+      target: { value: "Scout" },
+    });
+
+    // Mint → posts to the OS-level endpoint with the alias, no project.
+    fireEvent.click(screen.getByRole("button", { name: /Mint invite/i }));
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([url]: [string]) => url === "/api/agents/invites"),
+      ).toBe(true),
+    );
+    const call = fetchMock.mock.calls.find(([url]: [string]) => url === "/api/agents/invites");
+    expect(call?.[1]?.method).toBe("POST");
+    const body = JSON.parse(call?.[1]?.body as string);
+    expect(body.display_name).toBe("Scout");
+    expect(body.scopes).toContain("a2a_send");
+
+    // The result view shows the redeemable URL + PIN.
+    await waitFor(() => expect(screen.getByLabelText(/Invite result/i)).toBeInTheDocument());
+    // The invite id appears inside the /i/<id> URL; the PIN stands alone.
+    expect(screen.getAllByText(/482913/).length).toBeGreaterThan(0);
+    expect(screen.getByText("7788")).toBeInTheDocument();
+  });
+
+  it("chains to the project-scoped mint dialog when a project is chosen", async () => {
+    await act(async () => {
+      render(<RegistryPanel />);
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Agent Registry/ }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Invite external agent/i }),
+    );
+
+    const projectSelect = await screen.findByRole("combobox", { name: /Project to invite into/i });
+    fireEvent.change(projectSelect, { target: { value: "prj_a" } });
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+
+    // The existing project-scoped invite dialog opens (fetches its pending list).
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([url]: [string]) => url === "/api/projects/prj_a/invites"),
+      ).toBe(true),
+    );
   });
 });

--- a/tests/projects/test_invite_store.py
+++ b/tests/projects/test_invite_store.py
@@ -93,6 +93,131 @@ async def test_mint_enforces_pending_cap(store):
 
 
 # ---------------------------------------------------------------------------
+# OS-level (project-less) mint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_os_level_mint_no_project_tasks(store):
+    """An OS-level invite (project_id=None) keeps exactly the requested scopes;
+    project_tasks is NOT forced because the identity is not project-bound."""
+    result = await store.mint(
+        project_id=None,
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="user-admin",
+    )
+    scopes = result["record"]["scopes"]
+    assert scopes == ["a2a_send"]
+    assert "project_tasks" not in scopes
+    assert result["record"]["project_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_os_level_mint_stores_display_name(store):
+    result = await store.mint(
+        project_id=None,
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+        display_name="Scout",
+    )
+    iid = result["record"]["invite_id"]
+    assert result["record"]["display_name"] == "Scout"
+    row = await store.get(iid)
+    assert row["display_name"] == "Scout"
+
+
+@pytest.mark.asyncio
+async def test_os_level_pending_cap_uses_is_null(store):
+    """The pending cap stays live for OS-level invites (project_id IS NULL);
+    SQL ``= NULL`` would silently bypass it."""
+    for _ in range(10):
+        await store.mint(
+            project_id=None,
+            scopes=[],
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by="u",
+        )
+    with pytest.raises(InvitePendingCapError):
+        await store.mint(
+            project_id=None,
+            scopes=[],
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by="u",
+        )
+
+
+@pytest.mark.asyncio
+async def test_os_level_cap_independent_of_project_cap(store):
+    """OS-level pending invites do not count against a project's cap and vice
+    versa: 10 OS-level + a project mint still succeeds."""
+    for _ in range(10):
+        await store.mint(
+            project_id=None,
+            scopes=[],
+            approval_mode="auto",
+            check_interval_secs=1800,
+            created_by="u",
+        )
+    # A project mint is unaffected by the OS-level pending group.
+    result = await store.mint(
+        project_id="prj-x",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    assert result["record"]["project_id"] == "prj-x"
+
+
+@pytest.mark.asyncio
+async def test_list_os_level_omits_pin_hash(store):
+    await store.mint(
+        project_id=None,
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+        display_name="Scout",
+    )
+    # A project invite must NOT appear in the OS-level listing.
+    await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    items = await store.list_os_level()
+    assert len(items) == 1
+    assert items[0]["project_id"] is None
+    assert items[0]["display_name"] == "Scout"
+    assert "pin_hash" not in items[0]
+
+
+@pytest.mark.asyncio
+async def test_os_level_redeem_single_use(store):
+    result = await store.mint(
+        project_id=None,
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    record = await store.redeem(iid, result["pin"])
+    assert record["status"] == "redeemed"
+    assert record["project_id"] is None
+    with pytest.raises(InviteAlreadyRedeemedError):
+        await store.redeem(iid, result["pin"])
+
+
+# ---------------------------------------------------------------------------
 # get
 # ---------------------------------------------------------------------------
 
@@ -329,4 +454,6 @@ async def test_boot_migration_adds_missing_column(tmp_path):
     assert row is not None
     assert row["status"] == "pending"
     assert row.get("redeemed_request_id") is None
+    # The display_name column is added by the boot migration for legacy DBs.
+    assert row.get("display_name") is None
     await store.close()

--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -327,6 +327,172 @@ async def test_invite_info_html_for_browser(client, app):
     assert "taOS" in resp.text
 
 
+# ---------------------------------------------------------------------------
+# OS-level (project-less) invites: mint + redeem to a chat-available identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_os_mint_returns_pin_and_no_project_tasks(client, app):
+    resp = await client.post(
+        "/api/agents/invites",
+        json={
+            "scopes": ["a2a_send"],
+            "approval_mode": "auto",
+            "check_interval_secs": 1800,
+            "display_name": "Scout",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert len(data["invite_id"]) == 6 and data["invite_id"].isdigit()
+    assert len(data["pin"]) == 4 and data["pin"].isdigit()
+    # OS-level invites are not project-bound, so project_tasks is not forced.
+    assert data["scopes"] == ["a2a_send"]
+    assert data["display_name"] == "Scout"
+
+
+@pytest.mark.asyncio
+async def test_os_mint_non_admin_rejected(client, app):
+    app.dependency_overrides[current_user] = lambda: CurrentUser(
+        user_id="non-admin-user", is_admin=False
+    )
+    try:
+        resp = await client.post(
+            "/api/agents/invites",
+            json={"scopes": ["a2a_send"], "approval_mode": "auto"},
+        )
+        assert resp.status_code == 403, resp.text
+    finally:
+        app.dependency_overrides.pop(current_user, None)
+
+
+@pytest.mark.asyncio
+async def test_os_list_and_revoke(client, app):
+    mint = await client.post(
+        "/api/agents/invites",
+        json={"scopes": ["a2a_send"], "approval_mode": "auto", "display_name": "Scout"},
+    )
+    iid = mint.json()["invite_id"]
+
+    listing = await client.get("/api/agents/invites")
+    assert listing.status_code == 200, listing.text
+    rows = listing.json()
+    assert len(rows) == 1
+    assert rows[0]["invite_id"] == iid
+    assert rows[0]["display_name"] == "Scout"
+
+    revoke = await client.delete(f"/api/agents/invites/{iid}")
+    assert revoke.status_code == 204, revoke.text
+
+
+@pytest.mark.asyncio
+async def test_os_revoke_rejects_project_invite(client, app):
+    """The OS-level revoke route must not revoke a project-scoped invite."""
+    pid = await _create_project(client, slug="os-guard")
+    iid, _pin = await _mint_invite(client, pid, approval_mode="auto")
+    resp = await client.delete(f"/api/agents/invites/{iid}")
+    assert resp.status_code == 404, resp.text
+
+
+async def _mint_os_invite(client, *, approval_mode="auto", scopes=None, display_name=None):
+    resp = await client.post(
+        "/api/agents/invites",
+        json={
+            "scopes": scopes if scopes is not None else ["a2a_send"],
+            "approval_mode": approval_mode,
+            "check_interval_secs": 1800,
+            "display_name": display_name,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    return data["invite_id"], data["pin"]
+
+
+@pytest.mark.asyncio
+async def test_os_redeem_mints_chat_agent_no_project_grant(client, app, monkeypatch, tmp_path):
+    _registry, _auth, grants = await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    iid, pin = await _mint_os_invite(client, scopes=["a2a_send"], display_name="Scout")
+
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # The handle derives from the alias, not a project slug.
+    assert body["agent_handle"] == "scout"
+    # The bundle carries no project and no project/task/canvas apis.
+    bundle = body["bundle"]
+    assert bundle["project"] is None
+    assert "tasks_list" not in bundle["apis"]
+    assert "canvas_elements" not in bundle["apis"]
+    assert "a2a_bus_send" in bundle["apis"]
+
+    req_id = body["request_id"]
+    poll = await client.get(f"/api/agents/auth-requests/{req_id}")
+    assert poll.status_code == 200, poll.text
+    pdata = poll.json()
+    assert pdata["status"] == "accepted"
+    canonical_id = pdata["canonical_id"]
+    assert pdata["token"]
+
+    # No project membership row anywhere.
+    projects = await app.state.project_store.list_projects()
+    for p in projects:
+        assert await app.state.project_store.list_members(p["id"]) == []
+
+    # Grants are GLOBAL (project_id is None), never project-scoped.
+    agent_grants = await grants.list_grants(canonical_id)
+    assert agent_grants, "expected at least one global grant"
+    for g in agent_grants:
+        assert g["project_id"] is None
+    scopes_granted = {g["scope"] for g in agent_grants}
+    assert "a2a_send" in scopes_granted
+    assert "project_tasks" not in scopes_granted
+
+
+@pytest.mark.asyncio
+async def test_os_redeem_applies_display_name(client, app, monkeypatch, tmp_path):
+    registry, _auth, _grants = await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    iid, pin = await _mint_os_invite(client, scopes=["a2a_send"], display_name="My Cool Agent")
+
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert resp.status_code == 200, resp.text
+    # Handle is slugified; the display_name preserves the human alias.
+    assert resp.json()["agent_handle"] == "my-cool-agent"
+    canonical_id = (await client.get(
+        f"/api/agents/auth-requests/{resp.json()['request_id']}"
+    )).json()["canonical_id"]
+    record = await registry.get(canonical_id)
+    assert record["display_name"] == "My Cool Agent"
+
+
+@pytest.mark.asyncio
+async def test_os_invite_advert_json_works(client, app):
+    """The /i/{invite_id} advert must not 500 for a project-less invite."""
+    iid, _pin = await _mint_os_invite(client, scopes=["a2a_send"], display_name="Scout")
+    resp = await client.get(f"/i/{iid}", headers={"accept": "application/json"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["redeem"]["path"] == "/api/projects/invites/redeem"
+
+
+@pytest.mark.asyncio
+async def test_os_redeem_falls_back_to_harness_handle(client, app, monkeypatch, tmp_path):
+    await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    iid, pin = await _mint_os_invite(client, scopes=["a2a_send"], display_name=None)
+    resp = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "opencode"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["agent_handle"] == "opencode"
+
+
 @pytest.mark.asyncio
 async def test_invite_info_html_escapes_project_name(client, app):
     # A project name is owner-controlled and is interpolated into the invite

--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -411,6 +411,38 @@ async def _mint_os_invite(client, *, approval_mode="auto", scopes=None, display_
 
 
 @pytest.mark.asyncio
+async def test_os_invite_strips_project_scoped_grants(client, app):
+    # An OS-level (project-less) invite must not carry project-bound scopes.
+    resp = await client.post(
+        "/api/agents/invites",
+        json={
+            "scopes": ["a2a_send", "project_tasks", "canvas_read", "canvas_write"],
+            "approval_mode": "auto",
+            "check_interval_secs": 1800,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["scopes"] == ["a2a_send"]
+
+
+@pytest.mark.asyncio
+async def test_os_invite_display_name_validation(client, app):
+    # Control characters are rejected.
+    bad = await client.post(
+        "/api/agents/invites",
+        json={"scopes": ["a2a_send"], "display_name": "bad\x00name"},
+    )
+    assert bad.status_code == 422, bad.text
+    # All-whitespace collapses to no alias.
+    blank = await client.post(
+        "/api/agents/invites",
+        json={"scopes": ["a2a_send"], "display_name": "   "},
+    )
+    assert blank.status_code == 200, blank.text
+    assert blank.json()["display_name"] is None
+
+
+@pytest.mark.asyncio
 async def test_os_redeem_mints_chat_agent_no_project_grant(client, app, monkeypatch, tmp_path):
     _registry, _auth, grants = await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
     iid, pin = await _mint_os_invite(client, scopes=["a2a_send"], display_name="Scout")

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -28,7 +28,8 @@ CREATE TABLE IF NOT EXISTS project_invites (
     redeem_attempts      INTEGER DEFAULT 0,
     status               TEXT NOT NULL,
     redeemed_by          TEXT,
-    redeemed_request_id  TEXT
+    redeemed_request_id  TEXT,
+    display_name         TEXT
 );
 """
 
@@ -83,6 +84,11 @@ class ProjectInviteStore(BaseStore):
                 "ALTER TABLE project_invites ADD COLUMN redeemed_request_id TEXT"
             )
             await self._db.commit()
+        if "display_name" not in existing_cols:
+            await self._db.execute(
+                "ALTER TABLE project_invites ADD COLUMN display_name TEXT"
+            )
+            await self._db.commit()
         await self._db.execute(
             "CREATE INDEX IF NOT EXISTS idx_project_invites_project "
             "ON project_invites(project_id)"
@@ -100,22 +106,40 @@ class ProjectInviteStore(BaseStore):
         return f"{secrets.randbelow(10_000):04d}"
 
     async def mint(self, *, project_id=None, scopes: list[str], approval_mode: str,
-                   check_interval_secs: int, created_by: str) -> dict:
+                   check_interval_secs: int, created_by: str,
+                   display_name: str | None = None) -> dict:
         if self._db is None:
             raise RuntimeError("ProjectInviteStore not initialised")
 
-        cursor = await self._db.execute(
-            "SELECT COUNT(*) FROM project_invites WHERE project_id = ? AND status = 'pending'",
-            (project_id,),
-        )
+        # The pending cap is per-scope: project-scoped invites are capped per
+        # project, OS-level (project_id IS NULL) invites are capped as a group.
+        # SQL ``= NULL`` never matches, so branch on IS NULL to keep the cap live
+        # for OS-level invites too.
+        if project_id is None:
+            cursor = await self._db.execute(
+                "SELECT COUNT(*) FROM project_invites "
+                "WHERE project_id IS NULL AND status = 'pending'",
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT COUNT(*) FROM project_invites "
+                "WHERE project_id = ? AND status = 'pending'",
+                (project_id,),
+            )
         row = await cursor.fetchone()
         pending_count = row[0] if row else 0
         if pending_count >= _PENDING_CAP:
+            scope_label = "OS-level" if project_id is None else f"project {project_id}"
             raise InvitePendingCapError(
-                f"project {project_id} already has {_PENDING_CAP} pending invites"
+                f"{scope_label} already has {_PENDING_CAP} pending invites"
             )
 
-        scopes = list(dict.fromkeys(list(scopes) + ["project_tasks"]))
+        # project_tasks binds the token to a project, so it is only forced for
+        # project-scoped invites. An OS-level invite mints a chat-available
+        # identity with no project grant, so it keeps exactly the requested scopes.
+        scopes = list(dict.fromkeys(list(scopes)))
+        if project_id is not None:
+            scopes = list(dict.fromkeys(scopes + ["project_tasks"]))
 
         invite_id = self._generate_invite_id()
         pin = self._generate_pin()
@@ -127,8 +151,9 @@ class ProjectInviteStore(BaseStore):
             """
             INSERT INTO project_invites
                 (invite_id, project_id, pin_hash, scopes, approval_mode,
-                 check_interval_secs, created_by, created_ts, expires_ts, status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending')
+                 check_interval_secs, created_by, created_ts, expires_ts, status,
+                 display_name)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
             """,
             (
                 invite_id,
@@ -140,6 +165,7 @@ class ProjectInviteStore(BaseStore):
                 created_by,
                 now,
                 expires_ts,
+                display_name,
             ),
         )
         await self._db.commit()
@@ -159,6 +185,7 @@ class ProjectInviteStore(BaseStore):
                 "status": "pending",
                 "redeemed_by": None,
                 "redeemed_request_id": None,
+                "display_name": display_name,
             },
             "pin": pin,
         }
@@ -185,6 +212,23 @@ class ProjectInviteStore(BaseStore):
         cursor = await self._db.execute(
             "SELECT * FROM project_invites WHERE project_id = ? ORDER BY created_ts DESC",
             (project_id,),
+        )
+        rows = await cursor.fetchall()
+        result = []
+        for row in rows:
+            d = self._row_to_dict(row)
+            d.pop("pin_hash", None)
+            result.append(d)
+        return result
+
+    async def list_os_level(self) -> list[dict]:
+        """List OS-level invites (project_id IS NULL), newest first, without the
+        pin hash. Mirrors ``list_for_project`` for the project-less group."""
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+        cursor = await self._db.execute(
+            "SELECT * FROM project_invites WHERE project_id IS NULL "
+            "ORDER BY created_ts DESC",
         )
         rows = await cursor.fetchall()
         result = []

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -36,6 +36,14 @@ def register_all_routers(app):
     from tinyagentos.routes.delegation import router as delegation_router
     app.include_router(delegation_router, dependencies=_csrf)
 
+    # project_invites is registered before the agents router because it owns the
+    # literal /api/agents/invites routes, which must win over the agents router's
+    # /api/agents/{name} dynamic route (otherwise GET/DELETE resolve to "agent
+    # not found"). Its own routes are all literal, so this reorder cannot shadow
+    # any dynamic route in the projects/agents routers.
+    from tinyagentos.routes.project_invites import router as project_invites_router
+    app.include_router(project_invites_router, dependencies=_csrf)
+
     from tinyagentos.routes.agents import router as agents_router
     app.include_router(agents_router, dependencies=_csrf)
 
@@ -59,9 +67,6 @@ def register_all_routers(app):
 
     from tinyagentos.routes import projects as projects_routes
     app.include_router(projects_routes.router, dependencies=_csrf)
-
-    from tinyagentos.routes.project_invites import router as project_invites_router
-    app.include_router(project_invites_router, dependencies=_csrf)
 
     from tinyagentos.routes import routines as routines_routes
     app.include_router(routines_routes.router, dependencies=_csrf)

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -297,6 +297,7 @@ async def approve_request_record(
     effective_project: str | None,
     decided_by: str,
     project_id: str | None = None,
+    display_name: str | None = None,
 ) -> dict:
     """Register an agent, mint its token, write grants + relationships +
     membership + a2a sync, and record the decision.
@@ -365,7 +366,10 @@ async def approve_request_record(
     # which could still carry the "@", so display_name is always a clean,
     # non-empty value.
     _claim = record["identity_claim"].strip().removeprefix("@").strip()
-    display_name = _claim or record["framework"]
+    # An explicit display_name (e.g. the OS-level invite alias) wins so the human
+    # label is preserved even when the handle is slugified/deduped; otherwise fall
+    # back to the cleaned claim, then the framework name.
+    display_name = (display_name or "").strip() or _claim or record["framework"]
 
     handle = _slugify(_claim)
     existing_active = await registry.get_by_handle(handle, status="active")

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -5,7 +5,7 @@ import json
 import logging
 import socket
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, Field
 
@@ -28,6 +28,18 @@ class MintInviteIn(BaseModel):
     scopes: list[str] = Field(default_factory=list)
     approval_mode: str = Field(default="auto", pattern="^(auto|manual)$")
     check_interval_secs: int = Field(default=1800, ge=60)
+
+
+class MintOsInviteIn(BaseModel):
+    """Mint an OS-level (project-less) invite. The redeemed agent becomes
+    chat-available immediately with a global (non-project) grant; projects are
+    assigned later. ``display_name`` is the human alias applied to the minted
+    identity on redeem."""
+
+    scopes: list[str] = Field(default_factory=list)
+    approval_mode: str = Field(default="auto", pattern="^(auto|manual)$")
+    check_interval_secs: int = Field(default=1800, ge=60)
+    display_name: str | None = None
 
 
 class RedeemInviteIn(BaseModel):
@@ -65,6 +77,25 @@ def _derive_handle(project_slug: str, harness: str, label: str | None) -> str:
         if lbl:
             parts.append(lbl)
     return "-".join(p for p in parts if p)
+
+
+def _derive_os_handle(display_name: str | None, harness: str, label: str | None) -> str:
+    """Build the base handle for an OS-level (project-less) redeem.
+
+    There is no project slug to namespace on, so the alias (display_name) is the
+    primary name, falling back to the harness. An optional label disambiguates,
+    as in the project path. Each component is slugified independently.
+
+    ``_slugify`` returns the sentinel ``"agent"`` for empty input, so only
+    slugify a non-empty alias; otherwise the harness fallback never fires."""
+    alias = (display_name or "").strip()
+    base = _slugify(alias) if alias else _slugify(harness)
+    parts = [base]
+    if label:
+        lbl = _slugify(label)
+        if lbl:
+            parts.append(lbl)
+    return "-".join(p for p in parts if p) or _slugify(harness)
 
 
 async def _dedupe_handle(request: Request, base_handle: str) -> str:
@@ -160,29 +191,10 @@ def _enumerate_lan_ips() -> list[str]:
     return ips
 
 
-async def build_connection_bundle(
-    request: Request,
-    *,
-    invite_record: dict,
-    project: dict,
-    agent_handle: str,
-    granted_scopes: list[str],
-    check_interval_secs: int,
-) -> dict:
-    """Assemble the JSON connection bundle returned by a successful redeem.
-
-    The bundle carries NO token or secret (the token arrives via the status
-    poll). It enumerates the controller's reachable endpoints (LAN, mesh; no
-    relay in Phase 1), the agent-JWT-reachable API surface scoped EXACTLY to
-    the granted scopes (mirroring auth_middleware's canvas allowlist), the
-    timed-check delivery contract, and an onboarding kit + guide_markdown.
-
-    See design section 4 and the Approved-build addendum.
-    """
-    pid = project["id"]
-    project_slug = project.get("slug") or pid
-
-    # --- controller endpoints ---------------------------------------------
+async def _build_controller_dict(request: Request) -> dict:
+    """Enumerate the controller's reachable endpoints (operator override, LAN,
+    mesh; no relay in Phase 1) and wrap them in the controller descriptor shared
+    by the project and OS-level bundles."""
     endpoints: list[dict] = []
     priority = 1
 
@@ -225,11 +237,106 @@ async def build_connection_bundle(
     except Exception:  # noqa: BLE001 - mesh is optional
         pass
 
-    controller = {
+    return {
         "endpoints": endpoints,
         "health_path": "/api/health",
         "registry_pubkey_path": "/api/agents/registry/pubkey",
     }
+
+
+async def build_os_connection_bundle(
+    request: Request,
+    *,
+    invite_record: dict,
+    agent_handle: str,
+    granted_scopes: list[str],
+    check_interval_secs: int,
+) -> dict:
+    """Assemble the connection bundle for an OS-level (project-less) redeem.
+
+    Same security model as the project bundle (NO token or secret; the token
+    arrives via the status poll), but the agent joins taOS chat globally rather
+    than a project: the advertised API surface is the a2a bus only, with no
+    project/task/canvas routes. ``project`` is null in the returned bundle.
+    """
+    controller = await _build_controller_dict(request)
+
+    scopeset = set(granted_scopes)
+    apis: dict = {}
+    if "a2a_send" in scopeset or "a2a_receive" in scopeset:
+        apis["a2a_bus_send"] = "/api/a2a/bus/send"
+        apis["a2a_bus_messages"] = "/api/a2a/bus/messages"
+        apis["a2a_bus_channels"] = "/api/a2a/bus/channels"
+
+    delivery = {
+        "stream_path": "/api/a2a/bus/stream?channel={channel}&since={cursor}",
+        "poll_path": "/api/a2a/bus/messages?channel={channel}&since={cursor}",
+        "check_interval_secs": check_interval_secs,
+        "cursor": "ts",
+        "filter": "mentions",
+    }
+
+    onboarding = {
+        "links": [
+            {"label": "taOS repository", "url": "https://github.com/jaylfc/taOS"},
+            {
+                "label": "Agent manual (04-apps.md)",
+                "url": "https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/04-apps.md",
+            },
+            {
+                "label": "Agent manual (09-os-control.md)",
+                "url": "https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/09-os-control.md",
+            },
+        ],
+        "check_interval_secs": check_interval_secs,
+    }
+
+    guide = _build_os_guide_markdown(
+        agent_handle=agent_handle,
+        granted_scopes=granted_scopes,
+        check_interval_secs=check_interval_secs,
+    )
+
+    return {
+        "version": 1,
+        "invite_id": invite_record["invite_id"],
+        "project": None,
+        "controller": controller,
+        "auth": {
+            "flow": "auth_request",
+            "agent_handle": agent_handle,
+            "granted_scopes": sorted(granted_scopes),
+        },
+        "apis": apis,
+        "delivery": delivery,
+        "onboarding": onboarding,
+        "guide_markdown": guide,
+    }
+
+
+async def build_connection_bundle(
+    request: Request,
+    *,
+    invite_record: dict,
+    project: dict,
+    agent_handle: str,
+    granted_scopes: list[str],
+    check_interval_secs: int,
+) -> dict:
+    """Assemble the JSON connection bundle returned by a successful redeem.
+
+    The bundle carries NO token or secret (the token arrives via the status
+    poll). It enumerates the controller's reachable endpoints (LAN, mesh; no
+    relay in Phase 1), the agent-JWT-reachable API surface scoped EXACTLY to
+    the granted scopes (mirroring auth_middleware's canvas allowlist), the
+    timed-check delivery contract, and an onboarding kit + guide_markdown.
+
+    See design section 4 and the Approved-build addendum.
+    """
+    pid = project["id"]
+    project_slug = project.get("slug") or pid
+
+    controller = await _build_controller_dict(request)
 
     # --- agent_handle scoped api surface ----------------------------------
     apis: dict = {}
@@ -411,6 +518,72 @@ def _build_guide_markdown(
     return "\n".join(lines)
 
 
+def _build_os_guide_markdown(
+    *,
+    agent_handle: str,
+    granted_scopes: list[str],
+    check_interval_secs: int,
+) -> str:
+    """Generate the capability guide for an OS-level (project-less) redeem.
+
+    Contains NO secret (the token arrives via the status poll). The agent is
+    chat-available across taOS but is a member of no project yet; projects are
+    assigned later via the Assign-to-project flow."""
+    scopeset = set(granted_scopes)
+    lines: list[str] = []
+    lines.append(f"# Joining taOS in chat as `{agent_handle}`")
+    lines.append("")
+    lines.append(
+        "You were invited to taOS as an external agent. Redeeming your invite "
+        "registered you and minted an agent-identity token (delivered via your "
+        "status poll, not this guide). You are available in chat now; you are not "
+        "a member of any project yet. The operator can assign you to projects "
+        "later, which grants project-scoped capabilities at that time."
+    )
+    lines.append("")
+    lines.append("## Links")
+    lines.append("")
+    lines.append("- taOS repository: https://github.com/jaylfc/taOS")
+    lines.append("- Agent manual - apps: https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/04-apps.md")
+    lines.append("- Agent manual - OS control: https://github.com/jaylfc/taOS/blob/main/docs/agent-manual/09-os-control.md")
+    lines.append("")
+    lines.append("## A2A bus contract (authenticated proxy)")
+    lines.append("")
+    if "a2a_send" in scopeset or "a2a_receive" in scopeset:
+        lines.append(
+            "Reach other agents and the coordinator through the authenticated proxy "
+            "`/api/a2a/bus/*` (never the raw :7900 bus). The proxy forces `from` to your "
+            "own handle, so you always post as yourself. Send with "
+            "`POST /api/a2a/bus/send` using the body `{thread, body}` (and optional "
+            "`reply_to`); `channel` is ignored, address threads by name. Read via "
+            "`GET /api/a2a/bus/messages?channel={channel}&since={cursor}`."
+        )
+    else:
+        lines.append("- A2A bus: NOT granted.")
+    lines.append("")
+    lines.append("## WRITE THIS INTO YOUR OWN PERSISTENT MEMORY NOW")
+    lines.append("")
+    lines.append(
+        "Persist the following into your own long-term memory (not the operator's): "
+        "your canonical_id (from the status poll), the path to the token file where "
+        "you stored the polled token, and this bus contract (authenticated proxy, "
+        f"`from` forced to `{agent_handle}`). A re-spawn must reuse this identity, "
+        "not mint a new one."
+    )
+    lines.append("")
+    lines.append("## CHECK ON A TIMER")
+    lines.append("")
+    lines.append(
+        f"Poll every {check_interval_secs} seconds (or hold the SSE stream at "
+        "`/api/a2a/bus/stream`) for any @mentions addressed to "
+        f"`{agent_handle}`. On each check: read your mentions, act on them, and "
+        "report status. This timed check is the reliable delivery floor; the "
+        "stream is an optional optimization only if your harness can hold a "
+        "connection and wake on a message."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
 
 @router.post("/api/projects/{project_id}/invites")
 async def mint_invite(
@@ -494,6 +667,93 @@ async def revoke_invite(
 
 
 # ---------------------------------------------------------------------------
+# OS-level invites (project-less; admin-gated)
+# ---------------------------------------------------------------------------
+#
+# An OS-level invite mints the SAME redeemable link (URL + PIN) as a project
+# invite, but is not tied to a project. On redeem the agent gets a global
+# (chat) grant and NO project grant, so it is available in chat immediately and
+# projects are assigned later. There is no per-resource owner to check against,
+# so these routes are admin-only (matching mint-internal / seed-internal).
+
+
+def _require_admin(user: CurrentUser) -> None:
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="forbidden")
+
+
+@router.post("/api/agents/invites")
+async def mint_os_invite(
+    payload: MintOsInviteIn,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    _require_admin(user)
+    store = request.app.state.project_invites
+    try:
+        result = await store.mint(
+            project_id=None,
+            scopes=list(payload.scopes),
+            approval_mode=payload.approval_mode,
+            check_interval_secs=payload.check_interval_secs,
+            created_by=user.user_id,
+            display_name=payload.display_name,
+        )
+    except InvitePendingCapError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=429)
+    record = result["record"]
+    return {
+        "invite_id": record["invite_id"],
+        "pin": result["pin"],
+        "expires_ts": record["expires_ts"],
+        "scopes": record["scopes"],
+        "approval_mode": record["approval_mode"],
+        "check_interval_secs": record["check_interval_secs"],
+        "display_name": record["display_name"],
+    }
+
+
+@router.get("/api/agents/invites")
+async def list_os_invites(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    _require_admin(user)
+    store = request.app.state.project_invites
+    items = await store.list_os_level()
+    return [
+        {
+            "invite_id": i["invite_id"],
+            "scopes": i["scopes"],
+            "status": i["status"],
+            "expires_ts": i["expires_ts"],
+            "redeemed_by": i.get("redeemed_by"),
+            "display_name": i.get("display_name"),
+        }
+        for i in items
+    ]
+
+
+@router.delete("/api/agents/invites/{invite_id}")
+async def revoke_os_invite(
+    invite_id: str,
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    _require_admin(user)
+    store = request.app.state.project_invites
+    row = await store.get(invite_id)
+    # Only OS-level (project-less) invites are revocable through this route;
+    # project invites keep their per-project revoke endpoint.
+    if row is None or row.get("project_id") is not None:
+        return JSONResponse({"error": "invite not found"}, status_code=404)
+    ok = await store.revoke(invite_id)
+    if not ok:
+        return JSONResponse({"error": "invite not found or already redeemed"}, status_code=404)
+    return JSONResponse(content=None, status_code=204)
+
+
+# ---------------------------------------------------------------------------
 # Redeem (auth-EXEMPT) + content-negotiated invite advert
 # ---------------------------------------------------------------------------
 
@@ -537,6 +797,13 @@ async def redeem_invite(request: Request, body: RedeemInviteIn):
     except Exception as exc:  # noqa: BLE001 - mapped to HTTP below
         status, msg = _invite_exception_to_http(exc)
         return JSONResponse({"error": msg}, status_code=status)
+
+    # OS-level (project-less) invite: mint a chat-available identity with a
+    # global grant and NO project grant. Same PIN/expiry/attempt-cap security
+    # (already enforced by store.redeem above); only the grant is not
+    # project-scoped, so there is no membership row.
+    if invite["project_id"] is None:
+        return await _redeem_os_level(request, body, invite, store)
 
     project_store = request.app.state.project_store
     project = await project_store.get_project(invite["project_id"])
@@ -603,6 +870,79 @@ async def redeem_invite(request: Request, body: RedeemInviteIn):
         request,
         invite_record=invite,
         project=project,
+        agent_handle=handle,
+        granted_scopes=scopes,
+        check_interval_secs=invite.get("check_interval_secs") or 1800,
+    )
+
+    return {
+        "request_id": record["id"],
+        "agent_handle": handle,
+        "poll_path": f"/api/agents/auth-requests/{record['id']}",
+        "bundle": bundle,
+    }
+
+
+async def _redeem_os_level(request: Request, body: RedeemInviteIn, invite: dict, store) -> dict | JSONResponse:
+    """Redeem an OS-level (project-less) invite.
+
+    Mints a chat-available identity: the granted scopes are exactly the invite's
+    scopes (project_tasks is NOT forced), the auth-request carries project_id=None,
+    and approve_request_record writes GLOBAL grants (project_id=None) with no
+    membership row. The alias (display_name) from the invite is applied to the
+    minted identity.
+    """
+    # Parse scopes defensively (store returns a JSON string). No project_tasks
+    # is forced: this identity is not bound to any project.
+    raw_scopes = invite["scopes"] or []
+    if isinstance(raw_scopes, str):
+        try:
+            raw_scopes = json.loads(raw_scopes)
+        except (ValueError, TypeError):
+            raw_scopes = []
+    scopes = list(raw_scopes)
+
+    display_name = invite.get("display_name")
+    handle = _derive_os_handle(display_name, body.harness, body.label)
+    handle = await _dedupe_handle(request, handle)
+
+    from tinyagentos.routes.agent_auth_requests import approve_request_record
+
+    auth_store = request.app.state.auth_requests
+    record = await auth_store.create(
+        identity_claim=handle,
+        framework=body.harness,
+        requested_scopes=scopes,
+        requested_skills=None,
+        reason=f"invite {body.invite_id}",
+        duration_secs=None,
+        project_id=None,
+    )
+
+    if invite["approval_mode"] == "auto":
+        try:
+            await approve_request_record(
+                request,
+                record=record,
+                granted_scopes=scopes,
+                effective_project=None,
+                decided_by=invite["created_by"],
+                project_id=None,
+                display_name=display_name,
+            )
+        except Exception as exc:  # noqa: BLE001 - surface as JSON error
+            return JSONResponse({"error": str(exc)}, status_code=400)
+    else:
+        _notify_pending_invite(request, record)
+
+    try:
+        await store.mark_redeemed(body.invite_id, handle, record["id"])
+    except Exception:  # noqa: BLE001 - audit best-effort
+        pass
+
+    bundle = await build_os_connection_bundle(
+        request,
+        invite_record=invite,
         agent_handle=handle,
         granted_scopes=scopes,
         check_interval_secs=invite.get("check_interval_secs") or 1800,

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -7,7 +7,7 @@ import socket
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from tinyagentos.agent_registry_store import _slugify
 from tinyagentos.auth_context import CurrentUser, current_user, require_owner_or_admin
@@ -39,7 +39,21 @@ class MintOsInviteIn(BaseModel):
     scopes: list[str] = Field(default_factory=list)
     approval_mode: str = Field(default="auto", pattern="^(auto|manual)$")
     check_interval_secs: int = Field(default=1800, ge=60)
-    display_name: str | None = None
+    display_name: str | None = Field(default=None, max_length=64)
+
+    @field_validator("display_name")
+    @classmethod
+    def _clean_display_name(cls, v: str | None) -> str | None:
+        # Stored verbatim and echoed back, so trim and reject control chars;
+        # an all-whitespace alias collapses to None (no alias).
+        if v is None:
+            return None
+        v = v.strip()
+        if not v:
+            return None
+        if any(ord(c) < 0x20 for c in v):
+            raise ValueError("display_name must not contain control characters")
+        return v
 
 
 class RedeemInviteIn(BaseModel):
@@ -61,6 +75,12 @@ class RedeemInviteIn(BaseModel):
 # suffix is the fallback for same-harness/same-label re-invites.
 
 _CANCEL_SCOPES = {"canvas_read", "canvas_write"}
+
+# Scopes that only mean anything bound to a specific project. An OS-level
+# (project-less) invite has no project to bind them to, so they are stripped
+# before minting rather than granted verbatim: an OS invite must never hand out
+# project-scoped authority that resolves to no project.
+_PROJECT_SCOPED = {"project_tasks", "canvas_read", "canvas_write"}
 
 
 def _derive_handle(project_slug: str, harness: str, label: str | None) -> str:
@@ -690,10 +710,13 @@ async def mint_os_invite(
 ):
     _require_admin(user)
     store = request.app.state.project_invites
+    # OS-level invites carry no project, so drop any project-bound scopes rather
+    # than granting them against a non-existent project (kilo review #1918).
+    os_scopes = [s for s in payload.scopes if s not in _PROJECT_SCOPED]
     try:
         result = await store.mint(
             project_id=None,
-            scopes=list(payload.scopes),
+            scopes=os_scopes,
             approval_mode=payload.approval_mode,
             check_interval_secs=payload.check_interval_secs,
             created_by=user.user_id,


### PR DESCRIPTION
Closes #1913.

## What

Makes the "Invite external agent" flow project-optional and adds a name/alias. When no project is chosen the agent becomes chat-available immediately (projects assigned later via the existing Assign-to-project dialog), while still minting a redeemable URL+PIN invite link under the same external-agent security model.

## Backend

- **`invite_store`**: `mint()` accepts `display_name` and no longer force-appends `project_tasks` for project-less invites. The pending cap now uses an `IS NULL` branch so it stays enforced for OS-level invites (SQL `= NULL` never matches). Adds a `display_name` column with a boot migration for legacy DBs, plus `list_os_level()`.
- **`project_invites` routes**: new admin-gated `POST` / `GET` / `DELETE /api/agents/invites`. The shared redeem endpoint (`POST /api/projects/invites/redeem`) branches on a null `project_id` to mint a chat-available identity with **global** grants and **no** project membership. A dedicated OS-level connection bundle + guide is returned (a2a bus surface only, `project: null`).
- **`approve_request_record`**: optional `display_name` override so the human alias is preserved even when the handle is slugified/deduped.
- **Router order**: `project_invites` is registered before the `agents` router so the literal `/api/agents/invites` paths win over `/api/agents/{name}`.

## Frontend

- The invite entry is now one form: a **Name / alias** field + an optional **Project** select defaulting to *"None — available in chat, assign to projects later"*. "None" mints via the new OS-level endpoint and shows the URL+PIN result inline; choosing a project keeps the existing project-scoped mint dialog. Portal + `z-[10001]` preserved.

## Security notes

- PIN / expiry / attempt-cap / single-use are all still enforced by `store.redeem()` before any branch runs; the OS-level path only differs in that the grant is global (not project-scoped) and no membership row is written.
- The OS-level mint/list/revoke routes are **admin-only** (there is no per-resource owner to check against, matching `mint-internal` / `seed-internal`). The OS-level revoke route refuses to act on project-scoped invites.
- OS-level scopes are never widened to `project_tasks`, so `approve_request_record`'s `needs_project` guard is not triggered and no project binding is fabricated.

## Tests

- Python: `tests/projects/test_invite_store.py` (+6) and `tests/test_routes_project_invites.py` (+8) cover project-less mint (no `project_tasks`, pin returned), independent pending cap, list/revoke, admin gate, redeem to a chat-available identity with global-only grants + no membership, display_name application + handle slugify/fallback, and the advert page. Existing project-scoped tests unchanged and green.
- Vitest: `RegistryPanel.invite-assign.test.tsx` (+2) covers minting an OS-level invite with the alias (URL+PIN result) and chaining to the project dialog when a project is chosen.
- `desktop` `tsc -b` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-less agent invites that can be created with an optional display name.
  * Admins can create, view, revoke, and redeem OS-level invites.
  * Invite results now display a redeemable URL, one-time PIN, and copyable setup instructions.
  * Redeemed OS-level invites provide global access without project membership.
* **Improvements**
  * Project selection now defaults to “None” instead of automatically choosing a project.
  * Display names are preserved during invite redemption.
  * Added validation, single-use redemption, and pending-invite limits for OS-level invites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->