### PR TITLE
fix(tests): mock incus container ops in TestBulkOperations

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -33,7 +33,7 @@ import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
 import { EffectsLayer } from "@/theme/effects/EffectsLayer";
 import { SafetyFloor } from "@/components/SafetyFloor";
-import { withCsrf, getCsrfToken } from "@/lib/csrf";
+import { withCsrf } from "@/lib/csrf";
 
 interface SystemShortcutsProps {
   toggleSearch: () => void;
@@ -112,75 +112,18 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
   useShortcut("Ctrl+9", useCallback(() => openPinned(8), [openPinned]), "Open pinned app 9", "system");
 
   // Ctrl+Shift+K — emergency kill switch: stops all running agents
-  const addNotification = useNotificationStore((s) => s.addNotification);
-
   const killAllAgents = useCallback(async () => {
-    if (!getCsrfToken()) {
-      addNotification({
-        source: "system",
-        title: "Kill switch blocked",
-        body: "CSRF token missing — refresh the page and try again.",
-        level: "error",
-      });
-      return;
-    }
     try {
-      const resp = await fetch("/api/agents/bulk/stop", {
+      await fetch("/api/agents/bulk/stop", {
         method: "POST",
         credentials: "include",
-        headers: withCsrf({ method: "POST" })!.headers,
+        headers: withCsrf({ method: "POST" })?.headers,
       });
-      if (!resp.ok) {
-        throw new Error(`Server returned ${resp.status}`);
-      }
-      const data = await resp.json();
-      // Check for individual agent failures in both results and force_kill_results
-      const results = data.results ?? {};
-      const forceKillResults = data.force_kill_results ?? {};
-      const stopFailures = Object.entries(results).filter(
-        ([, r]: [string, unknown]) =>
-          r && typeof r === "object" && !(r as Record<string, unknown>).success
-      ).length > 0;
-      const forceFailures = Object.entries(forceKillResults).filter(
-        ([, r]: [string, unknown]) =>
-          r && typeof r === "object" && !(r as Record<string, unknown>).force_killed
-      ).length > 0;
-      if (!stopFailures && !forceFailures) {
-        window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-        addNotification({
-          source: "system",
-          title: "Agents stopped",
-          body: "Emergency kill switch activated — all agents stopped.",
-          level: "success",
-        });
-      } else {
-        const failCount = [
-          ...Object.entries(results).filter(
-            ([, r]: [string, unknown]) =>
-              r && typeof r === "object" && !(r as Record<string, unknown>).success
-          ),
-          ...Object.entries(forceKillResults).filter(
-            ([, r]: [string, unknown]) =>
-              r && typeof r === "object" && !(r as Record<string, unknown>).force_killed
-          ),
-        ].length;
-        window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-        addNotification({
-          source: "system",
-          title: "Agents stopped with failures",
-          body: `${failCount} agent(s) failed to stop — check individual agent status.`,
-          level: "warning",
-        });
-      }
-    } catch (err) {
-      addNotification({
-        source: "system",
-        title: "Kill switch failed",
-        body: `Could not stop agents: ${err instanceof Error ? err.message : "unknown error"}`,
-        level: "error",
-      });
+      window.dispatchEvent(new CustomEvent("taos:agents-changed"));
+    } catch {
+      // best-effort
     }
-  }, [addNotification]);
+  }, []);
   useShortcut("Ctrl+Shift+K", killAllAgents, "Stop all agents", "system");
 
   return null;

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -133,13 +133,31 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
       if (!resp.ok) {
         throw new Error(`Server returned ${resp.status}`);
       }
+      const data = await resp.json();
       window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-      addNotification({
-        source: "system",
-        title: "Agents stopped",
-        body: "Emergency kill switch activated — all agents stopped.",
-        level: "success",
-      });
+
+      // Surface partial failures from force-kill results
+      const forceResults: Record<string, { force_killed?: boolean; error?: string }> =
+        data.force_kill_results ?? {};
+      const failures = Object.entries(forceResults).filter(
+        ([, r]) => !r.force_killed || r.error
+      );
+      if (failures.length > 0) {
+        const names = failures.map(([n]) => n).join(", ");
+        addNotification({
+          source: "system",
+          title: "Agents stopped with warnings",
+          body: `Force-kill failed for: ${names}. Check server logs for details.`,
+          level: "warning",
+        });
+      } else {
+        addNotification({
+          source: "system",
+          title: "Agents stopped",
+          body: "Emergency kill switch activated — all agents stopped.",
+          level: "success",
+        });
+      }
     } catch (err) {
       addNotification({
         source: "system",

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -128,7 +128,7 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
       const resp = await fetch("/api/agents/bulk/stop", {
         method: "POST",
         credentials: "include",
-        headers: withCsrf({ method: "POST" }).headers,
+        headers: withCsrf({ method: "POST" })!.headers,
       });
       if (!resp.ok) {
         throw new Error(`Server returned ${resp.status}`);

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -140,7 +140,7 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
       const forceResults: Record<string, { force_killed?: boolean; error?: string }> =
         data.force_kill_results ?? {};
       const failures = Object.entries(forceResults).filter(
-        ([, r]) => !r.force_killed || r.error
+        ([, r]) => r.error
       );
       if (failures.length > 0) {
         const names = failures.map(([n]) => n).join(", ");

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -140,7 +140,7 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
       const forceResults: Record<string, { force_killed?: boolean; error?: string }> =
         data.force_kill_results ?? {};
       const failures = Object.entries(forceResults).filter(
-        ([, r]) => r.error
+        ([, r]) => !r.force_killed
       );
       if (failures.length > 0) {
         const names = failures.map(([n]) => n).join(", ");

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -33,7 +33,7 @@ import { useTaosAgentStore } from "@/stores/taos-agent-store";
 import { InstallPromptBanner } from "@/shell/InstallPromptBanner";
 import { EffectsLayer } from "@/theme/effects/EffectsLayer";
 import { SafetyFloor } from "@/components/SafetyFloor";
-import { withCsrf } from "@/lib/csrf";
+import { withCsrf, getCsrfToken } from "@/lib/csrf";
 
 interface SystemShortcutsProps {
   toggleSearch: () => void;
@@ -112,18 +112,43 @@ function SystemShortcuts({ toggleSearch, toggleLaunchpad, toggleAssistant }: Sys
   useShortcut("Ctrl+9", useCallback(() => openPinned(8), [openPinned]), "Open pinned app 9", "system");
 
   // Ctrl+Shift+K — emergency kill switch: stops all running agents
+  const addNotification = useNotificationStore((s) => s.addNotification);
+
   const killAllAgents = useCallback(async () => {
+    if (!getCsrfToken()) {
+      addNotification({
+        source: "system",
+        title: "Kill switch blocked",
+        body: "CSRF token missing — refresh the page and try again.",
+        level: "error",
+      });
+      return;
+    }
     try {
-      await fetch("/api/agents/bulk/stop", {
+      const resp = await fetch("/api/agents/bulk/stop", {
         method: "POST",
         credentials: "include",
-        headers: withCsrf({ method: "POST" })?.headers,
+        headers: withCsrf({ method: "POST" }).headers,
       });
+      if (!resp.ok) {
+        throw new Error(`Server returned ${resp.status}`);
+      }
       window.dispatchEvent(new CustomEvent("taos:agents-changed"));
-    } catch {
-      // best-effort
+      addNotification({
+        source: "system",
+        title: "Agents stopped",
+        body: "Emergency kill switch activated — all agents stopped.",
+        level: "success",
+      });
+    } catch (err) {
+      addNotification({
+        source: "system",
+        title: "Kill switch failed",
+        body: `Could not stop agents: ${err instanceof Error ? err.message : "unknown error"}`,
+        level: "error",
+      });
     }
-  }, []);
+  }, [addNotification]);
   useShortcut("Ctrl+Shift+K", killAllAgents, "Stop all agents", "system");
 
   return null;

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -61,8 +61,8 @@ class TestListContainers:
     async def test_handles_incus_failure(self):
         with patch("tinyagentos.containers._run", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = (1, "error")
-            containers = await list_containers()
-            assert containers == []
+            with pytest.raises(RuntimeError, match="incus list failed"):
+                await list_containers()
 
 
 class TestCreateContainer:

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -109,6 +109,7 @@ class TestBulkOperations:
 
         monkeypatch.setattr("tinyagentos.containers.restart_container", fake_restart)
 
+
         resp = await client.post("/api/agents/bulk/restart")
         assert resp.status_code == 200
         assert resp.json()["action"] == "restart"

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -233,6 +233,63 @@ class TestKillSwitchRunStateGate:
             "force-kill should be called on a Running container"
         )
 
+    async def test_bulk_stop_skips_force_kill_when_no_containers(
+        self, client, monkeypatch
+    ):
+        """Empty container list (healthy host, no agents) must NOT trigger force-kill."""
+        async def fake_list_containers(prefix="taos-agent-"):
+            return []
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/bulk/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "stop"
+        assert len(force_calls) == 0, (
+            f"force-kill should NOT be called when no containers exist, "
+            f"but stop_container(force=True) was called {force_calls}"
+        )
+
+    async def test_bulk_stop_force_kills_when_incus_down(
+        self, client, monkeypatch
+    ):
+        """When incus is unreachable (RuntimeError), force-kill all configured agents."""
+        async def fake_list_containers(prefix="taos-agent-"):
+            raise RuntimeError("incus list failed")
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        force_calls = []
+
+        async def fake_stop(name, force=False):
+            if force:
+                force_calls.append(name)
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/bulk/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "stop"
+        assert "taos-agent-test-agent" in force_calls, (
+            "force-kill should be attempted on configured agents when incus is down"
+        )
+
 
     async def test_stop_agent_force_kills_running_container(
         self, client, monkeypatch

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -232,6 +232,7 @@ class TestKillSwitchRunStateGate:
             "force-kill should be called on a Running container"
         )
 
+
     async def test_stop_agent_force_kills_running_container(
         self, client, monkeypatch
     ):
@@ -269,7 +270,6 @@ class TestKillSwitchRunStateGate:
         assert "taos-agent-test-agent" in force_calls, (
             "stop_container(force=True) should be called on a Running container"
         )
-
 
 def _seed_worker(app, name, model_names, status="online"):
     info = WorkerInfo(

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -290,6 +290,44 @@ class TestKillSwitchRunStateGate:
             "force-kill should be attempted on configured agents when incus is down"
         )
 
+    async def test_bulk_stop_populates_error_on_force_kill_failure(
+        self, client, monkeypatch
+    ):
+        """When force-kill fails, the result must include an error field for the UI."""
+        running = ContainerInfo(
+            name="taos-agent-test-agent",
+            status="Running",
+            ip="10.0.0.5",
+            memory_mb=1024,
+            cpu_cores=2,
+        )
+
+        async def fake_list_containers(prefix="taos-agent-"):
+            return [running]
+
+        monkeypatch.setattr(
+            "tinyagentos.containers.list_containers", fake_list_containers
+        )
+
+        async def fake_stop(name, force=False):
+            if force:
+                return {"success": False, "output": "Container is frozen"}
+            return {"success": True, "output": ""}
+
+        monkeypatch.setattr("tinyagentos.containers.stop_container", fake_stop)
+
+        resp = await client.post("/api/agents/bulk/stop")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["action"] == "stop"
+        fr = data["force_kill_results"].get("test-agent", {})
+        assert fr.get("force_killed") is False
+        assert "error" in fr, (
+            "error field must be present when force-kill fails, "
+            f"got: {fr}"
+        )
+        assert "frozen" in fr["error"].lower()
+
 
     async def test_stop_agent_force_kills_running_container(
         self, client, monkeypatch

--- a/tinyagentos/containers/__init__.py
+++ b/tinyagentos/containers/__init__.py
@@ -158,12 +158,13 @@ async def list_containers(prefix: str = "taos-agent-") -> list[ContainerInfo]:
     """List all agent containers."""
     code, output = await _run(["incus", "list", "-f", "json"])
     if code != 0:
-        logger.error(f"incus list failed: {output}")
-        return []
+        logger.error(f"incus list failed (exit {code}): {output}")
+        raise RuntimeError(f"incus list failed (exit {code}): {output.strip()}")
     try:
         containers = json.loads(output)
-    except json.JSONDecodeError:
-        return []
+    except json.JSONDecodeError as e:
+        logger.error(f"incus list JSON decode failed: {e}")
+        raise RuntimeError(f"incus list returned invalid JSON: {e}") from e
     results = []
     for c in containers:
         name = c.get("name", "")

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -803,7 +803,7 @@ async def bulk_stop_agents(request: Request):
     In-flight agent framework work is cancelled by the prepare step;
     LLM calls and tool invocations are terminated when the container dies.
     """
-    from tinyagentos.containers import stop_container, container_exists
+    from tinyagentos.containers import stop_container, list_containers
 
     config = request.app.state.config
     orchestrator = getattr(request.app.state, "orchestrator", None)
@@ -814,15 +814,18 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers (shielded from cancellation)
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers
+    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
+        containers = await list_containers(prefix="taos-agent-")
+        running = {c.name for c in containers if c.status == "Running"}
         force_results = {}
         for agent in config.agents:
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
-                if await container_exists(container_name):
+                if container_name in running:
                     force_result = await stop_container(container_name, force=True)
                     force_results[name] = {
                         "force_killed": force_result.get("success", False),
@@ -838,7 +841,16 @@ async def bulk_stop_agents(request: Request):
                 force_results[name] = {"force_killed": False, "error": str(e)}
         return force_results
 
-    force_results = await asyncio.shield(_grace_kill())
+    task = asyncio.create_task(_grace_kill())
+    try:
+        force_results = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     return {
         "action": "stop",
@@ -885,7 +897,7 @@ async def stop_agent(request: Request, name: str):
     Sends SIGTERM via incus stop. After a 2-second grace window, if the container
     is still running, sends SIGKILL (incus stop --force) to guarantee termination.
     """
-    from tinyagentos.containers import stop_container, container_exists
+    from tinyagentos.containers import stop_container, list_containers
 
     config = request.app.state.config
     agent = find_agent(config, name)
@@ -899,10 +911,13 @@ async def stop_agent(request: Request, name: str):
     container_name = f"taos-agent-{name}"
     stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL (shielded from cancellation)
+    # 2-second grace window, then SIGKILL
+    # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
-        if await container_exists(container_name):
+        containers = await list_containers(prefix="taos-agent-")
+        running = {c.name for c in containers if c.status == "Running"}
+        if container_name in running:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)
             if not success:
@@ -914,7 +929,16 @@ async def stop_agent(request: Request, name: str):
             return (success, force_result.get("output", ""))
         return (False, "")
 
-    force_killed, force_error = await asyncio.shield(_grace_kill())
+    task = asyncio.create_task(_grace_kill())
+    try:
+        force_killed, force_error = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        raise
 
     return {
         "prepare_report": report,

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -824,7 +824,11 @@ async def bulk_stop_agents(request: Request):
                 "list_containers returned empty; incus may be unhealthy. "
                 "Attempting force-kill on all configured agents."
             )
-        running = {c.name for c in containers if c.status == "Running"}
+        running = {
+            c.name
+            for c in containers
+            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+        }
         incus_unhealthy = not containers and bool(config.agents)
         force_results = {}
         for agent in config.agents:
@@ -927,7 +931,11 @@ async def stop_agent(request: Request, name: str):
                 "list_containers returned empty; incus may be unhealthy. "
                 "Attempting force-kill anyway."
             )
-        running = {c.name for c in containers if c.status == "Running"}
+        running = {
+            c.name
+            for c in containers
+            if c.status in ("Running", "Stopping", "Freezing", "Frozen")
+        }
         if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -860,6 +860,7 @@ async def bulk_stop_agents(request: Request):
                         "output": force_result.get("output", ""),
                     }
                     if not force_result.get("success", False):
+                        result["error"] = force_result.get("output") or "Force-kill command failed"
                         logger.warning(
                             "Force-kill of %s failed: %s",
                             container_name,

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -880,7 +880,6 @@ async def bulk_stop_agents(request: Request):
     try:
         force_results = await asyncio.shield(task)
     except asyncio.CancelledError:
-        task.cancel()
         try:
             await task
         except asyncio.CancelledError:
@@ -988,7 +987,6 @@ async def stop_agent(request: Request, name: str):
     try:
         force_killed, force_output = await asyncio.shield(task)
     except asyncio.CancelledError:
-        task.cancel()
         try:
             await task
         except asyncio.CancelledError:

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -803,7 +803,7 @@ async def bulk_stop_agents(request: Request):
     In-flight agent framework work is cancelled by the prepare step;
     LLM calls and tool invocations are terminated when the container dies.
     """
-    from tinyagentos.containers import stop_container, list_containers
+    from tinyagentos.containers import stop_container, container_exists
 
     config = request.app.state.config
     orchestrator = getattr(request.app.state, "orchestrator", None)
@@ -811,63 +811,24 @@ async def bulk_stop_agents(request: Request):
     if orchestrator is not None:
         report = await orchestrator.prepare("all", "stop")
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers
-    # (shielded from cancellation; the sleep+force is bounded)
-    async def _grace_kill():
-        await asyncio.sleep(2)
-        containers = await list_containers(prefix="taos-agent-")
-        if not containers and config.agents:
-            logger.warning(
-                "list_containers returned empty; incus may be unhealthy. "
-                "Attempting force-kill on all configured agents."
-            )
-        running = {
-            c.name
-            for c in containers
-            if c.status not in ("Stopped",)
-        }
-        incus_unhealthy = not containers and bool(config.agents)
-
-        async def _force_kill_one(agent):
-            agent_name = agent["name"]
-            container_name = f"taos-agent-{agent_name}"
-            try:
-                if container_name in running or incus_unhealthy:
-                    force_result = await stop_container(container_name, force=True)
-                    result = {
-                        "force_killed": force_result.get("success", False),
-                        "output": force_result.get("output", ""),
-                    }
-                    if not force_result.get("success", False):
-                        logger.warning(
-                            "Force-kill of %s failed: %s",
-                            container_name,
-                            force_result.get("output", "unknown"),
-                        )
-                    return (agent_name, result)
-            except Exception as e:
-                return (agent_name, {"force_killed": False, "error": str(e)})
-            return (agent_name, {"force_killed": False, "output": ""})
-
-        gathered = await asyncio.gather(
-            *(_force_kill_one(agent) for agent in config.agents)
-        )
-        return dict(gathered)
-
-    task = asyncio.create_task(_grace_kill())
-    # Phase 1: SIGTERM every agent container (concurrent with grace window)
+    # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers
+    await asyncio.sleep(2)
     force_results = {}
-    try:
-        force_results = await asyncio.wait_for(asyncio.shield(task), timeout=30)
-    except asyncio.CancelledError:
-        await task
-        raise
-    except asyncio.TimeoutError:
-        logger.warning(
-            "Grace-kill timed out after 30s; force-kill may still complete in background"
-        )
+    for agent in config.agents:
+        name = agent["name"]
+        container_name = f"taos-agent-{name}"
+        try:
+            if await container_exists(container_name):
+                force_result = await stop_container(container_name, force=True)
+                force_results[name] = {
+                    "force_killed": force_result.get("success", False),
+                    "output": force_result.get("output", ""),
+                }
+        except Exception as e:
+            force_results[name] = {"force_killed": False, "error": str(e)}
 
     return {
         "action": "stop",
@@ -914,7 +875,7 @@ async def stop_agent(request: Request, name: str):
     Sends SIGTERM via incus stop. After a 2-second grace window, if the container
     is still running, sends SIGKILL (incus stop --force) to guarantee termination.
     """
-    from tinyagentos.containers import stop_container, list_containers
+    from tinyagentos.containers import stop_container, container_exists
 
     config = request.app.state.config
     agent = find_agent(config, name)
@@ -926,56 +887,19 @@ async def stop_agent(request: Request, name: str):
         report = await orchestrator.prepare([name], "stop")
 
     container_name = f"taos-agent-{name}"
-
-    # 2-second grace window, then SIGKILL
-    # (shielded from cancellation; the sleep+force is bounded)
-    async def _grace_kill():
-        await asyncio.sleep(2)
-        containers = await list_containers(prefix="taos-agent-")
-        if not containers:
-            logger.warning(
-                "list_containers returned empty; incus may be unhealthy. "
-                "Attempting force-kill anyway."
-            )
-        running = {
-            c.name
-            for c in containers
-            if c.status not in ("Stopped",)
-        }
-        if container_name in running or not containers:
-            force_result = await stop_container(container_name, force=True)
-            success = force_result.get("success", False)
-            if not success:
-                logger.warning(
-                    "Force-kill of %s failed: %s",
-                    container_name,
-                    force_result.get("output", "unknown"),
-                )
-            return (success, force_result.get("output", ""))
-        return (False, "")
-
-    task = asyncio.create_task(_grace_kill())
     stop_result = await stop_container(container_name)
 
-    try:
-        force_killed, force_output = await asyncio.wait_for(
-            asyncio.shield(task), timeout=30
-        )
-    except asyncio.CancelledError:
-        await task
-        raise
-    except asyncio.TimeoutError:
-        logger.warning(
-            "Grace-kill timed out after 30s for %s; force-kill may still complete",
-            container_name,
-        )
-        force_killed, force_output = False, ""
+    # 2-second grace window, then SIGKILL
+    await asyncio.sleep(2)
+    force_killed = False
+    if await container_exists(container_name):
+        force_result = await stop_container(container_name, force=True)
+        force_killed = force_result.get("success", False)
 
     return {
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
-        "force_output": force_output,
     }
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -819,13 +819,19 @@ async def bulk_stop_agents(request: Request):
     async def _grace_kill():
         await asyncio.sleep(2)
         containers = await list_containers(prefix="taos-agent-")
+        if not containers and config.agents:
+            logger.warning(
+                "list_containers returned empty; incus may be unhealthy. "
+                "Attempting force-kill on all configured agents."
+            )
         running = {c.name for c in containers if c.status == "Running"}
+        incus_unhealthy = not containers and bool(config.agents)
         force_results = {}
         for agent in config.agents:
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
-                if container_name in running:
+                if container_name in running or incus_unhealthy:
                     force_result = await stop_container(container_name, force=True)
                     force_results[name] = {
                         "force_killed": force_result.get("success", False),
@@ -916,8 +922,13 @@ async def stop_agent(request: Request, name: str):
     async def _grace_kill():
         await asyncio.sleep(2)
         containers = await list_containers(prefix="taos-agent-")
+        if not containers:
+            logger.warning(
+                "list_containers returned empty; incus may be unhealthy. "
+                "Attempting force-kill anyway."
+            )
         running = {c.name for c in containers if c.status == "Running"}
-        if container_name in running:
+        if container_name in running or not containers:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)
             if not success:
@@ -931,7 +942,7 @@ async def stop_agent(request: Request, name: str):
 
     task = asyncio.create_task(_grace_kill())
     try:
-        force_killed, force_error = await asyncio.shield(task)
+        force_killed, force_output = await asyncio.shield(task)
     except asyncio.CancelledError:
         task.cancel()
         try:
@@ -944,7 +955,7 @@ async def stop_agent(request: Request, name: str):
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
-        "force_error": force_error,
+        "force_output": force_output,
     }
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -814,21 +814,31 @@ async def bulk_stop_agents(request: Request):
     # Phase 1: SIGTERM every agent container
     results = await _bulk_container_op(config, stop_container)
 
-    # Phase 2: 2-second grace window, then SIGKILL any stragglers
-    await asyncio.sleep(2)
-    force_results = {}
-    for agent in config.agents:
-        name = agent["name"]
-        container_name = f"taos-agent-{name}"
-        try:
-            if await container_exists(container_name):
-                force_result = await stop_container(container_name, force=True)
-                force_results[name] = {
-                    "force_killed": force_result.get("success", False),
-                    "output": force_result.get("output", ""),
-                }
-        except Exception as e:
-            force_results[name] = {"force_killed": False, "error": str(e)}
+    # Phase 2: 2-second grace window, then SIGKILL any stragglers (shielded from cancellation)
+    async def _grace_kill():
+        await asyncio.sleep(2)
+        force_results = {}
+        for agent in config.agents:
+            name = agent["name"]
+            container_name = f"taos-agent-{name}"
+            try:
+                if await container_exists(container_name):
+                    force_result = await stop_container(container_name, force=True)
+                    force_results[name] = {
+                        "force_killed": force_result.get("success", False),
+                        "output": force_result.get("output", ""),
+                    }
+                    if not force_result.get("success", False):
+                        logger.warning(
+                            "Force-kill of %s failed: %s",
+                            container_name,
+                            force_result.get("output", "unknown"),
+                        )
+            except Exception as e:
+                force_results[name] = {"force_killed": False, "error": str(e)}
+        return force_results
+
+    force_results = await asyncio.shield(_grace_kill())
 
     return {
         "action": "stop",
@@ -889,17 +899,28 @@ async def stop_agent(request: Request, name: str):
     container_name = f"taos-agent-{name}"
     stop_result = await stop_container(container_name)
 
-    # 2-second grace window, then SIGKILL
-    await asyncio.sleep(2)
-    force_killed = False
-    if await container_exists(container_name):
-        force_result = await stop_container(container_name, force=True)
-        force_killed = force_result.get("success", False)
+    # 2-second grace window, then SIGKILL (shielded from cancellation)
+    async def _grace_kill():
+        await asyncio.sleep(2)
+        if await container_exists(container_name):
+            force_result = await stop_container(container_name, force=True)
+            success = force_result.get("success", False)
+            if not success:
+                logger.warning(
+                    "Force-kill of %s failed: %s",
+                    container_name,
+                    force_result.get("output", "unknown"),
+                )
+            return (success, force_result.get("output", ""))
+        return (False, "")
+
+    force_killed, force_error = await asyncio.shield(_grace_kill())
 
     return {
         "prepare_report": report,
         "stop_result": stop_result,
         "force_killed": force_killed,
+        "force_error": force_error,
     }
 
 

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -171,7 +171,14 @@ async def list_agents(request: Request):
 async def list_agent_containers(request: Request):
     """List live LXC container status for all agent containers."""
     from tinyagentos.containers import list_containers
-    containers = await list_containers(prefix="taos-agent-")
+    try:
+        containers = await list_containers(prefix="taos-agent-")
+    except RuntimeError as e:
+        logger.error("list_agent_containers: incus unreachable: %s", e)
+        return JSONResponse(
+            {"error": "Incus daemon unreachable", "detail": str(e)},
+            status_code=503,
+        )
     return [
         {
             "name": c.name,
@@ -818,26 +825,37 @@ async def bulk_stop_agents(request: Request):
     # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
-        containers = await list_containers(prefix="taos-agent-")
-        if not containers and config.agents:
+        incus_unhealthy = False
+        containers = []
+        try:
+            containers = await list_containers(prefix="taos-agent-")
+        except RuntimeError as e:
             logger.warning(
-                "list_containers returned empty; incus may be unhealthy. "
-                "Attempting force-kill on all configured agents."
+                "list_containers failed; incus may be unhealthy: %s. "
+                "Attempting force-kill on all configured agents.",
+                e,
             )
+            incus_unhealthy = True
+        else:
+            if not containers and config.agents:
+                logger.warning(
+                    "list_containers returned empty; no agent containers found. "
+                    "Skipping force-kill."
+                )
         running = {
             c.name
             for c in containers
             if c.status in ("Running", "Stopping", "Freezing", "Frozen")
         }
-        incus_unhealthy = not containers and bool(config.agents)
-        force_results = {}
-        for agent in config.agents:
+        force_results: dict[str, dict] = {}
+
+        async def _force_kill_one(agent: dict) -> tuple[str, dict]:
             name = agent["name"]
             container_name = f"taos-agent-{name}"
             try:
                 if container_name in running or incus_unhealthy:
                     force_result = await stop_container(container_name, force=True)
-                    force_results[name] = {
+                    result = {
                         "force_killed": force_result.get("success", False),
                         "output": force_result.get("output", ""),
                     }
@@ -847,8 +865,14 @@ async def bulk_stop_agents(request: Request):
                             container_name,
                             force_result.get("output", "unknown"),
                         )
+                    return (name, result)
+                return (name, {"force_killed": False, "output": ""})
             except Exception as e:
-                force_results[name] = {"force_killed": False, "error": str(e)}
+                return (name, {"force_killed": False, "error": str(e)})
+
+        tasks = [_force_kill_one(agent) for agent in config.agents]
+        results_list = await asyncio.gather(*tasks)
+        force_results = dict(results_list)
         return force_results
 
     task = asyncio.create_task(_grace_kill())
@@ -925,18 +949,29 @@ async def stop_agent(request: Request, name: str):
     # (shielded from cancellation; the sleep+force is bounded by the 120s _run cap)
     async def _grace_kill():
         await asyncio.sleep(2)
-        containers = await list_containers(prefix="taos-agent-")
-        if not containers:
+        incus_unhealthy = False
+        containers = []
+        try:
+            containers = await list_containers(prefix="taos-agent-")
+        except RuntimeError as e:
             logger.warning(
-                "list_containers returned empty; incus may be unhealthy. "
-                "Attempting force-kill anyway."
+                "list_containers failed; incus may be unhealthy: %s. "
+                "Attempting force-kill anyway.",
+                e,
             )
+            incus_unhealthy = True
+        else:
+            if not containers:
+                logger.warning(
+                    "list_containers returned empty; no agent containers found. "
+                    "Skipping force-kill."
+                )
         running = {
             c.name
             for c in containers
             if c.status in ("Running", "Stopping", "Freezing", "Frozen")
         }
-        if container_name in running or not containers:
+        if container_name in running or incus_unhealthy:
             force_result = await stop_container(container_name, force=True)
             success = force_result.get("success", False)
             if not success:


### PR DESCRIPTION
Task: t_1068642b. Fixes CI failures on PR #1962 (kill-switch).

Mock stop_container, list_containers, start_container, and restart_container in TestBulkOperations to prevent FileNotFoundError when incus binary is not available in CI.

The kill-switch changes added incus list/incus stop calls to the bulk stop flow, which exposed the missing mocks in test_bulk_stop. Also fixed test_bulk_start and test_bulk_restart which had the same pattern.

----
## Summary by Gitar

- **New features:**
    - Implemented `Ctrl+Shift+K` emergency kill-switch in `App.tsx` for bulk agent termination.
- **Backend enhancements:**
    - Updated `bulk_stop_agents` and `stop_agent` to enforce a 2-second SIGTERM grace window followed by `SIGKILL` (via `incus stop --force`).
    - Added `asyncio.shield` to ensure the grace window completion even if the primary request is cancelled.
- **Logic improvements:**
    - Restricted force-kill operations to container statuses: `Running`, `Stopping`, `Freezing`, or `Frozen`.
    - Added handling for unhealthy Incus states where `list_containers` returns empty during shutdown.
- **Testing updates:**
    - Added `TestKillSwitchRunStateGate` to verify force-kill logic only targets active containers.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an emergency **Ctrl+Shift+K** shortcut to stop all agents.
  * Stop responses now include **force-termination details** (e.g., per-agent force-kill results when applicable).
* **Bug Fixes**
  * Stop now uses a **SIGTERM → grace → conditional SIGKILL** flow, force-killing only containers that are still running-like.
  * If the container service is unreachable, container listing returns a clear **503** error.
  * Avoids force-kill when no eligible target containers are found; includes robust handling when listing fails.
* **Tests**
  * Updated route/container tests to validate the new gating and failure behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->