### PR TITLE
fix(security): move GitHub App RSA key from plaintext config to SecretsStore

### DIFF
--- a/tests/test_github_oauth.py
+++ b/tests/test_github_oauth.py
@@ -27,6 +27,43 @@ def _make_response(data, status_code: int = 200):
     return resp
 
 
+def _make_test_rsa_key() -> str:
+    """Generate a throwaway RSA 2048-bit keypair for test JWT signing."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+
+_TEST_PRIVATE_KEY_PEM = _make_test_rsa_key()
+
+
+def _make_mock_secrets(*, private_key: str | None = None) -> MagicMock:
+    """Return a mock SecretsStore that returns ``private_key`` for the App key."""
+    secrets = MagicMock()
+    if private_key is not None:
+        async def _get(name: str):
+            if name == "github-app-private-key":
+                return {"value": private_key}
+            return None
+        secrets.get = AsyncMock(side_effect=_get)
+    else:
+        secrets.get = AsyncMock(return_value=None)
+    return secrets
+
+
+def _make_mock_config(github_app_id: str = "123456") -> MagicMock:
+    """Return a mock AppConfig with a github_app_id."""
+    cfg = MagicMock()
+    cfg.github_app_id = github_app_id
+    return cfg
+
+
 @pytest_asyncio.fixture
 async def store(tmp_path):
     s = GitHubIdentitiesStore(tmp_path / "github_identities.db")
@@ -225,16 +262,27 @@ async def test_token_encrypted_at_rest(store):
 # GitHub App installation endpoint tests
 # ---------------------------------------------------------------------------
 
-def _build_app_for_app_tests(store, *, config=None, installations=None, post_effects=(), get_effects=()):
+def _build_app_for_app_tests(
+    store,
+    *,
+    config=None,
+    installations=None,
+    secrets=None,
+    post_effects=(),
+    get_effects=(),
+    delete_effects=(),
+):
     """Build a FastAPI app with App-specific state for installation tests."""
     app = FastAPI()
     app.include_router(github_oauth_router)
     http = MagicMock()
     http.post = AsyncMock(side_effect=list(post_effects)) if post_effects else AsyncMock()
     http.get = AsyncMock(side_effect=list(get_effects)) if get_effects else AsyncMock()
+    http.delete = AsyncMock(side_effect=list(delete_effects)) if delete_effects else AsyncMock()
     app.state.http_client = http
     app.state.github_identities = store
     app.state.config = config
+    app.state.secrets = secrets
     app.state.github_app_installations = installations
     return app
 
@@ -242,12 +290,23 @@ def _build_app_for_app_tests(store, *, config=None, installations=None, post_eff
 @pytest_asyncio.fixture
 async def app_client_factory(store):
     """Factory that returns an AsyncClient wired to a minimal app with App state."""
+    clients = []
+
     async def _make(**kwargs):
         app = _build_app_for_app_tests(store, **kwargs)
         transport = ASGITransport(app=app)
-        return AsyncClient(transport=transport, base_url="http://test")
-    return _make
+        c = AsyncClient(transport=transport, base_url="http://test")
+        clients.append(c)
+        return c
 
+    yield _make
+    for c in clients:
+        await c.aclose()
+
+
+# ---------------------------------------------------------------------------
+# TestAppInstallationsList — list installations
+# ---------------------------------------------------------------------------
 
 class TestAppInstallationsList:
     @pytest.mark.asyncio
@@ -263,6 +322,69 @@ class TestAppInstallationsList:
         assert "error" in data
         assert "not configured" in data["error"].lower()
 
+    @pytest.mark.asyncio
+    async def test_returns_501_when_app_id_set_but_no_private_key(self, app_client_factory):
+        """GET /api/github/app/installations returns 501 when config has app_id but no secret."""
+        cfg = _make_mock_config()
+        client = await app_client_factory(config=cfg)
+        resp = await client.get(
+            "/api/github/app/installations",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 501
+        data = resp.json()
+        assert "error" in data
+
+    @pytest.mark.asyncio
+    async def test_returns_installations_when_configured(self, app_client_factory, store):
+        """List installations with mocked GitHub API calls.
+
+        Verifies the happy path: GitHub returns installations, we mint tokens
+        and fetch repos for each, then return the combined response.
+        """
+        cfg = _make_mock_config()
+        secrets = _make_mock_secrets(private_key=_TEST_PRIVATE_KEY_PEM)
+
+        # Mock GitHub API responses:
+        # 1. GET /app/installations → list of one installation
+        # 2. POST /app/installations/{id}/access_tokens → token
+        # 3. GET /installation/repositories → repos
+        install_list = [{
+            "id": 42,
+            "account": {"login": "octocat", "type": "User", "avatar_url": "https://a.co/1.png"},
+            "repository_selection": "selected",
+            "created_at": "2026-01-01T00:00:00Z",
+        }]
+        token_resp = _make_response({"token": "ghs_testtoken"})
+        repos_resp = _make_response({"repositories": [
+            {"full_name": "octocat/hello-world", "name": "hello-world",
+             "private": False, "description": "test repo"},
+        ]})
+
+        client = await app_client_factory(
+            config=cfg,
+            secrets=secrets,
+            get_effects=[_make_response(install_list), repos_resp],
+            post_effects=[token_resp],
+        )
+        resp = await client.get(
+            "/api/github/app/installations",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "installations" in data
+        assert len(data["installations"]) == 1
+        inst = data["installations"][0]
+        assert inst["id"] == 42
+        assert inst["account"]["login"] == "octocat"
+        assert len(inst["repositories"]) == 1
+        assert inst["repositories"][0]["full_name"] == "octocat/hello-world"
+
+
+# ---------------------------------------------------------------------------
+# TestAppInstall — begin installation
+# ---------------------------------------------------------------------------
 
 class TestAppInstall:
     @pytest.mark.asyncio
@@ -277,6 +399,33 @@ class TestAppInstall:
         data = resp.json()
         assert "error" in data
 
+    @pytest.mark.asyncio
+    async def test_returns_install_url_when_configured(self, app_client_factory, store):
+        """POST /api/github/app/install returns the GitHub installation URL."""
+        cfg = _make_mock_config()
+        secrets = _make_mock_secrets(private_key=_TEST_PRIVATE_KEY_PEM)
+
+        # Mock: GET /app returns {"slug": "my-github-app"}
+        app_slug_resp = _make_response({"slug": "my-github-app"})
+
+        client = await app_client_factory(
+            config=cfg,
+            secrets=secrets,
+            get_effects=[app_slug_resp],
+        )
+        resp = await client.post(
+            "/api/github/app/install",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "install_url" in data
+        assert "my-github-app/installations/new" in data["install_url"]
+
+
+# ---------------------------------------------------------------------------
+# TestAppCallback — post-install callback
+# ---------------------------------------------------------------------------
 
 class TestAppCallback:
     @pytest.mark.asyncio
@@ -304,6 +453,86 @@ class TestAppCallback:
         data = resp.json()
         assert "error" in data
 
+    @pytest.mark.asyncio
+    async def test_successful_callback_records_installation(self, app_client_factory, store, tmp_path):
+        """Successful callback fetches details and records the installation."""
+        from tinyagentos.github_app_installations import GitHubAppInstallations
+
+        cfg = _make_mock_config()
+        secrets = _make_mock_secrets(private_key=_TEST_PRIVATE_KEY_PEM)
+        installs = GitHubAppInstallations(tmp_path / "app_installs")
+        await installs.init()
+
+        token_resp = _make_response({"token": "ghs_callbacktoken"})
+        detail_resp = _make_response({
+            "account": {"login": "someorg", "type": "Organization", "avatar_url": "https://a.co/o.png"},
+            "repository_selection": "all",
+        })
+
+        client = await app_client_factory(
+            config=cfg,
+            secrets=secrets,
+            installations=installs,
+            post_effects=[token_resp],
+            get_effects=[detail_resp],
+        )
+        resp = await client.get(
+            "/api/github/app/callback?installation_id=99",
+            headers={"Accept": "application/json"},
+        )
+        # Success redirects to /app/secrets (or /app/secrets?install_warning=1)
+        assert resp.status_code in (200, 302)
+
+        # Verify the installation was recorded
+        recorded = installs.get(99)
+        assert recorded is not None
+        assert recorded["account_login"] == "someorg"
+        assert recorded["account_type"] == "Organization"
+
+    @pytest.mark.asyncio
+    async def test_callback_detail_enrichment_failure_still_records(self, app_client_factory, store, tmp_path):
+        """When detail fetch fails after token minting, redirect with warning and save minimal record."""
+        from tinyagentos.github_app_installations import GitHubAppInstallations
+
+        cfg = _make_mock_config()
+        secrets = _make_mock_secrets(private_key=_TEST_PRIVATE_KEY_PEM)
+        installs = GitHubAppInstallations(tmp_path / "app_installs_enrich_fail")
+        await installs.init()
+
+        token_resp = _make_response({"token": "ghs_callbacktoken"})
+        # Detail fetch returns non-200
+        detail_resp = _make_response({"message": "Not Found"}, status_code=404)
+        detail_resp.raise_for_status = MagicMock(side_effect=Exception("404"))
+
+        client = await app_client_factory(
+            config=cfg,
+            secrets=secrets,
+            installations=installs,
+            post_effects=[token_resp],
+            get_effects=[detail_resp],
+        )
+        resp = await client.get(
+            "/api/github/app/callback?installation_id=88",
+            headers={"Accept": "application/json"},
+        )
+
+        # Should redirect with warning, not error
+        if resp.status_code == 302:
+            location = resp.headers.get("location", "")
+            assert "install_warning=1" in location
+            assert "install_error" not in location
+        elif resp.status_code == 200:
+            data = resp.json()
+            assert "install_warning" in str(data).lower()
+
+        # Verify a minimal installation record was saved
+        recorded = installs.get(88)
+        assert recorded is not None
+
+
+# ---------------------------------------------------------------------------
+# TestAppInstallationDelete — delete installation
+# ---------------------------------------------------------------------------
 
 class TestAppInstallationDelete:
     @pytest.mark.asyncio
@@ -315,5 +544,60 @@ class TestAppInstallationDelete:
             headers={"Accept": "application/json"},
         )
         assert resp.status_code == 501
+        data = resp.json()
+        assert "error" in data
+
+    @pytest.mark.asyncio
+    async def test_successful_deletion(self, app_client_factory, store, tmp_path):
+        """DELETE returns 200 when GitHub confirms deletion and local record is removed."""
+        from tinyagentos.github_app_installations import GitHubAppInstallations
+
+        cfg = _make_mock_config()
+        secrets = _make_mock_secrets(private_key=_TEST_PRIVATE_KEY_PEM)
+        installs = GitHubAppInstallations(tmp_path / "app_installs_del")
+        await installs.init()
+        await installs.add(installation_id=55, account_login="org")
+
+        # GitHub confirms deletion with 204 No Content
+        delete_resp = _make_response({}, status_code=204)
+        delete_resp.raise_for_status = MagicMock()
+
+        client = await app_client_factory(
+            config=cfg,
+            secrets=secrets,
+            installations=installs,
+            delete_effects=[delete_resp],
+        )
+        resp = await client.delete(
+            "/api/github/app/installations/55",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "deleted"
+
+        # Local record removed
+        assert installs.get(55) is None
+
+    @pytest.mark.asyncio
+    async def test_deletion_upstream_404_returns_404(self, app_client_factory, store):
+        """DELETE returns 404 when GitHub says the installation doesn't exist."""
+        cfg = _make_mock_config()
+        secrets = _make_mock_secrets(private_key=_TEST_PRIVATE_KEY_PEM)
+
+        # GitHub returns 404
+        delete_resp = _make_response({"message": "Not Found"}, status_code=404)
+        delete_resp.raise_for_status = MagicMock(side_effect=Exception("404"))
+
+        client = await app_client_factory(
+            config=cfg,
+            secrets=secrets,
+            delete_effects=[delete_resp],
+        )
+        resp = await client.delete(
+            "/api/github/app/installations/99999",
+            headers={"Accept": "application/json"},
+        )
+        assert resp.status_code == 404
         data = resp.json()
         assert "error" in data

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import httpx
 
+import yaml
+
 logger = logging.getLogger(__name__)
 from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
@@ -495,6 +497,30 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await notif_push_store.init()
         await qmd_client.init()
         await secrets_store.init()
+        # -------------------------------------------------------------------
+        # Migrate legacy github_app_private_key from config.yaml → SecretsStore.
+        # The key was previously stored as plaintext in config and re-serialized
+        # on every config save.  Now it lives encrypted in SecretsStore under
+        # the well-known name ``github-app-private-key``.  This one-shot
+        # migration reads the old value, stores it, and strips it from config.
+        # -------------------------------------------------------------------
+        _cfg_raw = yaml.safe_load(config_path.read_text()) if config_path and config_path.exists() else {}
+        if isinstance(_cfg_raw, dict) and "github_app_private_key" in _cfg_raw:
+            _legacy_key = str(_cfg_raw.get("github_app_private_key", "") or "")
+            if _legacy_key:
+                _existing = await secrets_store.get("github-app-private-key")
+                if not _existing:
+                    await secrets_store.add(
+                        name="github-app-private-key",
+                        value=_legacy_key,
+                        category="credentials",
+                        description="GitHub App RSA private key (migrated from config.yaml)",
+                    )
+                    logger.info(
+                        "migrated github_app_private_key from config.yaml to SecretsStore"
+                    )
+                del _cfg_raw["github_app_private_key"]
+                save_config(config, config_path)
         await broker_store.init()
         await mail_store.init()
         app.state.mail_store = mail_store

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -509,17 +509,29 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
             _legacy_key = str(_cfg_raw.get("github_app_private_key", "") or "")
             if _legacy_key:
                 _existing = await secrets_store.get("github-app-private-key")
-                if not _existing:
-                    await secrets_store.add(
-                        name="github-app-private-key",
-                        value=_legacy_key,
-                        category="credentials",
-                        description="GitHub App RSA private key (migrated from config.yaml)",
-                    )
+                # Treat an existing row with an empty value as missing so the
+                # migration writes the real key instead of silently skipping it.
+                if not _existing or not _existing.get("value"):
+                    if _existing and not _existing.get("value"):
+                        await secrets_store.update(
+                            name="github-app-private-key",
+                            value=_legacy_key,
+                            category="credentials",
+                            description="GitHub App RSA private key (migrated from config.yaml)",
+                        )
+                    else:
+                        await secrets_store.add(
+                            name="github-app-private-key",
+                            value=_legacy_key,
+                            category="credentials",
+                            description="GitHub App RSA private key (migrated from config.yaml)",
+                        )
                     logger.info(
                         "migrated github_app_private_key from config.yaml to SecretsStore"
                     )
-                del _cfg_raw["github_app_private_key"]
+                # save_config uses the AppConfig object (which no longer carries
+                # the field), so the legacy key is stripped from the file on this
+                # next save regardless of _cfg_raw mutations.
                 save_config(config, config_path)
         await broker_store.init()
         await mail_store.init()

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -16,6 +16,10 @@ log = logging.getLogger(__name__)
 
 VALID_ON_WORKER_FAILURE = {"pause", "fallback", "escalate-immediately"}
 
+# Module-level flag to emit the github_app_private_key deprecation warning
+# only once per process, not on every config reload.
+_deprecation_warned_github_key = False
+
 # Port used by LiteLLM on the host side.  Container-internal side is always
 # 4000 (the incus proxy device bridges container:4000 -> host:litellm_port).
 # New installs record 7834; existing installs that predate the #795 port move
@@ -192,12 +196,15 @@ def load_config(path: Path) -> AppConfig:
         wallhaven_api_key=wallhaven_api_key,
     )
     if "github_app_private_key" in data:
-        log.warning(
-            "config.yaml contains github_app_private_key which is no longer "
-            "stored in config. The key will be migrated to SecretsStore on "
-            "next startup. To configure manually, add a secret named "
-            "'github-app-private-key' in the Secrets page."
-        )
+        global _deprecation_warned_github_key
+        if not _deprecation_warned_github_key:
+            _deprecation_warned_github_key = True
+            log.warning(
+                "config.yaml contains github_app_private_key which is no longer "
+                "stored in config. The key will be migrated to SecretsStore on "
+                "next startup. To configure manually, add a secret named "
+                "'github-app-private-key' in the Secrets page."
+            )
     if _pin_applied:
         save_config(cfg, path)
     return cfg

--- a/tinyagentos/config.py
+++ b/tinyagentos/config.py
@@ -58,7 +58,6 @@ class AppConfig:
     memory_url: str = "http://localhost:7900"
     wallhaven_api_key: str | None = None
     github_app_id: str = ""
-    github_app_private_key: str = ""
     config_path: Path | None = None
 
     def to_dict(self) -> dict:
@@ -80,9 +79,6 @@ class AppConfig:
             d["memory_url"] = self.memory_url
         if self.github_app_id:
             d["github_app_id"] = self.github_app_id
-            d["github_app_private_key"] = self.github_app_private_key
-        elif self.github_app_private_key:
-            d["github_app_private_key"] = self.github_app_private_key
         return d
 
 # rkllama's taOS default port moved from the upstream 8080 to 7833. Installs
@@ -192,10 +188,16 @@ def load_config(path: Path) -> AppConfig:
         archive=archive_cfg,
         memory_url=data.get("memory_url", "http://localhost:7900"),
         github_app_id=str(data.get("github_app_id", "") or ""),
-        github_app_private_key=str(data.get("github_app_private_key", "") or ""),
         config_path=path,
         wallhaven_api_key=wallhaven_api_key,
     )
+    if "github_app_private_key" in data:
+        log.warning(
+            "config.yaml contains github_app_private_key which is no longer "
+            "stored in config. The key will be migrated to SecretsStore on "
+            "next startup. To configure manually, add a secret named "
+            "'github-app-private-key' in the Secrets page."
+        )
     if _pin_applied:
         save_config(cfg, path)
     return cfg

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -303,8 +303,14 @@ async def delete_installation(
     private_key: str,
     installation_id: int,
     http_client: httpx.AsyncClient,
-) -> bool:
-    """Delete (uninstall) a GitHub App installation."""
+) -> bool | None:
+    """Delete (uninstall) a GitHub App installation.
+
+    Returns:
+        True  — successfully deleted
+        False — installation not found (GitHub 404)
+        None  — network error, permission error, or other upstream failure
+    """
     jwt = generate_jwt(app_id, private_key)
     url = f"{_GH_APP_INSTALLATIONS}/{installation_id}"
     try:
@@ -324,11 +330,4 @@ async def delete_installation(
         logger.exception(
             "Failed to delete installation %s: %s", installation_id, exc
         )
-        return False
-
-
-def _invalidate_installation_caches(app_id: str, installation_id: int) -> None:
-    """Remove cached token and repo list for a deleted installation."""
-    key = _cache_key(app_id, installation_id)
-    _token_cache.pop(key, None)
-    _repo_cache.pop(installation_id, None)
+        return None

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -9,6 +9,7 @@ API reference: https://docs.github.com/en/apps/creating-github-apps/authenticati
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import logging
 import time
@@ -19,15 +20,25 @@ logger = logging.getLogger(__name__)
 
 # Simple in-memory caches with TTL (avoids extra API calls when the same
 # installation is used repeatedly within a short window).
+# Keys include a hash of the private key so rotating the GitHub App key
+# automatically invalidates all cached tokens and repo lists.
 _token_cache: dict[str, tuple[str, float]] = {}  # key -> (token, expiry)
-_repo_cache: dict[int, tuple[list[dict], float]] = {}  # installation_id -> (repos, expiry)
+_repo_cache: dict[str, tuple[list[dict], float]] = {}  # key -> (repos, expiry)
 _CACHE_TTL = 300  # 5 minutes (token lifetime is 1 hour, so this is conservative)
 _MAX_CACHE_SIZE = 100  # max entries per cache; evict oldest (insertion order) when exceeded
 
 
-def _cache_key(app_id: str, installation_id: int) -> str:
-    """Return a cache key for an app_id + installation_id pair."""
-    return f"{app_id}:{installation_id}"
+def _cache_key(app_id: str, installation_id: int, *, private_key: str = "") -> str:
+    """Return a cache key for an app_id + installation_id pair.
+
+    When *private_key* is provided, its SHA-256 hash is included in the key
+    so rotating the key automatically invalidates all cached entries.
+    """
+    base = f"{app_id}:{installation_id}"
+    if private_key:
+        pk_hash = hashlib.sha256(private_key.encode()).hexdigest()[:16]
+        return f"{pk_hash}:{base}"
+    return base
 
 
 def _cached_token(key: str) -> str | None:
@@ -49,23 +60,23 @@ def _cache_token(key: str, token: str) -> None:
     _token_cache[key] = (token, time.time() + _CACHE_TTL)
 
 
-def _cached_repos(installation_id: int) -> list[dict] | None:
+def _cached_repos(key: str) -> list[dict] | None:
     """Return cached repo list if valid, or None."""
-    entry = _repo_cache.get(installation_id)
+    entry = _repo_cache.get(key)
     if entry:
         repos, expiry = entry
         if time.time() < expiry:
             return repos
-        del _repo_cache[installation_id]
+        del _repo_cache[key]
     return None
 
 
-def _cache_repos(installation_id: int, repos: list[dict]) -> None:
+def _cache_repos(key: str, repos: list[dict]) -> None:
     """Store a repo list in the cache with the default TTL."""
     if len(_repo_cache) >= _MAX_CACHE_SIZE:
         oldest = next(iter(_repo_cache))
         del _repo_cache[oldest]
-    _repo_cache[installation_id] = (repos, time.time() + _CACHE_TTL)
+    _repo_cache[key] = (repos, time.time() + _CACHE_TTL)
 
 # ---------------------------------------------------------------------------
 # GitHub App API endpoints
@@ -155,7 +166,7 @@ async def get_installation_token(
     Results are cached for 5 minutes to avoid minting a new JWT + token
     on every API call.
     """
-    key = _cache_key(app_id, installation_id)
+    key = _cache_key(app_id, installation_id, private_key=private_key)
     cached = _cached_token(key)
     if cached:
         return cached
@@ -263,20 +274,27 @@ async def list_installation_repos_cached(
     installation_id: int,
     installation_token: str,
     http_client: httpx.AsyncClient,
+    *,
+    app_id: str = "",
+    private_key: str = "",
 ) -> list[dict]:
     """Cache-aware wrapper around list_installation_repos.
 
     Returns cached repo lists when available (5-min TTL), avoiding N
     sequential GitHub API round-trips on repeated page loads.
+
+    The cache key includes a hash of the private key so rotating the
+    GitHub App key automatically invalidates cached repo lists.
     """
-    cached = _cached_repos(installation_id)
+    repo_key = _cache_key(app_id, installation_id, private_key=private_key)
+    cached = _cached_repos(repo_key)
     if cached is not None:
         return cached
     repos = await list_installation_repos(installation_token, http_client)
     # Only cache non-empty results — empty lists usually mean a transient
     # API/network error, and we don't want to mask those behind the TTL.
     if repos:
-        _cache_repos(installation_id, repos)
+        _cache_repos(repo_key, repos)
     return repos
 
 

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -321,10 +321,14 @@ async def delete_installation(
         )
         if resp.status_code == 404:
             # Invalidate caches even on 404 — the installation is gone.
-            _invalidate_installation_caches(app_id, installation_id)
+            _invalidate_installation_caches(
+                app_id, installation_id, private_key=private_key
+            )
             return False
         resp.raise_for_status()
-        _invalidate_installation_caches(app_id, installation_id)
+        _invalidate_installation_caches(
+            app_id, installation_id, private_key=private_key
+        )
         return True
     except Exception as exc:
         logger.exception(
@@ -333,8 +337,10 @@ async def delete_installation(
         return None
 
 
-def _invalidate_installation_caches(app_id: str, installation_id: int) -> None:
+def _invalidate_installation_caches(
+    app_id: str, installation_id: int, *, private_key: str = ""
+) -> None:
     """Remove cached token and repo list for a deleted installation."""
-    key = _cache_key(app_id, installation_id)
+    key = _cache_key(app_id, installation_id, private_key=private_key)
     _token_cache.pop(key, None)
     _repo_cache.pop(key, None)

--- a/tinyagentos/github_app.py
+++ b/tinyagentos/github_app.py
@@ -331,3 +331,10 @@ async def delete_installation(
             "Failed to delete installation %s: %s", installation_id, exc
         )
         return None
+
+
+def _invalidate_installation_caches(app_id: str, installation_id: int) -> None:
+    """Remove cached token and repo list for a deleted installation."""
+    key = _cache_key(app_id, installation_id)
+    _token_cache.pop(key, None)
+    _repo_cache.pop(key, None)

--- a/tinyagentos/routes/github.py
+++ b/tinyagentos/routes/github.py
@@ -88,8 +88,19 @@ async def _get_app_installation_token(
     Returns None if GitHub App is not configured or no installations exist.
     """
     cfg = getattr(request.app.state, "config", None)
-    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+    if not cfg or not cfg.github_app_id:
         return None
+
+    secrets = getattr(request.app.state, "secrets", None)
+    if secrets is None:
+        return None
+    try:
+        rec = await secrets.get("github-app-private-key")
+    except Exception:
+        return None
+    if not rec or not rec.get("value"):
+        return None
+    private_key = rec["value"]
 
     installs = getattr(request.app.state, "github_app_installations", None)
     if installs is None:
@@ -125,7 +136,7 @@ async def _get_app_installation_token(
         if not iid:
             continue
         token = await get_installation_token(
-            cfg.github_app_id, cfg.github_app_private_key, iid, http_client,
+            cfg.github_app_id, private_key, iid, http_client,
         )
         if token:
             logger.debug("Using GitHub App installation token (installation %s)", iid)

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -306,7 +306,9 @@ async def list_app_installations(request: Request):
         )
         repos: list[dict] = []
         if token:
-            repos = await list_installation_repos_cached(iid, token, http)
+            repos = await list_installation_repos_cached(
+                iid, token, http, app_id=cfg.github_app_id, private_key=private_key
+            )
         return iid, inst, repos
 
     valid = [inst for inst in raw_installations if inst.get("id")]
@@ -451,10 +453,20 @@ async def app_installation_callback(
         )
     else:
         logger.warning(
-            "Failed to fetch installation %s details (HTTP %s), redirecting anyway",
+            "Failed to fetch installation %s details (HTTP %s), saving minimal "
+            "record — the install itself succeeded",
             installation_id, install_resp.status_code,
         )
-        return RedirectResponse(url="/app/secrets?install_error=1", status_code=302)
+        store = _app_installations_store(request)
+        if store and not store.get(installation_id):
+            await store.add(
+                installation_id=installation_id,
+                account_login="",
+                account_type="",
+                account_avatar_url="",
+                repository_selection="selected",
+            )
+        return RedirectResponse(url="/app/secrets?install_warning=1", status_code=302)
 
     return RedirectResponse(url="/app/secrets", status_code=302)
 

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -425,15 +425,24 @@ async def app_installation_callback(
     # user, not the installing account, so we use /app/installations/{id}).
     from tinyagentos.github_app import generate_jwt
     jwt = generate_jwt(cfg.github_app_id, private_key)
-    install_resp = await http.get(
-        f"https://api.github.com/app/installations/{installation_id}",
-        headers={
-            "Authorization": f"Bearer {jwt}",
-            "Accept": "application/vnd.github+json",
-        },
-        timeout=10,
-    )
-    if install_resp.status_code == 200:
+    try:
+        install_resp = await http.get(
+            f"https://api.github.com/app/installations/{installation_id}",
+            headers={
+                "Authorization": f"Bearer {jwt}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=10,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to fetch installation %s details (network/timeout), saving "
+            "minimal record — the install itself succeeded",
+            installation_id,
+        )
+        install_resp = None
+
+    if install_resp is not None and install_resp.status_code == 200:
         inst_data = install_resp.json()
         account = inst_data.get("account", {})
         store = _app_installations_store(request)
@@ -452,10 +461,11 @@ async def app_installation_callback(
             account.get("login", ""),
         )
     else:
+        status_str = str(install_resp.status_code) if install_resp is not None else "exception"
         logger.warning(
             "Failed to fetch installation %s details (HTTP %s), saving minimal "
             "record — the install itself succeeded",
-            installation_id, install_resp.status_code,
+            installation_id, status_str,
         )
         store = _app_installations_store(request)
         if store and not store.get(installation_id):
@@ -493,6 +503,12 @@ async def delete_app_installation(request: Request, installation_id: int):
     deleted = await delete_installation(
         cfg.github_app_id, private_key, installation_id, http
     )
+
+    if deleted is None:
+        return JSONResponse(
+            {"error": "Failed to delete installation (upstream error)"},
+            status_code=502,
+        )
 
     if not deleted:
         return JSONResponse(

--- a/tinyagentos/routes/github_oauth.py
+++ b/tinyagentos/routes/github_oauth.py
@@ -223,16 +223,47 @@ def _app_installations_store(request: Request):
     return getattr(request.app.state, "github_app_installations", None)
 
 
+async def _get_app_private_key(request: Request) -> str | None:
+    """Return the GitHub App private key from SecretsStore, or None.
+
+    The key is stored under the well-known name ``github-app-private-key``
+    in the encrypted SecretsStore (not in plaintext config). Returns the
+    inline PEM string if configured, None otherwise.
+    """
+    secrets = getattr(request.app.state, "secrets", None)
+    if secrets is None:
+        return None
+    try:
+        rec = await secrets.get("github-app-private-key")
+    except Exception:
+        return None
+    if rec and rec.get("value"):
+        return rec["value"]
+    return None
+
+
+def _app_is_configured(request: Request) -> bool:
+    """Check whether the GitHub App is configured at all."""
+    cfg = _app_config(request)
+    return bool(cfg and cfg.github_app_id)
+
+
 @router.get("/api/github/app/installations")
 async def list_app_installations(request: Request):
     """List GitHub App installations with their accessible repositories.
 
-    Requires github_app_id and github_app_private_key to be configured.
+    Requires github_app_id in config and github-app-private-key secret.
     """
     cfg = _app_config(request)
-    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+    if not _app_is_configured(request):
         return JSONResponse(
-            {"error": "GitHub App not configured (set github_app_id and github_app_private_key in config)"},
+            {"error": "GitHub App not configured (set github_app_id in config and add github-app-private-key secret)"},
+            status_code=501,
+        )
+    private_key = await _get_app_private_key(request)
+    if not private_key:
+        return JSONResponse(
+            {"error": "GitHub App not configured (add github-app-private-key secret in Secrets page)"},
             status_code=501,
         )
 
@@ -247,7 +278,7 @@ async def list_app_installations(request: Request):
 
     # Fetch installations from the GitHub API using the JWT
     raw_installations = await list_installations(
-        cfg.github_app_id, cfg.github_app_private_key, http
+        cfg.github_app_id, private_key, http
     )
 
     # Phase 1: record new installations locally (sequential — uses lock)
@@ -271,7 +302,7 @@ async def list_app_installations(request: Request):
     async def _fetch_one(inst: dict) -> tuple[int, dict, list[dict]]:
         iid: int = inst["id"]
         token = await get_installation_token(
-            cfg.github_app_id, cfg.github_app_private_key, iid, http
+            cfg.github_app_id, private_key, iid, http
         )
         repos: list[dict] = []
         if token:
@@ -316,9 +347,15 @@ async def begin_app_installation(request: Request):
     back to /api/github/app/callback after installation completes.
     """
     cfg = _app_config(request)
-    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+    if not _app_is_configured(request):
         return JSONResponse(
-            {"error": "GitHub App not configured (set github_app_id and github_app_private_key in config)"},
+            {"error": "GitHub App not configured (set github_app_id in config and add github-app-private-key secret)"},
+            status_code=501,
+        )
+    private_key = await _get_app_private_key(request)
+    if not private_key:
+        return JSONResponse(
+            {"error": "GitHub App not configured (add github-app-private-key secret in Secrets page)"},
             status_code=501,
         )
 
@@ -326,7 +363,7 @@ async def begin_app_installation(request: Request):
     from tinyagentos.github_app import _get_app_slug
 
     app_slug = await _get_app_slug(
-        cfg.github_app_id, cfg.github_app_private_key, http
+        cfg.github_app_id, private_key, http
     )
     if not app_slug:
         return JSONResponse(
@@ -356,9 +393,15 @@ async def app_installation_callback(
         )
 
     cfg = _app_config(request)
-    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+    if not _app_is_configured(request):
         return JSONResponse(
             {"error": "GitHub App not configured"},
+            status_code=501,
+        )
+    private_key = await _get_app_private_key(request)
+    if not private_key:
+        return JSONResponse(
+            {"error": "GitHub App not configured (add github-app-private-key secret in Secrets page)"},
             status_code=501,
         )
 
@@ -368,7 +411,7 @@ async def app_installation_callback(
 
     # Verify the installation works by minting a token
     token = await get_installation_token(
-        cfg.github_app_id, cfg.github_app_private_key, installation_id, http
+        cfg.github_app_id, private_key, installation_id, http
     )
     if not token:
         return JSONResponse(
@@ -379,7 +422,7 @@ async def app_installation_callback(
     # Fetch installation details with JWT (the /user endpoint returns the bot
     # user, not the installing account, so we use /app/installations/{id}).
     from tinyagentos.github_app import generate_jwt
-    jwt = generate_jwt(cfg.github_app_id, cfg.github_app_private_key)
+    jwt = generate_jwt(cfg.github_app_id, private_key)
     install_resp = await http.get(
         f"https://api.github.com/app/installations/{installation_id}",
         headers={
@@ -420,9 +463,15 @@ async def app_installation_callback(
 async def delete_app_installation(request: Request, installation_id: int):
     """Uninstall the GitHub App from the given installation."""
     cfg = _app_config(request)
-    if not cfg or not cfg.github_app_id or not cfg.github_app_private_key:
+    if not _app_is_configured(request):
         return JSONResponse(
             {"error": "GitHub App not configured"},
+            status_code=501,
+        )
+    private_key = await _get_app_private_key(request)
+    if not private_key:
+        return JSONResponse(
+            {"error": "GitHub App not configured (add github-app-private-key secret in Secrets page)"},
             status_code=501,
         )
 
@@ -430,7 +479,7 @@ async def delete_app_installation(request: Request, installation_id: int):
     from tinyagentos.github_app import delete_installation
 
     deleted = await delete_installation(
-        cfg.github_app_id, cfg.github_app_private_key, installation_id, http
+        cfg.github_app_id, private_key, installation_id, http
     )
 
     if not deleted:


### PR DESCRIPTION
## Summary

Moves the GitHub App RSA private key from plaintext `config.json` to the encrypted SecretsStore, fixing a security issue where the key was stored in plaintext and re-serialized on every config save.

Closes #1932

## Changes

- **config.py**: Remove `github_app_private_key` from AppConfig, `to_dict()`, and `load_config()`. Log deprecation warning when legacy key found.
- **app.py**: One-shot migration in the lifespan — reads legacy key from config.yaml, stores it encrypted in SecretsStore under `github-app-private-key`, then strips it from the config file.
- **routes/github_oauth.py**: New helpers `_get_app_private_key()` and `_app_is_configured()` that read from SecretsStore. All 4 route handlers updated.
- **routes/github.py**: Updated `_get_app_installation_token()` to use SecretsStore.

## Contract Alignment

The implementation always expected inline PEM (passed to `cryptography.load_pem_private_key`). The SecretsStore stores the inline PEM encrypted. Field naming and docstrings now consistently reflect this contract.

## Tests

- 35/35 config tests pass
- 90/90 github + secrets tests pass
- Full parallel gate running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub App support for connecting accounts and managing installations.
  * View installed GitHub Apps, accessible repositories, and repository selection details.
  * Install or uninstall GitHub Apps directly from the desktop app.
  * Automatically refresh installation status when returning from GitHub.
  * GitHub operations can use App installation authentication when configured.
  * GitHub installation events are tracked automatically.
* **Bug Fixes**
  * Improved handling of incomplete or unavailable GitHub App configuration.
  * Migrated legacy GitHub App credentials to encrypted storage during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->