### PR TITLE
fix(wallpaper): bot-fix v2 — Kilo 1S + CodeRabbit 6 findings (supersedes #1902)

### DIFF
--- a/desktop/src/components/WallhavenBrowser.test.tsx
+++ b/desktop/src/components/WallhavenBrowser.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { WallhavenBrowser } from "./WallhavenBrowser";
+
+const MOCK_SEARCH_RESPONSE = {
+  data: [
+    {
+      id: "abc123",
+      url: "https://w.wallhaven.cc/full/ab/wallhaven-abc123.jpg",
+      path: "https://wallhaven.cc/w/abc123",
+      thumbs: {
+        small: "https://th.wallhaven.cc/small/ab/abc123.jpg",
+        original: "https://th.wallhaven.cc/original/ab/abc123.jpg",
+        large: "https://th.wallhaven.cc/large/ab/abc123.jpg",
+      },
+      resolution: "1920x1080",
+      category: "general",
+      purity: "sfw",
+    },
+    {
+      id: "def456",
+      url: "https://w.wallhaven.cc/full/de/wallhaven-def456.jpg",
+      path: "https://wallhaven.cc/w/def456",
+      thumbs: {
+        small: "https://th.wallhaven.cc/small/de/def456.jpg",
+        original: "https://th.wallhaven.cc/original/de/def456.jpg",
+        large: "https://th.wallhaven.cc/large/de/def456.jpg",
+      },
+      resolution: "2560x1440",
+      category: "anime",
+      purity: "sfw",
+    },
+  ],
+  meta: {
+    current_page: 1,
+    last_page: 3,
+    total: 30,
+  },
+};
+
+const MOCK_EMPTY_RESPONSE = {
+  data: [],
+  meta: { current_page: 1, last_page: 1, total: 0 },
+};
+
+describe("WallhavenBrowser", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+  });
+
+  it("renders the search input and idle prompt", () => {
+    render(<WallhavenBrowser onSelect={vi.fn()} />);
+    expect(screen.getByLabelText(/search wallhaven/i)).toBeInTheDocument();
+    expect(screen.getByText(/type a search term/i)).toBeInTheDocument();
+  });
+
+  it("debounces search and fetches results", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(MOCK_SEARCH_RESPONSE),
+    });
+
+    render(<WallhavenBrowser onSelect={vi.fn()} />);
+
+    const input = screen.getByLabelText(/search wallhaven/i);
+    fireEvent.change(input, { target: { value: "nature" } });
+
+    // Wait for debounce (300ms) + fetch to complete
+    await waitFor(
+      () => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining("/api/wallhaven/search?q=nature&page=1"),
+        );
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("shows loading state while fetching", async () => {
+    // Return a promise that resolves slowly so we can observe the loading state
+    let resolvePromise!: (value: unknown) => void;
+    const slowPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    mockFetch.mockReturnValueOnce(slowPromise);
+
+    render(<WallhavenBrowser onSelect={vi.fn()} />);
+
+    const input = screen.getByLabelText(/search wallhaven/i);
+    fireEvent.change(input, { target: { value: "nature" } });
+
+    // Wait for debounce to fire, then we should see loading
+    await waitFor(
+      () => {
+        expect(screen.getByText(/searching/i)).toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+
+    // Clean up: resolve the promise
+    resolvePromise({
+      ok: true,
+      json: () => Promise.resolve(MOCK_SEARCH_RESPONSE),
+    });
+  });
+
+  it("shows 'no wallpapers found' for empty results", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(MOCK_EMPTY_RESPONSE),
+    });
+
+    render(<WallhavenBrowser onSelect={vi.fn()} />);
+
+    const input = screen.getByLabelText(/search wallhaven/i);
+    fireEvent.change(input, { target: { value: "zzzzzz" } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/no wallpapers found/i)).toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("shows error state on fetch failure", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    render(<WallhavenBrowser onSelect={vi.fn()} />);
+
+    const input = screen.getByLabelText(/search wallhaven/i);
+    fireEvent.change(input, { target: { value: "nature" } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/network error/i)).toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("displays search results and calls onSelect on click", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(MOCK_SEARCH_RESPONSE),
+    });
+
+    const onSelect = vi.fn();
+    render(<WallhavenBrowser onSelect={onSelect} />);
+
+    const input = screen.getByLabelText(/search wallhaven/i);
+    fireEvent.change(input, { target: { value: "nature" } });
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByLabelText(/set wallpaper: abc123/i),
+        ).toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+
+    fireEvent.click(screen.getByLabelText(/set wallpaper: abc123/i));
+    expect(onSelect).toHaveBeenCalledWith(
+      "https://w.wallhaven.cc/full/ab/wallhaven-abc123.jpg",
+      "Wallhaven: abc123 (1920x1080)",
+    );
+  });
+
+  it("shows pagination controls when multiple pages exist", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(MOCK_SEARCH_RESPONSE),
+    });
+
+    render(<WallhavenBrowser onSelect={vi.fn()} />);
+
+    const input = screen.getByLabelText(/search wallhaven/i);
+    fireEvent.change(input, { target: { value: "nature" } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText(/previous page/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/next page/i)).toBeInTheDocument();
+        expect(screen.getByText("1 / 3")).toBeInTheDocument();
+      },
+      { timeout: 1000 },
+    );
+  });
+
+  it("previous page button is disabled on first page", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(MOCK_SEARCH_RESPONSE),
+    });
+
+    render(<WallhavenBrowser onSelect={vi.fn()} />);
+
+    const input = screen.getByLabelText(/search wallhaven/i);
+    fireEvent.change(input, { target: { value: "nature" } });
+
+    await waitFor(
+      () => {
+        const prevBtn = screen.getByLabelText(/previous page/i);
+        expect(prevBtn).toBeDisabled();
+      },
+      { timeout: 1000 },
+    );
+  });
+});

--- a/desktop/src/components/WallhavenBrowser.test.tsx
+++ b/desktop/src/components/WallhavenBrowser.test.tsx
@@ -6,8 +6,8 @@ const MOCK_SEARCH_RESPONSE = {
   data: [
     {
       id: "abc123",
-      url: "https://w.wallhaven.cc/full/ab/wallhaven-abc123.jpg",
-      path: "https://wallhaven.cc/w/abc123",
+      url: "https://wallhaven.cc/w/abc123",
+      path: "https://w.wallhaven.cc/full/ab/wallhaven-abc123.jpg",
       thumbs: {
         small: "https://th.wallhaven.cc/small/ab/abc123.jpg",
         original: "https://th.wallhaven.cc/original/ab/abc123.jpg",
@@ -19,8 +19,8 @@ const MOCK_SEARCH_RESPONSE = {
     },
     {
       id: "def456",
-      url: "https://w.wallhaven.cc/full/de/wallhaven-def456.jpg",
-      path: "https://wallhaven.cc/w/def456",
+      url: "https://wallhaven.cc/w/def456",
+      path: "https://w.wallhaven.cc/full/de/wallhaven-def456.jpg",
       thumbs: {
         small: "https://th.wallhaven.cc/small/de/def456.jpg",
         original: "https://th.wallhaven.cc/original/de/def456.jpg",

--- a/desktop/src/components/WallhavenBrowser.tsx
+++ b/desktop/src/components/WallhavenBrowser.tsx
@@ -40,7 +40,7 @@ export function WallhavenBrowser({ onSelect }: Props) {
   const [meta, setMeta] = useState<WallhavenMeta | null>(null);
   const [status, setStatus] = useState<Status>("idle");
   const [errorMsg, setErrorMsg] = useState("");
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   // Debounce search input (300ms)
   useEffect(() => {
@@ -80,6 +80,7 @@ export function WallhavenBrowser({ onSelect }: Props) {
 
         if (!resp.ok) {
           const body = await resp.json().catch(() => ({}));
+          if (cancelled) return;
           setErrorMsg(body.error || `Server error (${resp.status})`);
           setStatus("error");
           return;
@@ -109,7 +110,7 @@ export function WallhavenBrowser({ onSelect }: Props) {
 
   const handleSelect = useCallback(
     (img: WallhavenImage) => {
-      onSelect(img.url, `Wallhaven: ${img.id} (${img.resolution})`);
+      onSelect(img.path, `Wallhaven: ${img.id} (${img.resolution})`);
     },
     [onSelect],
   );

--- a/desktop/src/components/WallhavenBrowser.tsx
+++ b/desktop/src/components/WallhavenBrowser.tsx
@@ -1,0 +1,217 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Search, Loader2, AlertCircle, ChevronLeft, ChevronRight } from "lucide-react";
+
+interface WallhavenImage {
+  id: string;
+  url: string;
+  path: string;
+  thumbs: {
+    small: string;
+    original: string;
+    large: string;
+  };
+  resolution: string;
+  category: string;
+  purity: string;
+}
+
+interface WallhavenMeta {
+  current_page: number;
+  last_page: number;
+  total: number;
+}
+
+interface SearchResponse {
+  data: WallhavenImage[];
+  meta: WallhavenMeta;
+}
+
+interface Props {
+  onSelect: (url: string, label: string) => void;
+}
+
+type Status = "idle" | "loading" | "error" | "empty" | "results";
+
+export function WallhavenBrowser({ onSelect }: Props) {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [results, setResults] = useState<WallhavenImage[]>([]);
+  const [meta, setMeta] = useState<WallhavenMeta | null>(null);
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  // Debounce search input (300ms)
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedQuery(query);
+      setPage(1);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query]);
+
+  // Fetch results when debounced query or page changes
+  useEffect(() => {
+    if (!debouncedQuery.trim()) {
+      setResults([]);
+      setMeta(null);
+      setStatus("idle");
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchResults() {
+      setStatus("loading");
+      setErrorMsg("");
+
+      try {
+        const params = new URLSearchParams({
+          q: debouncedQuery,
+          page: String(page),
+        });
+        const resp = await fetch(`/api/wallhaven/search?${params}`);
+
+        if (cancelled) return;
+
+        if (!resp.ok) {
+          const body = await resp.json().catch(() => ({}));
+          setErrorMsg(body.error || `Server error (${resp.status})`);
+          setStatus("error");
+          return;
+        }
+
+        const data: SearchResponse = await resp.json();
+
+        if (cancelled) return;
+
+        setResults(data.data);
+        setMeta(data.meta);
+        setStatus(data.data.length === 0 ? "empty" : "results");
+      } catch {
+        if (!cancelled) {
+          setErrorMsg("Network error. Check your connection.");
+          setStatus("error");
+        }
+      }
+    }
+
+    fetchResults();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debouncedQuery, page]);
+
+  const handleSelect = useCallback(
+    (img: WallhavenImage) => {
+      onSelect(img.url, `Wallhaven: ${img.id} (${img.resolution})`);
+    },
+    [onSelect],
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Search input */}
+      <div className="relative">
+        <Search
+          size={14}
+          className="absolute left-2.5 top-1/2 -translate-y-1/2 text-shell-text-tertiary pointer-events-none"
+        />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search Wallhaven for wallpapers..."
+          aria-label="Search Wallhaven"
+          className="w-full pl-7 pr-3 py-1.5 text-xs rounded-md border border-shell-border bg-shell-surface text-shell-text placeholder:text-shell-text-tertiary focus:outline-none focus:border-accent/50"
+        />
+      </div>
+
+      {/* Loading state */}
+      {status === "loading" && (
+        <div className="flex items-center justify-center gap-2 py-8 text-xs text-shell-text-tertiary">
+          <Loader2 size={14} className="animate-spin" />
+          Searching...
+        </div>
+      )}
+
+      {/* Error state */}
+      {status === "error" && (
+        <div className="flex items-center justify-center gap-2 py-8 text-xs text-red-400">
+          <AlertCircle size={14} />
+          {errorMsg}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {status === "empty" && (
+        <div className="flex items-center justify-center py-8 text-xs text-shell-text-tertiary">
+          No wallpapers found for "{debouncedQuery}"
+        </div>
+      )}
+
+      {/* Results grid */}
+      {status === "results" && (
+        <>
+          <div className="grid grid-cols-3 gap-2">
+            {results.map((img) => (
+              <button
+                key={img.id}
+                onClick={() => handleSelect(img)}
+                aria-label={`Set wallpaper: ${img.id} (${img.resolution})`}
+                className="relative aspect-video rounded-md overflow-hidden border border-shell-border hover:border-accent/50 transition-colors focus:outline-none focus:border-accent focus:ring-1 focus:ring-accent/30 group"
+              >
+                <img
+                  src={img.thumbs.small}
+                  alt={img.id}
+                  loading="lazy"
+                  className="w-full h-full object-cover"
+                />
+                <div className="absolute inset-x-0 bottom-0 bg-black/60 px-1.5 py-0.5 text-[10px] text-white/80 opacity-0 group-hover:opacity-100 transition-opacity">
+                  {img.resolution}
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {/* Pagination */}
+          {meta && meta.last_page > 1 && (
+            <div className="flex items-center justify-center gap-2 pt-1">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+                aria-label="Previous page"
+                className="p-1 rounded text-shell-text-tertiary hover:text-shell-text disabled:opacity-30 disabled:cursor-default"
+              >
+                <ChevronLeft size={14} />
+              </button>
+              <span className="text-[10px] tabular-nums text-shell-text-tertiary">
+                {meta.current_page} / {meta.last_page}
+              </span>
+              <button
+                onClick={() => setPage((p) => p + 1)}
+                disabled={page >= meta.last_page}
+                aria-label="Next page"
+                className="p-1 rounded text-shell-text-tertiary hover:text-shell-text disabled:opacity-30 disabled:cursor-default"
+              >
+                <ChevronRight size={14} />
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Idle state */}
+      {status === "idle" && (
+        <div className="flex items-center justify-center py-6 text-xs text-shell-text-tertiary">
+          Type a search term to browse Wallhaven wallpapers
+        </div>
+      )}
+    </div>
+  );
+}

--- a/desktop/src/components/WallpaperPicker.test.tsx
+++ b/desktop/src/components/WallpaperPicker.test.tsx
@@ -35,7 +35,9 @@ describe("WallpaperPicker", () => {
     expect(themeDefaultHeadings.length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Built-in")).toBeInTheDocument();
     expect(screen.getByText("Your wallpapers")).toBeInTheDocument();
-    expect(screen.getByText("Browse online")).toBeInTheDocument();
+    // Use getByRole("heading") to disambiguate from the browser-toggle button
+    // that shares the text "Browse online" inside the Online section.
+    expect(screen.getByRole("heading", { name: "Browse online" })).toBeInTheDocument();
   });
 
   it("shows the theme default wallpaper in its own section with a badge when it matches", () => {

--- a/desktop/src/components/WallpaperPicker.tsx
+++ b/desktop/src/components/WallpaperPicker.tsx
@@ -1,6 +1,8 @@
 import { useThemeStore } from "@/stores/theme-store";
 import type { Wallpaper } from "@/stores/theme-store";
-import { Check } from "lucide-react";
+import { Check, Globe } from "lucide-react";
+import { WallhavenBrowser } from "./WallhavenBrowser";
+import { useState } from "react";
 
 interface Props {
   open: boolean;
@@ -105,6 +107,7 @@ export function WallpaperPicker({ open, onClose }: Props) {
   const sections = getWallpapersBySection();
   const themeDefaultId = themeDefaultWallpaperId[activeThemeId] || "graphite";
   const isThemeDefault = wallpaperId === themeDefaultId;
+  const [browseOnlineOpen, setBrowseOnlineOpen] = useState(false);
 
   if (!open) return null;
 
@@ -174,6 +177,38 @@ export function WallpaperPicker({ open, onClose }: Props) {
               )}
             </div>
           ))}
+        </div>
+        {/* Browse online section */}
+        <div className="border-t border-shell-border shrink-0">
+          <button
+            onClick={() => setBrowseOnlineOpen((v) => !v)}
+            className="flex items-center gap-2 w-full px-4 py-2 text-xs text-shell-text-secondary hover:text-shell-text transition-colors"
+            aria-expanded={browseOnlineOpen}
+            aria-label="Browse online wallpapers"
+          >
+            <Globe size={13} />
+            Browse online
+            <span
+              className={`ml-auto text-[10px] transition-transform ${browseOnlineOpen ? "rotate-180" : ""}`}
+            >
+              ▼
+            </span>
+          </button>
+          {browseOnlineOpen && (
+            <div className="px-4 pb-3">
+              <WallhavenBrowser
+                onSelect={(url, label) => {
+                  // Apply remote wallpaper directly — set background-image to the full URL
+                  useThemeStore.setState({
+                    wallpaperId: `wallhaven-${Date.now()}`,
+                    wallpaperImage: `url('${url}')`,
+                    wallpaperKind: "image",
+                    wallpaperOverlayText: null,
+                  });
+                }}
+              />
+            </div>
+          )}
         </div>
         {wallpaperKind === "animated" && (
           <div className="flex flex-col gap-2.5 px-4 py-3 border-t border-shell-border shrink-0">

--- a/desktop/src/components/WallpaperPicker.tsx
+++ b/desktop/src/components/WallpaperPicker.tsx
@@ -175,57 +175,60 @@ export function WallpaperPicker({ open, onClose }: Props) {
                   }
                 />
               )}
-            </div>
-          ))}
-        </div>
-        {/* Browse online section */}
-        <div className="border-t border-shell-border shrink-0">
-          <button
-            onClick={() => setBrowseOnlineOpen((v) => !v)}
-            className="flex items-center gap-2 w-full px-4 py-2 text-xs text-shell-text-secondary hover:text-shell-text transition-colors"
-            aria-expanded={browseOnlineOpen}
-            aria-label="Browse online wallpapers"
-          >
-            <Globe size={13} />
-            Browse online
-            <span
-              className={`ml-auto text-[10px] transition-transform ${browseOnlineOpen ? "rotate-180" : ""}`}
-            >
-              ▼
-            </span>
-          </button>
-          {browseOnlineOpen && (
-            <div className="px-4 pb-3">
-              <WallhavenBrowser
-                onSelect={(url, label) => {
-                  // Escape single-quotes and backslashes to prevent CSS injection
-                  // and render breakage from special characters in remote URLs.
-                  const safeUrl = url.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
-                  const id = `wallhaven-${Date.now()}`;
-                  const image = `url('${safeUrl}')`;
-                  // Route through a state updater so wallpaperIdByTheme is set for
-                  // the active theme — otherwise a theme switch loses the pick.
-                  // Also set light/mobile/fallback variants so the remote wallpaper
-                  // works in every scheme.
-                  useThemeStore.setState((s) => ({
-                    wallpaperId: id,
-                    wallpaperImage: image,
-                    wallpaperMobileImage: image,
-                    wallpaperFallback: "#1d1d1f",
-                    wallpaperLightImage: image,
-                    wallpaperLightMobileImage: image,
-                    wallpaperLightFallback: "#f0f0f0",
-                    wallpaperKind: "image",
-                    wallpaperOverlayText: label,
-                    wallpaperIdByTheme: {
-                      ...s.wallpaperIdByTheme,
-                      [s.activeThemeId]: id,
-                    },
-                  }));
-                }}
+              {/* Browse online: render inside the Online section so multi-row
+                  results scroll with the picker instead of getting clipped in
+                  a shrink-0 footer. */}
+              {section.id === "online" && (
+                <div className="mt-2">
+                  <button
+                    onClick={() => setBrowseOnlineOpen((v) => !v)}
+                    className="flex items-center gap-2 w-full px-1 py-1.5 text-xs text-shell-text-secondary hover:text-shell-text transition-colors"
+                    aria-expanded={browseOnlineOpen}
+                    aria-label="Browse online wallpapers"
+                  >
+                    <Globe size={13} />
+                    Browse online
+                    <span
+                      className={`ml-auto text-[10px] transition-transform ${browseOnlineOpen ? "rotate-180" : ""}`}
+                    >
+                      ▼
+                    </span>
+                  </button>
+                  {browseOnlineOpen && (
+                    <div className="pt-2">
+                      <WallhavenBrowser
+                        onSelect={(url, label) => {
+                          // Escape single-quotes and backslashes to prevent CSS injection
+                          // and render breakage from special characters in remote URLs.
+                          const safeUrl = url.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                          const id = `wallhaven-${Date.now()}`;
+                          const image = `url('${safeUrl}')`;
+                          // Route through a state updater so wallpaperIdByTheme is set for
+                          // the active theme — otherwise a theme switch loses the pick.
+                          // Also set light/mobile/fallback variants so the remote wallpaper
+                          // works in every scheme.
+                          useThemeStore.setState((s) => ({
+                            wallpaperId: id,
+                            wallpaperImage: image,
+                            wallpaperMobileImage: image,
+                            wallpaperFallback: "#1d1d1f",
+                            wallpaperLightImage: image,
+                            wallpaperLightMobileImage: image,
+                            wallpaperLightFallback: "#f0f0f0",
+                            wallpaperKind: "image",
+                            wallpaperOverlayText: label,
+                            wallpaperIdByTheme: {
+                              ...s.wallpaperIdByTheme,
+                              [s.activeThemeId]: id,
+                            },
+                          }));
+                        }}
               />
             </div>
           )}
+        </div>
+            </div>
+          ))}
         </div>
         {wallpaperKind === "animated" && (
           <div className="flex flex-col gap-2.5 px-4 py-3 border-t border-shell-border shrink-0">

--- a/desktop/src/components/WallpaperPicker.tsx
+++ b/desktop/src/components/WallpaperPicker.tsx
@@ -198,13 +198,30 @@ export function WallpaperPicker({ open, onClose }: Props) {
             <div className="px-4 pb-3">
               <WallhavenBrowser
                 onSelect={(url, label) => {
-                  // Apply remote wallpaper directly — set background-image to the full URL
-                  useThemeStore.setState({
-                    wallpaperId: `wallhaven-${Date.now()}`,
-                    wallpaperImage: `url('${url}')`,
+                  // Escape single-quotes and backslashes to prevent CSS injection
+                  // and render breakage from special characters in remote URLs.
+                  const safeUrl = url.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                  const id = `wallhaven-${Date.now()}`;
+                  const image = `url('${safeUrl}')`;
+                  // Route through a state updater so wallpaperIdByTheme is set for
+                  // the active theme — otherwise a theme switch loses the pick.
+                  // Also set light/mobile/fallback variants so the remote wallpaper
+                  // works in every scheme.
+                  useThemeStore.setState((s) => ({
+                    wallpaperId: id,
+                    wallpaperImage: image,
+                    wallpaperMobileImage: image,
+                    wallpaperFallback: "#1d1d1f",
+                    wallpaperLightImage: image,
+                    wallpaperLightMobileImage: image,
+                    wallpaperLightFallback: "#f0f0f0",
                     wallpaperKind: "image",
-                    wallpaperOverlayText: null,
-                  });
+                    wallpaperOverlayText: label,
+                    wallpaperIdByTheme: {
+                      ...s.wallpaperIdByTheme,
+                      [s.activeThemeId]: id,
+                    },
+                  }));
                 }}
               />
             </div>

--- a/desktop/src/components/WallpaperPicker.tsx
+++ b/desktop/src/components/WallpaperPicker.tsx
@@ -227,7 +227,8 @@ export function WallpaperPicker({ open, onClose }: Props) {
             </div>
           )}
         </div>
-            </div>
+          )}
+        </div>
           ))}
         </div>
         {wallpaperKind === "animated" && (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,22 @@ class TestLoadConfig:
         assert config.backends == []
         assert config.agents == []
 
+    def test_wallhaven_api_key_picked_up_on_fresh_install(self, tmp_path, monkeypatch):
+        """WALLHAVEN_API_KEY env var is read before branching, so fresh
+        installs (missing config file) also get the key."""
+        monkeypatch.setenv("WALLHAVEN_API_KEY", "test-fresh-key")
+        config = load_config(tmp_path / "nonexistent.yaml")
+        assert config.wallhaven_api_key == "test-fresh-key"
+
+    def test_wallhaven_api_key_picked_up_on_existing_config(
+        self, tmp_data_dir, monkeypatch
+    ):
+        """WALLHAVEN_API_KEY env var is read before branching when config
+        file exists too."""
+        monkeypatch.setenv("WALLHAVEN_API_KEY", "test-existing-key")
+        config = load_config(tmp_data_dir / "config.yaml")
+        assert config.wallhaven_api_key == "test-existing-key"
+
     def test_rejects_invalid_yaml(self, tmp_path):
         bad = tmp_path / "config.yaml"
         bad.write_text(": : : not valid yaml [[[")

--- a/tests/test_wallhaven.py
+++ b/tests/test_wallhaven.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import respx
+import httpx
+import pytest
+
+
+MOCK_SEARCH_RESPONSE = {
+    "data": [
+        {
+            "id": "abc123",
+            "url": "https://w.wallhaven.cc/full/abc/wallhaven-abc123.jpg",
+            "path": "https://wallhaven.cc/w/abc123",
+            "thumbs": {
+                "small": "https://th.wallhaven.cc/small/ab/abc123.jpg",
+                "original": "https://th.wallhaven.cc/original/ab/abc123.jpg",
+                "large": "https://th.wallhaven.cc/large/ab/abc123.jpg",
+            },
+            "resolution": "1920x1080",
+            "category": "general",
+            "purity": "sfw",
+        },
+        {
+            "id": "def456",
+            "url": "https://w.wallhaven.cc/full/de/wallhaven-def456.jpg",
+            "path": "https://wallhaven.cc/w/def456",
+            "thumbs": {
+                "small": "https://th.wallhaven.cc/small/de/def456.jpg",
+                "original": "https://th.wallhaven.cc/original/de/def456.jpg",
+                "large": "https://th.wallhaven.cc/large/de/def456.jpg",
+            },
+            "resolution": "2560x1440",
+            "category": "anime",
+            "purity": "sfw",
+        },
+    ],
+    "meta": {
+        "current_page": 1,
+        "last_page": 5,
+        "total": 50,
+    },
+}
+
+MOCK_EMPTY_RESPONSE = {
+    "data": [],
+    "meta": {"current_page": 1, "last_page": 1, "total": 0},
+}
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_returns_results(client):
+    """Search with a query should return Wallhaven results."""
+    respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_SEARCH_RESPONSE),
+    )
+
+    resp = await client.get("/api/wallhaven/search?q=nature")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["data"]) == 2
+    assert data["data"][0]["id"] == "abc123"
+    assert data["meta"]["current_page"] == 1
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_empty_results(client):
+    """Empty search results should return empty data array."""
+    respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_EMPTY_RESPONSE),
+    )
+
+    resp = await client.get("/api/wallhaven/search?q=nonexistent")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["data"] == []
+    assert data["meta"]["total"] == 0
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_default_params(client):
+    """Default pagination (page 1) and default category/purity should be sent."""
+    route = respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_SEARCH_RESPONSE),
+    )
+
+    await client.get("/api/wallhaven/search?q=nature")
+    assert route.called
+    # Verify params were forwarded: page=1, categories=111, purity=100
+    req = route.calls.last.request
+    assert req.url.params["page"] == "1"
+    assert req.url.params["categories"] == "111"
+    assert req.url.params["purity"] == "100"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_pagination(client):
+    """Page parameter should be forwarded."""
+    route = respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_SEARCH_RESPONSE),
+    )
+
+    await client.get("/api/wallhaven/search?q=nature&page=3")
+    assert route.calls.last.request.url.params["page"] == "3"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_search_custom_categories_purity(client):
+    """Custom categories and purity should be forwarded."""
+    route = respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_SEARCH_RESPONSE),
+    )
+
+    await client.get("/api/wallhaven/search?q=anime&categories=010&purity=110")
+    req = route.calls.last.request
+    assert req.url.params["categories"] == "010"
+    assert req.url.params["purity"] == "110"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_rate_limited(client):
+    """429 from Wallhaven should return 429 with friendly message."""
+    respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(429),
+    )
+
+    resp = await client.get("/api/wallhaven/search?q=nature")
+    assert resp.status_code == 429
+    data = resp.json()
+    assert "rate limited" in data["error"].lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_wallhaven_down(client):
+    """502 from Wallhaven should return 502."""
+    respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(502),
+    )
+
+    resp = await client.get("/api/wallhaven/search?q=nature")
+    assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_wallhaven_500(client):
+    """500 from Wallhaven should return 502 proxy error."""
+    respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(500),
+    )
+
+    resp = await client.get("/api/wallhaven/search?q=nature")
+    assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_timeout(client):
+    """Timeout should return 504."""
+    respx.get("https://wallhaven.cc/api/v1/search").mock(
+        side_effect=httpx.TimeoutException("timed out"),
+    )
+
+    resp = await client.get("/api/wallhaven/search?q=nature")
+    assert resp.status_code == 504
+    data = resp.json()
+    assert "timed out" in data["error"].lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_request_error(client):
+    """Connection error should return 502."""
+    respx.get("https://wallhaven.cc/api/v1/search").mock(
+        side_effect=httpx.RequestError("connection refused"),
+    )
+
+    resp = await client.get("/api/wallhaven/search?q=nature")
+    assert resp.status_code == 502
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_api_key_sent_when_configured(app, client):
+    """When wallhaven_api_key is set, X-API-Key header should be sent."""
+    app.state.config.wallhaven_api_key = "test-key-123"
+
+    route = respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_SEARCH_RESPONSE),
+    )
+
+    await client.get("/api/wallhaven/search?q=nature")
+    assert route.calls.last.request.headers["X-API-Key"] == "test-key-123"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_no_api_key_when_not_configured(client):
+    """When wallhaven_api_key is None, no X-API-Key header should be sent."""
+    route = respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_SEARCH_RESPONSE),
+    )
+
+    await client.get("/api/wallhaven/search?q=nature")
+    assert "X-API-Key" not in route.calls.last.request.headers

--- a/tests/test_wallhaven.py
+++ b/tests/test_wallhaven.py
@@ -9,8 +9,8 @@ MOCK_SEARCH_RESPONSE = {
     "data": [
         {
             "id": "abc123",
-            "url": "https://w.wallhaven.cc/full/abc/wallhaven-abc123.jpg",
-            "path": "https://wallhaven.cc/w/abc123",
+            "url": "https://wallhaven.cc/w/abc123",
+            "path": "https://w.wallhaven.cc/full/abc/wallhaven-abc123.jpg",
             "thumbs": {
                 "small": "https://th.wallhaven.cc/small/ab/abc123.jpg",
                 "original": "https://th.wallhaven.cc/original/ab/abc123.jpg",
@@ -22,8 +22,8 @@ MOCK_SEARCH_RESPONSE = {
         },
         {
             "id": "def456",
-            "url": "https://w.wallhaven.cc/full/de/wallhaven-def456.jpg",
-            "path": "https://wallhaven.cc/w/def456",
+            "url": "https://wallhaven.cc/w/def456",
+            "path": "https://w.wallhaven.cc/full/de/wallhaven-def456.jpg",
             "thumbs": {
                 "small": "https://th.wallhaven.cc/small/de/def456.jpg",
                 "original": "https://th.wallhaven.cc/original/de/def456.jpg",
@@ -209,3 +209,46 @@ async def test_no_api_key_when_not_configured(client):
 
     await client.get("/api/wallhaven/search?q=nature")
     assert "X-API-Key" not in route.calls.last.request.headers
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_invalid_sorting_rejected(client):
+    """Non-whitelisted sorting value should return 400."""
+    resp = await client.get("/api/wallhaven/search?q=nature&sorting=invalid_sort")
+    assert resp.status_code == 400
+    data = resp.json()
+    assert "sorting" in data["error"].lower()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_valid_sorting_forwarded(client):
+    """Known sorting value should be forwarded to Wallhaven."""
+    route = respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_SEARCH_RESPONSE),
+    )
+
+    await client.get("/api/wallhaven/search?q=nature&sorting=toplist")
+    assert route.calls.last.request.url.params["sorting"] == "toplist"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_query_max_length_enforced(client):
+    """q param longer than 200 chars should be rejected."""
+    long_q = "x" * 201
+    resp = await client.get(f"/api/wallhaven/search?q={long_q}")
+    assert resp.status_code == 422  # FastAPI validation error
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_empty_query_allowed(client):
+    """Empty q (default) should pass through to Wallhaven for unfiltered feed."""
+    route = respx.get("https://wallhaven.cc/api/v1/search").mock(
+        return_value=httpx.Response(200, json=MOCK_SEARCH_RESPONSE),
+    )
+
+    await client.get("/api/wallhaven/search")
+    assert route.calls.last.request.url.params["q"] == ""

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -127,10 +127,18 @@ def _migrate_legacy_rkllama_backend_name(backends: list[dict]) -> None:
 
 
 def load_config(path: Path) -> AppConfig:
+    # Wallhaven API key is env-only (never written to config.yaml).
+    # Read it once before any branching so both fresh-install and
+    # existing-config paths pick it up.
+    wallhaven_api_key: str | None = _os.environ.get("WALLHAVEN_API_KEY") or None
+
     if not path.exists():
         # Fresh install: build defaults with litellm_port explicitly recorded
         # so the choice is durable and never falls back to a hardcoded default.
-        cfg = AppConfig(config_path=path)
+        cfg = AppConfig(
+            config_path=path,
+            wallhaven_api_key=wallhaven_api_key,
+        )
         cfg.server.setdefault("litellm_port", _LITELLM_PORT_NEW)
         return cfg
     text = path.read_text()
@@ -177,9 +185,8 @@ def load_config(path: Path) -> AppConfig:
         archive=archive_cfg,
         memory_url=data.get("memory_url", "http://localhost:7900"),
         config_path=path,
+        wallhaven_api_key=wallhaven_api_key,
     )
-    # Wallhaven API key is env-only (never written to config.yaml)
-    cfg.wallhaven_api_key = _os.environ.get("WALLHAVEN_API_KEY") or None
     if _pin_applied:
         save_config(cfg, path)
     return cfg

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os as _os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -178,7 +179,6 @@ def load_config(path: Path) -> AppConfig:
         config_path=path,
     )
     # Wallhaven API key is env-only (never written to config.yaml)
-    import os as _os
     cfg.wallhaven_api_key = _os.environ.get("WALLHAVEN_API_KEY") or None
     if _pin_applied:
         save_config(cfg, path)

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -55,6 +55,7 @@ class AppConfig:
     archived_agents: list[dict] = field(default_factory=list)
     archive: dict = field(default_factory=lambda: DEFAULT_ARCHIVE_CONFIG.copy())
     memory_url: str = "http://localhost:7900"
+    wallhaven_api_key: str | None = None
     config_path: Path | None = None
 
     def to_dict(self) -> dict:
@@ -176,6 +177,9 @@ def load_config(path: Path) -> AppConfig:
         memory_url=data.get("memory_url", "http://localhost:7900"),
         config_path=path,
     )
+    # Wallhaven API key is env-only (never written to config.yaml)
+    import os as _os
+    cfg.wallhaven_api_key = _os.environ.get("WALLHAVEN_API_KEY") or None
     if _pin_applied:
         save_config(cfg, path)
     return cfg

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -394,5 +394,8 @@ def register_all_routers(app):
     from tinyagentos.routes.receipts import router as receipts_router
     app.include_router(receipts_router, dependencies=_csrf)
 
+    from tinyagentos.routes import wallhaven as wallhaven_routes
+    app.include_router(wallhaven_routes.router)
+
     from tinyagentos.routes.council import router as council_router
     app.include_router(council_router, dependencies=_csrf)

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -395,7 +395,7 @@ def register_all_routers(app):
     app.include_router(receipts_router, dependencies=_csrf)
 
     from tinyagentos.routes import wallhaven as wallhaven_routes
-    app.include_router(wallhaven_routes.router)
+    app.include_router(wallhaven_routes.router, dependencies=_csrf)
 
     from tinyagentos.routes.council import router as council_router
     app.include_router(council_router, dependencies=_csrf)

--- a/tinyagentos/routes/wallhaven.py
+++ b/tinyagentos/routes/wallhaven.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import httpx
 from fastapi import APIRouter, Request, Query
 from fastapi.responses import JSONResponse
@@ -7,6 +9,8 @@ from fastapi.responses import JSONResponse
 router = APIRouter()
 
 WALLHAVEN_BASE = "https://wallhaven.cc/api/v1"
+CATEGORY_PURITY_RE = re.compile(r"^[01]{3}$")
+_MAX_RESPONSE_BYTES = 1_000_000  # 1 MB cap
 
 
 @router.get("/api/wallhaven/search")
@@ -23,6 +27,16 @@ async def wallhaven_search(
     Keyless by default (~45 req/min). Pass WALLHAVEN_API_KEY env var for higher
     rate limits and NSFW access.
     """
+    if not CATEGORY_PURITY_RE.match(categories):
+        return JSONResponse(
+            {"error": "categories must be 3 characters of 0 or 1"},
+            status_code=400,
+        )
+    if not CATEGORY_PURITY_RE.match(purity):
+        return JSONResponse(
+            {"error": "purity must be 3 characters of 0 or 1"},
+            status_code=400,
+        )
     config = request.app.state.config
     api_key: str | None = getattr(config, "wallhaven_api_key", None)
 
@@ -68,4 +82,17 @@ async def wallhaven_search(
             status_code=502,
         )
 
-    return JSONResponse(resp.json())
+    content = resp.content
+    if len(content) > _MAX_RESPONSE_BYTES:
+        return JSONResponse(
+            {"error": "Wallhaven response too large"},
+            status_code=502,
+        )
+    try:
+        data = resp.json()
+    except ValueError:
+        return JSONResponse(
+            {"error": "Wallhaven returned invalid JSON"},
+            status_code=502,
+        )
+    return JSONResponse(data)

--- a/tinyagentos/routes/wallhaven.py
+++ b/tinyagentos/routes/wallhaven.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 
 import httpx
@@ -10,17 +11,32 @@ router = APIRouter()
 
 WALLHAVEN_BASE = "https://wallhaven.cc/api/v1"
 CATEGORY_PURITY_RE = re.compile(r"^[01]{3}$")
+_VALID_SORTING = frozenset(
+    {"relevance", "random", "date_added", "views", "favorites", "toplist"}
+)
 _MAX_RESPONSE_BYTES = 1_000_000  # 1 MB cap
 
 
 @router.get("/api/wallhaven/search")
 async def wallhaven_search(
     request: Request,
-    q: str = Query(default="", description="Search term"),
+    q: str = Query(
+        default="",
+        max_length=200,
+        description="Search term",
+    ),
     page: int = Query(default=1, ge=1, description="Page number"),
-    categories: str = Query(default="111", description="Category flags (3 chars: general/anime/people)"),
-    purity: str = Query(default="100", description="Purity flags (3 chars: sfw/sketchy/nsfw)"),
-    sorting: str = Query(default="relevance", description="Sort order"),
+    categories: str = Query(
+        default="111", description="Category flags (3 chars: general/anime/people)"
+    ),
+    purity: str = Query(
+        default="100", description="Purity flags (3 chars: sfw/sketchy/nsfw)"
+    ),
+    sorting: str = Query(
+        default="relevance",
+        max_length=200,
+        description="Sort order",
+    ),
 ):
     """Proxy search to Wallhaven API.
 
@@ -37,6 +53,14 @@ async def wallhaven_search(
             {"error": "purity must be 3 characters of 0 or 1"},
             status_code=400,
         )
+    if sorting not in _VALID_SORTING:
+        return JSONResponse(
+            {
+                "error": f"sorting must be one of {', '.join(sorted(_VALID_SORTING))}"
+            },
+            status_code=400,
+        )
+
     config = request.app.state.config
     api_key: str | None = getattr(config, "wallhaven_api_key", None)
 
@@ -54,11 +78,47 @@ async def wallhaven_search(
 
     try:
         async with httpx.AsyncClient(timeout=15) as client:
-            resp = await client.get(
+            async with client.stream(
+                "GET",
                 f"{WALLHAVEN_BASE}/search",
                 params=params,
                 headers=headers,
-            )
+            ) as resp:
+                if resp.status_code == 429:
+                    return JSONResponse(
+                        {
+                            "error": (
+                                "Rate limited by Wallhaven. "
+                                "Wait a moment and try again."
+                            )
+                        },
+                        status_code=429,
+                    )
+
+                if resp.status_code != 200:
+                    return JSONResponse(
+                        {"error": f"Wallhaven returned {resp.status_code}"},
+                        status_code=502,
+                    )
+
+                body = b""
+                async for chunk in resp.aiter_bytes():
+                    body += chunk
+                    if len(body) > _MAX_RESPONSE_BYTES:
+                        return JSONResponse(
+                            {"error": "Wallhaven response too large"},
+                            status_code=502,
+                        )
+
+                try:
+                    data = json.loads(body)
+                except (ValueError, json.JSONDecodeError):
+                    return JSONResponse(
+                        {"error": "Wallhaven returned invalid JSON"},
+                        status_code=502,
+                    )
+                return JSONResponse(data)
+
     except httpx.TimeoutException:
         return JSONResponse(
             {"error": "Wallhaven API timed out. Please try again."},
@@ -69,30 +129,3 @@ async def wallhaven_search(
             {"error": "Cannot reach Wallhaven API. Check your internet connection."},
             status_code=502,
         )
-
-    if resp.status_code == 429:
-        return JSONResponse(
-            {"error": "Rate limited by Wallhaven. Wait a moment and try again."},
-            status_code=429,
-        )
-
-    if resp.status_code != 200:
-        return JSONResponse(
-            {"error": f"Wallhaven returned {resp.status_code}"},
-            status_code=502,
-        )
-
-    content = resp.content
-    if len(content) > _MAX_RESPONSE_BYTES:
-        return JSONResponse(
-            {"error": "Wallhaven response too large"},
-            status_code=502,
-        )
-    try:
-        data = resp.json()
-    except ValueError:
-        return JSONResponse(
-            {"error": "Wallhaven returned invalid JSON"},
-            status_code=502,
-        )
-    return JSONResponse(data)

--- a/tinyagentos/routes/wallhaven.py
+++ b/tinyagentos/routes/wallhaven.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import httpx
+from fastapi import APIRouter, Request, Query
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+WALLHAVEN_BASE = "https://wallhaven.cc/api/v1"
+
+
+@router.get("/api/wallhaven/search")
+async def wallhaven_search(
+    request: Request,
+    q: str = Query(default="", description="Search term"),
+    page: int = Query(default=1, ge=1, description="Page number"),
+    categories: str = Query(default="111", description="Category flags (3 chars: general/anime/people)"),
+    purity: str = Query(default="100", description="Purity flags (3 chars: sfw/sketchy/nsfw)"),
+    sorting: str = Query(default="relevance", description="Sort order"),
+):
+    """Proxy search to Wallhaven API.
+
+    Keyless by default (~45 req/min). Pass WALLHAVEN_API_KEY env var for higher
+    rate limits and NSFW access.
+    """
+    config = request.app.state.config
+    api_key: str | None = getattr(config, "wallhaven_api_key", None)
+
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["X-API-Key"] = api_key
+
+    params: dict[str, str | int] = {
+        "q": q,
+        "page": page,
+        "categories": categories,
+        "purity": purity,
+        "sorting": sorting,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(
+                f"{WALLHAVEN_BASE}/search",
+                params=params,
+                headers=headers,
+            )
+    except httpx.TimeoutException:
+        return JSONResponse(
+            {"error": "Wallhaven API timed out. Please try again."},
+            status_code=504,
+        )
+    except httpx.RequestError:
+        return JSONResponse(
+            {"error": "Cannot reach Wallhaven API. Check your internet connection."},
+            status_code=502,
+        )
+
+    if resp.status_code == 429:
+        return JSONResponse(
+            {"error": "Rate limited by Wallhaven. Wait a moment and try again."},
+            status_code=429,
+        )
+
+    if resp.status_code != 200:
+        return JSONResponse(
+            {"error": f"Wallhaven returned {resp.status_code}"},
+            status_code=502,
+        )
+
+    return JSONResponse(resp.json())


### PR DESCRIPTION
Task: t_cc32e61b. Supersedes #1902.

## Changes
All 7 bot findings in one commit (7a5cb346):

### Kilo SUGGESTION
- **wallhaven.py:19** — Add `max_length=200` on `q` and `sorting` params, validate sorting against known Wallhaven values

### CodeRabbit MAJOR/MINOR
1. **WallhavenBrowser.tsx:43** — `useRef<ReturnType<typeof setTimeout>>(undefined)` fixes React 19 typings
2. **WallhavenBrowser.tsx:85** — Recheck `cancelled` after `resp.json()` to prevent stale error overwriting active state
3. **WallhavenBrowser.tsx:113** — Pass `img.path` (direct image) not `img.url` (details page) to onSelect. Fixtures swapped in both backend test and desktop test
4. **WallpaperPicker.tsx:229** — Move WallhavenBrowser into Online section's `overflow-y-auto` panel instead of `shrink-0` footer
5. **config.py:182** — Read `WALLHAVEN_API_KEY` before missing-file branch so fresh installs pick it up. Both config paths now receive the key
6. **wallhaven.py:61** — Replace `client.get()` + `resp.content` with `client.stream()` + `aiter_bytes()` to enforce 1MB limit incrementally

### Test additions
- `test_config.py`: 2 new tests for WALLHAVEN_API_KEY on fresh install + existing config
- `test_wallhaven.py`: 4 new tests (invalid sorting, valid sorting forwarded, query max_length, empty query allowed)
- `WallhavenBrowser.test.tsx`: url/path fixture swap

### Test results
- Config tests: 2/2 new tests pass
- Wallhaven test: `test_search_returns_results` passes (async fixture teardown hang is pre-existing in conftest, observed on unmodified code too)