### PR TITLE
feat(github): add GitHub App installation flow (C1)

### DIFF
--- a/tests/test_routes_github.py
+++ b/tests/test_routes_github.py
@@ -331,14 +331,12 @@ async def test_repo_upstream_error_returns_500():
 def _build_app_with_app_config(
     token: str | None = None,
     http_client=None,
-    gh_cli_token: str | None = None,
-    install_token: str | None = "ghs_app-token",
 ):
     """Build a minimal FastAPI app with mock GitHub App configuration.
 
-    - PAT is set via `token` (None = no PAT)
-    - gh CLI subprocess returns `gh_cli_token` (None = fails)
-    - App installation token returns `install_token` (None = fails)
+    - PAT is set via ``token`` (None = no PAT)
+    - Callers should mock ``create_subprocess_exec`` and
+      ``get_installation_token`` directly for gh CLI / App token behaviour
     """
     app = FastAPI()
     app.include_router(github_router)
@@ -381,7 +379,6 @@ async def test_starred_uses_gh_cli_when_app_configured_no_pat():
     app = _build_app_with_app_config(
         token=None,  # No PAT
         http_client=http_client,
-        gh_cli_token="gh-cli-token",
     )
 
     async def _fake_subprocess(*args, **kwargs):
@@ -424,7 +421,6 @@ async def test_notifications_use_gh_cli_when_app_configured_no_pat():
     app = _build_app_with_app_config(
         token=None,
         http_client=http_client,
-        gh_cli_token="gh-cli-token",
     )
 
     async def _fake_subprocess(*args, **kwargs):
@@ -458,7 +454,6 @@ async def test_auth_status_false_when_only_app_token_available():
     app = _build_app_with_app_config(
         token=None,  # No PAT
         http_client=http_client,
-        gh_cli_token=None,  # gh CLI fails
     )
 
     transport = ASGITransport(app=app)
@@ -501,7 +496,6 @@ async def test_repo_endpoint_still_uses_app_token():
     app = _build_app_with_app_config(
         token=None,  # No PAT
         http_client=http_client,
-        gh_cli_token=None,  # gh CLI not available
     )
 
     transport = ASGITransport(app=app)

--- a/tests/test_routes_github.py
+++ b/tests/test_routes_github.py
@@ -322,3 +322,204 @@ async def test_repo_upstream_error_returns_500():
     assert resp.status_code == 500
     data = resp.json()
     assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# User-scoped token resolution: App token must NOT serve user endpoints
+# ---------------------------------------------------------------------------
+
+def _build_app_with_app_config(
+    token: str | None = None,
+    http_client=None,
+    gh_cli_token: str | None = None,
+    install_token: str | None = "ghs_app-token",
+):
+    """Build a minimal FastAPI app with mock GitHub App configuration.
+
+    - PAT is set via `token` (None = no PAT)
+    - gh CLI subprocess returns `gh_cli_token` (None = fails)
+    - App installation token returns `install_token` (None = fails)
+    """
+    app = FastAPI()
+    app.include_router(github_router)
+
+    # SecretsStore (PAT)
+    mock_secrets = MagicMock()
+    if token:
+        mock_secrets.get = AsyncMock(return_value={"value": token})
+    else:
+        mock_secrets.get = AsyncMock(return_value=None)
+    app.state.secrets = mock_secrets
+
+    # App config
+    mock_config = MagicMock()
+    mock_config.github_app_id = "123456"
+    mock_config.github_app_private_key = "fake-private-key"
+    app.state.config = mock_config
+
+    # App installations store
+    mock_installs = MagicMock()
+    mock_installs.list_all = MagicMock(return_value=[{"installation_id": 42}])
+    app.state.github_app_installations = mock_installs
+
+    app.state.http_client = http_client or MagicMock()
+    return app
+
+
+@pytest.mark.asyncio
+async def test_starred_uses_gh_cli_when_app_configured_no_pat():
+    """When App is configured but no PAT, /starred (user-scoped) skips the
+    App token and falls through to gh CLI."""
+    starred_data = [{
+        "name": "repo1", "owner": {"login": "alice"},
+        "full_name": "alice/repo1", "description": "Repo 1",
+        "stargazers_count": 10, "language": "Python",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "html_url": "https://github.com/alice/repo1",
+    }]
+    http_client = _make_http_client(_make_response(starred_data))
+    app = _build_app_with_app_config(
+        token=None,  # No PAT
+        http_client=http_client,
+        gh_cli_token="gh-cli-token",
+    )
+
+    async def _fake_subprocess(*args, **kwargs):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"gh-cli-token", b""))
+        return proc
+
+    transport = ASGITransport(app=app)
+    with patch(
+        "tinyagentos.routes.github.asyncio.create_subprocess_exec",
+        side_effect=_fake_subprocess,
+    ):
+        # Also ensure get_installation_token is NOT called (user-scoped skips it)
+        with patch(
+            "tinyagentos.github_app.get_installation_token",
+        ) as mock_mint:
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as c:
+                resp = await c.get("/api/github/starred?page=1")
+
+    assert resp.status_code == 200
+    # App token minting must NOT have been called for a user-scoped endpoint
+    mock_mint.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_notifications_use_gh_cli_when_app_configured_no_pat():
+    """When App is configured but no PAT, /notifications (user-scoped) skips
+    the App token."""
+    notif_data = [{
+        "id": "1", "reason": "mention", "unread": True,
+        "updated_at": "2026-01-01T00:00:00Z",
+        "subject": {"type": "Issue", "title": "Bug",
+                     "url": "https://api.github.com/repos/owner/repo/issues/1"},
+        "repository": {"full_name": "owner/repo",
+                       "html_url": "https://github.com/owner/repo"},
+    }]
+    http_client = _make_http_client(_make_response(notif_data))
+    app = _build_app_with_app_config(
+        token=None,
+        http_client=http_client,
+        gh_cli_token="gh-cli-token",
+    )
+
+    async def _fake_subprocess(*args, **kwargs):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(b"gh-cli-token", b""))
+        return proc
+
+    transport = ASGITransport(app=app)
+    with patch(
+        "tinyagentos.routes.github.asyncio.create_subprocess_exec",
+        side_effect=_fake_subprocess,
+    ):
+        with patch(
+            "tinyagentos.github_app.get_installation_token",
+        ) as mock_mint:
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as c:
+                resp = await c.get("/api/github/notifications")
+
+    assert resp.status_code == 200
+    mock_mint.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auth_status_false_when_only_app_token_available():
+    """When only an App token is available (no PAT, no gh CLI),
+    /auth/status (user-scoped) returns authenticated=False."""
+    http_client = MagicMock()
+    http_client.get = AsyncMock(side_effect=Exception("should not be called"))
+    app = _build_app_with_app_config(
+        token=None,  # No PAT
+        http_client=http_client,
+        gh_cli_token=None,  # gh CLI fails
+    )
+
+    transport = ASGITransport(app=app)
+    with patch(
+        "tinyagentos.routes.github.asyncio.create_subprocess_exec",
+        side_effect=FileNotFoundError,  # gh CLI not installed
+    ):
+        with patch(
+            "tinyagentos.github_app.get_installation_token",
+        ) as mock_mint:
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as c:
+                resp = await c.get("/api/github/auth/status")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["authenticated"] is False
+    # App token minting must NOT have been called
+    mock_mint.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repo_endpoint_still_uses_app_token():
+    """When App is configured but no PAT, repo-scoped endpoints (/repo/...)
+    SHOULD use the App installation token (not user_scoped)."""
+    meta_data = {
+        "name": "myrepo", "owner": {"login": "bob"},
+        "description": "My repo", "stargazers_count": 100,
+        "forks_count": 5, "language": "Go",
+        "license": {"name": "MIT"}, "topics": ["tool"],
+        "updated_at": "2026-02-01T00:00:00Z",
+    }
+    readme_resp = MagicMock()
+    readme_resp.status_code = 200
+    readme_resp.text = "# MyRepo"
+    readme_resp.raise_for_status = MagicMock()
+
+    http_client = _make_http_client(_make_response(meta_data), readme_resp)
+    app = _build_app_with_app_config(
+        token=None,  # No PAT
+        http_client=http_client,
+        gh_cli_token=None,  # gh CLI not available
+    )
+
+    transport = ASGITransport(app=app)
+    with patch(
+        "tinyagentos.routes.github.asyncio.create_subprocess_exec",
+        side_effect=FileNotFoundError,
+    ):
+        # App token IS used for repo-scoped: mock it directly
+        with patch(
+            "tinyagentos.github_app.get_installation_token",
+            new_callable=AsyncMock,
+            return_value="ghs_app-install-token",
+        ):
+            async with AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as c:
+                resp = await c.get("/api/github/repo/bob/myrepo")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["name"] == "myrepo"

--- a/tinyagentos/routes/github.py
+++ b/tinyagentos/routes/github.py
@@ -35,7 +35,10 @@ router = APIRouter()
 # Token resolution helper
 # ---------------------------------------------------------------------------
 
-async def _get_token(request: Request) -> str | None:
+async def _get_token(
+    request: Request,
+    user_scoped: bool = False,
+) -> str | None:
     """Return a GitHub token or None.
 
     Resolution order:
@@ -43,6 +46,8 @@ async def _get_token(request: Request) -> str | None:
        identity takes precedence so personal repos and rate limits apply.
     2. GitHub App installation token (when github_app_id and key are configured)
        — fallback for repos accessible to the installed app.
+       **Skipped when ``user_scoped=True``** because installation tokens cannot
+       serve user-scoped endpoints (``/user/starred``, ``/notifications``, etc.).
     3. ``gh auth token`` subprocess fallback
     """
     # 1. Try SecretsStore PAT (user's own GitHub identity)
@@ -55,10 +60,11 @@ async def _get_token(request: Request) -> str | None:
         except Exception as exc:
             logger.warning("SecretsStore lookup for github_token failed: %s", exc)
 
-    # 2. Try GitHub App installation token (fallback)
-    token = await _get_app_installation_token(request)
-    if token:
-        return token
+    # 2. Try GitHub App installation token (fallback; skipped for user-scoped endpoints)
+    if not user_scoped:
+        token = await _get_app_installation_token(request)
+        if token:
+            return token
 
     # 3. Fallback: gh CLI
     try:
@@ -147,8 +153,8 @@ def _no_token_response() -> JSONResponse:
 
 @router.get("/api/github/auth/status")
 async def github_auth_status(request: Request):
-    """Return whether a GitHub token is available."""
-    token = await _get_token(request)
+    """Return whether a GitHub token is available for user-scoped API calls."""
+    token = await _get_token(request, user_scoped=True)
     if token:
         return {"authenticated": True, "source": "token"}
     return {"authenticated": False, "source": None}
@@ -161,7 +167,7 @@ async def github_auth_status(request: Request):
 @router.get("/api/github/starred")
 async def github_starred(request: Request, page: int = 1):
     """Return paginated starred repositories for the authenticated user."""
-    token = await _get_token(request)
+    token = await _get_token(request, user_scoped=True)
     if not token:
         return _no_token_response()
 
@@ -181,7 +187,7 @@ async def github_starred(request: Request, page: int = 1):
 @router.get("/api/github/notifications")
 async def github_notifications(request: Request):
     """Return unread notifications for the authenticated user."""
-    token = await _get_token(request)
+    token = await _get_token(request, user_scoped=True)
     if not token:
         return _no_token_response()
 


### PR DESCRIPTION
## Problem

taOS supports GitHub OAuth for agent identity, but there is no first-class GitHub App installation path. External repos and organization-level workflows need a cleaner integration than personal OAuth tokens.

## Implementation

- **Backend (tinyagentos/github_app.py):** Generates per-installation GitHub tokens via the App installation API. Handles JWT creation, token exchange, and permission scoping.
- **Store (tinyagentos/github_app_installations.py):** Persistent metadata for installed apps (installation_id, account name/avatar, repo list).
- **Routes:** POST /api/github/installations (start installation), DELETE /api/github/installations/:id (revoke), GET /api/github/installations/:id/repos (list repos).
- **Desktop UI (GitHubConnect.tsx):** New "GitHub App" section in Secrets page with install button, installations list with repo count, and uninstall.
- **Config:** github_app_id, github_app_private_key_path, github_app_webhook_secret — all optional, feature is inert when unconfigured.

## Token Resolution for User-Scoped Endpoints

The `_get_token()` helper in `tinyagentos/routes/github.py` was extended with a `user_scoped` parameter to prevent GitHub App installation tokens from being used on personal user endpoints. Installation tokens authenticate as the *App installation*, not as a *user* — endpoints like `/user/starred`, `/notifications`, and `/auth/status` require a user identity and return empty or misleading results when called with an installation token.

### Token preference order

Three sources are tried in order, but **step 2 is skipped for user-scoped endpoints**:

| Priority | Source | User-scoped | Repo-scoped |
|----------|--------|-------------|-------------|
| 1 | PAT from SecretsStore (user's own GitHub identity) | ✓ tried first | ✓ tried first |
| 2 | GitHub App installation token | ✗ **SKIPPED** | ✓ fallback |
| 3 | `gh auth token` subprocess | ✓ fallback | ✓ fallback |

If all sources are exhausted, the endpoint returns a 401 "No GitHub token available" response. For `/auth/status`, it returns `{"authenticated": false, "source": null}`.

### Affected endpoints

**User-scoped** — `_get_token(request, user_scoped=True)`. The App token gate is skipped; PAT is preferred, `gh` CLI is the fallback:
- `GET /api/github/auth/status` — accurately reports whether a personal token is available
- `GET /api/github/starred?page=N` — lists the user's personal starred repos
- `GET /api/github/notifications` — fetches the user's unread notifications

**Repo-scoped** — `_get_token(request)` (default, `user_scoped=False`). App token is used as a fallback when no PAT is configured:
- `GET /api/github/repo/{owner}/{name}` — repo metadata and README
- All other repo-scoped endpoints (backward-compatible, no behavioral change)

### Design rationale

1. **Correctness:** GitHub App installation tokens cannot access user-scoped GitHub API endpoints. Without this gate, user-scoped endpoints would silently return empty results or 401 errors when only an App token was available.
2. **Honest auth reporting:** `/auth/status` now returns `authenticated=false` when only an App token exists, so the UI can prompt the user to connect a personal account.
3. **Backward compatibility:** Repo-scoped endpoints continue to use App tokens as a fallback, so repos accessible to the App installation still work without a PAT.

## Bot-fix cycles

### Round 1 (7bb09e6a)
Addressed all 12 Kilo findings + CodeRabbit docstring coverage check:
- W1: Reversed token resolution order (github.py)
- W2: Removed dead /user API fetch (github_oauth.py)
- W3: DELETE removes local record after remote deletion
- S4-S12: Various improvements (private_key check, cache TTL, pagination, async save, content-type guard, etc.)

### Round 2 (cbb61eb7)
- **SPA build fix:** Added missing listAppInstallations/beginAppInstallation/deleteAppInstallation mocks to SecretsApp.test.tsx
- **CodeRabbit N1:** Simplified nested installs_store condition in github_oauth.py
- **CodeRabbit N2:** Added refreshInstallations to useEffect deps + window focus listener in GitHubConnect.tsx
- **Error handling:** Moved generate_jwt inside try blocks in get_installation_token and list_installations
- **Error handling:** Added AttributeError/TypeError to _load except clause in github_app_installations.py

## Testing

- Backend: 70/70 tests pass (64 original + 6 new route-level token resolution tests)
- Desktop: npm run build passes, 10/10 SecretsApp tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub auth fallback so user-scoped endpoints try personal credentials first and fall back to the GitHub CLI when unavailable.
  * User-scoped endpoints (auth status, starred, and notifications) no longer mint GitHub App installation tokens.
  * Auth status now correctly reports unauthenticated when neither personal tokens nor GitHub CLI credentials are available.
  * Repository-scoped endpoints continue using GitHub App installation tokens when personal authentication is missing.
* **Tests**
  * Added route-level coverage for these token-resolution and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
