### PR TITLE
fix(csrf): attach CSRF token in the global fetch wrapper (beta.41 deploy-blocker)

### DIFF
--- a/desktop/src/lib/auth-guard.test.ts
+++ b/desktop/src/lib/auth-guard.test.ts
@@ -36,5 +36,11 @@ describe("installAuthGuard CSRF wiring", () => {
     await window.fetch(`${window.location.origin}.evil.com/x`, { method: "POST" });
     const lookalike = spy.mock.calls.at(-1)?.[1] as RequestInit;
     expect(new Headers(lookalike.headers).get("X-CSRF-Token")).toBeNull();
+
+    // Request-object input for a same-origin mutating call: the wrapper rebuilds
+    // the Request with the header attached (first arg is the Request).
+    await window.fetch(new Request(`${window.location.origin}/api/x`, { method: "POST" }));
+    const reqArg = spy.mock.calls.at(-1)?.[0] as Request;
+    expect(reqArg.headers.get("X-CSRF-Token")).toBe("tok123");
   });
 });

--- a/desktop/src/lib/auth-guard.test.ts
+++ b/desktop/src/lib/auth-guard.test.ts
@@ -26,5 +26,15 @@ describe("installAuthGuard CSRF wiring", () => {
     await window.fetch("https://evil.example/x", { method: "POST" });
     const extInit = spy.mock.calls.at(-1)?.[1] as RequestInit;
     expect(new Headers(extInit.headers).get("X-CSRF-Token")).toBeNull();
+
+    // Protocol-relative and lookalike-host URLs must NOT be treated as
+    // same-origin (a prefix check would leak the token to these).
+    await window.fetch("//evil.example/x", { method: "POST" });
+    const protoRel = spy.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(new Headers(protoRel.headers).get("X-CSRF-Token")).toBeNull();
+
+    await window.fetch(`${window.location.origin}.evil.com/x`, { method: "POST" });
+    const lookalike = spy.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(new Headers(lookalike.headers).get("X-CSRF-Token")).toBeNull();
   });
 });

--- a/desktop/src/lib/auth-guard.test.ts
+++ b/desktop/src/lib/auth-guard.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from "vitest";
+import { installAuthGuard } from "./auth-guard";
+
+describe("installAuthGuard CSRF wiring", () => {
+  it("attaches X-CSRF-Token to same-origin mutating requests only", async () => {
+    document.cookie = "csrf_token=tok123";
+    const spy = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    // installAuthGuard captures window.fetch as the original at install time, so
+    // set the spy first, then install: subsequent window.fetch calls go through
+    // the patched wrapper into the spy.
+    window.fetch = spy as unknown as typeof window.fetch;
+    installAuthGuard();
+
+    // Same-origin mutating request: the double-submit header is attached so the
+    // backend's router-wide verify_csrf gate is satisfied.
+    await window.fetch("/api/projects", { method: "POST", body: "{}" });
+    const postInit = spy.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(new Headers(postInit.headers).get("X-CSRF-Token")).toBe("tok123");
+
+    // Non-mutating request: no header (verify_csrf only gates mutations).
+    await window.fetch("/api/projects");
+    const getInit = spy.mock.calls.at(-1)?.[1] as RequestInit | undefined;
+    expect(getInit ? new Headers(getInit.headers).get("X-CSRF-Token") : null).toBeNull();
+
+    // External origin: the token is never sent off-site.
+    await window.fetch("https://evil.example/x", { method: "POST" });
+    const extInit = spy.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(new Headers(extInit.headers).get("X-CSRF-Token")).toBeNull();
+  });
+});

--- a/desktop/src/lib/auth-guard.ts
+++ b/desktop/src/lib/auth-guard.ts
@@ -20,6 +20,8 @@
  * - Idempotent install — calling installAuthGuard() twice is a no-op.
  */
 
+import { withCsrf } from "./csrf";
+
 const SESSION_EXPIRED_EVENT = "taos-session-expired";
 
 // API prefixes whose 401s do NOT mean the controller session expired.
@@ -46,7 +48,26 @@ export function installAuthGuard(): void {
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> {
-    const response = await originalFetch(input, init);
+    // Attach the CSRF double-submit header to same-origin mutating requests so
+    // the backend's router-wide verify_csrf gate is satisfied at every call
+    // site, not only the handful that wrap withCsrf() by hand. withCsrf is a
+    // no-op for non-mutating methods and when no csrf_token cookie is present,
+    // and never overwrites an X-CSRF-Token a caller already set. Gated to
+    // same-origin (relative paths or this origin) so the token is never sent to
+    // an external host. Request-object callers already carry their own headers.
+    let effectiveInit = init;
+    let reqUrl = "";
+    if (typeof input === "string") reqUrl = input;
+    else if (input instanceof URL) reqUrl = input.toString();
+    else if (input && typeof (input as Request).url === "string") reqUrl = (input as Request).url;
+    if (typeof input !== "object" || input instanceof URL) {
+      const sameOrigin =
+        reqUrl.startsWith("/") ||
+        (typeof window !== "undefined" && !!window.location &&
+          reqUrl.startsWith(window.location.origin));
+      if (sameOrigin) effectiveInit = withCsrf(init);
+    }
+    const response = await originalFetch(input, effectiveInit);
     if (response.status === 401) {
       let url = "";
       if (typeof input === "string") url = input;

--- a/desktop/src/lib/auth-guard.ts
+++ b/desktop/src/lib/auth-guard.ts
@@ -61,10 +61,17 @@ export function installAuthGuard(): void {
     else if (input instanceof URL) reqUrl = input.toString();
     else if (input && typeof (input as Request).url === "string") reqUrl = (input as Request).url;
     if (typeof input !== "object" || input instanceof URL) {
-      const sameOrigin =
-        reqUrl.startsWith("/") ||
-        (typeof window !== "undefined" && !!window.location &&
-          reqUrl.startsWith(window.location.origin));
+      // Resolve to an absolute origin and compare exactly. A prefix check would
+      // be bypassable by a protocol-relative URL (//evil.example) or a lookalike
+      // host (https://<origin>.evil.com), either of which would leak the token.
+      let sameOrigin = false;
+      try {
+        if (typeof window !== "undefined" && window.location) {
+          sameOrigin = new URL(reqUrl, window.location.href).origin === window.location.origin;
+        }
+      } catch {
+        sameOrigin = false;
+      }
       if (sameOrigin) effectiveInit = withCsrf(init);
     }
     const response = await originalFetch(input, effectiveInit);

--- a/desktop/src/lib/auth-guard.ts
+++ b/desktop/src/lib/auth-guard.ts
@@ -20,9 +20,22 @@
  * - Idempotent install — calling installAuthGuard() twice is a no-op.
  */
 
-import { withCsrf } from "./csrf";
+import { withCsrf, getCsrfToken } from "./csrf";
 
 const SESSION_EXPIRED_EVENT = "taos-session-expired";
+const CSRF_MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+// Same-origin iff the resolved URL origin matches this page's. Parse the URL
+// (not a string prefix, which a protocol-relative //evil.example or a lookalike
+// host <origin>.evil.com would defeat, leaking the token).
+function isSameOrigin(u: string): boolean {
+  try {
+    if (typeof window === "undefined" || !window.location) return false;
+    return new URL(u, window.location.href).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
 
 // API prefixes whose 401s do NOT mean the controller session expired.
 // /api/account/* proxies to the taos.my cloud account, a separate auth
@@ -50,31 +63,34 @@ export function installAuthGuard(): void {
   ): Promise<Response> {
     // Attach the CSRF double-submit header to same-origin mutating requests so
     // the backend's router-wide verify_csrf gate is satisfied at every call
-    // site, not only the handful that wrap withCsrf() by hand. withCsrf is a
-    // no-op for non-mutating methods and when no csrf_token cookie is present,
-    // and never overwrites an X-CSRF-Token a caller already set. Gated to
-    // same-origin (relative paths or this origin) so the token is never sent to
-    // an external host. Request-object callers already carry their own headers.
+    // site, not only the handful that wrap withCsrf() by hand. Covers both
+    // string/URL inputs (via withCsrf on init) and Request-object inputs (by
+    // rebuilding the Request with the header). Gated to same-origin so the token
+    // never leaks off-site; never overwrites an X-CSRF-Token a caller already set.
+    let effectiveInput: RequestInfo | URL = input;
     let effectiveInit = init;
-    let reqUrl = "";
-    if (typeof input === "string") reqUrl = input;
-    else if (input instanceof URL) reqUrl = input.toString();
-    else if (input && typeof (input as Request).url === "string") reqUrl = (input as Request).url;
-    if (typeof input !== "object" || input instanceof URL) {
-      // Resolve to an absolute origin and compare exactly. A prefix check would
-      // be bypassable by a protocol-relative URL (//evil.example) or a lookalike
-      // host (https://<origin>.evil.com), either of which would leak the token.
-      let sameOrigin = false;
+    if (typeof input === "string" || input instanceof URL) {
+      if (isSameOrigin(input.toString())) effectiveInit = withCsrf(init);
+    } else if (typeof Request !== "undefined" && input instanceof Request) {
       try {
-        if (typeof window !== "undefined" && window.location) {
-          sameOrigin = new URL(reqUrl, window.location.href).origin === window.location.origin;
+        const method = (input.method || "GET").toUpperCase();
+        if (
+          CSRF_MUTATING.has(method) &&
+          isSameOrigin(input.url) &&
+          !input.headers.has("X-CSRF-Token")
+        ) {
+          const token = getCsrfToken();
+          if (token) {
+            const headers = new Headers(input.headers);
+            headers.set("X-CSRF-Token", token);
+            effectiveInput = new Request(input, { headers });
+          }
         }
       } catch {
-        sameOrigin = false;
+        effectiveInput = input;
       }
-      if (sameOrigin) effectiveInit = withCsrf(init);
     }
-    const response = await originalFetch(input, effectiveInit);
+    const response = await originalFetch(effectiveInput, effectiveInit);
     if (response.status === 401) {
       let url = "";
       if (typeof input === "string") url = input;


### PR DESCRIPTION
## Deploy-blocker caught by the beta.41 pre-deploy audit

#1898 attached `verify_csrf` to **every** router, so any cookie-session POST/PUT/PATCH/DELETE without `X-CSRF-Token` 403s. But only ~12 SPA files wrap `withCsrf`; ~230 bare `fetch` sites (including `SettingsApp/UpdatesPanel` POST /api/settings/update, rebuild-frontend, restart, and Messages sends) do not. Deploying as-is would 403 most desktop write actions on the Pi, and since **Settings→Update is itself broken**, there is no UI path left to deploy the fix. CI stayed green because `tests/conftest.py` autouse-monkeypatches `verify_csrf` to a no-op.

## Fix
Attach `withCsrf(init)` centrally inside `installAuthGuard`'s global `window.fetch` wrapper, so every same-origin mutating request carries the double-submit header at once. Gated to same-origin (relative paths / this origin) so the token is never sent off-site; `withCsrf` is a no-op for non-mutating methods and never overwrites a caller's own header, so the ~12 explicit `withCsrf` sites are unaffected.

Test: `auth-guard.test.ts` asserts the header is attached to a same-origin POST, absent on GET, and absent on an external-origin POST. tsc clean.

Follow-up (separate): narrow the conftest autouse CSRF bypass so a backend test exercises the real gate end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Automatically adds CSRF protection to same-origin requests that modify data.
  * Preserves existing CSRF headers when provided.
  * Applies protection consistently to standard URLs and request objects.

* **Bug Fixes**
  * Ensures external-origin and non-mutating requests are not incorrectly modified.
  * Maintains existing session-expiration handling for applicable API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->