### PR TITLE
feat(gpu-queue): TAOS_GPU_QUEUE rollout flag and gpu_op trace kind (#1864)

### DIFF
--- a/tests/test_gpu_queue_flag.py
+++ b/tests/test_gpu_queue_flag.py
@@ -1,0 +1,26 @@
+"""Tests for tinyagentos.gpu_queue_flag — taOS #1864 Slice A1."""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.gpu_queue_flag import gpu_queue_mode, GPU_QUEUE_MODES
+
+
+def test_gpu_queue_mode_default_off(monkeypatch):
+    monkeypatch.delenv("TAOS_GPU_QUEUE", raising=False)
+    assert gpu_queue_mode() == "off"
+
+
+@pytest.mark.parametrize("value", ["shadow", "on", "OFF", " Shadow "])
+def test_gpu_queue_mode_env_values(monkeypatch, value):
+    monkeypatch.setenv("TAOS_GPU_QUEUE", value)
+    assert gpu_queue_mode() == value.strip().lower()
+
+
+def test_gpu_queue_mode_invalid_coerces_off(monkeypatch):
+    monkeypatch.setenv("TAOS_GPU_QUEUE", "bananas")
+    assert gpu_queue_mode() == "off"
+
+
+def test_modes_tuple_is_locked():
+    assert GPU_QUEUE_MODES == ("off", "shadow", "on")

--- a/tests/test_trace_store.py
+++ b/tests/test_trace_store.py
@@ -549,3 +549,26 @@ async def test_list_dedup_by_id_primary_wins(tmp_path):
     if isinstance(payload, str):
         payload = json.loads(payload)
     assert payload.get("source") == "db", "DB version should win over late version"
+
+
+# ---------------------------------------------------------------------------
+# GPU work queue per-op audit record (taOS #1864 Slice A1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_record_gpu_op_kind_accepted(tmp_path):
+    store = AgentTraceStore(tmp_path, "_system_")
+    env = await store.record(
+        "gpu_op", model="qwen2.5:7b", backend_name="local-ollama",
+        duration_ms=1200,
+        payload={"op": "load", "outcome": "ok", "wait_ms": 0,
+                 "queue_position_at_enqueue": 0, "queue_depth_at_admit": 0,
+                 "required_vram_mb": 2048, "free_vram_mb_at_admit": 8192,
+                 "reserved_vram_mb_at_admit": 0, "resident_models_at_admit": 0,
+                 "evictions_triggered": [], "priority": 20,
+                 "submitter": "_system_"},
+    )
+    assert env["kind"] == "gpu_op"
+    rows = await store.list(kind="gpu_op")
+    assert rows and rows[0]["payload"]["outcome"] == "ok"
+    await store.close()

--- a/tinyagentos/gpu_queue_flag.py
+++ b/tinyagentos/gpu_queue_flag.py
@@ -1,0 +1,31 @@
+"""Rollout flag for the unified GPU work queue (taOS #1864).
+
+off    - all queue behavior disabled; every path is pre-feature behavior.
+shadow - instrument only: pull sites still 503 but record what would have
+         queued; the gateway (Phase C) forwards without gating.
+on     - full queue-and-wait behavior.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+GPU_QUEUE_MODES = ("off", "shadow", "on")
+_warned = False
+
+
+def gpu_queue_mode() -> str:
+    global _warned
+    raw = (os.environ.get("TAOS_GPU_QUEUE") or "off").strip().lower()
+    if raw not in GPU_QUEUE_MODES:
+        if not _warned:
+            logger.warning(
+                "TAOS_GPU_QUEUE=%r not in %s; using 'off'",
+                raw,
+                GPU_QUEUE_MODES,
+            )
+            _warned = True
+        return "off"
+    return raw

--- a/tinyagentos/trace_store.py
+++ b/tinyagentos/trace_store.py
@@ -76,6 +76,9 @@ VALID_KINDS = frozenset({
     # Registry governance audit events (PR1 — lifecycle state machine).
     # Payload shape: {action, canonical_id, actor_user_id, before_status, after_status}
     "governance",
+    # GPU work queue per-op audit record (taOS #1864). One per op on
+    # completion, plus one on eviction/cancel.
+    "gpu_op",
 })
 
 # Documented envelope schema — the librarian parses against this.
@@ -107,6 +110,19 @@ ENVELOPE_V1_SCHEMA = {
             "actor_user_id": "str",
             "before_status": "str",
             "after_status": "str",
+        },
+        # GPU work queue per-op audit record (taOS #1864). One per op on
+        # completion, plus one on eviction/cancel. model/backend_name/
+        # duration_ms ride the first-class columns.
+        "gpu_op": {
+            "op": "inference|load|unload|evict",
+            "outcome": "ok|error|cancelled|evicted|shadow_denied",
+            "wait_ms": "int", "queue_position_at_enqueue": "int",
+            "queue_depth_at_admit": "int", "required_vram_mb": "int",
+            "free_vram_mb_at_admit": "int", "reserved_vram_mb_at_admit": "int",
+            "resident_models_at_admit": "int",
+            "evictions_triggered": "list[str]", "priority": "int",
+            "submitter": "str",
         },
     },
 }


### PR DESCRIPTION
## Slice A1 — GPU queue feature flag + gpu_op trace kind

**Task:** Kanban t_fa88f488  
**Upstream:** closes #1864  

### Changes
- **NEW:** `tinyagentos/gpu_queue_flag.py` — `gpu_queue_mode()` reads `TAOS_GPU_QUEUE` env var (off|shadow|on, default off), `GPU_QUEUE_MODES` tuple  
- **MODIFY:** `tinyagentos/trace_store.py` — add `gpu_op` to `VALID_KINDS` and `ENVELOPE_V1_SCHEMA`  
- **NEW:** `tests/test_gpu_queue_flag.py` — 4 tests: default off, env values (parametrized), invalid coerce, tuple locked  
- **EXTEND:** `tests/test_trace_store.py` — 1 test: record+gpu_op round-trip  

### Interface produced
- `gpu_queue_mode() → 'off' | 'shadow' | 'on'` — consumed by later slices  
- `'gpu_op'` trace kind — consumed by A2+ for per-op audit records  

### Testing
- 25/25 targeted tests pass (7 new, 18 pre-existing)  
- Zero behavior change — flag defaults off, no caller exists yet  

### Design refs
- Plan: `docs/design/plans/2026-07-17-gpu-work-queue-plan.md` §Slice A1 (lines 102–242)  
- Spec: `docs/design/2026-07-17-gpu-work-queue.md` §7.4 (rollout flag)