### PR TITLE
feat(agents): collapse revoked/rejected/suspended registry entries by default (#1970)

### DIFF
--- a/desktop/src/apps/agents/RegistryPanel.test.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.test.tsx
@@ -337,7 +337,7 @@ describe("RegistryPanel collapsed retired", () => {
     // visibility)
     const retiredPanel = document.getElementById("retired-registry-panel");
     expect(retiredPanel).toBeInTheDocument();
-    expect(retiredPanel!.className).toContain("hidden");
+    expect(retiredPanel!).toHaveClass("hidden");
 
     // Revoked + suspended agents are IN the DOM but inside a hidden container
     expect(screen.getByText("RevokedAgent")).toBeInTheDocument();
@@ -350,6 +350,6 @@ describe("RegistryPanel collapsed retired", () => {
 
     // Retired toggle is now expanded, panel class loses "hidden"
     expect(retiredToggle).toHaveAttribute("aria-expanded", "true");
-    expect(retiredPanel!.className).not.toContain("hidden");
+    expect(retiredPanel!).not.toHaveClass("hidden");
   }, 10_000);
 });

--- a/desktop/src/apps/agents/RegistryPanel.test.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.test.tsx
@@ -273,3 +273,83 @@ describe("RegistryPanel polling", () => {
     expect(screen.getByText("taOSmd-dev")).toBeInTheDocument();
   });
 });
+
+/* ------------------------------------------------------------------ */
+/*  Collapse behaviour — retired agents                                */
+/* ------------------------------------------------------------------ */
+
+describe("RegistryPanel collapsed retired", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders retired section collapsed by default, expands on click, active agents always visible", async () => {
+    const entries: RegistryEntry[] = [
+      { ...fakeEntry, canonical_id: "active-1", display_name: "ActiveAgent", status: "active" },
+      { ...fakeEntry, canonical_id: "active-2", display_name: "ActiveTwo", status: "active" },
+      {
+        ...fakeEntry,
+        canonical_id: "revoked-1",
+        display_name: "RevokedAgent",
+        status: "revoked",
+      },
+      {
+        ...fakeEntry,
+        canonical_id: "suspended-1",
+        display_name: "SuspendedAgent",
+        status: "suspended",
+      },
+    ];
+    vi.stubGlobal("fetch", makeFetch(entries));
+
+    render(<RegistryPanel />);
+
+    // Expand the registry panel
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => {
+      toggle.click();
+    });
+
+    await waitFor(
+      () => {
+        // Active agents always visible
+        expect(screen.getByText("ActiveAgent")).toBeInTheDocument();
+        expect(screen.getByText("ActiveTwo")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    // Retired section is present
+    const retiredSection = screen.getByRole("region", {
+      name: "Retired registry entries",
+    });
+    expect(retiredSection).toBeInTheDocument();
+
+    // Retired toggle shows count and is collapsed
+    const retiredToggle = screen.getByRole("button", {
+      name: /retired \(2\)/i,
+    });
+    expect(retiredToggle).toBeInTheDocument();
+    expect(retiredToggle).toHaveAttribute("aria-expanded", "false");
+
+    // Retired panel is hidden (collapsed by default — jsdom does not compute
+    // Tailwind CSS visibility, so we assert on the class rather than element
+    // visibility)
+    const retiredPanel = document.getElementById("retired-registry-panel");
+    expect(retiredPanel).toBeInTheDocument();
+    expect(retiredPanel!.className).toContain("hidden");
+
+    // Revoked + suspended agents are IN the DOM but inside a hidden container
+    expect(screen.getByText("RevokedAgent")).toBeInTheDocument();
+    expect(screen.getByText("SuspendedAgent")).toBeInTheDocument();
+
+    // Click to expand retired section
+    await act(async () => {
+      retiredToggle.click();
+    });
+
+    // Retired toggle is now expanded, panel class loses "hidden"
+    expect(retiredToggle).toHaveAttribute("aria-expanded", "true");
+    expect(retiredPanel!.className).not.toContain("hidden");
+  }, 10_000);
+});

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -12,6 +12,7 @@ import {
   ScrollText,
   ArrowRight,
   UserPlus,
+  Archive,
 } from "lucide-react";
 import { Button, Card } from "@/components/ui";
 import { projectsApi } from "@/lib/projects";
@@ -753,6 +754,12 @@ export function RegistryPanel() {
   }
 
   const pendingCount = entries.filter((e) => e.status === "pending").length;
+  const activeEntries = entries.filter((e) => e.status === "active");
+  const pendingEntries = entries.filter((e) => e.status === "pending");
+  const retiredEntries = entries.filter(
+    (e) => e.status === "revoked" || e.status === "rejected" || e.status === "suspended",
+  );
+  const [retiredExpanded, setRetiredExpanded] = useState(false);
 
   return (
     <section className="mt-4" aria-label="Agent registry">
@@ -798,16 +805,54 @@ export function RegistryPanel() {
             No registered agents yet.
           </p>
         ) : (
-          entries.map((entry) => (
-            <RegistryEntryRow
-              key={entry.canonical_id}
-              entry={entry}
-              isAdmin={isAdmin}
-              currentUserId={currentUserId}
-              onAction={handleAction}
-              onAssign={setAssignEntry}
-            />
-          ))
+          <>
+            {/* Active + Pending: always visible, active first */}
+            {[...activeEntries, ...pendingEntries].map((entry) => (
+              <RegistryEntryRow
+                key={entry.canonical_id}
+                entry={entry}
+                isAdmin={isAdmin}
+                currentUserId={currentUserId}
+                onAction={handleAction}
+                onAssign={setAssignEntry}
+              />
+            ))}
+
+            {/* Retired: collapsed by default */}
+            {retiredEntries.length > 0 && (
+              <section className="mt-2" aria-label="Retired registry entries">
+                <button
+                  onClick={() => setRetiredExpanded((v) => !v)}
+                  className="flex items-center gap-2 text-xs text-shell-text-tertiary hover:text-shell-text-secondary transition-colors mb-2"
+                  aria-expanded={retiredExpanded}
+                  aria-controls="retired-registry-panel"
+                >
+                  <ChevronRight
+                    size={13}
+                    className={`transition-transform shrink-0 ${retiredExpanded ? "rotate-90" : ""}`}
+                    aria-hidden
+                  />
+                  <Archive size={12} aria-hidden />
+                  Retired ({retiredEntries.length})
+                </button>
+                <div
+                  id="retired-registry-panel"
+                  className={`space-y-2 ${retiredExpanded ? "" : "hidden"}`}
+                >
+                  {retiredEntries.map((entry) => (
+                    <RegistryEntryRow
+                      key={entry.canonical_id}
+                      entry={entry}
+                      isAdmin={isAdmin}
+                      currentUserId={currentUserId}
+                      onAction={handleAction}
+                      onAssign={setAssignEntry}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
+          </>
         )}
         <GovernanceAuditPanel isAdmin={isAdmin} />
       </div>

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -754,10 +754,17 @@ export function RegistryPanel() {
   }
 
   const pendingCount = entries.filter((e) => e.status === "pending").length;
-  const activeEntries = entries.filter((e) => e.status === "active");
-  const pendingEntries = entries.filter((e) => e.status === "pending");
+  // Anything not explicitly retired (revoked/rejected/suspended) is visible
+  // by default so future RegistryStatus values are never silently hidden.
   const retiredEntries = entries.filter(
     (e) => e.status === "revoked" || e.status === "rejected" || e.status === "suspended",
+  );
+  const knownVisibleEntries = entries.filter(
+    (e) => !retiredEntries.includes(e) && (e.status === "active" || e.status === "pending"),
+  );
+  // Catch-all for any RegistryStatus values not in the known groups above.
+  const otherEntries = entries.filter(
+    (e) => !retiredEntries.includes(e) && e.status !== "active" && e.status !== "pending",
   );
   const [retiredExpanded, setRetiredExpanded] = useState(false);
 
@@ -806,8 +813,8 @@ export function RegistryPanel() {
           </p>
         ) : (
           <>
-            {/* Active + Pending: always visible, active first */}
-            {[...activeEntries, ...pendingEntries].map((entry) => (
+            {/* Active + Pending: always visible */}
+            {knownVisibleEntries.map((entry) => (
               <RegistryEntryRow
                 key={entry.canonical_id}
                 entry={entry}
@@ -817,6 +824,28 @@ export function RegistryPanel() {
                 onAssign={setAssignEntry}
               />
             ))}
+
+            {/* Other: catch-all for unknown RegistryStatus values */}
+            {otherEntries.length > 0 && (
+              <section className="mt-2" aria-label="Other registry entries">
+                <div className="flex items-center gap-2 text-xs text-shell-text-tertiary mb-2">
+                  <Archive size={12} aria-hidden />
+                  Other ({otherEntries.length})
+                </div>
+                <div className="space-y-2">
+                  {otherEntries.map((entry) => (
+                    <RegistryEntryRow
+                      key={entry.canonical_id}
+                      entry={entry}
+                      isAdmin={isAdmin}
+                      currentUserId={currentUserId}
+                      onAction={handleAction}
+                      onAssign={setAssignEntry}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
 
             {/* Retired: collapsed by default */}
             {retiredEntries.length > 0 && (


### PR DESCRIPTION
## Summary

Issue #1970 quick-win: the Agents app's RegistryPanel now collapses revoked, rejected, and suspended registry entries into a collapsible "Retired (N)" section by default. Active and pending entries remain immediately visible, keeping the panel focused on what needs attention.

## Changes

- `desktop/src/apps/agents/RegistryPanel.tsx`: Split entries into active/pending (always visible) and retired (revoked/rejected/suspended) groups
- Added a collapsible "Retired" subsection that mirrors the existing ArchivvedAgentsPanel toggle pattern (ChevronRight + Archive icon, collapsed by default)
- Added `Archive` icon import from lucide-react

## Verification

- `npm run build` — TypeScript type-check and Vite production build pass cleanly
- `vitest run` — All 19 RegistryPanel tests + all 77 Agents app tests pass
- No backend changes — desktop-only

Closes #1970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorganized the Agent Registry UI into Active, Pending, and Retired sections.
  * Added a collapsible Retired section (revoked/rejected/suspended), which is collapsed by default.
  * Ensured Active and Pending entries are shown before Retired entries, with an “Other” grouping for the remaining statuses.
* **Tests**
  * Added coverage to verify Retired section default collapsed state and expand/collapse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->