### PR TITLE
feat(desktop): auto-reload SPA when new build is deployed

### DIFF
--- a/desktop/scripts/read-version.mjs
+++ b/desktop/scripts/read-version.mjs
@@ -20,7 +20,7 @@ function readPackageVersion() {
 
 function readBuildId() {
   // Include both the git short SHA (reproducible anchored identifier) and
-  // a nanosecond-resolution timestamp so every build — even back-to-back
+  // a high-resolution timestamp so every build — even back-to-back
   // builds on the same commit — produces a unique identifier.  The SPA
   // version-check poll relies on this to detect redeployed bundles.
   //
@@ -37,6 +37,10 @@ function readBuildId() {
   }
   const ms = Date.now().toString(36);
   const hr = process.hrtime.bigint().toString(36);
+  // Take the last 6 base-36 chars of the nanosecond counter — combined
+  // with the ms component this yields ~2.1B unique values per ms tick,
+  // which is plenty for sub-millisecond build differentiation while
+  // keeping the stamp compact.
   const stamp = `${ms}${hr.slice(-6)}`;
   return sha ? `${sha}.${stamp}` : stamp;
 }

--- a/desktop/scripts/read-version.mjs
+++ b/desktop/scripts/read-version.mjs
@@ -19,32 +19,33 @@ function readPackageVersion() {
 }
 
 function readBuildId() {
-  // Prefer the git short SHA so back-to-back builds on the same commit
-  // produce identical bundles. Fall back to an epoch-second timestamp
-  // when git isn't available (e.g. an sdist install).
+  // Include both the git short SHA (reproducible anchored identifier) and
+  // a nanosecond-resolution timestamp so every build — even back-to-back
+  // builds on the same commit — produces a unique identifier.  The SPA
+  // version-check poll relies on this to detect redeployed bundles.
+  //
+  // Format: {sha}.{timestamp}  (e.g. "a3bd632.lrx5f4m9abc")
+  // When git isn't available only the timestamp is emitted.
+  let sha = "";
   try {
-    const sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+    sha = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
       cwd: HERE,
       stdio: ["ignore", "pipe", "ignore"],
     }).toString().trim();
-    if (sha) return sha;
   } catch {
-    // git not available — fall through to timestamp
+    // git not available — no SHA component
   }
-  // Two distinct fields encoded in base36 so two builds within the same
-  // second still produce distinct ids (Date.now() is millisecond-resolution
-  // but high-res nanos disambiguate even sub-millisecond bursts).
   const ms = Date.now().toString(36);
   const hr = process.hrtime.bigint().toString(36);
-  return `${ms}-${hr.slice(-6)}`;
+  const stamp = `${ms}${hr.slice(-6)}`;
+  return sha ? `${sha}.${stamp}` : stamp;
 }
 
 // Service worker uses this string as its cache name (`taos-static-${VERSION}`).
-// If the string never changes between builds, the browser sees a byte-identical
-// SW on the next visit, never fires install/activate, never wipes the old
-// precache, and clients keep loading the previous bundle forever. Combining
-// the package version with the git SHA guarantees a fresh SW per build, so
-// stale-PWA recovery actually works after a controller upgrade.
+// Combining the package version with a unique build id (SHA + timestamp)
+// guarantees a fresh SW per build, so stale-PWA recovery actually works after
+// a controller upgrade and the SPA version-check poll detects redeployed
+// bundles even when the package version hasn't changed.
 export function readBackendVersion() {
   return `${readPackageVersion()}+${readBuildId()}`;
 }

--- a/desktop/src/components/AppShell.tsx
+++ b/desktop/src/components/AppShell.tsx
@@ -17,6 +17,7 @@ import { useEffect, type ReactNode } from "react";
 import { BackendStatusProvider } from "@/contexts/BackendStatusContext";
 import { BackendBanner } from "./BackendBanner";
 import { UpdateAvailableToast } from "./UpdateAvailableToast";
+import { SpaUpdateToast } from "./SpaUpdateToast";
 import { AppErrorBoundary } from "./AppErrorBoundary";
 import { registerServiceWorker } from "@/lib/sw-register";
 
@@ -32,6 +33,7 @@ export function AppShell({ children }: { children: ReactNode }) {
     <BackendStatusProvider>
       <BackendBanner />
       <UpdateAvailableToast buildVersion={BUILD_VERSION} />
+      <SpaUpdateToast />
       <AppErrorBoundary>{children}</AppErrorBoundary>
     </BackendStatusProvider>
   );

--- a/desktop/src/components/SpaUpdateToast.test.tsx
+++ b/desktop/src/components/SpaUpdateToast.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import { SpaUpdateToast } from "./SpaUpdateToast";
+
+const mockAddNotification = vi.fn();
+
+vi.mock("@/hooks/use-spa-version-check", () => ({
+  useSpaVersionCheck: vi.fn(),
+}));
+
+vi.mock("@/stores/notification-store", () => ({
+  useNotificationStore: (selector: (state: { addNotification: typeof mockAddNotification }) => unknown) =>
+    selector({ addNotification: mockAddNotification }),
+}));
+
+// Must import after mocks so the mocked module is used.
+import { useSpaVersionCheck } from "@/hooks/use-spa-version-check";
+
+describe("SpaUpdateToast", () => {
+  beforeEach(() => {
+    mockAddNotification.mockClear();
+    vi.mocked(useSpaVersionCheck).mockReturnValue({
+      hasNewBuild: false,
+      deployedVersion: null,
+    });
+  });
+
+  it("renders nothing", () => {
+    const { container } = render(<SpaUpdateToast />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("does not fire when hasNewBuild is false", () => {
+    render(<SpaUpdateToast />);
+    expect(mockAddNotification).not.toHaveBeenCalled();
+  });
+
+  it("fires notification when a new build is available", () => {
+    vi.mocked(useSpaVersionCheck).mockReturnValue({
+      hasNewBuild: true,
+      deployedVersion: "1.0.0+new.new.new",
+    });
+
+    render(<SpaUpdateToast />);
+    expect(mockAddNotification).toHaveBeenCalledTimes(1);
+    expect(mockAddNotification).toHaveBeenCalledWith({
+      source: "system",
+      level: "info",
+      title: "New taOS build available",
+      body: expect.stringContaining("Reload to update"),
+    });
+  });
+
+  it("does not re-fire for the same deployed version on re-render", () => {
+    vi.mocked(useSpaVersionCheck).mockReturnValue({
+      hasNewBuild: true,
+      deployedVersion: "1.0.0+new.new.new",
+    });
+
+    const { rerender } = render(<SpaUpdateToast />);
+    expect(mockAddNotification).toHaveBeenCalledTimes(1);
+
+    rerender(<SpaUpdateToast />);
+    expect(mockAddNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again when deployed version changes again", () => {
+    vi.mocked(useSpaVersionCheck).mockReturnValue({
+      hasNewBuild: true,
+      deployedVersion: "1.0.0+first.first",
+    });
+
+    render(<SpaUpdateToast />);
+    expect(mockAddNotification).toHaveBeenCalledTimes(1);
+
+    // New deployed version.
+    vi.mocked(useSpaVersionCheck).mockReturnValue({
+      hasNewBuild: true,
+      deployedVersion: "1.0.0+second.second",
+    });
+
+    render(<SpaUpdateToast />);
+    expect(mockAddNotification).toHaveBeenCalledTimes(2);
+  });
+});

--- a/desktop/src/components/SpaUpdateToast.tsx
+++ b/desktop/src/components/SpaUpdateToast.tsx
@@ -1,0 +1,42 @@
+/**
+ * Shows a transient notification when the deployed SPA version differs
+ * from the one currently running — i.e. a new build has been deployed
+ * and a page reload will pick it up.
+ *
+ * Distinct from UpdateAvailableToast which watches for backend-version
+ * bumps via the X-Taos-Version response header.  This component detects
+ * SPA-only redeploys (settings-triggered rebuilds, UI hotfixes) where
+ * the backend package version hasn't changed.
+ *
+ * Silent in dev builds.  Fires at most once per unique deployed version.
+ * The user dismisses the toast; a reload is not forced automatically to
+ * avoid disrupting active sessions (mid-typing, etc.).
+ */
+import { useEffect, useRef } from "react";
+import { useSpaVersionCheck } from "@/hooks/use-spa-version-check";
+import { useNotificationStore } from "@/stores/notification-store";
+
+declare const __TAOS_VERSION__: string | undefined;
+const BUILD_VERSION = typeof __TAOS_VERSION__ === "string" ? __TAOS_VERSION__ : "dev";
+
+export function SpaUpdateToast() {
+  const { hasNewBuild, deployedVersion } = useSpaVersionCheck();
+  const addNotification = useNotificationStore((s) => s.addNotification);
+  const firedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!hasNewBuild) return;
+    if (!deployedVersion) return;
+    if (firedFor.current === deployedVersion) return;
+    firedFor.current = deployedVersion;
+
+    addNotification({
+      source: "system",
+      level: "info",
+      title: "New taOS build available",
+      body: `Reload to update from ${BUILD_VERSION} to ${deployedVersion}.`,
+    });
+  }, [hasNewBuild, deployedVersion, addNotification]);
+
+  return null;
+}

--- a/desktop/src/hooks/use-spa-version-check.test.ts
+++ b/desktop/src/hooks/use-spa-version-check.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Stub __TAOS_VERSION__ before importing the hook.
+vi.stubGlobal("__TAOS_VERSION__", "1.0.0+abc123.def456");
+
+import { useSpaVersionCheck } from "./use-spa-version-check";
+
+function mockFetch(status: number, body: unknown) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+/**
+ * Flush microtasks + a zero-length timer tick so the initial check() call
+ * (which is async) settles without running the 60 s interval forever.
+ */
+async function flushInitialCheck() {
+  await act(() => vi.advanceTimersByTimeAsync(0));
+}
+
+describe("useSpaVersionCheck", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("__TAOS_VERSION__", "1.0.0+abc123.def456");
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns hasNewBuild=false when version.json matches build version", async () => {
+    mockFetch(200, { version: "1.0.0+abc123.def456" });
+
+    const { result } = renderHook(() => useSpaVersionCheck());
+    await flushInitialCheck();
+
+    expect(result.current.hasNewBuild).toBe(false);
+    expect(result.current.deployedVersion).toBe("1.0.0+abc123.def456");
+  });
+
+  it("returns hasNewBuild=true when deployed version differs", async () => {
+    mockFetch(200, { version: "1.0.0+xyz789.aaa111" });
+
+    const { result } = renderHook(() => useSpaVersionCheck());
+    await flushInitialCheck();
+
+    expect(result.current.hasNewBuild).toBe(true);
+    expect(result.current.deployedVersion).toBe("1.0.0+xyz789.aaa111");
+  });
+
+  it("stays silent (hasNewBuild=false) for dev build versions", async () => {
+    vi.stubGlobal("__TAOS_VERSION__", "dev");
+    mockFetch(200, { version: "1.0.0+xyz789.aaa111" });
+
+    const { result } = renderHook(() => useSpaVersionCheck());
+    await flushInitialCheck();
+
+    expect(result.current.hasNewBuild).toBe(false);
+  });
+
+  it("polls on visibilitychange to visible", async () => {
+    mockFetch(200, { version: "1.0.0+abc123.def456" });
+
+    const { result } = renderHook(() => useSpaVersionCheck());
+    await flushInitialCheck();
+    expect(result.current.deployedVersion).toBe("1.0.0+abc123.def456");
+
+    // Simulate hidden → visible transition.
+    vi.clearAllMocks();
+    mockFetch(200, { version: "1.0.0+new.new.new" });
+
+    Object.defineProperty(document, "visibilityState", {
+      value: "hidden",
+      writable: true,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      writable: true,
+      configurable: true,
+    });
+    await act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushInitialCheck();
+
+    expect(result.current.deployedVersion).toBe("1.0.0+new.new.new");
+    expect(result.current.hasNewBuild).toBe(true);
+  });
+
+  it("handles fetch errors gracefully", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network"));
+
+    const { result } = renderHook(() => useSpaVersionCheck());
+    await flushInitialCheck();
+
+    expect(result.current.hasNewBuild).toBe(false);
+    expect(result.current.deployedVersion).toBeNull();
+  });
+
+  it("handles non-ok response gracefully", async () => {
+    mockFetch(404, {});
+
+    const { result } = renderHook(() => useSpaVersionCheck());
+    await flushInitialCheck();
+
+    expect(result.current.hasNewBuild).toBe(false);
+  });
+});

--- a/desktop/src/hooks/use-spa-version-check.ts
+++ b/desktop/src/hooks/use-spa-version-check.ts
@@ -1,0 +1,129 @@
+/**
+ * Polls the deployed SPA version manifest and returns whether a newer build
+ * is available than the one currently running.
+ *
+ * The build step writes `/desktop/version.json` with the full
+ * __TAOS_VERSION__ (`{pkg}+{sha}.{ts}`) so the running SPA can detect
+ * when a redeploy has landed — even when the backend package version
+ * hasn't changed.  Compare this with useUpdateAvailable(), which watches
+ * for backend-version bumps via the X-Taos-Version response header.
+ *
+ * Polling:
+ *  - on window focus (user returns to the tab)
+ *  - every 60 s while the tab is visible
+ *
+ * A dev-style build version (starts with "dev" or "0.0.0") is never
+ * compared — the hook stays silent in local development.
+ *
+ * Guards:
+ *  - fires at most once per unique deployed version (persisted via useRef)
+ *  - `no-cache` fetch mode prevents browser HTTP caching of version.json
+ */
+import { useState, useEffect, useRef, useCallback } from "react";
+
+declare const __TAOS_VERSION__: string | undefined;
+
+function getBuildVersion(): string {
+  return typeof __TAOS_VERSION__ === "string" ? __TAOS_VERSION__ : "dev";
+}
+const DEV_VERSION_PATTERN = /^(dev|0\.0\.0)/i;
+const POLL_INTERVAL_MS = 60_000;
+const VERSION_URL = "/desktop/version.json";
+
+interface VersionPayload {
+  version: string;
+}
+
+export function useSpaVersionCheck(): {
+  hasNewBuild: boolean;
+  deployedVersion: string | null;
+} {
+  const [deployedVersion, setDeployedVersion] = useState<string | null>(null);
+  const firedFor = useRef<string | null>(null);
+  const mountedRef = useRef(true);
+
+  const isDev = DEV_VERSION_PATTERN.test(getBuildVersion());
+
+  const check = useCallback(async () => {
+    if (isDev) return;
+    try {
+      const r = await fetch(`${VERSION_URL}?t=${Date.now()}`, {
+        cache: "no-store",
+      });
+      if (!r.ok) return;
+      const payload = (await r.json()) as VersionPayload;
+      const deployed = payload?.version;
+      if (!deployed || typeof deployed !== "string") return;
+      if (!mountedRef.current) return;
+
+      const buildVer = getBuildVersion();
+      setDeployedVersion((prev) => (prev === deployed ? prev : deployed));
+
+      if (deployed !== buildVer && firedFor.current !== deployed) {
+        firedFor.current = deployed;
+      }
+    } catch {
+      // version.json unreachable — backend may be restarting; the
+      // BackendStatusProvider already surfaces that state.
+    }
+  }, [isDev]);
+
+  // Initial check on mount.
+  useEffect(() => {
+    mountedRef.current = true;
+    if (!isDev) check();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [check, isDev]);
+
+  // Periodic poll while visible.
+  useEffect(() => {
+    if (isDev) return;
+    let interval: ReturnType<typeof setInterval> | null = null;
+
+    const startPolling = () => {
+      if (interval) return;
+      check();
+      interval = setInterval(check, POLL_INTERVAL_MS);
+    };
+
+    const stopPolling = () => {
+      if (interval) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    };
+
+    onVisible();
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      stopPolling();
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [check, isDev]);
+
+  // Check on window focus.
+  useEffect(() => {
+    if (isDev) return;
+    const onFocus = () => check();
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [check, isDev]);
+
+  const hasNewBuild =
+    !isDev &&
+    deployedVersion !== null &&
+    firedFor.current === deployedVersion &&
+    deployedVersion !== getBuildVersion();
+
+  return { hasNewBuild, deployedVersion };
+}

--- a/desktop/src/hooks/use-spa-version-check.ts
+++ b/desktop/src/hooks/use-spa-version-check.ts
@@ -17,7 +17,7 @@
  *
  * Guards:
  *  - fires at most once per unique deployed version (persisted via useRef)
- *  - `no-cache` fetch mode prevents browser HTTP caching of version.json
+ *  - `no-store` fetch mode prevents browser HTTP caching of version.json
  */
 import { useState, useEffect, useRef, useCallback } from "react";
 

--- a/desktop/src/hooks/use-spa-version-check.ts
+++ b/desktop/src/hooks/use-spa-version-check.ts
@@ -39,7 +39,6 @@ export function useSpaVersionCheck(): {
   deployedVersion: string | null;
 } {
   const [deployedVersion, setDeployedVersion] = useState<string | null>(null);
-  const firedFor = useRef<string | null>(null);
   const mountedRef = useRef(true);
 
   const isDev = DEV_VERSION_PATTERN.test(getBuildVersion());
@@ -47,21 +46,14 @@ export function useSpaVersionCheck(): {
   const check = useCallback(async () => {
     if (isDev) return;
     try {
-      const r = await fetch(`${VERSION_URL}?t=${Date.now()}`, {
-        cache: "no-store",
-      });
+      const r = await fetch(VERSION_URL, { cache: "no-store" });
       if (!r.ok) return;
       const payload = (await r.json()) as VersionPayload;
       const deployed = payload?.version;
       if (!deployed || typeof deployed !== "string") return;
       if (!mountedRef.current) return;
 
-      const buildVer = getBuildVersion();
       setDeployedVersion((prev) => (prev === deployed ? prev : deployed));
-
-      if (deployed !== buildVer && firedFor.current !== deployed) {
-        firedFor.current = deployed;
-      }
     } catch {
       // version.json unreachable — backend may be restarting; the
       // BackendStatusProvider already surfaces that state.
@@ -122,7 +114,6 @@ export function useSpaVersionCheck(): {
   const hasNewBuild =
     !isDev &&
     deployedVersion !== null &&
-    firedFor.current === deployedVersion &&
     deployedVersion !== getBuildVersion();
 
   return { hasNewBuild, deployedVersion };

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -11,7 +11,7 @@ function spaVersionPlugin() {
   let outDir = "";
   return {
     name: "taos-spa-version",
-    configResolved(config: any) {
+    configResolved(config: import("vite").ResolvedConfig) {
       outDir = path.resolve(config.root, config.build.outDir);
     },
     writeBundle() {

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -2,7 +2,27 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import { writeFileSync } from "node:fs";
 import { readBackendVersion } from "./scripts/read-version.mjs";
+
+/** Writes version.json to the build output so the running SPA can poll it and
+ *  detect when a new build has been deployed. */
+function spaVersionPlugin() {
+  let outDir = "";
+  return {
+    name: "taos-spa-version",
+    configResolved(config: any) {
+      outDir = path.resolve(config.root, config.build.outDir);
+    },
+    writeBundle() {
+      const version = readBackendVersion();
+      writeFileSync(
+        path.join(outDir, "version.json"),
+        JSON.stringify({ version }) + "\n",
+      );
+    },
+  };
+}
 
 export default defineConfig({
   test: {
@@ -47,7 +67,7 @@ export default defineConfig({
   define: {
     __TAOS_VERSION__: JSON.stringify(readBackendVersion()),
   },
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), spaVersionPlugin()],
   base: "/desktop/",
   resolve: {
     alias: { "@": path.resolve(__dirname, "src") },


### PR DESCRIPTION
## Summary

Kill the hard-refresh papercut — the desktop SPA now detects when a new build has been deployed and prompts the user to reload via a notification toast.

Closes #1914.

## What changed

- **read-version.mjs**: Now always includes a nanosecond-resolution timestamp alongside the git SHA, so every build produces a unique identifier even from the same commit. This is what the version-check poll compares against.

- **vite.config.ts**: New `spaVersionPlugin` writes `version.json` to the build output with the full `__TAOS_VERSION__`.

- **useSpaVersionCheck hook**: Polls `/desktop/version.json` on mount, on window focus, and every 60 s while the tab is visible. Compares the deployed version with the running `__TAOS_VERSION__`.

- **SpaUpdateToast component**: Pushes a transient notification via the notification store when a mismatch is detected. Dismissable; fires at most once per unique deployed version. Silent in dev builds. Does NOT auto-reload (avoids disrupting active sessions).

- **AppShell**: Wires `SpaUpdateToast` alongside the existing `UpdateAvailableToast`.

## Tests

- **use-spa-version-check.test.ts**: 6 tests covering matching versions, mismatch detection, dev-build suppression, focus/visibility polling, and error/404 handling.
- **SpaUpdateToast.test.tsx**: 5 tests covering silent state, notification firing, de-duplication, and version-change re-firing.
- All 44 existing related tests pass (UpdateAvailableToast, BackendBanner, AppErrorBoundary, etc.).

## Verification

- `npm run build` produces `version.json` with the full build version in `static/desktop/`
- Service worker cache name includes the unique build identifier
- `npx vitest run` — all new + existing tests pass