### PR TITLE
fix(auth): XSS hardening, session race protection, and User-Agent binding

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1009,3 +1009,122 @@ class TestConcurrentHashUpgrade:
         stored = json.loads(mgr._user_file.read_text())
         final_hash = stored["users"][0]["password_hash"]
         assert final_hash.startswith("$argon2"), f"Hash was not upgraded: {final_hash[:40]}"
+
+
+class TestXSSHardening:
+    """html.escape() is applied to error and next_url in auth page templates."""
+
+    def test_login_page_escapes_error_param(self):
+        from tinyagentos.routes.auth import _login_page
+        html = _login_page(error='<script>alert(1)</script>')
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_login_page_escapes_next_url(self):
+        from tinyagentos.routes.auth import _login_page
+        html = _login_page(next_url='"/><script>alert(1)</script>')
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_setup_page_escapes_error_param(self):
+        from tinyagentos.routes.auth import _setup_page
+        html = _setup_page(error='<img src=x onerror=alert(1)>')
+        assert "<img" not in html
+        assert "&lt;img" in html
+
+
+class TestPersistentSessionsLock:
+    """_PersistentSessions lock prevents lost updates from concurrent writes."""
+
+    def test_concurrent_writes_dont_lose_data(self, tmp_path):
+        import threading
+        from tinyagentos.auth import _PersistentSessions
+        session_path = tmp_path / "sessions.json"
+        store = _PersistentSessions(session_path)
+
+        results_a = []
+        results_b = []
+
+        def writer_a():
+            for i in range(50):
+                store[f"key_a_{i}"] = {"v": i}
+                results_a.append(store.get(f"key_a_{i}"))
+
+        def writer_b():
+            for i in range(50):
+                store[f"key_b_{i}"] = {"v": i}
+                results_b.append(store.get(f"key_b_{i}"))
+
+        ta = threading.Thread(target=writer_a)
+        tb = threading.Thread(target=writer_b)
+        ta.start()
+        tb.start()
+        ta.join()
+        tb.join()
+
+        # All writes must be visible in final state
+        data = store._load()
+        for i in range(50):
+            assert f"key_a_{i}" in data, f"key_a_{i} missing after concurrent writes"
+            assert f"key_b_{i}" in data, f"key_b_{i} missing after concurrent writes"
+
+
+class TestSessionClientBinding:
+    """Sessions store a User-Agent hash and validate against it."""
+
+    def test_session_stores_user_agent_hash(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
+        rec = mgr.find_user("alice")
+        token = mgr.create_session(
+            user_id=rec["id"], user_agent="TestAgent/1.0"
+        )
+        entry = mgr._sessions.get(token)
+        assert entry is not None
+        assert "user_agent_hash" in entry
+        assert isinstance(entry["user_agent_hash"], str)
+
+    def test_session_validates_with_matching_user_agent(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
+        rec = mgr.find_user("alice")
+        token = mgr.create_session(
+            user_id=rec["id"], user_agent="TestAgent/1.0"
+        )
+        user_id = mgr.validate_session(token, user_agent="TestAgent/1.0")
+        assert user_id == rec["id"]
+
+    def test_session_rejects_mismatched_user_agent(self, tmp_path):
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
+        rec = mgr.find_user("alice")
+        token = mgr.create_session(
+            user_id=rec["id"], user_agent="Chrome/100"
+        )
+        user_id = mgr.validate_session(token, user_agent="Firefox/200")
+        assert user_id is None
+
+    def test_session_without_ua_hash_still_validates(self, tmp_path):
+        """Backward compat: sessions created without user_agent still work."""
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
+        rec = mgr.find_user("alice")
+        token = mgr.create_session(user_id=rec["id"])
+        # Should validate even without user_agent param
+        user_id = mgr.validate_session(token)
+        assert user_id == rec["id"]
+        # Should also validate with a user_agent param (no hash to compare)
+        user_id = mgr.validate_session(token, user_agent="Anything/1.0")
+        assert user_id == rec["id"]
+
+    def test_session_with_ua_hash_validates_without_ua_param(self, tmp_path):
+        """When caller doesn't supply user_agent, hash check is skipped."""
+        mgr = AuthManager(tmp_path)
+        mgr.setup_user("alice", "Alice", "", "alicepwd1")
+        rec = mgr.find_user("alice")
+        token = mgr.create_session(
+            user_id=rec["id"], user_agent="TestAgent/1.0"
+        )
+        # No user_agent param => skip check
+        user_id = mgr.validate_session(token)
+        assert user_id == rec["id"]

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -30,10 +30,14 @@ class _PersistentSessions:
     Session entries are dicts: {user_id, expires_at, long_lived}.
     Old float entries (single-user legacy) are tolerated and treated as the
     first user's session.
+
+    Thread-safe: all mutating operations (set, delete, pop) are protected by a
+    lock to prevent lost updates from concurrent read-modify-write cycles.
     """
 
     def __init__(self, path: Path):
         self._path = path
+        self._lock = threading.Lock()
 
     def _load(self) -> dict:
         if not self._path.exists():
@@ -51,14 +55,16 @@ class _PersistentSessions:
         return self._load()[key]
 
     def __setitem__(self, key: str, value) -> None:
-        data = self._load()
-        data[key] = value
-        self._save(data)
+        with self._lock:
+            data = self._load()
+            data[key] = value
+            self._save(data)
 
     def __delitem__(self, key: str) -> None:
-        data = self._load()
-        del data[key]
-        self._save(data)
+        with self._lock:
+            data = self._load()
+            del data[key]
+            self._save(data)
 
     def __contains__(self, key: object) -> bool:
         return key in self._load()
@@ -70,10 +76,11 @@ class _PersistentSessions:
         return self._load().get(key, default)
 
     def pop(self, key: str, *args):
-        data = self._load()
-        result = data.pop(key, *args)
-        self._save(data)
-        return result
+        with self._lock:
+            data = self._load()
+            result = data.pop(key, *args)
+            self._save(data)
+            return result
 
     def items(self):
         return list(self._load().items())
@@ -597,14 +604,17 @@ class AuthManager:
     #  Sessions                                                            #
     # ------------------------------------------------------------------ #
 
-    def create_session(self, user_id: str = "", long_lived: bool = False) -> str:
+    def create_session(self, user_id: str = "", long_lived: bool = False, user_agent: str | None = None) -> str:
         token = secrets.token_urlsafe(32)
         ttl = self.long_session_ttl if long_lived else self.session_ttl
-        self._sessions[token] = {
+        entry: dict = {
             "user_id": user_id,
             "expires_at": time.time() + ttl,
             "long_lived": long_lived,
         }
+        if user_agent:
+            entry["user_agent_hash"] = hashlib.sha256(user_agent.encode()).hexdigest()
+        self._sessions[token] = entry
         return token
 
     def session_ttl_for(self, long_lived: bool = False) -> int:
@@ -619,8 +629,14 @@ class AuthManager:
             return {"user_id": "", "expires_at": float(entry), "long_lived": False}
         return entry
 
-    def validate_session(self, token: str) -> str | None:
-        """Return user_id if the session is valid, else None."""
+    def validate_session(self, token: str, user_agent: str | None = None) -> str | None:
+        """Return user_id if the session is valid, else None.
+
+        When *user_agent* is provided and the session was created with a
+        User-Agent hash, the hash is verified as a basic stolen-cookie check.
+        Sessions created without a User-Agent hash (legacy) continue to
+        validate regardless.
+        """
         entry = self._get_session_entry(token)
         if entry is None:
             return None
@@ -630,6 +646,14 @@ class AuthManager:
             except (KeyError, Exception):
                 pass
             return None
+        # Client-binding check: only when the session was created with a
+        # user_agent_hash AND the caller supplies a user_agent for comparison.
+        stored_ua = entry.get("user_agent_hash")
+        if stored_ua and user_agent:
+            if not secrets.compare_digest(
+                stored_ua, hashlib.sha256(user_agent.encode()).hexdigest()
+            ):
+                return None
         return entry.get("user_id", "") or ""
 
     def revoke_session(self, token: str) -> None:

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -344,7 +344,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # Check session cookie
         token = request.cookies.get("taos_session")
         if token:
-            user_id = auth_mgr.validate_session(token)
+            user_agent = request.headers.get("user-agent", "")
+            user_id = auth_mgr.validate_session(token, user_agent=user_agent)
             if user_id is not None:
                 user_record = auth_mgr.get_user_by_id(user_id)
                 request.state.user_id = user_id

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import threading
 import time
 from collections import OrderedDict
@@ -204,7 +205,7 @@ button[type="submit"]:disabled { opacity: 0.4; cursor: not-allowed; }
 
 
 def _login_page(error: str = "", multi_user: bool = False, next_url: str = "") -> str:
-    err = f'<p class="error" role="alert">{error}</p>' if error else ""
+    err = f'<p class="error" role="alert">{html.escape(error)}</p>' if error else ""
     pwd_placeholder = "Password or invite code" if multi_user else "Password"
     autologin_default = "" if multi_user else "checked"
     username_field = '''
@@ -213,7 +214,7 @@ def _login_page(error: str = "", multi_user: bool = False, next_url: str = "") -
           <input type="text" name="username" autocomplete="username" autofocus required>
         </label>
         ''' if multi_user else ""
-    next_field = f'<input type="hidden" name="next" value="{next_url}">' if next_url else ""
+    next_field = f'<input type="hidden" name="next" value="{html.escape(next_url)}">' if next_url else ""
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -248,7 +249,7 @@ def _login_page(error: str = "", multi_user: bool = False, next_url: str = "") -
 
 
 def _setup_page(error: str = "") -> str:
-    err = f'<p class="error" role="alert">{error}</p>' if error else ""
+    err = f'<p class="error" role="alert">{html.escape(error)}</p>' if error else ""
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -369,6 +370,7 @@ async def login(request: Request):
     """
     auth_mgr = request.app.state.auth
     client_ip = request.client.host if request.client else "unknown"
+    user_agent = request.headers.get("user-agent", "")
 
     content_type = request.headers.get("content-type", "")
 
@@ -407,7 +409,7 @@ async def login(request: Request):
 
         # Pending user: invite code accepted as password
         if user_record and user_record.get("pending_invite"):
-            token = auth_mgr.create_session(user_id=user_record["id"], long_lived=long_lived)
+            token = auth_mgr.create_session(user_id=user_record["id"], long_lived=long_lived, user_agent=user_agent)
             resp = JSONResponse({
                 "ok": True,
                 "needs_onboarding": True,
@@ -425,7 +427,7 @@ async def login(request: Request):
         user_id = user_record["id"] if user_record else ""
         if user_record:
             auth_mgr.update_last_login(user_id)
-        token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived)
+        token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived, user_agent=user_agent)
         pub = auth_mgr._public_user(user_record) if user_record else auth_mgr.get_user()
         resp = JSONResponse({"ok": True, "user": pub})
         if long_lived:
@@ -460,12 +462,12 @@ async def login(request: Request):
         # Pending user — create their session, then send to /desktop. The
         # SPA's LoginGate will see needs_onboarding via /auth/status and
         # render the invite-completion screen.
-        token = auth_mgr.create_session(user_id=user_record["id"], long_lived=long_lived)
+        token = auth_mgr.create_session(user_id=user_record["id"], long_lived=long_lived, user_agent=user_agent)
     else:
         user_id = user_record["id"] if user_record else ""
         if user_record:
             auth_mgr.update_last_login(user_id)
-        token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived)
+        token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived, user_agent=user_agent)
 
     destination = next_url or "/desktop"
     response = RedirectResponse(destination, status_code=303)
@@ -516,6 +518,7 @@ async def auth_setup(request: Request):
     auth_mgr = request.app.state.auth
 
     content_type = request.headers.get("content-type", "")
+    user_agent = request.headers.get("user-agent", "")
     if "application/json" in content_type:
         try:
             body = await request.json()
@@ -540,7 +543,7 @@ async def auth_setup(request: Request):
         record = auth_mgr.find_user(username)
         user_id = record["id"] if record else ""
         auth_mgr.update_last_login(user_id)
-        token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived)
+        token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived, user_agent=user_agent)
         resp = JSONResponse({"ok": True, "user": user})
         if long_lived:
             resp.set_cookie(
@@ -573,7 +576,7 @@ async def auth_setup(request: Request):
     record = auth_mgr.find_user(username)
     user_id = record["id"] if record else ""
     auth_mgr.update_last_login(user_id)
-    token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived)
+    token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived, user_agent=user_agent)
     response = RedirectResponse("/desktop", status_code=303)
     if long_lived:
         response.set_cookie(
@@ -593,6 +596,7 @@ async def complete_invite(request: Request):
     """
     auth_mgr = request.app.state.auth
     client_ip = request.client.host if request.client else "unknown"
+    user_agent = request.headers.get("user-agent", "")
 
     if _complete_limiter.is_limited(client_ip):
         return JSONResponse(
@@ -629,7 +633,7 @@ async def complete_invite(request: Request):
     auth_mgr.update_last_login(user_id)
     # Revoke any existing invite-phase sessions and create a fresh one
     auth_mgr.revoke_user_sessions(user_id)
-    token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived)
+    token = auth_mgr.create_session(user_id=user_id, long_lived=long_lived, user_agent=user_agent)
     resp = JSONResponse({"ok": True, "user": user})
     if long_lived:
         resp.set_cookie(


### PR DESCRIPTION
## Summary

Addresses remaining items from #646 that weren't yet implemented:

1. **XSS hardening** — Add `html.escape()` to `error` and `next_url` parameters in `_login_page` and `_setup_page` template functions (defense-in-depth; route handlers already sanitize these inputs)
2. **Session race protection** — Add `threading.Lock` to `_PersistentSessions` to prevent lost updates from concurrent read-modify-write cycles on the sessions JSON file
3. **User-Agent binding** — Sessions now store a SHA-256 hash of the User-Agent header; `validate_session()` checks it when both the session has a hash and the caller supplies a User-Agent. Backward compatible: sessions without a hash (legacy) and calls without User-Agent (internal lookups) skip the check

## Changes

- `tinyagentos/auth.py`: Lock on `_PersistentSessions`, UA hash in `create_session`/`validate_session`
- `tinyagentos/routes/auth.py`: `html.escape()` in templates, pass `user_agent` to all `create_session()` calls
- `tinyagentos/auth_middleware.py`: Pass `user_agent` to `validate_session()`
- `tests/test_auth.py`: 9 new tests (TestXSSHardening, TestPersistentSessionsLock, TestSessionClientBinding)

## Test results

```
127 passed in tests/test_auth.py tests/test_auth_middleware.py tests/test_auth_email_login.py
```

Fixes #646