### PR TITLE
test: replace always-true assert with issubclass check in test_installer_class_available

### DIFF
--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -124,6 +124,9 @@ class TestLxcUsesCentralizedAllocator:
         assert hasattr(mod, "allocate_host_port"), (
             "lxc_installer must import allocate_host_port"
         )
+        assert not hasattr(mod, "RESERVED_PORTS"), (
+            "lxc_installer must not import RESERVED_PORTS; allocate_host_port handles that internally"
+        )
 
     def test_installer_class_available(self):
         """LXCInstaller is importable (sanity check — no import errors from the refactor)."""

--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -124,9 +124,6 @@ class TestLxcUsesCentralizedAllocator:
         assert hasattr(mod, "allocate_host_port"), (
             "lxc_installer must import allocate_host_port"
         )
-        assert not hasattr(mod, "RESERVED_PORTS"), (
-            "lxc_installer must not import RESERVED_PORTS; allocate_host_port handles that internally"
-        )
 
     def test_installer_class_available(self):
         """LXCInstaller is importable (sanity check — no import errors from the refactor)."""

--- a/tests/installers/test_port_allocator.py
+++ b/tests/installers/test_port_allocator.py
@@ -1,6 +1,7 @@
 """Tests for host-port allocation: every handed-out port is probed free."""
 import socket
 
+from tinyagentos.installers.base import AppInstaller
 from tinyagentos.installers.docker_installer import DockerInstaller
 from tinyagentos.installers.lxc_installer import LXCInstaller
 from tinyagentos.installers.port_allocator import (
@@ -129,5 +130,5 @@ class TestLxcUsesCentralizedAllocator:
         )
 
     def test_installer_class_available(self):
-        """LXCInstaller is importable (sanity check — no import errors from the refactor)."""
-        assert LXCInstaller is not None
+        """LXCInstaller is a proper AppInstaller subclass (class hierarchy regression check)."""
+        assert issubclass(LXCInstaller, AppInstaller)


### PR DESCRIPTION
Kilo suggestion on merged PR #1964: `assert LXCInstaller is not None` is always true at module scope and cannot detect the import-error regression the docstring claims.

**Fix:** Replace with `assert issubclass(LXCInstaller, AppInstaller)` — a meaningful class-hierarchy regression check.

- Added `AppInstaller` import from `tinyagentos.installers.base`
- Changed assertion from identity check to subclass check
- Updated docstring

Tests: 16/16 pass in test_port_allocator.py

----
## Summary by Gitar

- **Test Suite Refactoring:**
    - Added `TestLxcUsesCentralizedAllocator` to enforce that `LXCInstaller` uses the centralized port allocator.
    - Verified `lxc_installer` module no longer exposes `_find_free_port` or `RESERVED_PORTS`.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LXC installation port allocation and retry handling when ports are unavailable.
  * Prevented repeated attempts to use ports that previously failed.

* **Documentation**
  * Clarified how container and host ports are mapped during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->