### PR TITLE
fix(catalog): correct context_window for qwen2.5 rkllm models (32768 -> 4096)

### DIFF
--- a/app-catalog/models/pelochus-qwen-1.8b-rkllm/manifest.yaml
+++ b/app-catalog/models/pelochus-qwen-1.8b-rkllm/manifest.yaml
@@ -35,4 +35,4 @@ hardware_tiers:
     recommended: rkllm
   arm-npu-2gb:
     recommended: rkllm
-context_window: 32768
+context_window: 4096

--- a/app-catalog/models/qwen2.5-1.5b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b-rkllm/manifest.yaml
@@ -32,4 +32,4 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-2gb:
     recommended: w8a8
-context_window: 32768
+context_window: 4096

--- a/app-catalog/models/qwen2.5-14b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-14b-rkllm/manifest.yaml
@@ -33,4 +33,4 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-2gb:
     recommended: w8a8
-context_window: 32768
+context_window: 4096

--- a/app-catalog/models/qwen2.5-3b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-3b-rkllm/manifest.yaml
@@ -34,4 +34,4 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-2gb:
     recommended: w8a8
-context_window: 32768
+context_window: 4096

--- a/app-catalog/models/qwen2.5-7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-7b-rkllm/manifest.yaml
@@ -35,4 +35,4 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-2gb:
     recommended: w8a8
-context_window: 32768
+context_window: 4096

--- a/app-catalog/models/qwen2.5-coder-1.5b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-1.5b-rkllm/manifest.yaml
@@ -34,4 +34,4 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-2gb:
     recommended: w8a8
-context_window: 32768
+context_window: 4096

--- a/app-catalog/models/qwen2.5-coder-14b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-14b-rkllm/manifest.yaml
@@ -31,4 +31,4 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-2gb:
     recommended: w8a8
-context_window: 32768
+context_window: 4096

--- a/app-catalog/models/qwen2.5-coder-7b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-7b-rkllm/manifest.yaml
@@ -34,4 +34,4 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-2gb:
     recommended: w8a8
-context_window: 32768
+context_window: 4096

--- a/app-catalog/models/qwen3-4b-rkllm/manifest.yaml
+++ b/app-catalog/models/qwen3-4b-rkllm/manifest.yaml
@@ -33,4 +33,4 @@ hardware_tiers:
     recommended: w8a8
   arm-npu-2gb:
     recommended: w8a8
-context_window: 32768
+context_window: 4096


### PR DESCRIPTION
Task: t_920dfcfb. Fixes #1740.

## Problem
Nine qwen2.5/qwen3/pelochus-qwen rkllm model manifests declared `context_window: 32768`, but the rkllama backend caps text-only rkllm models at 4096 tokens. This mismatch caused `history_token_budget` to return 21744 tokens for history, sending oversized prompts that rkllama truncated. The truncation retained "residue" from previous agent task-template output, which the model then continued generating instead of responding to the user — the generation-loop reported in #1740.

## Fix
Change `context_window` from 32768 → 4096 in all 9 affected rkllm text model manifests (4 in commit 1, +5 in commit 2 per Kilo review):

- `qwen2.5-1.5b-rkllm`, `qwen2.5-3b-rkllm`, `qwen2.5-7b-rkllm`, `qwen2.5-coder-14b-rkllm`
- `qwen2.5-14b-rkllm`, `qwen2.5-coder-7b-rkllm`, `qwen2.5-coder-1.5b-rkllm`
- `qwen3-4b-rkllm`, `pelochus-qwen-1.8b-rkllm`

The `qwen2.5-math-*` manifests were already correct at 4096. VL models (qwen3-vl-*) have a higher cap (40960) from the quantizer and are unchanged.

## Impact
- `history_token_budget(4096)` = 512 (floored), preventing oversized prompts on all rkllm text models
- The small-context warning from #1744 now correctly fires for these models (< 8192)
- No code logic changes — pure manifest data fix

## Tests
All manifest/catalog tests pass: `test_real_catalog_is_clean` + full context_window test suite + chat_context_window tests.