### PR TITLE
fix(consent): send CSRF token on agent auth-request approve/deny

### DIFF
--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { CheckCircle, XCircle } from "lucide-react";
+import { withCsrf } from "@/lib/csrf";
 
 /**
  * Inline Allow / Deny actions for an external-agent access request.
@@ -142,12 +143,12 @@ export function ConsentActions({
       body = JSON.stringify(payload);
     }
     try {
-      const res = await fetch(url, {
+      const res = await fetch(url, withCsrf({
         method: "POST",
         headers: body ? { "Content-Type": "application/json" } : {},
         body,
         credentials: "include",
-      });
+      }));
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         setError((data as { detail?: string }).detail ?? `Request failed (${res.status})`);


### PR DESCRIPTION
ConsentActions used a plain fetch() with no X-CSRF-Token header, so every external-agent access approval/denial (bell notification, toast, Decisions app) failed with 'CSRF token missing'. Wraps the fetch init in withCsrf() like AgentKillSwitch. tsc clean. Unblocks the whole agent consent flow.

----
## Summary by Gitar

- **New doc-review system:**
    - Added `DocReviewStore` for tracking document states (`awaiting_review`, `approved`, `changes_requested`) with SQL persistence.
    - Implemented `project_doc_review` API routes for managing state transitions and actor tracking.
- **UI integration:**
    - Integrated `ReviewBadge` into `FilesApp` to display and cycle review states for project documents.
- **Security:**
    - Added `_AGENT_DOC_REVIEW_ROUTES` allowlist and middleware gating to ensure agents can only access doc-review routes for their scoped projects.
- **Testing:**
    - Added comprehensive `test_doc_review.py` covering state transitions, actor recording, and security gating (scoped tokens vs 404/403 scenarios).


<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security handling for consent approval and denial requests.
  * Preserved existing request details while ensuring required CSRF protection is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->