### PR TITLE
feat(todo): add kind=list → Todo migration with idempotent /api/todo/migrate endpoint

### DIFF
--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -87,6 +87,34 @@ class TestVerifyCSRF:
             )
         assert resp.status_code == 403
 
+    @pytest.mark.asyncio
+    async def test_todo_mutation_without_csrf_token_forbidden(self, app):
+        """Todo list creation without matching X-CSRF-Token returns 403."""
+        from tinyagentos.todo.todo_store import TodoStore
+
+        todo_store = TodoStore(app.state.data_dir / "todo.db")
+        await todo_store.init()
+        app.state.todo_store = todo_store
+
+        app.state.auth.setup_user("csrftest", "CSRF Test", "", "pass1234!")
+        record = app.state.auth.find_user("csrftest")
+        token = app.state.auth.create_session(user_id=record["id"], long_lived=False)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            cookies={"taos_session": token, "csrf_token": "real-token"},
+        ) as c:
+            resp = await c.post(
+                "/api/todo",
+                json={"title": "x"},
+                headers={"X-CSRF-Token": "wrong-token"},
+            )
+        assert resp.status_code == 403
+
+        await todo_store.close()
+
 
 def test_verify_csrf_is_noop_for_websocket_scope():
     # verify_csrf is typed HTTPConnection so FastAPI injects it on BOTH http and

--- a/tests/todo/test_migration.py
+++ b/tests/todo/test_migration.py
@@ -196,22 +196,24 @@ async def test_migrate_idempotent(shared_store, todo_store):
 
 @pytest.mark.asyncio
 async def test_migrate_recovers_from_interruption(shared_store, todo_store):
-    """If migration was interrupted after target creation but before source
-    deletion, a re-run detects the existing matching list, flows entries into
-    it, and stamps ``migrated_from`` so future re-runs skip by exact id."""
-    doc, entries = await _setup_list_doc(
+    """If migration was interrupted after target creation (migrated_from
+    stamped) but before items were copied, a re-run detects the incomplete
+    target, copies items in, sets migration_complete, and cleans up."""
+    doc, _ = await _setup_list_doc(
         shared_store, "user-a", "Interrupted",
         ["Item 1", "Item 2"],
         done_mask={0},
     )
 
-    # Simulate a partial migration: the target list already exists
-    # (as if the first run created it but crashed before deleting source).
-    partial = await todo_store.create_list("user-a", "Interrupted")
+    # Simulate a partial migration: target exists with migrated_from stamp
+    # but migration_complete is still 0 (crash before item copy).
+    partial = await todo_store.create_list(
+        "user-a", "Interrupted", migrated_from=doc["id"],
+    )
     partial_id = partial["id"]
 
-    # Run migration — it should detect the matching list, migrate entries
-    # into it (data-loss prevention), and stamp migrated_from.
+    # Run migration — it should detect the incomplete target, copy items,
+    # and mark complete.
     result = await migrate_list_docs(shared_store, todo_store)
     assert result["migrated"] == 0  # No new list created
     assert result["items"] == 2     # Entries flowed into existing list
@@ -224,21 +226,62 @@ async def test_migrate_recovers_from_interruption(shared_store, todo_store):
 
     # Exactly one list exists — no duplicate.
     all_lists = await todo_store.list_lists("user-a", include_archived=True)
-    matching = [l for l in all_lists if l["title"] == "Interrupted"]
+    matching = [lst for lst in all_lists if lst["title"] == "Interrupted"]
     assert len(matching) == 1
 
-    # Target list now has the items + the migrated_from stamp.
+    # Target list now has the items + migrated_from + migration_complete.
     target = await todo_store.get_list(partial_id)
     assert target is not None
     assert target.get("migrated_from") == doc["id"]
+    assert target.get("migration_complete") == 1
     assert len(target["items"]) == 2
     assert [i["text"] for i in target["items"]] == ["Item 1", "Item 2"]
 
-    # Idempotent re-run — migrated_from matches, so no duplicate items.
+    # Idempotent re-run — migration_complete=1, so no duplicate items.
     result2 = await migrate_list_docs(shared_store, todo_store)
     assert result2["items"] == 0
     target2 = await todo_store.get_list(partial_id)
     assert len(target2["items"]) == 2  # still only 2 items
+
+
+@pytest.mark.asyncio
+async def test_migrate_resumes_from_partial_item_copy(
+    shared_store, todo_store,
+):
+    """If migration crashed after copying one item (target stamped,
+    migration_complete=0, one item present), resume clears the partial
+    items and re-copies all entries without duplicates."""
+    doc, _ = await _setup_list_doc(
+        shared_store, "user-a", "Partial",
+        ["Item A", "Item B", "Item C"],
+        done_mask={2},
+    )
+
+    # Simulate: target created, one item copied, then crash.
+    partial = await todo_store.create_list(
+        "user-a", "Partial", migrated_from=doc["id"],
+    )
+    partial_id = partial["id"]
+    await todo_store.add_item(partial_id, "Item A", author="user-a")
+
+    # Run migration — should clear the partial item and re-copy all 3.
+    result = await migrate_list_docs(shared_store, todo_store)
+    assert result["migrated"] == 0
+    assert result["items"] == 3
+    assert len(result["lists"]) == 1
+    assert result["lists"][0]["new_id"] == partial_id
+
+    # Source deleted.
+    assert await shared_store.get_doc(doc["id"]) is None
+
+    # Target has exactly 3 items, no duplicates.
+    target = await todo_store.get_list(partial_id)
+    assert target.get("migration_complete") == 1
+    assert len(target["items"]) == 3
+    texts = [i["text"] for i in target["items"]]
+    assert texts == ["Item A", "Item B", "Item C"]
+    done_flags = [i["done"] for i in target["items"]]
+    assert done_flags == [False, False, True]
 
 
 @pytest.mark.asyncio
@@ -293,7 +336,7 @@ async def test_migrate_same_title_different_docs_no_data_loss(
 
     # Two distinct todo lists, each with correct items.
     all_lists = await todo_store.list_lists("user-a", include_archived=True)
-    matching = [l for l in all_lists if l["title"] == "Shopping"]
+    matching = [lst for lst in all_lists if lst["title"] == "Shopping"]
     assert len(matching) == 2
 
     items_a = (await todo_store.get_list(matching[0]["id"]))["items"]
@@ -302,7 +345,7 @@ async def test_migrate_same_title_different_docs_no_data_loss(
     assert all_texts == {"Milk", "Eggs", "Bread", "Butter"}
 
     # Each todo list should be stamped with its source doc id.
-    stamped = {l["id"]: l.get("migrated_from") for l in matching}
+    stamped = {lst["id"]: lst.get("migrated_from") for lst in matching}
     assert set(stamped.values()) == {doc_a["id"], doc_b["id"]}
 
 

--- a/tests/todo/test_migration.py
+++ b/tests/todo/test_migration.py
@@ -304,3 +304,48 @@ async def test_migrate_same_title_different_docs_no_data_loss(
     # Each todo list should be stamped with its source doc id.
     stamped = {l["id"]: l.get("migrated_from") for l in matching}
     assert set(stamped.values()) == {doc_a["id"], doc_b["id"]}
+
+
+@pytest.mark.asyncio
+async def test_migrate_skips_nonempty_user_created_list(
+    shared_store, todo_store,
+):
+    """A user-created todo list (non-empty) with the same title must not be
+    used as a recovery target — a new list is created instead."""
+    # User has an existing non-empty todo list named "Tasks".
+    user_list = await todo_store.create_list("user-a", "Tasks")
+    user_list_id = user_list["id"]
+    await todo_store.add_item(user_list_id, "Existing item", author="user-a")
+
+    # Now there's a source doc with the same title.
+    doc, _ = await _setup_list_doc(
+        shared_store, "user-a", "Tasks",
+        ["Migrated item 1", "Migrated item 2"],
+    )
+
+    result = await migrate_list_docs(shared_store, todo_store)
+
+    # A NEW list should be created (not merged into the user's list).
+    assert result["migrated"] == 1
+    assert result["items"] == 2
+
+    # Source doc deleted.
+    assert await shared_store.get_doc(doc["id"]) is None
+
+    # User's existing list untouched (still has its one item).
+    user_list_after = await todo_store.get_list(user_list_id)
+    assert user_list_after is not None
+    assert len(user_list_after["items"]) == 1
+    assert user_list_after["items"][0]["text"] == "Existing item"
+    assert user_list_after.get("migrated_from") is None
+
+    # New list has the migrated items + stamp.
+    new_id = result["lists"][0]["new_id"]
+    new_list = await todo_store.get_list(new_id)
+    assert new_list is not None
+    assert new_list["title"] == "Tasks"
+    assert new_list.get("migrated_from") == doc["id"]
+    assert [i["text"] for i in new_list["items"]] == [
+        "Migrated item 1", "Migrated item 2",
+    ]
+    assert new_list["id"] != user_list_id

--- a/tests/todo/test_migration.py
+++ b/tests/todo/test_migration.py
@@ -58,7 +58,7 @@ async def test_migrate_empty(shared_store, todo_store):
 @pytest.mark.asyncio
 async def test_migrate_single_list(shared_store, todo_store):
     """Single list with entries → migrated, source deleted."""
-    doc, entries = await _setup_list_doc(
+    doc, _entries = await _setup_list_doc(
         shared_store, "user-a", "Groceries",
         ["Milk", "Eggs", "Bread"],
         done_mask={1},
@@ -287,7 +287,7 @@ async def test_migrate_resumes_from_partial_item_copy(
 @pytest.mark.asyncio
 async def test_migrate_preserves_done_and_order(shared_store, todo_store):
     """Done flags and entry order are faithfully migrated."""
-    doc, entries = await _setup_list_doc(
+    _doc, _entries = await _setup_list_doc(
         shared_store, "user-a", "Checklist",
         ["First", "Second", "Third", "Fourth"],
         done_mask={0, 3},  # First and Fourth are done

--- a/tests/todo/test_migration.py
+++ b/tests/todo/test_migration.py
@@ -1,0 +1,213 @@
+"""Tests for the kind=list → Todo migration."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.notes.shared_docs_store import SharedDocsStore
+from tinyagentos.todo.todo_store import TodoStore
+from tinyagentos.todo.migration import migrate_list_docs
+
+
+@pytest_asyncio.fixture
+async def shared_store(tmp_path):
+    s = SharedDocsStore(tmp_path / "shared_docs.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest_asyncio.fixture
+async def todo_store(tmp_path):
+    s = TodoStore(tmp_path / "todo.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+# -------------------------------------------------------------------- helpers
+
+async def _setup_list_doc(store, owner, title, entries, done_mask=None):
+    """Create a kind=list doc with entries. done_mask is a set of indices."""
+    doc = await store.create_doc(owner, "list", title)
+    created = []
+    for i, text in enumerate(entries):
+        entry = await store.add_entry(doc["id"], text, author=owner)
+        if done_mask and i in done_mask:
+            await store.set_entry_done(entry["id"], True)
+        created.append(entry)
+    return doc, created
+
+
+# --------------------------------------------------------------------- tests
+
+@pytest.mark.asyncio
+async def test_migrate_empty(shared_store, todo_store):
+    """No list docs → zero migrated, idempotent."""
+    result = await migrate_list_docs(shared_store, todo_store)
+    assert result["migrated"] == 0
+    assert result["items"] == 0
+    assert result["lists"] == []
+
+    # Idempotent re-run.
+    result2 = await migrate_list_docs(shared_store, todo_store)
+    assert result2 == result
+
+
+@pytest.mark.asyncio
+async def test_migrate_single_list(shared_store, todo_store):
+    """Single list with entries → migrated, source deleted."""
+    doc, entries = await _setup_list_doc(
+        shared_store, "user-a", "Groceries",
+        ["Milk", "Eggs", "Bread"],
+        done_mask={1},
+    )
+
+    result = await migrate_list_docs(shared_store, todo_store)
+    assert result["migrated"] == 1
+    assert result["items"] == 3
+    assert len(result["lists"]) == 1
+    assert result["lists"][0]["old_id"] == doc["id"]
+
+    new_id = result["lists"][0]["new_id"]
+
+    # Source should be gone.
+    assert await shared_store.get_doc(doc["id"]) is None
+
+    # Target should have the list + items.
+    todo_list = await todo_store.get_list(new_id)
+    assert todo_list is not None
+    assert todo_list["owner_user_id"] == "user-a"
+    assert todo_list["title"] == "Groceries"
+    assert todo_list["archived_at"] is None
+
+    items = todo_list["items"]
+    assert len(items) == 3
+    assert [i["text"] for i in items] == ["Milk", "Eggs", "Bread"]
+    assert [i["done"] for i in items] == [False, True, False]
+    assert [i["author"] for i in items] == ["user-a", "user-a", "user-a"]
+
+
+@pytest.mark.asyncio
+async def test_migrate_multiple_lists(shared_store, todo_store):
+    """Multiple list docs from different owners → all migrated."""
+    doc1, _ = await _setup_list_doc(
+        shared_store, "alice", "Weekend",
+        ["Clean", "Cook"],
+    )
+    doc2, _ = await _setup_list_doc(
+        shared_store, "bob", "Work",
+        ["Report", "Slides", "Email"],
+        done_mask={0},
+    )
+
+    result = await migrate_list_docs(shared_store, todo_store)
+    assert result["migrated"] == 2
+    assert result["items"] == 5
+
+    # Both sources deleted.
+    assert await shared_store.get_doc(doc1["id"]) is None
+    assert await shared_store.get_doc(doc2["id"]) is None
+
+    # Verify data integrity by mapping.
+    by_old = {item["old_id"]: item for item in result["lists"]}
+    list1 = await todo_store.get_list(by_old[doc1["id"]]["new_id"])
+    list2 = await todo_store.get_list(by_old[doc2["id"]]["new_id"])
+
+    assert list1["owner_user_id"] == "alice"
+    assert list1["title"] == "Weekend"
+    assert [i["text"] for i in list1["items"]] == ["Clean", "Cook"]
+
+    assert list2["owner_user_id"] == "bob"
+    assert list2["title"] == "Work"
+    assert [i["text"] for i in list2["items"]] == ["Report", "Slides", "Email"]
+    assert [i["done"] for i in list2["items"]] == [True, False, False]
+
+
+@pytest.mark.asyncio
+async def test_migrate_skips_notes(shared_store, todo_store):
+    """kind=note docs are left untouched by the migration."""
+    note = await shared_store.create_doc("user-a", "note", "Ideas")
+    await shared_store.add_entry(note["id"], "AI todo app", author="user-a")
+
+    list_doc, _ = await _setup_list_doc(
+        shared_store, "user-a", "Tasks",
+        ["Do the thing"],
+    )
+
+    result = await migrate_list_docs(shared_store, todo_store)
+    assert result["migrated"] == 1
+    assert result["items"] == 1
+
+    # Note should still exist.
+    still_note = await shared_store.get_doc(note["id"])
+    assert still_note is not None
+    assert still_note["kind"] == "note"
+    assert len(still_note["entries"]) == 1
+    assert still_note["entries"][0]["text"] == "AI todo app"
+
+    # List should be gone.
+    assert await shared_store.get_doc(list_doc["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_migrate_archived_list_not_migrated(shared_store, todo_store):
+    """Archived list docs are excluded from migration."""
+    doc, _ = await _setup_list_doc(
+        shared_store, "user-a", "Old tasks",
+        ["Thing 1"],
+    )
+    await shared_store.archive_doc(doc["id"])
+
+    result = await migrate_list_docs(shared_store, todo_store)
+    assert result["migrated"] == 0
+    assert result["items"] == 0
+
+    # Archived doc still exists.
+    still_doc = await shared_store.get_doc(doc["id"])
+    assert still_doc is not None
+    assert still_doc["archived_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_migrate_idempotent(shared_store, todo_store):
+    """Running migration twice should be safe — second call is a no-op."""
+    await _setup_list_doc(
+        shared_store, "user-a", "Tasks",
+        ["A", "B", "C"],
+    )
+
+    r1 = await migrate_list_docs(shared_store, todo_store)
+    assert r1["migrated"] == 1
+    assert r1["items"] == 3
+
+    # Second run — nothing left to migrate.
+    r2 = await migrate_list_docs(shared_store, todo_store)
+    assert r2["migrated"] == 0
+    assert r2["items"] == 0
+
+    # Data still intact in todo store.
+    new_id = r1["lists"][0]["new_id"]
+    todo_list = await todo_store.get_list(new_id)
+    assert todo_list is not None
+    assert len(todo_list["items"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_migrate_preserves_done_and_order(shared_store, todo_store):
+    """Done flags and entry order are faithfully migrated."""
+    doc, entries = await _setup_list_doc(
+        shared_store, "user-a", "Checklist",
+        ["First", "Second", "Third", "Fourth"],
+        done_mask={0, 3},  # First and Fourth are done
+    )
+
+    result = await migrate_list_docs(shared_store, todo_store)
+    new_id = result["lists"][0]["new_id"]
+    todo_list = await todo_store.get_list(new_id)
+
+    items = todo_list["items"]
+    assert [i["text"] for i in items] == ["First", "Second", "Third", "Fourth"]
+    assert [i["done"] for i in items] == [True, False, False, True]
+    assert [i["author"] for i in items] == ["user-a"] * 4

--- a/tests/todo/test_migration.py
+++ b/tests/todo/test_migration.py
@@ -197,8 +197,8 @@ async def test_migrate_idempotent(shared_store, todo_store):
 @pytest.mark.asyncio
 async def test_migrate_recovers_from_interruption(shared_store, todo_store):
     """If migration was interrupted after target creation but before source
-    deletion, a re-run detects the existing matching list and skips duplicate
-    creation while cleaning up the source."""
+    deletion, a re-run detects the existing matching list, flows entries into
+    it, and stamps ``migrated_from`` so future re-runs skip by exact id."""
     doc, entries = await _setup_list_doc(
         shared_store, "user-a", "Interrupted",
         ["Item 1", "Item 2"],
@@ -210,10 +210,11 @@ async def test_migrate_recovers_from_interruption(shared_store, todo_store):
     partial = await todo_store.create_list("user-a", "Interrupted")
     partial_id = partial["id"]
 
-    # Run migration — it should detect the matching list and skip.
+    # Run migration — it should detect the matching list, migrate entries
+    # into it (data-loss prevention), and stamp migrated_from.
     result = await migrate_list_docs(shared_store, todo_store)
-    assert result["migrated"] == 0  # No new migration
-    assert result["items"] == 0
+    assert result["migrated"] == 0  # No new list created
+    assert result["items"] == 2     # Entries flowed into existing list
     assert len(result["lists"]) == 1
     assert result["lists"][0]["old_id"] == doc["id"]
     assert result["lists"][0]["new_id"] == partial_id
@@ -225,6 +226,19 @@ async def test_migrate_recovers_from_interruption(shared_store, todo_store):
     all_lists = await todo_store.list_lists("user-a", include_archived=True)
     matching = [l for l in all_lists if l["title"] == "Interrupted"]
     assert len(matching) == 1
+
+    # Target list now has the items + the migrated_from stamp.
+    target = await todo_store.get_list(partial_id)
+    assert target is not None
+    assert target.get("migrated_from") == doc["id"]
+    assert len(target["items"]) == 2
+    assert [i["text"] for i in target["items"]] == ["Item 1", "Item 2"]
+
+    # Idempotent re-run — migrated_from matches, so no duplicate items.
+    result2 = await migrate_list_docs(shared_store, todo_store)
+    assert result2["items"] == 0
+    target2 = await todo_store.get_list(partial_id)
+    assert len(target2["items"]) == 2  # still only 2 items
 
 
 @pytest.mark.asyncio
@@ -244,3 +258,49 @@ async def test_migrate_preserves_done_and_order(shared_store, todo_store):
     assert [i["text"] for i in items] == ["First", "Second", "Third", "Fourth"]
     assert [i["done"] for i in items] == [True, False, False, True]
     assert [i["author"] for i in items] == ["user-a"] * 4
+
+
+@pytest.mark.asyncio
+async def test_migrate_same_title_different_docs_no_data_loss(
+    shared_store, todo_store,
+):
+    """Two source docs with the same owner+title must both be fully migrated.
+
+    Regression test for the Kilo finding: matching by owner+title alone can
+    match the second source doc to the first doc's target, silently deleting
+    the second source without migrating its entries.
+    """
+    # Two distinct list docs with same owner and same title.
+    doc_a, _ = await _setup_list_doc(
+        shared_store, "user-a", "Shopping",
+        ["Milk", "Eggs"],
+    )
+    doc_b, _ = await _setup_list_doc(
+        shared_store, "user-a", "Shopping",
+        ["Bread", "Butter"],
+    )
+
+    result = await migrate_list_docs(shared_store, todo_store)
+
+    # Both should be migrated.
+    assert result["migrated"] == 2
+    assert result["items"] == 4
+    assert len(result["lists"]) == 2
+
+    # Both source docs deleted.
+    assert await shared_store.get_doc(doc_a["id"]) is None
+    assert await shared_store.get_doc(doc_b["id"]) is None
+
+    # Two distinct todo lists, each with correct items.
+    all_lists = await todo_store.list_lists("user-a", include_archived=True)
+    matching = [l for l in all_lists if l["title"] == "Shopping"]
+    assert len(matching) == 2
+
+    items_a = (await todo_store.get_list(matching[0]["id"]))["items"]
+    items_b = (await todo_store.get_list(matching[1]["id"]))["items"]
+    all_texts = {i["text"] for i in items_a} | {i["text"] for i in items_b}
+    assert all_texts == {"Milk", "Eggs", "Bread", "Butter"}
+
+    # Each todo list should be stamped with its source doc id.
+    stamped = {l["id"]: l.get("migrated_from") for l in matching}
+    assert set(stamped.values()) == {doc_a["id"], doc_b["id"]}

--- a/tests/todo/test_migration.py
+++ b/tests/todo/test_migration.py
@@ -195,6 +195,39 @@ async def test_migrate_idempotent(shared_store, todo_store):
 
 
 @pytest.mark.asyncio
+async def test_migrate_recovers_from_interruption(shared_store, todo_store):
+    """If migration was interrupted after target creation but before source
+    deletion, a re-run detects the existing matching list and skips duplicate
+    creation while cleaning up the source."""
+    doc, entries = await _setup_list_doc(
+        shared_store, "user-a", "Interrupted",
+        ["Item 1", "Item 2"],
+        done_mask={0},
+    )
+
+    # Simulate a partial migration: the target list already exists
+    # (as if the first run created it but crashed before deleting source).
+    partial = await todo_store.create_list("user-a", "Interrupted")
+    partial_id = partial["id"]
+
+    # Run migration — it should detect the matching list and skip.
+    result = await migrate_list_docs(shared_store, todo_store)
+    assert result["migrated"] == 0  # No new migration
+    assert result["items"] == 0
+    assert len(result["lists"]) == 1
+    assert result["lists"][0]["old_id"] == doc["id"]
+    assert result["lists"][0]["new_id"] == partial_id
+
+    # Source should be cleaned up.
+    assert await shared_store.get_doc(doc["id"]) is None
+
+    # Exactly one list exists — no duplicate.
+    all_lists = await todo_store.list_lists("user-a", include_archived=True)
+    matching = [l for l in all_lists if l["title"] == "Interrupted"]
+    assert len(matching) == 1
+
+
+@pytest.mark.asyncio
 async def test_migrate_preserves_done_and_order(shared_store, todo_store):
     """Done flags and entry order are faithfully migrated."""
     doc, entries = await _setup_list_doc(

--- a/tests/todo/test_todo_routes.py
+++ b/tests/todo/test_todo_routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import secrets
+
 import pytest
 import pytest_asyncio
 import yaml
@@ -41,11 +43,14 @@ async def client(tmp_path):
     token = app.state.auth.create_session(user_id=record["id"], long_lived=True)
     app.state._startup_complete = True
 
+    csrf_token = secrets.token_hex(32)
+
     transport = ASGITransport(app=app)
     async with AsyncClient(
         transport=transport,
         base_url="http://test",
-        cookies={"taos_session": token},
+        cookies={"taos_session": token, "csrf_token": csrf_token},
+        headers={"X-CSRF-Token": csrf_token},
     ) as c:
         yield c
 
@@ -77,12 +82,17 @@ async def two_user_clients(tmp_path):
     app.state._startup_complete = True
     transport = ASGITransport(app=app)
 
+    alice_csrf = secrets.token_hex(32)
+    bob_csrf = secrets.token_hex(32)
+
     async with AsyncClient(
         transport=transport, base_url="http://test",
-        cookies={"taos_session": alice_token},
+        cookies={"taos_session": alice_token, "csrf_token": alice_csrf},
+        headers={"X-CSRF-Token": alice_csrf},
     ) as alice, AsyncClient(
         transport=transport, base_url="http://test",
-        cookies={"taos_session": bob_token},
+        cookies={"taos_session": bob_token, "csrf_token": bob_csrf},
+        headers={"X-CSRF-Token": bob_csrf},
     ) as bob:
         yield alice, bob, app
 
@@ -291,7 +301,7 @@ async def test_add_item_with_due_date(client):
     doc = (await client.post("/api/todo", json={"title": "Deadlines"})).json()
     item = (await client.post(
         f"/api/todo/{doc['id']}/items",
-        json={"text": "Submit report", "due_at": "2026-12-31T23:59:59"},
+        json={"text": "Submit report", "due_at": "2026-12-31T23:59:59+00:00"},
     )).json()
     assert item["due_at"] is not None
     assert item["text"] == "Submit report"
@@ -308,6 +318,18 @@ async def test_add_item_with_invalid_due_date_returns_400(client):
 
 
 @pytest.mark.asyncio
+async def test_add_item_with_naive_due_date_returns_400(client):
+    """Offsetless (naive) datetime strings are rejected."""
+    doc = (await client.post("/api/todo", json={"title": "x"})).json()
+    resp = await client.post(
+        f"/api/todo/{doc['id']}/items",
+        json={"text": "x", "due_at": "2026-12-31T23:59:59"},
+    )
+    assert resp.status_code == 400
+    assert "timezone" in resp.json()["error"].lower()
+
+
+@pytest.mark.asyncio
 async def test_patch_item_due_date(client):
     doc = (await client.post("/api/todo", json={"title": "x"})).json()
     item = (await client.post(
@@ -316,7 +338,7 @@ async def test_patch_item_due_date(client):
 
     resp = await client.patch(
         f"/api/todo/{doc['id']}/items/{item['id']}",
-        json={"due_at": "2026-07-04T12:00:00"},
+        json={"due_at": "2026-07-04T12:00:00+00:00"},
     )
     assert resp.status_code == 200
     assert resp.json()["due_at"] is not None

--- a/tinyagentos/notes/shared_docs_store.py
+++ b/tinyagentos/notes/shared_docs_store.py
@@ -454,3 +454,37 @@ class SharedDocsStore(BaseStore):
         )
         rows = await cur.fetchall()
         return [_row(cur.description, r) for r in rows]
+
+    async def list_docs_by_kind(self, kind: str) -> list[dict]:
+        """Return all non-archived docs of a given kind, newest-updated first."""
+        cur = await self._db.execute(
+            "SELECT * FROM shared_docs WHERE kind = ? AND archived_at IS NULL "
+            "ORDER BY updated_at DESC",
+            (kind,),
+        )
+        rows = await cur.fetchall()
+        docs = []
+        for r in rows:
+            doc = _row(cur.description, r)
+            doc["entries"] = await self.list_entries(doc["id"])
+            doc["members"] = await self.list_members(doc["id"])
+            docs.append(doc)
+        return docs
+
+    async def delete_doc(self, doc_id: str) -> None:
+        """Delete a doc, its entries, and its members."""
+        await self._db.execute(
+            "DELETE FROM shared_doc_entry_revisions WHERE entry_id IN "
+            "(SELECT id FROM shared_doc_entries WHERE doc_id = ?)",
+            (doc_id,),
+        )
+        await self._db.execute(
+            "DELETE FROM shared_doc_entries WHERE doc_id = ?", (doc_id,)
+        )
+        await self._db.execute(
+            "DELETE FROM shared_doc_members WHERE doc_id = ?", (doc_id,)
+        )
+        await self._db.execute(
+            "DELETE FROM shared_docs WHERE id = ?", (doc_id,)
+        )
+        await self._db.commit()

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -394,7 +394,7 @@ def register_all_routers(app):
     app.include_router(notes_router, dependencies=_csrf)
 
     from tinyagentos.routes.todo import router as todo_router
-    app.include_router(todo_router)
+    app.include_router(todo_router, dependencies=_csrf)
 
     from tinyagentos.routes.coding_sessions import router as coding_sessions_router
     app.include_router(coding_sessions_router, dependencies=_csrf)

--- a/tinyagentos/routes/todo.py
+++ b/tinyagentos/routes/todo.py
@@ -149,7 +149,6 @@ async def add_item(
     if body.due_at:
         try:
             dt = datetime.fromisoformat(body.due_at)
-: address 9 bot review findings — atomicity, CSRF, timezone, position, done)
         except ValueError:
             return JSONResponse(
                 {"error": f"invalid due_at: {body.due_at!r}"}, status_code=400
@@ -164,7 +163,6 @@ async def add_item(
     if body.remind_at:
         try:
             dt = datetime.fromisoformat(body.remind_at)
-: address 9 bot review findings — atomicity, CSRF, timezone, position, done)
         except ValueError:
             return JSONResponse(
                 {"error": f"invalid remind_at: {body.remind_at!r}"}, status_code=400

--- a/tinyagentos/routes/todo.py
+++ b/tinyagentos/routes/todo.py
@@ -51,7 +51,11 @@ class ReorderItemsIn(BaseModel):
 # -------------------------------------------------------------------- helpers
 
 def _get_store(request: Request):
-    return request.app.state.todo_store
+    store = getattr(request.app.state, "todo_store", None)
+    if store is None:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=500, detail="todo_store not available")
+    return store
 
 
 def _check_owner(doc: dict, user: CurrentUser):
@@ -145,24 +149,32 @@ async def add_item(
     if body.due_at:
         try:
             dt = datetime.fromisoformat(body.due_at)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            due_at = dt.timestamp()
+: address 9 bot review findings — atomicity, CSRF, timezone, position, done)
         except ValueError:
             return JSONResponse(
                 {"error": f"invalid due_at: {body.due_at!r}"}, status_code=400
             )
+        if dt.tzinfo is None:
+            return JSONResponse(
+                {"error": f"due_at requires timezone offset: {body.due_at!r}"},
+                status_code=400,
+            )
+        due_at = dt.timestamp()
     remind_at = None
     if body.remind_at:
         try:
             dt = datetime.fromisoformat(body.remind_at)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            remind_at = dt.timestamp()
+: address 9 bot review findings — atomicity, CSRF, timezone, position, done)
         except ValueError:
             return JSONResponse(
                 {"error": f"invalid remind_at: {body.remind_at!r}"}, status_code=400
             )
+        if dt.tzinfo is None:
+            return JSONResponse(
+                {"error": f"remind_at requires timezone offset: {body.remind_at!r}"},
+                status_code=400,
+            )
+        remind_at = dt.timestamp()
 
     return await store.add_item(
         list_id, body.text, author=user.user_id, due_at=due_at, remind_at=remind_at
@@ -196,18 +208,24 @@ async def patch_item(
     _CLEAR_SENTINEL = -1.0
 
     def _parse_ts(val):
-        """None = no change, '' = clear, ISO str = set."""
+        """None = no change, '' = clear, ISO str = set.
+
+        Returns None (not sent), _CLEAR_SENTINEL (clear), a float
+        timestamp (valid aware datetime), or None (error — handled below).
+        Rejects naive (offsetless) datetime strings.
+        """
         if val is None:
             return None  # not sent
         if val == "":
             return _CLEAR_SENTINEL
         try:
             dt = datetime.fromisoformat(val)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt.timestamp()
+
         except ValueError:
             return None  # Will be handled below
+        if dt.tzinfo is None:
+            return None  # naive — handled below as error
+        return dt.timestamp()
 
     due_at = _parse_ts(body.due_at)
     if due_at is None and body.due_at is not None and body.due_at != "":

--- a/tinyagentos/routes/todo.py
+++ b/tinyagentos/routes/todo.py
@@ -277,3 +277,34 @@ async def reorder_items(
     items = [{"id": e.id, "position": e.position} for e in body.items]
     await store.reorder_items(list_id, items)
     return JSONResponse({"ok": True})
+
+
+# ------------------------------------------------------------ migration route
+
+
+@router.post("/api/todo/migrate")
+async def migrate_notes_lists(
+    request: Request,
+    user: CurrentUser = Depends(current_user),
+):
+    """Migrate kind=list docs from shared notes into Todo lists.
+
+    Admin-only. Idempotent — safe to run multiple times.
+    Reads all non-archived kind=list docs, converts each to a todo
+    list with items, then deletes the originals from shared_docs.
+    """
+    if not user.is_admin:
+        return JSONResponse({"error": "forbidden"}, status_code=403)
+
+    shared = getattr(request.app.state, "shared_docs_store", None)
+    if shared is None:
+        return JSONResponse(
+            {"error": "shared_docs_store not available"}, status_code=500
+        )
+
+    todo = _get_store(request)
+
+    from tinyagentos.todo.migration import migrate_list_docs
+
+    result = await migrate_list_docs(shared, todo)
+    return result

--- a/tinyagentos/todo/migration.py
+++ b/tinyagentos/todo/migration.py
@@ -19,14 +19,14 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
     todo items (preserving order, text, done status, and author), then deletes
     the original doc + entries + members from shared_docs.
 
-    Idempotent: if a matching todo list already exists for a source document
-    (same owner + title), the source doc is simply cleaned up without creating
-    a duplicate. This handles both re-runs and interrupted migrations where
-    the target was created but the source was never deleted.
+    Idempotent: newly created todo lists record the source document id in a
+    ``migrated_from`` column.  On re-run each source doc is matched by its
+    **exact** id rather than by owner+title alone, so two source docs that
+    happen to share the same title are never conflated.
 
     Returns:
-        dict with ``migrated`` (list count), ``items`` (total items moved),
-        and ``lists`` (list of {old_id, new_id} pairs) for verification.
+        dict with ``migrated`` (lists newly created), ``items`` (total items
+        moved), and ``lists`` (list of {old_id, new_id} pairs) for verification.
     """
     list_docs = await shared_docs_store.list_docs_by_kind("list")
 
@@ -38,50 +38,91 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
         title = doc.get("title", "")
         entries = doc.get("entries", [])
 
-        # Check for a pre-existing matching todo list (same owner + title).
-        # This guards against duplicate creation on re-run or after an
-        # interrupted migration where the target was created but the source
-        # was never deleted.
         existing_lists = await todo_store.list_lists(
             owner, include_archived=True
         )
-        matching = [l for l in existing_lists if l["title"] == title]
 
-        if matching:
-            new_id = matching[0]["id"]
+        # -- primary idempotency check: exact source-doc match -----------
+        # If a todo list already has migrated_from == old_id we know this
+        # exact source was migrated on a previous run.
+        migrated_match = [
+            l for l in existing_lists
+            if l.get("migrated_from") == old_id
+        ]
+
+        if migrated_match:
+            new_id = migrated_match[0]["id"]
             logger.info(
-                "todo-migration: skipping already-migrated list %r "
+                "todo-migration: skipping already-migrated doc %r "
                 "(owner=%r, title=%r) → existing %r",
                 old_id, owner, title, new_id,
             )
             result["lists"].append({"old_id": old_id, "new_id": new_id})
-        else:
-            todo_list = await todo_store.create_list(owner, title)
-            new_id = todo_list["id"]
+            # Clean up source doc (items already live in the target).
+            await shared_docs_store.delete_doc(old_id)
+            continue
 
-            # Convert entries to todo items in original order.
+        # -- fallback: owner+title match ---------------------------------
+        # Handles interrupted migrations from code that predates the
+        # migrated_from column.  The target list exists but was never
+        # stamped, so we recover by flowing entries into it and stamping.
+        title_match = [
+            l for l in existing_lists
+            if l["title"] == title and l.get("migrated_from") is None
+        ]
+
+        if title_match:
+            new_id = title_match[0]["id"]
+            logger.info(
+                "todo-migration: recovering interrupted migration for "
+                "doc %r (owner=%r, title=%r) → existing %r",
+                old_id, owner, title, new_id,
+            )
+            # Flow entries into the existing list (data-loss prevention).
             for entry in entries:
                 text = entry.get("text", "")
                 done = bool(entry.get("done", False))
                 author = entry.get("author", "")
                 item = await todo_store.add_item(
-                    new_id,
-                    text,
-                    author=author,
+                    new_id, text, author=author,
                 )
                 if done:
                     await todo_store.patch_item(item["id"], done=True)
 
-            result["migrated"] += 1
+            # Stamp so future re-runs take the primary check above.
+            await todo_store.set_migrated_from(new_id, old_id)
+
             result["items"] += len(entries)
             result["lists"].append({"old_id": old_id, "new_id": new_id})
+            # Clean up source doc.
+            await shared_docs_store.delete_doc(old_id)
+            continue
 
-            logger.info(
-                "todo-migration: migrated list %r → %r (%d items)",
-                old_id,
-                new_id,
-                len(entries),
+        # -- normal path: create a fresh todo list ------------------------
+        todo_list = await todo_store.create_list(
+            owner, title, migrated_from=old_id,
+        )
+        new_id = todo_list["id"]
+
+        # Convert entries to todo items in original order.
+        for entry in entries:
+            text = entry.get("text", "")
+            done = bool(entry.get("done", False))
+            author = entry.get("author", "")
+            item = await todo_store.add_item(
+                new_id, text, author=author,
             )
+            if done:
+                await todo_store.patch_item(item["id"], done=True)
+
+        result["migrated"] += 1
+        result["items"] += len(entries)
+        result["lists"].append({"old_id": old_id, "new_id": new_id})
+
+        logger.info(
+            "todo-migration: migrated list %r → %r (%d items)",
+            old_id, new_id, len(entries),
+        )
 
         # Delete the original doc from shared_docs.
         await shared_docs_store.delete_doc(old_id)

--- a/tinyagentos/todo/migration.py
+++ b/tinyagentos/todo/migration.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sqlite3
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,14 @@ async def _migrate_list_docs(shared_docs_store, todo_store) -> dict:
                 old_id, owner, title, target_id,
             )
 
+            if target is None:
+                logger.warning(
+                    "todo-migration: target %r for doc %r vanished; "
+                    "skipping this run",
+                    target_id, old_id,
+                )
+                continue
+
             # Clear any partial items already in the target.
             existing_items = target.get("items", [])
             for item in existing_items:
@@ -113,9 +122,18 @@ async def _migrate_list_docs(shared_docs_store, todo_store) -> dict:
             continue
 
         # -- normal path: create a fresh todo list ------------------------
-        todo_list = await todo_store.create_list(
-            owner, title, migrated_from=old_id,
-        )
+        try:
+            todo_list = await todo_store.create_list(
+                owner, title, migrated_from=old_id,
+            )
+        except sqlite3.IntegrityError:
+            logger.warning(
+                "todo-migration: concurrent migration detected for "
+                "doc %r (owner=%r, title=%r); another process already "
+                "claimed it",
+                old_id, owner, title,
+            )
+            continue
         new_id = todo_list["id"]
 
         # Convert entries to todo items in original order.

--- a/tinyagentos/todo/migration.py
+++ b/tinyagentos/todo/migration.py
@@ -1,0 +1,72 @@
+"""Migrate kind=list documents from SharedDocsStore into TodoStore.
+
+One-shot, idempotent migration. Run via the /api/todo/migrate endpoint
+(admin-only) or called programmatically.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
+    """Migrate all kind=list docs from shared_docs into todo lists.
+
+    Reads every non-archived ``kind=list`` document, creates a corresponding
+    todo list with the same owner/title/timestamps, converts all entries into
+    todo items (preserving order, text, done status, and author), then deletes
+    the original doc + entries + members from shared_docs.
+
+    Idempotent: re-running is safe. Already-migrated docs are skipped because
+    they are deleted from shared_docs after migration.
+
+    Returns:
+        dict with ``migrated`` (list count), ``items`` (total items moved),
+        and ``lists`` (list of {old_id, new_id} pairs) for verification.
+    """
+    list_docs = await shared_docs_store.list_docs_by_kind("list")
+
+    result = {"migrated": 0, "items": 0, "lists": []}
+
+    for doc in list_docs:
+        old_id = doc["id"]
+        owner = doc["owner_user_id"]
+        title = doc.get("title", "")
+        entries = doc.get("entries", [])
+
+        # Create the todo list — preserve original timestamps for
+        # fidelity, though TodoStore.create_list sets fresh ones.
+        todo_list = await todo_store.create_list(owner, title)
+
+        new_id = todo_list["id"]
+
+        # Convert entries to todo items in original order.
+        for entry in entries:
+            text = entry.get("text", "")
+            done = bool(entry.get("done", False))
+            author = entry.get("author", "")
+            item = await todo_store.add_item(
+                new_id,
+                text,
+                author=author,
+            )
+            if done:
+                await todo_store.patch_item(item["id"], done=True)
+
+        # Delete the original doc from shared_docs.
+        await shared_docs_store.delete_doc(old_id)
+
+        result["migrated"] += 1
+        result["items"] += len(entries)
+        result["lists"].append({"old_id": old_id, "new_id": new_id})
+
+        logger.info(
+            "todo-migration: migrated list %r → %r (%d items)",
+            old_id,
+            new_id,
+            len(entries),
+        )
+
+    return result

--- a/tinyagentos/todo/migration.py
+++ b/tinyagentos/todo/migration.py
@@ -15,12 +15,14 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
     """Migrate all kind=list docs from shared_docs into todo lists.
 
     Reads every non-archived ``kind=list`` document, creates a corresponding
-    todo list with the same owner/title/timestamps, converts all entries into
+    todo list with the same owner/title, converts all entries into
     todo items (preserving order, text, done status, and author), then deletes
     the original doc + entries + members from shared_docs.
 
-    Idempotent: re-running is safe. Already-migrated docs are skipped because
-    they are deleted from shared_docs after migration.
+    Idempotent: if a matching todo list already exists for a source document
+    (same owner + title), the source doc is simply cleaned up without creating
+    a duplicate. This handles both re-runs and interrupted migrations where
+    the target was created but the source was never deleted.
 
     Returns:
         dict with ``migrated`` (list count), ``items`` (total items moved),
@@ -36,37 +38,52 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
         title = doc.get("title", "")
         entries = doc.get("entries", [])
 
-        # Create the todo list — preserve original timestamps for
-        # fidelity, though TodoStore.create_list sets fresh ones.
-        todo_list = await todo_store.create_list(owner, title)
+        # Check for a pre-existing matching todo list (same owner + title).
+        # This guards against duplicate creation on re-run or after an
+        # interrupted migration where the target was created but the source
+        # was never deleted.
+        existing_lists = await todo_store.list_lists(
+            owner, include_archived=True
+        )
+        matching = [l for l in existing_lists if l["title"] == title]
 
-        new_id = todo_list["id"]
-
-        # Convert entries to todo items in original order.
-        for entry in entries:
-            text = entry.get("text", "")
-            done = bool(entry.get("done", False))
-            author = entry.get("author", "")
-            item = await todo_store.add_item(
-                new_id,
-                text,
-                author=author,
+        if matching:
+            new_id = matching[0]["id"]
+            logger.info(
+                "todo-migration: skipping already-migrated list %r "
+                "(owner=%r, title=%r) → existing %r",
+                old_id, owner, title, new_id,
             )
-            if done:
-                await todo_store.patch_item(item["id"], done=True)
+            result["lists"].append({"old_id": old_id, "new_id": new_id})
+        else:
+            todo_list = await todo_store.create_list(owner, title)
+            new_id = todo_list["id"]
+
+            # Convert entries to todo items in original order.
+            for entry in entries:
+                text = entry.get("text", "")
+                done = bool(entry.get("done", False))
+                author = entry.get("author", "")
+                item = await todo_store.add_item(
+                    new_id,
+                    text,
+                    author=author,
+                )
+                if done:
+                    await todo_store.patch_item(item["id"], done=True)
+
+            result["migrated"] += 1
+            result["items"] += len(entries)
+            result["lists"].append({"old_id": old_id, "new_id": new_id})
+
+            logger.info(
+                "todo-migration: migrated list %r → %r (%d items)",
+                old_id,
+                new_id,
+                len(entries),
+            )
 
         # Delete the original doc from shared_docs.
         await shared_docs_store.delete_doc(old_id)
-
-        result["migrated"] += 1
-        result["items"] += len(entries)
-        result["lists"].append({"old_id": old_id, "new_id": new_id})
-
-        logger.info(
-            "todo-migration: migrated list %r → %r (%d items)",
-            old_id,
-            new_id,
-            len(entries),
-        )
 
     return result

--- a/tinyagentos/todo/migration.py
+++ b/tinyagentos/todo/migration.py
@@ -20,9 +20,10 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
     the original doc + entries + members from shared_docs.
 
     Idempotent: newly created todo lists record the source document id in a
-    ``migrated_from`` column.  On re-run each source doc is matched by its
-    **exact** id rather than by owner+title alone, so two source docs that
-    happen to share the same title are never conflated.
+    ``migrated_from`` column.  A ``migration_complete`` flag is set only after
+    all entries have been successfully copied.  On re-run a source doc is
+    matched by its **exact** id rather than by owner+title alone, so two
+    source docs that happen to share the same title are never conflated.
 
     Returns:
         dict with ``migrated`` (lists newly created), ``items`` (total items
@@ -42,67 +43,63 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
             owner, include_archived=True
         )
 
-        # -- primary idempotency check: exact source-doc match -----------
-        # If a todo list already has migrated_from == old_id we know this
-        # exact source was migrated on a previous run.
+        # -- idempotency check: exact source-doc match via migrated_from ---
         migrated_match = [
-            l for l in existing_lists
-            if l.get("migrated_from") == old_id
+            candidate for candidate in existing_lists
+            if candidate.get("migrated_from") == old_id
         ]
 
         if migrated_match:
-            new_id = migrated_match[0]["id"]
-            logger.info(
-                "todo-migration: skipping already-migrated doc %r "
-                "(owner=%r, title=%r) → existing %r",
-                old_id, owner, title, new_id,
-            )
-            result["lists"].append({"old_id": old_id, "new_id": new_id})
-            # Clean up source doc (items already live in the target).
-            await shared_docs_store.delete_doc(old_id)
-            continue
+            target_id = migrated_match[0]["id"]
+            target = await todo_store.get_list(target_id)
 
-        # -- fallback: owner+title match (empty-list guard) ----------------
-        # Handles interrupted migrations from code that predates the
-        # migrated_from column.  The target list exists but was never
-        # stamped.  To avoid conflating a user-created list (which likely
-        # already has items), we only recover into a list that is *empty* —
-        # the hallmark of a migration that created the shell but crashed
-        # before flowing entries.
-        title_match = [
-            l for l in existing_lists
-            if l["title"] == title and l.get("migrated_from") is None
-        ]
-
-        recovered = False
-        if title_match:
-            candidate_id = title_match[0]["id"]
-            target = await todo_store.get_list(candidate_id)
-            if target and not target.get("items"):
-                # Empty list — interrupted migration.  Flow entries in.
-                new_id = candidate_id
+            if target and target.get("migration_complete"):
+                # Migration was fully completed on a previous run —
+                # target is intact, source can be cleaned up.
                 logger.info(
-                    "todo-migration: recovering interrupted migration for "
-                    "doc %r (owner=%r, title=%r) → existing %r",
-                    old_id, owner, title, new_id,
+                    "todo-migration: skipping already-migrated doc %r "
+                    "(owner=%r, title=%r) → existing %r",
+                    old_id, owner, title, target_id,
                 )
-                for entry in entries:
-                    text = entry.get("text", "")
-                    done = bool(entry.get("done", False))
-                    author = entry.get("author", "")
-                    item = await todo_store.add_item(
-                        new_id, text, author=author,
-                    )
-                    if done:
-                        await todo_store.patch_item(item["id"], done=True)
+                result["lists"].append(
+                    {"old_id": old_id, "new_id": target_id}
+                )
+                await shared_docs_store.delete_doc(old_id)
+                continue
 
-                await todo_store.set_migrated_from(new_id, old_id)
-                result["items"] += len(entries)
-                result["lists"].append({"old_id": old_id, "new_id": new_id})
-                recovered = True
+            # Partial migration — target exists with migrated_from stamp
+            # but migration_complete was never set.  Resume by re-copying
+            # all entries.  Delete any partial items already in the target
+            # to avoid duplicates, then re-copy from source.
+            logger.info(
+                "todo-migration: resuming incomplete migration for "
+                "doc %r (owner=%r, title=%r) → existing %r",
+                old_id, owner, title, target_id,
+            )
 
-        if recovered:
-            # Clean up source doc (entries now live in the recovered target).
+            # Clear any partial items already in the target.
+            existing_items = target.get("items", [])
+            for item in existing_items:
+                await todo_store.delete_item(item["id"])
+
+            # Re-copy all entries from source.
+            for entry in entries:
+                text = entry.get("text", "")
+                done = bool(entry.get("done", False))
+                author = entry.get("author", "")
+                item = await todo_store.add_item(
+                    target_id, text, author=author,
+                )
+                if done:
+                    await todo_store.patch_item(item["id"], done=True)
+
+            await todo_store.set_migration_complete(target_id)
+            result["items"] += len(entries)
+            result["lists"].append(
+                {"old_id": old_id, "new_id": target_id}
+            )
+
+            # Source cleanup — all entries now live in the target.
             await shared_docs_store.delete_doc(old_id)
             continue
 
@@ -123,6 +120,7 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
             if done:
                 await todo_store.patch_item(item["id"], done=True)
 
+        await todo_store.set_migration_complete(new_id)
         result["migrated"] += 1
         result["items"] += len(entries)
         result["lists"].append({"old_id": old_id, "new_id": new_id})

--- a/tinyagentos/todo/migration.py
+++ b/tinyagentos/todo/migration.py
@@ -6,9 +6,12 @@ One-shot, idempotent migration. Run via the /api/todo/migrate endpoint
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
+
+_migration_lock = asyncio.Lock()
 
 
 async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
@@ -29,6 +32,12 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
         dict with ``migrated`` (lists newly created), ``items`` (total items
         moved), and ``lists`` (list of {old_id, new_id} pairs) for verification.
     """
+    async with _migration_lock:
+        return await _migrate_list_docs(shared_docs_store, todo_store)
+
+
+async def _migrate_list_docs(shared_docs_store, todo_store) -> dict:
+    """Internal implementation — callers should use migrate_list_docs."""
     list_docs = await shared_docs_store.list_docs_by_kind("list")
 
     result = {"migrated": 0, "items": 0, "lists": []}

--- a/tinyagentos/todo/migration.py
+++ b/tinyagentos/todo/migration.py
@@ -62,39 +62,47 @@ async def migrate_list_docs(shared_docs_store, todo_store) -> dict:
             await shared_docs_store.delete_doc(old_id)
             continue
 
-        # -- fallback: owner+title match ---------------------------------
+        # -- fallback: owner+title match (empty-list guard) ----------------
         # Handles interrupted migrations from code that predates the
         # migrated_from column.  The target list exists but was never
-        # stamped, so we recover by flowing entries into it and stamping.
+        # stamped.  To avoid conflating a user-created list (which likely
+        # already has items), we only recover into a list that is *empty* —
+        # the hallmark of a migration that created the shell but crashed
+        # before flowing entries.
         title_match = [
             l for l in existing_lists
             if l["title"] == title and l.get("migrated_from") is None
         ]
 
+        recovered = False
         if title_match:
-            new_id = title_match[0]["id"]
-            logger.info(
-                "todo-migration: recovering interrupted migration for "
-                "doc %r (owner=%r, title=%r) → existing %r",
-                old_id, owner, title, new_id,
-            )
-            # Flow entries into the existing list (data-loss prevention).
-            for entry in entries:
-                text = entry.get("text", "")
-                done = bool(entry.get("done", False))
-                author = entry.get("author", "")
-                item = await todo_store.add_item(
-                    new_id, text, author=author,
+            candidate_id = title_match[0]["id"]
+            target = await todo_store.get_list(candidate_id)
+            if target and not target.get("items"):
+                # Empty list — interrupted migration.  Flow entries in.
+                new_id = candidate_id
+                logger.info(
+                    "todo-migration: recovering interrupted migration for "
+                    "doc %r (owner=%r, title=%r) → existing %r",
+                    old_id, owner, title, new_id,
                 )
-                if done:
-                    await todo_store.patch_item(item["id"], done=True)
+                for entry in entries:
+                    text = entry.get("text", "")
+                    done = bool(entry.get("done", False))
+                    author = entry.get("author", "")
+                    item = await todo_store.add_item(
+                        new_id, text, author=author,
+                    )
+                    if done:
+                        await todo_store.patch_item(item["id"], done=True)
 
-            # Stamp so future re-runs take the primary check above.
-            await todo_store.set_migrated_from(new_id, old_id)
+                await todo_store.set_migrated_from(new_id, old_id)
+                result["items"] += len(entries)
+                result["lists"].append({"old_id": old_id, "new_id": new_id})
+                recovered = True
 
-            result["items"] += len(entries)
-            result["lists"].append({"old_id": old_id, "new_id": new_id})
-            # Clean up source doc.
+        if recovered:
+            # Clean up source doc (entries now live in the recovered target).
             await shared_docs_store.delete_doc(old_id)
             continue
 

--- a/tinyagentos/todo/todo_store.py
+++ b/tinyagentos/todo/todo_store.py
@@ -26,6 +26,7 @@ CREATE TABLE IF NOT EXISTS todo_lists (
     id            TEXT PRIMARY KEY,
     owner_user_id TEXT NOT NULL,
     title         TEXT NOT NULL DEFAULT '',
+    migrated_from TEXT,
     created_at    REAL NOT NULL,
     updated_at    REAL NOT NULL,
     archived_at   REAL
@@ -62,13 +63,16 @@ class TodoStore(BaseStore):
 
     # ------------------------------------------------------------------ lists
 
-    async def create_list(self, owner_user_id: str, title: str = "") -> dict:
+    async def create_list(
+        self, owner_user_id: str, title: str = "", migrated_from: str | None = None,
+    ) -> dict:
         list_id = _new_id("tl")
         now = time.time()
         await self._db.execute(
-            "INSERT INTO todo_lists (id, owner_user_id, title, created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (list_id, owner_user_id, title, now, now),
+            "INSERT INTO todo_lists "
+            "(id, owner_user_id, title, migrated_from, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (list_id, owner_user_id, title, migrated_from, now, now),
         )
         await self._db.commit()
         return await self.get_list(list_id)
@@ -116,6 +120,13 @@ class TodoStore(BaseStore):
         await self._db.execute(
             "UPDATE todo_lists SET archived_at = NULL, updated_at = ? WHERE id = ?",
             (time.time(), list_id),
+        )
+        await self._db.commit()
+
+    async def set_migrated_from(self, list_id: str, source_doc_id: str) -> None:
+        await self._db.execute(
+            "UPDATE todo_lists SET migrated_from = ?, updated_at = ? WHERE id = ?",
+            (source_doc_id, time.time(), list_id),
         )
         await self._db.commit()
 

--- a/tinyagentos/todo/todo_store.py
+++ b/tinyagentos/todo/todo_store.py
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS todo_lists (
     owner_user_id TEXT NOT NULL,
     title         TEXT NOT NULL DEFAULT '',
     migrated_from TEXT,
+    migration_complete INTEGER NOT NULL DEFAULT 0,
     created_at    REAL NOT NULL,
     updated_at    REAL NOT NULL,
     archived_at   REAL
@@ -127,6 +128,13 @@ class TodoStore(BaseStore):
         await self._db.execute(
             "UPDATE todo_lists SET migrated_from = ?, updated_at = ? WHERE id = ?",
             (source_doc_id, time.time(), list_id),
+        )
+        await self._db.commit()
+
+    async def set_migration_complete(self, list_id: str) -> None:
+        await self._db.execute(
+            "UPDATE todo_lists SET migration_complete = 1, updated_at = ? WHERE id = ?",
+            (time.time(), list_id),
         )
         await self._db.commit()
 

--- a/tinyagentos/todo/todo_store.py
+++ b/tinyagentos/todo/todo_store.py
@@ -132,19 +132,12 @@ class TodoStore(BaseStore):
         item_id = _new_id("ti")
         now = time.time()
 
-        # Position at the end.
-        cur = await self._db.execute(
-            "SELECT COALESCE(MAX(position), -1) FROM todo_items WHERE list_id = ?",
-            (list_id,),
-        )
-        row = await cur.fetchone()
-        position = row[0] + 1
-
         await self._db.execute(
             "INSERT INTO todo_items "
             "(id, list_id, text, done, position, due_at, remind_at, author, created_at, updated_at) "
-            "VALUES (?, ?, ?, 0, ?, ?, ?, ?, ?, ?)",
-            (item_id, list_id, text, position, due_at, remind_at, author, now, now),
+            "SELECT ?, ?, ?, 0, COALESCE(MAX(position), -1) + 1, ?, ?, ?, ?, ? "
+            "FROM todo_items WHERE list_id = ?",
+            (item_id, list_id, text, due_at, remind_at, author, now, now, list_id),
         )
         await self._db.execute(
             "UPDATE todo_lists SET updated_at = ? WHERE id = ?", (now, list_id)
@@ -153,7 +146,9 @@ class TodoStore(BaseStore):
         cur = await self._db.execute(
             "SELECT * FROM todo_items WHERE id = ?", (item_id,)
         )
-        return _row(cur.description, await cur.fetchone())
+        row = _row(cur.description, await cur.fetchone())
+        row["done"] = bool(row["done"])
+        return row
 
     async def list_items(self, list_id: str) -> list[dict]:
         cur = await self._db.execute(

--- a/tinyagentos/todo/todo_store.py
+++ b/tinyagentos/todo/todo_store.py
@@ -49,6 +49,8 @@ CREATE TABLE IF NOT EXISTS todo_items (
 );
 CREATE INDEX IF NOT EXISTS idx_todo_items_list
     ON todo_items(list_id, position);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_todo_lists_migrated_from
+    ON todo_lists(migrated_from);
 """
 
 


### PR DESCRIPTION
Task: t_755b13e4 (C4 of #1923 notes→todo split)

## What
Migrates existing `kind=list` documents from `SharedDocsStore` into the new `TodoStore`.

## Changes
- **SharedDocsStore**: added `list_docs_by_kind()` and `delete_doc()` helper methods
- **Migration module** (`tinyagentos/todo/migration.py`): `migrate_list_docs()` — reads all non-archived list docs, creates todo lists + items, deletes originals
- **Endpoint**: `POST /api/todo/migrate` — admin-only, idempotent
- **Tests**: 7 tests in `tests/todo/test_migration.py`

## Properties
- Idempotent — safe to run multiple times
- Preserves entry order, text, done flags, author
- Skips archived lists and kind=note docs
- Returns `{migrated, items, lists: [{old_id, new_id}]}`

## Depends on
- C1: PR that adds TodoStore + /api/todo routes (feat/1923-todo-store)

Tests: 36/36 pass (7 migration + 16 todo routes + 11 shared docs + 2 conftest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added administrator-controlled migration of shared list documents into Todo lists, preserving item order, completion status, authors, and titles.
  - Added Todo list reordering and list archive/unarchive support.
  - Added reliable recovery for interrupted migrations without duplicating data.

- **Bug Fixes**
  - Todo requests now require CSRF verification.
  - Due dates and reminders must include a timezone; invalid values return clear errors.
  - Improved handling of missing lists and items with appropriate API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->