### PR TITLE
fix(notifications): persist archive to backend so it survives reload

### DIFF
--- a/desktop/src/lib/server-notifications.test.ts
+++ b/desktop/src/lib/server-notifications.test.ts
@@ -3,6 +3,7 @@ import {
   fetchServerNotifications,
   markServerRead,
   markAllServerRead,
+  archiveServerNotification,
   sourceToTarget,
 } from "./server-notifications";
 
@@ -179,6 +180,27 @@ describe("server-notifications", () => {
       const [url, init] = fetchMock.mock.calls[0];
       expect(url).toBe("/api/notifications/read-all");
       expect(init?.method).toBe("POST");
+    });
+  });
+
+  describe("archiveServerNotification", () => {
+    it("POSTs the numeric id for srv- ids to the archive endpoint", async () => {
+      fetchMock.mockResolvedValue({ ok: true });
+      await archiveServerNotification("srv-42");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/notifications/42/archive");
+      expect(init?.method).toBe("POST");
+    });
+
+    it("is a no-op for client (notif-) ids", async () => {
+      await archiveServerNotification("notif-3");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("swallows fetch failures", async () => {
+      fetchMock.mockRejectedValue(new Error("boom"));
+      await expect(archiveServerNotification("srv-1")).resolves.toBeUndefined();
     });
   });
 });

--- a/desktop/src/lib/server-notifications.ts
+++ b/desktop/src/lib/server-notifications.ts
@@ -179,6 +179,19 @@ export async function markServerRead(id: string): Promise<void> {
   }
 }
 
+/** Archive a single server-origin notification on the backend so it persists
+ *  across reloads and appears under History instead of the active Inbox.
+ *  No-op for client ids (notif-N) — those have no server row. */
+export async function archiveServerNotification(id: string): Promise<void> {
+  const n = serverId(id);
+  if (n == null) return;
+  try {
+    await fetch(`/api/notifications/${n}/archive`, withCsrf({ method: "POST" }));
+  } catch {
+    // best-effort; the optimistic local update already happened
+  }
+}
+
 /** Mark all server-origin notifications read on the backend. */
 export async function markAllServerRead(): Promise<void> {
   try {

--- a/desktop/src/stores/notification-store.test.ts
+++ b/desktop/src/stores/notification-store.test.ts
@@ -1,5 +1,12 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useNotificationStore, type Notification } from "./notification-store";
+
+// Mock the backend archive call so the store's fire-and-forget fetch doesn't
+// leak into the test environment (the store calls it optimistically and best-
+// effort, never awaiting; here we verify the calls are made for srv-* ids).
+vi.mock("@/lib/server-notifications", () => ({
+  archiveServerNotification: vi.fn(),
+}));
 
 function srv(id: number, ts: number, read = false): Notification {
   return {
@@ -179,5 +186,59 @@ describe("dismiss archives instead of removing", () => {
 
     store.dismiss(id1);
     expect(store.unreadCount()).toBe(1);
+  });
+});
+
+describe("archive backend persistence", () => {
+  let archiveMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const mod = await import("@/lib/server-notifications");
+    archiveMock = mod.archiveServerNotification as ReturnType<typeof vi.fn>;
+    archiveMock.mockClear();
+    useNotificationStore.setState({ notifications: [], centreOpen: false });
+  });
+
+  it("calls archiveServerNotification for srv-* ids on dismiss", () => {
+    const store = useNotificationStore.getState();
+    store.mergeServerNotifications([srv(1, 100)]);
+
+    store.dismiss("srv-1");
+
+    expect(archiveMock).toHaveBeenCalledTimes(1);
+    expect(archiveMock).toHaveBeenCalledWith("srv-1");
+  });
+
+  it("calls archiveServerNotification for srv-* ids on archiveRead", () => {
+    const store = useNotificationStore.getState();
+    store.mergeServerNotifications([srv(1, 100)]);
+
+    store.archiveRead("srv-1");
+
+    expect(archiveMock).toHaveBeenCalledTimes(1);
+    expect(archiveMock).toHaveBeenCalledWith("srv-1");
+  });
+
+  it("calls archiveServerNotification for each srv-* id on clearAll", () => {
+    const store = useNotificationStore.getState();
+    // Unique ids to avoid leaking into module-scoped dismissedServerIds from
+    // earlier tests in this file.
+    store.mergeServerNotifications([srv(8001, 100), srv(8002, 200)]);
+    store.addNotification({ source: "system", title: "local", body: "b", level: "info" });
+
+    store.clearAll();
+
+    expect(archiveMock).toHaveBeenCalledTimes(2);
+    expect(archiveMock).toHaveBeenCalledWith("srv-8001");
+    expect(archiveMock).toHaveBeenCalledWith("srv-8002");
+  });
+
+  it("does NOT call archiveServerNotification for client-origin (notif-N) ids", () => {
+    const store = useNotificationStore.getState();
+    const id = store.addNotification({ source: "system", title: "local", body: "b", level: "info" });
+
+    store.dismiss(id);
+
+    expect(archiveMock).not.toHaveBeenCalled();
   });
 });

--- a/desktop/src/stores/notification-store.ts
+++ b/desktop/src/stores/notification-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { archiveServerNotification } from "@/lib/server-notifications";
 
 export interface Notification {
   id: string;
@@ -95,7 +96,10 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
   },
 
   dismiss(id) {
-    if (id.startsWith("srv-")) dismissedServerIds.add(id);
+    if (id.startsWith("srv-")) {
+      dismissedServerIds.add(id);
+      void archiveServerNotification(id);
+    }
     set((s) => ({
       notifications: s.notifications.map((n) =>
         n.id === id ? { ...n, archived: true } : n,
@@ -107,7 +111,10 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
     // Resolving a notification (e.g. answering an agent access-request) both
     // reads and archives it: it leaves the active Inbox and lands in History
     // rather than being marked read in place or silently removed (#62).
-    if (id.startsWith("srv-")) dismissedServerIds.add(id);
+    if (id.startsWith("srv-")) {
+      dismissedServerIds.add(id);
+      void archiveServerNotification(id);
+    }
     set((s) => ({
       notifications: s.notifications.map((n) =>
         n.id === id ? { ...n, archived: true, read: true } : n,
@@ -118,7 +125,10 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
   clearAll() {
     set((s) => {
       for (const n of s.notifications) {
-        if (n.id.startsWith("srv-")) dismissedServerIds.add(n.id);
+        if (n.id.startsWith("srv-")) {
+          dismissedServerIds.add(n.id);
+          void archiveServerNotification(n.id);
+        }
       }
       return {
         notifications: s.notifications.map((n) => ({ ...n, archived: true })),


### PR DESCRIPTION
## Summary

Wire the client's notification archive actions (`dismiss`, `archiveRead`, `clearAll`) to call the existing backend endpoint `POST /api/notifications/{id}/archive` for server-origin (`srv-*`) notifications.

## Problem

Archiving or dismissing a server-origin notification in the desktop PWA only set a local `archived: true` flag and added the id to a module-scoped `dismissedServerIds` Set. Neither persisted across a reload, so archived notifications reappeared in the active inbox.

## Root Cause

The client never called `POST /api/notifications/{id}/archive`. The backend endpoint already existed and was fully tested (`test_notification_api_archive`).

## Fix

1. **`server-notifications.ts`** — Added `archiveServerNotification(id)` following the established `markServerRead` pattern. Calls `POST /api/notifications/{n}/archive` with CSRF header, best-effort (swallows failures).

2. **`notification-store.ts`** — `dismiss()`, `archiveRead()`, and `clearAll()` now call `archiveServerNotification()` for `srv-*` ids. Client-origin (`notif-N`) notifications remain local-only — no server row to persist.

## Tests

- **`server-notifications.test.ts`** — 3 new tests for `archiveServerNotification`: POSTs the correct endpoint, no-op for client ids, swallows fetch failures
- **`notification-store.test.ts`** — 4 new tests verifying the mock is called for srv-* ids on dismiss/archiveRead/clearAll, and NOT called for client-origin ids
- All 53 notification-related tests pass (store, lib, centre, toast)

## Scope

- **Not affected:** Client-origin notifications (`notif-N`), which remain ephemeral
- **Not affected:** The `dismissedServerIds` Set — it still prevents re-adding dismissed items mid-session from SSE polls

Task: t_b2a6a624. Fixes #1916.