### PR TITLE
feat(agents): Ctrl+Shift+K kill-switch shortcut + SIGTERM→SIGKILL grace window

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -33,6 +33,7 @@ import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
 import { EffectsLayer } from "@/theme/effects/EffectsLayer";
 import { SafetyFloor } from "@/components/SafetyFloor";
+import { withCsrf } from "@/lib/csrf";
 
 interface SystemShortcutsProps {
   toggleSearch: () => void;
@@ -109,6 +110,21 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
   useShortcut("Ctrl+7", useCallback(() => openPinned(6), [openPinned]), "Open pinned app 7", "system");
   useShortcut("Ctrl+8", useCallback(() => openPinned(7), [openPinned]), "Open pinned app 8", "system");
   useShortcut("Ctrl+9", useCallback(() => openPinned(8), [openPinned]), "Open pinned app 9", "system");
+
+  // Ctrl+Shift+K — emergency kill switch: stops all running agents
+  const killAllAgents = useCallback(async () => {
+    try {
+      await fetch("/api/agents/bulk/stop", {
+        method: "POST",
+        credentials: "include",
+        headers: withCsrf({ method: "POST" })?.headers,
+      });
+      window.dispatchEvent(new CustomEvent("taos:agents-changed"));
+    } catch {
+      // best-effort
+    }
+  }, []);
+  useShortcut("Ctrl+Shift+K", killAllAgents, "Stop all agents", "system");
 
   return null;
 }

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -128,7 +128,7 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
       const resp = await fetch("/api/agents/bulk/stop", {
         method: "POST",
         credentials: "include",
-        headers: withCsrf({ method: "POST" }).headers,
+        headers: withCsrf({ method: "POST" })!.headers,
       });
       if (!resp.ok) {
         throw new Error(`Server returned ${resp.status}`);

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -133,13 +133,45 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
       if (!resp.ok) {
         throw new Error(`Server returned ${resp.status}`);
       }
-      window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-      addNotification({
-        source: "system",
-        title: "Agents stopped",
-        body: "Emergency kill switch activated — all agents stopped.",
-        level: "success",
-      });
+      const data = await resp.json();
+      // Check for individual agent failures in both results and force_kill_results
+      const results = data.results ?? {};
+      const forceKillResults = data.force_kill_results ?? {};
+      const stopFailures = Object.entries(results).filter(
+        ([, r]: [string, unknown]) =>
+          r && typeof r === "object" && !(r as Record<string, unknown>).success
+      ).length > 0;
+      const forceFailures = Object.entries(forceKillResults).filter(
+        ([, r]: [string, unknown]) =>
+          r && typeof r === "object" && !(r as Record<string, unknown>).force_killed
+      ).length > 0;
+      if (!stopFailures && !forceFailures) {
+        window.dispatchEvent(new CustomEvent("taos:agents-changed"));
+        addNotification({
+          source: "system",
+          title: "Agents stopped",
+          body: "Emergency kill switch activated — all agents stopped.",
+          level: "success",
+        });
+      } else {
+        const failCount = [
+          ...Object.entries(results).filter(
+            ([, r]: [string, unknown]) =>
+              r && typeof r === "object" && !(r as Record<string, unknown>).success
+          ),
+          ...Object.entries(forceKillResults).filter(
+            ([, r]: [string, unknown]) =>
+              r && typeof r === "object" && !(r as Record<string, unknown>).force_killed
+          ),
+        ].length;
+        window.dispatchEvent(new CustomEvent("taos:agents-changed"));
+        addNotification({
+          source: "system",
+          title: "Agents stopped with failures",
+          body: `${failCount} agent(s) failed to stop — check individual agent status.`,
+          level: "warning",
+        });
+      }
     } catch (err) {
       addNotification({
         source: "system",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -33,7 +33,7 @@ import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
 import { EffectsLayer } from "@/theme/effects/EffectsLayer";
 import { SafetyFloor } from "@/components/SafetyFloor";
-import { withCsrf } from "@/lib/csrf";
+import { withCsrf, getCsrfToken } from "@/lib/csrf";
 
 interface SystemShortcutsProps {
   toggleSearch: () => void;
@@ -112,18 +112,43 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
   useShortcut("Ctrl+9", useCallback(() => openPinned(8), [openPinned]), "Open pinned app 9", "system");
 
   // Ctrl+Shift+K — emergency kill switch: stops all running agents
+  const addNotification = useNotificationStore((s) => s.addNotification);
+
   const killAllAgents = useCallback(async () => {
+    if (!getCsrfToken()) {
+      addNotification({
+        source: "system",
+        title: "Kill switch blocked",
+        body: "CSRF token missing — refresh the page and try again.",
+        level: "error",
+      });
+      return;
+    }
     try {
-      await fetch("/api/agents/bulk/stop", {
+      const resp = await fetch("/api/agents/bulk/stop", {
         method: "POST",
         credentials: "include",
-        headers: withCsrf({ method: "POST" })?.headers,
+        headers: withCsrf({ method: "POST" }).headers,
       });
+      if (!resp.ok) {
+        throw new Error(`Server returned ${resp.status}`);
+      }
       window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-    } catch {
-      // best-effort
+      addNotification({
+        source: "system",
+        title: "Agents stopped",
+        body: "Emergency kill switch activated — all agents stopped.",
+        level: "success",
+      });
+    } catch (err) {
+      addNotification({
+        source: "system",
+        title: "Kill switch failed",
+        body: `Could not stop agents: ${err instanceof Error ? err.message : "unknown error"}`,
+        level: "error",
+      });
     }
-  }, []);
+  }, [addNotification]);
   useShortcut("Ctrl+Shift+K", killAllAgents, "Stop all agents", "system");
 
   return null;

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -84,14 +84,24 @@ class TestBulkOperations:
             return {"success": True, "output": ""}
 
         async def fake_list_containers(prefix="taos-agent-"):
-            return []
+            return [
+                ContainerInfo(
+                    name="taos-agent-test-agent",
+                    status="Running",
+                    ip="10.0.0.5",
+                    memory_mb=1024,
+                    cpu_cores=2,
+                )
+            ]
 
         monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
         monkeypatch.setattr("tinyagentos.containers.list_containers", fake_list_containers)
 
         resp = await client.post("/api/agents/bulk/stop")
         assert resp.status_code == 200
-        assert resp.json()["action"] == "stop"
+        data = resp.json()
+        assert data["action"] == "stop"
+        assert "force_kill_results" in data
 
     async def test_bulk_restart(self, client, monkeypatch):
         async def fake_restart(name):
@@ -141,7 +151,7 @@ class TestKillSwitchRunStateGate:
         data = resp.json()
         assert data["action"] == "stop"
         # The stopped container should not receive a force kill
-        assert "test-agent" not in force_calls, (
+        assert "taos-agent-test-agent" not in force_calls, (
             f"force-kill should NOT be called on a Stopped container, "
             f"but stop_container(force=True) was called {force_calls}"
         )
@@ -220,6 +230,44 @@ class TestKillSwitchRunStateGate:
         assert data["action"] == "stop"
         assert "taos-agent-test-agent" in force_calls, (
             "force-kill should be called on a Running container"
+        )
+
+    async def test_stop_agent_force_kills_running_container(
+        self, client, monkeypatch
+    ):
+        """A single running agent container MUST receive incus stop --force."""
+        running = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Running",
+            ip="10.0.0.5",
+            memory_mb=1024,
+            cpu_cores=2,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [running]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/test-agent/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["force_killed"] is True, (
+            f"force_killed should be True for a Running container, got {data}"
+        )
+        assert "taos-agent-test-agent" in force_calls, (
+            "stop_container(force=True) should be called on a Running container"
         )
 
 

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -66,7 +66,12 @@ class TestAgentsPage:
 
 @pytest.mark.asyncio
 class TestBulkOperations:
-    async def test_bulk_start(self, client):
+    async def test_bulk_start(self, client, monkeypatch):
+        async def fake_start(name):
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.start_container", fake_start)
+
         resp = await client.post("/api/agents/bulk/start")
         assert resp.status_code == 200
         data = resp.json()
@@ -74,12 +79,26 @@ class TestBulkOperations:
         assert "results" in data
         assert "test-agent" in data["results"]
 
-    async def test_bulk_stop(self, client):
+    async def test_bulk_stop(self, client, monkeypatch):
+        async def fake_stop(name, force=False):
+            return {"success": True, "output": ""}
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return []
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+        monkeypatch.setattr("tinyagentos.containers.list_containers", fake_list_containers)
+
         resp = await client.post("/api/agents/bulk/stop")
         assert resp.status_code == 200
         assert resp.json()["action"] == "stop"
 
-    async def test_bulk_restart(self, client):
+    async def test_bulk_restart(self, client, monkeypatch):
+        async def fake_restart(name):
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.restart_container", fake_restart)
+
         resp = await client.post("/api/agents/bulk/restart")
         assert resp.status_code == 200
         assert resp.json()["action"] == "restart"

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1,6 +1,7 @@
 import pytest
 from tinyagentos.config import load_config
 from tinyagentos.cluster.worker_protocol import WorkerInfo
+from tinyagentos.containers.backend import ContainerInfo
 
 
 @pytest.fixture(autouse=True)
@@ -82,6 +83,125 @@ class TestBulkOperations:
         resp = await client.post("/api/agents/bulk/restart")
         assert resp.status_code == 200
         assert resp.json()["action"] == "restart"
+
+
+@pytest.mark.asyncio
+class TestKillSwitchRunStateGate:
+    """Verify that force-kill is gated on container run-state, not just existence."""
+
+    async def test_bulk_stop_skips_force_kill_for_stopped_container(
+        self, client, monkeypatch
+    ):
+        """A stopped container must NOT receive incus stop --force."""
+        stopped = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Stopped",
+            ip=None,
+            memory_mb=0,
+            cpu_cores=0,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [stopped]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/bulk/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "stop"
+        # The stopped container should not receive a force kill
+        assert "test-agent" not in force_calls, (
+            f"force-kill should NOT be called on a Stopped container, "
+            f"but stop_container(force=True) was called {force_calls}"
+        )
+
+    async def test_stop_agent_skips_force_kill_for_stopped_container(
+        self, client, monkeypatch
+    ):
+        """A single stopped agent container must NOT receive incus stop --force."""
+        stopped = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Stopped",
+            ip=None,
+            memory_mb=0,
+            cpu_cores=0,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [stopped]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/test-agent/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "force_killed" in data
+        assert data["force_killed"] is False, (
+            "force_killed should be False for a Stopped container"
+        )
+        assert len(force_calls) == 0, (
+            f"stop_container(force=True) should NOT be called on a Stopped container, "
+            f"but it was called {len(force_calls)} times"
+        )
+
+    async def test_bulk_stop_force_kills_running_container(
+        self, client, monkeypatch
+    ):
+        """A running container MUST receive incus stop --force."""
+        running = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Running",
+            ip="10.0.0.5",
+            memory_mb=1024,
+            cpu_cores=2,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [running]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/bulk/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "stop"
+        assert "taos-agent-test-agent" in force_calls, (
+            "force-kill should be called on a Running container"
+        )
 
 
 def _seed_worker(app, name, model_names, status="online"):

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -803,7 +803,7 @@ async def bulk_stop_agents(request: Request):
     In-flight agent framework work is cancelled by the prepare step;
     LLM calls and tool invocations are terminated when the container dies.
     """
-    from tinyagentos.containers import stop_container, container_exists
+    from tinyagentos.containers import stop_container, list_containers
 
     config = request.app.state.config
     orchestrator = getattr(request.app.state, "orchestrator", None)
@@ -814,15 +814,18 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers (shielded from cancellation)
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers
+    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
+        containers = await list_containers(prefix="taos-agent-")
+        running = {c.name for c in containers if c.status == "Running"}
         force_results = {}
         for agent in config.agents:
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
-                if await container_exists(container_name):
+                if container_name in running:
                     force_result = await stop_container(container_name, force=True)
                     force_results[name] = {
                         "force_killed": force_result.get("success", False),
@@ -838,7 +841,16 @@ async def bulk_stop_agents(request: Request):
                 force_results[name] = {"force_killed": False, "error": str(e)}
         return force_results
 
-    force_results = await asyncio.shield(_grace_kill())
+    task = asyncio.create_task(_grace_kill())
+    try:
+        force_results = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     return {
         "action": "stop",
@@ -885,7 +897,7 @@ async def stop_agent(request: Request, name: str):
     Sends SIGTERM via incus stop. After a 2-second grace window, if the container
     is still running, sends SIGKILL (incus stop --force) to guarantee termination.
     """
-    from tinyagentos.containers import stop_container, container_exists
+    from tinyagentos.containers import stop_container, list_containers
 
     config = request.app.state.config
     agent = find_agent(config, name)
@@ -899,10 +911,13 @@ async def stop_agent(request: Request, name: str):
     container_name = f"taos-agent-{name}"
     stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL (shielded from cancellation)
+    # 2-second grace window, then SIGKILL
+    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
-        if await container_exists(container_name):
+        containers = await list_containers(prefix="taos-agent-")
+        running = {c.name for c in containers if c.status == "Running"}
+        if container_name in running:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)
             if not success:
@@ -914,7 +929,16 @@ async def stop_agent(request: Request, name: str):
             return (success, force_result.get("output", ""))
         return (False, "")
 
-    force_killed, force_error = await asyncio.shield(_grace_kill())
+    task = asyncio.create_task(_grace_kill())
+    try:
+        force_killed, force_error = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     return {
         "prepare_report": report,

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -824,7 +824,7 @@ async def bulk_stop_agents(request: Request):
         running = {
             c.name
             for c in containers
-            if c.status in ("Running", "Stopping")
+            if c.status not in ("Stopped",)
         }
         incus_unhealthy = not containers and bool(config.agents)
 
@@ -858,11 +858,16 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container (concurrent with grace window)
     results = await _bulk_container_op(config, stop_container)
 
+    force_results = {}
     try:
-        force_results = await asyncio.shield(task)
+        force_results = await asyncio.wait_for(asyncio.shield(task), timeout=30)
     except asyncio.CancelledError:
         await task
         raise
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Grace-kill timed out after 30s; force-kill may still complete in background"
+        )
 
     return {
         "action": "stop",
@@ -935,7 +940,7 @@ async def stop_agent(request: Request, name: str):
         running = {
             c.name
             for c in containers
-            if c.status in ("Running", "Stopping")
+            if c.status not in ("Stopped",)
         }
         if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
@@ -953,10 +958,18 @@ async def stop_agent(request: Request, name: str):
     stop_result = await stop_container(container_name)
 
     try:
-        force_killed, force_output = await asyncio.shield(task)
+        force_killed, force_output = await asyncio.wait_for(
+            asyncio.shield(task), timeout=30
+        )
     except asyncio.CancelledError:
         await task
         raise
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Grace-kill timed out after 30s for %s; force-kill may still complete",
+            container_name,
+        )
+        force_killed, force_output = False, ""
 
     return {
         "prepare_report": report,

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -824,7 +824,11 @@ async def bulk_stop_agents(request: Request):
                 "list_containers returned empty; incus may be unhealthy. "
                 "Attempting force-kill on all configured agents."
             )
-        running = {c.name for c in containers if c.status == "Running"}
+        running = {
+            c.name
+            for c in containers
+            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+        }
         incus_unhealthy = not containers and bool(config.agents)
         force_results = {}
         for agent in config.agents:
@@ -927,7 +931,11 @@ async def stop_agent(request: Request, name: str):
                 "list_containers returned empty; incus may be unhealthy. "
                 "Attempting force-kill anyway."
             )
-        running = {c.name for c in containers if c.status == "Running"}
+        running = {
+            c.name
+            for c in containers
+            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+        }
         if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -855,11 +855,7 @@ async def bulk_stop_agents(request: Request):
     try:
         force_results = await asyncio.shield(task)
     except asyncio.CancelledError:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        await task
         raise
 
     return {
@@ -952,11 +948,7 @@ async def stop_agent(request: Request, name: str):
     try:
         force_killed, force_output = await asyncio.shield(task)
     except asyncio.CancelledError:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        await task
         raise
 
     return {

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -811,11 +811,8 @@ async def bulk_stop_agents(request: Request):
     if orchestrator is not None:
         report = await orchestrator.prepare("all", "stop")
 
-    # Phase 1: SIGTERM every agent container
-    results = await _bulk_container_op(config, stop_container)
-
     # Phase 2: 2-second grace window, then SIGKILL any stragglers
-    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
+    # (shielded from cancellation; the sleep+force is bounded)
     async def _grace_kill():
         await asyncio.sleep(2)
         containers = await list_containers(prefix="taos-agent-")
@@ -827,17 +824,17 @@ async def bulk_stop_agents(request: Request):
         running = {
             c.name
             for c in containers
-            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+            if c.status in ("Running", "Stopping")
         }
         incus_unhealthy = not containers and bool(config.agents)
-        force_results = {}
-        for agent in config.agents:
-            name = agent["name"]
-            container_name = f"taos-agent-{name}"
+
+        async def _force_kill_one(agent):
+            agent_name = agent["name"]
+            container_name = f"taos-agent-{agent_name}"
             try:
                 if container_name in running or incus_unhealthy:
                     force_result = await stop_container(container_name, force=True)
-                    force_results[name] = {
+                    result = {
                         "force_killed": force_result.get("success", False),
                         "output": force_result.get("output", ""),
                     }
@@ -847,11 +844,20 @@ async def bulk_stop_agents(request: Request):
                             container_name,
                             force_result.get("output", "unknown"),
                         )
+                    return (agent_name, result)
             except Exception as e:
-                force_results[name] = {"force_killed": False, "error": str(e)}
-        return force_results
+                return (agent_name, {"force_killed": False, "error": str(e)})
+            return (agent_name, {"force_killed": False, "output": ""})
+
+        gathered = await asyncio.gather(
+            *(_force_kill_one(agent) for agent in config.agents)
+        )
+        return dict(gathered)
 
     task = asyncio.create_task(_grace_kill())
+    # Phase 1: SIGTERM every agent container (concurrent with grace window)
+    results = await _bulk_container_op(config, stop_container)
+
     try:
         force_results = await asyncio.shield(task)
     except asyncio.CancelledError:
@@ -915,10 +921,9 @@ async def stop_agent(request: Request, name: str):
         report = await orchestrator.prepare([name], "stop")
 
     container_name = f"taos-agent-{name}"
-    stop_result = await stop_container(container_name)
 
     # 2-second grace window, then SIGKILL
-    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
+    # (shielded from cancellation; the sleep+force is bounded)
     async def _grace_kill():
         await asyncio.sleep(2)
         containers = await list_containers(prefix="taos-agent-")
@@ -930,7 +935,7 @@ async def stop_agent(request: Request, name: str):
         running = {
             c.name
             for c in containers
-            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+            if c.status in ("Running", "Stopping")
         }
         if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
@@ -945,6 +950,8 @@ async def stop_agent(request: Request, name: str):
         return (False, "")
 
     task = asyncio.create_task(_grace_kill())
+    stop_result = await stop_container(container_name)
+
     try:
         force_killed, force_output = await asyncio.shield(task)
     except asyncio.CancelledError:

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -819,13 +819,19 @@ async def bulk_stop_agents(request: Request):
     async def _grace_kill():
         await asyncio.sleep(2)
         containers = await list_containers(prefix="taos-agent-")
+        if not containers and config.agents:
+            logger.warning(
+                "list_containers returned empty; incus may be unhealthy. "
+                "Attempting force-kill on all configured agents."
+            )
         running = {c.name for c in containers if c.status == "Running"}
+        incus_unhealthy = not containers and bool(config.agents)
         force_results = {}
         for agent in config.agents:
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
-                if container_name in running:
+                if container_name in running or incus_unhealthy:
                     force_result = await stop_container(container_name, force=True)
                     force_results[name] = {
                         "force_killed": force_result.get("success", False),
@@ -916,8 +922,13 @@ async def stop_agent(request: Request, name: str):
     async def _grace_kill():
         await asyncio.sleep(2)
         containers = await list_containers(prefix="taos-agent-")
+        if not containers:
+            logger.warning(
+                "list_containers returned empty; incus may be unhealthy. "
+                "Attempting force-kill anyway."
+            )
         running = {c.name for c in containers if c.status == "Running"}
-        if container_name in running:
+        if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)
             if not success:
@@ -931,7 +942,7 @@ async def stop_agent(request: Request, name: str):
 
     task = asyncio.create_task(_grace_kill())
     try:
-        force_killed, force_error = await asyncio.shield(task)
+        force_killed, force_output = await asyncio.shield(task)
     except asyncio.CancelledError:
         task.cancel()
         try:
@@ -944,7 +955,7 @@ async def stop_agent(request: Request, name: str):
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
-        "force_error": force_error,
+        "force_output": force_output,
     }
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -814,21 +814,31 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers
-    await asyncio.sleep(2)
-    force_results = {}
-    for agent in config.agents:
-        name = agent["name"]
-        container_name = f"taos-agent-{name}"
-        try:
-            if await container_exists(container_name):
-                force_result = await stop_container(container_name, force=True)
-                force_results[name] = {
-                    "force_killed": force_result.get("success", False),
-                    "output": force_result.get("output", ""),
-                }
-        except Exception as e:
-            force_results[name] = {"force_killed": False, "error": str(e)}
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers (shielded from cancellation)
+    async def _grace_kill():
+        await asyncio.sleep(2)
+        force_results = {}
+        for agent in config.agents:
+            name = agent["name"]
+            container_name = f"taos-agent-{name}"
+            try:
+                if await container_exists(container_name):
+                    force_result = await stop_container(container_name, force=True)
+                    force_results[name] = {
+                        "force_killed": force_result.get("success", False),
+                        "output": force_result.get("output", ""),
+                    }
+                    if not force_result.get("success", False):
+                        logger.warning(
+                            "Force-kill of %s failed: %s",
+                            container_name,
+                            force_result.get("output", "unknown"),
+                        )
+            except Exception as e:
+                force_results[name] = {"force_killed": False, "error": str(e)}
+        return force_results
+
+    force_results = await asyncio.shield(_grace_kill())
 
     return {
         "action": "stop",
@@ -889,17 +899,28 @@ async def stop_agent(request: Request, name: str):
     container_name = f"taos-agent-{name}"
     stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL
-    await asyncio.sleep(2)
-    force_killed = False
-    if await container_exists(container_name):
-        force_result = await stop_container(container_name, force=True)
-        force_killed = force_result.get("success", False)
+    # 2-second grace window, then SIGKILL (shielded from cancellation)
+    async def _grace_kill():
+        await asyncio.sleep(2)
+        if await container_exists(container_name):
+            force_result = await stop_container(container_name, force=True)
+            success = force_result.get("success", False)
+            if not success:
+                logger.warning(
+                    "Force-kill of %s failed: %s",
+                    container_name,
+                    force_result.get("output", "unknown"),
+                )
+            return (success, force_result.get("output", ""))
+        return (False, "")
+
+    force_killed, force_error = await asyncio.shield(_grace_kill())
 
     return {
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
+        "force_error": force_error,
     }
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -796,15 +796,46 @@ async def bulk_start_agents(request: Request):
 
 @router.post("/api/agents/bulk/stop")
 async def bulk_stop_agents(request: Request):
-    """Stop all agent containers, running graceful prepare first."""
-    from tinyagentos.containers import stop_container
+    """Stop all agent containers with graceful prepare, then force-kill after 2s grace.
+
+    SIGTERM is sent first via incus stop. After a 2-second grace window,
+    any containers still running are force-killed with SIGKILL (incus stop --force).
+    In-flight agent framework work is cancelled by the prepare step;
+    LLM calls and tool invocations are terminated when the container dies.
+    """
+    from tinyagentos.containers import stop_container, container_exists
+
     config = request.app.state.config
     orchestrator = getattr(request.app.state, "orchestrator", None)
     report = {}
     if orchestrator is not None:
         report = await orchestrator.prepare("all", "stop")
+
+    # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
-    return {"action": "stop", "prepare_report": report, "results": results}
+
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers
+    await asyncio.sleep(2)
+    force_results = {}
+    for agent in config.agents:
+        name = agent["name"]
+        container_name = f"taos-agent-{name}"
+        try:
+            if await container_exists(container_name):
+                force_result = await stop_container(container_name, force=True)
+                force_results[name] = {
+                    "force_killed": force_result.get("success", False),
+                    "output": force_result.get("output", ""),
+                }
+        except Exception as e:
+            force_results[name] = {"force_killed": False, "error": str(e)}
+
+    return {
+        "action": "stop",
+        "prepare_report": report,
+        "results": results,
+        "force_kill_results": force_results,
+    }
 
 
 @router.post("/api/agents/bulk/restart")
@@ -839,8 +870,13 @@ async def pause_agent(request: Request, name: str):
 
 @router.post("/api/agents/{name}/stop")
 async def stop_agent(request: Request, name: str):
-    """Gracefully prepare then stop an agent's LXC container."""
-    from tinyagentos.containers import stop_container
+    """Gracefully prepare, then stop an agent's LXC container with force-kill after 2s.
+
+    Sends SIGTERM via incus stop. After a 2-second grace window, if the container
+    is still running, sends SIGKILL (incus stop --force) to guarantee termination.
+    """
+    from tinyagentos.containers import stop_container, container_exists
+
     config = request.app.state.config
     agent = find_agent(config, name)
     if not agent:
@@ -849,8 +885,22 @@ async def stop_agent(request: Request, name: str):
     report = {}
     if orchestrator is not None:
         report = await orchestrator.prepare([name], "stop")
-    stop_result = await stop_container(f"taos-agent-{name}")
-    return {"prepare_report": report, "stop_result": stop_result}
+
+    container_name = f"taos-agent-{name}"
+    stop_result = await stop_container(container_name)
+
+    # 2-second grace window, then SIGKILL
+    await asyncio.sleep(2)
+    force_killed = False
+    if await container_exists(container_name):
+        force_result = await stop_container(container_name, force=True)
+        force_killed = force_result.get("success", False)
+
+    return {
+        "prepare_report": report,
+        "stop_result": stop_result,
+        "force_killed": force_killed,
+    }
 
 
 @router.post("/api/agents/{name}/restart")


### PR DESCRIPTION
## What

Completes the agent kill switch feature (closes #132):

1. **Ctrl+Shift+K keyboard shortcut** — registered as a system-scope shortcut in the desktop SPA. Calls `POST /api/agents/bulk/stop` just like the existing "Kill all agents" button, then dispatches `taos:agents-changed` so UI components pick up the state change.

2. **SIGTERM → 2s → SIGKILL grace window** — both `bulk_stop_agents` and `stop_agent` routes now:
   - Run graceful `orchestrator.prepare()` (informs agent frameworks of shutdown)
   - Send SIGTERM via `incus stop`
   - Wait 2 seconds
   - Force-kill any remaining containers with `incus stop --force` (SIGKILL)

## Existing work preserved

The `AgentKillSwitch` dropdown component and its TopBar integration were already implemented — this PR adds the keyboard shortcut and hardens the backend termination guarantees.

## Files changed

- `desktop/src/App.tsx` — added `withCsrf` import and `Ctrl+Shift+K` shortcut in `SystemShortcuts`
- `tinyagentos/routes/agents.py` — hardened `bulk_stop_agents` and `stop_agent` with force-kill after 2s grace

## Testing

- Desktop AgentKillSwitch tests: 2/2 pass
- Backend: Python AST parse clean; container_exists import verified in containers `__all__`
- Existing `test_bulk_stop` assertion (`action == "stop"`) preserved — response is backward-compatible