### PR TITLE
fix(csrf): merge CSRF token into effectiveInit for Request inputs (bot-fix for #1991)

### DIFF
--- a/desktop/src/lib/auth-guard.test.ts
+++ b/desktop/src/lib/auth-guard.test.ts
@@ -37,10 +37,11 @@ describe("installAuthGuard CSRF wiring", () => {
     const lookalike = spy.mock.calls.at(-1)?.[1] as RequestInit;
     expect(new Headers(lookalike.headers).get("X-CSRF-Token")).toBeNull();
 
-    // Request-object input for a same-origin mutating call: the wrapper rebuilds
-    // the Request with the header attached (first arg is the Request).
+    // Request-object input for a same-origin mutating call: the wrapper merges
+    // the CSRF token into effectiveInit so native fetch respects any
+    // init-provided method/headers and preserves the original body stream.
     await window.fetch(new Request(`${window.location.origin}/api/x`, { method: "POST" }));
-    const reqArg = spy.mock.calls.at(-1)?.[0] as Request;
-    expect(reqArg.headers.get("X-CSRF-Token")).toBe("tok123");
+    const reqInit = spy.mock.calls.at(-1)?.[1] as RequestInit;
+    expect(new Headers(reqInit.headers).get("X-CSRF-Token")).toBe("tok123");
   });
 });

--- a/desktop/src/lib/auth-guard.test.ts
+++ b/desktop/src/lib/auth-guard.test.ts
@@ -43,5 +43,26 @@ describe("installAuthGuard CSRF wiring", () => {
     await window.fetch(new Request(`${window.location.origin}/api/x`, { method: "POST" }));
     const reqInit = spy.mock.calls.at(-1)?.[1] as RequestInit;
     expect(new Headers(reqInit.headers).get("X-CSRF-Token")).toBe("tok123");
+
+    // Request headers AND init headers together: `init?.headers || input.headers`
+    // discarded the Request's own headers whenever init carried any, so an
+    // Authorization set on the Request went missing on every mutating call that
+    // also passed init.headers. Both sources must survive, init winning ties.
+    // (These assertions live in this block deliberately: installAuthGuard has a
+    // module-level `installed` guard, so a second install in a new it() is a
+    // no-op and window.fetch would be the bare spy.)
+    await window.fetch(
+      new Request(`${window.location.origin}/api/y`, {
+        method: "POST",
+        headers: { Authorization: "Bearer abc", "X-From-Request": "1" },
+      }),
+      { headers: { "X-From-Init": "2" } },
+    );
+    const merged = new Headers((spy.mock.calls.at(-1)?.[1] as RequestInit).headers);
+    expect(merged.get("Authorization")).toBe("Bearer abc");
+    expect(merged.get("X-From-Request")).toBe("1");
+    expect(merged.get("X-From-Init")).toBe("2");
+    expect(merged.get("X-CSRF-Token")).toBe("tok123");
   });
+
 });

--- a/desktop/src/lib/auth-guard.ts
+++ b/desktop/src/lib/auth-guard.ts
@@ -77,8 +77,16 @@ export function installAuthGuard(): void {
         if (CSRF_MUTATING.has(method) && isSameOrigin(input.url)) {
           const token = getCsrfToken();
           if (token) {
-            const baseHeaders = init?.headers || input.headers;
-            const headers = new Headers(baseHeaders);
+            // Merge BOTH sources rather than picking one. `init?.headers ||
+            // input.headers` silently discarded the Request's own headers
+            // whenever init also carried headers, so
+            //   fetch(new Request(url, {headers: {Authorization}}), {method, headers})
+            // lost the Authorization header entirely. init wins on conflict,
+            // matching how fetch itself resolves the two.
+            const headers = new Headers(input.headers);
+            if (init?.headers) {
+              new Headers(init.headers).forEach((v, k) => headers.set(k, v));
+            }
             if (!headers.has("X-CSRF-Token")) {
               headers.set("X-CSRF-Token", token);
               effectiveInit = { ...init, headers };

--- a/desktop/src/lib/auth-guard.ts
+++ b/desktop/src/lib/auth-guard.ts
@@ -65,7 +65,7 @@ export function installAuthGuard(): void {
     // the backend's router-wide verify_csrf gate is satisfied at every call
     // site, not only the handful that wrap withCsrf() by hand. Covers both
     // string/URL inputs (via withCsrf on init) and Request-object inputs (by
-    // rebuilding the Request with the header). Gated to same-origin so the token
+    // merging the CSRF token into effectiveInit). Gated to same-origin so the token
     // never leaks off-site; never overwrites an X-CSRF-Token a caller already set.
     let effectiveInput: RequestInfo | URL = input;
     let effectiveInit = init;
@@ -73,21 +73,20 @@ export function installAuthGuard(): void {
       if (isSameOrigin(input.toString())) effectiveInit = withCsrf(init);
     } else if (typeof Request !== "undefined" && input instanceof Request) {
       try {
-        const method = (input.method || "GET").toUpperCase();
-        if (
-          CSRF_MUTATING.has(method) &&
-          isSameOrigin(input.url) &&
-          !input.headers.has("X-CSRF-Token")
-        ) {
+        const method = (init?.method || input.method || "GET").toUpperCase();
+        if (CSRF_MUTATING.has(method) && isSameOrigin(input.url)) {
           const token = getCsrfToken();
           if (token) {
-            const headers = new Headers(input.headers);
-            headers.set("X-CSRF-Token", token);
-            effectiveInput = new Request(input, { headers });
+            const baseHeaders = init?.headers || input.headers;
+            const headers = new Headers(baseHeaders);
+            if (!headers.has("X-CSRF-Token")) {
+              headers.set("X-CSRF-Token", token);
+              effectiveInit = { ...init, headers };
+            }
           }
         }
       } catch {
-        effectiveInput = input;
+        // Fallback to original input/init on error
       }
     }
     const response = await originalFetch(effectiveInput, effectiveInit);


### PR DESCRIPTION
## Summary

Fixes the 2 inline bot findings on PR #1991 (Kilo + CodeRabbit) in `auth-guard.ts`.

### Changes

**auth-guard.ts** — Request-object CSRF handling:
- Compute effective method from `init?.method || input.method` (was: `input.method` only)
- Merge CSRF token into `effectiveInit` headers instead of rebuilding the Request with `new Request(input, { headers })`
- This fixes 3 issues:
  1. **Kilo finding**: Request inputs were previously excluded from CSRF when init was provided (init.headers would override the rebuilt request's headers)
  2. **CodeRabbit #1**: `init.method` overrides were ignored — a GET Request with `init: { method: 'POST' }` would skip CSRF
  3. **CodeRabbit #2**: `new Request(input, ...)` consumes the original body stream

**auth-guard.test.ts** — Updated Request-object assertion:
- Now checks `spy.mock.calls[1]` (init arg) instead of `spy.mock.calls[0]` (Request arg) since the token lives in effectiveInit

### Tests

- tsc: clean
- auth-guard.test.ts: 1/1 pass
- csrf.test.ts: 17/17 pass