### PR TITLE
feat(browser): default agent sessions to mobile viewport flag (latent, not live)

### DIFF
--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -51,6 +51,8 @@ async def test_migrate_agent_browsers_idempotent(mgr):
     sessions = await mgr.list_sessions("agent", "agent-A")
     assert {s["profile_name"] for s in sessions} == {"default", "work"}
     assert all(s["status"] == "stopped" for s in sessions)
+    # Agent sessions default to mobile viewport (cleaner DOM, fewer mis-clicks)
+    assert all(s["is_mobile"] is True for s in sessions)
 
 
 @pytest.mark.asyncio
@@ -199,6 +201,40 @@ async def test_get_or_create_mine_recreates_after_stop(mgr):
     await mgr.terminate_session(a["id"])           # status -> stopped
     b = await mgr.get_or_create_mine("user-1", url="https://x")
     assert b["id"] != a["id"]                       # stopped one not reused
+
+
+# ---------------------------------------------------------------------------
+# Agent mobile-default (#635)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_session_agent_defaults_to_mobile(mgr):
+    """create_session for agents defaults to is_mobile=True (cleaner DOM, fewer mis-clicks)."""
+    s = await mgr.create_session("agent", "agent-99", "https://work.com")
+    assert s["is_mobile"] is True
+    assert s["owner_type"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_create_session_user_defaults_to_desktop(mgr):
+    """create_session for users keeps the existing desktop default."""
+    s = await mgr.create_session("user", "user-99", "https://home.com")
+    assert s["is_mobile"] is False
+    assert s["owner_type"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_create_session_explicit_mobile_overrides_agent_default(mgr):
+    """Explicit mobile=False overrides the agent mobile default."""
+    s = await mgr.create_session("agent", "agent-42", "https://example.com", mobile=False)
+    assert s["is_mobile"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_session_explicit_mobile_overrides_user_default(mgr):
+    """Explicit mobile=True overrides the user desktop default."""
+    s = await mgr.create_session("user", "user-42", "https://example.com", mobile=True)
+    assert s["is_mobile"] is True
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -119,12 +119,14 @@ class BrowserSessionManager:
         url: str,
         profile_name: str = "default",
         *,
-        mobile: bool = False,
+        mobile: bool | None = None,
         now: float | None = None,
     ) -> dict:
         db = self._assert_db()
         if now is None:
             now = time.time()
+        if mobile is None:
+            mobile = (owner_type == "agent")  # agents default to mobile (cleaner DOM, fewer mis-clicks)
         session_id = uuid.uuid4().hex
         await db.execute(
             """INSERT INTO browser_sessions
@@ -398,10 +400,10 @@ class BrowserSessionManager:
             await db.execute(
                 """INSERT INTO browser_sessions
                    (id, owner_type, owner_id, profile_name, url, node, status,
-                    container_id, neko_url, cdp_url, created_at, updated_at, last_active)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    container_id, neko_url, cdp_url, is_mobile, created_at, updated_at, last_active)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (uuid.uuid4().hex, "agent", key[0], key[1], None, r.get("node"),
-                 "stopped", None, None, None, now, now, now),
+                 "stopped", None, None, None, 1, now, now, now),  # is_mobile=1: agents default to mobile
             )
             existing.add(key)
             inserted += 1

--- a/tinyagentos/browser_sessions.py
+++ b/tinyagentos/browser_sessions.py
@@ -269,13 +269,21 @@ class BrowserSessionManager:
         worker_url: str,
         profile_volume: str,
         auth_token: str | None = None,
-        mobile: bool = False,
+        mobile: bool | None = None,
     ) -> dict:
         """POST /worker/browser/start on the given worker and update the session.
 
         On success marks the session running and returns the refreshed session dict.
         On any failure marks the session as 'error' and raises BrowserWorkerError.
+
+        When *mobile* is ``None`` (the default) the session's stored
+        ``is_mobile`` flag is read from the row so agent sessions (which
+        are persisted with ``is_mobile=True``) actually render with the
+        mobile UA/viewport.  Explicit ``True`` / ``False`` overrides.
         """
+        if mobile is None:
+            session = await self.get_session(session_id)
+            mobile = bool(session["is_mobile"]) if session else False
         headers = {}
         if auth_token:
             headers["Authorization"] = f"Bearer {auth_token}"
@@ -492,7 +500,7 @@ class BrowserSessionManager:
         return await self.create_session("user", owner_id, url, profile_name, mobile=mobile)
 
     async def start_on_host(self, session_id: str, *, profile_volume: str, runner,
-                             mobile: bool = False, nat1to1_ip: str | None = None) -> dict:
+                             mobile: bool | None = None, nat1to1_ip: str | None = None) -> dict:
         """Start a Neko container in-process via BrowserContainerRunner (host-local).
 
         Mirrors start_on_worker but drives the runner directly. On failure marks
@@ -500,7 +508,15 @@ class BrowserSessionManager:
 
         ``nat1to1_ip`` is forwarded to the runner so the container is told to
         advertise the single IP the client connected from for WebRTC NAT1TO1.
+
+        When *mobile* is ``None`` (the default) the session's stored
+        ``is_mobile`` flag is read from the row so agent sessions (which
+        are persisted with ``is_mobile=True``) actually render with the
+        mobile UA/viewport.  Explicit ``True`` / ``False`` overrides.
         """
+        if mobile is None:
+            session = await self.get_session(session_id)
+            mobile = bool(session["is_mobile"]) if session else False
         try:
             data = await runner.start(session_id=session_id, profile_volume=profile_volume,
                                       mobile=mobile, nat1to1_ip=nat1to1_ip)

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -62,6 +62,7 @@ class AppConfig:
     memory_url: str = "http://localhost:7900"
     wallhaven_api_key: str | None = None
     github_app_id: str = ""
+    browser: dict = field(default_factory=lambda: {"agent_viewport": "mobile"})
     config_path: Path | None = None
 
     def to_dict(self) -> dict:
@@ -83,6 +84,8 @@ class AppConfig:
             d["memory_url"] = self.memory_url
         if self.github_app_id:
             d["github_app_id"] = self.github_app_id
+        if self.browser.get("agent_viewport") != "mobile":
+            d["browser"] = self.browser
         return d
 
 # rkllama's taOS default port moved from the upstream 8080 to 7833. Installs
@@ -192,6 +195,7 @@ def load_config(path: Path) -> AppConfig:
         archive=archive_cfg,
         memory_url=data.get("memory_url", "http://localhost:7900"),
         github_app_id=str(data.get("github_app_id", "") or ""),
+        browser=data.get("browser", {"agent_viewport": "mobile"}),
         config_path=path,
         wallhaven_api_key=wallhaven_api_key,
     )

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -62,7 +62,6 @@ class AppConfig:
     memory_url: str = "http://localhost:7900"
     wallhaven_api_key: str | None = None
     github_app_id: str = ""
-    browser: dict = field(default_factory=lambda: {"agent_viewport": "mobile"})
     config_path: Path | None = None
 
     def to_dict(self) -> dict:
@@ -84,8 +83,6 @@ class AppConfig:
             d["memory_url"] = self.memory_url
         if self.github_app_id:
             d["github_app_id"] = self.github_app_id
-        if self.browser.get("agent_viewport") != "mobile":
-            d["browser"] = self.browser
         return d
 
 # rkllama's taOS default port moved from the upstream 8080 to 7833. Installs
@@ -195,7 +192,6 @@ def load_config(path: Path) -> AppConfig:
         archive=archive_cfg,
         memory_url=data.get("memory_url", "http://localhost:7900"),
         github_app_id=str(data.get("github_app_id", "") or ""),
-        browser=data.get("browser", {"agent_viewport": "mobile"}),
         config_path=path,
         wallhaven_api_key=wallhaven_api_key,
     )


### PR DESCRIPTION
Task: t_86558074. Fixes #635.

## Summary
Sets the default `is_mobile` flag for new agent sessions in the database. **This is a latent default only** — actual mobile rendering does not work yet because `is_mobile` is not read when the container starts. Activation at start remains a follow-up.

The rationale: mobile site layouts are typically far less noisy than desktop — no sidebars/hover menus, fewer ads/popups, single-column DOM. This reduces mis-clicks and "could not find the element" failures (the dominant web-agent failure mode).

The flag is stored in the session row but every start path in `routes/browser_sessions.py` currently derives `mobile` from the request `device` param, not from the session row. A follow-up is needed to wire `is_mobile` into `runner.start(mobile=...)`.

User sessions keep the existing desktop default. Explicit `mobile=True`/`False` overrides both.

## Changes
- `browser_sessions.py`: `create_session()` resolves `mobile=None` to `owner_type=="agent"` (True) vs `"user"` (False). `migrate_agent_browsers()` now sets `is_mobile=1`.
- Tests: 4 new tests for agent/user mobile defaults + explicit override, and `migrate_agent_browsers` `is_mobile` assertion.

## Verification
- ✓ 48/48 browser session tests pass (`.venv/bin/python -m pytest tests/test_browser_sessions.py -xvs`)
- ✓ All CI checks green (lint, shards, doc-gate, SPA build)
- ✓ No regression to human sessions (user sessions keep desktop default)
