### PR TITLE
fix(invites): failed approve no longer burns the invite + scope validation at mint (#1993)

### DIFF
--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -163,6 +163,64 @@ async def _mint_invite(client, pid, *, approval_mode="auto", scopes=None, check_
 
 
 @pytest.mark.asyncio
+async def test_mint_rejects_unknown_scopes(client, app):
+    # #1993: an invite minted with a bad scope would silently pass and then
+    # fail (and previously burn) at every redeem. Validate at mint on BOTH
+    # endpoints.
+    pid = await _create_project(client, slug="badscope")
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": ["a2a_send", "not_a_scope"], "approval_mode": "auto"},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "not_a_scope" in resp.json()["error"]
+
+    os_resp = await client.post(
+        "/api/agents/invites",
+        json={"scopes": ["definitely_bogus"], "approval_mode": "auto"},
+    )
+    assert os_resp.status_code == 400, os_resp.text
+    assert "definitely_bogus" in os_resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_failed_approve_does_not_burn_invite(client, app, monkeypatch, tmp_path):
+    # #1993: if approve_request_record raises after the pending->redeemed CAS,
+    # the invite must return to the pool so the agent can retry.
+    await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
+    pid = await _create_project(client, slug="noburn")
+    iid, pin = await _mint_invite(client, pid, approval_mode="auto", scopes=["a2a_send"])
+
+    import tinyagentos.routes.agent_auth_requests as aar
+
+    real_approve = aar.approve_request_record
+    calls = {"n": 0}
+
+    async def flaky_approve(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("simulated approve failure")
+        return await real_approve(*args, **kwargs)
+
+    monkeypatch.setattr(aar, "approve_request_record", flaky_approve)
+
+    first = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert first.status_code == 400, first.text
+    assert "simulated approve failure" in first.json()["error"]
+
+    # The invite went back to pending, so the SAME invite+pin redeems fine.
+    second = await client.post(
+        "/api/projects/invites/redeem",
+        json={"invite_id": iid, "pin": pin, "harness": "claude"},
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["agent_handle"].startswith("noburn-claude")
+
+
+@pytest.mark.asyncio
 async def test_redeem_auto_mode_end_to_end(client, app, monkeypatch, tmp_path):
     registry, auth_store, grants = await _setup_agent_ecosystem(app, monkeypatch, tmp_path)
     pid = await _create_project(client, slug="redauto")

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -300,6 +300,24 @@ class ProjectInviteStore(BaseStore):
         updated = await self._fetch_row(invite_id)
         return self._row_to_dict(updated)
 
+    async def restore_pending(self, invite_id: str) -> None:
+        """Return a just-redeemed invite to the open pool.
+
+        Called by the redeem route when the downstream approve fails AFTER the
+        atomic pending->redeemed flip in ``redeem`` (which stays the
+        concurrent-redeem race gate). Without this, any approve failure (bad
+        scope, handle 409) permanently consumes the invite (#1993). Guarded on
+        status='redeemed' so it can never resurrect an expired/revoked invite.
+        """
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+        await self._db.execute(
+            "UPDATE project_invites SET status = 'pending' "
+            "WHERE invite_id = ? AND status = 'redeemed'",
+            (invite_id,),
+        )
+        await self._db.commit()
+
     async def mark_redeemed(
         self, invite_id: str, redeemed_by: str, redeemed_request_id: str
     ) -> None:

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -19,9 +19,20 @@ from tinyagentos.projects.invite_store import (
     InvitePendingCapError,
     InviteRevokedError,
 )
+from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _unknown_scopes(scopes: list[str]) -> list[str]:
+    """Scopes not in the consent system's VALID_SCOPES, sorted for the error.
+
+    Validated at MINT time (#1993): an invite minted with a bad scope would
+    otherwise pass silently and then fail (and burn) at every redeem attempt,
+    because scope validation only existed on the auth-request path.
+    """
+    return sorted(set(scopes) - VALID_SCOPES)
 
 
 class MintInviteIn(BaseModel):
@@ -618,6 +629,12 @@ async def mint_invite(
     if project is None:
         return JSONResponse({"error": "project not found"}, status_code=404)
     require_owner_or_admin(user, project["user_id"])
+    bad = _unknown_scopes(payload.scopes)
+    if bad:
+        return JSONResponse(
+            {"error": f"unknown scopes: {bad}; valid: {sorted(VALID_SCOPES)}"},
+            status_code=400,
+        )
     try:
         result = await store.mint(
             project_id=project_id,
@@ -710,6 +727,12 @@ async def mint_os_invite(
 ):
     _require_admin(user)
     store = request.app.state.project_invites
+    bad = _unknown_scopes(payload.scopes)
+    if bad:
+        return JSONResponse(
+            {"error": f"unknown scopes: {bad}; valid: {sorted(VALID_SCOPES)}"},
+            status_code=400,
+        )
     # OS-level invites carry no project, so drop any project-bound scopes rather
     # than granting them against a non-existent project (kilo review #1918).
     os_scopes = [s for s in payload.scopes if s not in _PROJECT_SCOPED]
@@ -876,6 +899,16 @@ async def redeem_invite(request: Request, body: RedeemInviteIn):
                 project_id=invite["project_id"],
             )
         except Exception as exc:  # noqa: BLE001 - surface as JSON error
+            # A failed approve must not consume the invite (#1993): return it
+            # to the pool so the agent can retry, and refuse the dangling
+            # auth request so it does not linger in the consent inbox.
+            await store.restore_pending(body.invite_id)
+            try:
+                await auth_store.set_decision(
+                    record["id"], "refused", decided_by="system:invite-rollback"
+                )
+            except Exception:  # noqa: BLE001 - cleanup best-effort
+                pass
             return JSONResponse({"error": str(exc)}, status_code=400)
     else:
         # manual: leave pending so the consent bell fires (handled by
@@ -954,6 +987,15 @@ async def _redeem_os_level(request: Request, body: RedeemInviteIn, invite: dict,
                 display_name=display_name,
             )
         except Exception as exc:  # noqa: BLE001 - surface as JSON error
+            # Mirror the project-invite rollback (#1993): a failed approve must
+            # not consume the invite; refuse the dangling auth request.
+            await store.restore_pending(body.invite_id)
+            try:
+                await auth_store.set_decision(
+                    record["id"], "refused", decided_by="system:invite-rollback"
+                )
+            except Exception:  # noqa: BLE001 - cleanup best-effort
+                pass
             return JSONResponse({"error": str(exc)}, status_code=400)
     else:
         _notify_pending_invite(request, record)


### PR DESCRIPTION
Closes #1993 (P0 for the incoming external game-dev agent onboarding).

**Burn fix:** `store.redeem()` keeps its atomic pending->redeemed CAS as the concurrent-redeem race gate, but both redeem paths (project + OS-level) now call the new `restore_pending()` when `approve_request_record` fails, returning the invite to the pool, and refuse the dangling auth request (`decided_by=system:invite-rollback`) so it does not linger in the consent inbox. `restore_pending` is guarded on `status='redeemed'` so it can never resurrect an expired/revoked invite.

**Mint validation:** both mint endpoints validate `payload.scopes` against the consent system's `VALID_SCOPES` and 400 with the unknown names, so a typo'd scope can no longer produce an invite that fails at every redeem.

Tests: unknown-scope 400 on both endpoints; simulated approve failure -> 400 -> the SAME invite+pin redeems successfully on retry. 29/29 invite tests green.

Note: lands after the beta.41 release train (this is beta.42 material unless the deploy hits invite trouble).