### PR TITLE
fix(userspace): migrate container_deploy standalone _find_free_port to centralized allocate_host_port

### DIFF
--- a/tests/userspace/test_container_deploy.py
+++ b/tests/userspace/test_container_deploy.py
@@ -6,11 +6,11 @@ from tinyagentos.userspace import container_deploy as cd
 @pytest.mark.asyncio
 async def test_deploy_publishes_first_port_bound_to_localhost_and_applies_caps():
     with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
-         patch.object(cd, "_find_free_port", return_value=13042), \
+         patch.object(cd, "allocate_host_port", return_value=30421), \
          patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
         create.return_value = {"success": True, "name": "taos-app-echo"}
         out = await cd.deploy_app_container("echo", {"image": "hashicorp/http-echo:latest", "ports": [5678]})
-        assert out == {"success": True, "host": "127.0.0.1", "port": 13042}
+        assert out == {"success": True, "host": "127.0.0.1", "port": 30421}
         kwargs = create.call_args.kwargs
         args = create.call_args.args
         assert args[0] == "taos-app-echo"
@@ -18,7 +18,7 @@ async def test_deploy_publishes_first_port_bound_to_localhost_and_applies_caps()
         # (host_port, container_port) tuple reached the backend -- the actual
         # 127.0.0.1-only binding is enforced inside DockerBackend.create_container
         # (see test_docker_backend.py), not re-verified here.
-        assert kwargs["ports"] == [(13042, 5678)]
+        assert kwargs["ports"] == [(30421, 5678)]
         # untrusted app backend gets a conservative, fixed resource cap
         assert kwargs["memory_limit"] == "512m"
         assert kwargs["cpu_limit"] == 1
@@ -35,7 +35,7 @@ async def test_deploy_fails_cleanly_without_docker():
 @pytest.mark.asyncio
 async def test_deploy_propagates_backend_error():
     with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
-         patch.object(cd, "_find_free_port", return_value=13042), \
+         patch.object(cd, "allocate_host_port", return_value=30421), \
          patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
         create.return_value = {"success": False, "error": "image not found"}
         out = await cd.deploy_app_container("echo", {"image": "nope", "ports": [5678]})
@@ -45,14 +45,14 @@ async def test_deploy_propagates_backend_error():
 @pytest.mark.asyncio
 async def test_deploy_retries_on_port_race():
     with patch.object(cd.shutil, "which", return_value="/usr/bin/docker"), \
-         patch.object(cd, "_find_free_port", side_effect=[13042, 13043]), \
+         patch.object(cd, "allocate_host_port", side_effect=[30421, 30422]), \
          patch.object(cd.DockerBackend, "create_container", new_callable=AsyncMock) as create:
         create.side_effect = [
             {"success": False, "error": "port is already allocated"},
             {"success": True, "name": "taos-app-echo"},
         ]
         out = await cd.deploy_app_container("echo", {"image": "x", "ports": [5678]})
-        assert out == {"success": True, "host": "127.0.0.1", "port": 13043}
+        assert out == {"success": True, "host": "127.0.0.1", "port": 30422}
         assert create.await_count == 2
 
 

--- a/tinyagentos/userspace/container_deploy.py
+++ b/tinyagentos/userspace/container_deploy.py
@@ -8,27 +8,15 @@ low-level tinyagentos.containers Docker primitive. The agent deploy path
 from __future__ import annotations
 
 import shutil
-import socket
-from contextlib import closing
 
 from tinyagentos.containers.docker import DockerBackend
+from tinyagentos.installers.port_allocator import allocate_host_port
 
 # Untrusted third-party app backends get a conservative, fixed resource cap --
 # there is no per-app config for this today and these apps are not vetted the
 # way agent containers are.
 _MEMORY_LIMIT = "512m"
 _CPU_LIMIT = 1
-
-
-def _find_free_port(start: int = 13000, end: int = 14000) -> int:
-    for port in range(start, end):
-        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            try:
-                s.bind(("127.0.0.1", port))
-                return port
-            except OSError:
-                continue
-    raise RuntimeError("no free port available in range")
 
 
 def _app_container_name(app_id: str) -> str:
@@ -57,8 +45,9 @@ async def deploy_app_container(app_id: str, container_spec: dict) -> dict:
     # on the narrow TOCTOU window where the chosen port gets taken before
     # docker binds.
     last_error = "deploy failed"
+    tried: set[int] = set()
     for _ in range(3):
-        host_port = _find_free_port()
+        host_port = allocate_host_port(app_id, exclude=tried)
         result = await backend.create_container(
             name,
             image=image,
@@ -69,6 +58,7 @@ async def deploy_app_container(app_id: str, container_spec: dict) -> dict:
         if result.get("success"):
             return {"success": True, "host": "127.0.0.1", "port": host_port}
         last_error = result.get("error", "container create failed")
+        tried.add(host_port)
         if "port is already allocated" not in last_error and "address already in use" not in last_error:
             break  # a non-port error won't be fixed by retrying
     return {"success": False, "error": last_error}


### PR DESCRIPTION
## Summary
Replace the standalone `_find_free_port()` (port range 13000-14000) in `userspace/container_deploy.py` with the centralized `allocate_host_port` from `installers/port_allocator.py`.

## Changes
- Remove dead `_find_free_port` function, unused `socket` + `closing` imports
- Import `allocate_host_port` from `tinyagentos.installers.port_allocator`
- Update test patches: `cd._find_free_port` → `cd.allocate_host_port`

## Verification
- **Targeted tests:** 38/38 pass (container_deploy 5/5, port_allocator 16/16, broker 17/17)
- **Port pool verification:** centralized pool (30000-40000) is the single source of truth per #1964; old standalone pool (13000-14000) deliberately replaced
- No new imports beyond `allocate_host_port`

Closes #1966
Task: t_f32ea72d