### PR TITLE
fix(invites): failed approve no longer burns the invite + scope validation at mint

### DIFF
--- a/tests/projects/test_invite_store.py
+++ b/tests/projects/test_invite_store.py
@@ -211,7 +211,9 @@ async def test_os_level_redeem_single_use(store):
     )
     iid = result["record"]["invite_id"]
     record = await store.redeem(iid, result["pin"])
-    assert record["status"] == "redeemed"
+    # After redeem the invite is claimed (not yet redeemed — the route flips
+    # claimed→redeemed via mark_redeemed after approve succeeds, #1993).
+    assert record["status"] == "claimed"
     assert record["project_id"] is None
     with pytest.raises(InviteAlreadyRedeemedError):
         await store.redeem(iid, result["pin"])
@@ -367,7 +369,9 @@ async def test_redeem_correct_pin_single_use(store):
     iid = result["record"]["invite_id"]
     pin = result["pin"]
     record = await store.redeem(iid, pin)
-    assert record["status"] == "redeemed"
+    # After redeem the invite is claimed (not yet redeemed — the route flips
+    # claimed→redeemed via mark_redeemed after approve succeeds, #1993).
+    assert record["status"] == "claimed"
     with pytest.raises(InviteAlreadyRedeemedError):
         await store.redeem(iid, pin)
 
@@ -457,3 +461,81 @@ async def test_boot_migration_adds_missing_column(tmp_path):
     # The display_name column is added by the boot migration for legacy DBs.
     assert row.get("display_name") is None
     await store.close()
+
+
+# ---------------------------------------------------------------------------
+# mark_redeemed + rollback_to_pending (issue #1993)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_redeemed_flips_claimed_to_redeemed(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    # Claim it
+    record = await store.redeem(iid, result["pin"])
+    assert record["status"] == "claimed"
+
+    # mark_redeemed should flip claimed → redeemed
+    await store.mark_redeemed(iid, "agent-x", "req-1")
+    row = await store.get(iid)
+    assert row["status"] == "redeemed"
+    assert row["redeemed_by"] == "agent-x"
+    assert row["redeemed_request_id"] == "req-1"
+
+
+@pytest.mark.asyncio
+async def test_rollback_to_pending_after_claim(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    # Claim it
+    record = await store.redeem(iid, result["pin"])
+    assert record["status"] == "claimed"
+
+    # Roll back — simulate approve failure
+    await store.rollback_to_pending(iid)
+    row = await store.get(iid)
+    assert row["status"] == "pending"
+
+    # Can redeem again (re-claim)
+    record2 = await store.redeem(iid, result["pin"])
+    assert record2["status"] == "claimed"
+
+
+@pytest.mark.asyncio
+async def test_rollback_only_touches_claimed(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=["a2a_send"],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    # Still pending — rollback should be a no-op, not revert anything else
+    await store.rollback_to_pending(iid)
+    row = await store.get(iid)
+    assert row["status"] == "pending"
+
+    # Claim and then mark as redeemed
+    await store.redeem(iid, result["pin"])
+    await store.mark_redeemed(iid, "agent-x", "req-1")
+    row = await store.get(iid)
+    assert row["status"] == "redeemed"
+
+    # Rollback on a redeemed invite is a no-op
+    await store.rollback_to_pending(iid)
+    row = await store.get(iid)
+    assert row["status"] == "redeemed"  # stays redeemed

--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -67,6 +67,30 @@ async def test_mint_11th_pending_returns_429(client, app):
 
 
 @pytest.mark.asyncio
+async def test_mint_rejects_unknown_scopes(client, app):
+    """Mint must reject scopes not in the closed vocabulary (#1993)."""
+    pid = await _create_project(client)
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": ["a2a_send", "garbage_scope"], "approval_mode": "auto"},
+    )
+    assert resp.status_code == 400, resp.text
+    data = resp.json()
+    assert "garbage_scope" in data["error"]
+
+
+@pytest.mark.asyncio
+async def test_mint_accepts_known_scopes(client, app):
+    """Known scopes that are not project-scoped should mint just fine."""
+    pid = await _create_project(client)
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": ["a2a_send", "memory_read"], "approval_mode": "auto"},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
 async def test_list_invites_excludes_pin_hash(client, app):
     pid = await _create_project(client)
     await client.post(

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -289,8 +289,12 @@ class ProjectInviteStore(BaseStore):
                 await self._db.commit()
             raise InvitePinError("invalid invite id or pin")
 
+        # Atomically claim the invite (pending→claimed) rather than immediately
+        # marking it redeemed.  The caller must flip claimed→redeemed on success
+        # or roll back to pending on failure so a failed approve does not burn
+        # the invite unrecoverably (issue #1993).
         cursor = await self._db.execute(
-            "UPDATE project_invites SET status = 'redeemed' WHERE invite_id = ? AND status = 'pending'",
+            "UPDATE project_invites SET status = 'claimed' WHERE invite_id = ? AND status = 'pending'",
             (invite_id,),
         )
         await self._db.commit()
@@ -303,19 +307,30 @@ class ProjectInviteStore(BaseStore):
     async def mark_redeemed(
         self, invite_id: str, redeemed_by: str, redeemed_request_id: str
     ) -> None:
-        """Record who/what redeemed an invite for audit (called by the redeem
-        route after the auth-request has been created/approved). Best-effort
-        from the caller's perspective; the status flip already happened in
+        """Record who/what redeemed an invite for audit and flip claimed→redeemed
+        (called by the redeem route after the auth-request has been created/approved).
+        Best-effort from the caller's perspective; the status flip already happened in
         ``redeem``."""
         if self._db is None:
             raise RuntimeError("ProjectInviteStore not initialised")
         await self._db.execute(
             """
             UPDATE project_invites
-               SET redeemed_by = ?, redeemed_request_id = ?
+               SET redeemed_by = ?, redeemed_request_id = ?, status = 'redeemed'
              WHERE invite_id = ?
             """,
             (redeemed_by, redeemed_request_id, invite_id),
+        )
+        await self._db.commit()
+
+    async def rollback_to_pending(self, invite_id: str) -> None:
+        """Roll back a claimed invite to pending so the caller can retry after a
+        failed approve (issue #1993).  Only touches invites in 'claimed' status."""
+        if self._db is None:
+            raise RuntimeError("ProjectInviteStore not initialised")
+        await self._db.execute(
+            "UPDATE project_invites SET status = 'pending' WHERE invite_id = ? AND status = 'claimed'",
+            (invite_id,),
         )
         await self._db.commit()
 

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -317,7 +317,7 @@ class ProjectInviteStore(BaseStore):
             """
             UPDATE project_invites
                SET redeemed_by = ?, redeemed_request_id = ?, status = 'redeemed'
-             WHERE invite_id = ?
+             WHERE invite_id = ? AND status = 'claimed'
             """,
             (redeemed_by, redeemed_request_id, invite_id),
         )

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -905,6 +905,10 @@ async def redeem_invite(request: Request, body: RedeemInviteIn):
             )
         except Exception as exc:  # noqa: BLE001 - surface as JSON error
             await store.rollback_to_pending(body.invite_id)
+            try:
+                await auth_store.set_decision(record['id'], 'refused', decided_by='system:invite-rollback')
+            except Exception:  # noqa: BLE001 - cleanup best-effort
+                pass
             return JSONResponse({"error": str(exc)}, status_code=400)
     else:
         # manual: leave pending so the consent bell fires (handled by
@@ -984,6 +988,10 @@ async def _redeem_os_level(request: Request, body: RedeemInviteIn, invite: dict,
             )
         except Exception as exc:  # noqa: BLE001 - surface as JSON error
             await store.rollback_to_pending(body.invite_id)
+            try:
+                await auth_store.set_decision(record['id'], 'refused', decided_by='system:invite-rollback')
+            except Exception:  # noqa: BLE001 - cleanup best-effort
+                pass
             return JSONResponse({"error": str(exc)}, status_code=400)
     else:
         _notify_pending_invite(request, record)

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -19,6 +19,7 @@ from tinyagentos.projects.invite_store import (
     InvitePendingCapError,
     InviteRevokedError,
 )
+from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -618,6 +619,14 @@ async def mint_invite(
     if project is None:
         return JSONResponse({"error": "project not found"}, status_code=404)
     require_owner_or_admin(user, project["user_id"])
+    # Reject unknown scopes at mint so an owner can never create an auto-invite
+    # whose scopes can never redeem successfully (issue #1993).
+    unknown = sorted(set(payload.scopes) - VALID_SCOPES)
+    if unknown:
+        return JSONResponse(
+            {"error": f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}"},
+            status_code=400,
+        )
     try:
         result = await store.mint(
             project_id=project_id,
@@ -710,6 +719,13 @@ async def mint_os_invite(
 ):
     _require_admin(user)
     store = request.app.state.project_invites
+    # Reject unknown scopes at mint (issue #1993).
+    unknown = sorted(set(payload.scopes) - VALID_SCOPES)
+    if unknown:
+        return JSONResponse(
+            {"error": f"unknown scopes: {unknown}; valid: {sorted(VALID_SCOPES)}"},
+            status_code=400,
+        )
     # OS-level invites carry no project, so drop any project-bound scopes rather
     # than granting them against a non-existent project (kilo review #1918).
     os_scopes = [s for s in payload.scopes if s not in _PROJECT_SCOPED]
@@ -876,6 +892,7 @@ async def redeem_invite(request: Request, body: RedeemInviteIn):
                 project_id=invite["project_id"],
             )
         except Exception as exc:  # noqa: BLE001 - surface as JSON error
+            await store.rollback_to_pending(body.invite_id)
             return JSONResponse({"error": str(exc)}, status_code=400)
     else:
         # manual: leave pending so the consent bell fires (handled by
@@ -954,6 +971,7 @@ async def _redeem_os_level(request: Request, body: RedeemInviteIn, invite: dict,
                 display_name=display_name,
             )
         except Exception as exc:  # noqa: BLE001 - surface as JSON error
+            await store.rollback_to_pending(body.invite_id)
             return JSONResponse({"error": str(exc)}, status_code=400)
     else:
         _notify_pending_invite(request, record)

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -729,6 +729,7 @@ async def mint_os_invite(
     # OS-level invites carry no project, so drop any project-bound scopes rather
     # than granting them against a non-existent project (kilo review #1918).
     os_scopes = [s for s in payload.scopes if s not in _PROJECT_SCOPED]
+    dropped = sorted(set(payload.scopes) & _PROJECT_SCOPED)
     try:
         result = await store.mint(
             project_id=None,
@@ -741,7 +742,7 @@ async def mint_os_invite(
     except InvitePendingCapError as exc:
         return JSONResponse({"error": str(exc)}, status_code=429)
     record = result["record"]
-    return {
+    response = {
         "invite_id": record["invite_id"],
         "pin": result["pin"],
         "expires_ts": record["expires_ts"],
@@ -750,6 +751,11 @@ async def mint_os_invite(
         "check_interval_secs": record["check_interval_secs"],
         "display_name": record["display_name"],
     }
+    if dropped:
+        response["warnings"] = [
+            f"project-scoped scopes dropped (OS invites cannot grant project access): {dropped}"
+        ]
+    return response
 
 
 @router.get("/api/agents/invites")
@@ -871,15 +877,21 @@ async def redeem_invite(request: Request, body: RedeemInviteIn):
     from tinyagentos.routes.agent_auth_requests import approve_request_record
 
     auth_store = request.app.state.auth_requests
-    record = await auth_store.create(
-        identity_claim=handle,
-        framework=body.harness,
-        requested_scopes=scopes,
-        requested_skills=None,
-        reason=f"invite {body.invite_id}",
-        duration_secs=None,
-        project_id=invite["project_id"],
-    )
+    try:
+        record = await auth_store.create(
+            identity_claim=handle,
+            framework=body.harness,
+            requested_scopes=scopes,
+            requested_skills=None,
+            reason=f"invite {body.invite_id}",
+            duration_secs=None,
+            project_id=invite["project_id"],
+        )
+    except Exception as exc:  # noqa: BLE001 - release claimed invite on auth failure
+        await store.rollback_to_pending(body.invite_id)
+        return JSONResponse(
+            {"error": f"failed to create auth request: {exc}"}, status_code=500
+        )
 
     if invite["approval_mode"] == "auto":
         try:


### PR DESCRIPTION
Task: t_587276ad. Fixes #1993.

Two bugs from the beta.41 pre-deploy audit:

### 1. Failed approve burns the invite (invite_store.py:292-298)

`redeem()` now atomically CASes `pending→claimed` instead of
`pending→redeemed`. The route layer flips `claimed→redeemed` via
`mark_redeemed()` after approve succeeds, and calls the new
`rollback_to_pending()` on approve failure — so a failed approve no longer
burns the invite unrecoverably.

### 2. Mint accepts unknown scopes

`mint_invite` and `mint_os_invite` now validate `payload.scopes` against
`VALID_SCOPES` before calling `store.mint()`, preventing creation of
auto-invites whose scopes can never redeem successfully.

### Files changed

- `tinyagentos/projects/invite_store.py` — claimed status, rollback, mark_redeemed update
- `tinyagentos/routes/project_invites.py` — scope validation + rollback on failure
- `tests/projects/test_invite_store.py` — 3 new tests (mark_redeemed, rollback, idempotent)
- `tests/test_routes_project_invites.py` — 2 new tests (reject unknown, accept known scopes)

All targeted tests pass. Canonical gate (`pytest --ignore=e2e -n auto`) running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invite redemption now supports a claim step before final redemption.
  * Failed approval attempts return invites to pending so they can be retried.
  * Added validation to prevent invites with unknown scopes.
  * Project-scoped scopes are removed from OS-level invites, with warnings shown when applicable.
* **Bug Fixes**
  * Improved error handling during invite approval, including appropriate refusal status updates.
  * Invite audit details are recorded only after successful redemption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->