### PR TITLE
feat(agents): request additional scopes for an existing agent identity

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -145,6 +145,36 @@ further project via `POST /api/projects/{project_id}/members/assign-agent`
 active identity (the existing canonical_id and token are reused instead of
 409ing).
 
+## Requesting more scope for an existing identity (scope requests)
+
+The auth-request flow (`POST /api/agents/auth-requests`) MINTS A NEW identity on
+approval, so an agent that already holds an active registry identity cannot use
+it to gain more scopes without duplicating itself. A scope request adds grants to
+that SAME canonical_id instead:
+
+- `POST /api/agents/registry/{canonical_id}/scope-requests`
+  `{requested_scopes, project_id?, reason?}` — create a pending request. Unlike
+  the new-agent auth-request (unauthenticated, since the agent has no creds yet),
+  this is CREDENTIALLED: the caller must be the agent's OWN registry bearer token
+  (`sub` == `canonical_id`) OR the owning user / an admin. An anonymous caller can
+  never escalate an existing identity. The middleware allowlist exposes only the
+  create path to a registry JWT; the route re-checks identity == canonical_id.
+- `POST /api/agents/registry/{canonical_id}/scope-requests/{req_id}/approve`
+  `{granted_scopes, project_id?}` — owner/admin only. The admin may narrow but
+  never widen the requested scopes; each granted scope is added via
+  `add_grant(canonical_id, scope, project_id)` (idempotent on the
+  `(canonical_id, scope, project_id)` UNIQUE key, so re-approving is a no-op). No
+  new identity is created.
+- `POST /api/agents/registry/{canonical_id}/scope-requests/{req_id}/deny` —
+  owner/admin only.
+
+Requested scopes are validated against the same closed `VALID_SCOPES` vocabulary
+as the consent flow. `project_tasks` and the canvas scopes still require an
+explicit `project_id`; `decisions_read` / `decisions_write` (and the other global
+scopes) may be granted globally (`project_id=None`) or per-project. Creation
+surfaces a bell notification (`source: agent_scope_requests`) to the owner/admin,
+retired when the request is decided.
+
 ## Project invite redeem route (link + PIN)
 
 A project invite lets an external agent join without going through the consent

--- a/tests/test_agent_scope_requests.py
+++ b/tests/test_agent_scope_requests.py
@@ -1,0 +1,402 @@
+"""Scope-request flow: an EXISTING registry agent asks for MORE scopes on its
+own identity, the owner/admin approves, and the grant lands on the SAME
+canonical_id (no new identity is minted).
+
+Mirrors the auth-request route tests (tests/test_routes_agent_auth_requests.py):
+each test wires fresh registry / grants / scope-request stores + keypair onto
+app.state via monkeypatch, so the flow is exercised end to end through the real
+routes and middleware.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import (
+    AgentRegistryStore,
+    load_or_create_signing_keypair,
+    mint_registry_token,
+)
+from tinyagentos.agent_grants_store import AgentGrantsStore
+from tinyagentos.agent_scope_requests_store import AgentScopeRequestsStore
+
+
+class _Env:
+    """Fresh stores + a registered active agent, wired onto app.state."""
+
+    def __init__(self, registry, grants, scope_store, priv, pub, admin_uid):
+        self.registry = registry
+        self.grants = grants
+        self.scope_store = scope_store
+        self.priv = priv
+        self.pub = pub
+        self.admin_uid = admin_uid
+
+    def agent_token(self, canonical_id: str, framework: str = "claude") -> str:
+        return mint_registry_token(
+            canonical_id, self.priv, user_id=self.admin_uid, framework=framework
+        )
+
+    async def close(self):
+        await self.registry.close()
+        await self.grants.close()
+        await self.scope_store.close()
+
+
+async def _wire(client, monkeypatch, tmp_path, *, owner_uid=None):
+    """Build fresh stores, register one ACTIVE agent, monkeypatch app.state."""
+    app = client._transport.app
+    admin = app.state.auth.find_user("admin")
+    admin_uid = admin["id"] if admin else ""
+    owner_uid = owner_uid if owner_uid is not None else admin_uid
+
+    registry = AgentRegistryStore(tmp_path / "reg.db")
+    await registry.init()
+    grants = AgentGrantsStore(tmp_path / "grants.db")
+    await grants.init()
+    scope_store = AgentScopeRequestsStore(tmp_path / "scope.db")
+    await scope_store.init()
+    priv, pub = load_or_create_signing_keypair(tmp_path / "keys")
+
+    monkeypatch.setattr(app.state, "agent_registry", registry)
+    monkeypatch.setattr(app.state, "agent_grants", grants)
+    monkeypatch.setattr(app.state, "agent_scope_requests", scope_store)
+    monkeypatch.setattr(app.state, "agent_registry_keypair", (priv, pub))
+
+    env = _Env(registry, grants, scope_store, priv, pub, admin_uid)
+    env.owner_uid = owner_uid
+    return env
+
+
+async def _register_active(env, *, handle="@worker", display="worker", framework="claude"):
+    rec = await env.registry.register(
+        framework=framework,
+        display_name=display,
+        user_id=env.owner_uid,
+        origin="taos-deployed",  # taos-deployed registers active immediately
+        handle=handle,
+    )
+    return rec["canonical_id"]
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_owner_creates_and_approves_grant_on_existing_identity(
+    client, monkeypatch, tmp_path
+):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        before = len(await env.registry.list_all())
+
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests",
+            json={"requested_scopes": ["memory_read", "memory_write"], "reason": "need memory"},
+        )
+        assert resp.status_code == 200, resp.text
+        req_id = resp.json()["request_id"]
+        assert resp.json()["status"] == "pending"
+
+        # Admin narrows to a subset on approve.
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests/{req_id}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["canonical_id"] == cid
+
+        # Grant landed on the EXISTING canonical_id, and NO new identity exists.
+        grants = await env.grants.list_grants(cid)
+        assert {g["scope"] for g in grants} == {"memory_read"}
+        assert all(g["project_id"] is None for g in grants)
+        assert len(await env.registry.list_all()) == before  # no new identity
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_can_self_request_with_own_token(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        token = env.agent_token(cid)
+        app = client._transport.app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp = await bare.post(
+                f"/api/agents/registry/{cid}/scope-requests",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"requested_scopes": ["a2a_send"]},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "pending"
+        assert await env.scope_store.count_pending_for(cid) == 1
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_cannot_request_for_another_identity(client, monkeypatch, tmp_path):
+    """Agent A's token must not create a scope request against agent B's id."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid_a = await _register_active(env, handle="@a", display="a")
+        cid_b = await _register_active(env, handle="@b", display="b")
+        token_a = env.agent_token(cid_a)
+        app = client._transport.app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp = await bare.post(
+                f"/api/agents/registry/{cid_b}/scope-requests",
+                headers={"Authorization": f"Bearer {token_a}"},
+                json={"requested_scopes": ["a2a_send"]},
+            )
+        assert resp.status_code == 403, resp.text
+        assert await env.scope_store.count_pending_for(cid_b) == 0
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_canonical_id_404(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        resp = await client.post(
+            "/api/agents/registry/does-not-exist/scope-requests",
+            json={"requested_scopes": ["memory_read"]},
+        )
+        assert resp.status_code == 404, resp.text
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_inactive_canonical_id_404(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        await env.registry.revoke(cid)  # now inactive
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests",
+            json={"requested_scopes": ["memory_read"]},
+        )
+        assert resp.status_code == 404, resp.text
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_requested_scope_outside_vocabulary_400(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests",
+            json={"requested_scopes": ["root_everything"]},
+        )
+        assert resp.status_code == 400, resp.text
+    finally:
+        await env.close()
+
+
+# ---------------------------------------------------------------------------
+# Approve / deny guards
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_granted_must_be_subset_of_requested_400(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        rec = await env.scope_store.create(
+            canonical_id=cid, requested_scopes=["memory_read"]
+        )
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
+            json={"granted_scopes": ["memory_read", "memory_write"]},
+        )
+        assert resp.status_code == 400, resp.text
+        # Nothing was granted on the rejected approval.
+        assert await env.grants.list_grants(cid) == []
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_global_decisions_write_grant_works(client, monkeypatch, tmp_path):
+    """decisions_write is global-capable: a null-project grant is allowed and no
+    project_id is required."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        rec = await env.scope_store.create(
+            canonical_id=cid, requested_scopes=["decisions_read", "decisions_write"]
+        )
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
+            json={"granted_scopes": ["decisions_read", "decisions_write"]},
+        )
+        assert resp.status_code == 200, resp.text
+        grants = await env.grants.list_grants(cid)
+        assert {g["scope"] for g in grants} == {"decisions_read", "decisions_write"}
+        assert all(g["project_id"] is None for g in grants)  # global grants
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_project_scope_requires_project_id_400(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        rec = await env.scope_store.create(
+            canonical_id=cid, requested_scopes=["project_tasks"]
+        )
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
+            json={"granted_scopes": ["project_tasks"]},
+        )
+        assert resp.status_code == 400, resp.text
+        assert "project_id" in resp.text
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_approve(client, monkeypatch, tmp_path):
+    """A non-admin user who does not own the agent cannot approve."""
+    app = client._transport.app
+    # Create a non-admin second user and its session.
+    code = app.state.auth.add_user_invite("bob", "admin")
+    app.state.auth.complete_invite("bob", code, "Bob", "", "bobpass123")
+    bob = app.state.auth.find_user("bob")
+    bob_session = app.state.auth.create_session(user_id=bob["id"], long_lived=True)
+
+    # The agent is owned by the admin, not bob.
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        rec = await env.scope_store.create(
+            canonical_id=cid, requested_scopes=["memory_read"]
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"taos_session": bob_session},
+        ) as bob_client:
+            resp = await bob_client.post(
+                f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
+                json={"granted_scopes": ["memory_read"]},
+            )
+        assert resp.status_code == 403, resp.text
+        assert await env.grants.list_grants(cid) == []
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_cannot_approve_its_own_request(client, monkeypatch, tmp_path):
+    """The agent's own registry token cannot reach the approve endpoint: the
+    middleware allowlist only exposes the create path to a registry JWT, so an
+    agent token on /approve falls through to the session gate and is rejected."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        rec = await env.scope_store.create(
+            canonical_id=cid, requested_scopes=["memory_read"]
+        )
+        token = env.agent_token(cid)
+        app = client._transport.app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as bare:
+            resp = await bare.post(
+                f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
+                headers={"Authorization": f"Bearer {token}"},
+                json={"granted_scopes": ["memory_read"]},
+            )
+        assert resp.status_code in (401, 403), resp.text
+        assert await env.grants.list_grants(cid) == []
+        # Request is still pending — the agent could not self-approve.
+        assert (await env.scope_store.get(rec["id"]))["status"] == "pending"
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_idempotent_reapprove_no_duplicate_grant_or_identity(
+    client, monkeypatch, tmp_path
+):
+    """Approving a scope already granted (via a fresh request) is a no-op on the
+    grant table (UNIQUE key) and never creates a second identity."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        before = len(await env.registry.list_all())
+
+        for _ in range(2):
+            rec = await env.scope_store.create(
+                canonical_id=cid, requested_scopes=["decisions_write"]
+            )
+            resp = await client.post(
+                f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
+                json={"granted_scopes": ["decisions_write"]},
+            )
+            assert resp.status_code == 200, resp.text
+
+        grants = await env.grants.list_grants(cid)
+        # Exactly one grant row for (cid, decisions_write, NULL) despite two approvals.
+        assert [g["scope"] for g in grants] == ["decisions_write"]
+        assert len(await env.registry.list_all()) == before  # still no new identity
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_deny_marks_refused_and_second_deny_conflicts(client, monkeypatch, tmp_path):
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        rec = await env.scope_store.create(
+            canonical_id=cid, requested_scopes=["memory_read"]
+        )
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/deny",
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "refused"
+        assert await env.grants.list_grants(cid) == []
+
+        # A second deny on an already-decided request is a 409.
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/deny",
+        )
+        assert resp.status_code == 409, resp.text
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_approve_wrong_agent_path_404(client, monkeypatch, tmp_path):
+    """A request id that belongs to a different canonical_id is not found under
+    this agent's path (no cross-agent approval)."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid_a = await _register_active(env, handle="@a", display="a")
+        cid_b = await _register_active(env, handle="@b", display="b")
+        rec = await env.scope_store.create(
+            canonical_id=cid_a, requested_scopes=["memory_read"]
+        )
+        resp = await client.post(
+            f"/api/agents/registry/{cid_b}/scope-requests/{rec['id']}/approve",
+            json={"granted_scopes": ["memory_read"]},
+        )
+        assert resp.status_code == 404, resp.text
+    finally:
+        await env.close()

--- a/tests/test_agent_scope_requests.py
+++ b/tests/test_agent_scope_requests.py
@@ -400,3 +400,62 @@ async def test_approve_wrong_agent_path_404(client, monkeypatch, tmp_path):
         assert resp.status_code == 404, resp.text
     finally:
         await env.close()
+
+
+@pytest.mark.asyncio
+async def test_global_scope_ignores_agent_supplied_project_id(client, monkeypatch, tmp_path):
+    """A global-capable scope requested with an agent-named project_id must NOT
+    bind the grant to that unvalidated project when the operator approves without
+    an explicit project_id: it is granted globally (project_id=None). Guards the
+    cross-project escalation the old agent-supplied fallback allowed."""
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)
+        # The agent names a project it should not reach, on the request itself.
+        rec = await env.scope_store.create(
+            canonical_id=cid,
+            requested_scopes=["decisions_write"],
+            project_id="prj-victim",
+        )
+        # Operator approves WITHOUT an explicit body.project_id.
+        resp = await client.post(
+            f"/api/agents/registry/{cid}/scope-requests/{rec['id']}/approve",
+            json={"granted_scopes": ["decisions_write"]},
+        )
+        assert resp.status_code == 200, resp.text
+        grants = await env.grants.list_grants(cid)
+        assert {g["scope"] for g in grants} == {"decisions_write"}
+        # Bound globally, NEVER to the agent-named project.
+        assert all(g["project_id"] is None for g in grants)
+        assert all(g["project_id"] != "prj-victim" for g in grants)
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_create_authorizes_before_scope_vocab(client, monkeypatch, tmp_path):
+    """An unauthorized caller is rejected BEFORE scope-vocabulary validation, so an
+    authz failure cannot leak whether a scope name is valid."""
+    app = client._transport.app
+    code = app.state.auth.add_user_invite("carol", "admin")
+    app.state.auth.complete_invite("carol", code, "Carol", "", "carolpass123")
+    carol = app.state.auth.find_user("carol")
+    carol_session = app.state.auth.create_session(user_id=carol["id"], long_lived=True)
+
+    env = await _wire(client, monkeypatch, tmp_path)
+    try:
+        cid = await _register_active(env)  # owned by admin, not carol
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"taos_session": carol_session},
+        ) as carol_client:
+            resp = await carol_client.post(
+                f"/api/agents/registry/{cid}/scope-requests",
+                json={"requested_scopes": ["not_a_real_scope"]},
+            )
+        # Authz runs first -> 403, NOT a 400 vocab error confirming the bad scope.
+        assert resp.status_code == 403, resp.text
+        assert "not_a_real_scope" not in resp.text
+    finally:
+        await env.close()

--- a/tinyagentos/agent_scope_requests_store.py
+++ b/tinyagentos/agent_scope_requests_store.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+"""Store for scope-request records raised by ALREADY-REGISTERED agents.
+
+Unlike ``auth_requests`` (which mints a NEW identity on approval), a
+scope-request targets an EXISTING canonical_id: an agent that already holds an
+active registry identity asks the owner/admin for ADDITIONAL scope grants on
+that same identity.  Approval writes grants to the existing canonical_id; it
+never registers a second identity.
+
+The state machine mirrors ``auth_requests``: pending → accepted | refused
+(terminal).  ``set_decision`` is atomic — a conditional UPDATE that only
+matches rows still in ``pending`` status, so two concurrent approvals cannot
+both win a read-check-then-write race.
+"""
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+import aiosqlite
+
+from tinyagentos.base_store import BaseStore
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS agent_scope_requests (
+    id                TEXT PRIMARY KEY,
+    canonical_id      TEXT NOT NULL,
+    requested_scopes  TEXT NOT NULL DEFAULT '[]',
+    project_id        TEXT,
+    reason            TEXT NOT NULL DEFAULT '',
+    status            TEXT NOT NULL DEFAULT 'pending',
+    granted_scopes    TEXT,
+    created_ts        TEXT NOT NULL,
+    decided_ts        TEXT,
+    decided_by        TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_scope_requests_status ON agent_scope_requests(status);
+CREATE INDEX IF NOT EXISTS idx_scope_requests_canonical ON agent_scope_requests(canonical_id, status);
+"""
+
+_VALID_DECISION_STATUSES = frozenset({"accepted", "refused"})
+
+
+def _row_to_dict(row: aiosqlite.Row) -> dict:
+    d = {k: row[k] for k in row.keys()}
+    for field in ("requested_scopes", "granted_scopes"):
+        raw = d.get(field)
+        if raw is not None:
+            try:
+                d[field] = json.loads(raw)
+            except (ValueError, TypeError):
+                d[field] = []
+        else:
+            d[field] = None if field == "granted_scopes" else []
+    return d
+
+
+class AgentScopeRequestsStore(BaseStore):
+    """Persistent store for existing-agent scope-request records."""
+
+    SCHEMA = SCHEMA
+
+    async def init(self) -> None:
+        await super().init()
+        if self._db is not None:
+            self._db.row_factory = aiosqlite.Row
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    async def create(
+        self,
+        *,
+        canonical_id: str,
+        requested_scopes: list[str],
+        project_id: Optional[str] = None,
+        reason: str = "",
+    ) -> dict:
+        """Create a new pending scope request. Returns the full record."""
+        if self._db is None:
+            raise RuntimeError("AgentScopeRequestsStore not initialised — call init() first")
+
+        request_id = uuid.uuid4().hex
+        now = datetime.now(timezone.utc).isoformat()
+
+        await self._db.execute(
+            """
+            INSERT INTO agent_scope_requests
+                (id, canonical_id, requested_scopes, project_id, reason, status, created_ts)
+            VALUES (?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            (
+                request_id,
+                canonical_id,
+                json.dumps(requested_scopes),
+                project_id,
+                reason,
+                now,
+            ),
+        )
+        await self._db.commit()
+        record = await self.get(request_id)
+        if record is None:
+            raise RuntimeError(f"scope_request {request_id!r} missing immediately after insert")
+        return record
+
+    async def set_decision(
+        self,
+        request_id: str,
+        status: str,
+        *,
+        granted_scopes: Optional[list[str]] = None,
+        decided_by: str,
+    ) -> Optional[dict]:
+        """Atomically transition a pending request to accepted or refused.
+
+        Returns the updated record on success, or ``None`` if the row was
+        already decided (rowcount == 0 from the conditional UPDATE).
+        Raises ``ValueError`` for an invalid target status.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentScopeRequestsStore not initialised")
+        if status not in _VALID_DECISION_STATUSES:
+            raise ValueError(f"status must be 'accepted' or 'refused', got {status!r}")
+
+        now = datetime.now(timezone.utc).isoformat()
+        granted_json = json.dumps(granted_scopes) if granted_scopes is not None else None
+
+        cur = await self._db.execute(
+            """
+            UPDATE agent_scope_requests
+               SET status         = ?,
+                   granted_scopes = ?,
+                   decided_ts     = ?,
+                   decided_by     = ?
+             WHERE id = ? AND status = 'pending'
+            """,
+            (status, granted_json, now, decided_by, request_id),
+        )
+        await self._db.commit()
+
+        if cur.rowcount == 0:
+            # Already decided — caller should treat as conflict.
+            return None
+
+        return await self.get(request_id)
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def get(self, request_id: str) -> Optional[dict]:
+        """Return the record for *request_id*, or ``None``."""
+        if self._db is None:
+            raise RuntimeError("AgentScopeRequestsStore not initialised")
+        row = await (
+            await self._db.execute(
+                "SELECT * FROM agent_scope_requests WHERE id = ?", (request_id,)
+            )
+        ).fetchone()
+        return _row_to_dict(row) if row else None
+
+    async def list_pending(self, canonical_id: Optional[str] = None) -> list[dict]:
+        """Return pending scope requests, oldest first.
+
+        Optional ``canonical_id`` narrows to a single agent.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentScopeRequestsStore not initialised")
+        if canonical_id is not None:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_scope_requests "
+                "WHERE status = 'pending' AND canonical_id = ? ORDER BY created_ts",
+                (canonical_id,),
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_scope_requests WHERE status = 'pending' ORDER BY created_ts"
+            )
+        rows = await cursor.fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    async def count_pending_for(self, canonical_id: str) -> int:
+        """Return the number of pending requests for a given canonical_id."""
+        if self._db is None:
+            raise RuntimeError("AgentScopeRequestsStore not initialised")
+        row = await (
+            await self._db.execute(
+                "SELECT COUNT(*) FROM agent_scope_requests "
+                "WHERE canonical_id = ? AND status = 'pending'",
+                (canonical_id,),
+            )
+        ).fetchone()
+        return row[0] if row else 0

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -148,6 +148,48 @@ async def check_agent_scope(request: Request, required_scope: str) -> Optional[s
     return canonical_id
 
 
+async def check_agent_identity(request: Request) -> Optional[str]:
+    """Return the canonical_id from a valid Bearer registry JWT for an ACTIVE
+    agent, without requiring any scope grant.
+
+    This proves only *who* the caller is, not *what* it may do — the caller is
+    responsible for the authorization decision (e.g. only allowing an agent to
+    act on its OWN canonical_id).  It is used by the scope-request create flow,
+    where an already-registered agent asks for MORE scopes: it must not need a
+    scope it does not yet hold in order to request one.
+
+    Returns None when no Authorization header is present (the caller falls
+    through to its own admin/session handling).
+
+    Raises:
+      401 -- Authorization header present but the token is malformed, has a bad
+             signature, or is missing the sub claim.
+      403 -- Token is valid but the agent is not active in the registry.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None
+
+    raw_token = auth_header[7:].strip()
+
+    _private_pem, public_pem = _get_keypair(request)
+    try:
+        payload = verify_registry_token(raw_token, public_pem)
+    except ValueError:
+        raise HTTPException(status_code=401, detail="invalid or malformed registry token")
+
+    canonical_id: str = payload.get("sub", "")
+    if not canonical_id:
+        raise HTTPException(status_code=401, detail="token missing sub claim")
+
+    registry = _get_store(request)
+    record = await registry.get(canonical_id)
+    if record is None or record.get("status") != "active":
+        raise HTTPException(status_code=403, detail="agent is not active in the registry")
+
+    return canonical_id
+
+
 async def check_agent_scope_for_project(
     request: Request, required_scope: str, project_id: str
 ) -> Optional[str]:

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -281,6 +281,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
 
     from tinyagentos.auth_requests_store import AuthRequestsStore
     auth_requests_store = AuthRequestsStore(data_dir / "auth_requests.db")
+    from tinyagentos.agent_scope_requests_store import AgentScopeRequestsStore
+    agent_scope_requests_store = AgentScopeRequestsStore(data_dir / "agent_scope_requests.db")
     from tinyagentos.agent_grants_store import AgentGrantsStore
     agent_grants_store = AgentGrantsStore(data_dir / "agent_grants.db")
     from tinyagentos.app_grants_store import AppGrantsStore
@@ -502,6 +504,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state._startup_complete = False
         await agent_registry_store.init()
         await auth_requests_store.init()
+        await agent_scope_requests_store.init()
         await agent_grants_store.init()
         await app_grants_store.init()
         await license_acceptances_store.init()
@@ -1658,6 +1661,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.agent_registry_keypair = agent_registry_keypair
     app.state.agent_model_keys = agent_model_key_store
     app.state.auth_requests = auth_requests_store
+    app.state.agent_scope_requests = agent_scope_requests_store
     app.state.agent_grants = agent_grants_store
     app.state.app_grants = app_grants_store
     app.state.license_acceptances = license_acceptances_store

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -106,6 +106,15 @@ _AGENT_FILES_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/{_SEG}/stats$")),
 )
 
+# Scope-request CREATE an agent may reach with its own registry JWT to ask for
+# MORE scopes on its own identity. Only the create endpoint; the approve/deny
+# subactions have extra path segments and are NOT matched here, so they stay
+# owner/admin session-only. The route verifies the JWT identity == the path
+# canonical_id (an agent may only self-request).
+_AGENT_SCOPE_REQUEST_ROUTES = (
+    ("POST", re.compile(rf"^/api/agents/registry/{_SEG}/scope-requests$")),
+)
+
 
 def _is_agent_task_path(method: str, path: str) -> bool:
     """True only for the exact subset of task routes a project_tasks token may
@@ -132,6 +141,14 @@ def _is_agent_files_path(method: str, path: str) -> bool:
     may reach.  Strict method + anchored-regex match; the route verifies the
     JWT + grant + project binding."""
     return any(m == method and rx.match(path) for m, rx in _AGENT_FILES_ROUTES)
+
+
+def _is_agent_scope_request_path(method: str, path: str) -> bool:
+    """True only for POST /api/agents/registry/{cid}/scope-requests, which an
+    agent may reach with its own registry JWT to self-request more scopes. The
+    route verifies the JWT identity == canonical_id; approve/deny are excluded
+    (extra path segments) and stay owner/admin session-only."""
+    return any(m == method and rx.match(path) for m, rx in _AGENT_SCOPE_REQUEST_ROUTES)
 # Bundle assets and the SPA shell HTML must be reachable without auth so:
 #   1. The browser can install and cache the shell for offline / PWA use.
 #   2. After a backend restart the cached shell loads immediately without
@@ -375,6 +392,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             or _is_agent_canvas_path(request.method, path)
             or _is_agent_decisions_path(request.method, path)
             or _is_agent_files_path(request.method, path)
+            or _is_agent_scope_request_path(request.method, path)
         ) and auth_header.lower().startswith("bearer "):
             request.state.user_id = None
             request.state.is_admin = False

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -1106,21 +1106,26 @@ async def deny_scope_request(
     require_owner_or_admin(user, record["user_id"])
 
     store = _get_scope_requests_store(request)
-    req = await store.get(req_id)
-    if req is None or req.get("canonical_id") != canonical_id:
-        raise HTTPException(status_code=404, detail="scope request not found")
-    if req["status"] != "pending":
-        raise HTTPException(
-            status_code=409,
-            detail=f"request is already {req['status']!r}; cannot deny",
-        )
 
-    result = await store.set_decision(req_id, "refused", decided_by=user.user_id)
-    if result is None:
-        raise HTTPException(
-            status_code=409,
-            detail="request was decided concurrently; check current status",
-        )
+    # Serialize against a concurrent approve of the same request (same per-req
+    # lock the approve path uses), with a pending re-check inside the lock.
+    lock = _get_approve_lock(request, req_id)
+    async with lock:
+        req = await store.get(req_id)
+        if req is None or req.get("canonical_id") != canonical_id:
+            raise HTTPException(status_code=404, detail="scope request not found")
+        if req["status"] != "pending":
+            raise HTTPException(
+                status_code=409,
+                detail=f"request is already {req['status']!r}; cannot deny",
+            )
+
+        result = await store.set_decision(req_id, "refused", decided_by=user.user_id)
+        if result is None:
+            raise HTTPException(
+                status_code=409,
+                detail="request was decided concurrently; check current status",
+            )
 
     await _retire_scope_request_notification(request, req_id)
     return {"status": "refused"}

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -902,6 +902,12 @@ async def create_scope_request(
             status_code=404, detail="agent not found or not active"
         )
 
+    # Authorize BEFORE any request-shape validation so an unauthorized caller
+    # cannot probe scope validity (an authz failure must not leak whether a
+    # scope name is valid). The record fetch above is the minimum needed to
+    # authorize against the agent's owner.
+    await _authorize_scope_request_creation(request, canonical_id, record)
+
     if not body.requested_scopes:
         raise HTTPException(status_code=400, detail="requested_scopes must not be empty")
 
@@ -912,8 +918,6 @@ async def create_scope_request(
             status_code=400,
             detail=f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}",
         )
-
-    await _authorize_scope_request_creation(request, canonical_id, record)
 
     store = _get_scope_requests_store(request)
     pending_count = await store.count_pending_for(canonical_id)
@@ -982,84 +986,102 @@ async def approve_scope_request(
     require_owner_or_admin(user, record["user_id"])
 
     store = _get_scope_requests_store(request)
-    req = await store.get(req_id)
-    if req is None or req.get("canonical_id") != canonical_id:
-        raise HTTPException(status_code=404, detail="scope request not found")
-    if req["status"] != "pending":
-        raise HTTPException(
-            status_code=409,
-            detail=f"request is already {req['status']!r}; cannot approve",
+
+    # Serialize concurrent approvals of the SAME request (mirror the consent
+    # approve path). All the state-changing work runs inside the lock with a
+    # pending re-check, so two racing approvals cannot both write grants and flip
+    # the decision. Grants are written before the decision flip; that ordering is
+    # safe only under this lock plus idempotent add_grant.
+    lock = _get_approve_lock(request, req_id)
+    async with lock:
+        req = await store.get(req_id)
+        if req is None or req.get("canonical_id") != canonical_id:
+            raise HTTPException(status_code=404, detail="scope request not found")
+        if req["status"] != "pending":
+            raise HTTPException(
+                status_code=409,
+                detail=f"request is already {req['status']!r}; cannot approve",
+            )
+
+        if not body.granted_scopes:
+            raise HTTPException(
+                status_code=400, detail="granted_scopes must not be empty"
+            )
+
+        # Narrow-not-widen: granted must be a subset of the requested scopes, and
+        # every granted scope must be in the closed vocabulary.
+        requested = set(req["requested_scopes"] or [])
+        granted = set(body.granted_scopes)
+        invalid = sorted((granted - requested) | (granted - VALID_SCOPES))
+        if invalid:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"granted scopes must be a subset of the requested scopes; "
+                    f"not grantable: {invalid}"
+                ),
+            )
+
+        # Project binding: ONLY the operator's explicit picker value binds a grant
+        # to a project. NEVER fall back to the agent-named req.project_id -- an
+        # agent can self-request (see _authorize_scope_request_creation), so the
+        # request could name any project the operator never validated, and a
+        # global-capable scope (decisions_*) silently bound to it would be a
+        # cross-project escalation. A global-capable scope with no operator
+        # project is granted globally (project_id=None).
+        validated_project = (
+            body.project_id if (body.project_id and body.project_id.strip()) else None
         )
 
-    if not body.granted_scopes:
-        raise HTTPException(status_code=400, detail="granted_scopes must not be empty")
+        # project_tasks and the canvas scopes bind the grant to a specific project
+        # and add a membership row, so they require an explicit validated project.
+        needs_project = bool(granted & _SCOPE_PROJECT_SCOPES)
+        if needs_project and validated_project is None:
+            missing = sorted(granted & _SCOPE_PROJECT_SCOPES)
+            raise HTTPException(
+                status_code=400,
+                detail=f"project_id is required when granting {missing}",
+            )
 
-    # Narrow-not-widen: granted must be a subset of the requested scopes, and
-    # every granted scope must be in the closed vocabulary.
-    requested = set(req["requested_scopes"] or [])
-    granted = set(body.granted_scopes)
-    invalid = sorted((granted - requested) | (granted - VALID_SCOPES))
-    if invalid:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"granted scopes must be a subset of the requested scopes; "
-                f"not grantable: {invalid}"
-            ),
-        )
+        grants_store = _get_grants_store(request)
+        rel_mgr = _get_relationships(request)
 
-    # Resolve project binding: the admin's picker value wins; fall back to the
-    # project_id the agent named on the request.
-    effective_project = (
-        body.project_id if body.project_id is not None else req.get("project_id")
-    )
+        # Global (non-project) grants: write the grant + relationship edge bound
+        # to the validated project (None = global). Project-scoped grants: route
+        # through add_agent_to_project so the membership + a2a channel are synced,
+        # exactly like the consent-approve path. add_grant is idempotent, so
+        # re-approving an already-granted scope changes nothing.
+        project_scopes = [
+            s for s in body.granted_scopes if s in _SCOPE_PROJECT_SCOPES
+        ]
+        other_scopes = [
+            s for s in body.granted_scopes if s not in _SCOPE_PROJECT_SCOPES
+        ]
+        for scope in other_scopes:
+            await grants_store.add_grant(
+                canonical_id, scope, tier="once", project_id=validated_project
+            )
+            await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
+        if project_scopes:
+            await add_agent_to_project(
+                request,
+                canonical_id=canonical_id,
+                project_id=validated_project,
+                granted_scopes=project_scopes,
+                decided_by=user.user_id,
+            )
 
-    # project_tasks and the canvas scopes bind the grant to a specific project
-    # and add a membership row, so require an EXPLICIT picker project_id for them
-    # (the agent-named fallback is not an operator-validated binding). decisions
-    # scopes are global-capable, so they do not require a project_id.
-    needs_project = bool(granted & _SCOPE_PROJECT_SCOPES)
-    if needs_project and not (body.project_id and body.project_id.strip()):
-        missing = sorted(granted & _SCOPE_PROJECT_SCOPES)
-        raise HTTPException(
-            status_code=400,
-            detail=f"project_id is required when granting {missing}",
-        )
-
-    grants_store = _get_grants_store(request)
-    rel_mgr = _get_relationships(request)
-
-    # Global (non-project) grants: write the grant + relationship edge directly.
-    # Project-scoped grants: route through add_agent_to_project so the membership
-    # + a2a channel are synced, exactly like the consent-approve path. add_grant
-    # is idempotent, so re-approving an already-granted scope changes nothing.
-    project_scopes = [s for s in body.granted_scopes if s in _SCOPE_PROJECT_SCOPES]
-    other_scopes = [s for s in body.granted_scopes if s not in _SCOPE_PROJECT_SCOPES]
-    for scope in other_scopes:
-        await grants_store.add_grant(
-            canonical_id, scope, tier="once", project_id=effective_project
-        )
-        await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
-    if project_scopes:
-        await add_agent_to_project(
-            request,
-            canonical_id=canonical_id,
-            project_id=effective_project,
-            granted_scopes=project_scopes,
+        result = await store.set_decision(
+            req_id,
+            "accepted",
+            granted_scopes=body.granted_scopes,
             decided_by=user.user_id,
         )
-
-    result = await store.set_decision(
-        req_id,
-        "accepted",
-        granted_scopes=body.granted_scopes,
-        decided_by=user.user_id,
-    )
-    if result is None:
-        raise HTTPException(
-            status_code=409,
-            detail="request was decided concurrently; check current status",
-        )
+        if result is None:
+            raise HTTPException(
+                status_code=409,
+                detail="request was decided concurrently; check current status",
+            )
 
     await _retire_scope_request_notification(request, req_id)
     return {

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -101,6 +101,22 @@ class AssignAgentBody(BaseModel):
     is_lead: bool = False
 
 
+class CreateScopeRequest(BaseModel):
+    """Body for POST /api/agents/registry/{canonical_id}/scope-requests.
+
+    An ALREADY-REGISTERED agent (or its owner/admin) asks for additional scope
+    grants on that same identity. No new identity is minted on approval.
+    """
+    requested_scopes: list[str]
+    project_id: Optional[str] = None
+    reason: str = ""
+
+
+class ApproveScopeBody(BaseModel):
+    granted_scopes: list[str]
+    project_id: Optional[str] = None
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -126,6 +142,13 @@ def _get_registry_store(request: Request):
     return store
 
 
+def _get_scope_requests_store(request: Request):
+    store = getattr(request.app.state, "agent_scope_requests", None)
+    if store is None:
+        raise RuntimeError("agent_scope_requests store not on app.state")
+    return store
+
+
 def _get_keypair(request: Request) -> tuple[bytes, bytes]:
     kp = getattr(request.app.state, "agent_registry_keypair", None)
     if kp is None:
@@ -148,6 +171,18 @@ async def _retire_request_notification(request: Request, request_id: str) -> Non
         return
     try:
         await notifs.archive_by_source_ref("auth_requests", request_id)
+    except Exception:
+        pass
+
+
+async def _retire_scope_request_notification(request: Request, request_id: str) -> None:
+    """Archive the bell notification for a now-decided scope request so it leaves
+    the active list. Best effort: never fails the decision."""
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is None:
+        return
+    try:
+        await notifs.archive_by_source_ref("agent_scope_requests", request_id)
     except Exception:
         pass
 
@@ -800,3 +835,270 @@ async def list_auth_requests(
     store = _get_auth_requests_store(request)
     pending = await store.list_pending()
     return {"requests": pending}
+
+
+# ---------------------------------------------------------------------------
+# Scope requests — an EXISTING agent asks for MORE scopes on its own identity.
+#
+# Unlike the auth-request flow above, approval here does NOT mint a new
+# identity: it adds grants to the existing canonical_id. Creation is gated to
+# the agent's OWN registry token (self-request) OR the owner/admin, because the
+# agent already has credentials — an anonymous caller must never be able to
+# escalate an existing identity. Approve/deny are owner/admin only.
+# ---------------------------------------------------------------------------
+
+# Maximum unresolved scope requests per canonical_id before new ones are 429'd.
+_SCOPE_REQUEST_PENDING_CAP = 10
+
+# Scopes that bind a grant to a specific project (and add a membership row), so
+# a real project_id is required for them. decisions_read/decisions_write are
+# NOT here: they may be granted globally (project_id=None) or per-project.
+_SCOPE_CANVAS_SCOPES = {"canvas_read", "canvas_write"}
+_SCOPE_PROJECT_SCOPES = {"project_tasks"} | _SCOPE_CANVAS_SCOPES
+
+
+async def _authorize_scope_request_creation(
+    request: Request, canonical_id: str, record: dict
+) -> None:
+    """Authorize the caller to create a scope request for *canonical_id*.
+
+    Allowed: an owner/admin session (or admin local token), OR the agent's own
+    registry bearer token whose ``sub`` matches *canonical_id*. Any other caller
+    (including a different agent's token, or no credentials) is a 403/401.
+    """
+    is_admin = bool(getattr(request.state, "is_admin", False))
+    uid = getattr(request.state, "user_id", None)
+    if is_admin or (uid and uid == record.get("user_id")):
+        return
+
+    # The agent's own registry token. check_agent_identity returns None when no
+    # Authorization header is present (an unauthenticated caller never reaches
+    # here anyway — the middleware 401s a credential-less non-exempt request) and
+    # raises 401/403 for a malformed/inactive token.
+    from tinyagentos.agent_token_auth import check_agent_identity
+
+    agent_cid = await check_agent_identity(request)
+    if agent_cid is not None and agent_cid == canonical_id:
+        return
+
+    raise HTTPException(status_code=403, detail="forbidden")
+
+
+@router.post("/api/agents/registry/{canonical_id}/scope-requests")
+async def create_scope_request(
+    request: Request, canonical_id: str, body: CreateScopeRequest
+):
+    """Create a pending scope request for an EXISTING active agent.
+
+    Auth: the agent's own registry bearer token (sub == canonical_id) OR the
+    owning user / an admin. Returns {request_id, status: 'pending'}.
+    """
+    registry = _get_registry_store(request)
+    record = await registry.get(canonical_id)
+    if record is None or record.get("status") != "active":
+        # Existence-hiding is unnecessary here (the caller must already be the
+        # agent or its owner/admin) but an inactive/unknown id is simply a 404.
+        raise HTTPException(
+            status_code=404, detail="agent not found or not active"
+        )
+
+    if not body.requested_scopes:
+        raise HTTPException(status_code=400, detail="requested_scopes must not be empty")
+
+    # Only known scopes may be requested — an unknown scope can never be enforced.
+    unknown = sorted(set(body.requested_scopes) - VALID_SCOPES)
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}",
+        )
+
+    await _authorize_scope_request_creation(request, canonical_id, record)
+
+    store = _get_scope_requests_store(request)
+    pending_count = await store.count_pending_for(canonical_id)
+    if pending_count >= _SCOPE_REQUEST_PENDING_CAP:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"too many pending scope requests for {canonical_id!r} "
+                f"({pending_count} pending; resolve existing requests first)"
+            ),
+        )
+
+    rec = await store.create(
+        canonical_id=canonical_id,
+        requested_scopes=body.requested_scopes,
+        project_id=body.project_id,
+        reason=body.reason,
+    )
+
+    # Surface the request as a bell + toast for the owner/admin. Best effort: a
+    # notification failure must not fail the created request (mirrors the
+    # auth-request create flow and decisions.py).
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is not None:
+        try:
+            scopes = rec["requested_scopes"] or []
+            handle = record.get("handle") or record.get("display_name") or canonical_id
+            where = f"project {rec['project_id']}" if rec.get("project_id") else "global scope"
+            await notifs.add(
+                title="Scope request",
+                message=f"{handle} is requesting {', '.join(scopes)} on {where}",
+                level="info",
+                source="agent_scope_requests",
+                data={
+                    "request_id": rec["id"],
+                    "canonical_id": canonical_id,
+                    "requested_scopes": list(scopes),
+                    "project_id": rec.get("project_id"),
+                },
+            )
+        except Exception:
+            pass
+
+    return {"request_id": rec["id"], "status": "pending"}
+
+
+@router.post("/api/agents/registry/{canonical_id}/scope-requests/{req_id}/approve")
+async def approve_scope_request(
+    request: Request,
+    canonical_id: str,
+    req_id: str,
+    body: ApproveScopeBody,
+    user: CurrentUser = Depends(current_user),
+):
+    """Approve a scope request: add the granted scopes to the EXISTING agent.
+
+    Owner/admin only. The admin may narrow but never widen the requested scopes.
+    Grants are idempotent (UNIQUE(canonical_id, scope, project_id)), so
+    re-approving an already-granted scope is a no-op, not an error. No new
+    identity is minted.
+    """
+    registry = _get_registry_store(request)
+    record = await registry.get(canonical_id)
+    if record is None or record.get("status") != "active":
+        raise HTTPException(status_code=404, detail="agent not found or not active")
+    require_owner_or_admin(user, record["user_id"])
+
+    store = _get_scope_requests_store(request)
+    req = await store.get(req_id)
+    if req is None or req.get("canonical_id") != canonical_id:
+        raise HTTPException(status_code=404, detail="scope request not found")
+    if req["status"] != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"request is already {req['status']!r}; cannot approve",
+        )
+
+    if not body.granted_scopes:
+        raise HTTPException(status_code=400, detail="granted_scopes must not be empty")
+
+    # Narrow-not-widen: granted must be a subset of the requested scopes, and
+    # every granted scope must be in the closed vocabulary.
+    requested = set(req["requested_scopes"] or [])
+    granted = set(body.granted_scopes)
+    invalid = sorted((granted - requested) | (granted - VALID_SCOPES))
+    if invalid:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"granted scopes must be a subset of the requested scopes; "
+                f"not grantable: {invalid}"
+            ),
+        )
+
+    # Resolve project binding: the admin's picker value wins; fall back to the
+    # project_id the agent named on the request.
+    effective_project = (
+        body.project_id if body.project_id is not None else req.get("project_id")
+    )
+
+    # project_tasks and the canvas scopes bind the grant to a specific project
+    # and add a membership row, so require an EXPLICIT picker project_id for them
+    # (the agent-named fallback is not an operator-validated binding). decisions
+    # scopes are global-capable, so they do not require a project_id.
+    needs_project = bool(granted & _SCOPE_PROJECT_SCOPES)
+    if needs_project and not (body.project_id and body.project_id.strip()):
+        missing = sorted(granted & _SCOPE_PROJECT_SCOPES)
+        raise HTTPException(
+            status_code=400,
+            detail=f"project_id is required when granting {missing}",
+        )
+
+    grants_store = _get_grants_store(request)
+    rel_mgr = _get_relationships(request)
+
+    # Global (non-project) grants: write the grant + relationship edge directly.
+    # Project-scoped grants: route through add_agent_to_project so the membership
+    # + a2a channel are synced, exactly like the consent-approve path. add_grant
+    # is idempotent, so re-approving an already-granted scope changes nothing.
+    project_scopes = [s for s in body.granted_scopes if s in _SCOPE_PROJECT_SCOPES]
+    other_scopes = [s for s in body.granted_scopes if s not in _SCOPE_PROJECT_SCOPES]
+    for scope in other_scopes:
+        await grants_store.add_grant(
+            canonical_id, scope, tier="once", project_id=effective_project
+        )
+        await rel_mgr.set_permission(canonical_id, "taos-instance", scope)
+    if project_scopes:
+        await add_agent_to_project(
+            request,
+            canonical_id=canonical_id,
+            project_id=effective_project,
+            granted_scopes=project_scopes,
+            decided_by=user.user_id,
+        )
+
+    result = await store.set_decision(
+        req_id,
+        "accepted",
+        granted_scopes=body.granted_scopes,
+        decided_by=user.user_id,
+    )
+    if result is None:
+        raise HTTPException(
+            status_code=409,
+            detail="request was decided concurrently; check current status",
+        )
+
+    await _retire_scope_request_notification(request, req_id)
+    return {
+        "status": "accepted",
+        "canonical_id": canonical_id,
+        "granted_scopes": body.granted_scopes,
+    }
+
+
+@router.post("/api/agents/registry/{canonical_id}/scope-requests/{req_id}/deny")
+async def deny_scope_request(
+    request: Request,
+    canonical_id: str,
+    req_id: str,
+    user: CurrentUser = Depends(current_user),
+):
+    """Deny a pending scope request (owner/admin only)."""
+    registry = _get_registry_store(request)
+    record = await registry.get(canonical_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="agent not found")
+    require_owner_or_admin(user, record["user_id"])
+
+    store = _get_scope_requests_store(request)
+    req = await store.get(req_id)
+    if req is None or req.get("canonical_id") != canonical_id:
+        raise HTTPException(status_code=404, detail="scope request not found")
+    if req["status"] != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"request is already {req['status']!r}; cannot deny",
+        )
+
+    result = await store.set_decision(req_id, "refused", decided_by=user.user_id)
+    if result is None:
+        raise HTTPException(
+            status_code=409,
+            detail="request was decided concurrently; check current status",
+        )
+
+    await _retire_scope_request_notification(request, req_id)
+    return {"status": "refused"}


### PR DESCRIPTION
Fixes #1920.

## What

Adds a scope-request flow so an ALREADY-REGISTERED agent can gain additional scope grants on its SAME canonical_id. The existing auth-request flow (`POST /api/agents/auth-requests` -> `/approve`) mints a NEW identity on approval and 409s on an active-handle collision, so an agent that already holds an active identity could not use it to request more scope without duplicating itself.

## Endpoints (routes/agent_auth_requests.py)

- `POST /api/agents/registry/{canonical_id}/scope-requests` `{requested_scopes, project_id?, reason?}` - create a pending request.
- `POST /api/agents/registry/{canonical_id}/scope-requests/{req_id}/approve` `{granted_scopes, project_id?}` - approve, owner/admin only.
- `POST /api/agents/registry/{canonical_id}/scope-requests/{req_id}/deny` - deny, owner/admin only.

## Auth gates (security-critical)

- **Create**: allowed for the agent's OWN registry bearer token (JWT `sub` == path `canonical_id`) OR the owning user / an admin (session or admin local token). An anonymous caller can never escalate an existing identity - unlike the new-agent auth-request, which is unauthenticated only because the agent has no creds yet. The middleware allowlist (`auth_middleware.py`) exposes ONLY the create path to a registry JWT (anchored regex, so the approve/deny subpaths are excluded); the route then re-checks identity == canonical_id, so an agent can only self-request.
- **Approve / deny**: owner/admin only (`require_owner_or_admin` against the agent's registry-record owner). An agent's own token cannot reach these - the middleware does not pass a registry JWT through to them, so it falls to the session gate and is rejected.

## Behaviour

- Approval writes `add_grant(canonical_id, scope, project_id)` per granted scope. No new identity is registered. The admin may narrow but never widen the requested scopes.
- Idempotent via `UNIQUE(canonical_id, scope, project_id)`: re-approving an already-granted scope is a no-op.
- `decisions_read` / `decisions_write` (and other global scopes) may be granted globally (`project_id=None`) or per-project; `project_tasks` and canvas scopes still require an explicit `project_id`.
- Creation surfaces a bell notification (`source: agent_scope_requests`) to the owner/admin, retired on decision.
- Requested scopes are validated against the closed `VALID_SCOPES` vocabulary; `test_allowed_scopes_matches_canonical_valid_scopes` still passes.

## New pieces

- `AgentScopeRequestsStore` (parallel to `AuthRequestsStore`; pending -> accepted|refused, atomic conditional-UPDATE decision).
- `check_agent_identity` in `agent_token_auth.py`: scope-agnostic identity verify (proves who, not what), so an agent does not need a scope it lacks in order to request one.

## Tests

`tests/test_agent_scope_requests.py` (14 tests): create + owner-approve lands a grant on the existing canonical_id with the identity count unchanged; agent self-request via own token; agent cannot request for another identity; unknown / inactive id 404; scope outside VALID_SCOPES 400; granted must be subset of requested; global decisions_write grant; project scope requires project_id; non-owner cannot approve; agent cannot approve its own request; idempotent re-approve; deny + conflict.

Local: `pytest tests/ --ignore=tests/e2e -k "scope_request or auth_request or internal_mint or registry"` = 469 passed. New file = 14/14 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a scope-request workflow for already-registered (active) agents to request additional permissions on the same identity.
  - Added endpoints to create, approve, and deny scope requests, with request notifications and retirement after a decision.
  - Added persistent scope-request storage and enhanced registry token verification.
- **Bug Fixes**
  - Enforced ownership/admin authorization for approvals, idempotent approvals, correct project-scoped vs global scope rules (including required project identifiers), and tighter input/rate validation.
- **Documentation**
  - Documented the end-to-end scope-request and scope/project validation behavior.
- **Tests**
  - Added end-to-end coverage for the scope-request flow, including edge cases and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->