### PR TITLE
fix(csrf): verify_csrf no-op on websocket scope (fixes Messages Offline / chat WS 500)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,10 @@ from tinyagentos.routes.desktop import SPA_DIR
 from fastapi import Request as _FastAPIRequest
 
 
-def _noop_verify_csrf(request: _FastAPIRequest) -> None:
+def _noop_verify_csrf(request: _FastAPIRequest | None = None) -> None:
+    # request is optional so this override is callable on websocket routes too
+    # (FastAPI injects no Request into a websocket scope), matching the real
+    # verify_csrf which no-ops when request is None.
     return
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,13 +25,14 @@ from tinyagentos.routes.desktop import SPA_DIR
 # real function directly and test it in isolation.
 # ---------------------------------------------------------------------------
 
-from fastapi import Request as _FastAPIRequest
+from starlette.requests import HTTPConnection as _HTTPConnection
 
 
-def _noop_verify_csrf(request: _FastAPIRequest | None = None) -> None:
-    # request is optional so this override is callable on websocket routes too
-    # (FastAPI injects no Request into a websocket scope), matching the real
-    # verify_csrf which no-ops when request is None.
+def _noop_verify_csrf(conn: _HTTPConnection) -> None:
+    # Typed as HTTPConnection (base of Request + WebSocket) so this override is
+    # FastAPI-injectable on both http and websocket routes, matching the real
+    # verify_csrf. A `Request` param TypeErrors on a websocket scope and
+    # `Request | None` is not a valid injectable type at all.
     return
 
 

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -89,13 +89,16 @@ class TestVerifyCSRF:
 
 
 def test_verify_csrf_is_noop_for_websocket_scope():
-    # WebSocket routes on a router carrying dependencies=[Depends(verify_csrf)]
-    # invoke verify_csrf with no Request (FastAPI does not inject one into a
-    # websocket scope), so request arrives as None. It must be a no-op, not
-    # raise a TypeError that rejects the socket with a 500 (the /ws/chat
-    # "Offline" regression). WebSocket handshakes are cookie-authenticated in
-    # their own handler and are not susceptible to form-based CSRF.
+    # verify_csrf is typed HTTPConnection so FastAPI injects it on BOTH http and
+    # websocket routes (a router-level dep also runs on @router.websocket routes).
+    # A websocket scope carries no HTTP method, so verify_csrf must skip rather
+    # than raise a TypeError that rejects the socket with a 500 (the /ws/chat
+    # "Offline" regression). WS handshakes are cookie-authenticated in-handler
+    # and are not susceptible to form-based CSRF.
+    from starlette.requests import HTTPConnection
+
     from tinyagentos.middleware.csrf import verify_csrf
 
-    assert verify_csrf() is None
-    assert verify_csrf(None) is None
+    ws_conn = HTTPConnection({"type": "websocket", "headers": []})
+    assert getattr(ws_conn, "method", None) is None
+    assert verify_csrf(ws_conn) is None

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -86,3 +86,16 @@ class TestVerifyCSRF:
                 follow_redirects=False,
             )
         assert resp.status_code == 403
+
+
+def test_verify_csrf_is_noop_for_websocket_scope():
+    # WebSocket routes on a router carrying dependencies=[Depends(verify_csrf)]
+    # invoke verify_csrf with no Request (FastAPI does not inject one into a
+    # websocket scope), so request arrives as None. It must be a no-op, not
+    # raise a TypeError that rejects the socket with a 500 (the /ws/chat
+    # "Offline" regression). WebSocket handshakes are cookie-authenticated in
+    # their own handler and are not susceptible to form-based CSRF.
+    from tinyagentos.middleware.csrf import verify_csrf
+
+    assert verify_csrf() is None
+    assert verify_csrf(None) is None

--- a/tinyagentos/middleware/csrf.py
+++ b/tinyagentos/middleware/csrf.py
@@ -64,11 +64,17 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         return response
 
 
-def verify_csrf(request: Request) -> None:
+def verify_csrf(request: Request | None = None) -> None:
     """FastAPI dependency — enforce the double-submit CSRF check.
 
     Scope
     -----
+    * WebSocket routes are exempt. When this dependency is attached at the
+      router level (``dependencies=_csrf``), it also applies to any
+      ``@router.websocket`` route on that router. FastAPI does not inject a
+      ``Request`` into a websocket scope, so ``request`` arrives as ``None``;
+      websocket connections are not susceptible to form-based CSRF (their
+      handshake is authenticated in-handler via the session cookie), so skip.
     * Safe HTTP methods (GET / HEAD / OPTIONS) are always exempt.
     * Requests authenticated via ``Authorization: Bearer …`` are exempt —
       the bearer token itself is unforgeable from a third-party origin.
@@ -79,6 +85,10 @@ def verify_csrf(request: Request) -> None:
     For protected requests the ``X-CSRF-Token`` header must match the
     ``csrf_token`` cookie value (double-submit pattern).
     """
+    # WebSocket scope: no Request is injected. Not CSRF-able; skip.
+    if request is None:
+        return
+
     # Safe methods need no protection.
     if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
         return

--- a/tinyagentos/middleware/csrf.py
+++ b/tinyagentos/middleware/csrf.py
@@ -30,6 +30,7 @@ import secrets
 
 from fastapi import HTTPException, Request
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import HTTPConnection
 from starlette.responses import Response
 
 _COOKIE_NAME = "csrf_token"
@@ -64,17 +65,22 @@ class CSRFMiddleware(BaseHTTPMiddleware):
         return response
 
 
-def verify_csrf(request: Request | None = None) -> None:
+def verify_csrf(conn: HTTPConnection) -> None:
     """FastAPI dependency — enforce the double-submit CSRF check.
+
+    Typed as ``HTTPConnection`` (the shared base of ``Request`` and
+    ``WebSocket``) so FastAPI injects it on BOTH http and websocket scopes.
+    A plain ``Request`` param would make FastAPI call the dependency with no
+    argument on a websocket route (TypeError), and ``Request | None`` is not a
+    valid injectable type at all — either one breaks route registration when
+    this dependency is attached at the router level (``dependencies=_csrf``)
+    and that router also carries an ``@router.websocket`` route.
 
     Scope
     -----
-    * WebSocket routes are exempt. When this dependency is attached at the
-      router level (``dependencies=_csrf``), it also applies to any
-      ``@router.websocket`` route on that router. FastAPI does not inject a
-      ``Request`` into a websocket scope, so ``request`` arrives as ``None``;
-      websocket connections are not susceptible to form-based CSRF (their
-      handshake is authenticated in-handler via the session cookie), so skip.
+    * WebSocket routes are exempt: a websocket connection has no HTTP method
+      and is not susceptible to form-based CSRF (its handshake is
+      authenticated in-handler via the session cookie), so skip.
     * Safe HTTP methods (GET / HEAD / OPTIONS) are always exempt.
     * Requests authenticated via ``Authorization: Bearer …`` are exempt —
       the bearer token itself is unforgeable from a third-party origin.
@@ -85,25 +91,22 @@ def verify_csrf(request: Request | None = None) -> None:
     For protected requests the ``X-CSRF-Token`` header must match the
     ``csrf_token`` cookie value (double-submit pattern).
     """
-    # WebSocket scope: no Request is injected. Not CSRF-able; skip.
-    if request is None:
-        return
-
-    # Safe methods need no protection.
-    if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+    # WebSocket scope has no HTTP method — not CSRF-able; skip.
+    method = getattr(conn, "method", None)
+    if method is None or method in ("GET", "HEAD", "OPTIONS", "TRACE"):
         return
 
     # Bearer-authenticated requests are not subject to CSRF.
-    auth_header = request.headers.get("authorization", "")
+    auth_header = conn.headers.get("authorization", "")
     if auth_header.lower().startswith("bearer "):
         return
 
     # No session cookie → not cookie-authenticated → no CSRF risk.
-    if not request.cookies.get("taos_session"):
+    if not conn.cookies.get("taos_session"):
         return
 
-    cookie_token = request.cookies.get(_COOKIE_NAME, "")
-    header_token = request.headers.get(_HEADER_NAME, "")
+    cookie_token = conn.cookies.get(_COOKIE_NAME, "")
+    header_token = conn.headers.get(_HEADER_NAME, "")
 
     if not cookie_token or not header_token:
         raise HTTPException(status_code=403, detail="CSRF token missing")


### PR DESCRIPTION
## Live regression

The Messages app shows a permanent **Offline** state. Root cause (confirmed from the Pi journal):

```
TypeError: verify_csrf() missing 1 required positional argument: 'request'
INFO: connection rejected (500 Internal Server Error)   # /ws/chat
```

The CSRF hardening (#1898) attaches `verify_csrf` at the router level via `dependencies=_csrf`. That also applies to `@router.websocket` routes on those routers -- `/ws/chat` (chat.py), and any other WS route on a CSRF'd router. FastAPI does not inject a `Request` into a websocket scope, so `verify_csrf` was invoked with no argument and raised, rejecting every chat WebSocket with a 500. Message content still loaded over HTTP polling, so only the realtime socket was dead -> permanent Offline.

## Fix
`verify_csrf(request: Request | None = None)` and return early when `request is None` (websocket scope). WebSocket handshakes are cookie-authenticated in their own handler and are not susceptible to form-based CSRF, so skipping is correct. This fixes `/ws/chat` and any other websocket route sharing a CSRF'd router in one place, with no change to HTTP CSRF enforcement.

Test: `test_verify_csrf_is_noop_for_websocket_scope` (verify_csrf() and verify_csrf(None) do not raise). Verified the fixed function directly; CI runs the suite against the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSRF verification for WebSocket routes by making CSRF checks compatible with non-HTTP connection scopes.
  * CSRF enforcement now safely returns when no HTTP method is present, and still bypasses for safe methods, Bearer-authenticated requests, and requests missing the session cookie.
  * Existing HTTP CSRF protection behavior (including token mismatch handling) remains unchanged.

* **Tests**
  * Added a regression test covering that CSRF verification is a no-op for WebSocket scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->