### PR TITLE
fix(frameworks): verified_only returns tested+beta (unbreak dev CI)

### DIFF
--- a/tests/test_framework_tools.py
+++ b/tests/test_framework_tools.py
@@ -26,11 +26,15 @@ async def test_lists_all_frameworks():
 
 
 @pytest.mark.asyncio
-async def test_verified_only_returns_beta_subset():
+async def test_verified_only_returns_verified_subset():
     all_res = await execute_list_frameworks({}, _req())
-    beta_res = await execute_list_frameworks({"verified_only": True}, _req())
-    assert beta_res["count"] <= all_res["count"]
-    assert all(f["verification_status"] == "beta" for f in beta_res["frameworks"])
-    # hermes and openclaw are beta, so verified_only must include them.
-    ids = {f["id"] for f in beta_res["frameworks"]}
+    verified_res = await execute_list_frameworks({"verified_only": True}, _req())
+    assert verified_res["count"] <= all_res["count"]
+    # tested and beta are the two verified tiers; nothing else may appear.
+    assert all(
+        f["verification_status"] in ("tested", "beta")
+        for f in verified_res["frameworks"]
+    )
+    # hermes is tested and openclaw is beta, so verified_only must include both.
+    ids = {f["id"] for f in verified_res["frameworks"]}
     assert "openclaw" in ids and "hermes" in ids

--- a/tinyagentos/skills.py
+++ b/tinyagentos/skills.py
@@ -466,11 +466,11 @@ class SkillStore(BaseStore):
                 "description": "List the agent frameworks taOS can deploy, so the agent can offer one",
                 "tool_schema": {
                     "name": "list_frameworks",
-                    "description": "List the agent frameworks taOS can deploy (id, name, description, verification_status; beta = recommended). Use before offering to deploy/set up an agent so you name a real framework and prefer a beta one. Optional verified_only=true returns beta only.",
+                    "description": "List the agent frameworks taOS can deploy (id, name, description, verification_status; tested and beta are recommended, tested being the most verified). Use before offering to deploy/set up an agent so you name a real framework and prefer a tested or beta one. Optional verified_only=true returns the verified (tested + beta) frameworks.",
                     "input_schema": {
                         "type": "object",
                         "properties": {
-                            "verified_only": {"type": "boolean", "description": "Only beta (recommended) frameworks. Default false."},
+                            "verified_only": {"type": "boolean", "description": "Only verified (tested + beta) frameworks. Default false."},
                         },
                     },
                 },

--- a/tinyagentos/tools/framework_tools.py
+++ b/tinyagentos/tools/framework_tools.py
@@ -16,17 +16,18 @@ LIST_FRAMEWORKS_TOOL = {
     "name": "list_frameworks",
     "description": (
         "List the agent frameworks taOS can deploy (id, name, description, and "
-        "verification_status: beta is recommended, alpha is experimental). Use "
-        "this before offering to deploy or set up an agent for the user, so you "
-        "name a framework that actually exists and prefer a beta one. Read-only; "
-        "the user deploys from the Agents app."
+        "verification_status: tested and beta are recommended, tested being the "
+        "most verified; experimental is unverified). Use this before offering to "
+        "deploy or set up an agent for the user, so you name a framework that "
+        "actually exists and prefer a tested or beta one. Read-only; the user "
+        "deploys from the Agents app."
     ),
     "input_schema": {
         "type": "object",
         "properties": {
             "verified_only": {
                 "type": "boolean",
-                "description": "If true, return only beta (recommended) frameworks. Default false (all).",
+                "description": "If true, return only verified (tested + beta) frameworks. Default false (all).",
             },
         },
     },
@@ -37,7 +38,11 @@ async def execute_list_frameworks(args: dict, request: Request) -> dict:
     verified_only = bool((args or {}).get("verified_only", False))
     frameworks = list_frameworks()
     if verified_only:
-        frameworks = [f for f in frameworks if f.get("verification_status") == "beta"]
+        # tested and beta are the two verified tiers (tested is the most verified);
+        # experimental and broken are not recommended.
+        frameworks = [
+            f for f in frameworks if f.get("verification_status") in ("tested", "beta")
+        ]
     slim = [
         {
             "id": f.get("id"),


### PR DESCRIPTION
## Problem
`tests/test_framework_tools.py::test_verified_only_returns_beta_subset` is failing on dev, which blocks the test job on every open PR.

Root cause: #1963 introduced the 4-tier verification vocabulary (**tested > beta > experimental > broken**) and correctly promoted **hermes** to `tested` (Layer 4 passes on both arches, fork PR merged). But two things were not reconciled:
1. `execute_list_frameworks(verified_only=True)` still filtered on `== "beta"`, so it excluded the *most*-verified framework (hermes/tested) from the recommended list.
2. The test still asserted `hermes in` the beta-only subset.

## Fix
- `verified_only` now returns the two verified tiers `{tested, beta}` (tested is the most verified).
- Updated both copies of the tool description (`framework_tools.py` + `skills.py`) to the new vocabulary.
- Updated the stale test (renamed to `test_verified_only_returns_verified_subset`); asserts every result is tested-or-beta and that hermes (tested) + openclaw (beta) are both included.

Reconciles part of #1967.

## Verify
`uv run pytest tests/test_framework_tools.py -q` -> 2 passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated framework discovery to include both tested and beta frameworks when using the verified-only filter.
  * Improved guidance to clarify verification levels, with tested frameworks identified as the most verified option.
* **Bug Fixes**
  * Corrected verified-only filtering so tested frameworks are no longer excluded.
* **Tests**
  * Expanded coverage to confirm verified results contain only tested or beta frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->