### PR TITLE
feat(agent-registry): grant @taOS-dev project_tasks/canvas scopes on prj-5y722y (#1968 C1)

### DIFF
--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -330,7 +330,25 @@ class TestMintInternalRoute:
         for s in seeded:
             assert s["created"] is True
             assert s["token"]
-            assert set(s["scopes"]) == {"a2a_send", "a2a_receive"}
+            if s["handle"] == "@taOS-dev":
+                # Lead curator: gets project_tasks + canvas on prj-5y722y
+                # in addition to the baseline a2a scopes (#1968 C1).
+                assert set(s["scopes"]) == {
+                    "a2a_send", "a2a_receive",
+                    "project_tasks", "canvas_read", "canvas_write",
+                }
+                # Grants should be project-scoped.
+                grants = await mint_client._app.state.agent_grants.list_grants(
+                    s["canonical_id"]
+                )
+                for g in grants:
+                    if g["scope"] in ("project_tasks", "canvas_read", "canvas_write"):
+                        assert g.get("project_id") == "prj-5y722y", (
+                            f"scope {g['scope']!r} not bound to prj-5y722y"
+                        )
+            else:
+                # Baseline agents: only a2a comms.
+                assert set(s["scopes"]) == {"a2a_send", "a2a_receive"}
 
         # Re-run: no duplicate rows, all created=False.
         r2 = await mint_client.post("/api/agents/registry/seed-internal")

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -167,11 +167,24 @@ _mint_lock = asyncio.Lock()
 # come up active without a consent round-trip.
 _INTERNAL_ORIGIN = "taos-internal"
 
-# The four internal driver agents and the scopes they need to read/write the
-# coordination bus.  seed-internal mints all four idempotently by handle.
+# Baseline scopes every internal driver agent needs to read/write the
+# coordination bus.  Individual agents may carry additional per-agent scopes
+# (and optional project binding) for their specific roles.
 _INTERNAL_AGENT_SCOPES = ["a2a_send", "a2a_receive"]
 _INTERNAL_AGENTS = (
-    {"handle": "@taOS-dev", "slug": "taos-dev"},
+    {
+        "handle": "@taOS-dev",
+        "slug": "taos-dev",
+        # Lead curator: needs project-task + canvas access on the build fleet project
+        # so it can curate the board (mark cards claimable) and read/write the
+        # project canvas — all via Bearer auth (CSRF-exempt).  Bound to prj-5y722y
+        # (the fleet project) per #1968 C1.
+        "scopes": [
+            "a2a_send", "a2a_receive",
+            "project_tasks", "canvas_read", "canvas_write",
+        ],
+        "project_id": "prj-5y722y",
+    },
     {"handle": "@taOS-website-dev", "slug": "taos-website-dev"},
     {"handle": "@taOSmd-dev", "slug": "taosmd-dev"},
     {"handle": "@Hermes", "slug": "hermes"},
@@ -417,13 +430,16 @@ async def seed_internal_agents(
         )
     seeded = []
     for spec in _INTERNAL_AGENTS:
+        scopes = spec.get("scopes") or list(_INTERNAL_AGENT_SCOPES)
+        project_id = spec.get("project_id")
         seeded.append(
             await _mint_internal_identity(
                 request,
                 user,
                 handle=spec["handle"],
                 slug=spec["slug"],
-                scopes=list(_INTERNAL_AGENT_SCOPES),
+                scopes=scopes,
+                project_id=project_id,
                 adopt=spec["handle"] in adopt_handles,
             )
         )


### PR DESCRIPTION
Task: t_0957c44a. Fixes #1968 (C1 — foundation slice).

## What this does

Grants the lead curator agent (@taOS-dev) per-agent scopes beyond the baseline
a2a_send/a2a_receive that all four internal agents share:

- `project_tasks` — curate the board (mark cards claimable)
- `canvas_read` / `canvas_write` — read/write the project canvas
- All bound to `prj-5y722y` (the build fleet project)

The seed-internal endpoint now reads per-agent scopes and optional project_id
from `_INTERNAL_AGENTS`, falling back to `_INTERNAL_AGENT_SCOPES` when a
spec omits them. The other three agents (@taOS-website-dev, @taOSmd-dev,
@Hermes) keep their baseline a2a-only scopes with no project binding.

This lets @taOS-dev authenticate independently via Bearer registry JWT
(CSRF-exempt) — no more shared board client config.

## Changes

- `tinyagentos/routes/agent_registry.py`: per-agent scopes + project_id in
  `_INTERNAL_AGENTS`; `seed_internal_agents` reads per-agent fields
- `tests/test_agent_internal_mint.py`: verifies @taOS-dev's expanded scopes
  and project binding, baseline scopes for other agents

## Tests

19/19 internal mint tests pass (local). Full CI matrix runs on push.
