### PR TITLE
docs(skill): fix bot suffix claim and jq null guard (Kilo findings on #2000)

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -191,12 +191,15 @@ findings **before** surfacing the PR for human maintainer review.
 ### Procedure
 
 1. **Push PR and mark ready.** Wait ~10 minutes for bot reviews to complete.
-2. **Pull bot findings - reviews AND inline comments, all bots.** Bot logins have NO `[bot]`
-   suffix in the JSON (`kilo-code-bot`, `gitar-bot`, `coderabbitai`, `qodo-code-review`):
+2. **Pull bot findings - reviews AND inline comments, all bots.** Bot logins carry a `[bot]`
+   suffix in the JSON (`kilo-code-bot[bot]`, `gitar-bot[bot]`, `coderabbitai[bot]`,
+   `qodo-code-review[bot]`). The jq below uses `?.author.login` (null-safe, survives deleted
+   users) and falls back to `.user.login` for reviews; the regex matches `[bot]`-suffixed
+   and bare logins alike via substring matching:
    ```bash
    # Review summaries + issue comments:
    gh pr view <PR#> --repo jaylfc/taOS --json reviews,comments --jq \
-     '(.reviews[], .comments[]) | select(.author.login | test("kilo-code-bot|gitar-bot|coderabbitai|qodo")) | {login: .author.login, body: .body}'
+     '(.reviews[], .comments[]) | select((.author.login? // .user.login? // "") | test("kilo-code-bot|gitar-bot|coderabbitai|qodo")) | {login: (.author.login? // .user.login? // "unknown"), body: .body}'
    # Inline (line-anchored) review comments - Kilo/CodeRabbit post most findings here:
    gh api repos/jaylfc/taOS/pulls/<PR#>/comments --jq \
      '.[] | {login: .user.login, path, line, body}'


### PR DESCRIPTION
Fixes 2 Kilo Code Review findings on PR #2000:

1. **WARNING (SKILL.md:194):** Corrected the claim that bot logins have NO `[bot]` suffix — reviews DO carry it (`kilo-code-bot[bot]`, `gitar-bot[bot]`), while issue comments may show logins without it. Updated the jq to handle both forms.

2. **SUGGESTION (SKILL.md:199):** Added null-safe `?.author.login?` with `.user.login?` fallback to the jq pipeline — prevents pipeline abort when a review/comment has a null author (deleted user). Also handles the reviews-vs-comments login field difference (.user.login vs .author.login).

Tests: n/a (docs-only change). Target base: docs/skill-refresh (original PR branch).