### PR TITLE
feat(config): make taOSmd memory URL configurable

### DIFF
--- a/desktop/src/apps/SettingsApp.tsx
+++ b/desktop/src/apps/SettingsApp.tsx
@@ -16,6 +16,7 @@ import {
   Palette,
   UserCircle,
   ScrollText,
+  Save,
 } from "lucide-react";
 import {
   Button,
@@ -294,6 +295,10 @@ function MemorySection() {
   const [settings, setSettings] = useState<MemorySettings | null>(null);
   const [stats, setStats] = useState<{ total: number; collections: Record<string, number> } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [memoryUrl, setMemoryUrl] = useState("http://localhost:7900");
+  const [memoryUrlDirty, setMemoryUrlDirty] = useState(false);
+  const [memoryUrlSaving, setMemoryUrlSaving] = useState(false);
+  const [memoryUrlError, setMemoryUrlError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/user-memory/settings")
@@ -313,6 +318,13 @@ function MemorySection() {
         if (data) setStats(data);
       })
       .catch(() => {});
+
+    fetch("/api/settings/memory-url")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.url) setMemoryUrl(data.url);
+      })
+      .catch(() => {});
   }, []);
 
   const update = (key: keyof MemorySettings, value: boolean) => {
@@ -328,6 +340,27 @@ function MemorySection() {
         else setError(null);
       })
       .catch(() => setError("Could not reach backend."));
+  };
+
+  const saveMemoryUrl = async () => {
+    setMemoryUrlSaving(true);
+    setMemoryUrlError(null);
+    try {
+      const res = await fetch("/api/settings/memory-url", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: memoryUrl }),
+      });
+      if (res.ok) {
+        setMemoryUrlDirty(false);
+      } else {
+        const data = await res.json();
+        setMemoryUrlError(data.error || `Failed to save (${res.status})`);
+      }
+    } catch {
+      setMemoryUrlError("Could not reach backend.");
+    }
+    setMemoryUrlSaving(false);
   };
 
   if (!settings) {
@@ -374,6 +407,36 @@ function MemorySection() {
           );
         })}
       </div>
+
+      {/* --- Memory URL (taOSmd) --- */}
+      <h3 className="text-sm font-medium mt-6 mb-2">taOSmd Server URL</h3>
+      <p className="text-xs text-shell-text-tertiary mb-3">
+        URL of the taOSmd memory server. Change this to point to a remote instance.
+      </p>
+      <div className="flex items-start gap-2">
+        <input
+          type="text"
+          value={memoryUrl}
+          onChange={(e) => { setMemoryUrl(e.target.value); setMemoryUrlDirty(true); }}
+          className="flex-1 px-3 py-2 text-sm rounded bg-white/5 border border-white/10 text-shell-text focus:outline-none focus:border-sky-500/50"
+          placeholder="http://localhost:7900"
+          aria-label="taOSmd memory server URL"
+        />
+        <Button
+          size="sm"
+          onClick={saveMemoryUrl}
+          disabled={!memoryUrlDirty || memoryUrlSaving}
+          aria-label="Save memory URL"
+        >
+          <Save size={14} />
+          {memoryUrlSaving ? "Saving..." : "Save"}
+        </Button>
+      </div>
+      {memoryUrlError && (
+        <p className="mt-2 text-xs text-amber-400 flex items-center gap-1.5">
+          <AlertCircle size={12} /> {memoryUrlError}
+        </p>
+      )}
 
       {stats && (
         <Card className="mt-6 p-4">

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -465,3 +465,53 @@ def test_auto_register_hailo_ollama_skipped_without_hailo10h(tmp_path):
     )
     assert added is False
     assert [b for b in cfg.backends if b["type"] == "hailo-ollama"] == []
+
+
+class TestMemoryUrl:
+    """Config persistence and defaults for memory_url (taOSmd)."""
+
+    def test_default_memory_url(self):
+        """memory_url defaults to http://localhost:7900."""
+        cfg = AppConfig()
+        assert cfg.memory_url == "http://localhost:7900"
+
+    def test_custom_memory_url(self):
+        """Custom memory_url survives to_dict + load_config roundtrip."""
+        from tinyagentos.config import load_config
+
+        cfg = AppConfig(memory_url="https://taosmd.example.com:7900")
+        assert cfg.memory_url == "https://taosmd.example.com:7900"
+
+        d = cfg.to_dict()
+        assert d["memory_url"] == "https://taosmd.example.com:7900"
+
+    def test_default_not_in_to_dict(self):
+        """Default memory_url should not appear in to_dict output."""
+        cfg = AppConfig()
+        d = cfg.to_dict()
+        assert "memory_url" not in d
+
+    def test_roundtrip(self, tmp_path):
+        """memory_url survives yaml save+load cycle."""
+        from tinyagentos.config import load_config, save_config
+
+        p = tmp_path / "config.yaml"
+        cfg = AppConfig(
+            memory_url="http://192.168.1.50:7900",
+            config_path=p,
+        )
+        save_config(cfg, p)
+        reloaded = load_config(p)
+        assert reloaded.memory_url == "http://192.168.1.50:7900"
+
+    def test_roundtrip_default_is_omitted(self, tmp_path):
+        """Default memory_url not in YAML, load_config fills it in."""
+        from tinyagentos.config import load_config, save_config
+
+        p = tmp_path / "config.yaml"
+        cfg = AppConfig(config_path=p)
+        save_config(cfg, p)
+        assert "memory_url" not in p.read_text()
+
+        reloaded = load_config(p)
+        assert reloaded.memory_url == "http://localhost:7900"

--- a/tests/test_user_memory.py
+++ b/tests/test_user_memory.py
@@ -285,3 +285,65 @@ async def test_migrate_error_response_does_not_leak_exception_text(mem_client, t
     assert resp.status_code == 500
     assert "internal-taosmd" not in resp.text
     assert resp.json()["error"] == "taosmd ingest failed"
+
+
+# ---------------------------------------------------------------------------
+# taOSmd base URL resolution (_taosmd_base)
+# ---------------------------------------------------------------------------
+
+
+def test_taosmd_base_reads_from_config_memory_url(mem_client):
+    """_taosmd_base returns config.memory_url when no state override is set."""
+    from tinyagentos.routes.user_memory import _taosmd_base
+
+    client, _store = mem_client
+    application = client._transport.app
+
+    class FakeReq:
+        app = application
+
+    application.state.taosmd_url = None
+    application.state.config.memory_url = "https://remote-taosmd:7900"
+    try:
+        url = _taosmd_base(FakeReq())
+        assert url == "https://remote-taosmd:7900"
+    finally:
+        application.state.config.memory_url = "http://localhost:7900"
+
+
+def test_taosmd_base_returns_default_when_nothing_set(mem_client):
+    """_taosmd_base returns default localhost when nothing is configured."""
+    from tinyagentos.routes.user_memory import _taosmd_base
+
+    client, _store = mem_client
+    application = client._transport.app
+
+    class FakeReq:
+        app = application
+
+    application.state.taosmd_url = None
+    application.state.config.memory_url = "http://localhost:7900"
+    try:
+        url = _taosmd_base(FakeReq())
+        assert url == "http://localhost:7900"
+    finally:
+        pass
+
+
+def test_taosmd_base_state_override_wins(mem_client):
+    """_taosmd_base uses app.state.taosmd_url even when config differs."""
+    from tinyagentos.routes.user_memory import _taosmd_base
+
+    client, _store = mem_client
+    application = client._transport.app
+
+    class FakeReq:
+        app = application
+
+    application.state.taosmd_url = "http://test-override:9999"
+    application.state.config.memory_url = "http://configured-url:7900"
+    try:
+        url = _taosmd_base(FakeReq())
+        assert url == "http://test-override:9999"
+    finally:
+        application.state.taosmd_url = None

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -28,6 +28,7 @@ DEFAULT_CONFIG = {
     "qmd": {"url": "http://localhost:7832"},
     "agents": [],
     "metrics": {"poll_interval": 30, "retention_days": 30},
+    "memory_url": "http://localhost:7900",
     "webhooks": [],
 }
 
@@ -53,6 +54,7 @@ class AppConfig:
     webhooks: list[dict] = field(default_factory=list)
     archived_agents: list[dict] = field(default_factory=list)
     archive: dict = field(default_factory=lambda: DEFAULT_ARCHIVE_CONFIG.copy())
+    memory_url: str = "http://localhost:7900"
     config_path: Path | None = None
 
     def to_dict(self) -> dict:
@@ -70,6 +72,8 @@ class AppConfig:
         archive_target = (self.archive or {}).get("target", "pool:")
         if archive_target != "pool:":
             d["archive"] = self.archive
+        if self.memory_url != "http://localhost:7900":
+            d["memory_url"] = self.memory_url
         return d
 
 # rkllama's taOS default port moved from the upstream 8080 to 7833. Installs
@@ -169,6 +173,7 @@ def load_config(path: Path) -> AppConfig:
         webhooks=data.get("webhooks", []),
         archived_agents=data.get("archived_agents", []),
         archive=archive_cfg,
+        memory_url=data.get("memory_url", "http://localhost:7900"),
         config_path=path,
     )
     if _pin_applied:

--- a/tinyagentos/routes/settings.py
+++ b/tinyagentos/routes/settings.py
@@ -8,6 +8,7 @@ import shutil
 import tarfile
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
@@ -211,6 +212,7 @@ async def save_config_endpoint(request: Request, body: ConfigUpdate, validate_on
         agents=data.get("agents", []),
         metrics=data.get("metrics", {}),
         webhooks=data.get("webhooks", []),
+        memory_url=data.get("memory_url", "http://localhost:7900"),
         config_path=request.app.state.config_path,
     )
     errors = validate_config(new_config)
@@ -220,6 +222,9 @@ async def save_config_endpoint(request: Request, body: ConfigUpdate, validate_on
         return {"status": "valid", "message": "Config is valid"}
     await save_config_locked(new_config, request.app.state.config_path)
     request.app.state.config = new_config
+    # Clear stale runtime override so _taosmd_base picks up the new config value
+    if hasattr(request.app.state, "taosmd_url"):
+        del request.app.state.taosmd_url
     return {"status": "saved", "message": "Config saved successfully"}
 
 
@@ -328,9 +333,12 @@ async def restore_backup(request: Request, file: UploadFile):
                 agents=data.get("agents", []),
                 metrics=data.get("metrics", {}),
                 webhooks=data.get("webhooks", []),
+                memory_url=data.get("memory_url", "http://localhost:7900"),
                 config_path=config_path,
             )
             request.app.state.config = new_config
+            if hasattr(request.app.state, "taosmd_url"):
+                del request.app.state.taosmd_url
         except Exception:
             pass
     return {"status": "restored", "message": "Backup restored successfully"}
@@ -1061,3 +1069,37 @@ async def set_update_channel(request: Request, body: UpdateChannel):
         "recovery_tag": result.recovery_tag,
         "message": result.message,
     }
+
+
+# ---------------------------------------------------------------------------
+# Memory URL (taOSmd)
+# ---------------------------------------------------------------------------
+
+class MemoryUrlUpdate(BaseModel):
+    url: str
+
+
+@router.get("/api/settings/memory-url")
+async def get_memory_url(request: Request):
+    """Return the current taOSmd memory URL."""
+    config = request.app.state.config
+    return {"url": config.memory_url}
+
+
+@router.put("/api/settings/memory-url")
+async def set_memory_url(request: Request, body: MemoryUrlUpdate):
+    """Update the taOSmd memory URL and persist to config."""
+    url = body.url.strip()
+    if not url:
+        return JSONResponse({"error": "URL must not be empty"}, status_code=400)
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return JSONResponse({"error": "URL must use http:// or https:// scheme"}, status_code=400)
+    if not parsed.netloc:
+        return JSONResponse({"error": "URL must include a hostname"}, status_code=400)
+    config = request.app.state.config
+    config.memory_url = url
+    await save_config_locked(config, request.app.state.config_path)
+    # Keep app.state.taosmd_url in sync for runtime access
+    request.app.state.taosmd_url = url
+    return {"status": "saved", "url": url}

--- a/tinyagentos/routes/user_memory.py
+++ b/tinyagentos/routes/user_memory.py
@@ -23,10 +23,16 @@ def _store(request: Request):
 def _taosmd_base(request: Request) -> str:
     """Base URL for the taosmd HTTP API.
 
-    Reads from app.state.taosmd_url when set (tests can override),
-    otherwise falls back to the local default.
+    Precedence: app.state.taosmd_url (explicit runtime override, used by
+    tests) → config.memory_url (persisted setting) → default localhost.
     """
-    return getattr(request.app.state, "taosmd_url", None) or "http://localhost:7900"
+    explicit = getattr(request.app.state, "taosmd_url", None)
+    if explicit:
+        return explicit
+    config = getattr(request.app.state, "config", None)
+    if config and getattr(config, "memory_url", None):
+        return config.memory_url
+    return "http://localhost:7900"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes the taOSmd memory backend URL configurable via the settings UI and config system.

### Changes
- `tinyagentos/config.py`: Add `memory_url` field to config schema with sensible default
- `tinyagentos/routes/settings.py`: Expose memory URL in settings endpoint
- `tinyagentos/routes/user_memory.py`: Read memory URL from config at runtime
- `desktop/src/apps/SettingsApp.tsx`: Add memory URL setting in the desktop UI
- `tests/test_config.py`: TestMemoryUrl — config roundtrip, defaults, custom URLs
- `tests/test_user_memory.py`: taOSmd base URL tests — config fallback, state override

### Testing
All 55 tests pass (test_config.py + test_user_memory.py).