### PR TITLE
fix(github-app): snapshot installations dict before asyncio.to_thread to prevent data race

### DIFF
--- a/desktop/src/apps/SecretsApp.test.tsx
+++ b/desktop/src/apps/SecretsApp.test.tsx
@@ -9,6 +9,9 @@ vi.mock("@/lib/github", () => ({
   pollDeviceFlow: vi.fn(),
   listIdentities: vi.fn().mockResolvedValue([]),
   deleteIdentity: vi.fn(),
+  listAppInstallations: vi.fn().mockResolvedValue([]),
+  beginAppInstallation: vi.fn(),
+  deleteAppInstallation: vi.fn(),
 }));
 
 function mockFetch(

--- a/desktop/src/apps/secrets/GitHubConnect.tsx
+++ b/desktop/src/apps/secrets/GitHubConnect.tsx
@@ -1,12 +1,16 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Github, Copy, Check, ExternalLink, Trash2, Plus, Loader2 } from "lucide-react";
+import { Github, Copy, Check, ExternalLink, Trash2, Plus, Loader2, Settings, X } from "lucide-react";
 import { Button, Card, CardContent } from "@/components/ui";
 import {
   startDeviceFlow,
   pollDeviceFlow,
   listIdentities,
   deleteIdentity,
+  listAppInstallations,
+  beginAppInstallation,
+  deleteAppInstallation,
   type GitHubIdentity,
+  type GitHubAppInstallation,
 } from "@/lib/github";
 
 type FlowState =
@@ -29,6 +33,11 @@ export function GitHubConnect() {
   const [flow, setFlow] = useState<FlowState>({ phase: "idle" });
   const [copied, setCopied] = useState(false);
 
+  // GitHub App installations state
+  const [installations, setInstallations] = useState<GitHubAppInstallation[]>([]);
+  const [installsLoading, setInstallsLoading] = useState(false);
+  const [installing, setInstalling] = useState(false);
+
   // Refs so the polling loop can be cancelled cleanly on unmount / restart.
   const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const expiryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -37,8 +46,39 @@ export function GitHubConnect() {
     setIdentities(await listIdentities());
   }, []);
 
+  const refreshInstallations = useCallback(async () => {
+    setInstallsLoading(true);
+    try {
+      setInstallations(await listAppInstallations());
+    } finally {
+      setInstallsLoading(false);
+    }
+  }, []);
+
+  const handleAppInstall = useCallback(async () => {
+    setInstalling(true);
+    try {
+      const url = await beginAppInstallation();
+      if (url) {
+        window.open(url, "_blank");
+      }
+    } finally {
+      setInstalling(false);
+    }
+  }, []);
+
+  const handleAppUninstall = useCallback(
+    async (installationId: number) => {
+      if (await deleteAppInstallation(installationId)) {
+        await refreshInstallations();
+      }
+    },
+    [refreshInstallations],
+  );
+
   useEffect(() => {
     refreshIdentities();
+    refreshInstallations();
   }, [refreshIdentities]);
 
   const stopPolling = useCallback(() => {
@@ -241,6 +281,92 @@ export function GitHubConnect() {
             ))}
           </ul>
         )}
+
+        {/* GitHub App Installations */}
+        <div className="rounded-lg border border-white/10 bg-shell-bg-deep p-4 space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Settings size={16} className="text-shell-text-secondary" />
+              <h3 className="text-sm font-medium text-shell-text">GitHub App</h3>
+            </div>
+            <Button
+              size="sm"
+              onClick={handleAppInstall}
+              disabled={installing}
+              aria-label="Install GitHub App on repos"
+            >
+              {installing ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Plus size={14} />
+              )}
+              {installing ? "Opening..." : "Install on repos"}
+            </Button>
+          </div>
+
+          {installsLoading ? (
+            <div className="flex items-center gap-2 text-sm text-shell-text-secondary">
+              <Loader2 size={14} className="animate-spin" />
+              Loading installations...
+            </div>
+          ) : installations.length > 0 ? (
+            <ul className="space-y-3" aria-label="GitHub App installations">
+              {installations.map((inst) => (
+                <li key={inst.id} className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      {inst.account.avatar_url ? (
+                        <img
+                          src={inst.account.avatar_url}
+                          alt=""
+                          className="h-5 w-5 rounded-full shrink-0"
+                        />
+                      ) : (
+                        <div className="h-5 w-5 rounded-full bg-white/10 shrink-0" />
+                      )}
+                      <span className="text-sm font-medium text-shell-text">
+                        {inst.account.login}
+                      </span>
+                      <span className="text-xs text-shell-text-tertiary capitalize">
+                        ({inst.account.type})
+                      </span>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => handleAppUninstall(inst.id)}
+                      className="h-7 w-7 hover:text-red-400 hover:bg-red-500/15"
+                      aria-label={`Uninstall ${inst.account.login}`}
+                      title="Uninstall"
+                    >
+                      <X size={14} />
+                    </Button>
+                  </div>
+                  {inst.repositories.length > 0 && (
+                    <div className="ml-7 space-y-1">
+                      {inst.repositories.map((repo) => (
+                        <div
+                          key={repo.full_name}
+                          className="flex items-center gap-1.5 text-xs text-shell-text-secondary"
+                        >
+                          <span className="text-shell-text-tertiary">
+                            {repo.private ? "🔒" : "📁"}
+                          </span>
+                          <span className="font-mono">{repo.full_name}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-xs text-shell-text-tertiary">
+              No GitHub App installations yet. Click "Install on repos" to give
+              taOS access to your repositories.
+            </p>
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/desktop/src/apps/secrets/GitHubConnect.tsx
+++ b/desktop/src/apps/secrets/GitHubConnect.tsx
@@ -79,7 +79,15 @@ export function GitHubConnect() {
   useEffect(() => {
     refreshIdentities();
     refreshInstallations();
-  }, [refreshIdentities]);
+
+    // Refresh when the user returns from the external GitHub App install flow
+    const onFocus = () => {
+      refreshIdentities();
+      refreshInstallations();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [refreshIdentities, refreshInstallations]);
 
   const stopPolling = useCallback(() => {
     if (pollTimer.current) clearTimeout(pollTimer.current);

--- a/desktop/src/lib/github.ts
+++ b/desktop/src/lib/github.ts
@@ -307,6 +307,8 @@ export async function beginAppInstallation(): Promise<string | null> {
       }),
     );
     if (!res.ok) return null;
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("application/json")) return null;
     const data: AppInstallUrl = await res.json();
     return data.install_url || null;
   } catch {

--- a/desktop/src/lib/github.ts
+++ b/desktop/src/lib/github.ts
@@ -257,3 +257,67 @@ export async function deleteIdentity(id: string): Promise<boolean> {
   );
   return res.ok;
 }
+
+/* ------------------------------------------------------------------ */
+/*  GitHub App Installations                                           */
+/* ------------------------------------------------------------------ */
+
+export interface GitHubAppRepo {
+  full_name: string;
+  name: string;
+  private: boolean;
+  description: string;
+}
+
+export interface GitHubAppInstallation {
+  id: number;
+  account: {
+    login: string;
+    type: string;
+    avatar_url: string;
+  };
+  repository_selection: string;
+  repositories: GitHubAppRepo[];
+  created_at: string;
+}
+
+export interface AppInstallationList {
+  installations: GitHubAppInstallation[];
+}
+
+export interface AppInstallUrl {
+  install_url: string;
+}
+
+export async function listAppInstallations(): Promise<GitHubAppInstallation[]> {
+  const data = await fetchJson<AppInstallationList>(
+    "/api/github/app/installations",
+    { installations: [] },
+  );
+  return Array.isArray(data.installations) ? data.installations : [];
+}
+
+export async function beginAppInstallation(): Promise<string | null> {
+  try {
+    const res = await fetch(
+      "/api/github/app/install",
+      withCsrf({
+        method: "POST",
+        headers: { Accept: "application/json" },
+      }),
+    );
+    if (!res.ok) return null;
+    const data: AppInstallUrl = await res.json();
+    return data.install_url || null;
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteAppInstallation(installationId: number): Promise<boolean> {
+  const res = await fetch(
+    `/api/github/app/installations/${installationId}`,
+    withCsrf({ method: "DELETE", headers: { Accept: "application/json" } }),
+  );
+  return res.ok;
+}

--- a/tests/test_github_app.py
+++ b/tests/test_github_app.py
@@ -1,0 +1,128 @@
+"""Tests for the GitHub App authentication module."""
+from __future__ import annotations
+
+import json
+import base64
+
+import pytest
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from tinyagentos.github_app import generate_jwt, _b64url
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _generate_rsa_key() -> str:
+    """Return a PEM-encoded RSA private key for testing."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestB64Url:
+    def test_encodes_basic(self):
+        assert _b64url(b"test") == "dGVzdA"
+
+    def test_no_padding(self):
+        # Standard base64 adds '=', b64url strips it
+        result = _b64url(b"abc")
+        assert "=" not in result
+
+
+class TestGenerateJwt:
+    def test_returns_three_part_token(self):
+        pem = _generate_rsa_key()
+        jwt = generate_jwt("12345", pem)
+        parts = jwt.split(".")
+        assert len(parts) == 3
+
+    def test_header_is_valid_rs256(self):
+        pem = _generate_rsa_key()
+        jwt = generate_jwt("12345", pem)
+        parts = jwt.split(".")
+        header = json.loads(base64.urlsafe_b64decode(parts[0] + "=="))
+        assert header["alg"] == "RS256"
+        assert header["typ"] == "JWT"
+
+    def test_claims_include_app_id_as_iss(self):
+        pem = _generate_rsa_key()
+        jwt = generate_jwt("67890", pem)
+        parts = jwt.split(".")
+        claims = json.loads(base64.urlsafe_b64decode(parts[1] + "=="))
+        assert claims["iss"] == "67890"
+
+    def test_claims_have_iat_and_exp(self):
+        pem = _generate_rsa_key()
+        jwt = generate_jwt("12345", pem)
+        parts = jwt.split(".")
+        claims = json.loads(base64.urlsafe_b64decode(parts[1] + "=="))
+        assert "iat" in claims
+        assert "exp" in claims
+        assert claims["exp"] > claims["iat"]
+
+    def test_exp_is_within_10_minutes(self):
+        pem = _generate_rsa_key()
+        jwt = generate_jwt("12345", pem)
+        parts = jwt.split(".")
+        claims = json.loads(base64.urlsafe_b64decode(parts[1] + "=="))
+        # Expiry should be close to iat + 600 (10 min)
+        assert 540 < claims["exp"] - claims["iat"] <= 660
+
+    def test_signature_is_base64url(self):
+        pem = _generate_rsa_key()
+        jwt = generate_jwt("12345", pem)
+        parts = jwt.split(".")
+        # Signature should be valid base64url (no padding)
+        sig = parts[2]
+        decoded = base64.urlsafe_b64decode(sig + "==")
+        assert len(decoded) > 0
+
+    def test_same_input_produces_different_jwt(self):
+        pem = _generate_rsa_key()
+        jwt1 = generate_jwt("12345", pem)
+        import time
+        time.sleep(1.5)  # Ensure timestamp changes (second-level granularity)
+        jwt2 = generate_jwt("12345", pem)
+        # Different timestamps → different JWTs
+        assert jwt1 != jwt2
+
+    def test_rejects_non_rsa_key(self):
+        from cryptography.hazmat.primitives.asymmetric import ec
+        ec_key = ec.generate_private_key(ec.SECP256R1())
+        pem = ec_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ).decode()
+        with pytest.raises(ValueError, match="RSA"):
+            generate_jwt("12345", pem)
+
+    def test_app_id_is_cast_to_string(self):
+        pem = _generate_rsa_key()
+        jwt = generate_jwt(12345, pem)  # type: ignore — test int coercion
+        parts = jwt.split(".")
+        claims = json.loads(base64.urlsafe_b64decode(parts[1] + "=="))
+        assert claims["iss"] == "12345"
+
+
+class TestJwtHeaderClaimsDecoding:
+    def test_iat_is_reasonable(self):
+        """iat should be within 2 minutes of now."""
+        import time
+        pem = _generate_rsa_key()
+        jwt = generate_jwt("12345", pem)
+        parts = jwt.split(".")
+        claims = json.loads(base64.urlsafe_b64decode(parts[1] + "=="))
+        now = int(time.time())
+        assert abs(claims["iat"] - now) < 120

--- a/tests/test_github_oauth.py
+++ b/tests/test_github_oauth.py
@@ -219,3 +219,101 @@ async def test_token_encrypted_at_rest(store):
     assert "gho_plaintexttoken" not in row[0]
     # And get_token decrypts it back.
     assert await store.get_token(identity["id"]) == "gho_plaintexttoken"
+
+
+# ---------------------------------------------------------------------------
+# GitHub App installation endpoint tests
+# ---------------------------------------------------------------------------
+
+def _build_app_for_app_tests(store, *, config=None, installations=None, post_effects=(), get_effects=()):
+    """Build a FastAPI app with App-specific state for installation tests."""
+    app = FastAPI()
+    app.include_router(github_oauth_router)
+    http = MagicMock()
+    http.post = AsyncMock(side_effect=list(post_effects)) if post_effects else AsyncMock()
+    http.get = AsyncMock(side_effect=list(get_effects)) if get_effects else AsyncMock()
+    app.state.http_client = http
+    app.state.github_identities = store
+    app.state.config = config
+    app.state.github_app_installations = installations
+    return app
+
+
+@pytest_asyncio.fixture
+async def app_client_factory(store):
+    """Factory that returns an AsyncClient wired to a minimal app with App state."""
+    async def _make(**kwargs):
+        app = _build_app_for_app_tests(store, **kwargs)
+        transport = ASGITransport(app=app)
+        return AsyncClient(transport=transport, base_url="http://test")
+    return _make
+
+
+class TestAppInstallationsList:
+    @pytest.mark.asyncio
+    async def test_returns_501_when_app_not_configured(self, app_client_factory):
+        """GET /api/github/app/installations returns 501 if app not configured."""
+        client = await app_client_factory()
+        resp = await client.get(
+            "/api/github/app/installations",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 501
+        data = resp.json()
+        assert "error" in data
+        assert "not configured" in data["error"].lower()
+
+
+class TestAppInstall:
+    @pytest.mark.asyncio
+    async def test_returns_501_when_app_not_configured(self, app_client_factory):
+        """POST /api/github/app/install returns 501 if app not configured."""
+        client = await app_client_factory()
+        resp = await client.post(
+            "/api/github/app/install",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 501
+        data = resp.json()
+        assert "error" in data
+
+
+class TestAppCallback:
+    @pytest.mark.asyncio
+    async def test_returns_400_without_installation_id(self, app_client_factory):
+        """GET /api/github/app/callback without installation_id returns 400."""
+        client = await app_client_factory()
+        resp = await client.get(
+            "/api/github/app/callback",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 400
+        data = resp.json()
+        assert "error" in data
+        assert "installation_id" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_returns_501_with_installation_id_but_no_app_config(self, app_client_factory):
+        """GET /api/github/app/callback?installation_id=1 returns 501 if app missing."""
+        client = await app_client_factory()
+        resp = await client.get(
+            "/api/github/app/callback?installation_id=12345",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 501
+        data = resp.json()
+        assert "error" in data
+
+
+class TestAppInstallationDelete:
+    @pytest.mark.asyncio
+    async def test_returns_501_when_app_not_configured(self, app_client_factory):
+        """DELETE /api/github/app/installations/1 returns 501 if app not configured."""
+        client = await app_client_factory()
+        resp = await client.delete(
+            "/api/github/app/installations/12345",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 501
+        data = resp.json()
+        assert "error" in data

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -65,6 +65,7 @@ from tinyagentos.scheduler.gpu_arbiter import GpuArbiter
 from tinyagentos.torrent_settings import TorrentSettingsStore
 from tinyagentos.relationships import RelationshipManager
 from tinyagentos.github_identities import GitHubIdentitiesStore
+from tinyagentos.github_app_installations import GitHubAppInstallations
 from tinyagentos.broker import BrokerService, BrokerStore
 from tinyagentos.broker.store import default_broker_path
 from tinyagentos.secrets import SecretsStore
@@ -289,6 +290,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     broker_service = BrokerService(broker_store)
     mail_store = MailAccountStore(data_dir / "mail.db")
     github_identities_store = GitHubIdentitiesStore(data_dir / "github_identities.db")
+    github_app_installations = GitHubAppInstallations(data_dir)
     relationship_mgr = RelationshipManager(data_dir / "relationships.db")
     channel_store = ChannelStore(data_dir / "channels.db")
     scheduler = TaskScheduler(data_dir / "scheduler.db")
@@ -495,6 +497,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await mail_store.init()
         app.state.mail_store = mail_store
         await github_identities_store.init()
+        await github_app_installations.init()
         await relationship_mgr.init()
         await channel_store.init()
         await scheduler.init()
@@ -760,6 +763,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         app.state.models_root = models_root()
         app.state.models_root.mkdir(parents=True, exist_ok=True)
         app.state.torrent_settings_store = torrent_settings_store
+
         # Ensure the local token file exists before any request can arrive.
         # Logs the path at INFO so the user can find it.
         _local_token_path = auth_manager.local_token_path()
@@ -1388,6 +1392,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await cluster_pairing_store.close()
         await agent_registry_store.close()
         await github_identities_store.close()
+        await github_app_installations.close()
         # Backstop: close any aiosqlite-backed store still open on app.state.
         # An unclosed BaseStore leaves a NON-daemon connection worker thread
         # alive, which blocks Python's threading._shutdown() until systemd
@@ -1474,6 +1479,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.broker = broker_service
     app.state.broker_store = broker_store
     app.state.github_identities = github_identities_store
+    app.state.github_app_installations = github_app_installations
     app.state.relationships = relationship_mgr
     app.state.channels = channel_store
     app.state.fallback = fallback

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -57,6 +57,8 @@ class AppConfig:
     archive: dict = field(default_factory=lambda: DEFAULT_ARCHIVE_CONFIG.copy())
     memory_url: str = "http://localhost:7900"
     wallhaven_api_key: str | None = None
+    github_app_id: str = ""
+    github_app_private_key: str = ""
     config_path: Path | None = None
 
     def to_dict(self) -> dict:
@@ -76,6 +78,9 @@ class AppConfig:
             d["archive"] = self.archive
         if self.memory_url != "http://localhost:7900":
             d["memory_url"] = self.memory_url
+        if self.github_app_id:
+            d["github_app_id"] = self.github_app_id
+            d["github_app_private_key"] = self.github_app_private_key
         return d
 
 # rkllama's taOS default port moved from the upstream 8080 to 7833. Installs
@@ -184,6 +189,8 @@ def load_config(path: Path) -> AppConfig:
         archived_agents=data.get("archived_agents", []),
         archive=archive_cfg,
         memory_url=data.get("memory_url", "http://localhost:7900"),
+        github_app_id=str(data.get("github_app_id", "") or ""),
+        github_app_private_key=str(data.get("github_app_private_key", "") or ""),
         config_path=path,
         wallhaven_api_key=wallhaven_api_key,
     )

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -81,6 +81,8 @@ class AppConfig:
         if self.github_app_id:
             d["github_app_id"] = self.github_app_id
             d["github_app_private_key"] = self.github_app_private_key
+        elif self.github_app_private_key:
+            d["github_app_private_key"] = self.github_app_private_key
         return d
 
 # rkllama's taOS default port moved from the upstream 8080 to 7833. Installs

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 _token_cache: dict[str, tuple[str, float]] = {}  # key -> (token, expiry)
 _repo_cache: dict[int, tuple[list[dict], float]] = {}  # installation_id -> (repos, expiry)
 _CACHE_TTL = 300  # 5 minutes (token lifetime is 1 hour, so this is conservative)
+_MAX_CACHE_SIZE = 100  # max entries per cache; evict oldest (insertion order) when exceeded
 
 
 def _cache_key(app_id: str, installation_id: int) -> str:
@@ -42,6 +43,9 @@ def _cached_token(key: str) -> str | None:
 
 def _cache_token(key: str, token: str) -> None:
     """Store a token in the cache with the default TTL."""
+    if len(_token_cache) >= _MAX_CACHE_SIZE:
+        oldest = next(iter(_token_cache))
+        del _token_cache[oldest]
     _token_cache[key] = (token, time.time() + _CACHE_TTL)
 
 
@@ -58,6 +62,9 @@ def _cached_repos(installation_id: int) -> list[dict] | None:
 
 def _cache_repos(installation_id: int, repos: list[dict]) -> None:
     """Store a repo list in the cache with the default TTL."""
+    if len(_repo_cache) >= _MAX_CACHE_SIZE:
+        oldest = next(iter(_repo_cache))
+        del _repo_cache[oldest]
     _repo_cache[installation_id] = (repos, time.time() + _CACHE_TTL)
 
 # ---------------------------------------------------------------------------
@@ -266,7 +273,10 @@ async def list_installation_repos_cached(
     if cached is not None:
         return cached
     repos = await list_installation_repos(installation_token, http_client)
-    _cache_repos(installation_id, repos)
+    # Only cache non-empty results — empty lists usually mean a transient
+    # API/network error, and we don't want to mask those behind the TTL.
+    if repos:
+        _cache_repos(installation_id, repos)
     return repos
 
 

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -17,9 +17,10 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-# Simple in-memory token cache with TTL (avoids minting a new JWT + token
-# on every API call when the same installation is used repeatedly).
+# Simple in-memory caches with TTL (avoids extra API calls when the same
+# installation is used repeatedly within a short window).
 _token_cache: dict[str, tuple[str, float]] = {}  # key -> (token, expiry)
+_repo_cache: dict[int, tuple[list[dict], float]] = {}  # installation_id -> (repos, expiry)
 _CACHE_TTL = 300  # 5 minutes (token lifetime is 1 hour, so this is conservative)
 
 
@@ -42,6 +43,22 @@ def _cached_token(key: str) -> str | None:
 def _cache_token(key: str, token: str) -> None:
     """Store a token in the cache with the default TTL."""
     _token_cache[key] = (token, time.time() + _CACHE_TTL)
+
+
+def _cached_repos(installation_id: int) -> list[dict] | None:
+    """Return cached repo list if valid, or None."""
+    entry = _repo_cache.get(installation_id)
+    if entry:
+        repos, expiry = entry
+        if time.time() < expiry:
+            return repos
+        del _repo_cache[installation_id]
+    return None
+
+
+def _cache_repos(installation_id: int, repos: list[dict]) -> None:
+    """Store a repo list in the cache with the default TTL."""
+    _repo_cache[installation_id] = (repos, time.time() + _CACHE_TTL)
 
 # ---------------------------------------------------------------------------
 # GitHub App API endpoints
@@ -233,6 +250,24 @@ async def list_installation_repos(
             logger.exception("Failed to list installation repos: %s", exc)
             break
     return all_repos
+
+
+async def list_installation_repos_cached(
+    installation_id: int,
+    installation_token: str,
+    http_client: httpx.AsyncClient,
+) -> list[dict]:
+    """Cache-aware wrapper around list_installation_repos.
+
+    Returns cached repo lists when available (5-min TTL), avoiding N
+    sequential GitHub API round-trips on repeated page loads.
+    """
+    cached = _cached_repos(installation_id)
+    if cached is not None:
+        return cached
+    repos = await list_installation_repos(installation_token, http_client)
+    _cache_repos(installation_id, repos)
+    return repos
 
 
 async def delete_installation(

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -296,11 +296,21 @@ async def delete_installation(
             timeout=15,
         )
         if resp.status_code == 404:
+            # Invalidate caches even on 404 — the installation is gone.
+            _invalidate_installation_caches(app_id, installation_id)
             return False
         resp.raise_for_status()
+        _invalidate_installation_caches(app_id, installation_id)
         return True
     except Exception as exc:
         logger.exception(
             "Failed to delete installation %s: %s", installation_id, exc
         )
         return False
+
+
+def _invalidate_installation_caches(app_id: str, installation_id: int) -> None:
+    """Remove cached token and repo list for a deleted installation."""
+    key = _cache_key(app_id, installation_id)
+    _token_cache.pop(key, None)
+    _repo_cache.pop(installation_id, None)

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -17,6 +17,32 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+# Simple in-memory token cache with TTL (avoids minting a new JWT + token
+# on every API call when the same installation is used repeatedly).
+_token_cache: dict[str, tuple[str, float]] = {}  # key -> (token, expiry)
+_CACHE_TTL = 300  # 5 minutes (token lifetime is 1 hour, so this is conservative)
+
+
+def _cache_key(app_id: str, installation_id: int) -> str:
+    """Return a cache key for an app_id + installation_id pair."""
+    return f"{app_id}:{installation_id}"
+
+
+def _cached_token(key: str) -> str | None:
+    """Return a cached token if valid, or None."""
+    entry = _token_cache.get(key)
+    if entry:
+        token, expiry = entry
+        if time.time() < expiry:
+            return token
+        del _token_cache[key]
+    return None
+
+
+def _cache_token(key: str, token: str) -> None:
+    """Store a token in the cache with the default TTL."""
+    _token_cache[key] = (token, time.time() + _CACHE_TTL)
+
 # ---------------------------------------------------------------------------
 # GitHub App API endpoints
 # ---------------------------------------------------------------------------
@@ -102,7 +128,14 @@ async def get_installation_token(
 
     Returns the token string or None on failure. The token is scoped to the
     repositories the installation has access to and expires after 1 hour.
+    Results are cached for 5 minutes to avoid minting a new JWT + token
+    on every API call.
     """
+    key = _cache_key(app_id, installation_id)
+    cached = _cached_token(key)
+    if cached:
+        return cached
+
     jwt = generate_jwt(app_id, private_key)
     url = _INSTALL_TOKEN_URL.format(installation_id=installation_id)
     try:
@@ -113,7 +146,10 @@ async def get_installation_token(
         )
         resp.raise_for_status()
         data = resp.json()
-        return data.get("token")
+        token = data.get("token")
+        if token:
+            _cache_token(key, token)
+        return token
     except Exception as exc:
         logger.exception(
             "Failed to get installation token for installation %s: %s",
@@ -128,7 +164,7 @@ async def list_installations(
     private_key: str,
     http_client: httpx.AsyncClient,
 ) -> list[dict]:
-    """List all installations of the GitHub App.
+    """List all installations of the GitHub App (follows pagination).
 
     Returns a list of installation dicts, each containing:
       - id (int): installation ID
@@ -137,18 +173,28 @@ async def list_installations(
       - created_at, updated_at
     """
     jwt = generate_jwt(app_id, private_key)
-    try:
-        resp = await http_client.get(
-            _GH_APP_INSTALLATIONS,
-            headers=_auth_headers(jwt),
-            params={"per_page": 100},
-            timeout=15,
-        )
-        resp.raise_for_status()
-        return resp.json()
-    except Exception as exc:
-        logger.exception("Failed to list installations: %s", exc)
-        return []
+    all_installations: list[dict] = []
+    page = 1
+    while True:
+        try:
+            resp = await http_client.get(
+                _GH_APP_INSTALLATIONS,
+                headers=_auth_headers(jwt),
+                params={"per_page": 100, "page": page},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            installations = resp.json()
+            if not installations:
+                break
+            all_installations.extend(installations)
+            if len(installations) < 100:
+                break
+            page += 1
+        except Exception as exc:
+            logger.exception("Failed to list installations: %s", exc)
+            break
+    return all_installations
 
 
 async def list_installation_repos(

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -1,0 +1,215 @@
+"""GitHub App authentication helpers.
+
+Generates JWTs for app-to-GitHub API communication, mints short-lived
+installation tokens, and lists installations/repos. Uses ``cryptography``
+for RS256 signing (already a project dependency).
+
+API reference: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# GitHub App API endpoints
+# ---------------------------------------------------------------------------
+
+_GH_API = "https://api.github.com"
+_GH_APP_INSTALLATIONS = f"{_GH_API}/app/installations"
+_INSTALL_TOKEN_URL = f"{_GH_API}/app/installations/{{installation_id}}/access_tokens"
+_APP_SLUG_URL = f"{_GH_API}/app"
+
+
+def _b64url(data: bytes) -> str:
+    """URL-safe base64 without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def generate_jwt(app_id: str, private_key: str) -> str:
+    """Generate a GitHub App JWT (RS256) for app-to-API authentication.
+
+    The JWT is valid for 10 minutes (GitHub's maximum). It identifies the
+    app itself (not a specific installation).
+    """
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+    now = int(time.time())
+    header = {"alg": "RS256", "typ": "JWT"}
+    claims = {
+        "iat": now - 60,         # 60s clock drift tolerance
+        "exp": now + 600,        # max 10 min per GitHub spec
+        "iss": str(app_id),
+    }
+    signing_input = (
+        _b64url(json.dumps(header, separators=(",", ":")).encode())
+        + "."
+        + _b64url(json.dumps(claims, separators=(",", ":")).encode())
+    )
+    key = serialization.load_pem_private_key(private_key.encode(), password=None)
+    if not isinstance(key, rsa.RSAPrivateKey):
+        raise ValueError("GitHub App private key must be an RSA private key")
+    signature = key.sign(
+        signing_input.encode(),
+        padding.PKCS1v15(),
+        hashes.SHA256(),
+    )
+    return signing_input + "." + _b64url(signature)
+
+
+def _auth_headers(jwt: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {jwt}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+async def _get_app_slug(
+    app_id: str,
+    private_key: str,
+    http_client: httpx.AsyncClient,
+) -> str | None:
+    """Return the GitHub App's slug name, or None on failure."""
+    jwt = generate_jwt(app_id, private_key)
+    try:
+        resp = await http_client.get(
+            _APP_SLUG_URL,
+            headers=_auth_headers(jwt),
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return resp.json().get("slug")
+    except Exception as exc:
+        logger.warning("Failed to get app slug: %s", exc)
+        return None
+
+
+async def get_installation_token(
+    app_id: str,
+    private_key: str,
+    installation_id: int,
+    http_client: httpx.AsyncClient,
+) -> str | None:
+    """Mint a short-lived installation access token.
+
+    Returns the token string or None on failure. The token is scoped to the
+    repositories the installation has access to and expires after 1 hour.
+    """
+    jwt = generate_jwt(app_id, private_key)
+    url = _INSTALL_TOKEN_URL.format(installation_id=installation_id)
+    try:
+        resp = await http_client.post(
+            url,
+            headers=_auth_headers(jwt),
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("token")
+    except Exception as exc:
+        logger.exception(
+            "Failed to get installation token for installation %s: %s",
+            installation_id,
+            exc,
+        )
+        return None
+
+
+async def list_installations(
+    app_id: str,
+    private_key: str,
+    http_client: httpx.AsyncClient,
+) -> list[dict]:
+    """List all installations of the GitHub App.
+
+    Returns a list of installation dicts, each containing:
+      - id (int): installation ID
+      - account (dict): login, avatar_url, type (User/Organization)
+      - repository_selection: "selected" or "all"
+      - created_at, updated_at
+    """
+    jwt = generate_jwt(app_id, private_key)
+    try:
+        resp = await http_client.get(
+            _GH_APP_INSTALLATIONS,
+            headers=_auth_headers(jwt),
+            params={"per_page": 100},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:
+        logger.exception("Failed to list installations: %s", exc)
+        return []
+
+
+async def list_installation_repos(
+    installation_token: str,
+    http_client: httpx.AsyncClient,
+) -> list[dict]:
+    """List repositories accessible to an installation.
+
+    Returns a list of repo dicts from the GitHub API.
+    """
+    headers = {
+        "Authorization": f"Bearer {installation_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    all_repos: list[dict] = []
+    page = 1
+    while True:
+        try:
+            resp = await http_client.get(
+                f"{_GH_API}/installation/repositories",
+                headers=headers,
+                params={"per_page": 100, "page": page},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            repos = data.get("repositories", [])
+            if not repos:
+                break
+            all_repos.extend(repos)
+            if len(repos) < 100:
+                break
+            page += 1
+        except Exception as exc:
+            logger.exception("Failed to list installation repos: %s", exc)
+            break
+    return all_repos
+
+
+async def delete_installation(
+    app_id: str,
+    private_key: str,
+    installation_id: int,
+    http_client: httpx.AsyncClient,
+) -> bool:
+    """Delete (uninstall) a GitHub App installation."""
+    jwt = generate_jwt(app_id, private_key)
+    url = f"{_GH_APP_INSTALLATIONS}/{installation_id}"
+    try:
+        resp = await http_client.delete(
+            url,
+            headers=_auth_headers(jwt),
+            timeout=15,
+        )
+        if resp.status_code == 404:
+            return False
+        resp.raise_for_status()
+        return True
+    except Exception as exc:
+        logger.exception(
+            "Failed to delete installation %s: %s", installation_id, exc
+        )
+        return False

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -160,9 +160,9 @@ async def get_installation_token(
     if cached:
         return cached
 
-    jwt = generate_jwt(app_id, private_key)
     url = _INSTALL_TOKEN_URL.format(installation_id=installation_id)
     try:
+        jwt = generate_jwt(app_id, private_key)
         resp = await http_client.post(
             url,
             headers=_auth_headers(jwt),
@@ -196,11 +196,11 @@ async def list_installations(
       - repository_selection: "selected" or "all"
       - created_at, updated_at
     """
-    jwt = generate_jwt(app_id, private_key)
     all_installations: list[dict] = []
     page = 1
     while True:
         try:
+            jwt = generate_jwt(app_id, private_key)
             resp = await http_client.get(
                 _GH_APP_INSTALLATIONS,
                 headers=_auth_headers(jwt),

--- a/tinyagentos/github_app_installations.py
+++ b/tinyagentos/github_app_installations.py
@@ -55,18 +55,26 @@ class GitHubAppInstallations:
             )
             self._installations = {}
 
-    def _save_sync(self) -> None:
-        data = {
-            "installations": {str(k): v for k, v in self._installations.items()},
-            "updated_at": int(time.time()),
-        }
+    def _save_sync(self, data: dict) -> None:
+        """Write pre-serialised data to disk (called in a thread)."""
         tmp = self._path.with_suffix(".tmp")
         tmp.write_text(json.dumps(data, indent=2))
         tmp.replace(self._path)
 
     async def _save(self) -> None:
-        """Persist installations to disk without blocking the event loop."""
-        await asyncio.to_thread(self._save_sync)
+        """Persist installations to disk without blocking the event loop.
+
+        Snapshot the installations dict on the event-loop thread before
+        dispatching to ``asyncio.to_thread`` to avoid a data race: the
+        thread iterates over a local copy, so concurrent ``add()`` /
+        ``remove()`` calls cannot trigger ``RuntimeError`` from dict
+        mutation during iteration.
+        """
+        data = {
+            "installations": {str(k): v for k, v in self._installations.items()},
+            "updated_at": int(time.time()),
+        }
+        await asyncio.to_thread(self._save_sync, data)
 
     # -- public API ---------------------------------------------------------
 

--- a/tinyagentos/github_app_installations.py
+++ b/tinyagentos/github_app_installations.py
@@ -24,6 +24,7 @@ class GitHubAppInstallations:
         self._path: Path = data_dir / _INSTALLATIONS_FILE
         self._installations: dict[int, dict] = {}
         self._loaded: bool = False
+        self._lock: asyncio.Lock = asyncio.Lock()
 
     async def init(self) -> None:
         """Load installations from disk. Idempotent."""
@@ -98,14 +99,15 @@ class GitHubAppInstallations:
         repository_selection: str = "selected",
     ) -> None:
         """Record an active installation."""
-        self._installations[installation_id] = {
-            "account_login": account_login,
-            "account_type": account_type,
-            "account_avatar_url": account_avatar_url,
-            "repository_selection": repository_selection,
-            "installed_at": int(time.time()),
-        }
-        await self._save()
+        async with self._lock:
+            self._installations[installation_id] = {
+                "account_login": account_login,
+                "account_type": account_type,
+                "account_avatar_url": account_avatar_url,
+                "repository_selection": repository_selection,
+                "installed_at": int(time.time()),
+            }
+            await self._save()
         logger.info(
             "GitHub App installation %s added (%s/%s)",
             installation_id,
@@ -115,9 +117,10 @@ class GitHubAppInstallations:
 
     async def remove(self, installation_id: int) -> bool:
         """Remove an installation. Returns False if not found."""
-        if installation_id not in self._installations:
-            return False
-        del self._installations[installation_id]
-        await self._save()
+        async with self._lock:
+            if installation_id not in self._installations:
+                return False
+            del self._installations[installation_id]
+            await self._save()
         logger.info("GitHub App installation %s removed", installation_id)
         return True

--- a/tinyagentos/github_app_installations.py
+++ b/tinyagentos/github_app_installations.py
@@ -49,7 +49,7 @@ class GitHubAppInstallations:
             self._installations = {
                 int(k): v for k, v in data.get("installations", {}).items()
             }
-        except (json.JSONDecodeError, ValueError, KeyError) as exc:
+        except (json.JSONDecodeError, ValueError, KeyError, AttributeError, TypeError) as exc:
             logger.warning(
                 "Corrupt %s, starting fresh: %s", self._path.name, exc
             )

--- a/tinyagentos/github_app_installations.py
+++ b/tinyagentos/github_app_installations.py
@@ -1,0 +1,110 @@
+"""GitHub App installation registry.
+
+Stores active installation IDs + metadata in a JSON file under the data
+directory. This is intentionally NOT a SQLite store — installation data is
+small, infrequently written, and referenced at startup time.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_INSTALLATIONS_FILE = "github_app_installations.json"
+
+
+class GitHubAppInstallations:
+    """In-memory + JSON-backed registry of active GitHub App installations."""
+
+    def __init__(self, data_dir: Path) -> None:
+        self._path: Path = data_dir / _INSTALLATIONS_FILE
+        self._installations: dict[int, dict] = {}
+        self._loaded: bool = False
+
+    async def init(self) -> None:
+        """Load installations from disk. Idempotent."""
+        if self._loaded:
+            return
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._load()
+        self._loaded = True
+
+    async def close(self) -> None:
+        """No-op (no open handles). Present for symmetry with BaseStore."""
+        pass
+
+    # -- persistence --------------------------------------------------------
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            self._installations = {}
+            return
+        try:
+            data = json.loads(self._path.read_text())
+            # Convert string keys back to int
+            self._installations = {
+                int(k): v for k, v in data.get("installations", {}).items()
+            }
+        except (json.JSONDecodeError, ValueError, KeyError) as exc:
+            logger.warning(
+                "Corrupt %s, starting fresh: %s", self._path.name, exc
+            )
+            self._installations = {}
+
+    def _save(self) -> None:
+        data = {
+            "installations": {str(k): v for k, v in self._installations.items()},
+            "updated_at": int(time.time()),
+        }
+        tmp = self._path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(data, indent=2))
+        tmp.replace(self._path)
+
+    # -- public API ---------------------------------------------------------
+
+    def get(self, installation_id: int) -> dict | None:
+        """Return installation metadata or None."""
+        return self._installations.get(installation_id)
+
+    def list_all(self) -> list[dict]:
+        """Return all active installations with their metadata."""
+        return [
+            {"installation_id": iid, **meta}
+            for iid, meta in self._installations.items()
+        ]
+
+    def add(
+        self,
+        installation_id: int,
+        account_login: str = "",
+        account_type: str = "",
+        account_avatar_url: str = "",
+        repository_selection: str = "selected",
+    ) -> None:
+        """Record an active installation."""
+        self._installations[installation_id] = {
+            "account_login": account_login,
+            "account_type": account_type,
+            "account_avatar_url": account_avatar_url,
+            "repository_selection": repository_selection,
+            "installed_at": int(time.time()),
+        }
+        self._save()
+        logger.info(
+            "GitHub App installation %s added (%s/%s)",
+            installation_id,
+            account_login,
+            account_type,
+        )
+
+    def remove(self, installation_id: int) -> bool:
+        """Remove an installation. Returns False if not found."""
+        if installation_id not in self._installations:
+            return False
+        del self._installations[installation_id]
+        self._save()
+        logger.info("GitHub App installation %s removed", installation_id)
+        return True

--- a/tinyagentos/github_app_installations.py
+++ b/tinyagentos/github_app_installations.py
@@ -6,6 +6,7 @@ small, infrequently written, and referenced at startup time.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -54,7 +55,7 @@ class GitHubAppInstallations:
             )
             self._installations = {}
 
-    def _save(self) -> None:
+    def _save_sync(self) -> None:
         data = {
             "installations": {str(k): v for k, v in self._installations.items()},
             "updated_at": int(time.time()),
@@ -62,6 +63,10 @@ class GitHubAppInstallations:
         tmp = self._path.with_suffix(".tmp")
         tmp.write_text(json.dumps(data, indent=2))
         tmp.replace(self._path)
+
+    async def _save(self) -> None:
+        """Persist installations to disk without blocking the event loop."""
+        await asyncio.to_thread(self._save_sync)
 
     # -- public API ---------------------------------------------------------
 
@@ -76,7 +81,7 @@ class GitHubAppInstallations:
             for iid, meta in self._installations.items()
         ]
 
-    def add(
+    async def add(
         self,
         installation_id: int,
         account_login: str = "",
@@ -92,7 +97,7 @@ class GitHubAppInstallations:
             "repository_selection": repository_selection,
             "installed_at": int(time.time()),
         }
-        self._save()
+        await self._save()
         logger.info(
             "GitHub App installation %s added (%s/%s)",
             installation_id,
@@ -100,11 +105,11 @@ class GitHubAppInstallations:
             account_type,
         )
 
-    def remove(self, installation_id: int) -> bool:
+    async def remove(self, installation_id: int) -> bool:
         """Remove an installation. Returns False if not found."""
         if installation_id not in self._installations:
             return False
         del self._installations[installation_id]
-        self._save()
+        await self._save()
         logger.info("GitHub App installation %s removed", installation_id)
         return True

--- a/tinyagentos/routes/gh_webhook.py
+++ b/tinyagentos/routes/gh_webhook.py
@@ -24,6 +24,9 @@ router = APIRouter()
 
 EVENTS_LOG_PATH = Path.home() / ".taos-gh-events.jsonl"
 
+# Installation event actions that we explicitly handle for store management.
+_HANDLED_INSTALLATION_ACTIONS = frozenset({"created", "deleted", "unsuspend"})
+
 
 def _extract_event_data(event_type: str, payload: dict) -> dict | None:
     """Extract the canonical fields from a payload for the given event type.
@@ -76,6 +79,13 @@ def _extract_event_data(event_type: str, payload: dict) -> dict | None:
 async def _handle_installation_event(request: Request, event_type: str, payload: dict) -> None:
     """Auto-register / auto-remove GitHub App installations from webhook events."""
     action = payload.get("action", "")
+    if action not in _HANDLED_INSTALLATION_ACTIONS:
+        logger.debug(
+            "Webhook: unhandled installation action %r — ignored (handled: %s)",
+            action, sorted(_HANDLED_INSTALLATION_ACTIONS),
+        )
+        return
+
     installation = payload.get("installation", {})
     installation_id = installation.get("id")
     if not installation_id:
@@ -108,11 +118,6 @@ async def _handle_installation_event(request: Request, event_type: str, payload:
             account.get("type", ""),
         )
         return
-
-    logger.debug(
-        "Webhook: unhandled installation action %r for id %s — ignored",
-        action, installation_id,
-    )
 
 
 @router.post("/api/webhooks/github")

--- a/tinyagentos/routes/gh_webhook.py
+++ b/tinyagentos/routes/gh_webhook.py
@@ -73,6 +73,42 @@ def _extract_event_data(event_type: str, payload: dict) -> dict | None:
         return None
 
 
+def _handle_installation_event(request: Request, event_type: str, payload: dict) -> None:
+    """Auto-register / auto-remove GitHub App installations from webhook events."""
+    action = payload.get("action", "")
+    installation = payload.get("installation", {})
+    installation_id = installation.get("id")
+    if not installation_id:
+        return
+
+    installs_store = getattr(request.app.state, "github_app_installations", None)
+    if installs_store is None:
+        return
+
+    if action == "deleted":
+        installs_store.remove(installation_id)
+        logger.info(
+            "Webhook: removed installation %s (%s)", installation_id, action
+        )
+        return
+
+    if action in ("created", "unsuspend"):
+        account = installation.get("account", {})
+        installs_store.add(
+            installation_id=installation_id,
+            account_login=account.get("login", ""),
+            account_type=account.get("type", ""),
+            account_avatar_url=account.get("avatar_url", ""),
+            repository_selection=installation.get("repository_selection", "selected"),
+        )
+        logger.info(
+            "Webhook: added installation %s (%s/%s)",
+            installation_id,
+            account.get("login", ""),
+            account.get("type", ""),
+        )
+
+
 @router.post("/api/webhooks/github")
 async def github_webhook(request: Request) -> Response:
     """Receive and validate a GitHub webhook event."""
@@ -125,6 +161,10 @@ async def github_webhook(request: Request) -> Response:
             "sender": "",
             "url": "",
         }
+
+    # Handle GitHub App installation lifecycle events
+    if event_type == "installation":
+        _handle_installation_event(request, event_type, payload)
 
     # Append as a single JSONL line
     jsonl_line = json.dumps(event_data, ensure_ascii=False) + "\n"

--- a/tinyagentos/routes/gh_webhook.py
+++ b/tinyagentos/routes/gh_webhook.py
@@ -73,7 +73,7 @@ def _extract_event_data(event_type: str, payload: dict) -> dict | None:
         return None
 
 
-def _handle_installation_event(request: Request, event_type: str, payload: dict) -> None:
+async def _handle_installation_event(request: Request, event_type: str, payload: dict) -> None:
     """Auto-register / auto-remove GitHub App installations from webhook events."""
     action = payload.get("action", "")
     installation = payload.get("installation", {})
@@ -86,7 +86,7 @@ def _handle_installation_event(request: Request, event_type: str, payload: dict)
         return
 
     if action == "deleted":
-        installs_store.remove(installation_id)
+        await installs_store.remove(installation_id)
         logger.info(
             "Webhook: removed installation %s (%s)", installation_id, action
         )
@@ -94,7 +94,7 @@ def _handle_installation_event(request: Request, event_type: str, payload: dict)
 
     if action in ("created", "unsuspend"):
         account = installation.get("account", {})
-        installs_store.add(
+        await installs_store.add(
             installation_id=installation_id,
             account_login=account.get("login", ""),
             account_type=account.get("type", ""),
@@ -107,6 +107,12 @@ def _handle_installation_event(request: Request, event_type: str, payload: dict)
             account.get("login", ""),
             account.get("type", ""),
         )
+        return
+
+    logger.debug(
+        "Webhook: unhandled installation action %r for id %s — ignored",
+        action, installation_id,
+    )
 
 
 @router.post("/api/webhooks/github")
@@ -164,7 +170,7 @@ async def github_webhook(request: Request) -> Response:
 
     # Handle GitHub App installation lifecycle events
     if event_type == "installation":
-        _handle_installation_event(request, event_type, payload)
+        await _handle_installation_event(request, event_type, payload)
 
     # Append as a single JSONL line
     jsonl_line = json.dumps(event_data, ensure_ascii=False) + "\n"

--- a/tinyagentos/routes/github.py
+++ b/tinyagentos/routes/github.py
@@ -38,8 +38,17 @@ router = APIRouter()
 async def _get_token(request: Request) -> str | None:
     """Return a GitHub token or None.
 
-    Tries SecretsStore first, then falls back to ``gh auth token``.
+    Resolution order:
+    1. GitHub App installation token (when github_app_id and key are configured)
+    2. SecretsStore key ``github_token`` (PAT from device flow)
+    3. ``gh auth token`` subprocess fallback
     """
+    # 1. Try GitHub App installation token
+    token = await _get_app_installation_token(request)
+    if token:
+        return token
+
+    # 2. Try SecretsStore PAT
     secrets_store = getattr(request.app.state, "secrets", None)
     if secrets_store is not None:
         try:
@@ -49,7 +58,7 @@ async def _get_token(request: Request) -> str | None:
         except Exception as exc:
             logger.warning("SecretsStore lookup for github_token failed: %s", exc)
 
-    # Fallback: gh CLI (uses list form to avoid shell injection)
+    # 3. Fallback: gh CLI
     try:
         proc = await asyncio.create_subprocess_exec(
             "gh", "auth", "token",
@@ -62,6 +71,42 @@ async def _get_token(request: Request) -> str | None:
             return token
     except Exception as exc:
         logger.debug("gh auth token fallback failed: %s", exc)
+
+    return None
+
+
+async def _get_app_installation_token(request: Request) -> str | None:
+    """Mint a short-lived installation token from the configured GitHub App.
+
+    Returns None if GitHub App is not configured or no installations exist.
+    """
+    cfg = getattr(request.app.state, "config", None)
+    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+        return None
+
+    installs = getattr(request.app.state, "github_app_installations", None)
+    if installs is None:
+        return None
+
+    active = installs.list_all()
+    if not active:
+        return None
+
+    http_client = request.app.state.http_client
+    from tinyagentos.github_app import get_installation_token
+
+    # Use the first active installation. In the future, the caller could
+    # pass a repo hint to select the right installation.
+    for inst in active:
+        iid = inst.get("installation_id")
+        if not iid:
+            continue
+        token = await get_installation_token(
+            cfg.github_app_id, cfg.github_app_private_key, iid, http_client,
+        )
+        if token:
+            logger.debug("Using GitHub App installation token (installation %s)", iid)
+            return token
 
     return None
 

--- a/tinyagentos/routes/github.py
+++ b/tinyagentos/routes/github.py
@@ -39,16 +39,13 @@ async def _get_token(request: Request) -> str | None:
     """Return a GitHub token or None.
 
     Resolution order:
-    1. GitHub App installation token (when github_app_id and key are configured)
-    2. SecretsStore key ``github_token`` (PAT from device flow)
+    1. SecretsStore key ``github_token`` (PAT from device flow) — user's own
+       identity takes precedence so personal repos and rate limits apply.
+    2. GitHub App installation token (when github_app_id and key are configured)
+       — fallback for repos accessible to the installed app.
     3. ``gh auth token`` subprocess fallback
     """
-    # 1. Try GitHub App installation token
-    token = await _get_app_installation_token(request)
-    if token:
-        return token
-
-    # 2. Try SecretsStore PAT
+    # 1. Try SecretsStore PAT (user's own GitHub identity)
     secrets_store = getattr(request.app.state, "secrets", None)
     if secrets_store is not None:
         try:
@@ -57,6 +54,11 @@ async def _get_token(request: Request) -> str | None:
                 return secret["value"]
         except Exception as exc:
             logger.warning("SecretsStore lookup for github_token failed: %s", exc)
+
+    # 2. Try GitHub App installation token (fallback)
+    token = await _get_app_installation_token(request)
+    if token:
+        return token
 
     # 3. Fallback: gh CLI
     try:

--- a/tinyagentos/routes/github.py
+++ b/tinyagentos/routes/github.py
@@ -77,8 +77,13 @@ async def _get_token(request: Request) -> str | None:
     return None
 
 
-async def _get_app_installation_token(request: Request) -> str | None:
+async def _get_app_installation_token(
+    request: Request, installation_id: int | None = None
+) -> str | None:
     """Mint a short-lived installation token from the configured GitHub App.
+
+    If *installation_id* is provided, uses that specific installation.
+    Otherwise, uses the first active installation (backward-compatible default).
 
     Returns None if GitHub App is not configured or no installations exist.
     """
@@ -90,6 +95,22 @@ async def _get_app_installation_token(request: Request) -> str | None:
     if installs is None:
         return None
 
+    if installation_id is not None:
+        inst = installs.get(installation_id)
+        if not inst:
+            return None
+        http_client = request.app.state.http_client
+        from tinyagentos.github_app import get_installation_token
+
+        token = await get_installation_token(
+            cfg.github_app_id, cfg.github_app_private_key, installation_id,
+            http_client,
+        )
+        if token:
+            logger.debug("Using GitHub App installation token (installation %s)", installation_id)
+            return token
+        return None
+
     active = installs.list_all()
     if not active:
         return None
@@ -97,8 +118,8 @@ async def _get_app_installation_token(request: Request) -> str | None:
     http_client = request.app.state.http_client
     from tinyagentos.github_app import get_installation_token
 
-    # Use the first active installation. In the future, the caller could
-    # pass a repo hint to select the right installation.
+    # Use the first active installation. The caller may pass an explicit
+    # installation_id to select a specific installation (e.g. scoped by repo).
     for inst in active:
         iid = inst.get("installation_id")
         if not iid:

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -201,3 +201,237 @@ async def delete_identity(request: Request, identity_id: str):
     if not deleted:
         return JSONResponse({"error": "Identity not found"}, status_code=404)
     return {"status": "deleted"}
+
+
+# ---------------------------------------------------------------------------
+# GitHub App: installation endpoints
+# ---------------------------------------------------------------------------
+
+_INSTALL_PAGE_URL = "https://github.com/apps/{app_slug}/installations/new"
+
+
+def _app_config(request: Request):
+    """Return the AppConfig from app state."""
+    return getattr(request.app.state, "config", None)
+
+
+def _app_installations_store(request: Request):
+    """Return the GitHubAppInstallations store from app state."""
+    return getattr(request.app.state, "github_app_installations", None)
+
+
+@router.get("/api/github/app/installations")
+async def list_app_installations(request: Request):
+    """List GitHub App installations with their accessible repositories.
+
+    Requires github_app_id and github_app_private_key to be configured.
+    """
+    cfg = _app_config(request)
+    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+        return JSONResponse(
+            {"error": "GitHub App not configured (set github_app_id and github_app_private_key in config)"},
+            status_code=501,
+        )
+
+    http = _http(request)
+    installs_store = _app_installations_store(request)
+
+    from tinyagentos.github_app import (
+        list_installations,
+        list_installation_repos,
+        get_installation_token,
+    )
+
+    # Fetch installations from the GitHub API using the JWT
+    raw_installations = await list_installations(
+        cfg.github_app_id, cfg.github_app_private_key, http
+    )
+
+    result = []
+    for inst in raw_installations:
+        iid = inst.get("id")
+        if not iid:
+            continue
+        account = inst.get("account", {})
+
+        # If we have a locally stored installation, use its metadata;
+        # otherwise, record it now (it was installed via GitHub web UI).
+        if not installs_store or not installs_store.get(iid):
+            if installs_store:
+                installs_store.add(
+                    installation_id=iid,
+                    account_login=account.get("login", ""),
+                    account_type=account.get("type", ""),
+                    account_avatar_url=account.get("avatar_url", ""),
+                    repository_selection=inst.get("repository_selection", "selected"),
+                )
+
+        repos = []
+        token = await get_installation_token(
+            cfg.github_app_id, cfg.github_app_private_key, iid, http
+        )
+        if token:
+            repos = await list_installation_repos(token, http)
+
+        result.append({
+            "id": iid,
+            "account": {
+                "login": account.get("login", ""),
+                "type": account.get("type", ""),
+                "avatar_url": account.get("avatar_url", ""),
+            },
+            "repository_selection": inst.get("repository_selection", "selected"),
+            "repositories": [
+                {
+                    "full_name": r.get("full_name", ""),
+                    "name": r.get("name", ""),
+                    "private": r.get("private", False),
+                    "description": r.get("description", ""),
+                }
+                for r in repos
+            ],
+            "created_at": inst.get("created_at", ""),
+        })
+
+    return {"installations": result}
+
+
+@router.post("/api/github/app/install")
+async def begin_app_installation(request: Request):
+    """Redirect the user to GitHub's App installation page.
+
+    Returns the URL the frontend should open. The user will be redirected
+    back to /api/github/app/callback after installation completes.
+    """
+    cfg = _app_config(request)
+    if not cfg or not cfg.github_app_id:
+        return JSONResponse(
+            {"error": "GitHub App not configured"},
+            status_code=501,
+        )
+
+    http = _http(request)
+    from tinyagentos.github_app import _get_app_slug
+
+    app_slug = await _get_app_slug(
+        cfg.github_app_id, cfg.github_app_private_key, http
+    )
+    if not app_slug:
+        return JSONResponse(
+            {"error": "Could not determine GitHub App slug from API"},
+            status_code=502,
+        )
+
+    install_url = _INSTALL_PAGE_URL.format(app_slug=app_slug)
+    return {"install_url": install_url}
+
+
+@router.get("/api/github/app/callback")
+async def app_installation_callback(
+    request: Request,
+    installation_id: int | None = None,
+    setup_action: str = "install",
+):
+    """Handle the post-installation redirect from GitHub.
+
+    GitHub redirects here after a user installs the app, with
+    ?installation_id=...&setup_action=install in the query string.
+    """
+    if not installation_id:
+        return JSONResponse(
+            {"error": "Missing installation_id parameter"},
+            status_code=400,
+        )
+
+    cfg = _app_config(request)
+    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+        return JSONResponse(
+            {"error": "GitHub App not configured"},
+            status_code=501,
+        )
+
+    http = _http(request)
+    from tinyagentos.github_app import get_installation_token
+
+    # Verify the installation works by minting a token
+    token = await get_installation_token(
+        cfg.github_app_id, cfg.github_app_private_key, installation_id, http
+    )
+    if not token:
+        return JSONResponse(
+            {"error": "Failed to verify installation"},
+            status_code=502,
+        )
+
+    # Fetch account info from the token's scoped API call
+    try:
+        user_resp = await http.get(
+            "https://api.github.com/user",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=10,
+        )
+        user_resp.raise_for_status()
+        # For installations, the "user" endpoint returns the GitHub App bot user.
+        # We need the actual installing account. Use /app/installations/{id} instead.
+    except Exception:
+        pass
+
+    # Fetch full installation details with JWT
+    from tinyagentos.github_app import generate_jwt
+    jwt = generate_jwt(cfg.github_app_id, cfg.github_app_private_key)
+    install_resp = await http.get(
+        f"https://api.github.com/app/installations/{installation_id}",
+        headers={
+            "Authorization": f"Bearer {jwt}",
+            "Accept": "application/vnd.github+json",
+        },
+        timeout=10,
+    )
+    if install_resp.status_code == 200:
+        inst_data = install_resp.json()
+        account = inst_data.get("account", {})
+        store = _app_installations_store(request)
+        if store:
+            store.add(
+                installation_id=installation_id,
+                account_login=account.get("login", ""),
+                account_type=account.get("type", ""),
+                account_avatar_url=account.get("avatar_url", ""),
+                repository_selection=inst_data.get("repository_selection", "selected"),
+            )
+
+    # Redirect to the secrets page so the user sees their installation
+    from fastapi.responses import RedirectResponse
+    return RedirectResponse(url="/app/secrets", status_code=302)
+
+
+@router.delete("/api/github/app/installations/{installation_id}")
+async def delete_app_installation(request: Request, installation_id: int):
+    """Uninstall the GitHub App from the given installation."""
+    cfg = _app_config(request)
+    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+        return JSONResponse(
+            {"error": "GitHub App not configured"},
+            status_code=501,
+        )
+
+    http = _http(request)
+    from tinyagentos.github_app import delete_installation
+
+    deleted = await delete_installation(
+        cfg.github_app_id, cfg.github_app_private_key, installation_id, http
+    )
+
+    store = _app_installations_store(request)
+    if store:
+        store.remove(installation_id)
+
+    if not deleted:
+        return JSONResponse(
+            {"error": "Installation not found or could not be deleted"},
+            status_code=404,
+        )
+    return {"status": "deleted"}

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -240,7 +240,7 @@ async def list_app_installations(request: Request):
 
     from tinyagentos.github_app import (
         list_installations,
-        list_installation_repos,
+        list_installation_repos_cached,
         get_installation_token,
     )
 
@@ -273,7 +273,7 @@ async def list_app_installations(request: Request):
             cfg.github_app_id, cfg.github_app_private_key, iid, http
         )
         if token:
-            repos = await list_installation_repos(token, http)
+            repos = await list_installation_repos_cached(iid, token, http)
 
         result.append({
             "id": iid,
@@ -353,6 +353,7 @@ async def app_installation_callback(
         )
 
     http = _http(request)
+    from fastapi.responses import RedirectResponse
     from tinyagentos.github_app import get_installation_token
 
     # Verify the installation works by minting a token
@@ -394,9 +395,8 @@ async def app_installation_callback(
             "Failed to fetch installation %s details (HTTP %s), redirecting anyway",
             installation_id, install_resp.status_code,
         )
+        return RedirectResponse(url="/app/secrets?install_error=1", status_code=302)
 
-    # Redirect to the secrets page so the user sees their installation
-    from fastapi.responses import RedirectResponse
     return RedirectResponse(url="/app/secrets", status_code=302)
 
 

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -14,6 +14,7 @@ NEVER logged or returned by any endpoint.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 
@@ -249,16 +250,13 @@ async def list_app_installations(request: Request):
         cfg.github_app_id, cfg.github_app_private_key, http
     )
 
-    result = []
+    # Phase 1: record new installations locally (sequential — uses lock)
     for inst in raw_installations:
         iid = inst.get("id")
         if not iid:
             continue
-        account = inst.get("account", {})
-
-        # Record the installation locally if we haven't seen it yet
-        # (it may have been installed via GitHub web UI).
         if installs_store and not installs_store.get(iid):
+            account = inst.get("account", {})
             await installs_store.add(
                 installation_id=iid,
                 account_login=account.get("login", ""),
@@ -267,13 +265,24 @@ async def list_app_installations(request: Request):
                 repository_selection=inst.get("repository_selection", "selected"),
             )
 
-        repos = []
+    # Phase 2: mint tokens and fetch repos in parallel across installations
+    async def _fetch_one(inst: dict) -> tuple[int, dict, list[dict]]:
+        iid: int = inst["id"]
         token = await get_installation_token(
             cfg.github_app_id, cfg.github_app_private_key, iid, http
         )
+        repos: list[dict] = []
         if token:
             repos = await list_installation_repos_cached(iid, token, http)
+        return iid, inst, repos
 
+    valid = [inst for inst in raw_installations if inst.get("id")]
+    fetched = await asyncio.gather(*(_fetch_one(inst) for inst in valid))
+
+    # Phase 3: build result list
+    result = []
+    for iid, inst, repos in fetched:
+        account = inst.get("account", {})
         result.append({
             "id": iid,
             "account": {
@@ -381,7 +390,12 @@ async def app_installation_callback(
         inst_data = install_resp.json()
         account = inst_data.get("account", {})
         store = _app_installations_store(request)
-        if store:
+        if setup_action == "update":
+            logger.info(
+                "GitHub App installation %s updated (%s)",
+                installation_id, account.get("login", ""),
+            )
+        elif store:
             await store.add(
                 installation_id=installation_id,
                 account_login=account.get("login", ""),

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -256,17 +256,16 @@ async def list_app_installations(request: Request):
             continue
         account = inst.get("account", {})
 
-        # If we have a locally stored installation, use its metadata;
-        # otherwise, record it now (it was installed via GitHub web UI).
-        if not installs_store or not installs_store.get(iid):
-            if installs_store:
-                await installs_store.add(
-                    installation_id=iid,
-                    account_login=account.get("login", ""),
-                    account_type=account.get("type", ""),
-                    account_avatar_url=account.get("avatar_url", ""),
-                    repository_selection=inst.get("repository_selection", "selected"),
-                )
+        # Record the installation locally if we haven't seen it yet
+        # (it may have been installed via GitHub web UI).
+        if installs_store and not installs_store.get(iid):
+            await installs_store.add(
+                installation_id=iid,
+                account_login=account.get("login", ""),
+                account_type=account.get("type", ""),
+                account_avatar_url=account.get("avatar_url", ""),
+                repository_selection=inst.get("repository_selection", "selected"),
+            )
 
         repos = []
         token = await get_installation_token(

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -265,7 +265,9 @@ async def list_app_installations(request: Request):
                 repository_selection=inst.get("repository_selection", "selected"),
             )
 
-    # Phase 2: mint tokens and fetch repos in parallel across installations
+    # Phase 2: mint tokens and fetch repos in parallel across installations.
+    # get_installation_token has its own 5-min TTL cache (_token_cache), so
+    # subsequent calls within the window reuse cached tokens — no extra POSTs.
     async def _fetch_one(inst: dict) -> tuple[int, dict, list[dict]]:
         iid: int = inst["id"]
         token = await get_installation_token(
@@ -390,12 +392,7 @@ async def app_installation_callback(
         inst_data = install_resp.json()
         account = inst_data.get("account", {})
         store = _app_installations_store(request)
-        if setup_action == "update":
-            logger.info(
-                "GitHub App installation %s updated (%s)",
-                installation_id, account.get("login", ""),
-            )
-        elif store:
+        if store:
             await store.add(
                 installation_id=installation_id,
                 account_login=account.get("login", ""),
@@ -403,6 +400,12 @@ async def app_installation_callback(
                 account_avatar_url=account.get("avatar_url", ""),
                 repository_selection=inst_data.get("repository_selection", "selected"),
             )
+        logger.info(
+            "GitHub App installation %s %s (%s)",
+            installation_id,
+            setup_action,
+            account.get("login", ""),
+        )
     else:
         logger.warning(
             "Failed to fetch installation %s details (HTTP %s), redirecting anyway",

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -47,10 +47,12 @@ class DevicePollBody(BaseModel):
 
 
 def _http(request: Request):
+    """Return the shared httpx.AsyncClient from application state."""
     return request.app.state.http_client
 
 
 def _identities_store(request: Request):
+    """Return the GitHubIdentitiesStore from application state."""
     return getattr(request.app.state, "github_identities", None)
 
 
@@ -211,12 +213,12 @@ _INSTALL_PAGE_URL = "https://github.com/apps/{app_slug}/installations/new"
 
 
 def _app_config(request: Request):
-    """Return the AppConfig from app state."""
+    """Return the AppConfig from application state."""
     return getattr(request.app.state, "config", None)
 
 
 def _app_installations_store(request: Request):
-    """Return the GitHubAppInstallations store from app state."""
+    """Return the GitHubAppInstallations store from application state."""
     return getattr(request.app.state, "github_app_installations", None)
 
 
@@ -258,7 +260,7 @@ async def list_app_installations(request: Request):
         # otherwise, record it now (it was installed via GitHub web UI).
         if not installs_store or not installs_store.get(iid):
             if installs_store:
-                installs_store.add(
+                await installs_store.add(
                     installation_id=iid,
                     account_login=account.get("login", ""),
                     account_type=account.get("type", ""),
@@ -304,9 +306,9 @@ async def begin_app_installation(request: Request):
     back to /api/github/app/callback after installation completes.
     """
     cfg = _app_config(request)
-    if not cfg or not cfg.github_app_id:
+    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
         return JSONResponse(
-            {"error": "GitHub App not configured"},
+            {"error": "GitHub App not configured (set github_app_id and github_app_private_key in config)"},
             status_code=501,
         )
 
@@ -363,23 +365,8 @@ async def app_installation_callback(
             status_code=502,
         )
 
-    # Fetch account info from the token's scoped API call
-    try:
-        user_resp = await http.get(
-            "https://api.github.com/user",
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
-            },
-            timeout=10,
-        )
-        user_resp.raise_for_status()
-        # For installations, the "user" endpoint returns the GitHub App bot user.
-        # We need the actual installing account. Use /app/installations/{id} instead.
-    except Exception:
-        pass
-
-    # Fetch full installation details with JWT
+    # Fetch installation details with JWT (the /user endpoint returns the bot
+    # user, not the installing account, so we use /app/installations/{id}).
     from tinyagentos.github_app import generate_jwt
     jwt = generate_jwt(cfg.github_app_id, cfg.github_app_private_key)
     install_resp = await http.get(
@@ -395,13 +382,18 @@ async def app_installation_callback(
         account = inst_data.get("account", {})
         store = _app_installations_store(request)
         if store:
-            store.add(
+            await store.add(
                 installation_id=installation_id,
                 account_login=account.get("login", ""),
                 account_type=account.get("type", ""),
                 account_avatar_url=account.get("avatar_url", ""),
                 repository_selection=inst_data.get("repository_selection", "selected"),
             )
+    else:
+        logger.warning(
+            "Failed to fetch installation %s details (HTTP %s), redirecting anyway",
+            installation_id, install_resp.status_code,
+        )
 
     # Redirect to the secrets page so the user sees their installation
     from fastapi.responses import RedirectResponse
@@ -425,13 +417,14 @@ async def delete_app_installation(request: Request, installation_id: int):
         cfg.github_app_id, cfg.github_app_private_key, installation_id, http
     )
 
-    store = _app_installations_store(request)
-    if store:
-        store.remove(installation_id)
-
     if not deleted:
         return JSONResponse(
             {"error": "Installation not found or could not be deleted"},
             status_code=404,
         )
+
+    store = _app_installations_store(request)
+    if store:
+        await store.remove(installation_id)
+
     return {"status": "deleted"}


### PR DESCRIPTION
## Problem
CodeRabbit CRITICAL on PR #1932: `_save_sync` iterates `self._installations` inside `asyncio.to_thread`. Concurrent `add()` / `remove()` calls from the event loop can mutate the dict while the thread is iterating, causing `RuntimeError` or silent corruption.

## Fix
Snapshot the installations dict into a local `data` dict **on the event-loop thread** before dispatching to `asyncio.to_thread`. `_save_sync` now receives the pre-built dict as a parameter instead of reading `self._installations` directly.

## Testing
- `test_github_app.py`: 12/12 pass
- `test_github_oauth.py`: 17/17 pass

Task: t_a3f0a632

----
## Summary by Gitar

- **GitHub App integration:**
    - Implemented `GitHubAppInstallations` registry in `github_app_installations.py` to manage installation state.
    - Added authentication logic in `github_app.py` including JWT generation and installation token minting.
    - Exposed API endpoints for managing installations in `github_oauth.py` and added webhook support in `gh_webhook.py`.
- **Frontend & Config:**
    - Added UI components in `GitHubConnect.tsx` for managing app installations and repository access.
    - Updated `config.py` to support `github_app_id` and `github_app_private_key` configuration fields.
- **Testing:**
    - Added `test_github_app.py` and expanded `test_github_oauth.py` to cover new authentication and management workflows.

<sub>This will update automatically on new commits.</sub>