### PR TITLE
fix(install): route LXC port allocation through centralized allocator

### DIFF
--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -124,6 +124,9 @@ class TestLxcUsesCentralizedAllocator:
         assert hasattr(mod, "allocate_host_port"), (
             "lxc_installer must import allocate_host_port"
         )
+        assert not hasattr(mod, "RESERVED_PORTS"), (
+            "lxc_installer must not import RESERVED_PORTS; allocate_host_port handles that internally"
+        )
 
     def test_installer_class_available(self):
         """LXCInstaller is importable (sanity check — no import errors from the refactor)."""

--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -2,6 +2,7 @@
 import socket
 
 from tinyagentos.installers.docker_installer import DockerInstaller
+from tinyagentos.installers.lxc_installer import LXCInstaller
 from tinyagentos.installers.port_allocator import (
     RESERVED_PORTS,
     _POOL_END,
@@ -102,3 +103,28 @@ class TestDockerComposeMultiPort:
             ]
         assert first + 1 not in host_side
         assert len(set(host_side)) == 2
+
+
+class TestLxcUsesCentralizedAllocator:
+    """LXCInstaller must route through the centralized allocator, not a standalone scanner."""
+
+    def test_no_standalone_find_free_port(self):
+        """_find_free_port must not exist on the module (removed in favour of allocate_host_port)."""
+        import tinyagentos.installers.lxc_installer as mod
+        assert not hasattr(mod, "_find_free_port"), (
+            "lxc_installer must not carry its own _find_free_port; "
+            "use allocate_host_port from port_allocator instead"
+        )
+
+    def test_allocate_host_port_imported(self):
+        """lxc_installer imports allocate_host_port (not RESERVED_PORTS) from port_allocator."""
+        import tinyagentos.installers.lxc_installer as mod
+        # The only port-allocation import should be allocate_host_port.
+        # RESERVED_PORTS was only used by the removed _find_free_port.
+        assert hasattr(mod, "allocate_host_port"), (
+            "lxc_installer must import allocate_host_port"
+        )
+
+    def test_installer_class_available(self):
+        """LXCInstaller is importable (sanity check — no import errors from the refactor)."""
+        assert LXCInstaller is not None

--- a/tests/test_lxc_installer.py
+++ b/tests/test_lxc_installer.py
@@ -78,7 +78,7 @@ class TestLXCInstallerHappyPath:
                 return_value={"success": True},
             ),
             patch(
-                "tinyagentos.installers.lxc_installer._find_free_port",
+                "tinyagentos.installers.lxc_installer.allocate_host_port",
                 return_value=13000,
             ),
         ):
@@ -130,7 +130,7 @@ class TestLXCInstallerHappyPath:
                 return_value={"success": True},
             ),
             patch(
-                "tinyagentos.installers.lxc_installer._find_free_port",
+                "tinyagentos.installers.lxc_installer.allocate_host_port",
                 return_value=13001,
             ),
         ):
@@ -179,7 +179,7 @@ class TestLXCInstallerHappyPath:
                 return_value={"success": True},
             ),
             patch(
-                "tinyagentos.installers.lxc_installer._find_free_port",
+                "tinyagentos.installers.lxc_installer.allocate_host_port",
                 return_value=13500,
             ),
         ):
@@ -239,7 +239,7 @@ class TestLXCInstallerRestoreMode:
                 return_value={"success": True},
             ),
             patch(
-                "tinyagentos.installers.lxc_installer._find_free_port",
+                "tinyagentos.installers.lxc_installer.allocate_host_port",
                 return_value=13002,
             ),
         ):
@@ -302,7 +302,7 @@ class TestLXCInstallerRestoreMode:
                 return_value={"success": True},
             ),
             patch(
-                "tinyagentos.installers.lxc_installer._find_free_port",
+                "tinyagentos.installers.lxc_installer.allocate_host_port",
                 return_value=13003,
             ),
         ):
@@ -367,7 +367,7 @@ class TestLXCInstallerRestoreMode:
                 return_value={"success": True},
             ),
             patch(
-                "tinyagentos.installers.lxc_installer._find_free_port",
+                "tinyagentos.installers.lxc_installer.allocate_host_port",
                 return_value=13004,
             ),
         ):
@@ -427,7 +427,7 @@ class TestLXCInstallerRestoreMode:
                 return_value={"success": True},
             ),
             patch(
-                "tinyagentos.installers.lxc_installer._find_free_port",
+                "tinyagentos.installers.lxc_installer.allocate_host_port",
                 return_value=13005,
             ),
         ):

--- a/tinyagentos/installers/lxc_installer.py
+++ b/tinyagentos/installers/lxc_installer.py
@@ -3,11 +3,8 @@ from __future__ import annotations
 import logging
 import secrets
 import shlex
-import socket
-from contextlib import closing
-
 from tinyagentos.installers.base import AppInstaller
-from tinyagentos.installers.port_allocator import RESERVED_PORTS
+from tinyagentos.installers.port_allocator import allocate_host_port
 import tinyagentos.containers as containers
 
 logger = logging.getLogger(__name__)
@@ -69,20 +66,6 @@ def _render_app_ini(app_id: str = "gitea-lxc") -> str:
         internal_token=secrets.token_hex(32),
         root_url=f"/apps/{app_id}/",
     )
-
-
-def _find_free_port(start: int = 30_000, end: int = 40_000) -> int:
-    """Return the first available TCP port in [start, end) that is not reserved."""
-    for port in range(start, end):
-        if port in RESERVED_PORTS:
-            continue
-        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            try:
-                s.bind(("0.0.0.0", port))
-                return port
-            except OSError:
-                continue
-    raise RuntimeError(f"No free non-reserved port found in range {start}-{end}")
 
 
 class LXCInstaller(AppInstaller):
@@ -305,9 +288,12 @@ class LXCInstaller(AppInstaller):
 
             # Step 8: Add proxy device (host_port → container:3000).
             # Retry up to 10 times to handle the TOCTOU window between the
-            # port probe and the actual bind by incus.
+            # port probe and the actual bind by incus.  Each failed port is
+            # accumulated so the deterministic allocator doesn't hand it out
+            # again in the next retry.
+            failed_ports: set[int] = set()
             for _attempt in range(10):
-                host_port = _find_free_port()
+                host_port = allocate_host_port(app_id, exclude=failed_ports)
                 logger.info(
                     "LXCInstaller: adding proxy device host:%d -> container:3000 (attempt %d)",
                     host_port, _attempt + 1,
@@ -324,6 +310,7 @@ class LXCInstaller(AppInstaller):
                     raise RuntimeError(
                         f"Failed to add proxy device: {res.get('output', '')}"
                     )
+                failed_ports.add(host_port)
                 logger.warning(
                     "LXCInstaller: port %d already in use, retrying", host_port
                 )

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -267,12 +267,16 @@ async def _install_agent_framework(
 
 
 def _docker_published_port(install_config: dict) -> int:
-    """Return the first host port a docker service publishes, or 0.
+    """Return the first container port a docker service publishes, or 0.
 
-    DockerInstaller maps each declared port as ``{p}:{p}`` so the host port
-    equals the container port. Ports may be declared either at the top level
-    (``install.ports``) or nested under ``install.requires.ports`` — mirror
-    the precedence DockerInstaller._generate_compose uses (requires first).
+    DockerInstaller maps each declared port as ``{allocated_host_port}:{container_port}``
+    so the container-side port is distinct from the host port.  This function
+    reads the container ports from the manifest (install.ports or
+    install.requires.ports) for use as a fallback when the installer
+    doesn't return a host_port.  Ports may be declared either at the top
+    level (``install.ports``) or nested under ``install.requires.ports`` —
+    mirror the precedence DockerInstaller._generate_compose uses (requires
+    first).
     """
     if not isinstance(install_config, dict):
         return 0


### PR DESCRIPTION
## Summary

Routes the LXC installer's port allocation through the centralized `allocate_host_port()` from `port_allocator.py` instead of its own standalone `_find_free_port()`. This makes the port allocator the single source of truth for all app host-port assignments (Docker + LXC).

## Changes

- **`lxc_installer.py`**: Remove standalone `_find_free_port()`, `socket`, and `closing` imports. Import `allocate_host_port` instead of `RESERVED_PORTS`. Accumulate failed ports in an `exclude` set across the TOCTOU retry loop so the deterministic allocator doesn't re-hand the same port.
- **`store_install.py`**: Fix stale `_docker_published_port` docstring — DockerInstaller now maps `{allocated_host_port}:{container_port}`, not `{p}:{p}`.
- **`tests/installers/test_port_allocator.py`**: Add `TestLxcUsesCentralizedAllocator` class (3 tests) verifying `_find_free_port` is gone and `allocate_host_port` is the only import.

Task: t_6840d494
Refs: #695

## Tests

All 16 port_allocator tests pass (including 3 new). Broader installer + config + backend tests (304 total) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LXC container proxy port allocation by switching to the shared deterministic host-port allocator.
  * Added retry logic that avoids reusing host ports that previously failed due to “address already in use,” preserving existing rollback behavior.

* **Documentation**
  * Clarified Docker published port mapping as `{allocated_host_port}:{container_port}`.
  * Updated guidance on where port declarations can appear (`install.ports` vs `install.requires.ports`) and the precedence rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->