### PR TITLE
feat(chat): truncate conversation branch + re-trigger agent on message edit

### DIFF
--- a/tests/test_chat_edit_delete.py
+++ b/tests/test_chat_edit_delete.py
@@ -176,3 +176,127 @@ async def test_delete_idempotent(tmp_path):
         r2 = await client.delete(f"/api/chat/messages/{msg_id}")
         assert r1.status_code == 204
         assert r2.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_edit_truncates_subsequent_messages(tmp_path):
+    """Editing a user message soft-deletes every message created after it
+    in the same channel, and broadcasts delete events for each."""
+    app, client, rec = await _authed_client(tmp_path)
+    async with client:
+        ch_r = await client.post(
+            "/api/chat/channels",
+            json={"name": "g", "type": "group", "description": "", "topic": "",
+                  "members": ["user", "tom"], "created_by": "user"},
+        )
+        ch_id = ch_r.json()["id"]
+
+        # Post three messages: m1, m2, m3
+        m1 = await client.post(
+            "/api/chat/messages",
+            json={"channel_id": ch_id, "author_id": rec["id"], "author_type": "user",
+                  "content": "first", "content_type": "text"},
+        )
+        m2 = await client.post(
+            "/api/chat/messages",
+            json={"channel_id": ch_id, "author_id": "tom", "author_type": "agent",
+                  "content": "second", "content_type": "text"},
+        )
+        m3 = await client.post(
+            "/api/chat/messages",
+            json={"channel_id": ch_id, "author_id": rec["id"], "author_type": "user",
+                  "content": "third", "content_type": "text"},
+        )
+        m1_id = m1.json()["id"]
+        m2_id = m2.json()["id"]
+        m3_id = m3.json()["id"]
+
+        # Edit m1 — this should soft-delete m2 and m3
+        r = await client.patch(
+            f"/api/chat/messages/{m1_id}", json={"content": "first-edited"},
+        )
+        assert r.status_code == 200, r.json()
+        assert r.json()["content"] == "first-edited"
+
+        # m1 should still exist (edited, not deleted)
+        got_m1 = await app.state.chat_messages.get_message(m1_id)
+        assert got_m1["content"] == "first-edited"
+        assert got_m1["deleted_at"] is None
+
+        # m2 and m3 should be soft-deleted
+        got_m2 = await app.state.chat_messages.get_message(m2_id)
+        assert got_m2["deleted_at"] is not None
+        got_m3 = await app.state.chat_messages.get_message(m3_id)
+        assert got_m3["deleted_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_messages_after_empty_when_nothing_after(tmp_path):
+    """soft_delete_messages_after returns an empty list when there are no
+    messages created after the given timestamp."""
+    app, client, rec = await _authed_client(tmp_path)
+    async with client:
+        ch_r = await client.post(
+            "/api/chat/channels",
+            json={"name": "g", "type": "group", "description": "", "topic": "",
+                  "members": ["user"], "created_by": "user"},
+        )
+        ch_id = ch_r.json()["id"]
+        m = await app.state.chat_messages.send_message(
+            channel_id=ch_id, author_id=rec["id"], author_type="user",
+            content="only message",
+        )
+        store = app.state.chat_messages
+        # After the message's own timestamp there should be nothing.
+        ids = await store.soft_delete_messages_after(ch_id, m["created_at"])
+        assert ids == []
+        # The message itself should still be intact.
+        got = await store.get_message(m["id"])
+        assert got["deleted_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_edit_only_truncates_own_channel(tmp_path):
+    """Editing a message in channel A must not affect messages in channel B."""
+    app, client, rec = await _authed_client(tmp_path)
+    async with client:
+        # Channel A
+        ch_a = await client.post(
+            "/api/chat/channels",
+            json={"name": "a", "type": "group", "description": "", "topic": "",
+                  "members": ["user"], "created_by": "user"},
+        )
+        a_id = ch_a.json()["id"]
+        # Channel B
+        ch_b = await client.post(
+            "/api/chat/channels",
+            json={"name": "b", "type": "group", "description": "", "topic": "",
+                  "members": ["user"], "created_by": "user"},
+        )
+        b_id = ch_b.json()["id"]
+
+        m_a = await client.post(
+            "/api/chat/messages",
+            json={"channel_id": a_id, "author_id": rec["id"], "author_type": "user",
+                  "content": "a1", "content_type": "text"},
+        )
+        await client.post(
+            "/api/chat/messages",
+            json={"channel_id": a_id, "author_id": rec["id"], "author_type": "user",
+                  "content": "a2", "content_type": "text"},
+        )
+        m_b = await client.post(
+            "/api/chat/messages",
+            json={"channel_id": b_id, "author_id": rec["id"], "author_type": "user",
+                  "content": "b1", "content_type": "text"},
+        )
+
+        # Edit m_a (channel A) — should truncate a2 but not b1
+        r = await client.patch(
+            f"/api/chat/messages/{m_a.json()['id']}", json={"content": "a1-edited"},
+        )
+        assert r.status_code == 200
+
+        # b1 should still be intact
+        got_b = await app.state.chat_messages.get_message(m_b.json()["id"])
+        assert got_b["deleted_at"] is None

--- a/tests/test_chat_edit_delete.py
+++ b/tests/test_chat_edit_delete.py
@@ -180,13 +180,14 @@ async def test_delete_idempotent(tmp_path):
 
 @pytest.mark.asyncio
 async def test_edit_truncates_subsequent_messages(tmp_path):
-    """Editing a user message soft-deletes every message created after it
-    in the same channel, and broadcasts delete events for each."""
+    """Editing a user message in a DM channel soft-deletes every message
+    created after it in the same channel and thread, and broadcasts delete
+    events for each."""
     app, client, rec = await _authed_client(tmp_path)
     async with client:
         ch_r = await client.post(
             "/api/chat/channels",
-            json={"name": "g", "type": "group", "description": "", "topic": "",
+            json={"name": "dm-chat", "type": "dm", "description": "", "topic": "",
                   "members": ["user", "tom"], "created_by": "user"},
         )
         ch_id = ch_r.json()["id"]
@@ -257,21 +258,22 @@ async def test_soft_delete_messages_after_empty_when_nothing_after(tmp_path):
 
 @pytest.mark.asyncio
 async def test_edit_only_truncates_own_channel(tmp_path):
-    """Editing a message in channel A must not affect messages in channel B."""
+    """Editing a message in DM channel A must not affect messages in
+    DM channel B."""
     app, client, rec = await _authed_client(tmp_path)
     async with client:
         # Channel A
         ch_a = await client.post(
             "/api/chat/channels",
-            json={"name": "a", "type": "group", "description": "", "topic": "",
-                  "members": ["user"], "created_by": "user"},
+            json={"name": "dm-a", "type": "dm", "description": "", "topic": "",
+                  "members": ["user", "alice"], "created_by": "user"},
         )
         a_id = ch_a.json()["id"]
         # Channel B
         ch_b = await client.post(
             "/api/chat/channels",
-            json={"name": "b", "type": "group", "description": "", "topic": "",
-                  "members": ["user"], "created_by": "user"},
+            json={"name": "dm-b", "type": "dm", "description": "", "topic": "",
+                  "members": ["user", "bob"], "created_by": "user"},
         )
         b_id = ch_b.json()["id"]
 
@@ -280,11 +282,12 @@ async def test_edit_only_truncates_own_channel(tmp_path):
             json={"channel_id": a_id, "author_id": rec["id"], "author_type": "user",
                   "content": "a1", "content_type": "text"},
         )
-        await client.post(
+        a2_r = await client.post(
             "/api/chat/messages",
             json={"channel_id": a_id, "author_id": rec["id"], "author_type": "user",
                   "content": "a2", "content_type": "text"},
         )
+        a2_id = a2_r.json()["id"]
         m_b = await client.post(
             "/api/chat/messages",
             json={"channel_id": b_id, "author_id": rec["id"], "author_type": "user",
@@ -296,6 +299,10 @@ async def test_edit_only_truncates_own_channel(tmp_path):
             f"/api/chat/messages/{m_a.json()['id']}", json={"content": "a1-edited"},
         )
         assert r.status_code == 200
+
+        # a2 should be soft-deleted (it came after a1 in the same DM)
+        got_a2 = await app.state.chat_messages.get_message(a2_id)
+        assert got_a2["deleted_at"] is not None
 
         # b1 should still be intact
         got_b = await app.state.chat_messages.get_message(m_b.json()["id"])

--- a/tinyagentos/chat/message_store.py
+++ b/tinyagentos/chat/message_store.py
@@ -208,21 +208,14 @@ class ChatMessageStore(BaseStore):
         per-message delete events."""
         now = time.time()
         cursor = await self._db.execute(
-            """SELECT id FROM chat_messages
-               WHERE channel_id = ? AND created_at > ? AND deleted_at IS NULL""",
-            (channel_id, after_timestamp),
+            """UPDATE chat_messages SET deleted_at = ?
+               WHERE channel_id = ? AND created_at > ? AND deleted_at IS NULL
+               RETURNING id""",
+            (now, channel_id, after_timestamp),
         )
         rows = await cursor.fetchall()
-        ids = [r[0] for r in rows]
-        if not ids:
-            return []
-        placeholders = ",".join("?" for _ in ids)
-        await self._db.execute(
-            f"UPDATE chat_messages SET deleted_at = ? WHERE id IN ({placeholders})",
-            (now, *ids),
-        )
         await self._db.commit()
-        return ids
+        return [r[0] for r in rows]
 
     async def add_reaction(self, message_id: str, emoji: str, user_id: str) -> None:
         async with self._reaction_lock:

--- a/tinyagentos/chat/message_store.py
+++ b/tinyagentos/chat/message_store.py
@@ -231,6 +231,78 @@ class ChatMessageStore(BaseStore):
         await self._db.commit()
         return [r[0] for r in rows]
 
+    async def edit_and_truncate_branch(
+        self,
+        message_id: str,
+        content: str,
+        *,
+        channel_type: str | None = None,
+        thread_id: str | None = None,
+    ) -> tuple[dict | None, list[str]]:
+        """Edit a message and, if *channel_type* is ``"dm"``, soft-delete
+        every subsequent message in the same channel and thread so the
+        agent branch is rewritten on the next turn.
+
+        All writes happen inside a single transaction so the edit +
+        truncation are atomic.  Timestamp-tie rows are handled
+        deterministically: messages with a strictly later ``created_at``
+        are deleted; messages sharing the exact same timestamp are only
+        deleted when their stable ``id`` sorts after *message_id*.
+
+        Returns ``(updated_message, deleted_ids)``.
+        """
+        now = time.time()
+        deleted_ids: list[str] = []
+
+        await self._db.execute("BEGIN")
+        try:
+            # 1. Edit the message
+            await self._db.execute(
+                "UPDATE chat_messages SET content = ?, edited_at = ? WHERE id = ?",
+                (content, now, message_id),
+            )
+
+            # 2. Truncate subsequent messages in DM channels
+            if channel_type == "dm":
+                cursor = await self._db.execute(
+                    "SELECT channel_id, created_at FROM chat_messages WHERE id = ?",
+                    (message_id,),
+                )
+                row = await cursor.fetchone()
+                if row is not None:
+                    ch_id, created_at = row[0], row[1]
+                    if thread_id is not None:
+                        thread_clause = "AND thread_id = ?"
+                        params = (now, ch_id, created_at, created_at,
+                                  message_id, thread_id)
+                    else:
+                        thread_clause = "AND thread_id IS NULL"
+                        params = (now, ch_id, created_at, created_at,
+                                  message_id)
+                    # Deterministic tie-breaking:
+                    #   created_at > msg.created_at  → later → delete
+                    #   created_at = msg.created_at AND id > msg.id → same time,
+                    #   later row in stable-id order → delete
+                    cursor = await self._db.execute(
+                        f"""UPDATE chat_messages SET deleted_at = ?
+                           WHERE channel_id = ? AND deleted_at IS NULL
+                           AND (created_at > ? OR (created_at = ? AND id > ?))
+                           {thread_clause}
+                           RETURNING id""",
+                        params,
+                    )
+                    rows = await cursor.fetchall()
+                    deleted_ids = [r[0] for r in rows]
+
+            await self._db.commit()
+        except Exception:
+            await self._db.execute("ROLLBACK")
+            raise
+
+        # Fetch the updated message outside the transaction
+        updated = await self.get_message(message_id)
+        return updated, deleted_ids
+
     async def add_reaction(self, message_id: str, emoji: str, user_id: str) -> None:
         async with self._reaction_lock:
             async with self._db.execute(

--- a/tinyagentos/chat/message_store.py
+++ b/tinyagentos/chat/message_store.py
@@ -199,6 +199,31 @@ class ChatMessageStore(BaseStore):
         """Canonical delete = soft delete (Phase 2b-2a)."""
         return await self.soft_delete_message(message_id)
 
+    async def soft_delete_messages_after(
+        self, channel_id: str, after_timestamp: float,
+    ) -> list[str]:
+        """Soft-delete all non-deleted messages in *channel_id* whose
+        ``created_at`` is strictly greater than *after_timestamp*.
+        Returns the list of affected message ids so callers can broadcast
+        per-message delete events."""
+        now = time.time()
+        cursor = await self._db.execute(
+            """SELECT id FROM chat_messages
+               WHERE channel_id = ? AND created_at > ? AND deleted_at IS NULL""",
+            (channel_id, after_timestamp),
+        )
+        rows = await cursor.fetchall()
+        ids = [r[0] for r in rows]
+        if not ids:
+            return []
+        placeholders = ",".join("?" for _ in ids)
+        await self._db.execute(
+            f"UPDATE chat_messages SET deleted_at = ? WHERE id IN ({placeholders})",
+            (now, *ids),
+        )
+        await self._db.commit()
+        return ids
+
     async def add_reaction(self, message_id: str, emoji: str, user_id: str) -> None:
         async with self._reaction_lock:
             async with self._db.execute(

--- a/tinyagentos/chat/message_store.py
+++ b/tinyagentos/chat/message_store.py
@@ -201,17 +201,31 @@ class ChatMessageStore(BaseStore):
 
     async def soft_delete_messages_after(
         self, channel_id: str, after_timestamp: float,
+        thread_id: str | None = None,
     ) -> list[str]:
         """Soft-delete all non-deleted messages in *channel_id* whose
         ``created_at`` is strictly greater than *after_timestamp*.
+        When *thread_id* is given, only messages within that thread are
+        deleted; when it is ``None``, only main-timeline messages (those
+        with ``thread_id IS NULL``) are deleted.
         Returns the list of affected message ids so callers can broadcast
         per-message delete events."""
         now = time.time()
+        if thread_id is not None:
+            thread_clause = "AND thread_id = ?"
+            params = (now, channel_id, after_timestamp, thread_id)
+        else:
+            thread_clause = "AND thread_id IS NULL"
+            params = (now, channel_id, after_timestamp)
+        # NOTE: strict > means a message sharing the edited message's exact
+        # time.time() survives — at most one stale adjacent message can
+        # slip through a timestamp tie.
         cursor = await self._db.execute(
-            """UPDATE chat_messages SET deleted_at = ?
+            f"""UPDATE chat_messages SET deleted_at = ?
                WHERE channel_id = ? AND created_at > ? AND deleted_at IS NULL
+               {thread_clause}
                RETURNING id""",
-            (now, channel_id, after_timestamp),
+            params,
         )
         rows = await cursor.fetchall()
         await self._db.commit()

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -216,39 +216,47 @@ async def chat_ws(websocket: WebSocket):
 
             elif msg_type == "edit":
                 msg_store = websocket.app.state.chat_messages
-                msg = await msg_store.get_message(data["message_id"])
+                edit_msg_id = data.get("message_id")
+                edit_content = data.get("content")
+                if not edit_msg_id or not isinstance(edit_content, str):
+                    continue
+                msg = await msg_store.get_message(edit_msg_id)
                 if msg is None or msg.get("deleted_at"):
                     continue
                 if msg["author_id"] != user_id:
                     continue
-                await msg_store.edit_message(data["message_id"], data["content"])
-                msg = await msg_store.get_message(data["message_id"])
+                await msg_store.edit_message(edit_msg_id, edit_content)
+                msg = await msg_store.get_message(edit_msg_id)
                 if msg:
                     await hub.broadcast(msg["channel_id"], {
                         "type": "message_edit",
                         "seq": hub.next_seq(),
-                        "message_id": data["message_id"],
-                        "content": data["content"],
+                        "message_id": edit_msg_id,
+                        "content": edit_content,
                         "edited_at": msg["edited_at"],
                     })
-                    # Truncate subsequent messages in this channel so the
-                    # agent branch is rewritten.
-                    truncated_ids = await msg_store.soft_delete_messages_after(
-                        msg["channel_id"], msg["created_at"],
-                    )
-                    for tid in truncated_ids:
-                        await hub.broadcast(msg["channel_id"], {
-                            "type": "message_delete",
-                            "seq": hub.next_seq(),
-                            "message_id": tid,
-                            "channel_id": msg["channel_id"],
-                        })
+                    # Truncate subsequent messages in this DM channel and
+                    # thread so the agent branch is rewritten.  Only DM
+                    # channels are truncated — editing in a multi-human group
+                    # must not delete other people's messages.
+                    ch_store = websocket.app.state.chat_channels
+                    channel = await ch_store.get_channel(msg["channel_id"])
+                    if channel is not None and channel.get("type") == "dm":
+                        truncated_ids = await msg_store.soft_delete_messages_after(
+                            msg["channel_id"], msg["created_at"],
+                            thread_id=msg.get("thread_id"),
+                        )
+                        for tid in truncated_ids:
+                            await hub.broadcast(msg["channel_id"], {
+                                "type": "message_delete",
+                                "seq": hub.next_seq(),
+                                "message_id": tid,
+                                "channel_id": msg["channel_id"],
+                            })
                     # Re-trigger the agent.
                     router_svc = getattr(
                         websocket.app.state, "agent_chat_router", None,
                     )
-                    ch_store = websocket.app.state.chat_channels
-                    channel = await ch_store.get_channel(msg["channel_id"])
                     if router_svc is not None and channel is not None:
                         router_svc.dispatch(msg, channel)
 
@@ -591,10 +599,17 @@ async def edit_message_endpoint(message_id: str, request: Request):
         return JSONResponse({"error": "not the author"}, status_code=403)
     await msg_store.edit_message(message_id, body["content"])
     # Truncate: soft-delete every message created after this one in the same
-    # channel so the agent sees the corrected branch on its next turn.
-    truncated_ids = await msg_store.soft_delete_messages_after(
-        msg["channel_id"], msg["created_at"],
-    )
+    # DM channel and thread so the agent sees the corrected branch on its
+    # next turn.  Only DM channels are truncated — in a multi-human group,
+    # editing should not delete other people's messages.
+    truncated_ids: list[str] = []
+    ch_store = request.app.state.chat_channels
+    channel = await ch_store.get_channel(msg["channel_id"])
+    if channel is not None and channel.get("type") == "dm":
+        truncated_ids = await msg_store.soft_delete_messages_after(
+            msg["channel_id"], msg["created_at"],
+            thread_id=msg.get("thread_id"),
+        )
     updated = await msg_store.get_message(message_id)
     hub = request.app.state.chat_hub
     seq = hub.next_seq()
@@ -612,8 +627,6 @@ async def edit_message_endpoint(message_id: str, request: Request):
         })
     # Re-trigger the agent with the updated conversation branch.
     router_svc = getattr(request.app.state, "agent_chat_router", None)
-    ch_store = request.app.state.chat_channels
-    channel = await ch_store.get_channel(msg["channel_id"])
     if router_svc is not None and channel is not None:
         router_svc.dispatch(updated, channel)
     return JSONResponse(updated)

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -225,40 +225,40 @@ async def chat_ws(websocket: WebSocket):
                     continue
                 if msg["author_id"] != user_id:
                     continue
-                await msg_store.edit_message(edit_msg_id, edit_content)
-                msg = await msg_store.get_message(edit_msg_id)
-                if msg:
-                    await hub.broadcast(msg["channel_id"], {
+                # Only truncate subsequent messages in DM channels —
+                # editing in a multi-human group must not delete other
+                # people's messages.  The agent is only re-triggered in
+                # DM channels for the same reason.
+                ch_store = websocket.app.state.chat_channels
+                channel = await ch_store.get_channel(msg["channel_id"])
+                channel_type = channel.get("type") if channel else None
+                updated, truncated_ids = await msg_store.edit_and_truncate_branch(
+                    edit_msg_id, edit_content,
+                    channel_type=channel_type,
+                    thread_id=msg.get("thread_id"),
+                )
+                if updated:
+                    await hub.broadcast(updated["channel_id"], {
                         "type": "message_edit",
                         "seq": hub.next_seq(),
                         "message_id": edit_msg_id,
                         "content": edit_content,
-                        "edited_at": msg["edited_at"],
+                        "edited_at": updated["edited_at"],
                     })
-                    # Truncate subsequent messages in this DM channel and
-                    # thread so the agent branch is rewritten.  Only DM
-                    # channels are truncated — editing in a multi-human group
-                    # must not delete other people's messages.
-                    ch_store = websocket.app.state.chat_channels
-                    channel = await ch_store.get_channel(msg["channel_id"])
-                    if channel is not None and channel.get("type") == "dm":
-                        truncated_ids = await msg_store.soft_delete_messages_after(
-                            msg["channel_id"], msg["created_at"],
-                            thread_id=msg.get("thread_id"),
+                    for tid in truncated_ids:
+                        await hub.broadcast(msg["channel_id"], {
+                            "type": "message_delete",
+                            "seq": hub.next_seq(),
+                            "message_id": tid,
+                            "channel_id": msg["channel_id"],
+                        })
+                    # Re-trigger the agent only in DM channels.
+                    if channel_type == "dm":
+                        router_svc = getattr(
+                            websocket.app.state, "agent_chat_router", None,
                         )
-                        for tid in truncated_ids:
-                            await hub.broadcast(msg["channel_id"], {
-                                "type": "message_delete",
-                                "seq": hub.next_seq(),
-                                "message_id": tid,
-                                "channel_id": msg["channel_id"],
-                            })
-                    # Re-trigger the agent.
-                    router_svc = getattr(
-                        websocket.app.state, "agent_chat_router", None,
-                    )
-                    if router_svc is not None and channel is not None:
-                        router_svc.dispatch(msg, channel)
+                        if router_svc is not None and channel is not None:
+                            router_svc.dispatch(updated, channel)
 
             elif msg_type == "delete":
                 msg_store = websocket.app.state.chat_messages
@@ -597,20 +597,19 @@ async def edit_message_endpoint(message_id: str, request: Request):
     caller_id = session_user["id"] if session_user else None
     if msg["author_id"] != caller_id:
         return JSONResponse({"error": "not the author"}, status_code=403)
-    await msg_store.edit_message(message_id, body["content"])
-    # Truncate: soft-delete every message created after this one in the same
-    # DM channel and thread so the agent sees the corrected branch on its
-    # next turn.  Only DM channels are truncated — in a multi-human group,
-    # editing should not delete other people's messages.
-    truncated_ids: list[str] = []
+    # Only truncate subsequent messages in DM channels — editing in a
+    # multi-human group must not delete other people's messages.  The
+    # agent is only re-triggered in DM channels for the same reason.
     ch_store = request.app.state.chat_channels
     channel = await ch_store.get_channel(msg["channel_id"])
-    if channel is not None and channel.get("type") == "dm":
-        truncated_ids = await msg_store.soft_delete_messages_after(
-            msg["channel_id"], msg["created_at"],
-            thread_id=msg.get("thread_id"),
-        )
-    updated = await msg_store.get_message(message_id)
+    channel_type = channel.get("type") if channel else None
+    updated, truncated_ids = await msg_store.edit_and_truncate_branch(
+        message_id, body["content"],
+        channel_type=channel_type,
+        thread_id=msg.get("thread_id"),
+    )
+    if not updated:
+        return JSONResponse({"error": "message not found"}, status_code=404)
     hub = request.app.state.chat_hub
     seq = hub.next_seq()
     await hub.broadcast(msg["channel_id"], {
@@ -625,10 +624,11 @@ async def edit_message_endpoint(message_id: str, request: Request):
             "type": "message_delete", "seq": seq,
             "channel_id": msg["channel_id"], "message_id": tid,
         })
-    # Re-trigger the agent with the updated conversation branch.
-    router_svc = getattr(request.app.state, "agent_chat_router", None)
-    if router_svc is not None and channel is not None:
-        router_svc.dispatch(updated, channel)
+    # Re-trigger the agent only in DM channels.
+    if channel_type == "dm":
+        router_svc = getattr(request.app.state, "agent_chat_router", None)
+        if router_svc is not None and channel is not None:
+            router_svc.dispatch(updated, channel)
     return JSONResponse(updated)
 
 

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -216,6 +216,11 @@ async def chat_ws(websocket: WebSocket):
 
             elif msg_type == "edit":
                 msg_store = websocket.app.state.chat_messages
+                msg = await msg_store.get_message(data["message_id"])
+                if msg is None or msg.get("deleted_at"):
+                    continue
+                if msg["author_id"] != user_id:
+                    continue
                 await msg_store.edit_message(data["message_id"], data["content"])
                 msg = await msg_store.get_message(data["message_id"])
                 if msg:

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -226,6 +226,26 @@ async def chat_ws(websocket: WebSocket):
                         "content": data["content"],
                         "edited_at": msg["edited_at"],
                     })
+                    # Truncate subsequent messages in this channel so the
+                    # agent branch is rewritten.
+                    truncated_ids = await msg_store.soft_delete_messages_after(
+                        msg["channel_id"], msg["created_at"],
+                    )
+                    for tid in truncated_ids:
+                        await hub.broadcast(msg["channel_id"], {
+                            "type": "message_delete",
+                            "seq": hub.next_seq(),
+                            "message_id": tid,
+                            "channel_id": msg["channel_id"],
+                        })
+                    # Re-trigger the agent.
+                    router_svc = getattr(
+                        websocket.app.state, "agent_chat_router", None,
+                    )
+                    ch_store = websocket.app.state.chat_channels
+                    channel = await ch_store.get_channel(msg["channel_id"])
+                    if router_svc is not None and channel is not None:
+                        router_svc.dispatch(msg, channel)
 
             elif msg_type == "delete":
                 msg_store = websocket.app.state.chat_messages
@@ -565,14 +585,32 @@ async def edit_message_endpoint(message_id: str, request: Request):
     if msg["author_id"] != caller_id:
         return JSONResponse({"error": "not the author"}, status_code=403)
     await msg_store.edit_message(message_id, body["content"])
+    # Truncate: soft-delete every message created after this one in the same
+    # channel so the agent sees the corrected branch on its next turn.
+    truncated_ids = await msg_store.soft_delete_messages_after(
+        msg["channel_id"], msg["created_at"],
+    )
     updated = await msg_store.get_message(message_id)
     hub = request.app.state.chat_hub
+    seq = hub.next_seq()
     await hub.broadcast(msg["channel_id"], {
-        "type": "message_edit", "seq": hub.next_seq(),
+        "type": "message_edit", "seq": seq,
         "message_id": message_id,
         "content": updated["content"],
         "edited_at": updated["edited_at"],
     })
+    for tid in truncated_ids:
+        seq = hub.next_seq()
+        await hub.broadcast(msg["channel_id"], {
+            "type": "message_delete", "seq": seq,
+            "channel_id": msg["channel_id"], "message_id": tid,
+        })
+    # Re-trigger the agent with the updated conversation branch.
+    router_svc = getattr(request.app.state, "agent_chat_router", None)
+    ch_store = request.app.state.chat_channels
+    channel = await ch_store.get_channel(msg["channel_id"])
+    if router_svc is not None and channel is not None:
+        router_svc.dispatch(updated, channel)
     return JSONResponse(updated)
 
 


### PR DESCRIPTION
Fixes #800.

## What
When a user edits a past message:
1. Soft-deletes all messages created after the edited message (truncation)
2. Broadcasts per-message delete events to connected clients
3. Re-dispatches the edited message through AgentChatRouter to re-trigger the agent

## Changes
- `tinyagentos/chat/message_store.py`: new `soft_delete_messages_after(channel_id, timestamp)` method
- `tinyagentos/routes/chat.py`: updated `edit_message_endpoint` and WS edit handler
- `tests/test_chat_edit_delete.py`: 3 new tests (truncation, empty-after edge case, cross-channel isolation)

## Tests
```
tests/test_chat_edit_delete.py ..........
tests/test_chat_messages.py ........................
tests/test_routes_chat.py::test_post_message ✓
tests/test_routes_chat.py::test_post_message_with_embeds ✓
```
All 34 targeted tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editing a chat message now removes later messages only within the same DM conversation branch (and thread, if applicable).
  * Updated messages automatically re-trigger agent responses.

* **Bug Fixes**
  * Message edits are now strictly validated (must target an existing, non-deleted message authored by the requester).
  * Subsequent message removal is scoped to the correct channel/thread, leaving other channels unaffected.

* **Tests**
  * Added coverage for edit/delete side effects, empty-results behavior, and DM scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->