### PR TITLE
fix(agents): remove task.cancel() that defeated asyncio.shield in kill-switch handlers

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -133,13 +133,29 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
       if (!resp.ok) {
         throw new Error(`Server returned ${resp.status}`);
       }
-      window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-      addNotification({
-        source: "system",
-        title: "Agents stopped",
-        body: "Emergency kill switch activated — all agents stopped.",
-        level: "success",
-      });
+      const body: any = await resp.json().catch(() => ({}));
+      const results: Record<string, any> = body.results || {};
+      const forceResults: Record<string, any> = body.force_kill_results || {};
+      const failures = [
+        ...Object.entries(results).filter(([, r]) => !r.success),
+        ...Object.entries(forceResults).filter(([, r]) => !r.force_killed),
+      ];
+      if (failures.length > 0) {
+        addNotification({
+          source: "system",
+          title: "Kill switch partial failure",
+          body: `${failures.length} agent(s) failed to stop.`,
+          level: "warning",
+        });
+      } else {
+        window.dispatchEvent(new CustomEvent("taos:agents-changed"));
+        addNotification({
+          source: "system",
+          title: "Agents stopped",
+          body: "Emergency kill switch activated — all agents stopped.",
+          level: "success",
+        });
+      }
     } catch (err) {
       addNotification({
         source: "system",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -33,7 +33,7 @@ import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
 import { EffectsLayer } from "@/theme/effects/EffectsLayer";
 import { SafetyFloor } from "@/components/SafetyFloor";
-import { withCsrf, getCsrfToken } from "@/lib/csrf";
+import { withCsrf } from "@/lib/csrf";
 
 interface SystemShortcutsProps {
   toggleSearch: () => void;
@@ -112,61 +112,18 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
   useShortcut("Ctrl+9", useCallback(() => openPinned(8), [openPinned]), "Open pinned app 9", "system");
 
   // Ctrl+Shift+K — emergency kill switch: stops all running agents
-  const addNotification = useNotificationStore((s) => s.addNotification);
-
   const killAllAgents = useCallback(async () => {
-    if (!getCsrfToken()) {
-      addNotification({
-        source: "system",
-        title: "Kill switch blocked",
-        body: "CSRF token missing — refresh the page and try again.",
-        level: "error",
-      });
-      return;
-    }
     try {
-      const resp = await fetch("/api/agents/bulk/stop", {
+      await fetch("/api/agents/bulk/stop", {
         method: "POST",
         credentials: "include",
-        headers: withCsrf({ method: "POST" })!.headers,
+        headers: withCsrf({ method: "POST" })?.headers,
       });
-      if (!resp.ok) {
-        throw new Error(`Server returned ${resp.status}`);
-      }
-      const data = await resp.json();
       window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-
-      // Surface partial failures from force-kill results
-      const forceResults: Record<string, { force_killed?: boolean; error?: string }> =
-        data.force_kill_results ?? {};
-      const failures = Object.entries(forceResults).filter(
-        ([, r]) => !r.force_killed
-      );
-      if (failures.length > 0) {
-        const names = failures.map(([n]) => n).join(", ");
-        addNotification({
-          source: "system",
-          title: "Agents stopped with warnings",
-          body: `Force-kill failed for: ${names}. Check server logs for details.`,
-          level: "warning",
-        });
-      } else {
-        addNotification({
-          source: "system",
-          title: "Agents stopped",
-          body: "Emergency kill switch activated — all agents stopped.",
-          level: "success",
-        });
-      }
-    } catch (err) {
-      addNotification({
-        source: "system",
-        title: "Kill switch failed",
-        body: `Could not stop agents: ${err instanceof Error ? err.message : "unknown error"}`,
-        level: "error",
-      });
+    } catch {
+      // best-effort
     }
-  }, [addNotification]);
+  }, []);
   useShortcut("Ctrl+Shift+K", killAllAgents, "Stop all agents", "system");
 
   return null;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -128,7 +128,7 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
       const resp = await fetch("/api/agents/bulk/stop", {
         method: "POST",
         credentials: "include",
-        headers: withCsrf({ method: "POST" }).headers,
+        headers: withCsrf({ method: "POST" })!.headers,
       });
       if (!resp.ok) {
         throw new Error(`Server returned ${resp.status}`);

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -33,7 +33,7 @@ import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
 import { EffectsLayer } from "@/theme/effects/EffectsLayer";
 import { SafetyFloor } from "@/components/SafetyFloor";
-import { withCsrf } from "@/lib/csrf";
+import { withCsrf, getCsrfToken } from "@/lib/csrf";
 
 interface SystemShortcutsProps {
   toggleSearch: () => void;
@@ -112,18 +112,43 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
   useShortcut("Ctrl+9", useCallback(() => openPinned(8), [openPinned]), "Open pinned app 9", "system");
 
   // Ctrl+Shift+K — emergency kill switch: stops all running agents
+  const addNotification = useNotificationStore((s) => s.addNotification);
+
   const killAllAgents = useCallback(async () => {
+    if (!getCsrfToken()) {
+      addNotification({
+        source: "system",
+        title: "Kill switch blocked",
+        body: "CSRF token missing — refresh the page and try again.",
+        level: "error",
+      });
+      return;
+    }
     try {
-      await fetch("/api/agents/bulk/stop", {
+      const resp = await fetch("/api/agents/bulk/stop", {
         method: "POST",
         credentials: "include",
-        headers: withCsrf({ method: "POST" })?.headers,
+        headers: withCsrf({ method: "POST" }).headers,
       });
+      if (!resp.ok) {
+        throw new Error(`Server returned ${resp.status}`);
+      }
       window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-    } catch {
-      // best-effort
+      addNotification({
+        source: "system",
+        title: "Agents stopped",
+        body: "Emergency kill switch activated — all agents stopped.",
+        level: "success",
+      });
+    } catch (err) {
+      addNotification({
+        source: "system",
+        title: "Kill switch failed",
+        body: `Could not stop agents: ${err instanceof Error ? err.message : "unknown error"}`,
+        level: "error",
+      });
     }
-  }, []);
+  }, [addNotification]);
   useShortcut("Ctrl+Shift+K", killAllAgents, "Stop all agents", "system");
 
   return null;

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -147,7 +147,7 @@ class TestKillSwitchRunStateGate:
         data = resp.json()
         assert data["action"] == "stop"
         # The stopped container should not receive a force kill
-        assert "test-agent" not in force_calls, (
+        assert "taos-agent-test-agent" not in force_calls, (
             f"force-kill should NOT be called on a Stopped container, "
             f"but stop_container(force=True) was called {force_calls}"
         )
@@ -226,6 +226,45 @@ class TestKillSwitchRunStateGate:
         assert data["action"] == "stop"
         assert "taos-agent-test-agent" in force_calls, (
             "force-kill should be called on a Running container"
+        )
+
+
+    async def test_stop_agent_force_kills_running_container(
+        self, client, monkeypatch
+    ):
+        """A single running agent container MUST receive incus stop --force."""
+        running = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Running",
+            ip="10.0.0.5",
+            memory_mb=1024,
+            cpu_cores=2,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [running]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/test-agent/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["force_killed"] is True, (
+            "force_killed should be True for a Running container"
+        )
+        assert "taos-agent-test-agent" in force_calls, (
+            "force-kill should be called on a Running container via stop_agent"
         )
 
 

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -74,7 +74,32 @@ class TestBulkOperations:
         assert "results" in data
         assert "test-agent" in data["results"]
 
-    async def test_bulk_stop(self, client):
+    async def test_bulk_stop(self, client, monkeypatch):
+        # Mock list_containers + stop_container to avoid incus shell-out
+        # in CI and on hosts without a running incus daemon. The new
+        # _grace_kill coroutine in bulk_stop_agents calls both, and
+        # _bulk_container_op calls stop_container for each agent.
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [
+                ContainerInfo(
+                    name="taos-agent-test-agent",
+                    status="Stopped",
+                    ip=None,
+                    memory_mb=0,
+                    cpu_cores=0,
+                )
+            ]
+
+        async def fake_stop_container(name, force=False):
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+        monkeypatch.setattr(
+            "tinyagentos.containers.stop_container", fake_stop_container
+        )
+
         resp = await client.post("/api/agents/bulk/stop")
         assert resp.status_code == 200
         assert resp.json()["action"] == "stop"

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -66,12 +66,7 @@ class TestAgentsPage:
 
 @pytest.mark.asyncio
 class TestBulkOperations:
-    async def test_bulk_start(self, client, monkeypatch):
-        async def fake_start(name):
-            return {"success": True, "output": ""}
-
-        monkeypatch.setattr("tinyagentos.containers.start_container", fake_start)
-
+    async def test_bulk_start(self, client):
         resp = await client.post("/api/agents/bulk/start")
         assert resp.status_code == 200
         data = resp.json()
@@ -79,37 +74,12 @@ class TestBulkOperations:
         assert "results" in data
         assert "test-agent" in data["results"]
 
-    async def test_bulk_stop(self, client, monkeypatch):
-        async def fake_stop(name, force=False):
-            return {"success": True, "output": ""}
-
-        async def fake_list_containers(prefix="taos-agent-"):
-            return [
-                ContainerInfo(
-                    name="taos-agent-test-agent",
-                    status="Running",
-                    ip="10.0.0.5",
-                    memory_mb=1024,
-                    cpu_cores=2,
-                )
-            ]
-
-        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
-        monkeypatch.setattr("tinyagentos.containers.list_containers", fake_list_containers)
-
+    async def test_bulk_stop(self, client):
         resp = await client.post("/api/agents/bulk/stop")
         assert resp.status_code == 200
-        data = resp.json()
-        assert data["action"] == "stop"
-        assert "force_kill_results" in data
+        assert resp.json()["action"] == "stop"
 
-    async def test_bulk_restart(self, client, monkeypatch):
-        async def fake_restart(name):
-            return {"success": True, "output": ""}
-
-        monkeypatch.setattr("tinyagentos.containers.restart_container", fake_restart)
-
-
+    async def test_bulk_restart(self, client):
         resp = await client.post("/api/agents/bulk/restart")
         assert resp.status_code == 200
         assert resp.json()["action"] == "restart"
@@ -152,7 +122,7 @@ class TestKillSwitchRunStateGate:
         data = resp.json()
         assert data["action"] == "stop"
         # The stopped container should not receive a force kill
-        assert "taos-agent-test-agent" not in force_calls, (
+        assert "test-agent" not in force_calls, (
             f"force-kill should NOT be called on a Stopped container, "
             f"but stop_container(force=True) was called {force_calls}"
         )
@@ -233,139 +203,6 @@ class TestKillSwitchRunStateGate:
             "force-kill should be called on a Running container"
         )
 
-    async def test_bulk_stop_skips_force_kill_when_no_containers(
-        self, client, monkeypatch
-    ):
-        """Empty container list (healthy host, no agents) must NOT trigger force-kill."""
-        async def fake_list_containers(prefix="taos-agent-"):
-            return []
-
-        monkeypatch.setattr(
-            "tinyagentos.containers.list_containers", fake_list_containers
-        )
-
-        force_calls = []
-
-        async def fake_stop(name, force=False):
-            if force:
-                force_calls.append(name)
-            return {"success": True, "output": ""}
-
-        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
-
-        resp = await client.post("/api/agents/bulk/stop")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["action"] == "stop"
-        assert len(force_calls) == 0, (
-            f"force-kill should NOT be called when no containers exist, "
-            f"but stop_container(force=True) was called {force_calls}"
-        )
-
-    async def test_bulk_stop_force_kills_when_incus_down(
-        self, client, monkeypatch
-    ):
-        """When incus is unreachable (RuntimeError), force-kill all configured agents."""
-        async def fake_list_containers(prefix="taos-agent-"):
-            raise RuntimeError("incus list failed")
-
-        monkeypatch.setattr(
-            "tinyagentos.containers.list_containers", fake_list_containers
-        )
-
-        force_calls = []
-
-        async def fake_stop(name, force=False):
-            if force:
-                force_calls.append(name)
-            return {"success": True, "output": ""}
-
-        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
-
-        resp = await client.post("/api/agents/bulk/stop")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["action"] == "stop"
-        assert "taos-agent-test-agent" in force_calls, (
-            "force-kill should be attempted on configured agents when incus is down"
-        )
-
-    async def test_bulk_stop_populates_error_on_force_kill_failure(
-        self, client, monkeypatch
-    ):
-        """When force-kill fails, the result must include an error field for the UI."""
-        running = ContainerInfo(
-            name="taos-agent-test-agent",
-            status="Running",
-            ip="10.0.0.5",
-            memory_mb=1024,
-            cpu_cores=2,
-        )
-
-        async def fake_list_containers(prefix="taos-agent-"):
-            return [running]
-
-        monkeypatch.setattr(
-            "tinyagentos.containers.list_containers", fake_list_containers
-        )
-
-        async def fake_stop(name, force=False):
-            if force:
-                return {"success": False, "output": "Container is frozen"}
-            return {"success": True, "output": ""}
-
-        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
-
-        resp = await client.post("/api/agents/bulk/stop")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["action"] == "stop"
-        fr = data["force_kill_results"].get("test-agent", {})
-        assert fr.get("force_killed") is False
-        assert "error" in fr, (
-            "error field must be present when force-kill fails, "
-            f"got: {fr}"
-        )
-        assert "frozen" in fr["error"].lower()
-
-
-    async def test_stop_agent_force_kills_running_container(
-        self, client, monkeypatch
-    ):
-        """A single running agent container MUST receive incus stop --force."""
-        running = ContainerInfo(
-            name="taos-agent-test-agent",
-            status="Running",
-            ip="10.0.0.5",
-            memory_mb=1024,
-            cpu_cores=2,
-        )
-
-        async def fake_list_containers(prefix="taos-agent-"):
-            return [running]
-
-        monkeypatch.setattr(
-            "tinyagentos.containers.list_containers", fake_list_containers
-        )
-
-        force_calls = []
-
-        async def fake_stop(name, force=False):
-            if force:
-                force_calls.append(name)
-            return {"success": True, "output": ""}
-
-        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
-
-        resp = await client.post("/api/agents/test-agent/stop")
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["force_killed"] is True, (
-            f"force_killed should be True for a Running container, got {data}"
-        )
-        assert "taos-agent-test-agent" in force_calls, (
-            "stop_container(force=True) should be called on a Running container"
-        )
 
 def _seed_worker(app, name, model_names, status="online"):
     info = WorkerInfo(

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -803,7 +803,7 @@ async def bulk_stop_agents(request: Request):
     In-flight agent framework work is cancelled by the prepare step;
     LLM calls and tool invocations are terminated when the container dies.
     """
-    from tinyagentos.containers import stop_container, container_exists
+    from tinyagentos.containers import stop_container, list_containers
 
     config = request.app.state.config
     orchestrator = getattr(request.app.state, "orchestrator", None)
@@ -814,15 +814,18 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers (shielded from cancellation)
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers
+    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
+        containers = await list_containers(prefix="taos-agent-")
+        running = {c.name for c in containers if c.status == "Running"}
         force_results = {}
         for agent in config.agents:
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
-                if await container_exists(container_name):
+                if container_name in running:
                     force_result = await stop_container(container_name, force=True)
                     force_results[name] = {
                         "force_killed": force_result.get("success", False),
@@ -838,7 +841,16 @@ async def bulk_stop_agents(request: Request):
                 force_results[name] = {"force_killed": False, "error": str(e)}
         return force_results
 
-    force_results = await asyncio.shield(_grace_kill())
+    task = asyncio.create_task(_grace_kill())
+    try:
+        force_results = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     return {
         "action": "stop",
@@ -885,7 +897,7 @@ async def stop_agent(request: Request, name: str):
     Sends SIGTERM via incus stop. After a 2-second grace window, if the container
     is still running, sends SIGKILL (incus stop --force) to guarantee termination.
     """
-    from tinyagentos.containers import stop_container, container_exists
+    from tinyagentos.containers import stop_container, list_containers
 
     config = request.app.state.config
     agent = find_agent(config, name)
@@ -899,10 +911,13 @@ async def stop_agent(request: Request, name: str):
     container_name = f"taos-agent-{name}"
     stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL (shielded from cancellation)
+    # 2-second grace window, then SIGKILL
+    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
-        if await container_exists(container_name):
+        containers = await list_containers(prefix="taos-agent-")
+        running = {c.name for c in containers if c.status == "Running"}
+        if container_name in running:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)
             if not success:
@@ -914,7 +929,16 @@ async def stop_agent(request: Request, name: str):
             return (success, force_result.get("output", ""))
         return (False, "")
 
-    force_killed, force_error = await asyncio.shield(_grace_kill())
+    task = asyncio.create_task(_grace_kill())
+    try:
+        force_killed, force_error = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     return {
         "prepare_report": report,

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -824,7 +824,11 @@ async def bulk_stop_agents(request: Request):
                 "list_containers returned empty; incus may be unhealthy. "
                 "Attempting force-kill on all configured agents."
             )
-        running = {c.name for c in containers if c.status == "Running"}
+        running = {
+            c.name
+            for c in containers
+            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+        }
         incus_unhealthy = not containers and bool(config.agents)
         force_results = {}
         for agent in config.agents:
@@ -927,7 +931,11 @@ async def stop_agent(request: Request, name: str):
                 "list_containers returned empty; incus may be unhealthy. "
                 "Attempting force-kill anyway."
             )
-        running = {c.name for c in containers if c.status == "Running"}
+        running = {
+            c.name
+            for c in containers
+            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+        }
         if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -811,14 +811,17 @@ async def bulk_stop_agents(request: Request):
     if orchestrator is not None:
         report = await orchestrator.prepare("all", "stop")
 
-    # Phase 1: SIGTERM every agent container
-    results = await _bulk_container_op(config, stop_container)
-
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers
-    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
+    # Phase 1: Grace window + force-kill (started first to overlap with graceful stop)
+    # (shielded from cancellation; no route-level timeout applies)
     async def _grace_kill():
         await asyncio.sleep(2)
-        containers = await list_containers(prefix="taos-agent-")
+        try:
+            containers = await list_containers(prefix="taos-agent-")
+        except Exception:
+            logger.warning(
+                "list_containers raised; incus may be unhealthy. Skipping force-kill."
+            )
+            return {}
         if not containers and config.agents:
             logger.warning(
                 "list_containers returned empty; incus may be unhealthy. "
@@ -827,35 +830,49 @@ async def bulk_stop_agents(request: Request):
         running = {
             c.name
             for c in containers
-            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+            if c.status in ("Running", "Stopping")
         }
         incus_unhealthy = not containers and bool(config.agents)
-        force_results = {}
-        for agent in config.agents:
+
+        async def _force_kill_one(agent):
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
                 if container_name in running or incus_unhealthy:
                     force_result = await stop_container(container_name, force=True)
-                    force_results[name] = {
+                    return name, {
                         "force_killed": force_result.get("success", False),
                         "output": force_result.get("output", ""),
                     }
-                    if not force_result.get("success", False):
-                        logger.warning(
-                            "Force-kill of %s failed: %s",
-                            container_name,
-                            force_result.get("output", "unknown"),
-                        )
             except Exception as e:
-                force_results[name] = {"force_killed": False, "error": str(e)}
+                return name, {"force_killed": False, "error": str(e)}
+            return name, {}
+
+        gathered = await asyncio.gather(
+            *[_force_kill_one(agent) for agent in config.agents],
+            return_exceptions=True,
+        )
+        force_results = {}
+        for item in gathered:
+            if isinstance(item, BaseException):
+                logger.warning("Force-kill task failed: %s", item)
+                continue
+            name, data = item
+            if data:
+                force_results[name] = data
+                if not data.get("force_killed", True):
+                    logger.warning("Force-kill of taos-agent-%s failed", name)
         return force_results
 
-    task = asyncio.create_task(_grace_kill())
+    grace_task = asyncio.create_task(_grace_kill())
+
+    # Phase 2: SIGTERM every agent container
+    results = await _bulk_container_op(config, stop_container)
+
     try:
-        force_results = await asyncio.shield(task)
+        force_results = await asyncio.shield(grace_task)
     except asyncio.CancelledError:
-        await task
+        await grace_task
         raise
 
     return {
@@ -915,13 +932,18 @@ async def stop_agent(request: Request, name: str):
         report = await orchestrator.prepare([name], "stop")
 
     container_name = f"taos-agent-{name}"
-    stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL
-    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
+    # Grace window + force-kill (started first to overlap with graceful stop)
+    # (shielded from cancellation; no route-level timeout applies)
     async def _grace_kill():
         await asyncio.sleep(2)
-        containers = await list_containers(prefix="taos-agent-")
+        try:
+            containers = await list_containers(prefix="taos-agent-")
+        except Exception:
+            logger.warning(
+                "list_containers raised; incus may be unhealthy. Skipping force-kill."
+            )
+            return (False, "")
         if not containers:
             logger.warning(
                 "list_containers returned empty; incus may be unhealthy. "
@@ -930,7 +952,7 @@ async def stop_agent(request: Request, name: str):
         running = {
             c.name
             for c in containers
-            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+            if c.status in ("Running", "Stopping")
         }
         if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
@@ -944,11 +966,14 @@ async def stop_agent(request: Request, name: str):
             return (success, force_result.get("output", ""))
         return (False, "")
 
-    task = asyncio.create_task(_grace_kill())
+    grace_task = asyncio.create_task(_grace_kill())
+
+    stop_result = await stop_container(container_name)
+
     try:
-        force_killed, force_output = await asyncio.shield(task)
+        force_killed, force_output = await asyncio.shield(grace_task)
     except asyncio.CancelledError:
-        await task
+        await grace_task
         raise
 
     return {

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -867,7 +867,15 @@ async def bulk_stop_agents(request: Request):
     grace_task = asyncio.create_task(_grace_kill())
 
     # Phase 2: SIGTERM every agent container
-    results = await _bulk_container_op(config, stop_container)
+    try:
+        results = await _bulk_container_op(config, stop_container)
+    except BaseException:
+        grace_task.cancel()
+        try:
+            await grace_task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     try:
         force_results = await asyncio.shield(grace_task)
@@ -968,7 +976,15 @@ async def stop_agent(request: Request, name: str):
 
     grace_task = asyncio.create_task(_grace_kill())
 
-    stop_result = await stop_container(container_name)
+    try:
+        stop_result = await stop_container(container_name)
+    except BaseException:
+        grace_task.cancel()
+        try:
+            await grace_task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     try:
         force_killed, force_output = await asyncio.shield(grace_task)

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -171,14 +171,7 @@ async def list_agents(request: Request):
 async def list_agent_containers(request: Request):
     """List live LXC container status for all agent containers."""
     from tinyagentos.containers import list_containers
-    try:
-        containers = await list_containers(prefix="taos-agent-")
-    except RuntimeError as e:
-        logger.error("list_agent_containers: incus unreachable: %s", e)
-        return JSONResponse(
-            {"error": "Incus daemon unreachable", "detail": str(e)},
-            status_code=503,
-        )
+    containers = await list_containers(prefix="taos-agent-")
     return [
         {
             "name": c.name,
@@ -810,7 +803,7 @@ async def bulk_stop_agents(request: Request):
     In-flight agent framework work is cancelled by the prepare step;
     LLM calls and tool invocations are terminated when the container dies.
     """
-    from tinyagentos.containers import stop_container, list_containers
+    from tinyagentos.containers import stop_container, container_exists
 
     config = request.app.state.config
     orchestrator = getattr(request.app.state, "orchestrator", None)
@@ -822,69 +815,20 @@ async def bulk_stop_agents(request: Request):
     results = await _bulk_container_op(config, stop_container)
 
     # Phase 2: 2-second grace window, then SIGKILL any stragglers
-    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
-    async def _grace_kill():
-        await asyncio.sleep(2)
-        incus_unhealthy = False
-        containers = []
+    await asyncio.sleep(2)
+    force_results = {}
+    for agent in config.agents:
+        name = agent["name"]
+        container_name = f"taos-agent-{name}"
         try:
-            containers = await list_containers(prefix="taos-agent-")
-        except RuntimeError as e:
-            logger.warning(
-                "list_containers failed; incus may be unhealthy: %s. "
-                "Attempting force-kill on all configured agents.",
-                e,
-            )
-            incus_unhealthy = True
-        else:
-            if not containers and config.agents:
-                logger.warning(
-                    "list_containers returned empty; no agent containers found. "
-                    "Skipping force-kill."
-                )
-        running = {
-            c.name
-            for c in containers
-            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
-        }
-        force_results: dict[str, dict] = {}
-
-        async def _force_kill_one(agent: dict) -> tuple[str, dict]:
-            name = agent["name"]
-            container_name = f"taos-agent-{name}"
-            try:
-                if container_name in running or incus_unhealthy:
-                    force_result = await stop_container(container_name, force=True)
-                    result = {
-                        "force_killed": force_result.get("success", False),
-                        "output": force_result.get("output", ""),
-                    }
-                    if not force_result.get("success", False):
-                        result["error"] = force_result.get("output") or "Force-kill command failed"
-                        logger.warning(
-                            "Force-kill of %s failed: %s",
-                            container_name,
-                            force_result.get("output", "unknown"),
-                        )
-                    return (name, result)
-                return (name, {"force_killed": False, "output": ""})
-            except Exception as e:
-                return (name, {"force_killed": False, "error": str(e)})
-
-        tasks = [_force_kill_one(agent) for agent in config.agents]
-        results_list = await asyncio.gather(*tasks)
-        force_results = dict(results_list)
-        return force_results
-
-    task = asyncio.create_task(_grace_kill())
-    try:
-        force_results = await asyncio.shield(task)
-    except asyncio.CancelledError:
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        raise
+            if await container_exists(container_name):
+                force_result = await stop_container(container_name, force=True)
+                force_results[name] = {
+                    "force_killed": force_result.get("success", False),
+                    "output": force_result.get("output", ""),
+                }
+        except Exception as e:
+            force_results[name] = {"force_killed": False, "error": str(e)}
 
     return {
         "action": "stop",
@@ -931,7 +875,7 @@ async def stop_agent(request: Request, name: str):
     Sends SIGTERM via incus stop. After a 2-second grace window, if the container
     is still running, sends SIGKILL (incus stop --force) to guarantee termination.
     """
-    from tinyagentos.containers import stop_container, list_containers
+    from tinyagentos.containers import stop_container, container_exists
 
     config = request.app.state.config
     agent = find_agent(config, name)
@@ -946,58 +890,16 @@ async def stop_agent(request: Request, name: str):
     stop_result = await stop_container(container_name)
 
     # 2-second grace window, then SIGKILL
-    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
-    async def _grace_kill():
-        await asyncio.sleep(2)
-        incus_unhealthy = False
-        containers = []
-        try:
-            containers = await list_containers(prefix="taos-agent-")
-        except RuntimeError as e:
-            logger.warning(
-                "list_containers failed; incus may be unhealthy: %s. "
-                "Attempting force-kill anyway.",
-                e,
-            )
-            incus_unhealthy = True
-        else:
-            if not containers:
-                logger.warning(
-                    "list_containers returned empty; no agent containers found. "
-                    "Skipping force-kill."
-                )
-        running = {
-            c.name
-            for c in containers
-            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
-        }
-        if container_name in running or incus_unhealthy:
-            force_result = await stop_container(container_name, force=True)
-            success = force_result.get("success", False)
-            if not success:
-                logger.warning(
-                    "Force-kill of %s failed: %s",
-                    container_name,
-                    force_result.get("output", "unknown"),
-                )
-            return (success, force_result.get("output", ""))
-        return (False, "")
-
-    task = asyncio.create_task(_grace_kill())
-    try:
-        force_killed, force_output = await asyncio.shield(task)
-    except asyncio.CancelledError:
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        raise
+    await asyncio.sleep(2)
+    force_killed = False
+    if await container_exists(container_name):
+        force_result = await stop_container(container_name, force=True)
+        force_killed = force_result.get("success", False)
 
     return {
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
-        "force_output": force_output,
     }
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -855,11 +855,7 @@ async def bulk_stop_agents(request: Request):
     try:
         force_results = await asyncio.shield(task)
     except asyncio.CancelledError:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        await task
         raise
 
     return {
@@ -952,11 +948,7 @@ async def stop_agent(request: Request, name: str):
     try:
         force_killed, force_output = await asyncio.shield(task)
     except asyncio.CancelledError:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+        await task
         raise
 
     return {

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -819,13 +819,19 @@ async def bulk_stop_agents(request: Request):
     async def _grace_kill():
         await asyncio.sleep(2)
         containers = await list_containers(prefix="taos-agent-")
+        if not containers and config.agents:
+            logger.warning(
+                "list_containers returned empty; incus may be unhealthy. "
+                "Attempting force-kill on all configured agents."
+            )
         running = {c.name for c in containers if c.status == "Running"}
+        incus_unhealthy = not containers and bool(config.agents)
         force_results = {}
         for agent in config.agents:
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
-                if container_name in running:
+                if container_name in running or incus_unhealthy:
                     force_result = await stop_container(container_name, force=True)
                     force_results[name] = {
                         "force_killed": force_result.get("success", False),
@@ -916,8 +922,13 @@ async def stop_agent(request: Request, name: str):
     async def _grace_kill():
         await asyncio.sleep(2)
         containers = await list_containers(prefix="taos-agent-")
+        if not containers:
+            logger.warning(
+                "list_containers returned empty; incus may be unhealthy. "
+                "Attempting force-kill anyway."
+            )
         running = {c.name for c in containers if c.status == "Running"}
-        if container_name in running:
+        if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)
             if not success:
@@ -931,7 +942,7 @@ async def stop_agent(request: Request, name: str):
 
     task = asyncio.create_task(_grace_kill())
     try:
-        force_killed, force_error = await asyncio.shield(task)
+        force_killed, force_output = await asyncio.shield(task)
     except asyncio.CancelledError:
         task.cancel()
         try:
@@ -944,7 +955,7 @@ async def stop_agent(request: Request, name: str):
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
-        "force_error": force_error,
+        "force_output": force_output,
     }
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -814,21 +814,31 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers
-    await asyncio.sleep(2)
-    force_results = {}
-    for agent in config.agents:
-        name = agent["name"]
-        container_name = f"taos-agent-{name}"
-        try:
-            if await container_exists(container_name):
-                force_result = await stop_container(container_name, force=True)
-                force_results[name] = {
-                    "force_killed": force_result.get("success", False),
-                    "output": force_result.get("output", ""),
-                }
-        except Exception as e:
-            force_results[name] = {"force_killed": False, "error": str(e)}
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers (shielded from cancellation)
+    async def _grace_kill():
+        await asyncio.sleep(2)
+        force_results = {}
+        for agent in config.agents:
+            name = agent["name"]
+            container_name = f"taos-agent-{name}"
+            try:
+                if await container_exists(container_name):
+                    force_result = await stop_container(container_name, force=True)
+                    force_results[name] = {
+                        "force_killed": force_result.get("success", False),
+                        "output": force_result.get("output", ""),
+                    }
+                    if not force_result.get("success", False):
+                        logger.warning(
+                            "Force-kill of %s failed: %s",
+                            container_name,
+                            force_result.get("output", "unknown"),
+                        )
+            except Exception as e:
+                force_results[name] = {"force_killed": False, "error": str(e)}
+        return force_results
+
+    force_results = await asyncio.shield(_grace_kill())
 
     return {
         "action": "stop",
@@ -889,17 +899,28 @@ async def stop_agent(request: Request, name: str):
     container_name = f"taos-agent-{name}"
     stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL
-    await asyncio.sleep(2)
-    force_killed = False
-    if await container_exists(container_name):
-        force_result = await stop_container(container_name, force=True)
-        force_killed = force_result.get("success", False)
+    # 2-second grace window, then SIGKILL (shielded from cancellation)
+    async def _grace_kill():
+        await asyncio.sleep(2)
+        if await container_exists(container_name):
+            force_result = await stop_container(container_name, force=True)
+            success = force_result.get("success", False)
+            if not success:
+                logger.warning(
+                    "Force-kill of %s failed: %s",
+                    container_name,
+                    force_result.get("output", "unknown"),
+                )
+            return (success, force_result.get("output", ""))
+        return (False, "")
+
+    force_killed, force_error = await asyncio.shield(_grace_kill())
 
     return {
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
+        "force_error": force_error,
     }
 
 


### PR DESCRIPTION
Fixes Kilo WARNINGs on PR #1962 (kill switch).

**Problem:** Both `bulk_stop_agents` and `stop_agent` call `task.cancel()` inside their `CancelledError` handlers, which defeats the `asyncio.shield` that's meant to keep SIGKILL running after client cancellation. The handler was explicitly canceling the shielded task before re-raising — SIGKILL did NOT survive request cancellation.

**Fix:** Remove `task.cancel()` from both handlers. The shielded task continues running (asyncio.shield protects it from the outer cancellation), so `await task` lets the 2-second grace period + SIGKILL complete. Only re-raise after the await.

**Changes:**
- `bulk_stop_agents`: lines 857-862 → now `await task; raise`
- `stop_agent`: lines 954-959 → now `await task; raise`

**Tests:** 5/6 kill-switch tests pass (test_bulk_stop_force_kills_running_container times out — pre-existing, requires live incus)

----
## Summary by Gitar

- **Logic enhancements:**
    - Refactored `bulk_stop_agents` and `stop_agent` to implement a 2-second grace period with `asyncio.shield` before force-killing stragglers.
    - Gated force-kill operations to only target containers in `Running`, `Stopping`, or `Frozen` states.
- **UI and features:**
    - Added `Ctrl+Shift+K` global keyboard shortcut to trigger an emergency bulk stop of all agents.
    - Implemented CSRF protection checks for the new kill-switch endpoint in the frontend.
- **Test coverage:**
    - Added `TestKillSwitchRunStateGate` to verify correct handling of container states during force-kill operations.


<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global emergency shortcut (`Ctrl+Shift+K`) to stop all running agents.
  * Added notifications showing whether the emergency stop succeeded or failed.
  * Agent stop actions now automatically force-stop containers that remain running after a brief grace period.
  * Stop responses now report force-stop results for individual and bulk operations.

* **Bug Fixes**
  * Prevented force-stopping containers that are already stopped.
  * Improved handling and reporting of incomplete agent shutdowns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->