### PR TITLE
feat(projects): rename agents + confirm before removing a member

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectMembers.test.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.test.tsx
@@ -188,6 +188,79 @@ describe("ProjectMembers exclusive Lead selector (D7)", () => {
   });
 });
 
+describe("ProjectMembers remove confirmation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("asks for confirmation before removing a member and only removes on confirm", async () => {
+    const fetchMock = mockFetch({
+      "/api/projects/prj-test/members": { ok: true, body: { items: [memberRow("agent-a")] } },
+      "/api/agents": { ok: true, body: [agentA] },
+      "/api/agents/registry": { ok: true, body: [] },
+      "/api/projects/prj-test/members/agent-a": { ok: true, body: { ok: true } },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProjectMembers project={baseProject} onChanged={vi.fn()} />);
+    await flush();
+
+    // Clicking Remove opens a confirm dialog and does NOT delete yet.
+    fireEvent.click(screen.getByLabelText("Remove Alpha"));
+    expect(screen.getByRole("dialog", { name: "Remove member" })).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/projects/prj-test/members/agent-a",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+
+    // Confirming fires the DELETE.
+    const dialog = screen.getByRole("dialog", { name: "Remove member" });
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("button", { name: "Remove" }));
+      await flush();
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/projects/prj-test/members/agent-a",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});
+
+describe("ProjectMembers rename external agent", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renames an external agent via PATCH /api/agents/registry/{id}", async () => {
+    const fetchMock = mockFetch({
+      "/api/projects/prj-test/members": { ok: true, body: { items: [externalMember] } },
+      "/api/agents": { ok: true, body: [] },
+      "/api/agents/registry": { ok: true, body: [registryEntry] },
+      "/api/agents/registry/grok-taos-20260711-000736": { ok: true, body: { ok: true } },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProjectMembers project={project} onChanged={vi.fn()} />);
+    await flush();
+
+    fireEvent.click(screen.getByLabelText("Rename grok-taOS"));
+    const input = screen.getByLabelText("New name for grok-taOS") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "hy3 (grok)" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await flush();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/agents/registry/grok-taos-20260711-000736",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ display_name: "hy3 (grok)" }),
+      }),
+    );
+  });
+});
+
 const project = { id: "prj-test", name: "taOS", slug: "taos" } as unknown as Project;
 
 // A consent-flow external agent: the member row keys on the canonical id, and

--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -3,6 +3,8 @@ import { projectsApi, type Project, type ProjectMember } from "@/lib/projects";
 import { AddAgentDialog } from "./AddAgentDialog";
 import { InviteAgentDialog } from "./InviteAgentDialog";
 import { canvasApi } from "./canvas/canvas-api";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { withCsrf } from "@/lib/csrf";
 
 interface AgentSummary {
   id: string;
@@ -93,6 +95,40 @@ function MemberRow({
 }) {
   const typeLabel = frameworkLabel(framework);
   const isAgent = member.member_kind === "native" || member.member_kind === "clone";
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  // Registry-backed (external) agents can be renamed: member_id is the canonical
+  // id, and display_name is a registry-wide field, so the new name shows here and
+  // anywhere else the agent appears.
+  const canRename = !!isExternal;
+  const [renaming, setRenaming] = useState(false);
+  const [nameDraft, setNameDraft] = useState(label);
+  const [renameError, setRenameError] = useState("");
+
+  async function saveRename() {
+    const next = nameDraft.trim();
+    if (!next || next === label) {
+      setRenaming(false);
+      return;
+    }
+    setRenameError("");
+    const res = await fetch(
+      `/api/agents/registry/${encodeURIComponent(member.member_id)}`,
+      withCsrf({
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ display_name: next }),
+      }),
+    );
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      setRenameError(data?.error || `Rename failed (${res.status})`);
+      return;
+    }
+    setRenaming(false);
+    onRefresh();
+    onChanged();
+  }
   return (
     <li
       className={
@@ -102,28 +138,83 @@ function MemberRow({
       }
     >
       <div className="min-w-0">
-        <div className="truncate text-sm flex items-center gap-1" title={hint || member.member_id}>
-          {emoji && <span aria-hidden>{emoji}</span>}
-          <span>{label}</span>
-          {isExternal && (
-            <span className="ml-1 text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-sky-500/15 text-sky-300 border border-sky-500/25">
-              external
-            </span>
-          )}
-          {typeLabel && (
-            <span
-              className="ml-1 text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-zinc-700/40 text-zinc-300 border border-zinc-600/40"
-              title="Agent type"
+        {renaming ? (
+          <div className="flex items-center gap-1 text-sm">
+            <input
+              type="text"
+              value={nameDraft}
+              autoFocus
+              maxLength={64}
+              aria-label={`New name for ${label}`}
+              onChange={(e) => setNameDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") saveRename();
+                if (e.key === "Escape") {
+                  setRenaming(false);
+                  setNameDraft(label);
+                  setRenameError("");
+                }
+              }}
+              className="bg-zinc-800 rounded px-2 py-0.5 text-sm w-48"
+            />
+            <button
+              type="button"
+              onClick={saveRename}
+              className="text-xs px-2 py-0.5 bg-blue-600 rounded hover:bg-blue-500 text-white"
             >
-              {typeLabel}
-            </span>
-          )}
-          {isLead && (
-            <span className="ml-1 text-xs text-yellow-400 font-medium" aria-label="Lead agent">
-              ★ Lead
-            </span>
-          )}
-        </div>
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setRenaming(false);
+                setNameDraft(label);
+                setRenameError("");
+              }}
+              className="text-xs px-2 py-0.5 bg-zinc-800 rounded hover:bg-zinc-700"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <div className="truncate text-sm flex items-center gap-1" title={hint || member.member_id}>
+            {emoji && <span aria-hidden>{emoji}</span>}
+            <span>{label}</span>
+            {canRename && (
+              <button
+                type="button"
+                onClick={() => {
+                  setNameDraft(label);
+                  setRenaming(true);
+                }}
+                className="text-[11px] text-zinc-500 hover:text-zinc-300"
+                aria-label={`Rename ${label}`}
+                title="Rename"
+              >
+                ✎
+              </button>
+            )}
+            {isExternal && (
+              <span className="ml-1 text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-sky-500/15 text-sky-300 border border-sky-500/25">
+                external
+              </span>
+            )}
+            {typeLabel && (
+              <span
+                className="ml-1 text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-zinc-700/40 text-zinc-300 border border-zinc-600/40"
+                title="Agent type"
+              >
+                {typeLabel}
+              </span>
+            )}
+            {isLead && (
+              <span className="ml-1 text-xs text-yellow-400 font-medium" aria-label="Lead agent">
+                ★ Lead
+              </span>
+            )}
+          </div>
+        )}
+        {renameError && <div className="text-xs text-red-400">{renameError}</div>}
         {member.member_kind === "clone" && (
           <div className="text-xs text-zinc-500">clone · {member.memory_seed}</div>
         )}
@@ -167,17 +258,27 @@ function MemberRow({
         )}
         <button
           type="button"
-          onClick={async () => {
-            await projectsApi.members.remove(projectId, member.member_id);
-            onRefresh();
-            onChanged();
-          }}
+          onClick={() => setConfirmRemove(true)}
           className="text-xs text-red-400 hover:underline"
           aria-label={`Remove ${label}`}
         >
           Remove
         </button>
       </div>
+      <ConfirmDialog
+        open={confirmRemove}
+        title="Remove member"
+        message={`Remove ${label} from this project? Their project access is revoked. This does not delete the agent's identity.`}
+        confirmLabel="Remove"
+        danger
+        onCancel={() => setConfirmRemove(false)}
+        onConfirm={async () => {
+          setConfirmRemove(false);
+          await projectsApi.members.remove(projectId, member.member_id);
+          onRefresh();
+          onChanged();
+        }}
+      />
     </li>
   );
 }

--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -77,9 +77,11 @@ function MemberRow({
   hint,
   isExternal,
   framework,
+  canonicalId,
   projectId,
   isLead,
   onRefresh,
+  onRegistryRefresh,
   onChanged,
 }: {
   member: ProjectMember;
@@ -88,21 +90,25 @@ function MemberRow({
   hint?: string;
   isExternal?: boolean;
   framework?: string;
+  canonicalId?: string;
   projectId: string;
   isLead?: boolean;
   onRefresh: () => void;
+  onRegistryRefresh?: () => void;
   onChanged: () => void;
 }) {
   const typeLabel = frameworkLabel(framework);
   const isAgent = member.member_kind === "native" || member.member_kind === "clone";
   const [confirmRemove, setConfirmRemove] = useState(false);
-  // Registry-backed (external) agents can be renamed: member_id is the canonical
-  // id, and display_name is a registry-wide field, so the new name shows here and
-  // anywhere else the agent appears.
+  // Registry-backed (external) agents can be renamed. display_name is a
+  // registry-wide field, so the new name shows here and anywhere the agent
+  // appears. Prefer the canonical id (member_id may be a legacy handle).
   const canRename = !!isExternal;
+  const renameId = canonicalId || member.member_id;
   const [renaming, setRenaming] = useState(false);
   const [nameDraft, setNameDraft] = useState(label);
   const [renameError, setRenameError] = useState("");
+  const [savingRename, setSavingRename] = useState(false);
 
   async function saveRename() {
     const next = nameDraft.trim();
@@ -111,23 +117,33 @@ function MemberRow({
       return;
     }
     setRenameError("");
-    const res = await fetch(
-      `/api/agents/registry/${encodeURIComponent(member.member_id)}`,
-      withCsrf({
-        method: "PATCH",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ display_name: next }),
-      }),
-    );
-    if (!res.ok) {
-      const data = await res.json().catch(() => ({}));
-      setRenameError(data?.error || `Rename failed (${res.status})`);
-      return;
+    setSavingRename(true);
+    try {
+      const res = await fetch(
+        `/api/agents/registry/${encodeURIComponent(renameId)}`,
+        withCsrf({
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ display_name: next }),
+        }),
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setRenameError(data?.error || `Rename failed (${res.status})`);
+        return;
+      }
+      setRenaming(false);
+      // Reload the registry roster so the new display_name is reflected in the
+      // label (the members list alone does not carry display_name).
+      onRegistryRefresh?.();
+      onRefresh();
+      onChanged();
+    } catch {
+      setRenameError("Network error, please try again");
+    } finally {
+      setSavingRename(false);
     }
-    setRenaming(false);
-    onRefresh();
-    onChanged();
   }
   return (
     <li
@@ -148,7 +164,7 @@ function MemberRow({
               aria-label={`New name for ${label}`}
               onChange={(e) => setNameDraft(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") saveRename();
+                if (e.key === "Enter" && !savingRename) saveRename();
                 if (e.key === "Escape") {
                   setRenaming(false);
                   setNameDraft(label);
@@ -160,9 +176,10 @@ function MemberRow({
             <button
               type="button"
               onClick={saveRename}
-              className="text-xs px-2 py-0.5 bg-blue-600 rounded hover:bg-blue-500 text-white"
+              disabled={savingRename}
+              className="text-xs px-2 py-0.5 bg-blue-600 rounded hover:bg-blue-500 text-white disabled:opacity-50"
             >
-              Save
+              {savingRename ? "Saving..." : "Save"}
             </button>
             <button
               type="button"
@@ -319,6 +336,31 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
 
   const refresh = () =>
     projectsApi.members.list(project.id).then(setMembers).catch(() => setMembers([]));
+
+  // Reload the external registry roster so a rename (which updates a registry
+  // display_name, not a project_members row) is reflected in the label. Members
+  // list alone does not carry the display_name, so onRefresh is not enough.
+  const reloadExternalRegistry = () =>
+    fetch("/api/agents/registry", { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((rows) => {
+        if (!Array.isArray(rows)) return;
+        const active = rows.filter(
+          (e: { origin?: string; status?: string }) =>
+            e.origin === "external-selfjoin" && e.status === "active",
+        );
+        setExternalAgents(
+          active.map(
+            (e: { handle?: string; canonical_id?: string; display_name?: string; framework?: string }) => ({
+              handle: e.handle || "",
+              canonical_id: e.canonical_id,
+              display_name: e.display_name,
+              framework: e.framework,
+            }),
+          ),
+        );
+      })
+      .catch(() => {});
 
   useEffect(() => {
     let cancelled = false;
@@ -502,8 +544,10 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
                   isLead={m.member_id === leadMemberId}
                   isExternal
                   framework={byHandle.get(m.member_id)?.framework}
+                  canonicalId={byHandle.get(m.member_id)?.canonical_id}
                   projectId={project.id}
                   onRefresh={refresh}
+                  onRegistryRefresh={reloadExternalRegistry}
                   onChanged={onChanged}
                 />
               );

--- a/desktop/src/components/ConfirmDialog.tsx
+++ b/desktop/src/components/ConfirmDialog.tsx
@@ -15,8 +15,8 @@ interface ConfirmDialogProps {
 /**
  * A small modal that asks the user to confirm before a destructive or
  * hard-to-undo action. Matches the app dialog style (overlay + zinc panel),
- * focuses the confirm button, closes on Escape or backdrop click, and traps the
- * click inside the panel so a stray click does not dismiss it.
+ * focuses the confirm button, closes on Escape or backdrop click, and keeps
+ * keyboard focus inside the panel (Tab cycles within the dialog).
  */
 export function ConfirmDialog({
   open,
@@ -29,6 +29,7 @@ export function ConfirmDialog({
   onCancel,
 }: ConfirmDialogProps) {
   const confirmRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (open) confirmRef.current?.focus();
@@ -37,7 +38,28 @@ export function ConfirmDialog({
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
+      if (e.key === "Escape") {
+        onCancel();
+        return;
+      }
+      if (e.key !== "Tab" || !panelRef.current) return;
+      // Trap Tab focus inside the panel so it cannot reach controls behind the
+      // modal.
+      const focusable = panelRef.current.querySelectorAll<HTMLElement>("button");
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) return;
+      const active = document.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      } else if (!panelRef.current.contains(active)) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -54,6 +76,7 @@ export function ConfirmDialog({
       onClick={onCancel}
     >
       <div
+        ref={panelRef}
         className="bg-zinc-900 p-4 rounded shadow w-full max-w-sm space-y-3"
         onClick={(e) => e.stopPropagation()}
       >

--- a/desktop/src/components/ConfirmDialog.tsx
+++ b/desktop/src/components/ConfirmDialog.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from "react";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  message?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Style the confirm button as destructive (red) when the action removes/deletes. */
+  danger?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * A small modal that asks the user to confirm before a destructive or
+ * hard-to-undo action. Matches the app dialog style (overlay + zinc panel),
+ * focuses the confirm button, closes on Escape or backdrop click, and traps the
+ * click inside the panel so a stray click does not dismiss it.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  danger = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (open) confirmRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-[10002] bg-black/50 flex items-center justify-center p-4"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-zinc-900 p-4 rounded shadow w-full max-w-sm space-y-3"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="text-lg font-semibold">{title}</h3>
+        {message && <p className="text-sm text-zinc-400">{message}</p>}
+        <div className="flex justify-end gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="text-xs px-3 py-1.5 bg-zinc-800 rounded hover:bg-zinc-700"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={onConfirm}
+            className={
+              danger
+                ? "text-xs px-3 py-1.5 bg-red-600 rounded hover:bg-red-500 text-white"
+                : "text-xs px-3 py-1.5 bg-blue-600 rounded hover:bg-blue-500 text-white"
+            }
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Two Members-tab improvements Jay asked for while onboarding the fleet:

- **Rename agents**: registry-backed agents get an inline ✎ rename that PATCHes the existing `/api/agents/registry/{id}` display_name endpoint, so they can be labelled to match their model (e.g. "hy3 (opencode)"). Registry-wide, so it reflects anywhere the agent shows.
- **Confirm on remove**: the Remove button now opens a confirmation dialog (new reusable `ConfirmDialog`) instead of removing on first click.

Backend already supported the rename (owner/admin-gated PATCH, emits a rename notification). Frontend-only. 6/6 ProjectMembers tests green (2 new). tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation modal before removing project members.
  * Added CSRF-protected inline renaming for external/registry-backed members, with Save/Cancel controls.
  * Added Enter/Escape keyboard support for the rename editor.
  * Added inline rename error display and ensured updated names refresh across member views.
* **Bug Fixes**
  * Member access is revoked only after the removal is explicitly confirmed.
* **Tests**
  * Extended coverage for member removal confirmation and external agent renaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->