### PR TITLE
fix(projects): send CSRF token on project create/update/delete (403 CSRF token missing)

### DIFF
--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -90,12 +90,12 @@ export function ConsentActions({
   async function createProject(): Promise<string | null> {
     const name = newName.trim();
     if (!name) return null;
-    const res = await fetch("/api/projects", {
+    const res = await fetch("/api/projects", withCsrf({
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
       body: JSON.stringify({ name, slug: slugify(name) }),
-    });
+    }));
     if (!res.ok) {
       const d = await res.json().catch(() => ({}));
       setError((d as { error?: string }).error ?? `Could not create project (${res.status})`);

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -1,3 +1,5 @@
+import { withCsrf } from "@/lib/csrf";
+
 export type Project = {
   id: string;
   name: string;
@@ -133,11 +135,14 @@ export type TaskContext = {
 };
 
 async function http<T>(path: string, init?: RequestInit): Promise<T> {
-  const r = await fetch(path, {
+  // withCsrf attaches X-CSRF-Token on mutating methods (POST/PUT/PATCH/DELETE);
+  // without it, cookie-authenticated project create/update/delete 403 with
+  // "CSRF token missing". Non-mutating GETs pass through unchanged.
+  const r = await fetch(path, withCsrf({
     credentials: "include",
     headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
     ...init,
-  });
+  }));
   if (!r.ok) {
     const text = await r.text().catch(() => r.statusText);
     throw new Error(`${r.status}: ${text}`);


### PR DESCRIPTION
The projectsApi `http()` helper (desktop/src/lib/projects.ts) sent no X-CSRF-Token, so project create/update/delete 403'd for a cookie session ("CSRF token missing"). Same class as #1969. Wrapped the helper's fetch in withCsrf() (mutating methods only). Also fixed the inline create-project fetch in ConsentActions. tsc clean.