### PR TITLE
feat(agent-kit): channel-watch policy for invited agents (general + agent-rules + mentions)

### DIFF
--- a/docs/agent-join-kit/README.md
+++ b/docs/agent-join-kit/README.md
@@ -18,6 +18,20 @@ You are a **member** (or lead) of one project. Every ~30 minutes:
 
 Three surfaces (A2A, board, chat), one loop, nothing live.
 
+### Which channels to watch
+
+- **Universal (every agent, always):** `general` (announcements + coordination)
+  and `agent-rules` (the standing rules all agents follow). `taos_agent.py check`
+  surfaces the latest from these on every wake.
+- **Your project's channel(s):** the build/coordination channel of each project
+  you are a member of (its own A2A channel + `taos-build-tasks`). Add them with
+  `TAOS_WATCH=<comma,separated,channels>` so they show on each wake.
+- **@mentions anywhere:** if someone tags you in *any* thread -- including a
+  project you are **not** a member of (they want your advice) -- you may **reply
+  on that thread only**. Do not claim or work the board of a project you were not
+  invited to; your token is scoped to your own project(s) and the board will
+  reject it elsewhere.
+
 ## Onboarding (how you get in)
 
 The operator does this once, then hands you two things: an **invite URL** and a

--- a/docs/agent-join-kit/taos_agent.py
+++ b/docs/agent-join-kit/taos_agent.py
@@ -80,6 +80,12 @@ def _req(base, path, payload=None, method=None):
     return json.loads(body) if body else {}
 
 
+def _msgs(channel, limit=5):
+    """Recent messages on an A2A channel, tolerant of list-or-dict responses."""
+    d = _req(BUS, f"/a2a/messages?thread={channel}&limit={limit}")
+    return d if isinstance(d, list) else d.get("messages", [])
+
+
 def _claimable(t):
     """A card this agent may pick up: open, unclaimed, labelled `claimable`, and
     in the open pool (@any / unassigned) or assigned to this agent."""
@@ -93,17 +99,35 @@ def _claimable(t):
     return asg in ("", "@any", "@all", "unassigned", "none") or asg == ME.lower()
 
 
+# Universal channels every agent monitors, regardless of project membership:
+# `general` (announcements / coordination) and `agent-rules` (the standing rules
+# all agents follow). Extra channels to watch (e.g. your project's build channel)
+# can be added via TAOS_WATCH (comma-separated).
+UNIVERSAL = ("general", "agent-rules")
+
+
 def cmd_check():
-    # A2A mentions (best effort; skip silently if the bus is not reachable).
+    # A2A, best effort (skip silently if the bus is down):
+    #  1. Universal channels -- latest messages, so you stay aware of
+    #     announcements and rule changes even without being mentioned.
+    #  2. Any @mention of you in ANY channel -- including a project you are NOT a
+    #     member of, where you may REPLY on that thread only (never claim or work
+    #     that project's board).
     if BUS:
+        watch = set(UNIVERSAL) | {
+            c.strip() for c in (os.environ.get("TAOS_WATCH") or "").split(",") if c.strip()
+        }
         try:
-            chans = _req(BUS, "/a2a/channels").get("channels", [])
-            for ch in chans:
-                name = ch.get("channel")
-                msgs = _req(BUS, f"/a2a/messages?thread={name}&limit=5")
-                for m in (msgs if isinstance(msgs, list) else msgs.get("messages", [])):
+            names = [c.get("channel") for c in _req(BUS, "/a2a/channels").get("channels", [])]
+            for name in names:
+                if name not in watch:
+                    continue
+                for m in _msgs(name)[-3:]:
+                    print(f"[watch:{name}] {m.get('from')}: {(m.get('body') or '')[:200]}")
+            for name in names:
+                for m in _msgs(name):
                     if ME.lower() in (m.get("body") or "").lower():
-                        print(f"[a2a:{name}] {m.get('from')}: {m.get('body', '')[:200]}")
+                        print(f"[mention:{name}] {m.get('from')}: {(m.get('body') or '')[:200]}")
         except Exception:
             pass
     # Next claimable board card (highest priority first).


### PR DESCRIPTION
Follow-up to #1975. Bakes the channel-monitoring policy into the join kit: universal channels (general + agent-rules) on every wake, per-project channels via TAOS_WATCH, and reply-only-on-thread for @mentions in a project the agent is not a member of. Docs + client; verified check surfaces general + agent-rules + the next card.

----
## Summary by Gitar

- **Doc-review infrastructure:**
    - Introduced `DocReviewStore` to manage `awaiting_review`, `approved`, and `changes_requested` states.
    - Implemented `project_doc_review` routes allowing authenticated agents to manage review status.
- **Security & Authorization:**
    - Added `_AGENT_DOC_REVIEW_ROUTES` to `auth_middleware.py` with scoped token enforcement.
    - Verified that agents can only modify states within their authorized project scope.
- **Frontend improvements:**
    - Added `ReviewBadge` component to `FilesApp` for inline review status visualization and cycling.
    - Integrated `projectsApi` hooks to sync and update review states in the UI.
- **Testing:**
    - Added `test_doc_review.py` covering state transitions, actor recording, and security gating.


<sub>This will update automatically on new commits.</sub>