### PR TITLE
fix(agents): gate force-kill on container run-state, add bounded-hang comment, fix shield orphan

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -33,6 +33,7 @@ import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
 import { EffectsLayer } from "@/theme/effects/EffectsLayer";
 import { SafetyFloor } from "@/components/SafetyFloor";
+import { withCsrf } from "@/lib/csrf";
 
 interface SystemShortcutsProps {
   toggleSearch: () => void;
@@ -109,6 +110,21 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
   useShortcut("Ctrl+7", useCallback(() => openPinned(6), [openPinned]), "Open pinned app 7", "system");
   useShortcut("Ctrl+8", useCallback(() => openPinned(7), [openPinned]), "Open pinned app 8", "system");
   useShortcut("Ctrl+9", useCallback(() => openPinned(8), [openPinned]), "Open pinned app 9", "system");
+
+  // Ctrl+Shift+K — emergency kill switch: stops all running agents
+  const killAllAgents = useCallback(async () => {
+    try {
+      await fetch("/api/agents/bulk/stop", {
+        method: "POST",
+        credentials: "include",
+        headers: withCsrf({ method: "POST" })?.headers,
+      });
+      window.dispatchEvent(new CustomEvent("taos:agents-changed"));
+    } catch {
+      // best-effort
+    }
+  }, []);
+  useShortcut("Ctrl+Shift+K", killAllAgents, "Stop all agents", "system");
 
   return null;
 }

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -1,6 +1,7 @@
 import pytest
 from tinyagentos.config import load_config
 from tinyagentos.cluster.worker_protocol import WorkerInfo
+from tinyagentos.containers.backend import ContainerInfo
 
 
 @pytest.fixture(autouse=True)
@@ -82,6 +83,125 @@ class TestBulkOperations:
         resp = await client.post("/api/agents/bulk/restart")
         assert resp.status_code == 200
         assert resp.json()["action"] == "restart"
+
+
+@pytest.mark.asyncio
+class TestKillSwitchRunStateGate:
+    """Verify that force-kill is gated on container run-state, not just existence."""
+
+    async def test_bulk_stop_skips_force_kill_for_stopped_container(
+        self, client, monkeypatch
+    ):
+        """A stopped container must NOT receive incus stop --force."""
+        stopped = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Stopped",
+            ip=None,
+            memory_mb=0,
+            cpu_cores=0,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [stopped]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/bulk/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "stop"
+        # The stopped container should not receive a force kill
+        assert "test-agent" not in force_calls, (
+            f"force-kill should NOT be called on a Stopped container, "
+            f"but stop_container(force=True) was called {force_calls}"
+        )
+
+    async def test_stop_agent_skips_force_kill_for_stopped_container(
+        self, client, monkeypatch
+    ):
+        """A single stopped agent container must NOT receive incus stop --force."""
+        stopped = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Stopped",
+            ip=None,
+            memory_mb=0,
+            cpu_cores=0,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [stopped]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/test-agent/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "force_killed" in data
+        assert data["force_killed"] is False, (
+            "force_killed should be False for a Stopped container"
+        )
+        assert len(force_calls) == 0, (
+            f"stop_container(force=True) should NOT be called on a Stopped container, "
+            f"but it was called {len(force_calls)} times"
+        )
+
+    async def test_bulk_stop_force_kills_running_container(
+        self, client, monkeypatch
+    ):
+        """A running container MUST receive incus stop --force."""
+        running = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Running",
+            ip="10.0.0.5",
+            memory_mb=1024,
+            cpu_cores=2,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [running]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/bulk/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "stop"
+        assert "taos-agent-test-agent" in force_calls, (
+            "force-kill should be called on a Running container"
+        )
 
 
 def _seed_worker(app, name, model_names, status="online"):

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -803,7 +803,7 @@ async def bulk_stop_agents(request: Request):
     In-flight agent framework work is cancelled by the prepare step;
     LLM calls and tool invocations are terminated when the container dies.
     """
-    from tinyagentos.containers import stop_container, container_exists
+    from tinyagentos.containers import stop_container, list_containers
 
     config = request.app.state.config
     orchestrator = getattr(request.app.state, "orchestrator", None)
@@ -814,15 +814,18 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers (shielded from cancellation)
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers
+    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
+        containers = await list_containers(prefix="taos-agent-")
+        running = {c.name for c in containers if c.status == "Running"}
         force_results = {}
         for agent in config.agents:
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
-                if await container_exists(container_name):
+                if container_name in running:
                     force_result = await stop_container(container_name, force=True)
                     force_results[name] = {
                         "force_killed": force_result.get("success", False),
@@ -838,7 +841,16 @@ async def bulk_stop_agents(request: Request):
                 force_results[name] = {"force_killed": False, "error": str(e)}
         return force_results
 
-    force_results = await asyncio.shield(_grace_kill())
+    task = asyncio.create_task(_grace_kill())
+    try:
+        force_results = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     return {
         "action": "stop",
@@ -885,7 +897,7 @@ async def stop_agent(request: Request, name: str):
     Sends SIGTERM via incus stop. After a 2-second grace window, if the container
     is still running, sends SIGKILL (incus stop --force) to guarantee termination.
     """
-    from tinyagentos.containers import stop_container, container_exists
+    from tinyagentos.containers import stop_container, list_containers
 
     config = request.app.state.config
     agent = find_agent(config, name)
@@ -899,10 +911,13 @@ async def stop_agent(request: Request, name: str):
     container_name = f"taos-agent-{name}"
     stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL (shielded from cancellation)
+    # 2-second grace window, then SIGKILL
+    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
-        if await container_exists(container_name):
+        containers = await list_containers(prefix="taos-agent-")
+        running = {c.name for c in containers if c.status == "Running"}
+        if container_name in running:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)
             if not success:
@@ -914,7 +929,16 @@ async def stop_agent(request: Request, name: str):
             return (success, force_result.get("output", ""))
         return (False, "")
 
-    force_killed, force_error = await asyncio.shield(_grace_kill())
+    task = asyncio.create_task(_grace_kill())
+    try:
+        force_killed, force_error = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     return {
         "prepare_report": report,

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -814,21 +814,31 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers
-    await asyncio.sleep(2)
-    force_results = {}
-    for agent in config.agents:
-        name = agent["name"]
-        container_name = f"taos-agent-{name}"
-        try:
-            if await container_exists(container_name):
-                force_result = await stop_container(container_name, force=True)
-                force_results[name] = {
-                    "force_killed": force_result.get("success", False),
-                    "output": force_result.get("output", ""),
-                }
-        except Exception as e:
-            force_results[name] = {"force_killed": False, "error": str(e)}
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers (shielded from cancellation)
+    async def _grace_kill():
+        await asyncio.sleep(2)
+        force_results = {}
+        for agent in config.agents:
+            name = agent["name"]
+            container_name = f"taos-agent-{name}"
+            try:
+                if await container_exists(container_name):
+                    force_result = await stop_container(container_name, force=True)
+                    force_results[name] = {
+                        "force_killed": force_result.get("success", False),
+                        "output": force_result.get("output", ""),
+                    }
+                    if not force_result.get("success", False):
+                        logger.warning(
+                            "Force-kill of %s failed: %s",
+                            container_name,
+                            force_result.get("output", "unknown"),
+                        )
+            except Exception as e:
+                force_results[name] = {"force_killed": False, "error": str(e)}
+        return force_results
+
+    force_results = await asyncio.shield(_grace_kill())
 
     return {
         "action": "stop",
@@ -889,17 +899,28 @@ async def stop_agent(request: Request, name: str):
     container_name = f"taos-agent-{name}"
     stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL
-    await asyncio.sleep(2)
-    force_killed = False
-    if await container_exists(container_name):
-        force_result = await stop_container(container_name, force=True)
-        force_killed = force_result.get("success", False)
+    # 2-second grace window, then SIGKILL (shielded from cancellation)
+    async def _grace_kill():
+        await asyncio.sleep(2)
+        if await container_exists(container_name):
+            force_result = await stop_container(container_name, force=True)
+            success = force_result.get("success", False)
+            if not success:
+                logger.warning(
+                    "Force-kill of %s failed: %s",
+                    container_name,
+                    force_result.get("output", "unknown"),
+                )
+            return (success, force_result.get("output", ""))
+        return (False, "")
+
+    force_killed, force_error = await asyncio.shield(_grace_kill())
 
     return {
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
+        "force_error": force_error,
     }
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -796,15 +796,46 @@ async def bulk_start_agents(request: Request):
 
 @router.post("/api/agents/bulk/stop")
 async def bulk_stop_agents(request: Request):
-    """Stop all agent containers, running graceful prepare first."""
-    from tinyagentos.containers import stop_container
+    """Stop all agent containers with graceful prepare, then force-kill after 2s grace.
+
+    SIGTERM is sent first via incus stop. After a 2-second grace window,
+    any containers still running are force-killed with SIGKILL (incus stop --force).
+    In-flight agent framework work is cancelled by the prepare step;
+    LLM calls and tool invocations are terminated when the container dies.
+    """
+    from tinyagentos.containers import stop_container, container_exists
+
     config = request.app.state.config
     orchestrator = getattr(request.app.state, "orchestrator", None)
     report = {}
     if orchestrator is not None:
         report = await orchestrator.prepare("all", "stop")
+
+    # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
-    return {"action": "stop", "prepare_report": report, "results": results}
+
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers
+    await asyncio.sleep(2)
+    force_results = {}
+    for agent in config.agents:
+        name = agent["name"]
+        container_name = f"taos-agent-{name}"
+        try:
+            if await container_exists(container_name):
+                force_result = await stop_container(container_name, force=True)
+                force_results[name] = {
+                    "force_killed": force_result.get("success", False),
+                    "output": force_result.get("output", ""),
+                }
+        except Exception as e:
+            force_results[name] = {"force_killed": False, "error": str(e)}
+
+    return {
+        "action": "stop",
+        "prepare_report": report,
+        "results": results,
+        "force_kill_results": force_results,
+    }
 
 
 @router.post("/api/agents/bulk/restart")
@@ -839,8 +870,13 @@ async def pause_agent(request: Request, name: str):
 
 @router.post("/api/agents/{name}/stop")
 async def stop_agent(request: Request, name: str):
-    """Gracefully prepare then stop an agent's LXC container."""
-    from tinyagentos.containers import stop_container
+    """Gracefully prepare, then stop an agent's LXC container with force-kill after 2s.
+
+    Sends SIGTERM via incus stop. After a 2-second grace window, if the container
+    is still running, sends SIGKILL (incus stop --force) to guarantee termination.
+    """
+    from tinyagentos.containers import stop_container, container_exists
+
     config = request.app.state.config
     agent = find_agent(config, name)
     if not agent:
@@ -849,8 +885,22 @@ async def stop_agent(request: Request, name: str):
     report = {}
     if orchestrator is not None:
         report = await orchestrator.prepare([name], "stop")
-    stop_result = await stop_container(f"taos-agent-{name}")
-    return {"prepare_report": report, "stop_result": stop_result}
+
+    container_name = f"taos-agent-{name}"
+    stop_result = await stop_container(container_name)
+
+    # 2-second grace window, then SIGKILL
+    await asyncio.sleep(2)
+    force_killed = False
+    if await container_exists(container_name):
+        force_result = await stop_container(container_name, force=True)
+        force_killed = force_result.get("success", False)
+
+    return {
+        "prepare_report": report,
+        "stop_result": stop_result,
+        "force_killed": force_killed,
+    }
 
 
 @router.post("/api/agents/{name}/restart")


### PR DESCRIPTION
Task: t_aef4a61c. Addresses jaylfc's v3 re-review on #1962.

## Changes

### 1. Run-state gate (the real bug)
Both `bulk_stop_agents` and `stop_agent` previously gated force-kill on
`container_exists()`, which only resolves project membership — it returns
True for existing-but-Stopped containers. A clean graceful stop fires
`incus stop --force` on an already-dead container and reports misleading
`force_killed: false`.

Fix: gate on `list_containers()` with `status == 'Running'`.  The
`list_containers` pattern is already used at agents.py:173-174.

### 2. Bounded-hang comment
Added one-line note that the sleep+force inside asyncio.shield is bounded
by the 120s `_run` cap, to both `_grace_kill` closures.

### 3. Shield orphan
`asyncio.shield(_grace_kill())` left the grace-kill task running detached
if the request was cancelled during the shield window.  Fixed by creating
an explicit Task, catching CancelledError, cancelling the orphan, and
awaiting its cleanup before re-raising.

### Tests
Added `TestKillSwitchRunStateGate` with 3 tests:
- `test_bulk_stop_skips_force_kill_for_stopped_container`
- `test_stop_agent_skips_force_kill_for_stopped_container`
- `test_bulk_stop_force_kills_running_container`

All 3 pass. Existing `test_bulk_stop` still passes.