### PR TITLE
fix: retire alpha verification_status in frameworks.py, fix broken-status docstring

### DIFF
--- a/tests/test_frameworks.py
+++ b/tests/test_frameworks.py
@@ -278,7 +278,7 @@ def test_all_ids_are_unique():
 
 
 def test_all_verification_statuses_valid():
-    valid = {"alpha", "beta", "stable"}
+    valid = {"tested", "beta", "experimental", "broken"}
     for fw_id, entry in FRAMEWORKS.items():
         status = entry.get("verification_status")
         assert status in valid, f"{fw_id}: unexpected verification_status {status!r}"

--- a/tinyagentos/frameworks.py
+++ b/tinyagentos/frameworks.py
@@ -67,7 +67,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "generic",
         "name": "Generic",
         "description": "Fallback adapter — echos messages; use as a starting point",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show Generic adapter help"},
         ],
@@ -159,7 +159,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "agent_zero",
         "name": "Agent Zero",
         "description": "Proxies messages to the Agent Zero HTTP API (agent0ai/agent-zero)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show Agent Zero help"},
         ],
@@ -168,7 +168,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "ironclaw",
         "name": "IronClaw",
         "description": "OpenClaw-inspired Rust agent focused on privacy and security (nearai/ironclaw)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show IronClaw help"},
         ],
@@ -177,7 +177,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "microclaw",
         "name": "MicroClaw",
         "description": "Agentic AI assistant in Rust, inspired by NanoClaw (microclaw/microclaw)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show MicroClaw help"},
         ],
@@ -186,7 +186,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "moltis",
         "name": "Moltis",
         "description": "Secure persistent personal agent server in Rust (moltis-org/moltis)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show Moltis help"},
         ],
@@ -195,7 +195,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "nanoclaw",
         "name": "NanoClaw",
         "description": "Lightweight container-based OpenClaw alternative on Anthropic Agents SDK (qwibitai/nanoclaw)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show NanoClaw help"},
         ],
@@ -204,7 +204,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "nullclaw",
         "name": "NullClaw",
         "description": "Fully autonomous AI assistant infrastructure in Zig (nullclaw/nullclaw)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show NullClaw help"},
         ],
@@ -213,7 +213,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "picoclaw",
         "name": "PicoClaw",
         "description": "Tiny, fast, and deployable anywhere — automate the mundane, unleash creativity (sipeed/picoclaw)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show PicoClaw help"},
         ],
@@ -222,7 +222,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "shibaclaw",
         "name": "ShibaClaw",
         "description": "Self-hosted AI agent with 5-layer prompt injection protection (RikyZ90/ShibaClaw)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show ShibaClaw help"},
         ],
@@ -231,7 +231,7 @@ FRAMEWORKS: dict[str, dict] = {
         "id": "zeroclaw",
         "name": "ZeroClaw",
         "description": "Fast, small, fully autonomous AI personal assistant in Rust (zeroclaw-labs/zeroclaw)",
-        "verification_status": "alpha",
+        "verification_status": "experimental",
         "slash_commands": [
             {"name": "help", "description": "Show ZeroClaw help"},
         ],

--- a/tinyagentos/tools/framework_tools.py
+++ b/tinyagentos/tools/framework_tools.py
@@ -39,7 +39,7 @@ async def execute_list_frameworks(args: dict, request: Request) -> dict:
     frameworks = list_frameworks()
     if verified_only:
         # tested and beta are the two verified tiers (tested is the most verified);
-        # experimental and broken are not recommended.
+        # experimental is functional but unverified; broken is known-failing and blocked.
         frameworks = [
             f for f in frameworks if f.get("verification_status") in ("tested", "beta")
         ]


### PR DESCRIPTION
Task: t_8bdd399e. Fixes #1967.

Two cosmetic changes from the post-#1963 verification_status standardization:

1. Migrate all ~10 `alpha` entries in `FRAMEWORKS` (frameworks.py) to `experimental`
2. Fix `framework_tools.py` docstring: broken status now reads "functional but unverified" / "known-failing and blocked"

Tests: 44/44 pass (test_frameworks.py + test_framework_tools.py).