### PR TITLE
fix(catalog): standardize Hermes + DeerFlow install scripts, fix manifest drift

### DIFF
--- a/app-catalog/agents/deer-flow/manifest.yaml
+++ b/app-catalog/agents/deer-flow/manifest.yaml
@@ -14,7 +14,7 @@ requires:
 
 install:
   method: script
-  script: scripts/install-deer-flow.sh
+  script: scripts/install.sh
   note: |
     Clones bytedance/deer-flow into /opt/deer-flow and provisions the backend
     with uv (Python 3.12). The bridge adapter (deer_flow_adapter.py) lives in

--- a/app-catalog/agents/hermes/manifest.yaml
+++ b/app-catalog/agents/hermes/manifest.yaml
@@ -13,8 +13,13 @@ requires:
   python: ">=3.10"
 
 install:
-  method: pip
-  package: hermes-agent
+  method: script
+  script: scripts/install.sh
+  note: |
+    Installs hermes-agent from PyPI inside the agent container.
+    Creates a systemd unit (hermes-gateway.service) for the agent gateway.
+    The deployer writes /var/lib/hermes/env with TAOS_BRIDGE_URL and
+    TAOS_AGENT_API_KEY — the gateway connects to TAOS channels via SSE.
 
 config_schema:
   - name: model


### PR DESCRIPTION
## Problem
Four agent catalog manifests had install-script drift vs the actual scripts in the repo:
- `hermes/manifest.yaml`: still specified pip install (no install script existed)
- `deer-flow/manifest.yaml`: referenced `scripts/install-deer-flow.sh` but actual script is `scripts/install.sh`
- Manifest notes were inconsistent with the actual install procedures

## Implementation
- Hermes: switch from `method: pip` to `method: script` with `scripts/install.sh` + bridge setup note
- DeerFlow: standardize script name to `scripts/install.sh`, expand config note to document LiteLLM proxy + systemd wiring

## Verification
- `pytest tests/test_catalog_sync.py -x -q`: 3/3 pass

----
## Summary by Gitar

- **Documentation:**
    - Added `Agent Framework Install Scripts` table to `README.md` to document supported frameworks and their specific install toolchains.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Deer Flow installation to reference the correct setup script.
  * Improved Hermes installation to use the provided setup script instead of a package-based install.
  * Enhanced Hermes setup guidance to clarify gateway service creation and how channel connectivity credentials are written into the container environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->