### PR TITLE
fix(security): HTML-escape project name in invite advert (stored XSS)

### DIFF
--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -328,6 +328,25 @@ async def test_invite_info_html_for_browser(client, app):
 
 
 @pytest.mark.asyncio
+async def test_invite_info_html_escapes_project_name(client, app):
+    # A project name is owner-controlled and is interpolated into the invite
+    # advert HTML. It must be HTML-escaped or a name like "<script>..." would
+    # execute in the browser of whoever opens the invite link (stored XSS).
+    resp = await client.post(
+        "/api/projects",
+        json={"name": "<script>alert(1)</script>", "slug": "xssproj"},
+    )
+    assert resp.status_code == 200, resp.text
+    pid = resp.json()["id"]
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto")
+
+    resp = await client.get(f"/i/{iid}", headers={"accept": "text/html"})
+    assert resp.status_code == 200, resp.text
+    assert "<script>alert(1)</script>" not in resp.text
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in resp.text
+
+
+@pytest.mark.asyncio
 async def test_guide_markdown_contains_required_instructions(client, app, monkeypatch, tmp_path):
     await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
     pid = await _create_project(client, slug="redguide")

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import json
 import logging
 import socket
@@ -707,7 +708,7 @@ async def invite_info(request: Request, invite_id: str):
 
 def _invite_html(invite: dict, project: dict) -> str:
     """Minimal self-contained HTML page for a human who opens the invite link."""
-    name = (project.get("name") or invite.get("project_id") or "a taOS project")
+    name = html.escape(project.get("name") or invite.get("project_id") or "a taOS project")
     return (
         "<!doctype html><meta charset=utf-8><title>taOS project invite</title>"
         "<h1>You have been invited to a taOS project</h1>"


### PR DESCRIPTION
Automated security review flagged a HIGH stored-XSS in `_invite_html` (tinyagentos/routes/project_invites.py). The invite advert page (served on `Accept: text/html` at `/i/{invite_id}`) interpolated the owner-controlled project `name` into the HTML unescaped, so a project named e.g. `<script>...</script>` executes in the browser of whoever opens the invite link.

Fix: `html.escape(...)` the name before embedding. Added `test_invite_info_html_escapes_project_name` (asserts the raw markup is absent and the escaped form present). Verified the pure function directly (raw absent, escaped present); the full pytest run is green in CI (local run is shadowed by the editable-install import path).

Separate from #1913 (which also touches this file); rebase that onto this.