### PR TITLE
feat(projects): lead agent can mark cards claimable (fleet curation)

### DIFF
--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -448,3 +448,71 @@ class TestAgentElementFilter:
             )
         assert resp.status_code == 200
         assert [t["id"] for t in resp.json()["items"]] == [tagged]
+
+
+@pytest.mark.asyncio
+class TestLeadAgentMarkClaimable:
+    """The project LEAD agent may flag cards claimable; a non-lead project_tasks
+    agent may not (curation is lead-only, narrower than the read/claim scope)."""
+
+    async def test_lead_agent_marks_and_unmarks_claimable(self, ctx):
+        pid = await _new_project(ctx, "claimable-lead")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            on = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/claimable",
+                json={"claimable": True},
+                headers=_hdr(token),
+            )
+            assert on.status_code == 200, on.text
+            assert "claimable" in on.json()["labels"]
+            off = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/claimable",
+                json={"claimable": False},
+                headers=_hdr(token),
+            )
+            assert off.status_code == 200
+            assert "claimable" not in off.json()["labels"]
+
+    async def test_non_lead_agent_cannot_mark_claimable(self, ctx):
+        pid = await _new_project(ctx, "claimable-nonlead")
+        tid = await _new_task(ctx, pid)
+        _cid, token = await _mint_agent(ctx, pid)  # project_tasks but NOT the lead
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/claimable",
+                json={"claimable": True},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 404, resp.text  # existence-hiding refusal
+
+    async def test_claimable_preserves_other_labels(self, ctx):
+        pid = await _new_project(ctx, "claimable-preserve")
+        tid = await _new_task(ctx, pid)
+        await ctx.client.patch(
+            f"/api/projects/{pid}/tasks/{tid}", json={"labels": ["urgent"]}
+        )
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks/{tid}/claimable",
+                json={"claimable": True},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        labels = resp.json()["labels"]
+        assert "claimable" in labels and "urgent" in labels
+
+    async def test_session_owner_marks_claimable(self, ctx):
+        pid = await _new_project(ctx, "claimable-owner")
+        tid = await _new_task(ctx, pid)
+        resp = await ctx.client.post(
+            f"/api/projects/{pid}/tasks/{tid}/claimable", json={"claimable": True}
+        )
+        assert resp.status_code == 200, resp.text
+        assert "claimable" in resp.json()["labels"]

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -58,6 +58,11 @@ _AGENT_TASK_ROUTES = (
     # PATCH (free task-field mutation) is intentionally NOT here: it is broader
     # than the "read + lifecycle + comments" the project_tasks scope documents.
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
+    # Mark-claimable curation: reachable by a Bearer token, but the handler
+    # (_authorize_project_lead) then restricts it to THIS project's LEAD agent --
+    # a plain project_tasks worker is refused. Toggles only the "claimable"
+    # label, so it does not widen the scope into free field edits (cf. PATCH).
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/claimable$")),
 )
 
 _AGENT_CANVAS_ROUTES = (

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -489,6 +489,52 @@ async def _authorize_task_actor(
     return (caller, True, project)
 
 
+async def _authorize_project_lead(
+    request: Request, pstore, project_id: str
+) -> "tuple[str, bool, dict] | JSONResponse":
+    """Authorize a LEAD-only curation action (mark a card claimable).
+
+    Accepts EITHER a session owner/admin OR the project's LEAD agent's registry
+    JWT (scope ``project_tasks`` bound to THIS project AND the agent is this
+    project's ``lead_member_id``).  This is deliberately narrower than
+    ``_authorize_task_actor``: a plain ``project_tasks`` agent (a worker lane)
+    can claim/work cards but may NOT curate the board.  Only the lead flags
+    which cards the fleet may pick up.
+
+    Mirrors ``_authorize_task_actor``'s existence-hiding 404 for every refusal
+    (non-owner session, wrong-project token, or a non-lead agent) so a caller
+    can never distinguish "exists but I am not the lead" from "does not exist".
+    """
+    uid = getattr(request.state, "user_id", None)
+    if uid:
+        user = CurrentUser(
+            user_id=uid, is_admin=bool(getattr(request.state, "is_admin", False))
+        )
+        project_or_err = await _get_owned_project(pstore, project_id, user)
+        if isinstance(project_or_err, JSONResponse):
+            return project_or_err
+        return (user.user_id, False, project_or_err)
+
+    try:
+        caller = await check_agent_scope_for_project(
+            request, "project_tasks", project_id
+        )
+    except HTTPException as exc:
+        if exc.status_code == 403 and exc.detail == PROJECT_SCOPE_MISMATCH_DETAIL:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        raise
+    if caller is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    project = await pstore.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    # Curation is lead-only: a non-lead agent (even one holding project_tasks)
+    # is collapsed into the same existence-hiding 404 as a non-owner session.
+    if project.get("lead_member_id") != caller:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return (caller, True, project)
+
+
 def _resolve_actor(
     is_agent: bool, actor_id: str, body_actor: "str | None"
 ) -> "str | None | JSONResponse":
@@ -708,6 +754,51 @@ async def claim_task(
     notifs = getattr(request.app.state, "notifications", None)
     if notifs is not None:
         await notifs.emit_event("task.claimed", "Task claimed", f"{task_id} claimed by {claimer_id}")
+    return await store.get_task(task_id)
+
+
+class MarkClaimableIn(BaseModel):
+    claimable: bool
+
+
+@router.post("/api/projects/{project_id}/tasks/{task_id}/claimable")
+async def mark_task_claimable(
+    project_id: str,
+    task_id: str,
+    payload: MarkClaimableIn,
+    request: Request,
+):
+    """Add or remove the ``claimable`` label on a task (fleet-pickup flag).
+
+    LEAD-only curation: a project LEAD (session owner/admin, or the lead agent's
+    ``project_tasks`` token) flags which cards the build fleet may pick up. This
+    is deliberately narrower than PATCH ``update_task`` (which stays session-only
+    per #1774): it touches ONLY the ``claimable`` label and preserves every other
+    label, so granting it to the lead agent does not widen the ``project_tasks``
+    scope into free field edits.
+    """
+    pstore = request.app.state.project_store
+    auth = await _authorize_project_lead(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_task_store
+    existing = await store.get_task(task_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    labels = list(existing.get("labels") or [])
+    has = "claimable" in labels
+    if payload.claimable and not has:
+        labels.append("claimable")
+    elif not payload.claimable and has:
+        labels = [lbl for lbl in labels if lbl != "claimable"]
+    else:
+        return await store.get_task(task_id)  # already in the requested state
+    await store.update_task(task_id, labels=labels)
+    _beads_mark_dirty(request, project_id)
+    await pstore.log_activity(
+        project_id, actor_id, "task.claimable", {"task_id": task_id, "claimable": payload.claimable}
+    )
     return await store.get_task(task_id)
 
 


### PR DESCRIPTION
Part of #1968. The build fleet needs a project LEAD to flag which cards it may pick up (the 'claimable' label). PATCH update_task stays session-only per #1774 (free field mutation exceeds project_tasks); instead this adds a NARROW lead-gated endpoint that toggles ONLY the claimable label.

- `_authorize_project_lead`: session owner/admin OR the project's lead agent (project_tasks token AND canonical_id == project.lead_member_id). Non-lead agents get the same existence-hiding 404 as non-owner sessions.
- Route allowlisted for Bearer passthrough in auth_middleware (`_AGENT_TASK_ROUTES`); the handler does the lead check.
- Preserves all other labels; idempotent; append-only activity log.
- 4 new tests (lead marks/unmarks, non-lead 404, labels preserved, session owner); full agent-task suite 30/30 green.

Security-reviewed for allowlist over-match + authorizer bypass before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project leads can mark tasks as claimable for fleet pickup or remove that eligibility.
  * Existing task labels are preserved when claimability changes.
  * Task activity is recorded when claimability is updated.

* **Bug Fixes**
  * Unauthorized agents receive an access-denied response when attempting to change task claimability.
  * Existing session-owner task claimability behavior remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->