### PR TITLE
feat(contacts): contacts_store + peer_links + signed-envelope peer channel

### DIFF
--- a/tests/test_contacts_peer.py
+++ b/tests/test_contacts_peer.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import os
 import time
 from pathlib import Path
 
@@ -453,7 +452,7 @@ class TestPeerTokens:
 
 
 @pytest_asyncio.fixture
-async def app_with_contacts(tmp_data_dir):
+async def app_with_contacts(tmp_data_dir, monkeypatch):
     """Create an app, initialise contacts_store, and bootstrap a local hub identity."""
     from tinyagentos.app import create_app
 
@@ -467,7 +466,7 @@ async def app_with_contacts(tmp_data_dir):
 
     # Bootstrap a hub identity so resolve_local_identity_id() works in tests.
     # Must set TAOS_DATA_DIR so hub.identity module resolves to tmp_data_dir.
-    os.environ["TAOS_DATA_DIR"] = str(tmp_data_dir)
+    monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_data_dir))
     _ensure_hub_identity(tmp_data_dir)
 
     return _app

--- a/tests/test_contacts_peer.py
+++ b/tests/test_contacts_peer.py
@@ -14,8 +14,6 @@ from tinyagentos.peer import (
     verify_envelope,
     verify_envelope_signature,
     mint_peer_token,
-    verify_peer_token,
-    hash_peer_token,
 )
 
 
@@ -356,24 +354,17 @@ class TestPeerTokens:
         token, token_hash = mint_peer_token("contact:hogne")
         assert len(token) == 64  # 32 bytes hex
         assert len(token_hash) == 64  # SHA-256 hex
-        assert token_hash != _hash_token(token)  # sub: prefix makes it different
+        # mint_peer_token and _hash_token now use the same plain SHA-256.
+        assert token_hash == _hash_token(token)
 
-    def test_hash_peer_token_deterministic(self):
+    def test_token_hash_deterministic(self):
         token = generate_peer_token()
-        assert hash_peer_token(token) == hash_peer_token(token)
+        assert _hash_token(token) == _hash_token(token)
 
-    def test_verify_peer_token_matches(self):
-        token = generate_peer_token()
-        stored = hash_peer_token(token)
-        assert verify_peer_token(token, stored)
-
-    def test_verify_peer_token_rejects_wrong(self):
-        stored = hash_peer_token(generate_peer_token())
-        assert not verify_peer_token("wrong-token", stored)
-
-    def test_verify_peer_token_rejects_empty(self):
-        stored = hash_peer_token(generate_peer_token())
-        assert not verify_peer_token("", stored)
+    def test_token_hash_different_tokens(self):
+        t1 = generate_peer_token()
+        t2 = generate_peer_token()
+        assert _hash_token(t1) != _hash_token(t2)
 
     def test_mint_peer_token_unique(self):
         t1, _ = mint_peer_token("contact:a")
@@ -518,6 +509,47 @@ class TestPeerRoutes:
             headers={"Authorization": f"Bearer {inbound}"},
         )
         assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
+
+    async def test_inbox_nonce_replay(self, client_with_contacts, app_with_contacts):
+        """Replaying an envelope with the same nonce must return 409."""
+        from tinyagentos.peer import build_envelope
+
+        store = app_with_contacts.state.contacts_store
+        await store.add_contact(
+            contact_id="hub:nonce-test", hub_username="nonce-test", display_name="N",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:nonce-test",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="nonce-test",
+            kind="handshake",
+        )
+
+        headers = {"Authorization": f"Bearer {inbound}"}
+
+        # First delivery — should succeed (200 or 400 depending on sig check;
+        # the key point is it's not 409).
+        resp1 = await client_with_contacts.post(
+            "/api/peer/inbox",
+            json={"envelope": env},
+            headers=headers,
+        )
+        assert resp1.status_code != 409, f"first send should not be replay: {resp1.status_code}"
+
+        # Replay the same envelope — must be 409 Conflict.
+        resp2 = await client_with_contacts.post(
+            "/api/peer/inbox",
+            json={"envelope": env},
+            headers=headers,
+        )
+        assert resp2.status_code == 409, f"replay should be 409, got {resp2.status_code}: {resp2.text}"
 
     async def test_peer_routes_csrf_exempt(self, client_with_contacts, app_with_contacts):
         """Peer routes should work without a CSRF token (bearer-only auth)."""

--- a/tests/test_contacts_peer.py
+++ b/tests/test_contacts_peer.py
@@ -1,0 +1,566 @@
+"""Tests for contacts_store, peer envelope crypto, and peer routes."""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.contacts_store import ContactsStore, generate_peer_token, _hash_token
+from tinyagentos.peer import (
+    build_envelope,
+    verify_envelope,
+    verify_envelope_signature,
+    mint_peer_token,
+    verify_peer_token,
+    hash_peer_token,
+)
+
+
+# ---------------------------------------------------------------------------
+# contacts_store tests
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ContactsStore(tmp_path / "contacts.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+class TestContactsStore:
+    async def test_add_and_get_contact(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne",
+            hub_username="hogne",
+            display_name="Hogne",
+            ed25519_pub="abc123",
+            x25519_pub="def456",
+        )
+        c = await store.get_contact("hub:hogne")
+        assert c is not None
+        assert c["contact_id"] == "hub:hogne"
+        assert c["hub_username"] == "hogne"
+        assert c["display_name"] == "Hogne"
+        assert c["ed25519_pub"] == "abc123"
+        assert c["x25519_pub"] == "def456"
+        assert c["status"] == "active"
+
+    async def test_get_contact_not_found(self, store):
+        assert await store.get_contact("hub:nonexistent") is None
+
+    async def test_get_contact_by_username(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne",
+            hub_username="hogne",
+            display_name="H",
+            ed25519_pub="pk",
+            x25519_pub="ek",
+        )
+        c = await store.get_contact_by_username("hogne")
+        assert c is not None
+        assert c["contact_id"] == "hub:hogne"
+
+    async def test_upsert_contact(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne",
+            hub_username="hogne",
+            display_name="Hogne v1",
+            ed25519_pub="old-key",
+            x25519_pub="old-enc",
+        )
+        # Re-add with new key material
+        await store.add_contact(
+            contact_id="hub:hogne",
+            hub_username="hogne",
+            display_name="Hogne v2",
+            ed25519_pub="new-key",
+            x25519_pub="new-enc",
+        )
+        c = await store.get_contact("hub:hogne")
+        assert c["ed25519_pub"] == "new-key"
+        assert c["x25519_pub"] == "new-enc"
+        assert c["display_name"] == "Hogne v2"
+
+    async def test_list_contacts(self, store):
+        await store.add_contact(
+            contact_id="hub:a", hub_username="a", display_name="A",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        await store.add_contact(
+            contact_id="hub:b", hub_username="b", display_name="B",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        contacts = await store.list_contacts()
+        assert len(contacts) == 2
+
+    async def test_list_contacts_filtered(self, store):
+        await store.add_contact(
+            contact_id="hub:a", hub_username="a", display_name="A",
+            ed25519_pub="pk", x25519_pub="ek", status="active",
+        )
+        await store.add_contact(
+            contact_id="hub:b", hub_username="b", display_name="B",
+            ed25519_pub="pk", x25519_pub="ek", status="blocked",
+        )
+        active = await store.list_contacts(status="active")
+        assert len(active) == 1
+        assert active[0]["contact_id"] == "hub:a"
+
+    async def test_set_contact_status(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        await store.set_contact_status("hub:hogne", "blocked")
+        c = await store.get_contact("hub:hogne")
+        assert c["status"] == "blocked"
+        assert c["revoked_at"] is not None
+
+    async def test_peer_link_establish_and_lookup(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        outbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=inbound,
+            outbound_token=outbound,
+            endpoints=["https://hogne.example.com:6969"],
+        )
+        link = await store.get_peer_link("hub:hogne")
+        assert link is not None
+        assert link["inbound_token_hash"] == _hash_token(inbound)
+        assert link["outbound_token"] == outbound
+        assert link["endpoints"] == ["https://hogne.example.com:6969"]
+
+    async def test_find_contact_by_inbound_token(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+        contact = await store.find_contact_by_inbound_token(inbound)
+        assert contact is not None
+        assert contact["contact_id"] == "hub:hogne"
+
+    async def test_find_contact_by_invalid_token(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+        assert await store.find_contact_by_inbound_token("bogus-token") is None
+
+    async def test_find_contact_token_revoked_contact(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+        await store.set_contact_status("hub:hogne", "revoked")
+        assert await store.find_contact_by_inbound_token(inbound) is None
+
+    async def test_mark_peer_seen(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=generate_peer_token(),
+            outbound_token=generate_peer_token(),
+        )
+        await store.mark_peer_seen("hub:hogne")
+        link = await store.get_peer_link("hub:hogne")
+        assert link["last_seen_at"] is not None
+
+    async def test_revoke_peer_link_cascades(self, store):
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=generate_peer_token(),
+            outbound_token=generate_peer_token(),
+        )
+        await store.revoke_peer_link("hub:hogne")
+        link = await store.get_peer_link("hub:hogne")
+        assert link["revoked_at"] is not None
+        c = await store.get_contact("hub:hogne")
+        assert c["status"] == "revoked"
+
+
+# ---------------------------------------------------------------------------
+# peer envelope crypto tests
+# ---------------------------------------------------------------------------
+
+
+class TestPeerEnvelope:
+    def test_build_envelope_structure(self):
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+            body={"greeting": "hello"},
+        )
+        assert env["from"] == "hub:jaylfc"
+        assert env["to"] == "hub:hogne"
+        assert env["kind"] == "handshake"
+        assert env["body"] == {"greeting": "hello"}
+        assert "ts" in env
+        assert "nonce" in env
+        assert "sig" in env
+        assert len(env["sig"]) == 128  # 64 bytes hex
+
+    def test_build_envelope_no_body(self):
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="ack",
+        )
+        assert "body" not in env
+        assert env["kind"] == "ack"
+
+    def test_verify_envelope_fresh(self):
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+        )
+        ok, err = verify_envelope(env)
+        assert err == "", f"expected empty error, got: {err}"
+
+    def test_verify_envelope_missing_field(self):
+        env = {"from": "hub:jaylfc", "kind": "handshake"}
+        ok, err = verify_envelope(env)
+        assert not ok
+        assert "missing required field" in err
+
+    def test_verify_envelope_wrong_kind(self):
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+        )
+        ok, err = verify_envelope(env, expected_kind="chat")
+        assert not ok
+        assert "unexpected kind" in err
+
+    def test_verify_envelope_too_old(self):
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+        )
+        # Artificially age the timestamp
+        env["ts"] = time.time() - 400  # 400 seconds ago
+        ok, err = verify_envelope(env, max_age_seconds=300)
+        assert not ok
+        assert "too old" in err
+
+    def test_verify_envelope_signature_roundtrip(self):
+        """Verify that a locally-built envelope's signature passes verification."""
+        from tinyagentos.hub.identity import load_or_create, clear as _clear, public_identity
+
+        # Generate a fresh identity for this test
+        _clear()
+        identity = load_or_create()
+        pub = public_identity()
+        signing_pub = pub["signing_pubkey"]
+
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+            body={"hello": "world"},
+        )
+
+        # Remove sig to re-verify
+        assert verify_envelope_signature(env, signing_pub), "own signature must verify"
+
+        # Clean up
+        _clear()
+
+    def test_verify_envelope_bad_signature(self):
+        """Tempered envelope fails signature verification."""
+        from tinyagentos.hub.identity import load_or_create, clear as _clear, public_identity
+
+        _clear()
+        identity = load_or_create()
+        pub = public_identity()
+        signing_pub = pub["signing_pubkey"]
+
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+        )
+        # Tamper with the payload
+        env["kind"] = "evil"
+        assert not verify_envelope_signature(env, signing_pub)
+
+        _clear()
+
+    def test_verify_envelope_signature_restores_dict(self):
+        """verify_envelope_signature restores the 'sig' field after popping it."""
+        from tinyagentos.hub.identity import load_or_create, clear as _clear, public_identity
+
+        _clear()
+        identity = load_or_create()
+        pub = public_identity()
+        signing_pub = pub["signing_pubkey"]
+
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+        )
+        original_sig = env["sig"]
+        verify_envelope_signature(env, signing_pub)
+        assert env["sig"] == original_sig  # restored
+
+        _clear()
+
+
+# ---------------------------------------------------------------------------
+# peer token tests
+# ---------------------------------------------------------------------------
+
+
+class TestPeerTokens:
+    def test_mint_peer_token(self):
+        token, token_hash = mint_peer_token("contact:hogne")
+        assert len(token) == 64  # 32 bytes hex
+        assert len(token_hash) == 64  # SHA-256 hex
+        assert token_hash != _hash_token(token)  # sub: prefix makes it different
+
+    def test_hash_peer_token_deterministic(self):
+        token = generate_peer_token()
+        assert hash_peer_token(token) == hash_peer_token(token)
+
+    def test_verify_peer_token_matches(self):
+        token = generate_peer_token()
+        stored = hash_peer_token(token)
+        assert verify_peer_token(token, stored)
+
+    def test_verify_peer_token_rejects_wrong(self):
+        stored = hash_peer_token(generate_peer_token())
+        assert not verify_peer_token("wrong-token", stored)
+
+    def test_verify_peer_token_rejects_empty(self):
+        stored = hash_peer_token(generate_peer_token())
+        assert not verify_peer_token("", stored)
+
+    def test_mint_peer_token_unique(self):
+        t1, _ = mint_peer_token("contact:a")
+        t2, _ = mint_peer_token("contact:b")
+        assert t1 != t2
+
+
+# ---------------------------------------------------------------------------
+# peer route integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def app_with_contacts(tmp_data_dir):
+    """Create an app and initialise the contacts store."""
+    from tinyagentos.app import create_app
+
+    _app = create_app(data_dir=tmp_data_dir)
+
+    # Initialise contacts_store (not done by create_app for peers)
+    store = _app.state.contacts_store
+    if store._db is not None:
+        await store.close()
+    await store.init()
+
+    return _app
+
+
+@pytest_asyncio.fixture
+async def client_with_contacts(app_with_contacts):
+    """Async client with contacts_store initialized and auth bypassed for peer routes."""
+    _app = app_with_contacts
+
+    # Set up auth user for admin session
+    _app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    _rec = _app.state.auth.find_user("admin")
+    _uid = _rec["id"] if _rec else ""
+    _token = _app.state.auth.create_session(user_id=_uid, long_lived=True)
+    _app.state._startup_complete = True
+
+    transport = ASGITransport(app=_app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": _token},
+    ) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+class TestPeerRoutes:
+    async def test_inbox_missing_token(self, client_with_contacts):
+        resp = await client_with_contacts.post(
+            "/api/peer/inbox",
+            json={"envelope": {}},
+        )
+        assert resp.status_code == 401
+
+    async def test_inbox_invalid_token(self, client_with_contacts):
+        resp = await client_with_contacts.post(
+            "/api/peer/inbox",
+            json={"envelope": {}},
+            headers={"Authorization": "Bearer bogus"},
+        )
+        assert resp.status_code == 401
+
+    async def test_inbox_rate_limit(self, client_with_contacts, app_with_contacts):
+        """Verify rate limiting kicks in after 60 requests in a window."""
+        store = app_with_contacts.state.contacts_store
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+
+        headers = {"Authorization": f"Bearer {inbound}"}
+
+        # The route returns 400 for invalid envelopes but 429 if rate-limited.
+        # Send 61 requests — the 61st should be 429.
+        statuses = []
+        for _ in range(65):
+            resp = await client_with_contacts.post(
+                "/api/peer/inbox",
+                json={"envelope": {}},
+                headers=headers,
+            )
+            statuses.append(resp.status_code)
+
+        assert 429 in statuses, f"expected 429 in statuses, got: {set(statuses)}"
+
+    async def test_inbox_envelope_too_large(self, client_with_contacts, app_with_contacts):
+        store = app_with_contacts.state.contacts_store
+        await store.add_contact(
+            contact_id="hub:big-msg", hub_username="big-msg", display_name="B",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:big-msg",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+
+        # Create an envelope that's too large
+        big_body = "x" * (33 * 1024)  # 33 KB > 32 KB limit
+        resp = await client_with_contacts.post(
+            "/api/peer/inbox",
+            json={"envelope": {"body": big_body}},
+            headers={"Authorization": f"Bearer {inbound}"},
+        )
+        assert resp.status_code == 413
+
+    async def test_inbox_wrong_to_field(self, client_with_contacts, app_with_contacts):
+        """Envelope addressed to a different contact must be rejected."""
+        from tinyagentos.peer import build_envelope
+
+        store = app_with_contacts.state.contacts_store
+        await store.add_contact(
+            contact_id="hub:wrong-to", hub_username="wrong-to", display_name="W",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:wrong-to",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="someone-else",  # wrong recipient
+            kind="handshake",
+        )
+        resp = await client_with_contacts.post(
+            "/api/peer/inbox",
+            json={"envelope": env},
+            headers={"Authorization": f"Bearer {inbound}"},
+        )
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
+
+    async def test_peer_routes_csrf_exempt(self, client_with_contacts, app_with_contacts):
+        """Peer routes should work without a CSRF token (bearer-only auth)."""
+        store = app_with_contacts.state.contacts_store
+        await store.add_contact(
+            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:hogne",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+
+        # POST without CSRF header — should NOT get 403 CSRF error
+        resp = await client_with_contacts.post(
+            "/api/peer/ack",
+            json={"envelope_id": "test-nonce", "contact_id": "hub:hogne"},
+            headers={"Authorization": f"Bearer {inbound}"},
+        )
+        # Won't be 403 CSRF — auth passes even without CSRF header
+        assert resp.status_code != 403
+
+    async def test_ack_endpoint(self, client_with_contacts, app_with_contacts):
+        store = app_with_contacts.state.contacts_store
+        await store.add_contact(
+            contact_id="hub:ack-test", hub_username="ack-test", display_name="A",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:ack-test",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+
+        resp = await client_with_contacts.post(
+            "/api/peer/ack",
+            json={"envelope_id": "test-nonce-123", "contact_id": "hub:ack-test"},
+            headers={"Authorization": f"Bearer {inbound}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "acked"
+        assert data["envelope_id"] == "test-nonce-123"

--- a/tests/test_contacts_peer.py
+++ b/tests/test_contacts_peer.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import json
+import os
 import time
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -11,10 +13,55 @@ from httpx import ASGITransport, AsyncClient
 from tinyagentos.contacts_store import ContactsStore, generate_peer_token, _hash_token
 from tinyagentos.peer import (
     build_envelope,
+    resolve_local_identity_id,
     verify_envelope,
     verify_envelope_signature,
     mint_peer_token,
 )
+
+# Local hub username used in route integration tests.
+_TEST_HUB_USERNAME = "testnode"
+
+
+# ---------------------------------------------------------------------------
+# Helper — bootstrap a hub identity in the given data dir so
+# ``resolve_local_identity_id()`` returns ``"hub:<username>"``.
+# ---------------------------------------------------------------------------
+
+def _ensure_hub_identity(data_dir: Path, username: str = _TEST_HUB_USERNAME) -> str:
+    """Create a hub identity keystore + author row and return the local id."""
+    import sqlite3
+
+    from tinyagentos.hub import identity as _hub_identity
+
+    hub_dir = data_dir / "hub"
+    hub_dir.mkdir(parents=True, exist_ok=True)
+
+    # Clear any stale identity so we get a fresh fingerprint.
+    _hub_identity.clear()
+    ident = _hub_identity.load_or_create()
+    fp = _hub_identity.signing_fingerprint()
+
+    # Register the local author in hub.db
+    hub_db = hub_dir / "hub.db"
+    conn = sqlite3.connect(str(hub_db))
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS hub_authors (
+            fingerprint TEXT PRIMARY KEY,
+            username TEXT,
+            signing_pubkey TEXT,
+            encryption_pubkey TEXT,
+            updated_at REAL
+        )"""
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO hub_authors (fingerprint, username, signing_pubkey, encryption_pubkey, updated_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (fp, username, ident["signing_public"], ident["encryption_public"], time.time()),
+    )
+    conn.commit()
+    conn.close()
+    return f"hub:{username}"
 
 
 # ---------------------------------------------------------------------------
@@ -280,68 +327,96 @@ class TestPeerEnvelope:
         assert not ok
         assert "too old" in err
 
-    def test_verify_envelope_signature_roundtrip(self):
+    def test_verify_envelope_nan_ts_rejected(self):
+        """NaN timestamp must be rejected (bypass fix)."""
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+        )
+        env["ts"] = float("nan")
+        ok, err = verify_envelope(env)
+        assert not ok
+        assert "non-finite" in err
+
+    def test_verify_envelope_future_ts_rejected(self):
+        """Timestamp more than 30s in the future must be rejected."""
+        env = build_envelope(
+            from_username="jaylfc",
+            to_username="hogne",
+            kind="handshake",
+        )
+        env["ts"] = time.time() + 60  # 60s in the future
+        ok, err = verify_envelope(env)
+        assert not ok
+        assert "future" in err
+
+    def test_verify_envelope_signature_roundtrip(self, monkeypatch, tmp_path):
         """Verify that a locally-built envelope's signature passes verification."""
         from tinyagentos.hub.identity import load_or_create, clear as _clear, public_identity
 
-        # Generate a fresh identity for this test
+        # Isolate identity to a temp dir so the real node identity is untouched.
+        monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
         _clear()
-        identity = load_or_create()
-        pub = public_identity()
-        signing_pub = pub["signing_pubkey"]
+        try:
+            identity = load_or_create()
+            pub = public_identity()
+            signing_pub = pub["signing_pubkey"]
 
-        env = build_envelope(
-            from_username="jaylfc",
-            to_username="hogne",
-            kind="handshake",
-            body={"hello": "world"},
-        )
+            env = build_envelope(
+                from_username="jaylfc",
+                to_username="hogne",
+                kind="handshake",
+                body={"hello": "world"},
+            )
 
-        # Remove sig to re-verify
-        assert verify_envelope_signature(env, signing_pub), "own signature must verify"
+            assert verify_envelope_signature(env, signing_pub), "own signature must verify"
+        finally:
+            _clear()
 
-        # Clean up
-        _clear()
-
-    def test_verify_envelope_bad_signature(self):
+    def test_verify_envelope_bad_signature(self, monkeypatch, tmp_path):
         """Tempered envelope fails signature verification."""
         from tinyagentos.hub.identity import load_or_create, clear as _clear, public_identity
 
+        monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
         _clear()
-        identity = load_or_create()
-        pub = public_identity()
-        signing_pub = pub["signing_pubkey"]
+        try:
+            identity = load_or_create()
+            pub = public_identity()
+            signing_pub = pub["signing_pubkey"]
 
-        env = build_envelope(
-            from_username="jaylfc",
-            to_username="hogne",
-            kind="handshake",
-        )
-        # Tamper with the payload
-        env["kind"] = "evil"
-        assert not verify_envelope_signature(env, signing_pub)
+            env = build_envelope(
+                from_username="jaylfc",
+                to_username="hogne",
+                kind="handshake",
+            )
+            # Tamper with the payload
+            env["kind"] = "evil"
+            assert not verify_envelope_signature(env, signing_pub)
+        finally:
+            _clear()
 
-        _clear()
-
-    def test_verify_envelope_signature_restores_dict(self):
+    def test_verify_envelope_signature_restores_dict(self, monkeypatch, tmp_path):
         """verify_envelope_signature restores the 'sig' field after popping it."""
         from tinyagentos.hub.identity import load_or_create, clear as _clear, public_identity
 
+        monkeypatch.setenv("TAOS_DATA_DIR", str(tmp_path))
         _clear()
-        identity = load_or_create()
-        pub = public_identity()
-        signing_pub = pub["signing_pubkey"]
+        try:
+            identity = load_or_create()
+            pub = public_identity()
+            signing_pub = pub["signing_pubkey"]
 
-        env = build_envelope(
-            from_username="jaylfc",
-            to_username="hogne",
-            kind="handshake",
-        )
-        original_sig = env["sig"]
-        verify_envelope_signature(env, signing_pub)
-        assert env["sig"] == original_sig  # restored
-
-        _clear()
+            env = build_envelope(
+                from_username="jaylfc",
+                to_username="hogne",
+                kind="handshake",
+            )
+            original_sig = env["sig"]
+            verify_envelope_signature(env, signing_pub)
+            assert env["sig"] == original_sig  # restored
+        finally:
+            _clear()
 
 
 # ---------------------------------------------------------------------------
@@ -379,7 +454,7 @@ class TestPeerTokens:
 
 @pytest_asyncio.fixture
 async def app_with_contacts(tmp_data_dir):
-    """Create an app and initialise the contacts store."""
+    """Create an app, initialise contacts_store, and bootstrap a local hub identity."""
     from tinyagentos.app import create_app
 
     _app = create_app(data_dir=tmp_data_dir)
@@ -389,6 +464,11 @@ async def app_with_contacts(tmp_data_dir):
     if store._db is not None:
         await store.close()
     await store.init()
+
+    # Bootstrap a hub identity so resolve_local_identity_id() works in tests.
+    # Must set TAOS_DATA_DIR so hub.identity module resolves to tmp_data_dir.
+    os.environ["TAOS_DATA_DIR"] = str(tmp_data_dir)
+    _ensure_hub_identity(tmp_data_dir)
 
     return _app
 
@@ -448,7 +528,7 @@ class TestPeerRoutes:
         headers = {"Authorization": f"Bearer {inbound}"}
 
         # The route returns 400 for invalid envelopes but 429 if rate-limited.
-        # Send 61 requests — the 61st should be 429.
+        # Send 65 requests — some should be 429.
         statuses = []
         for _ in range(65):
             resp = await client_with_contacts.post(
@@ -482,10 +562,37 @@ class TestPeerRoutes:
         )
         assert resp.status_code == 413
 
-    async def test_inbox_wrong_to_field(self, client_with_contacts, app_with_contacts):
-        """Envelope addressed to a different contact must be rejected."""
-        from tinyagentos.peer import build_envelope
+    async def test_inbox_spoofed_from_rejected(self, client_with_contacts, app_with_contacts):
+        """An envelope whose 'from' doesn't match the authenticated contact must 403."""
+        local_id = resolve_local_identity_id()
 
+        store = app_with_contacts.state.contacts_store
+        await store.add_contact(
+            contact_id="hub:spoofer", hub_username="spoofer", display_name="S",
+            ed25519_pub="pk", x25519_pub="ek",
+        )
+        inbound = generate_peer_token()
+        await store.establish_peer_link(
+            contact_id="hub:spoofer",
+            inbound_token=inbound,
+            outbound_token=generate_peer_token(),
+        )
+
+        # Envelope claims to be from "jaylfc" but auth token is for "spoofer"
+        env = build_envelope(
+            from_username="jaylfc",  # impersonation!
+            to_username=_TEST_HUB_USERNAME,
+            kind="handshake",
+        )
+        resp = await client_with_contacts.post(
+            "/api/peer/inbox",
+            json={"envelope": env},
+            headers={"Authorization": f"Bearer {inbound}"},
+        )
+        assert resp.status_code == 403, f"expected 403, got {resp.status_code}: {resp.text}"
+
+    async def test_inbox_wrong_to_field(self, client_with_contacts, app_with_contacts):
+        """Envelope addressed to a different identity must be rejected."""
         store = app_with_contacts.state.contacts_store
         await store.add_contact(
             contact_id="hub:wrong-to", hub_username="wrong-to", display_name="W",
@@ -498,8 +605,9 @@ class TestPeerRoutes:
             outbound_token=generate_peer_token(),
         )
 
+        # Envelope addressed to a different hub identity, from the authenticated contact.
         env = build_envelope(
-            from_username="jaylfc",
+            from_username="wrong-to",
             to_username="someone-else",  # wrong recipient
             kind="handshake",
         )
@@ -512,12 +620,21 @@ class TestPeerRoutes:
 
     async def test_inbox_nonce_replay(self, client_with_contacts, app_with_contacts):
         """Replaying an envelope with the same nonce must return 409."""
-        from tinyagentos.peer import build_envelope
+        local_id = resolve_local_identity_id()
+
+        # Use the local hub identity signing pubkey as the contact's pinned
+        # key so that signature verification passes.  In production the
+        # contact is a different node with its own key, but for an
+        # integration test we need the key to match whoever signed the
+        # envelope (which is always the local identity in unit tests since
+        # build_envelope calls hub.identity.sign).
+        from tinyagentos.hub.identity import public_identity as _hub_pub
+        signing_pub = _hub_pub()["signing_pubkey"]
 
         store = app_with_contacts.state.contacts_store
         await store.add_contact(
             contact_id="hub:nonce-test", hub_username="nonce-test", display_name="N",
-            ed25519_pub="pk", x25519_pub="ek",
+            ed25519_pub=signing_pub, x25519_pub="ek",
         )
         inbound = generate_peer_token()
         await store.establish_peer_link(
@@ -526,22 +643,22 @@ class TestPeerRoutes:
             outbound_token=generate_peer_token(),
         )
 
+        # Envelope from the authenticated contact to the local node.
         env = build_envelope(
-            from_username="jaylfc",
-            to_username="nonce-test",
+            from_username="nonce-test",
+            to_username=_TEST_HUB_USERNAME,
             kind="handshake",
         )
 
         headers = {"Authorization": f"Bearer {inbound}"}
 
-        # First delivery — should succeed (200 or 400 depending on sig check;
-        # the key point is it's not 409).
+        # First delivery — should succeed (200).
         resp1 = await client_with_contacts.post(
             "/api/peer/inbox",
             json={"envelope": env},
             headers=headers,
         )
-        assert resp1.status_code != 409, f"first send should not be replay: {resp1.status_code}"
+        assert resp1.status_code == 200, f"first send should be 200, got {resp1.status_code}: {resp1.text}"
 
         # Replay the same envelope — must be 409 Conflict.
         resp2 = await client_with_contacts.post(

--- a/tests/test_contacts_peer.py
+++ b/tests/test_contacts_peer.py
@@ -672,12 +672,12 @@ class TestPeerRoutes:
         """Peer routes should work without a CSRF token (bearer-only auth)."""
         store = app_with_contacts.state.contacts_store
         await store.add_contact(
-            contact_id="hub:hogne", hub_username="hogne", display_name="H",
+            contact_id="hub:csrf-test", hub_username="csrf-test", display_name="C",
             ed25519_pub="pk", x25519_pub="ek",
         )
         inbound = generate_peer_token()
         await store.establish_peer_link(
-            contact_id="hub:hogne",
+            contact_id="hub:csrf-test",
             inbound_token=inbound,
             outbound_token=generate_peer_token(),
         )
@@ -685,11 +685,11 @@ class TestPeerRoutes:
         # POST without CSRF header — should NOT get 403 CSRF error
         resp = await client_with_contacts.post(
             "/api/peer/ack",
-            json={"envelope_id": "test-nonce", "contact_id": "hub:hogne"},
+            json={"envelope_id": "test-nonce", "contact_id": "hub:csrf-test"},
             headers={"Authorization": f"Bearer {inbound}"},
         )
         # Won't be 403 CSRF — auth passes even without CSRF header
-        assert resp.status_code != 403
+        assert resp.status_code == 200
 
     async def test_ack_endpoint(self, client_with_contacts, app_with_contacts):
         store = app_with_contacts.state.contacts_store

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -99,6 +99,7 @@ from tinyagentos.user_personas import UserPersonaStore
 from tinyagentos.installed_apps import InstalledAppsStore
 from tinyagentos.skills import SkillStore
 from tinyagentos.office_docs import OfficeDocStore
+from tinyagentos.contacts_store import ContactsStore
 from tinyagentos.web_sites import WebSiteStore
 from tinyagentos.music_songs import SongStore
 from tinyagentos.design_docs import DesignStore
@@ -427,6 +428,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     web_sites = WebSiteStore(data_dir / "web_sites.db")
     song_store = SongStore(data_dir / "songs.db")
     design_docs = DesignStore(data_dir / "design_docs.db")
+    contacts_store = ContactsStore(data_dir / "contacts.db")
     coding_workspaces_store = CodingWorkspaceStore(
         data_dir / "coding_workspaces.db",
         data_dir / "coding-workspaces",
@@ -533,6 +535,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await web_sites.init()
         await song_store.init()
         await design_docs.init()
+        await contacts_store.init()
         await coding_workspaces_store.init()
         await install_registry_store.init()
         await store_submissions.init()
@@ -1326,6 +1329,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await web_sites.close()
         await song_store.close()
         await design_docs.close()
+        await contacts_store.close()
         await coding_workspaces_store.close()
         await install_registry_store.close()
         await user_memory.close()
@@ -1540,6 +1544,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.web_sites = web_sites
     app.state.song_store = song_store
     app.state.design_docs = design_docs
+    app.state.contacts_store = contacts_store
     app.state.coding_workspaces = coding_workspaces_store
     app.state.install_registry = install_registry_store
     app.state.store_submissions = store_submissions

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -119,7 +119,7 @@ def _is_agent_decisions_path(method: str, path: str) -> bool:
 # wrapping a WS upgrade can cause connection-level issues in some Starlette
 # versions, so /ws/ remains exempt at the middleware layer; the per-endpoint
 # check is the authoritative guard for all WebSocket endpoints.
-EXEMPT_PREFIXES = ("/static/", "/desktop/", "/chat-pwa/", "/ws/", "/shortcut/")
+EXEMPT_PREFIXES = ("/static/", "/desktop/", "/chat-pwa/", "/ws/", "/shortcut/", "/api/peer/")
 
 # Consent-loop status-poll paths are unauthenticated (the opaque request_id is
 # the capability), but the sub-action paths (/approve, /deny) require admin

--- a/tinyagentos/contacts_store.py
+++ b/tinyagentos/contacts_store.py
@@ -25,17 +25,26 @@ CREATE TABLE IF NOT EXISTS contacts (
 CREATE TABLE IF NOT EXISTS peer_links (
     contact_id              TEXT PRIMARY KEY REFERENCES contacts(contact_id),
     inbound_token_hash      TEXT NOT NULL,    -- token WE minted for their instance (SHA-256)
-    outbound_token          TEXT NOT NULL,    -- token THEY minted for us (encrypted at rest)
+    outbound_token          TEXT NOT NULL,    -- token THEY minted for us (stored in plaintext; encryption deferred to post-MVP)
     endpoints               TEXT NOT NULL DEFAULT '[]',  -- JSON list of advertised endpoints
     established_at          REAL NOT NULL,
     last_seen_at            REAL,
     revoked_at              REAL
+);
+
+CREATE TABLE IF NOT EXISTS peer_nonces (
+    nonce                   TEXT PRIMARY KEY,  -- 16-byte hex nonce from envelope
+    contact_id              TEXT NOT NULL,
+    seen_at                 REAL NOT NULL
 );
 """
 
 # Peer tokens are 256-bit opaque strings, SHA-256 hashed at rest (same pattern
 # as registry tokens).  The peer-token sub concept is "contact:{hub_username}".
 _PEER_TOKEN_BYTES = 32
+# Nonces live for the envelope freshness window (300s) + 30s clock-skew grace
+# + 60s buffer.  After this window a nonce is pruned so the table stays small.
+NONCE_MAX_AGE_SECS = 600
 
 
 def _hash_token(token: str) -> str:
@@ -99,14 +108,16 @@ class ContactsStore(BaseStore):
             "SELECT * FROM contacts WHERE contact_id = ?", (contact_id,)
         ) as cursor:
             rows = await cursor.fetchall()
-        return _row_to_dict(cursor, rows[0]) if rows else None
+            columns = [desc[0] for desc in cursor.description]
+        return _row_to_dict(columns, rows[0]) if rows else None
 
     async def get_contact_by_username(self, hub_username: str) -> Optional[dict]:
         async with self._db.execute(
             "SELECT * FROM contacts WHERE hub_username = ?", (hub_username,)
         ) as cursor:
             rows = await cursor.fetchall()
-        return _row_to_dict(cursor, rows[0]) if rows else None
+            columns = [desc[0] for desc in cursor.description]
+        return _row_to_dict(columns, rows[0]) if rows else None
 
     async def set_contact_status(self, contact_id: str, status: str) -> None:
         now = time.time()
@@ -132,12 +143,14 @@ class ContactsStore(BaseStore):
                 (status,),
             ) as cursor:
                 rows = await cursor.fetchall()
+                columns = [desc[0] for desc in cursor.description]
         else:
             async with self._db.execute(
                 "SELECT * FROM contacts ORDER BY created_at"
             ) as cursor:
                 rows = await cursor.fetchall()
-        return [_row_to_dict(cursor, r) for r in rows]
+                columns = [desc[0] for desc in cursor.description]
+        return [_row_to_dict(columns, r) for r in rows]
 
     # ------------------------------------------------------------------
     # peer_links
@@ -178,9 +191,10 @@ class ContactsStore(BaseStore):
             "SELECT * FROM peer_links WHERE contact_id = ?", (contact_id,)
         ) as cursor:
             rows = await cursor.fetchall()
+            columns = [desc[0] for desc in cursor.description]
         if not rows:
             return None
-        rec = _row_to_dict(cursor, rows[0])
+        rec = _row_to_dict(columns, rows[0])
         # Deserialise endpoints for the caller.
         rec["endpoints"] = _json_loads(rec.get("endpoints", "[]"))
         return rec
@@ -203,11 +217,47 @@ class ContactsStore(BaseStore):
             (token_hash,),
         ) as cursor:
             rows = await cursor.fetchall()
+            columns = [desc[0] for desc in cursor.description]
         if not rows:
             return None
-        rec = _row_to_dict(cursor, rows[0])
+        rec = _row_to_dict(columns, rows[0])
         rec["endpoints"] = _json_loads(rec.get("endpoints", "[]"))
         return rec
+
+    async def record_nonce(self, nonce: str, contact_id: str) -> bool:
+        """Record a seen nonce for replay protection.
+
+        Returns True if the nonce was recorded (first time seen), False if it
+        was already present (replay detected).
+
+        Nonces older than ``NONCE_MAX_AGE_SECS`` are pruned on insert so the
+        table does not grow unbounded.
+        """
+        now = time.time()
+        # Prune expired nonces (opportunistic, one DELETE per insert keeps the
+        # table small without a separate vacuum job).
+        cutoff = now - NONCE_MAX_AGE_SECS
+        await self._db.execute(
+            "DELETE FROM peer_nonces WHERE seen_at < ?", (cutoff,)
+        )
+        try:
+            await self._db.execute(
+                "INSERT INTO peer_nonces (nonce, contact_id, seen_at) VALUES (?, ?, ?)",
+                (nonce, contact_id, now),
+            )
+            await self._db.commit()
+            return True
+        except Exception:
+            # Nonce already exists (PRIMARY KEY conflict) — replay detected.
+            return False
+
+    async def is_nonce_seen(self, nonce: str) -> bool:
+        """Return True if this nonce has already been recorded."""
+        async with self._db.execute(
+            "SELECT 1 FROM peer_nonces WHERE nonce = ?", (nonce,)
+        ) as cursor:
+            row = await cursor.fetchone()
+        return row is not None
 
     async def mark_peer_seen(self, contact_id: str) -> None:
         """Update last_seen_at for the peer link (called on every valid request)."""
@@ -235,12 +285,11 @@ class ContactsStore(BaseStore):
 # helpers
 # ---------------------------------------------------------------------------
 
-def _row_to_dict(cursor, row) -> dict:
-    """Convert an aiosqlite result row to a dict using cursor.description."""
+def _row_to_dict(columns: list[str], row) -> dict:
+    """Convert a result row to a dict using pre-captured column names."""
     if row is None:
         return {}
-    cols = [desc[0] for desc in cursor.description]
-    return dict(zip(cols, row))
+    return dict(zip(columns, row))
 
 
 def _json_dumps(obj) -> str:

--- a/tinyagentos/contacts_store.py
+++ b/tinyagentos/contacts_store.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+import time
+from pathlib import Path
+from typing import Optional
+
+from tinyagentos.base_store import BaseStore
+
+
+CONTACTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS contacts (
+    contact_id        TEXT PRIMARY KEY,       -- "hub:{username}" e.g. "hub:hogne"
+    hub_username      TEXT NOT NULL UNIQUE,
+    display_name      TEXT NOT NULL,
+    ed25519_pub       TEXT NOT NULL,          -- pinned at friend-accept
+    x25519_pub        TEXT NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'pending',  -- pending|active|blocked|revoked
+    local_crm_id      TEXT,                   -- optional link to existing CRM row
+    created_at        REAL NOT NULL,
+    revoked_at        REAL
+);
+
+CREATE TABLE IF NOT EXISTS peer_links (
+    contact_id              TEXT PRIMARY KEY REFERENCES contacts(contact_id),
+    inbound_token_hash      TEXT NOT NULL,    -- token WE minted for their instance (SHA-256)
+    outbound_token          TEXT NOT NULL,    -- token THEY minted for us (encrypted at rest)
+    endpoints               TEXT NOT NULL DEFAULT '[]',  -- JSON list of advertised endpoints
+    established_at          REAL NOT NULL,
+    last_seen_at            REAL,
+    revoked_at              REAL
+);
+"""
+
+# Peer tokens are 256-bit opaque strings, SHA-256 hashed at rest (same pattern
+# as registry tokens).  The peer-token sub concept is "contact:{hub_username}".
+_PEER_TOKEN_BYTES = 32
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_peer_token() -> str:
+    """Return a new opaque peer token (hex-encoded random bytes)."""
+    return secrets.token_hex(_PEER_TOKEN_BYTES)
+
+
+class ContactsStore(BaseStore):
+    """SQLite store for contacts and peer links.
+
+    Contacts are created from accepted hub friend-edges. Each active contact
+    gets a peer link with bidirectional tokens for the instance-to-instance
+    peer channel (``POST /api/peer/*``).
+    """
+
+    SCHEMA = CONTACTS_SCHEMA
+
+    # ------------------------------------------------------------------
+    # contacts
+    # ------------------------------------------------------------------
+
+    async def add_contact(
+        self,
+        *,
+        contact_id: str,
+        hub_username: str,
+        display_name: str,
+        ed25519_pub: str,
+        x25519_pub: str,
+        status: str = "active",
+        local_crm_id: str | None = None,
+    ) -> None:
+        """Insert or upsert (by contact_id) a contact row.
+
+        On conflict (same contact_id) the key material is updated — this is
+        the trust-on-first-use refresh when a friend re-accepts.
+        """
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO contacts
+               (contact_id, hub_username, display_name, ed25519_pub, x25519_pub,
+                status, local_crm_id, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(contact_id) DO UPDATE SET
+                 ed25519_pub = excluded.ed25519_pub,
+                 x25519_pub = excluded.x25519_pub,
+                 display_name = excluded.display_name,
+                 status = excluded.status,
+                 local_crm_id = excluded.local_crm_id""",
+            (contact_id, hub_username, display_name, ed25519_pub, x25519_pub,
+             status, local_crm_id, now),
+        )
+        await self._db.commit()
+
+    async def get_contact(self, contact_id: str) -> Optional[dict]:
+        async with self._db.execute(
+            "SELECT * FROM contacts WHERE contact_id = ?", (contact_id,)
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return _row_to_dict(cursor, rows[0]) if rows else None
+
+    async def get_contact_by_username(self, hub_username: str) -> Optional[dict]:
+        async with self._db.execute(
+            "SELECT * FROM contacts WHERE hub_username = ?", (hub_username,)
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return _row_to_dict(cursor, rows[0]) if rows else None
+
+    async def set_contact_status(self, contact_id: str, status: str) -> None:
+        now = time.time()
+        if status in ("blocked", "revoked"):
+            await self._db.execute(
+                "UPDATE contacts SET status = ?, revoked_at = ? WHERE contact_id = ?",
+                (status, now, contact_id),
+            )
+        else:
+            await self._db.execute(
+                "UPDATE contacts SET status = ? WHERE contact_id = ?",
+                (status, contact_id),
+            )
+        await self._db.commit()
+
+    async def list_contacts(
+        self, status: str | None = None
+    ) -> list[dict]:
+        """List contacts, optionally filtered by status."""
+        if status:
+            async with self._db.execute(
+                "SELECT * FROM contacts WHERE status = ? ORDER BY created_at",
+                (status,),
+            ) as cursor:
+                rows = await cursor.fetchall()
+        else:
+            async with self._db.execute(
+                "SELECT * FROM contacts ORDER BY created_at"
+            ) as cursor:
+                rows = await cursor.fetchall()
+        return [_row_to_dict(cursor, r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # peer_links
+    # ------------------------------------------------------------------
+
+    async def establish_peer_link(
+        self,
+        *,
+        contact_id: str,
+        inbound_token: str,
+        outbound_token: str,
+        endpoints: list[str] | None = None,
+    ) -> None:
+        """Create a peer link row.  Called after the handshake completes.
+
+        ``inbound_token`` is the plaintext token WE minted for them (hashed at
+        rest); ``outbound_token`` is the token THEY minted for us.
+        """
+        now = time.time()
+        eps_json = _json_dumps(endpoints or [])
+        await self._db.execute(
+            """INSERT INTO peer_links
+               (contact_id, inbound_token_hash, outbound_token, endpoints,
+                established_at)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(contact_id) DO UPDATE SET
+                 inbound_token_hash = excluded.inbound_token_hash,
+                 outbound_token = excluded.outbound_token,
+                 endpoints = excluded.endpoints,
+                 established_at = excluded.established_at,
+                 revoked_at = NULL""",
+            (contact_id, _hash_token(inbound_token), outbound_token, eps_json, now),
+        )
+        await self._db.commit()
+
+    async def get_peer_link(self, contact_id: str) -> Optional[dict]:
+        async with self._db.execute(
+            "SELECT * FROM peer_links WHERE contact_id = ?", (contact_id,)
+        ) as cursor:
+            rows = await cursor.fetchall()
+        if not rows:
+            return None
+        rec = _row_to_dict(cursor, rows[0])
+        # Deserialise endpoints for the caller.
+        rec["endpoints"] = _json_loads(rec.get("endpoints", "[]"))
+        return rec
+
+    async def find_contact_by_inbound_token(self, token: str) -> Optional[dict]:
+        """Look up a contact by their inbound token (the one we minted for them).
+
+        Returns the contact + peer_link joined row, or None if the token is
+        invalid, the contact is not active, or the link is revoked.
+        """
+        token_hash = _hash_token(token)
+        async with self._db.execute(
+            """SELECT c.*, p.inbound_token_hash, p.outbound_token, p.endpoints,
+                      p.established_at, p.last_seen_at, p.revoked_at as link_revoked_at
+               FROM contacts c
+               JOIN peer_links p ON c.contact_id = p.contact_id
+               WHERE p.inbound_token_hash = ?
+                 AND c.status = 'active'
+                 AND p.revoked_at IS NULL""",
+            (token_hash,),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        if not rows:
+            return None
+        rec = _row_to_dict(cursor, rows[0])
+        rec["endpoints"] = _json_loads(rec.get("endpoints", "[]"))
+        return rec
+
+    async def mark_peer_seen(self, contact_id: str) -> None:
+        """Update last_seen_at for the peer link (called on every valid request)."""
+        await self._db.execute(
+            "UPDATE peer_links SET last_seen_at = ? WHERE contact_id = ?",
+            (time.time(), contact_id),
+        )
+        await self._db.commit()
+
+    async def revoke_peer_link(self, contact_id: str) -> None:
+        """Revoke the peer link (cascades to block contact)."""
+        now = time.time()
+        await self._db.execute(
+            "UPDATE peer_links SET revoked_at = ? WHERE contact_id = ?",
+            (now, contact_id),
+        )
+        await self._db.execute(
+            "UPDATE contacts SET status = 'revoked', revoked_at = ? WHERE contact_id = ?",
+            (now, contact_id),
+        )
+        await self._db.commit()
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _row_to_dict(cursor, row) -> dict:
+    """Convert an aiosqlite result row to a dict using cursor.description."""
+    if row is None:
+        return {}
+    cols = [desc[0] for desc in cursor.description]
+    return dict(zip(cols, row))
+
+
+def _json_dumps(obj) -> str:
+    import json
+    return json.dumps(obj)
+
+
+def _json_loads(s: str):
+    import json
+    return json.loads(s)

--- a/tinyagentos/contacts_store.py
+++ b/tinyagentos/contacts_store.py
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS contacts (
 
 CREATE TABLE IF NOT EXISTS peer_links (
     contact_id              TEXT PRIMARY KEY REFERENCES contacts(contact_id),
-    inbound_token_hash      TEXT NOT NULL UNIQUE,  -- token WE minted for their instance (SHA-256); indexed for lookup
+    inbound_token_hash      TEXT NOT NULL,    -- token WE minted for their instance (SHA-256); indexed for lookup
     outbound_token          TEXT NOT NULL,    -- token THEY minted for us (stored in plaintext; encryption deferred to post-MVP)
     endpoints               TEXT NOT NULL DEFAULT '[]',  -- JSON list of advertised endpoints
     established_at          REAL NOT NULL,

--- a/tinyagentos/contacts_store.py
+++ b/tinyagentos/contacts_store.py
@@ -25,13 +25,15 @@ CREATE TABLE IF NOT EXISTS contacts (
 
 CREATE TABLE IF NOT EXISTS peer_links (
     contact_id              TEXT PRIMARY KEY REFERENCES contacts(contact_id),
-    inbound_token_hash      TEXT NOT NULL,    -- token WE minted for their instance (SHA-256)
+    inbound_token_hash      TEXT NOT NULL UNIQUE,  -- token WE minted for their instance (SHA-256); indexed for lookup
     outbound_token          TEXT NOT NULL,    -- token THEY minted for us (stored in plaintext; encryption deferred to post-MVP)
     endpoints               TEXT NOT NULL DEFAULT '[]',  -- JSON list of advertised endpoints
     established_at          REAL NOT NULL,
     last_seen_at            REAL,
     revoked_at              REAL
 );
+
+CREATE INDEX IF NOT EXISTS idx_peer_links_token_hash ON peer_links(inbound_token_hash);
 
 CREATE TABLE IF NOT EXISTS peer_nonces (
     nonce                   TEXT NOT NULL,       -- 16-byte hex nonce from envelope
@@ -257,15 +259,8 @@ class ContactsStore(BaseStore):
             return True
         except sqlite3.IntegrityError:
             # Nonce already exists for this (contact_id, kind) — replay detected.
+            await self._db.rollback()
             return False
-
-    async def is_nonce_seen(self, nonce: str) -> bool:
-        """Return True if this nonce has already been recorded."""
-        async with self._db.execute(
-            "SELECT 1 FROM peer_nonces WHERE nonce = ?", (nonce,)
-        ) as cursor:
-            row = await cursor.fetchone()
-        return row is not None
 
     async def mark_peer_seen(self, contact_id: str) -> None:
         """Update last_seen_at for the peer link (called on every valid request)."""

--- a/tinyagentos/contacts_store.py
+++ b/tinyagentos/contacts_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import secrets
+import sqlite3
 import time
 from pathlib import Path
 from typing import Optional
@@ -33,9 +34,11 @@ CREATE TABLE IF NOT EXISTS peer_links (
 );
 
 CREATE TABLE IF NOT EXISTS peer_nonces (
-    nonce                   TEXT PRIMARY KEY,  -- 16-byte hex nonce from envelope
+    nonce                   TEXT NOT NULL,       -- 16-byte hex nonce from envelope
     contact_id              TEXT NOT NULL,
-    seen_at                 REAL NOT NULL
+    kind                    TEXT NOT NULL DEFAULT '',
+    seen_at                 REAL NOT NULL,
+    PRIMARY KEY (contact_id, kind, nonce)
 );
 """
 
@@ -224,7 +227,7 @@ class ContactsStore(BaseStore):
         rec["endpoints"] = _json_loads(rec.get("endpoints", "[]"))
         return rec
 
-    async def record_nonce(self, nonce: str, contact_id: str) -> bool:
+    async def record_nonce(self, nonce: str, contact_id: str, kind: str = "") -> bool:
         """Record a seen nonce for replay protection.
 
         Returns True if the nonce was recorded (first time seen), False if it
@@ -232,6 +235,11 @@ class ContactsStore(BaseStore):
 
         Nonces older than ``NONCE_MAX_AGE_SECS`` are pruned on insert so the
         table does not grow unbounded.
+
+        The uniqueness key is ``(contact_id, kind, nonce)`` — a nonce is only
+        a replay when all three match (per design section 2).  A rejected
+        envelope (bad sig / bad to) must NOT burn its nonce; the caller should
+        only record a nonce AFTER verification passes.
         """
         now = time.time()
         # Prune expired nonces (opportunistic, one DELETE per insert keeps the
@@ -242,13 +250,13 @@ class ContactsStore(BaseStore):
         )
         try:
             await self._db.execute(
-                "INSERT INTO peer_nonces (nonce, contact_id, seen_at) VALUES (?, ?, ?)",
-                (nonce, contact_id, now),
+                "INSERT INTO peer_nonces (nonce, contact_id, kind, seen_at) VALUES (?, ?, ?, ?)",
+                (nonce, contact_id, kind, now),
             )
             await self._db.commit()
             return True
-        except Exception:
-            # Nonce already exists (PRIMARY KEY conflict) — replay detected.
+        except sqlite3.IntegrityError:
+            # Nonce already exists for this (contact_id, kind) — replay detected.
             return False
 
     async def is_nonce_seen(self, nonce: str) -> bool:

--- a/tinyagentos/contacts_store.py
+++ b/tinyagentos/contacts_store.py
@@ -51,6 +51,8 @@ _PEER_TOKEN_BYTES = 32
 # + 60s buffer.  After this window a nonce is pruned so the table stays small.
 NONCE_MAX_AGE_SECS = 600
 
+VALID_CONTACT_STATUSES = frozenset({"pending", "active", "blocked", "revoked"})
+
 
 def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode("utf-8")).hexdigest()
@@ -70,6 +72,8 @@ class ContactsStore(BaseStore):
     """
 
     SCHEMA = CONTACTS_SCHEMA
+
+    MIGRATIONS: list = []
 
     # ------------------------------------------------------------------
     # contacts
@@ -91,6 +95,11 @@ class ContactsStore(BaseStore):
         On conflict (same contact_id) the key material is updated — this is
         the trust-on-first-use refresh when a friend re-accepts.
         """
+        if status not in VALID_CONTACT_STATUSES:
+            raise ValueError(
+                f"invalid contact status: {status!r} — "
+                f"must be one of {sorted(VALID_CONTACT_STATUSES)}"
+            )
         now = time.time()
         await self._db.execute(
             """INSERT INTO contacts
@@ -125,6 +134,11 @@ class ContactsStore(BaseStore):
         return _row_to_dict(columns, rows[0]) if rows else None
 
     async def set_contact_status(self, contact_id: str, status: str) -> None:
+        if status not in VALID_CONTACT_STATUSES:
+            raise ValueError(
+                f"invalid contact status: {status!r} — "
+                f"must be one of {sorted(VALID_CONTACT_STATUSES)}"
+            )
         now = time.time()
         if status in ("blocked", "revoked"):
             await self._db.execute(

--- a/tinyagentos/contacts_store.py
+++ b/tinyagentos/contacts_store.py
@@ -111,7 +111,8 @@ class ContactsStore(BaseStore):
                  x25519_pub = excluded.x25519_pub,
                  display_name = excluded.display_name,
                  status = excluded.status,
-                 local_crm_id = excluded.local_crm_id""",
+                 local_crm_id = excluded.local_crm_id,
+                 revoked_at = NULL""",
             (contact_id, hub_username, display_name, ed25519_pub, x25519_pub,
              status, local_crm_id, now),
         )
@@ -147,7 +148,7 @@ class ContactsStore(BaseStore):
             )
         else:
             await self._db.execute(
-                "UPDATE contacts SET status = ? WHERE contact_id = ?",
+                "UPDATE contacts SET status = ?, revoked_at = NULL WHERE contact_id = ?",
                 (status, contact_id),
             )
         await self._db.commit()

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -1,0 +1,183 @@
+"""Ed25519-signed envelopes and peer-token auth for the peer channel.
+
+Reuses ``tinyagentos.hub.identity`` for key material: the node's own Ed25519
+signing key signs every outgoing envelope; incoming envelopes are verified
+against the sender's pinned public key from the contacts store.
+
+Peer tokens are minted by the owning instance and presented by the remote
+instance as ``Authorization: Bearer <peer-token>`` on ``POST /api/peer/*``.
+They are opaque hex strings, hashed at rest in the peer_links table (same
+pattern as registry tokens).  The ``sub`` concept is ``contact:{username}``
+and peer tokens grant *only* the peer route family — never the general API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Optional
+
+from tinyagentos.hub.identity import (
+    fingerprint,
+    sign as _sign,
+    verify_signature,
+)
+
+
+# ---------------------------------------------------------------------------
+# Signed envelopes
+# ---------------------------------------------------------------------------
+
+def build_envelope(
+    *,
+    from_username: str,
+    to_username: str,
+    kind: str,
+    body: dict | None = None,
+) -> dict:
+    """Build a signed envelope from this node to a remote contact.
+
+    ``kind`` is one of: ``handshake``, ``collab_invite``, ``delegation_request``,
+    ``chat``, ``ack``.  ``body`` is the payload dict.
+
+    The envelope is signed with this node's Ed25519 signing key (from
+    ``hub.identity``), so the receiver can verify it against the pinned pubkey
+    from the contacts store (trust-on-first-use at friend-accept).
+
+    Envelope shape::
+
+        {
+            "from": "hub:jaylfc",
+            "to":   "hub:hogne",
+            "kind": "collab_invite",
+            "body": { ... },
+            "ts":   1710000000.0,
+            "nonce": "hex...",
+            "sig":   "hex..."
+        }
+    """
+    import secrets
+
+    nonce = secrets.token_hex(16)
+    ts = time.time()
+    envelope: dict = {
+        "from": f"hub:{from_username}",
+        "to": f"hub:{to_username}",
+        "kind": kind,
+        "ts": ts,
+        "nonce": nonce,
+    }
+    if body is not None:
+        envelope["body"] = body
+
+    # Sign the canonical JSON representation (sorted keys, compact).
+    payload = _canonical_json(envelope)
+    sig = _sign(payload)
+    envelope["sig"] = sig
+    return envelope
+
+
+def verify_envelope(
+    envelope: dict,
+    *,
+    expected_kind: str | None = None,
+    max_age_seconds: float = 300.0,
+) -> tuple[bool, str]:
+    """Verify a signed envelope against the sender's pinned Ed25519 pubkey.
+
+    Returns ``(ok, error_reason)``.  ``ok`` is True only when all checks pass.
+    The caller MUST have already resolved the sender's pubkey from the contacts
+    store before calling this function.
+
+    Checks performed:
+    1. Required fields present (from, to, kind, ts, nonce, sig).
+    2. Timestamp is within ``max_age_seconds`` of now (replay window).
+    3. ``expected_kind`` matches if provided.
+    4. Signature verifies against the sender's pubkey.
+    """
+    required = ("from", "to", "kind", "ts", "nonce", "sig")
+    for field in required:
+        if field not in envelope:
+            return False, f"missing required field: {field}"
+
+    # Timestamp freshness (with 30s clock-skew grace).
+    age = abs(time.time() - envelope["ts"])
+    if age > max_age_seconds + 30.0:
+        return False, f"envelope too old: {age:.0f}s > {max_age_seconds}s"
+
+    if expected_kind is not None and envelope["kind"] != expected_kind:
+        return False, f"unexpected kind: {envelope['kind']} != {expected_kind}"
+
+    return True, ""
+
+
+def verify_envelope_signature(
+    envelope: dict,
+    sender_ed25519_pub: str,
+) -> bool:
+    """Verify ONLY the Ed25519 signature, assuming the caller has already checked
+    freshness and structure. Returns True/False (never raises)."""
+    sig = envelope.pop("sig", None)
+    if sig is None:
+        # Restore and fail.
+        envelope["sig"] = sig
+        return False
+    try:
+        payload = _canonical_json(envelope)
+        result = verify_signature(sender_ed25519_pub, payload, sig)
+    finally:
+        # Always restore the envelope dict.
+        envelope["sig"] = sig
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Peer tokens
+# ---------------------------------------------------------------------------
+
+_PEER_TOKEN_BYTES = 32
+
+
+def mint_peer_token(sub: str) -> tuple[str, str]:
+    """Mint a new peer token for a contact.
+
+    Returns ``(plaintext_token, token_hash)``.  The plaintext is given to the
+    remote instance; the hash is stored in ``peer_links.inbound_token_hash``.
+
+    ``sub`` is the token subject, e.g. ``"contact:hogne"``.
+    """
+    import secrets
+
+    raw = secrets.token_hex(_PEER_TOKEN_BYTES)
+    # Include the sub in the hash so two contacts can never share a hash even
+    # if (astronomically unlikely) token collision occurs.
+    token_hash = hashlib.sha256(
+        f"{sub}:{raw}".encode("utf-8")
+    ).hexdigest()
+    return raw, token_hash
+
+
+def hash_peer_token(token: str) -> str:
+    """Return the SHA-256 hash of a peer token (for at-rest storage)."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def verify_peer_token(
+    presented: str,
+    stored_hash: str,
+) -> bool:
+    """Constant-time comparison of a presented peer token against stored hash."""
+    computed = hash_peer_token(presented)
+    return hmac.compare_digest(computed, stored_hash)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json(obj: dict) -> bytes:
+    """Canonical JSON: sorted keys, compact, UTF-8 bytes (no trailing newline)."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -14,13 +14,11 @@ and peer tokens grant *only* the peer route family — never the general API.
 from __future__ import annotations
 
 import hashlib
-import hmac
 import json
 import time
 from typing import Optional
 
 from tinyagentos.hub.identity import (
-    fingerprint,
     sign as _sign,
     verify_signature,
 )
@@ -147,30 +145,15 @@ def mint_peer_token(sub: str) -> tuple[str, str]:
     remote instance; the hash is stored in ``peer_links.inbound_token_hash``.
 
     ``sub`` is the token subject, e.g. ``"contact:hogne"``.
+
+    Uses the same plain SHA-256 as ``ContactsStore._hash_token`` so that
+    minting and verification are consistent.
     """
     import secrets
 
     raw = secrets.token_hex(_PEER_TOKEN_BYTES)
-    # Include the sub in the hash so two contacts can never share a hash even
-    # if (astronomically unlikely) token collision occurs.
-    token_hash = hashlib.sha256(
-        f"{sub}:{raw}".encode("utf-8")
-    ).hexdigest()
+    token_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()
     return raw, token_hash
-
-
-def hash_peer_token(token: str) -> str:
-    """Return the SHA-256 hash of a peer token (for at-rest storage)."""
-    return hashlib.sha256(token.encode("utf-8")).hexdigest()
-
-
-def verify_peer_token(
-    presented: str,
-    stored_hash: str,
-) -> bool:
-    """Constant-time comparison of a presented peer token against stored hash."""
-    computed = hash_peer_token(presented)
-    return hmac.compare_digest(computed, stored_hash)
 
 
 # ---------------------------------------------------------------------------

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -15,11 +15,15 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
+import os
+import sqlite3
 import time
-from typing import Optional
+from pathlib import Path
 
 from tinyagentos.hub.identity import (
     sign as _sign,
+    signing_fingerprint,
     verify_signature,
 )
 
@@ -100,8 +104,14 @@ def verify_envelope(
         if field not in envelope:
             return False, f"missing required field: {field}"
 
-    # Timestamp freshness (with 30s clock-skew grace).
-    age = abs(time.time() - envelope["ts"])
+    # Timestamp freshness: reject non-finite, future-only (past skew), and stale.
+    ts = envelope["ts"]
+    if not isinstance(ts, (int, float)) or not math.isfinite(ts):
+        return False, f"non-finite timestamp: {ts!r}"
+    now = time.time()
+    age = now - ts  # positive = past, negative = future
+    if age < -30.0:
+        return False, f"envelope from the future: {abs(age):.0f}s ahead"
     if age > max_age_seconds + 30.0:
         return False, f"envelope too old: {age:.0f}s > {max_age_seconds}s"
 
@@ -119,8 +129,6 @@ def verify_envelope_signature(
     freshness and structure. Returns True/False (never raises)."""
     sig = envelope.pop("sig", None)
     if sig is None:
-        # Restore and fail.
-        envelope["sig"] = sig
         return False
     try:
         payload = _canonical_json(envelope)
@@ -164,3 +172,44 @@ def mint_peer_token(sub: str) -> tuple[str, str]:
 def _canonical_json(obj: dict) -> bytes:
     """Canonical JSON: sorted keys, compact, UTF-8 bytes (no trailing newline)."""
     return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def resolve_local_identity_id(data_dir: str | Path | None = None) -> str | None:
+    """Return this node's local hub identity ID (``"hub:<username>"``), or None.
+
+    Resolved from the hub identity keystore and the hub_authors table in
+    hub.db.  Returns None if the node has not registered a hub identity
+    (no identity keystore, or no matching author row).
+    """
+    try:
+        fp = signing_fingerprint()
+    except Exception:
+        return None
+
+    # Resolve hub.db path the same way hub.store resolves it:
+    # TAOS_DATA_DIR override, else project data dir.
+    if data_dir:
+        hub_dir = Path(data_dir) / "hub"
+    else:
+        env = os.environ.get("TAOS_DATA_DIR")
+        if env:
+            hub_dir = Path(env) / "hub"
+        else:
+            hub_dir = Path(__file__).resolve().parent.parent / "data" / "hub"
+
+    hub_db = hub_dir / "hub.db"
+    if not hub_db.is_file():
+        return None
+
+    try:
+        conn = sqlite3.connect(str(hub_db))
+        row = conn.execute(
+            "SELECT username FROM hub_authors WHERE fingerprint = ?",
+            (fp,),
+        ).fetchone()
+        conn.close()
+        if row and row[0]:
+            return f"hub:{row[0]}"
+    except Exception:
+        pass
+    return None

--- a/tinyagentos/peer.py
+++ b/tinyagentos/peer.py
@@ -97,7 +97,8 @@ def verify_envelope(
     1. Required fields present (from, to, kind, ts, nonce, sig).
     2. Timestamp is within ``max_age_seconds`` of now (replay window).
     3. ``expected_kind`` matches if provided.
-    4. Signature verifies against the sender's pubkey.
+    (The caller must separately verify the Ed25519 signature against the
+     sender's pinned pubkey via ``verify_envelope_signature``.)
     """
     required = ("from", "to", "kind", "ts", "nonce", "sig")
     for field in required:
@@ -201,15 +202,18 @@ def resolve_local_identity_id(data_dir: str | Path | None = None) -> str | None:
     if not hub_db.is_file():
         return None
 
+    conn = None
     try:
         conn = sqlite3.connect(str(hub_db))
         row = conn.execute(
             "SELECT username FROM hub_authors WHERE fingerprint = ?",
             (fp,),
         ).fetchone()
-        conn.close()
         if row and row[0]:
             return f"hub:{row[0]}"
-    except Exception:
+    except (sqlite3.OperationalError, sqlite3.DatabaseError):
         pass
+    finally:
+        if conn is not None:
+            conn.close()
     return None

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -402,5 +402,8 @@ def register_all_routers(app):
     from tinyagentos.routes import wallhaven as wallhaven_routes
     app.include_router(wallhaven_routes.router, dependencies=_csrf)
 
+    from tinyagentos.routes.peer import router as peer_router
+    app.include_router(peer_router)  # CSRF-exempt — bearer-only auth
+
     from tinyagentos.routes.council import router as council_router
     app.include_router(council_router, dependencies=_csrf)

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from tinyagentos.peer import (
+    resolve_local_identity_id,
     verify_envelope,
     verify_envelope_signature,
 )
@@ -27,6 +28,9 @@ from tinyagentos.peer import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/peer", tags=["peer"])
+# IMPORTANT: every route under this prefix MUST call _authenticate_peer.
+# Do not add a route here without bearer-auth — this is an instance-to-instance
+# surface facing other nodes, not an end-user API.
 
 # Rate limits per spec section 8: 60 req/min/contact, 32KB envelope cap.
 _RATE_WINDOW_SECS = 60.0
@@ -100,9 +104,8 @@ async def _authenticate_peer(request: Request) -> str:
     Raises 401 if the token is missing, invalid, or the contact is not active.
 
     The peer token is stored hashed in peer_links.inbound_token_hash.  We
-    look up the contact by iterating active contacts and comparing token
-    hashes — this is O(n) but n is small (contacts are human-scale, not
-    agent-scale) and avoids adding an index table.
+    look up the contact via an indexed hash lookup on the inbound_token_hash
+    column (JOIN with contacts), so lookup is O(1) regardless of contact count.
     """
     store = request.app.state.contacts_store
     if store is None:
@@ -144,7 +147,18 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
     if not _rate_limit_ok(contact_id):
         raise HTTPException(status_code=429, detail="rate limit exceeded (60/min/contact)")
 
-    # Size limit
+    # Size limit — reject on Content-Length before we re-serialise.
+    cl = request.headers.get("content-length")
+    if cl is not None:
+        try:
+            cl_int = int(cl)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid Content-Length")
+        if cl_int > _MAX_ENVELOPE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"request too large: {cl_int} bytes > {_MAX_ENVELOPE_BYTES}",
+            )
     raw = json.dumps(body.envelope, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     if len(raw) > _MAX_ENVELOPE_BYTES:
         raise HTTPException(
@@ -154,25 +168,29 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
 
     envelope = body.envelope
 
+    # Verify sender binding: envelope["from"] must match the authenticated contact.
+    from_field = envelope.get("from", "")
+    if from_field != contact_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"from field {from_field!r} does not match authenticated contact {contact_id!r}",
+        )
+
+    # Verify recipient: envelope["to"] must match the local hub identity.
+    local_id = resolve_local_identity_id(request.app.state.data_dir)
+    if local_id is None:
+        raise HTTPException(status_code=503, detail="hub identity not configured")
+    to_field = envelope.get("to", "")
+    if to_field != local_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"envelope addressed to {to_field!r}, not {local_id!r}",
+        )
+
     # Verify structure + freshness
     ok, err = verify_envelope(envelope)
     if not ok:
         raise HTTPException(status_code=400, detail=f"invalid envelope: {err}")
-
-    # Nonce replay protection — each envelope must have a unique nonce.
-    nonce = envelope.get("nonce", "")
-    if not nonce:
-        raise HTTPException(status_code=400, detail="missing nonce")
-    if not await store.record_nonce(nonce, contact_id):
-        raise HTTPException(status_code=409, detail="nonce replay detected")
-
-    # Verify the "to" field matches this contact's id
-    to_field = envelope.get("to", "")
-    if to_field != contact_id:
-        raise HTTPException(
-            status_code=403,
-            detail=f"envelope addressed to {to_field}, not {contact_id}",
-        )
 
     # Verify signature against pinned pubkey
     contact_rec = await store.get_contact(contact_id)
@@ -182,6 +200,15 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
     sender_pubkey = contact_rec.get("ed25519_pub", "")
     if not verify_envelope_signature(envelope, sender_pubkey):
         raise HTTPException(status_code=403, detail="invalid signature")
+
+    # Nonce replay protection — record only AFTER all verification passes so
+    # a rejected envelope (bad sig, bad recipient) does not burn its nonce.
+    nonce = envelope.get("nonce", "")
+    if not nonce:
+        raise HTTPException(status_code=400, detail="missing nonce")
+    kind = envelope.get("kind", "")
+    if not await store.record_nonce(nonce, contact_id, kind):
+        raise HTTPException(status_code=409, detail="nonce replay detected")
 
     # Mark peer as seen
     await store.mark_peer_seen(contact_id)
@@ -211,6 +238,18 @@ async def peer_chat(body: PeerEnvelope, request: Request):
     if not _rate_limit_ok(contact_id):
         raise HTTPException(status_code=429, detail="rate limit exceeded")
 
+    # Size limit — reject on Content-Length before we re-serialise.
+    cl = request.headers.get("content-length")
+    if cl is not None:
+        try:
+            cl_int = int(cl)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="invalid Content-Length")
+        if cl_int > _MAX_ENVELOPE_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=f"request too large: {cl_int} bytes > {_MAX_ENVELOPE_BYTES}",
+            )
     raw = json.dumps(body.envelope, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
     if len(raw) > _MAX_ENVELOPE_BYTES:
         raise HTTPException(
@@ -222,23 +261,28 @@ async def peer_chat(body: PeerEnvelope, request: Request):
     if envelope.get("kind") != "chat":
         raise HTTPException(status_code=400, detail="kind must be 'chat'")
 
+    # Verify sender binding: envelope["from"] must match the authenticated contact.
+    from_field = envelope.get("from", "")
+    if from_field != contact_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"from field {from_field!r} does not match authenticated contact {contact_id!r}",
+        )
+
+    # Verify recipient: envelope["to"] must match the local hub identity.
+    local_id = resolve_local_identity_id(request.app.state.data_dir)
+    if local_id is None:
+        raise HTTPException(status_code=503, detail="hub identity not configured")
+    to_field = envelope.get("to", "")
+    if to_field != local_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"envelope addressed to {to_field!r}, not {local_id!r}",
+        )
+
     ok, err = verify_envelope(envelope, expected_kind="chat")
     if not ok:
         raise HTTPException(status_code=400, detail=f"invalid envelope: {err}")
-
-    # Nonce replay protection
-    nonce = envelope.get("nonce", "")
-    if not nonce:
-        raise HTTPException(status_code=400, detail="missing nonce")
-    if not await store.record_nonce(nonce, contact_id):
-        raise HTTPException(status_code=409, detail="nonce replay detected")
-
-    to_field = envelope.get("to", "")
-    if to_field != contact_id:
-        raise HTTPException(
-            status_code=403,
-            detail=f"envelope addressed to {to_field}, not {contact_id}",
-        )
 
     contact_rec = await store.get_contact(contact_id)
     if contact_rec is None:
@@ -246,6 +290,14 @@ async def peer_chat(body: PeerEnvelope, request: Request):
 
     if not verify_envelope_signature(envelope, contact_rec.get("ed25519_pub", "")):
         raise HTTPException(status_code=403, detail="invalid signature")
+
+    # Nonce replay protection — record only AFTER all verification passes.
+    nonce = envelope.get("nonce", "")
+    if not nonce:
+        raise HTTPException(status_code=400, detail="missing nonce")
+    kind = envelope.get("kind", "")
+    if not await store.record_nonce(nonce, contact_id, kind):
+        raise HTTPException(status_code=409, detail="nonce replay detected")
 
     await store.mark_peer_seen(contact_id)
 

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -34,19 +34,38 @@ _RATE_MAX_PER_WINDOW = 60
 _MAX_ENVELOPE_BYTES = 32 * 1024  # 32 KB
 
 # In-memory per-contact rate limiter: contact_id -> (window_start, count).
+# Per-process only — under multi-worker deployments each worker maintains its
+# own counter.  A shared store (Redis or sqlite) is needed for accurate
+# limits across workers.
 _rate_hits: dict[str, tuple[float, int]] = {}
+# Max entries before stale-window cleanup triggers.  Keeps the dict bounded
+# for long-running servers that see many distinct contacts over time.
+_RATE_HITS_MAX_SIZE = 2000
 
 
 def _rate_limit_ok(contact_id: str) -> bool:
     """Fixed-window per-contact rate limiter.
 
     Returns False when the contact has exceeded 60 requests in the current
-    60-second window.
+    60-second window.  Evicts entries with expired windows when the dict
+    grows past ``_RATE_HITS_MAX_SIZE`` to prevent unbounded memory growth.
     """
     now = time.time()
     window_start, count = _rate_hits.get(contact_id, (now, 0))
     if now - window_start >= _RATE_WINDOW_SECS:
         window_start, count = now, 0
+
+    # Opportunistic eviction: when the dict exceeds the max size, sweep out
+    # every entry whose window has expired.  This is O(n) but only runs
+    # occasionally when the dict is full.
+    if len(_rate_hits) >= _RATE_HITS_MAX_SIZE:
+        expired = [
+            cid for cid, (ws, _) in _rate_hits.items()
+            if now - ws >= _RATE_WINDOW_SECS
+        ]
+        for cid in expired:
+            del _rate_hits[cid]
+
     count += 1
     _rate_hits[contact_id] = (window_start, count)
     return count <= _RATE_MAX_PER_WINDOW
@@ -140,6 +159,13 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
     if not ok:
         raise HTTPException(status_code=400, detail=f"invalid envelope: {err}")
 
+    # Nonce replay protection — each envelope must have a unique nonce.
+    nonce = envelope.get("nonce", "")
+    if not nonce:
+        raise HTTPException(status_code=400, detail="missing nonce")
+    if not await store.record_nonce(nonce, contact_id):
+        raise HTTPException(status_code=409, detail="nonce replay detected")
+
     # Verify the "to" field matches this contact's id
     to_field = envelope.get("to", "")
     if to_field != contact_id:
@@ -199,6 +225,13 @@ async def peer_chat(body: PeerEnvelope, request: Request):
     ok, err = verify_envelope(envelope, expected_kind="chat")
     if not ok:
         raise HTTPException(status_code=400, detail=f"invalid envelope: {err}")
+
+    # Nonce replay protection
+    nonce = envelope.get("nonce", "")
+    if not nonce:
+        raise HTTPException(status_code=400, detail="missing nonce")
+    if not await store.record_nonce(nonce, contact_id):
+        raise HTTPException(status_code=409, detail="nonce replay detected")
 
     to_field = envelope.get("to", "")
     if to_field != contact_id:

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -1,0 +1,247 @@
+"""Peer channel routes — instance-to-instance API for contacts.
+
+CSRF-exempt (bearer-only auth, no cookies). Peer tokens grant ONLY this
+route family.
+
+Endpoints
+---------
+POST /api/peer/inbox   — receive a signed envelope from a contact
+POST /api/peer/chat    — receive a chat message envelope
+POST /api/peer/ack     — acknowledge delivery of an envelope
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from tinyagentos.peer import (
+    verify_envelope,
+    verify_envelope_signature,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/peer", tags=["peer"])
+
+# Rate limits per spec section 8: 60 req/min/contact, 32KB envelope cap.
+_RATE_WINDOW_SECS = 60.0
+_RATE_MAX_PER_WINDOW = 60
+_MAX_ENVELOPE_BYTES = 32 * 1024  # 32 KB
+
+# In-memory per-contact rate limiter: contact_id -> (window_start, count).
+_rate_hits: dict[str, tuple[float, int]] = {}
+
+
+def _rate_limit_ok(contact_id: str) -> bool:
+    """Fixed-window per-contact rate limiter.
+
+    Returns False when the contact has exceeded 60 requests in the current
+    60-second window.
+    """
+    now = time.time()
+    window_start, count = _rate_hits.get(contact_id, (now, 0))
+    if now - window_start >= _RATE_WINDOW_SECS:
+        window_start, count = now, 0
+    count += 1
+    _rate_hits[contact_id] = (window_start, count)
+    return count <= _RATE_MAX_PER_WINDOW
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class PeerEnvelope(BaseModel):
+    """A signed envelope received from a remote contact."""
+
+    envelope: dict = Field(..., description="The signed envelope dict")
+
+
+class PeerAck(BaseModel):
+    """Delivery acknowledgement."""
+
+    envelope_id: str = Field(..., description="The nonce of the acknowledged envelope")
+    contact_id: str = Field(..., description="The acknowledging contact")
+
+
+# ---------------------------------------------------------------------------
+# Auth helper
+# ---------------------------------------------------------------------------
+
+
+async def _authenticate_peer(request: Request) -> str:
+    """Verify the bearer peer token and return the contact_id.
+
+    Raises 401 if the token is missing, invalid, or the contact is not active.
+
+    The peer token is stored hashed in peer_links.inbound_token_hash.  We
+    look up the contact by iterating active contacts and comparing token
+    hashes — this is O(n) but n is small (contacts are human-scale, not
+    agent-scale) and avoids adding an index table.
+    """
+    store = request.app.state.contacts_store
+    if store is None:
+        raise HTTPException(status_code=503, detail="peer channel not available")
+
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="bearer token required")
+
+    presented = auth[7:].strip()
+    if not presented:
+        raise HTTPException(status_code=401, detail="empty bearer token")
+
+    # Find the contact whose inbound token hash matches.
+    contact = await store.find_contact_by_inbound_token(presented)
+    if contact is None:
+        raise HTTPException(status_code=401, detail="invalid peer token")
+
+    contact_id = contact["contact_id"]
+    return contact_id
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.post("/inbox")
+async def peer_inbox(body: PeerEnvelope, request: Request):
+    """Receive a signed envelope from a remote contact.
+
+    The envelope body is verified against the sender's pinned Ed25519 pubkey
+    (from the contacts store).  Rate-limited per contact.
+    """
+    contact_id = await _authenticate_peer(request)
+    store = request.app.state.contacts_store
+
+    # Rate limit
+    if not _rate_limit_ok(contact_id):
+        raise HTTPException(status_code=429, detail="rate limit exceeded (60/min/contact)")
+
+    # Size limit
+    raw = json.dumps(body.envelope, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(raw) > _MAX_ENVELOPE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"envelope too large: {len(raw)} bytes > {_MAX_ENVELOPE_BYTES}",
+        )
+
+    envelope = body.envelope
+
+    # Verify structure + freshness
+    ok, err = verify_envelope(envelope)
+    if not ok:
+        raise HTTPException(status_code=400, detail=f"invalid envelope: {err}")
+
+    # Verify the "to" field matches this contact's id
+    to_field = envelope.get("to", "")
+    if to_field != contact_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"envelope addressed to {to_field}, not {contact_id}",
+        )
+
+    # Verify signature against pinned pubkey
+    contact_rec = await store.get_contact(contact_id)
+    if contact_rec is None:
+        raise HTTPException(status_code=404, detail="contact not found")
+
+    sender_pubkey = contact_rec.get("ed25519_pub", "")
+    if not verify_envelope_signature(envelope, sender_pubkey):
+        raise HTTPException(status_code=403, detail="invalid signature")
+
+    # Mark peer as seen
+    await store.mark_peer_seen(contact_id)
+
+    # Log the envelope kind for debugging; the real dispatch (collab invites,
+    # chat messages, etc.) happens in later milestones.
+    kind = envelope.get("kind", "unknown")
+    logger.info(
+        "peer_inbox: contact=%s kind=%s nonce=%s",
+        contact_id, kind, envelope.get("nonce", "?"),
+    )
+
+    return {"status": "received", "kind": kind, "nonce": envelope.get("nonce")}
+
+
+@router.post("/chat")
+async def peer_chat(body: PeerEnvelope, request: Request):
+    """Receive a chat message envelope from a contact.
+
+    Identical auth/envelope verification as /inbox, with a separate rate-limit
+    path for chat-specific limits (600 msgs/day/contact per spec, but enforced
+    per-minute for simplicity in v1).
+    """
+    contact_id = await _authenticate_peer(request)
+    store = request.app.state.contacts_store
+
+    if not _rate_limit_ok(contact_id):
+        raise HTTPException(status_code=429, detail="rate limit exceeded")
+
+    raw = json.dumps(body.envelope, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(raw) > _MAX_ENVELOPE_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"envelope too large: {len(raw)} bytes > {_MAX_ENVELOPE_BYTES}",
+        )
+
+    envelope = body.envelope
+    if envelope.get("kind") != "chat":
+        raise HTTPException(status_code=400, detail="kind must be 'chat'")
+
+    ok, err = verify_envelope(envelope, expected_kind="chat")
+    if not ok:
+        raise HTTPException(status_code=400, detail=f"invalid envelope: {err}")
+
+    to_field = envelope.get("to", "")
+    if to_field != contact_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"envelope addressed to {to_field}, not {contact_id}",
+        )
+
+    contact_rec = await store.get_contact(contact_id)
+    if contact_rec is None:
+        raise HTTPException(status_code=404, detail="contact not found")
+
+    if not verify_envelope_signature(envelope, contact_rec.get("ed25519_pub", "")):
+        raise HTTPException(status_code=403, detail="invalid signature")
+
+    await store.mark_peer_seen(contact_id)
+
+    logger.info(
+        "peer_chat: contact=%s nonce=%s",
+        contact_id, envelope.get("nonce", "?"),
+    )
+
+    return {"status": "received", "nonce": envelope.get("nonce")}
+
+
+@router.post("/ack")
+async def peer_ack(body: PeerAck, request: Request):
+    """Acknowledge delivery of an envelope (double-tick).
+
+    The remote instance calls this after successfully processing an envelope
+    so the sender can mark it as delivered.
+    """
+    contact_id = await _authenticate_peer(request)
+    store = request.app.state.contacts_store
+
+    if not _rate_limit_ok(contact_id):
+        raise HTTPException(status_code=429, detail="rate limit exceeded")
+
+    await store.mark_peer_seen(contact_id)
+
+    logger.info(
+        "peer_ack: contact=%s envelope_nonce=%s",
+        contact_id, body.envelope_id,
+    )
+
+    return {"status": "acked", "envelope_id": body.envelope_id}

--- a/tinyagentos/routes/peer.py
+++ b/tinyagentos/routes/peer.py
@@ -12,6 +12,7 @@ POST /api/peer/ack     — acknowledge delivery of an envelope
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -177,7 +178,7 @@ async def peer_inbox(body: PeerEnvelope, request: Request):
         )
 
     # Verify recipient: envelope["to"] must match the local hub identity.
-    local_id = resolve_local_identity_id(request.app.state.data_dir)
+    local_id = await asyncio.to_thread(resolve_local_identity_id, request.app.state.data_dir)
     if local_id is None:
         raise HTTPException(status_code=503, detail="hub identity not configured")
     to_field = envelope.get("to", "")
@@ -270,7 +271,7 @@ async def peer_chat(body: PeerEnvelope, request: Request):
         )
 
     # Verify recipient: envelope["to"] must match the local hub identity.
-    local_id = resolve_local_identity_id(request.app.state.data_dir)
+    local_id = await asyncio.to_thread(resolve_local_identity_id, request.app.state.data_dir)
     if local_id is None:
         raise HTTPException(status_code=503, detail="hub identity not configured")
     to_field = envelope.get("to", "")
@@ -318,6 +319,13 @@ async def peer_ack(body: PeerAck, request: Request):
     """
     contact_id = await _authenticate_peer(request)
     store = request.app.state.contacts_store
+
+    # The ack must come from the contact named in the body.
+    if body.contact_id != contact_id:
+        raise HTTPException(
+            status_code=400,
+            detail=f"contact_id {body.contact_id!r} does not match authenticated contact {contact_id!r}",
+        )
 
     if not _rate_limit_ok(contact_id):
         raise HTTPException(status_code=429, detail="rate limit exceeded")


### PR DESCRIPTION
## Changes since last review

Addresses jaylfc's review (#2025) — all items marked CRITICAL/HIGH/MED fixed:

### CRITICAL
- **from/to reversed** — added sender binding (`envelope["from"] == contact_id`) and recipient check (`envelope["to"] == local_hub_identity`) in both `/inbox` and `/chat` handlers. Added `resolve_local_identity_id()` to `peer.py` that resolves `"hub:<username>"` from the hub identity keystore + hub_authors table. Returns 503 if no local identity is configured.

### HIGH
- **ts NaN/future bypass** — `verify_envelope()` now rejects non-finite timestamps and future timestamps (>30s skew), using `now - ts` instead of `abs()`.
- **test isolation** — identity-using tests set `TAOS_DATA_DIR` via `monkeypatch` + `tmp_path`, isolatating the hub identity keystore from the real node identity.
- **plaintext outbound_token** — code comment already states "encryption deferred to post-MVP". This is surfaced as an explicit design decision; encryption-at-rest for peer tokens is deferred to a follow-up PR.
- **Content-Length pre-check** — both handlers now check `Content-Length` header before re-serialisation.

### MED
- **peer_nonces schema** — changed PK from `nonce` alone to `(contact_id, kind, nonce)` composite key per design section 2. `record_nonce` now accepts `kind` parameter.
- **Nonce recorded AFTER verification** — moved `record_nonce` call after signature verification so rejected envelopes (bad sig / bad recipient) do not burn their nonce.
- **record_nonce exception** — narrowed from bare `except Exception` to `sqlite3.IntegrityError`.

### LOW (folded)
- Fixed `_authenticate_peer` docstring (O(1) indexed hash lookup, not O(n))
- Fixed `verify_envelope_signature` to not mutate `envelope["sig"] = None` on missing sig
- Added guard comment at `/api/peer` router requiring `_authenticate_peer` on every route

### Tests
- 37/37 peer tests pass
- Added: `test_inbox_spoofed_from_rejected`, `test_verify_envelope_nan_ts_rejected`, `test_verify_envelope_future_ts_rejected`
- Updated: all route tests for corrected to/from semantics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a SQLite-backed contacts/peer-link store with contact status management, inbound-token lookup, endpoint persistence, and peer “last seen” tracking.
  - Implemented signed peer envelopes and bearer peer-token minting.
  - Added `/api/peer/inbox`, `/api/peer/chat`, and `/api/peer/ack` with CSRF-exempt, bearer-only handling.
- **Bug Fixes**
  - Enforced envelope freshness, signature verification, nonce replay protection, token/contact mismatch checks, oversize rejection, and correct revocation cascade behavior.
- **Tests**
  - Added comprehensive async integration tests covering store behavior, envelope/token verification, and peer route edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->