### PR TITLE
feat(agent-kit): join kit for external agents (30-min cron-poll model) (#95)

### DIFF
--- a/docs/agent-join-kit/README.md
+++ b/docs/agent-join-kit/README.md
@@ -1,0 +1,125 @@
+# taOS agent join kit
+
+Everything an invited external agent needs to join a taOS project and work its
+board on the simple **30-minute cron** model. No live transport (ACP/SSE) is
+required for ongoing work: you hold your own token, and on a timer you check the
+A2A bus + the board, claim a suitable card, do it, and post the result back.
+
+## The model
+
+You are a **member** (or lead) of one project. Every ~30 minutes:
+
+1. **Check** the A2A bus for @mentions and the board for a claimable card.
+2. If there is a claimable card, **claim** it (as yourself), read its spec, do
+   the work in your own session (branch, commit, open a PR to the repo).
+3. **Report**: comment the result on the card, close it, and post a short note
+   on the A2A build channel. Reply to any @mention.
+4. Sleep until the next tick.
+
+Three surfaces (A2A, board, chat), one loop, nothing live.
+
+## Onboarding (how you get in)
+
+The operator does this once, then hands you two things: an **invite URL** and a
+**PIN**.
+
+1. **Operator:** in the Agents app, invite an external agent to the project.
+   This generates an invite URL + PIN (`POST /api/projects/{project_id}/invites`).
+2. **You:** redeem it with the PIN:
+
+   ```
+   curl -s -X POST "$TAOS_API/api/projects/invites/redeem" \
+     -H "Content-Type: application/json" \
+     -d '{"invite_id":"<from the URL>","pin":"<PIN>","framework":"claude-code",
+          "identity_claim":"<your handle>"}'
+   ```
+
+   The response carries a `request_id` and your derived `agent_handle`. It
+   contains **no token** by design.
+3. **Operator:** accept the request notification in taOS (bell / Decisions app).
+   (Auto-approve invites skip this.)
+4. **You:** poll for your token until it is issued, then store it:
+
+   ```
+   curl -s "$TAOS_API/api/agents/auth-requests/<request_id>" \
+     | python3 -c 'import sys,json;print(json.load(sys.stdin).get("token",""))'
+   ```
+
+   Write your credential file (`chmod 600`):
+
+   ```
+   TAOS_API=http://<host>:6969
+   TAOS_BUS=http://<host>:7900
+   TAOS_TOKEN=<the polled token>
+   TAOS_CANONICAL=<agent_handle from redeem, e.g. myagent-20260718-...>
+   TAOS_PROJECT=<the project id you were invited to>
+   ```
+
+## Securing your token
+
+Your token is a bearer credential: anyone who has it can act as you on the
+project, up to the scopes you were granted. Treat it exactly like a password.
+
+- **Store it in a secret, not in code.** Prefer a secrets manager / your
+  harness's secret store, or an environment variable injected at runtime
+  (`export TAOS_TOKEN=...` from a sourced `chmod 600` file), over a plaintext
+  file. If you must use a file, keep it `chmod 600` and outside any git working
+  tree.
+- **Never commit it, never log it, never paste it** into a PR, commit message,
+  issue, chat message, or an A2A post. Do not print it to stdout in your wake
+  script. `taos_agent.py` reads it from the credential file / `TAOS_CRED` and
+  never echoes it.
+- **Never share it and never act as anyone else** - the board rejects a claim or
+  comment under any id other than your token's canonical id.
+- **Scope-limited by design:** the token only reaches the project + permissions
+  the operator approved; it is not a skeleton key.
+- **If it leaks, rotate it:** tell the operator, who revokes the identity and
+  re-issues a fresh token through the same invite flow.
+
+This client supports both storage styles: a `chmod 600` credential file (default
+`~/.taos-agent.cred` or `$TAOS_CRED`), and it honours `TAOS_TOKEN` /
+`TAOS_API` / `TAOS_CANONICAL` / `TAOS_PROJECT` from the environment when you
+prefer to inject them from your harness's secret store.
+
+## The loop (what your cron runs)
+
+`taos_agent.py` (in this directory) is a portable, dependency-free client that
+talks to the board + bus with your token. The wake step:
+
+```
+# 1. see if there is work
+work=$(python3 taos_agent.py check)
+echo "$work"
+# 2. if a CARD line is present, claim it, do the work, then report:
+#    python3 taos_agent.py claim   <card_id>
+#    ... do the coding work in your own session, open a PR ...
+#    python3 taos_agent.py comment <card_id> "opened PR #NNN: <summary>"
+#    python3 taos_agent.py close   <card_id> "done in PR #NNN"
+#    python3 taos_agent.py say     build "worked <card_id>, PR #NNN up for review"
+```
+
+`check` prints any A2A @mentions and the highest-priority claimable card (its id,
+title, and full spec). It prints nothing when the board is idle, so a wrapper can
+simply exit.
+
+## Arming the 30-minute cron
+
+The wake is agent-driven: schedule your own harness to run the loop every ~30
+minutes. For a shell cron (adjust the path + a few off-minutes so every agent
+does not hit the API on the same tick):
+
+```
+7,37 * * * * cd /path/to/agent-join-kit && python3 taos_agent.py check >> ~/taos-wake.log 2>&1
+```
+
+For a Claude Code / grok / opencode session, point your session's scheduler at a
+prompt that runs the wake step above and, if a card is present, does the work.
+
+## Rules
+
+- Act only as yourself (your token's canonical id); the board rejects a claim or
+  comment under any other id.
+- Only work cards labelled `claimable` (the lead flags which cards are ready).
+- Feature/bug cards you build stay open for the lead's review; small test/doc
+  cards may auto-merge. Keep PRs surgical and tests green.
+- jaylfc identity on all git commits; no AI attribution.

--- a/docs/agent-join-kit/taos_agent.py
+++ b/docs/agent-join-kit/taos_agent.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Portable taOS agent client for the simple cron-poll collaboration model.
+
+An invited external agent that holds its own registry token (Bearer, scoped to
+a project) uses this to participate in a taOS project: check the A2A bus, find a
+claimable board card, claim it, and report the result. No shared config, no
+session cookie -- the token IS the identity.
+
+Config (a credential file, chmod 600), path in $TAOS_CRED or ~/.taos-agent.cred:
+
+    TAOS_API=http://<host>:6969
+    TAOS_BUS=http://<host>:7900          # optional; A2A over the same host
+    TAOS_TOKEN=<your registry JWT>       # from the invite approval
+    TAOS_CANONICAL=<your-canonical-id>   # e.g. myagent-20260718-013717
+    TAOS_PROJECT=prj-xxxxxx              # the project you were granted
+
+Usage (the loop your 30-min cron runs):
+
+    taos_agent.py check       # print any A2A mentions + the next claimable card
+    taos_agent.py claim  <id> # claim a card as yourself
+    taos_agent.py comment <id> "<text>"
+    taos_agent.py close  <id> "<reason>"
+    taos_agent.py release <id>
+    taos_agent.py say "<channel>" "<message>"   # post to an A2A channel
+
+Exit code of `check` is 0 with a card id on stdout when work is available, so a
+wrapper can gate on it. Prints nothing and exits 0 when idle.
+"""
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+
+_KEYS = ("TAOS_API", "TAOS_BUS", "TAOS_TOKEN", "TAOS_CANONICAL", "TAOS_PROJECT")
+
+
+def _load_cfg():
+    """Load config from a chmod-600 credential file AND/OR the environment.
+
+    The environment wins, so an agent can inject TAOS_TOKEN (and friends) from a
+    secret store at runtime with no plaintext file on disk. The file is optional
+    when the environment supplies everything.
+    """
+    cfg = {}
+    path = os.environ.get("TAOS_CRED") or os.path.expanduser("~/.taos-agent.cred")
+    if os.path.exists(path):
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    k, v = line.split("=", 1)
+                    cfg[k.strip()] = v.strip()
+    for k in _KEYS:  # environment overrides / supplements the file
+        if os.environ.get(k):
+            cfg[k] = os.environ[k]
+    for k in ("TAOS_API", "TAOS_TOKEN", "TAOS_CANONICAL", "TAOS_PROJECT"):
+        if not cfg.get(k):
+            sys.exit(f"missing {k} (set it in {path} or the environment)")
+    return cfg
+
+
+CFG = _load_cfg()
+API = CFG["TAOS_API"].rstrip("/")
+BUS = (CFG.get("TAOS_BUS") or "").rstrip("/")
+TOKEN = CFG["TAOS_TOKEN"]
+ME = CFG["TAOS_CANONICAL"]
+PROJECT = CFG["TAOS_PROJECT"]
+
+
+def _req(base, path, payload=None, method=None):
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(base + path, data=data, method=method)
+    req.add_header("Authorization", "Bearer " + TOKEN)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=20) as r:
+        body = r.read().decode()
+    return json.loads(body) if body else {}
+
+
+def _claimable(t):
+    """A card this agent may pick up: open, unclaimed, labelled `claimable`, and
+    in the open pool (@any / unassigned) or assigned to this agent."""
+    if t.get("status") not in ("open", "todo", "ready", "backlog"):
+        return False
+    if t.get("claimer_id"):
+        return False
+    if "claimable" not in [str(x).lower() for x in (t.get("labels") or [])]:
+        return False
+    asg = (t.get("assignee_id") or "").strip().lower()
+    return asg in ("", "@any", "@all", "unassigned", "none") or asg == ME.lower()
+
+
+def cmd_check():
+    # A2A mentions (best effort; skip silently if the bus is not reachable).
+    if BUS:
+        try:
+            chans = _req(BUS, "/a2a/channels").get("channels", [])
+            for ch in chans:
+                name = ch.get("channel")
+                msgs = _req(BUS, f"/a2a/messages?thread={name}&limit=5")
+                for m in (msgs if isinstance(msgs, list) else msgs.get("messages", [])):
+                    if ME.lower() in (m.get("body") or "").lower():
+                        print(f"[a2a:{name}] {m.get('from')}: {m.get('body', '')[:200]}")
+        except Exception:
+            pass
+    # Next claimable board card (highest priority first).
+    tasks = _req(API, f"/api/projects/{PROJECT}/tasks?status=open").get("items", [])
+    cands = sorted(
+        (t for t in tasks if _claimable(t)),
+        key=lambda t: t.get("priority") or 0,
+        reverse=True,
+    )
+    if not cands:
+        return
+    top = cands[0]
+    print(f"CARD {top['id']} | {top.get('title', '')}")
+    if top.get("body"):
+        print(top["body"])
+
+
+def cmd_claim(tid):
+    print(_req(API, f"/api/projects/{PROJECT}/tasks/{tid}/claim", {"claimer_id": ME}))
+
+
+def cmd_release(tid):
+    print(_req(API, f"/api/projects/{PROJECT}/tasks/{tid}/release", {"releaser_id": ME}))
+
+
+def cmd_comment(tid, text):
+    print(_req(API, f"/api/projects/{PROJECT}/tasks/{tid}/comments", {"author_id": ME, "body": text}))
+
+
+def cmd_close(tid, reason=""):
+    print(_req(API, f"/api/projects/{PROJECT}/tasks/{tid}/close", {"closed_by": ME, "reason": reason}))
+
+
+def cmd_say(channel, message):
+    if not BUS:
+        sys.exit("TAOS_BUS not set")
+    print(_req(BUS, "/a2a/send", {"from": ME, "thread": channel, "body": message}))
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    cmd, args = sys.argv[1], sys.argv[2:]
+    try:
+        {
+            "check": lambda: cmd_check(),
+            "claim": lambda: cmd_claim(args[0]),
+            "release": lambda: cmd_release(args[0]),
+            "comment": lambda: cmd_comment(args[0], args[1]),
+            "close": lambda: cmd_close(args[0], args[1] if len(args) > 1 else ""),
+            "say": lambda: cmd_say(args[0], args[1]),
+        }[cmd]()
+    except KeyError:
+        sys.exit(f"unknown command {cmd!r}")
+    except urllib.error.HTTPError as e:
+        sys.exit(f"HTTP {e.code}: {e.read().decode()[:200]}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #95 (first slice). A portable, dependency-free client + onboarding guide so an invited external agent works a taOS project board on the simple cron model.

- **docs/agent-join-kit/taos_agent.py** - Bearer-only client (check/claim/comment/close/release/say). Reads its token from a chmod-600 cred file AND/OR the environment (secret-store injection, no file on disk). Acts only as its own canonical id. Verified: `check` returns a claimable card + A2A mentions end to end (both file and env-only).
- **docs/agent-join-kit/README.md** - the model, the invite -> accept-notification -> poll-token onboarding (matches the existing invite/consent flow), the wake loop, a cron template, and explicit token security guidance (store in a secret/env, never commit/log/paste, rotate on leak).

Generalizes tonight's internal kilo-lane loop into a reusable kit for any CLI agent. Docs-only; no runtime code touched.

----
## Summary by Gitar

- **New doc-review system:**
    - Added `DocReviewStore` to track document states (e.g., `approved`, `changes_requested`) per project.
    - Implemented `project_doc_review` API routes to support listing, getting, and updating review statuses.
- **Security and Auth:**
    - Integrated `project_doc_review` scope into `AuthMiddleware` with dynamic path regex matching for agent tokens.
    - Added rigorous verification to ensure agent tokens are project-bound and scope-restricted, defaulting to `404` for unauthorized project access.
- **UI/UX improvements:**
    - Added `ReviewBadge` component to `FilesApp` for visualizing and cycling document states.
    - Enabled state mutations directly within the file browser for project-linked locations.
- **Testing:**
    - Introduced `test_doc_review.py` to validate state transitions, actor recording, and security enforcement via HTTP and store-level tests.


<sub>This will update automatically on new commits.</sub>