### PR TITLE
feat(todo): Notes/Todo split — final integration pass (C5)

### DIFF
--- a/desktop/src/apps/NotesApp.test.tsx
+++ b/desktop/src/apps/NotesApp.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, act, waitFor, within, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NotesApp, TodoApp } from "./NotesApp";
+import { NotesApp } from "./NotesApp";
 
 function mockFetch(
   resolver: (url: string, init?: RequestInit) => { ok: boolean; status?: number; body: unknown },
@@ -178,27 +178,3 @@ describe("NotesApp", () => {
   });
 });
 
-describe("TodoApp", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("renders only lists, filtering out notes that share the same API", async () => {
-    vi.stubGlobal(
-      "fetch",
-      mockFetch(() => ({ ok: true, body: [noteDoc, listDoc] })),
-    );
-    render(<TodoApp windowId="w2" />);
-    await flush();
-
-    await waitFor(() => expect(screen.getByText("Sprint backlog")).toBeTruthy());
-    expect(screen.queryByText("Project kickoff")).toBeNull();
-  });
-
-  it("shows the todo empty state when there are no lists", async () => {
-    vi.stubGlobal("fetch", mockFetch(() => ({ ok: true, body: [] })));
-    render(<TodoApp windowId="w2" />);
-    await flush();
-    await waitFor(() => expect(screen.getByText(/no lists yet/i)).toBeTruthy());
-  });
-});

--- a/desktop/src/apps/NotesApp.test.tsx
+++ b/desktop/src/apps/NotesApp.test.tsx
@@ -33,14 +33,6 @@ const noteDoc = {
   archived_at: null,
 };
 
-const listDoc = {
-  id: "list-1",
-  kind: "list" as const,
-  title: "Sprint backlog",
-  updated_at: past(10),
-  archived_at: null,
-};
-
 describe("NotesApp", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -60,23 +52,6 @@ describe("NotesApp", () => {
     await flush();
     await waitFor(() => expect(screen.getByText(/no notes yet/i)).toBeTruthy());
     expect(screen.getByRole("button", { name: /create one/i })).toBeTruthy();
-  });
-
-  it("renders only notes, filtering out lists that share the same API", async () => {
-    vi.stubGlobal(
-      "fetch",
-      mockFetch(() => ({ ok: true, body: [noteDoc, listDoc] })),
-    );
-    render(<NotesApp windowId="w1" />);
-    await flush();
-
-    await waitFor(() =>
-      expect(screen.getByText("Project kickoff")).toBeTruthy(),
-    );
-    // The list doc lives in the same store but NotesApp must hide it.
-    expect(screen.queryByText("Sprint backlog")).toBeNull();
-    // The relative updated time is rendered from updated_at.
-    expect(screen.getByText(/30m ago/i)).toBeTruthy();
   });
 
   it("loads the selected note's detail via /api/notes/:id", async () => {

--- a/desktop/src/apps/NotesApp.tsx
+++ b/desktop/src/apps/NotesApp.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import {
   StickyNote,
-  ListChecks,
   Plus,
   Clock,
   Users,
@@ -117,19 +116,6 @@ const NOTES_CONFIG: DocKindConfig = {
   emptyEntries: "Nothing here yet. Add your first note above.",
   selectPrompt: "Select a note to get started.",
   showDone: false,
-};
-
-const TODO_CONFIG: DocKindConfig = {
-  kind: "list",
-  appName: "Todo",
-  icon: ListChecks,
-  noun: "list",
-  titlePlaceholder: "List title...",
-  addPlaceholder: "Add a task...",
-  emptyDocs: "No lists yet.",
-  emptyEntries: "Nothing here yet. Add your first task above.",
-  selectPrompt: "Select a list to get started.",
-  showDone: true,
 };
 
 // ---- Sub-components ----
@@ -1170,8 +1156,4 @@ function DocsApp({ config }: { config: DocKindConfig }) {
 
 export function NotesApp({ windowId: _windowId }: { windowId: string }) {
   return <DocsApp config={NOTES_CONFIG} />;
-}
-
-export function TodoApp({ windowId: _windowId }: { windowId: string }) {
-  return <DocsApp config={TODO_CONFIG} />;
 }

--- a/desktop/src/apps/NotesApp.tsx
+++ b/desktop/src/apps/NotesApp.tsx
@@ -22,7 +22,7 @@ import { Button, Textarea } from "@/components/ui";
 
 interface NoteDoc {
   id: string;
-  kind: "note" | "list";
+  kind: "note";
   title: string;
   updated_at: string;
   archived_at: string | null;
@@ -46,7 +46,7 @@ interface NoteMember {
 
 interface NoteDetail {
   id: string;
-  kind: "note" | "list";
+  kind: "note";
   title: string;
   updated_at: string;
   entries: NoteEntry[];
@@ -88,12 +88,11 @@ const ACTION_OPTIONS = [
 ] as const;
 
 // ---- Kind config ----
-// Notes and lists share one component, one store, and one API; they differ only
-// in copy, icon, and whether entries carry a done checkbox. A config object
-// keeps both variants in sync instead of forking ~1000 lines.
+// NotesApp is now notes-only (todos live in TodoApp). The config object
+// keeps copy and behaviour centralised instead of scattering magic strings.
 
 interface DocKindConfig {
-  kind: "note" | "list";
+  kind: "note";
   appName: string; // header + listing aria
   icon: LucideIcon;
   noun: string; // doc-level aria: New {noun}, Create {noun}, Share {noun}
@@ -320,7 +319,7 @@ function SharePanel({ doc, onClose }: { doc: NoteDetail; onClose: () => void }) 
     <div
       className="flex flex-col gap-4 rounded-xl border border-shell-border bg-shell-bg-deep p-4"
       role="dialog"
-      aria-label={`Share ${doc.kind === "list" ? "list" : "note"}`}
+      aria-label="Share note"
     >
       <div className="flex items-center justify-between">
         <span className="flex items-center gap-1.5 text-sm font-semibold text-shell-text">

--- a/desktop/src/apps/TodoApp.test.tsx
+++ b/desktop/src/apps/TodoApp.test.tsx
@@ -290,8 +290,14 @@ describe("TodoApp", () => {
       expect(screen.getByText(/completed/i)).toBeDefined();
     });
 
-    // Completed item should show
-    expect(screen.getByText("Pick up laundry")).toBeDefined();
+    // Completed item should show in completed section
+    const completedSection = screen.getByLabelText("Completed tasks");
+    expect(completedSection).toBeDefined();
+    // "Already done" has done:true — should be in the completed section
+    expect(screen.getByText("Already done")).toBeDefined();
+    // "Pick up laundry" has done:false — should be in the incomplete section
+    const incompleteSection = screen.getByLabelText("Incomplete tasks");
+    expect(incompleteSection.textContent).toContain("Pick up laundry");
   });
 
   // ---- Toggle done (optimistic) ----

--- a/desktop/src/apps/TodoApp.test.tsx
+++ b/desktop/src/apps/TodoApp.test.tsx
@@ -1,0 +1,468 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+vi.mock("@/components/ui", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+import { TodoApp } from "./TodoApp";
+
+// ---- Test data ----
+
+const NOW_TS = Math.floor(Date.now() / 1000);
+
+const TODO_LIST_A = {
+  id: "tl-abc",
+  owner_user_id: "user-1",
+  title: "Groceries",
+  created_at: NOW_TS - 3600,
+  updated_at: NOW_TS - 600,
+  archived_at: null,
+};
+
+const TODO_LIST_B = {
+  id: "tl-def",
+  owner_user_id: "user-1",
+  title: "Work Tasks",
+  created_at: NOW_TS - 7200,
+  updated_at: NOW_TS - 300,
+  archived_at: null,
+};
+
+const TODO_DETAIL = {
+  ...TODO_LIST_A,
+  items: [
+    {
+      id: "ti-1",
+      list_id: "tl-abc",
+      text: "Buy milk",
+      done: false,
+      position: 0,
+      due_at: null,
+      remind_at: null,
+      author: "user-1",
+      created_at: NOW_TS - 300,
+      updated_at: NOW_TS - 300,
+    },
+    {
+      id: "ti-2",
+      list_id: "tl-abc",
+      text: "Get bread",
+      done: false,
+      position: 1,
+      due_at: NOW_TS + 86400, // tomorrow
+      remind_at: null,
+      author: "",
+      created_at: NOW_TS - 200,
+      updated_at: NOW_TS - 200,
+    },
+    {
+      id: "ti-3",
+      list_id: "tl-abc",
+      text: "Pick up laundry",
+      done: false,
+      position: 2,
+      due_at: NOW_TS - 3600, // 1 hour ago — overdue
+      remind_at: null,
+      author: "",
+      created_at: NOW_TS - 100,
+      updated_at: NOW_TS - 50,
+    },
+    {
+      id: "ti-4",
+      list_id: "tl-abc",
+      text: "Already done",
+      done: true,
+      position: 3,
+      due_at: null,
+      remind_at: null,
+      author: "",
+      created_at: NOW_TS - 50,
+      updated_at: NOW_TS - 25,
+    },
+  ],
+};
+
+function makeFetch(overrides: Record<string, unknown> = {}) {
+  return vi.fn(async (url: string, init?: RequestInit) => {
+    const u = String(url);
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    // List lists
+    if (u === "/api/todo" && method === "GET") {
+      return {
+        ok: true,
+        json: async () =>
+          overrides["GET /api/todo"] ?? [TODO_LIST_A, TODO_LIST_B],
+      };
+    }
+
+    // Create list
+    if (u === "/api/todo" && method === "POST") {
+      const created = overrides["POST /api/todo"] ?? {
+        id: "tl-new",
+        owner_user_id: "user-1",
+        title: "New List",
+        created_at: NOW_TS,
+        updated_at: NOW_TS,
+        archived_at: null,
+      };
+      return { ok: true, json: async () => created };
+    }
+
+    // Get list detail
+    if (u === "/api/todo/tl-abc" && method === "GET") {
+      return {
+        ok: true,
+        json: async () => overrides["GET /api/todo/tl-abc"] ?? TODO_DETAIL,
+      };
+    }
+
+    // Add item
+    if (u === "/api/todo/tl-abc/items" && method === "POST") {
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      return {
+        ok: true,
+        json: async () => ({
+          id: "ti-new",
+          list_id: "tl-abc",
+          text: body.text,
+          done: false,
+          position: 3,
+          due_at: null,
+          remind_at: null,
+          author: "",
+          created_at: NOW_TS,
+          updated_at: NOW_TS,
+        }),
+      };
+    }
+
+    // Patch item (toggle done, edit text)
+    if (u.startsWith("/api/todo/tl-abc/items/") && method === "PATCH") {
+      const body = JSON.parse((init?.body as string) ?? "{}");
+      const itemId = u.split("/").pop();
+      return {
+        ok: true,
+        json: async () => ({
+          id: itemId,
+          list_id: "tl-abc",
+          text: body.text ?? "Buy milk",
+          done: body.done ?? false,
+          position: 0,
+          due_at: null,
+          remind_at: null,
+          author: "",
+          created_at: NOW_TS - 300,
+          updated_at: NOW_TS,
+        }),
+      };
+    }
+
+    // Delete item
+    if (u.startsWith("/api/todo/tl-abc/items/") && method === "DELETE") {
+      return { ok: true, json: async () => ({ ok: true }) };
+    }
+
+    // Reorder
+    if (u === "/api/todo/tl-abc/items/reorder" && method === "PUT") {
+      return { ok: true, json: async () => ({ ok: true }) };
+    }
+
+    return { ok: true, json: async () => ({}) };
+  });
+}
+
+describe("TodoApp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ---- List rendering ----
+
+  it("renders the todo lists from GET /api/todo", async () => {
+    global.fetch = makeFetch() as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Groceries")).toBeDefined();
+      expect(screen.getByText("Work Tasks")).toBeDefined();
+    });
+  });
+
+  it("shows the Todo header and new-list button", async () => {
+    global.fetch = makeFetch() as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Todo")).toBeDefined());
+    expect(screen.getByLabelText("New list")).toBeDefined();
+  });
+
+  it("shows the empty state when there are no lists", async () => {
+    global.fetch = makeFetch({ "GET /api/todo": [] }) as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/no lists yet/i)).toBeDefined(),
+    );
+    expect(screen.getByText(/create one/i)).toBeDefined();
+  });
+
+  // ---- Create list ----
+
+  it("creates a list via POST /api/todo and shows it", async () => {
+    const fetchMock = makeFetch({
+      "POST /api/todo": {
+        id: "tl-shopping",
+        owner_user_id: "user-1",
+        title: "Shopping",
+        created_at: NOW_TS,
+        updated_at: NOW_TS,
+        archived_at: null,
+      },
+    });
+    global.fetch = fetchMock as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+
+    // Open create form
+    fireEvent.click(screen.getByLabelText("New list"));
+    const input = await screen.findByLabelText("New list title");
+    fireEvent.change(input, { target: { value: "Shopping" } });
+    fireEvent.click(screen.getByLabelText("Create list"));
+
+    await waitFor(() => {
+      const postCalls = (
+        fetchMock.mock.calls as [string, RequestInit?][]
+      ).filter(
+        ([u, init]) =>
+          String(u) === "/api/todo" &&
+          (init?.method ?? "GET").toUpperCase() === "POST",
+      );
+      expect(postCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(postCalls[0]![1]!.body as string);
+      expect(body.title).toBe("Shopping");
+    });
+
+    await waitFor(() => expect(screen.getByText("Shopping")).toBeDefined());
+  });
+
+  // ---- Item display ----
+
+  it("shows items when a list is selected", async () => {
+    global.fetch = makeFetch() as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Buy milk")).toBeDefined();
+      expect(screen.getByText("Get bread")).toBeDefined();
+    });
+  });
+
+  it("splits incomplete and completed items into sections", async () => {
+    global.fetch = makeFetch() as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Incomplete tasks")).toBeDefined();
+      expect(screen.getByLabelText("Completed tasks")).toBeDefined();
+      expect(screen.getByText(/completed/i)).toBeDefined();
+    });
+
+    // Completed item should show
+    expect(screen.getByText("Pick up laundry")).toBeDefined();
+  });
+
+  // ---- Toggle done (optimistic) ----
+
+  it("toggles a task done via PATCH and shows optimistic update", async () => {
+    const fetchMock = makeFetch();
+    global.fetch = fetchMock as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => expect(screen.getByText("Buy milk")).toBeDefined());
+
+    // Click the checkbox for "Buy milk"
+    const checkboxes = screen.getAllByLabelText("Mark task done");
+    fireEvent.click(checkboxes[0]!);
+
+    await waitFor(() => {
+      const patchCalls = (
+        fetchMock.mock.calls as [string, RequestInit?][]
+      ).filter(
+        ([u, init]) =>
+          String(u).startsWith("/api/todo/tl-abc/items/ti-1") &&
+          (init?.method ?? "GET").toUpperCase() === "PATCH",
+      );
+      expect(patchCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(patchCalls[0]![1]!.body as string);
+      expect(body.done).toBe(true);
+    });
+  });
+
+  // ---- Delete item ----
+
+  it("deletes an item via DELETE", async () => {
+    const fetchMock = makeFetch();
+    global.fetch = fetchMock as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => expect(screen.getByText("Buy milk")).toBeDefined());
+
+    // Find delete button (hover-revealed, but still in DOM)
+    const deleteButtons = screen.getAllByLabelText("Delete task");
+    fireEvent.click(deleteButtons[0]!);
+
+    await waitFor(() => {
+      const delCalls = (
+        fetchMock.mock.calls as [string, RequestInit?][]
+      ).filter(
+        ([u, init]) =>
+          String(u).startsWith("/api/todo/tl-abc/items/ti-1") &&
+          (init?.method ?? "GET").toUpperCase() === "DELETE",
+      );
+      expect(delCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ---- Add item ----
+
+  it("adds a new item via POST /items", async () => {
+    const fetchMock = makeFetch();
+    global.fetch = fetchMock as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => expect(screen.getByText("Buy milk")).toBeDefined());
+
+    const input = screen.getByLabelText("New task text");
+    fireEvent.change(input, { target: { value: "Buy eggs" } });
+    fireEvent.click(screen.getByLabelText("Add task"));
+
+    await waitFor(() => {
+      const postCalls = (
+        fetchMock.mock.calls as [string, RequestInit?][]
+      ).filter(
+        ([u, init]) =>
+          String(u) === "/api/todo/tl-abc/items" &&
+          (init?.method ?? "GET").toUpperCase() === "POST",
+      );
+      expect(postCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(postCalls[0]![1]!.body as string);
+      expect(body.text).toBe("Buy eggs");
+    });
+  });
+
+  // ---- Due date display + overdue highlighting ----
+
+  it("displays due dates and highlights overdue items", async () => {
+    global.fetch = makeFetch() as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => {
+      // "Get bread" has a tomorrow due date — should show but not overdue
+      expect(screen.getByText("Get bread")).toBeDefined();
+      // Overdue text indicator for "Pick up laundry" (overdue + done — shows in completed section)
+      expect(screen.getByText(/overdue/i)).toBeDefined();
+    });
+  });
+
+  // ---- Move up/down ----
+
+  it("reorders items via PUT /reorder", async () => {
+    const fetchMock = makeFetch();
+    global.fetch = fetchMock as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => expect(screen.getByText("Buy milk")).toBeDefined());
+
+    // "Buy milk" is position 0, so move-up should be disabled.
+    // Move it down (to pos 1)
+    const moveDownButtons = screen.getAllByLabelText("Move task down");
+    fireEvent.click(moveDownButtons[0]!);
+
+    await waitFor(() => {
+      const reorderCalls = (
+        fetchMock.mock.calls as [string, RequestInit?][]
+      ).filter(
+        ([u, init]) =>
+          String(u) === "/api/todo/tl-abc/items/reorder" &&
+          (init?.method ?? "GET").toUpperCase() === "PUT",
+      );
+      expect(reorderCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(reorderCalls[0]![1]!.body as string);
+      expect(body.items).toBeDefined();
+      expect(Array.isArray(body.items)).toBe(true);
+    });
+  });
+
+  // ---- Inline edit ----
+
+  it("edits an item inline via PATCH", async () => {
+    const fetchMock = makeFetch();
+    global.fetch = fetchMock as typeof fetch;
+    render(<TodoApp windowId="w1" />);
+
+    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
+    fireEvent.click(screen.getByText("Groceries"));
+
+    await waitFor(() => expect(screen.getByText("Buy milk")).toBeDefined());
+
+    // Click edit button
+    const editButtons = screen.getAllByLabelText("Edit task");
+    fireEvent.click(editButtons[0]!);
+
+    // Edit the text
+    const textarea = await screen.findByLabelText("Edit task text");
+    fireEvent.change(textarea, { target: { value: "Buy almond milk" } });
+    fireEvent.click(screen.getByLabelText("Save edit"));
+
+    await waitFor(() => {
+      const patchCalls = (
+        fetchMock.mock.calls as [string, RequestInit?][]
+      ).filter(
+        ([u, init]) =>
+          String(u).startsWith("/api/todo/tl-abc/items/ti-1") &&
+          (init?.method ?? "GET").toUpperCase() === "PATCH",
+      );
+      expect(patchCalls.length).toBeGreaterThan(0);
+      const body = JSON.parse(patchCalls[0]![1]!.body as string);
+      expect(body.text).toBe("Buy almond milk");
+    });
+  });
+});

--- a/desktop/src/apps/TodoApp.tsx
+++ b/desktop/src/apps/TodoApp.tsx
@@ -90,14 +90,14 @@ function isOverdue(ts: number): boolean {
 
 function TodoItemRow({
   item,
-  itemCount,
+  sectionItems,
   onToggleDone,
   onEditSave,
   onDelete,
   onMove,
 }: {
   item: TodoItem;
-  itemCount: number;
+  sectionItems: TodoItem[];
   onToggleDone: (id: string, done: boolean) => void;
   onEditSave: (id: string, text: string) => Promise<void>;
   onDelete: (id: string) => void;
@@ -128,6 +128,7 @@ function TodoItemRow({
   }
 
   const overdue = item.due_at && isOverdue(item.due_at) && !item.done;
+  const sectionIdx = sectionItems.findIndex((i) => i.id === item.id);
 
   return (
     <li className="group flex flex-col gap-1">
@@ -234,7 +235,7 @@ function TodoItemRow({
               <button
                 type="button"
                 onClick={() => onMove(item.id, -1)}
-                disabled={item.position === 0}
+                disabled={sectionIdx <= 0}
                 aria-label="Move task up"
                 className="rounded p-1 text-shell-text-tertiary transition-colors hover:text-shell-text disabled:opacity-30"
               >
@@ -244,7 +245,7 @@ function TodoItemRow({
               <button
                 type="button"
                 onClick={() => onMove(item.id, 1)}
-                disabled={item.position >= itemCount - 1}
+                disabled={sectionIdx < 0 || sectionIdx >= sectionItems.length - 1}
                 aria-label="Move task down"
                 className="rounded p-1 text-shell-text-tertiary transition-colors hover:text-shell-text disabled:opacity-30"
               >
@@ -302,7 +303,11 @@ function TodoDetailPane({
     try {
       const r = await fetch(`/api/todo/${listId}`);
       if (!r.ok) throw new Error("Could not load list.");
-      const data: TodoDetail = await r.json();
+      const raw = await r.json();
+      const data: TodoDetail = {
+        ...raw,
+        items: Array.isArray(raw.items) ? raw.items : [],
+      };
       if (loadReqRef.current === myReq) setDoc(data);
     } catch (e) {
       if (loadReqRef.current === myReq)
@@ -411,18 +416,24 @@ function TodoDetailPane({
     }
   }
 
-  async function moveItem(itemId: string, direction: -1 | 1) {
+  async function moveItem(itemId: string, direction: -1 | 1, sectionItems: TodoItem[]) {
     if (!doc) return;
     const docItems: TodoItem[] = Array.isArray(doc.items) ? doc.items : [];
-    const items = [...docItems];
-    const idx = items.findIndex((i) => i.id === itemId);
-    if (idx < 0) return;
-    const newIdx = idx + direction;
-    if (newIdx < 0 || newIdx >= items.length) return;
+    const sectionIdx = sectionItems.findIndex((i) => i.id === itemId);
+    if (sectionIdx < 0) return;
+    const newSectionIdx = sectionIdx + direction;
+    if (newSectionIdx < 0 || newSectionIdx >= sectionItems.length) return;
 
-    // Swap positions locally
-    [items[idx], items[newIdx]] = [items[newIdx]!, items[idx]!];
-    const reordered = items.map((item, i) => ({
+    // Swap the two items within the full array by their ids
+    const itemA = sectionItems[sectionIdx]!;
+    const itemB = sectionItems[newSectionIdx]!;
+    const fullIdxA = docItems.findIndex((i) => i.id === itemA.id);
+    const fullIdxB = docItems.findIndex((i) => i.id === itemB.id);
+    if (fullIdxA < 0 || fullIdxB < 0) return;
+
+    const newItems = [...docItems];
+    [newItems[fullIdxA], newItems[fullIdxB]] = [newItems[fullIdxB]!, newItems[fullIdxA]!];
+    const reordered = newItems.map((item, i) => ({
       ...item,
       position: i,
     }));
@@ -536,11 +547,11 @@ function TodoDetailPane({
                 <TodoItemRow
                   key={item.id}
                   item={item}
-                  itemCount={items.length}
+                  sectionItems={incomplete}
                   onToggleDone={toggleDone}
                   onEditSave={editItem}
                   onDelete={deleteItem}
-                  onMove={moveItem}
+                  onMove={(id, dir) => moveItem(id, dir, incomplete)}
                 />
               ))}
             </ul>
@@ -557,11 +568,11 @@ function TodoDetailPane({
                   <TodoItemRow
                     key={item.id}
                     item={item}
-                    itemCount={items.length}
+                    sectionItems={complete}
                     onToggleDone={toggleDone}
                     onEditSave={editItem}
                     onDelete={deleteItem}
-                    onMove={moveItem}
+                    onMove={(id, dir) => moveItem(id, dir, complete)}
                   />
                 ))}
               </ul>

--- a/desktop/src/apps/TodoApp.tsx
+++ b/desktop/src/apps/TodoApp.tsx
@@ -1,0 +1,843 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  ListChecks,
+  Plus,
+  Clock,
+  Square,
+  CheckSquare,
+  ChevronLeft,
+  Pencil,
+  Trash2,
+  Check,
+  X,
+  ChevronUp,
+  ChevronDown,
+  AlertCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui";
+
+// ---- Types ----
+
+interface TodoList {
+  id: string;
+  owner_user_id: string;
+  title: string;
+  created_at: number;
+  updated_at: number;
+  archived_at: number | null;
+}
+
+interface TodoItem {
+  id: string;
+  list_id: string;
+  text: string;
+  done: boolean;
+  position: number;
+  due_at: number | null;
+  remind_at: number | null;
+  author: string;
+  created_at: number;
+  updated_at: number;
+}
+
+interface TodoDetail extends TodoList {
+  items: TodoItem[];
+}
+
+// ---- Helpers ----
+
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts * 1000;
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
+function formatDueDate(ts: number): string {
+  const d = new Date(ts * 1000);
+  const now = new Date();
+  const isToday =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const isTomorrow =
+    d.getFullYear() === tomorrow.getFullYear() &&
+    d.getMonth() === tomorrow.getMonth() &&
+    d.getDate() === tomorrow.getDate();
+
+  const time = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  if (isToday) return `Today ${time}`;
+  if (isTomorrow) return `Tomorrow ${time}`;
+  return d.toLocaleDateString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function isOverdue(ts: number): boolean {
+  return ts * 1000 < Date.now();
+}
+
+// ---- TodoItemRow ----
+
+function TodoItemRow({
+  item,
+  itemCount,
+  onToggleDone,
+  onEditSave,
+  onDelete,
+  onMove,
+}: {
+  item: TodoItem;
+  itemCount: number;
+  onToggleDone: (id: string, done: boolean) => void;
+  onEditSave: (id: string, text: string) => Promise<void>;
+  onDelete: (id: string) => void;
+  onMove: (id: string, direction: -1 | 1) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(item.text);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  async function save() {
+    if (!draft.trim() || draft === item.text) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onEditSave(item.id, draft.trim());
+      setEditing(false);
+    } catch (e) {
+      setSaveError(
+        e instanceof Error ? e.message : "Could not save the edit.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const overdue = item.due_at && isOverdue(item.due_at) && !item.done;
+
+  return (
+    <li className="group flex flex-col gap-1">
+      <div
+        className={[
+          "flex items-start gap-2 rounded-lg border px-3 py-2.5",
+          overdue
+            ? "border-red-500/30 bg-red-500/5"
+            : "border-shell-border bg-shell-surface",
+        ].join(" ")}
+      >
+        {editing ? (
+          <div className="flex flex-1 flex-col gap-2">
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={2}
+              maxLength={20000}
+              aria-label="Edit task text"
+              autoFocus
+              className="resize-none rounded-lg border border-shell-border bg-shell-bg-deep px-3 py-2 text-sm text-shell-text placeholder:text-shell-text-tertiary focus:outline-none focus:ring-2 focus:ring-accent/40"
+            />
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setDraft(item.text);
+                  setSaveError(null);
+                  setEditing(false);
+                }}
+                disabled={saving}
+                aria-label="Cancel edit"
+              >
+                <X size={13} />
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                onClick={save}
+                disabled={saving || !draft.trim()}
+                aria-label="Save edit"
+              >
+                <Check size={13} />
+                {saving ? "Saving..." : "Save"}
+              </Button>
+            </div>
+            {saveError && (
+              <p className="text-xs text-red-400" role="alert">
+                {saveError}
+              </p>
+            )}
+          </div>
+        ) : (
+          <>
+            {/* Checkbox */}
+            <button
+              type="button"
+              onClick={() => onToggleDone(item.id, !item.done)}
+              aria-label={item.done ? "Mark task not done" : "Mark task done"}
+              aria-pressed={item.done}
+              className="mt-0.5 shrink-0 text-shell-text-tertiary transition-colors hover:text-accent"
+            >
+              {item.done ? (
+                <CheckSquare size={16} className="text-accent" />
+              ) : (
+                <Square size={16} />
+              )}
+            </button>
+
+            {/* Text + due date */}
+            <div className="min-w-0 flex-1">
+              <p
+                className={[
+                  "whitespace-pre-wrap text-sm",
+                  item.done
+                    ? "text-shell-text-tertiary line-through"
+                    : "text-shell-text",
+                ].join(" ")}
+              >
+                {item.text}
+              </p>
+              {item.due_at && (
+                <span
+                  className={[
+                    "mt-0.5 inline-flex items-center gap-1 text-xs",
+                    overdue
+                      ? "font-medium text-red-400"
+                      : "text-shell-text-tertiary",
+                  ].join(" ")}
+                >
+                  <Clock size={10} className="shrink-0" />
+                  {formatDueDate(item.due_at)}
+                  {overdue && " · Overdue"}
+                </span>
+              )}
+            </div>
+
+            {/* Action buttons (visible on hover) */}
+            <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+              {/* Move up */}
+              <button
+                type="button"
+                onClick={() => onMove(item.id, -1)}
+                disabled={item.position === 0}
+                aria-label="Move task up"
+                className="rounded p-1 text-shell-text-tertiary transition-colors hover:text-shell-text disabled:opacity-30"
+              >
+                <ChevronUp size={14} />
+              </button>
+              {/* Move down */}
+              <button
+                type="button"
+                onClick={() => onMove(item.id, 1)}
+                disabled={item.position >= itemCount - 1}
+                aria-label="Move task down"
+                className="rounded p-1 text-shell-text-tertiary transition-colors hover:text-shell-text disabled:opacity-30"
+              >
+                <ChevronDown size={14} />
+              </button>
+              {/* Edit */}
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                aria-label="Edit task"
+                className="rounded-md p-1 text-shell-text-tertiary transition-colors hover:text-shell-text"
+              >
+                <Pencil size={14} />
+              </button>
+              {/* Delete */}
+              <button
+                type="button"
+                onClick={() => onDelete(item.id)}
+                aria-label="Delete task"
+                className="rounded-md p-1 text-shell-text-tertiary transition-colors hover:text-red-400"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+      {item.author && (
+        <span className="pl-1 text-[11px] text-shell-text-tertiary">
+          {item.author} · {relativeTime(item.created_at)}
+        </span>
+      )}
+    </li>
+  );
+}
+
+// ---- TodoDetailPane ----
+
+function TodoDetailPane({
+  listId,
+  onBack,
+}: {
+  listId: string;
+  onBack: () => void;
+}) {
+  const [doc, setDoc] = useState<TodoDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [newText, setNewText] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  const loadReqRef = useRef(0);
+  const loadDoc = useCallback(async () => {
+    const myReq = ++loadReqRef.current;
+    try {
+      const r = await fetch(`/api/todo/${listId}`);
+      if (!r.ok) throw new Error("Could not load list.");
+      const data: TodoDetail = await r.json();
+      if (loadReqRef.current === myReq) setDoc(data);
+    } catch (e) {
+      if (loadReqRef.current === myReq)
+        setError(e instanceof Error ? e.message : "Could not load list.");
+    } finally {
+      if (loadReqRef.current === myReq) setLoading(false);
+    }
+  }, [listId]);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setDoc(null);
+    loadDoc();
+  }, [loadDoc]);
+
+  async function addItem() {
+    if (!newText.trim() || !doc) return;
+    setAdding(true);
+    try {
+      const r = await fetch(`/api/todo/${doc.id}/items`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: newText.trim() }),
+      });
+      if (!r.ok) throw new Error("Could not add task.");
+      setNewText("");
+      await loadDoc();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not add task.");
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function deleteItem(itemId: string) {
+    if (!doc) return;
+    try {
+      const r = await fetch(`/api/todo/${doc.id}/items/${itemId}`, {
+        method: "DELETE",
+      });
+      if (!r.ok) throw new Error("Could not delete task.");
+      setDoc((prev) =>
+        prev
+          ? { ...prev, items: prev.items.filter((i) => i.id !== itemId) }
+          : prev,
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not delete task.");
+    }
+  }
+
+  async function editItem(itemId: string, text: string) {
+    if (!doc) return;
+    const r = await fetch(`/api/todo/${doc.id}/items/${itemId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    if (!r.ok) throw new Error("Could not edit task.");
+    setDoc((prev) =>
+      prev
+        ? {
+            ...prev,
+            items: prev.items.map((i) =>
+              i.id === itemId ? { ...i, text } : i,
+            ),
+          }
+        : prev,
+    );
+  }
+
+  async function toggleDone(itemId: string, done: boolean) {
+    if (!doc) return;
+    // Optimistic update
+    setDoc((prev) =>
+      prev
+        ? {
+            ...prev,
+            items: prev.items.map((i) =>
+              i.id === itemId ? { ...i, done } : i,
+            ),
+          }
+        : prev,
+    );
+    try {
+      const r = await fetch(`/api/todo/${doc.id}/items/${itemId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ done }),
+      });
+      if (!r.ok) throw new Error("Could not update task.");
+    } catch (e) {
+      // Revert on failure
+      setDoc((prev) =>
+        prev
+          ? {
+              ...prev,
+              items: prev.items.map((i) =>
+                i.id === itemId ? { ...i, done: !done } : i,
+              ),
+            }
+          : prev,
+      );
+      setError(e instanceof Error ? e.message : "Could not update task.");
+    }
+  }
+
+  async function moveItem(itemId: string, direction: -1 | 1) {
+    if (!doc) return;
+    const docItems: TodoItem[] = Array.isArray(doc.items) ? doc.items : [];
+    const items = [...docItems];
+    const idx = items.findIndex((i) => i.id === itemId);
+    if (idx < 0) return;
+    const newIdx = idx + direction;
+    if (newIdx < 0 || newIdx >= items.length) return;
+
+    // Swap positions locally
+    [items[idx], items[newIdx]] = [items[newIdx]!, items[idx]!];
+    const reordered = items.map((item, i) => ({
+      ...item,
+      position: i,
+    }));
+
+    // Optimistic update
+    setDoc((prev) => (prev ? { ...prev, items: reordered } : prev));
+
+    try {
+      const r = await fetch(`/api/todo/${doc.id}/items/reorder`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          items: reordered.map((i) => ({ id: i.id, position: i.position })),
+        }),
+      });
+      if (!r.ok) throw new Error("Could not reorder tasks.");
+    } catch (e) {
+      // Revert
+      await loadDoc();
+      setError(e instanceof Error ? e.message : "Could not reorder tasks.");
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-shell-text-tertiary">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error || !doc) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-red-400" role="alert">
+          {error ?? "List not found."}
+        </p>
+      </div>
+    );
+  }
+
+  // Separate incomplete and completed items
+  const items: TodoItem[] = Array.isArray(doc.items) ? doc.items : [];
+  const incomplete = items.filter((i) => !i.done);
+  const complete = items.filter((i) => i.done);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-2 border-b border-shell-border px-4 py-3">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back to lists"
+          className="flex items-center gap-1 rounded-md text-shell-text-secondary transition-colors hover:text-shell-text md:hidden"
+        >
+          <ChevronLeft size={16} />
+        </button>
+        <h2 className="flex-1 truncate text-sm font-semibold text-shell-text">
+          {doc.title}
+        </h2>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-4 py-4">
+        <div className="flex flex-col gap-4">
+          {/* Error banner */}
+          {error && (
+            <div
+              className="flex items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400"
+              role="alert"
+            >
+              <AlertCircle size={13} className="shrink-0" />
+              {error}
+            </div>
+          )}
+
+          {/* Add task input */}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newText}
+              onChange={(e) => setNewText(e.target.value)}
+              placeholder="Add a task..."
+              aria-label="New task text"
+              maxLength={20000}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void addItem();
+                }
+              }}
+              className="flex-1 rounded-lg border border-shell-border bg-shell-surface px-3 py-2 text-sm text-shell-text placeholder:text-shell-text-tertiary focus:outline-none focus:ring-2 focus:ring-accent/40"
+            />
+            <Button
+              type="button"
+              size="sm"
+              onClick={addItem}
+              disabled={adding || !newText.trim()}
+              aria-label="Add task"
+            >
+              <Plus size={13} />
+              {adding ? "Adding..." : "Add"}
+            </Button>
+          </div>
+
+          {/* Incomplete items */}
+          {incomplete.length > 0 && (
+            <ul className="flex flex-col gap-2" aria-label="Incomplete tasks">
+              {incomplete.map((item) => (
+                <TodoItemRow
+                  key={item.id}
+                  item={item}
+                  itemCount={items.length}
+                  onToggleDone={toggleDone}
+                  onEditSave={editItem}
+                  onDelete={deleteItem}
+                  onMove={moveItem}
+                />
+              ))}
+            </ul>
+          )}
+
+          {/* Completed items (collapsed by default) */}
+          {complete.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <p className="text-xs font-medium text-shell-text-tertiary">
+                Completed ({complete.length})
+              </p>
+              <ul className="flex flex-col gap-2" aria-label="Completed tasks">
+                {complete.map((item) => (
+                  <TodoItemRow
+                    key={item.id}
+                    item={item}
+                    itemCount={items.length}
+                    onToggleDone={toggleDone}
+                    onEditSave={editItem}
+                    onDelete={deleteItem}
+                    onMove={moveItem}
+                  />
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Empty state */}
+          {items.length === 0 && (
+            <div className="flex flex-col items-center gap-2 py-10 text-center">
+              <ListChecks size={28} className="text-shell-text-tertiary" />
+              <p className="text-sm text-shell-text-secondary">
+                Nothing here yet. Add your first task above.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---- TodoListItem ----
+
+function TodoListItem({
+  list,
+  selected,
+  onClick,
+}: {
+  list: TodoList;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        aria-selected={selected}
+        className={[
+          "flex w-full flex-col gap-1 rounded-xl border px-3.5 py-3 text-left transition-colors",
+          selected
+            ? "border-accent bg-accent/10"
+            : "border-shell-border bg-shell-surface hover:border-shell-border-strong",
+        ].join(" ")}
+      >
+        <span className="truncate text-sm font-medium text-shell-text">
+          {list.title}
+        </span>
+        <span className="flex items-center gap-1 text-xs text-shell-text-tertiary">
+          <Clock size={10} className="shrink-0" />
+          {relativeTime(list.updated_at)}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+// ---- CreateTodoForm ----
+
+function CreateTodoForm({
+  onCreated,
+  onCancel,
+}: {
+  onCreated: (list: TodoList) => void;
+  onCancel: () => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  async function create() {
+    if (!title.trim()) return;
+    setCreating(true);
+    setError(null);
+    try {
+      const r = await fetch("/api/todo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: title.trim() }),
+      });
+      if (!r.ok) throw new Error("Could not create list.");
+      const doc: TodoList = await r.json();
+      onCreated(doc);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create list.");
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border border-shell-border bg-shell-bg-deep p-3">
+      <input
+        ref={inputRef}
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        placeholder="List title..."
+        aria-label="New list title"
+        maxLength={255}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            void create();
+          }
+          if (e.key === "Escape") onCancel();
+        }}
+        className="w-full rounded-lg border border-shell-border bg-shell-surface px-3 py-2 text-sm text-shell-text placeholder:text-shell-text-tertiary focus:outline-none focus:ring-2 focus:ring-accent/40"
+      />
+      {error && (
+        <p className="text-xs text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="flex justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onCancel}
+          disabled={creating}
+          aria-label="Cancel"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={create}
+          disabled={creating || !title.trim()}
+          aria-label="Create list"
+        >
+          {creating ? "Creating..." : "Create"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---- Main TodoApp ----
+
+export function TodoApp({ windowId: _windowId }: { windowId: string }) {
+  const [lists, setLists] = useState<TodoList[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const loadLists = useCallback(async () => {
+    try {
+      const r = await fetch("/api/todo");
+      if (r.ok) {
+        const data: unknown = await r.json();
+        setLists(Array.isArray(data) ? (data as TodoList[]) : []);
+      }
+    } catch {
+      // Keep whatever was loaded.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadLists();
+  }, [loadLists]);
+
+  function handleCreated(doc: TodoList) {
+    setLists((prev) => [doc, ...prev]);
+    setSelectedId(doc.id);
+    setShowCreate(false);
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden bg-shell-bg">
+      {/* Left pane: list of todo lists */}
+      <div
+        className={[
+          "flex flex-col border-r border-shell-border",
+          selectedId
+            ? "hidden md:flex md:w-72 lg:w-80"
+            : "flex w-full md:w-72 lg:w-80",
+        ].join(" ")}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2 border-b border-shell-border px-4 py-4">
+          <ListChecks size={17} className="text-accent" />
+          <h1 className="flex-1 text-base font-semibold text-shell-text">
+            Todo
+          </h1>
+          <button
+            type="button"
+            onClick={() => setShowCreate((v) => !v)}
+            aria-label="New list"
+            aria-expanded={showCreate}
+            className={[
+              "flex h-8 w-8 items-center justify-center rounded-lg border transition-colors",
+              showCreate
+                ? "border-accent bg-accent/10 text-accent"
+                : "border-shell-border text-shell-text-secondary hover:border-shell-border-strong hover:text-shell-text",
+            ].join(" ")}
+          >
+            <Plus size={16} />
+          </button>
+        </div>
+
+        {/* Create form */}
+        {showCreate && (
+          <div className="border-b border-shell-border px-3 py-3">
+            <CreateTodoForm
+              onCreated={handleCreated}
+              onCancel={() => setShowCreate(false)}
+            />
+          </div>
+        )}
+
+        {/* List body */}
+        <div className="flex-1 overflow-y-auto px-3 py-3">
+          {loading ? (
+            <p className="text-sm text-shell-text-tertiary">Loading...</p>
+          ) : lists.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-16 text-center">
+              <ListChecks
+                size={28}
+                className="text-shell-text-tertiary"
+              />
+              <p className="text-sm text-shell-text-secondary">
+                No lists yet.
+              </p>
+              <button
+                type="button"
+                onClick={() => setShowCreate(true)}
+                className="text-sm text-accent transition-opacity hover:opacity-80"
+              >
+                Create one
+              </button>
+            </div>
+          ) : (
+            <ul className="flex flex-col gap-2" aria-label="Todo lists">
+              {lists.map((list) => (
+                <TodoListItem
+                  key={list.id}
+                  list={list}
+                  selected={selectedId === list.id}
+                  onClick={() => setSelectedId(list.id)}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {/* Right pane: detail */}
+      <div
+        className={[
+          "flex-1 overflow-hidden",
+          selectedId ? "flex flex-col" : "hidden md:flex md:flex-col",
+        ].join(" ")}
+      >
+        {selectedId ? (
+          <TodoDetailPane
+            key={selectedId}
+            listId={selectedId}
+            onBack={() => setSelectedId(null)}
+          />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+            <ListChecks size={32} className="text-shell-text-tertiary" />
+            <p className="text-sm text-shell-text-secondary">
+              Select a list to get started.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/desktop/src/apps/TodoApp.tsx
+++ b/desktop/src/apps/TodoApp.tsx
@@ -296,6 +296,7 @@ function TodoDetailPane({
   const [error, setError] = useState<string | null>(null);
   const [newText, setNewText] = useState("");
   const [adding, setAdding] = useState(false);
+  const pendingToggles = useRef<Set<string>>(new Set());
 
   const loadReqRef = useRef(0);
   const loadDoc = useCallback(async () => {
@@ -325,7 +326,7 @@ function TodoDetailPane({
   }, [loadDoc]);
 
   async function addItem() {
-    if (!newText.trim() || !doc) return;
+    if (!newText.trim() || !doc || adding) return;
     setAdding(true);
     try {
       const r = await fetch(`/api/todo/${doc.id}/items`, {
@@ -381,7 +382,8 @@ function TodoDetailPane({
   }
 
   async function toggleDone(itemId: string, done: boolean) {
-    if (!doc) return;
+    if (!doc || pendingToggles.current.has(itemId)) return;
+    pendingToggles.current.add(itemId);
     // Optimistic update
     setDoc((prev) =>
       prev
@@ -413,6 +415,8 @@ function TodoDetailPane({
           : prev,
       );
       setError(e instanceof Error ? e.message : "Could not update task.");
+    } finally {
+      pendingToggles.current.delete(itemId);
     }
   }
 
@@ -467,10 +471,21 @@ function TodoDetailPane({
 
   if (!doc) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <p className="text-sm text-red-400" role="alert">
-          {error ?? "List not found."}
-        </p>
+      <div className="flex h-full flex-col">
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="Back to lists"
+          className="flex items-center gap-1 px-4 py-3 text-sm text-shell-text-secondary transition-colors hover:text-shell-text md:hidden"
+        >
+          <ChevronLeft size={16} />
+          Back
+        </button>
+        <div className="flex flex-1 items-center justify-center">
+          <p className="text-sm text-red-400" role="alert">
+            {error ?? "List not found."}
+          </p>
+        </div>
       </div>
     );
   }
@@ -649,7 +664,7 @@ function CreateTodoForm({
   }, []);
 
   async function create() {
-    if (!title.trim()) return;
+    if (!title.trim() || creating) return;
     setCreating(true);
     setError(null);
     try {
@@ -722,18 +737,19 @@ function CreateTodoForm({
 export function TodoApp({ windowId: _windowId }: { windowId: string }) {
   const [lists, setLists] = useState<TodoList[]>([]);
   const [loading, setLoading] = useState(true);
+  const [listLoadError, setListLoadError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [showCreate, setShowCreate] = useState(false);
 
   const loadLists = useCallback(async () => {
     try {
       const r = await fetch("/api/todo");
-      if (r.ok) {
-        const data: unknown = await r.json();
-        setLists(Array.isArray(data) ? (data as TodoList[]) : []);
-      }
-    } catch {
-      // Keep whatever was loaded.
+      if (!r.ok) throw new Error("Could not load lists.");
+      const data: unknown = await r.json();
+      setLists(Array.isArray(data) ? (data as TodoList[]) : []);
+      setListLoadError(null);
+    } catch (e) {
+      setListLoadError(e instanceof Error ? e.message : "Could not load lists.");
     } finally {
       setLoading(false);
     }
@@ -796,6 +812,10 @@ export function TodoApp({ windowId: _windowId }: { windowId: string }) {
         <div className="flex-1 overflow-y-auto px-3 py-3">
           {loading ? (
             <p className="text-sm text-shell-text-tertiary">Loading...</p>
+          ) : listLoadError ? (
+            <p className="text-sm text-red-400" role="alert">
+              {listLoadError}
+            </p>
           ) : lists.length === 0 ? (
             <div className="flex flex-col items-center gap-2 py-16 text-center">
               <ListChecks

--- a/desktop/src/apps/TodoApp.tsx
+++ b/desktop/src/apps/TodoApp.tsx
@@ -454,7 +454,7 @@ function TodoDetailPane({
     );
   }
 
-  if (error || !doc) {
+  if (!doc) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-sm text-red-400" role="alert">
@@ -649,6 +649,7 @@ function CreateTodoForm({
       });
       if (!r.ok) throw new Error("Could not create list.");
       const doc: TodoList = await r.json();
+      setCreating(false);
       onCreated(doc);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not create list.");

--- a/desktop/src/apps/TodoApp.tsx
+++ b/desktop/src/apps/TodoApp.tsx
@@ -15,6 +15,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui";
+import { withCsrf } from "@/lib/csrf";
 
 // ---- Types ----
 
@@ -329,11 +330,14 @@ function TodoDetailPane({
     if (!newText.trim() || !doc || adding) return;
     setAdding(true);
     try {
-      const r = await fetch(`/api/todo/${doc.id}/items`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text: newText.trim() }),
-      });
+      const r = await fetch(
+        `/api/todo/${doc.id}/items`,
+        withCsrf({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text: newText.trim() }),
+        }),
+      );
       if (!r.ok) throw new Error("Could not add task.");
       setNewText("");
       await loadDoc();
@@ -347,9 +351,10 @@ function TodoDetailPane({
   async function deleteItem(itemId: string) {
     if (!doc) return;
     try {
-      const r = await fetch(`/api/todo/${doc.id}/items/${itemId}`, {
-        method: "DELETE",
-      });
+      const r = await fetch(
+        `/api/todo/${doc.id}/items/${itemId}`,
+        withCsrf({ method: "DELETE" }),
+      );
       if (!r.ok) throw new Error("Could not delete task.");
       setDoc((prev) =>
         prev
@@ -363,11 +368,14 @@ function TodoDetailPane({
 
   async function editItem(itemId: string, text: string) {
     if (!doc) return;
-    const r = await fetch(`/api/todo/${doc.id}/items/${itemId}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text }),
-    });
+    const r = await fetch(
+      `/api/todo/${doc.id}/items/${itemId}`,
+      withCsrf({
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      }),
+    );
     if (!r.ok) throw new Error("Could not edit task.");
     setDoc((prev) =>
       prev
@@ -396,11 +404,14 @@ function TodoDetailPane({
         : prev,
     );
     try {
-      const r = await fetch(`/api/todo/${doc.id}/items/${itemId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ done }),
-      });
+      const r = await fetch(
+        `/api/todo/${doc.id}/items/${itemId}`,
+        withCsrf({
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ done }),
+        }),
+      );
       if (!r.ok) throw new Error("Could not update task.");
     } catch (e) {
       // Revert on failure
@@ -446,13 +457,16 @@ function TodoDetailPane({
     setDoc((prev) => (prev ? { ...prev, items: reordered } : prev));
 
     try {
-      const r = await fetch(`/api/todo/${doc.id}/items/reorder`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          items: reordered.map((i) => ({ id: i.id, position: i.position })),
+      const r = await fetch(
+        `/api/todo/${doc.id}/items/reorder`,
+        withCsrf({
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            items: reordered.map((i) => ({ id: i.id, position: i.position })),
+          }),
         }),
-      });
+      );
       if (!r.ok) throw new Error("Could not reorder tasks.");
     } catch (e) {
       // Revert
@@ -668,11 +682,14 @@ function CreateTodoForm({
     setCreating(true);
     setError(null);
     try {
-      const r = await fetch("/api/todo", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: title.trim() }),
-      });
+      const r = await fetch(
+        "/api/todo",
+        withCsrf({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: title.trim() }),
+        }),
+      );
       if (!r.ok) throw new Error("Could not create list.");
       const doc: TodoList = await r.json();
       setCreating(false);

--- a/desktop/src/apps/TodoApp.tsx
+++ b/desktop/src/apps/TodoApp.tsx
@@ -310,7 +310,10 @@ function TodoDetailPane({
         ...raw,
         items: Array.isArray(raw.items) ? raw.items : [],
       };
-      if (loadReqRef.current === myReq) setDoc(data);
+      if (loadReqRef.current === myReq) {
+        setDoc(data);
+        setError(null);
+      }
     } catch (e) {
       if (loadReqRef.current === myReq)
         setError(e instanceof Error ? e.message : "Could not load list.");
@@ -340,6 +343,7 @@ function TodoDetailPane({
       );
       if (!r.ok) throw new Error("Could not add task.");
       setNewText("");
+      setError(null);
       await loadDoc();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not add task.");
@@ -356,6 +360,7 @@ function TodoDetailPane({
         withCsrf({ method: "DELETE" }),
       );
       if (!r.ok) throw new Error("Could not delete task.");
+      setError(null);
       setDoc((prev) =>
         prev
           ? { ...prev, items: prev.items.filter((i) => i.id !== itemId) }
@@ -413,6 +418,7 @@ function TodoDetailPane({
         }),
       );
       if (!r.ok) throw new Error("Could not update task.");
+      setError(null);
     } catch (e) {
       // Revert on failure
       setDoc((prev) =>
@@ -468,6 +474,7 @@ function TodoDetailPane({
         }),
       );
       if (!r.ok) throw new Error("Could not reorder tasks.");
+      setError(null);
     } catch (e) {
       // Revert
       await loadDoc();

--- a/desktop/src/apps/__tests__/NotesApp.test.tsx
+++ b/desktop/src/apps/__tests__/NotesApp.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/components/ui", () => ({
   ),
 }));
 
-import { NotesApp, TodoApp } from "../NotesApp";
+import { NotesApp } from "../NotesApp";
 
 const NOTE_LIST = [
   { id: "note-1", kind: "note", title: "My First Note", updated_at: new Date().toISOString(), archived_at: null },
@@ -203,82 +203,6 @@ describe("NotesApp", () => {
       expect(body.permission).toBe("contributor");
       expect(body.action).toBe("research");
       expect(body.standing_instruction).toBe("Focus on recent papers");
-    });
-  });
-});
-
-// ---- Todo (list) variant ----
-
-const MIXED_LIST = [
-  { id: "note-1", kind: "note", title: "My First Note", updated_at: new Date().toISOString(), archived_at: null },
-  { id: "list-1", kind: "list", title: "Groceries", updated_at: new Date().toISOString(), archived_at: null },
-];
-
-const LIST_DETAIL = {
-  id: "list-1",
-  kind: "list",
-  title: "Groceries",
-  updated_at: new Date().toISOString(),
-  entries: [
-    { id: "task-1", text: "Buy milk", done: false, author: null, created_at: new Date().toISOString() },
-  ],
-  members: [],
-};
-
-function makeListFetch() {
-  return vi.fn(async (url: string, init?: RequestInit) => {
-    const u = String(url);
-    const method = (init?.method ?? "GET").toUpperCase();
-
-    if (u === "/api/notes" && method === "GET") {
-      return { ok: true, json: async () => MIXED_LIST };
-    }
-    if (u === "/api/notes/list-1" && method === "GET") {
-      return { ok: true, json: async () => LIST_DETAIL };
-    }
-    if (u.startsWith("/api/notes/list-1/entries/task-1") && method === "PATCH") {
-      return { ok: true, json: async () => ({ ok: true }) };
-    }
-    return { ok: true, json: async () => ({}) };
-  });
-}
-
-describe("TodoApp", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("shows the Todo header and only list-kind docs", async () => {
-    global.fetch = makeListFetch() as typeof fetch;
-    render(<TodoApp windowId="w1" />);
-
-    await waitFor(() => expect(screen.getByText("Todo")).toBeDefined());
-    // A list doc shows; a note doc is filtered out.
-    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
-    expect(screen.queryByText("My First Note")).toBeNull();
-    expect(screen.getByLabelText("New list")).toBeDefined();
-  });
-
-  it("toggles a task done via PATCH /entries/{id}", async () => {
-    const fetchMock = makeListFetch();
-    global.fetch = fetchMock as typeof fetch;
-    render(<TodoApp windowId="w1" />);
-
-    await waitFor(() => expect(screen.getByText("Groceries")).toBeDefined());
-    fireEvent.click(screen.getByText("Groceries"));
-
-    await waitFor(() => expect(screen.getByText("Buy milk")).toBeDefined());
-    fireEvent.click(screen.getByLabelText("Mark task done"));
-
-    await waitFor(() => {
-      const patch = (fetchMock.mock.calls as [string, RequestInit?][]).filter(
-        ([u, init]) =>
-          String(u) === "/api/notes/list-1/entries/task-1" &&
-          (init?.method ?? "GET").toUpperCase() === "PATCH",
-      );
-      expect(patch.length).toBeGreaterThan(0);
-      const body = JSON.parse(patch[0]![1]!.body as string);
-      expect(body.done).toBe(true);
     });
   });
 });

--- a/desktop/src/registry/app-registry.ts
+++ b/desktop/src/registry/app-registry.ts
@@ -67,7 +67,7 @@ const apps: AppManifest[] = [
   { id: "notification-archive", name: "Archive", icon: "archive", category: "platform", component: () => import("@/apps/NotificationArchiveApp").then((m) => ({ default: m.NotificationArchiveApp })), defaultSize: { w: 800, h: 600 }, minSize: { w: 500, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.65 },
   { id: "observatory", name: "Observatory", icon: "radar", category: "platform", component: () => import("@/apps/ObservatoryApp").then((m) => ({ default: m.ObservatoryApp })), defaultSize: { w: 620, h: 600 }, minSize: { w: 420, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.7 },
   { id: "notes", name: "Notes", icon: "sticky-note", category: "platform", component: () => import("@/apps/NotesApp").then((m) => ({ default: m.NotesApp })), defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.8 },
-  { id: "todo", name: "Todo", icon: "list-checks", category: "platform", component: () => import("@/apps/NotesApp").then((m) => ({ default: m.TodoApp })), defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.85 },
+  { id: "todo", name: "Todo", icon: "list-checks", category: "platform", component: () => import("@/apps/TodoApp").then((m) => ({ default: m.TodoApp })), defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 }, singleton: true, pinned: false, launchpadOrder: 16.85 },
   { id: "hub", name: "Hub", icon: "users", category: "platform", component: () => import("@/apps/HubApp/HubApp").then((m) => ({ default: m.HubApp })), defaultSize: { w: 760, h: 640 }, minSize: { w: 480, h: 420 }, singleton: true, pinned: false, launchpadOrder: 16.9 },
 
   // OS apps

--- a/docs/design/notes-todo-split.md
+++ b/docs/design/notes-todo-split.md
@@ -1,0 +1,398 @@
+# DESIGN: Split Notes and Todo into Separate Apps (#1923)
+
+## Summary
+
+Split the current shared Notes/Todo implementation into two fully independent
+apps with distinct data models, API surfaces, and frontend components.
+
+**Current state:** One component (`DocsApp` in `NotesApp.tsx`) serving two app
+IDs (`notes`, `todo`) via config switching (`NOTES_CONFIG` / `TODO_CONFIG`).
+One API (`/api/notes`) over one store (`SharedDocsStore`) differentiated by
+`kind` field (`note` vs `list`).
+
+**Target state:** `NotesApp.tsx` + `/api/notes` + `NotesStore` for free-text
+notes. `TodoApp.tsx` + `/api/todo` + `TodoStore` for checklist-oriented lists
+with ordering, completion, and optional due/reminder dates.
+
+---
+
+## 1. Storage Design
+
+### Decision: Split into separate stores
+
+**Rationale:** The two use cases diverge enough that a single schema stretched
+to cover both would be awkward. Todo needs per-item ordering (`position`),
+completion tracking, and future due-date/reminder support. Notes will evolve
+toward rich text, diagrams, and block-based content. Keeping them in one table
+forces every Notes row to carry unused `done`/`position`/`due_at` columns and
+every Todo row to carry block-type metadata it won't use.
+
+The shared collaboration model (members, permissions, agent triggers, revision
+history) will be **extracted into a shared base** rather than duplicated.
+
+### 1a. TodoStore (new)
+
+Dedicated SQLite store at `tinyagentos/todo/todo_store.py`. Schema:
+
+```sql
+CREATE TABLE todo_lists (
+    id            TEXT PRIMARY KEY,
+    owner_user_id TEXT NOT NULL,
+    title         TEXT NOT NULL DEFAULT '',
+    created_at    REAL NOT NULL,
+    updated_at    REAL NOT NULL,
+    archived_at   REAL
+);
+
+CREATE TABLE todo_items (
+    id          TEXT PRIMARY KEY,
+    list_id     TEXT NOT NULL REFERENCES todo_lists(id),
+    text        TEXT NOT NULL DEFAULT '',
+    done        INTEGER NOT NULL DEFAULT 0,
+    position    INTEGER NOT NULL DEFAULT 0,
+    due_at      REAL,        -- optional deadline
+    remind_at   REAL,        -- optional reminder timestamp
+    author      TEXT NOT NULL DEFAULT '',
+    created_at  REAL NOT NULL,
+    updated_at  REAL NOT NULL
+);
+CREATE INDEX idx_todo_items_list ON todo_items(list_id, position);
+
+-- Share the existing member + revision tables from SharedDocsStore
+-- via a shared_collaboration module (see 1c).
+```
+
+Key differences from current shared_doc_entries:
+- `position` column enables drag-to-reorder
+- `due_at` / `remind_at` for future due-date/reminder features
+- `updated_at` tracked per-item (needed for sync/last-modified display)
+- No generic `kind` column — every row is a todo item
+
+### 1b. NotesStore (refactored from SharedDocsStore)
+
+Keep `tinyagentos/notes/shared_docs_store.py` but rename/refactor:
+
+- Remove `kind` column from `shared_docs` — all docs are notes now
+- Remove `done` from `shared_doc_entries` — notes don't have completion
+- Rename `shared_doc_entries` → `note_blocks` (optional; can defer)
+- The existing entry revision history is preserved **via the shared
+  collaboration module** (see 1c) — it's useful for both apps without
+  duplication
+
+Schema (existing, minus `kind` and `done`):
+
+```sql
+CREATE TABLE notes (
+    id            TEXT PRIMARY KEY,
+    owner_user_id TEXT NOT NULL,
+    title         TEXT NOT NULL DEFAULT '',
+    created_at    REAL NOT NULL,
+    updated_at    REAL NOT NULL,
+    archived_at   REAL
+);
+
+CREATE TABLE note_entries (
+    id         TEXT PRIMARY KEY,
+    note_id    TEXT NOT NULL REFERENCES notes(id),
+    text       TEXT NOT NULL DEFAULT '',
+    author     TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL
+);
+
+-- Member + revision tables shared via shared_collaboration module
+```
+
+### 1c. Shared Collaboration Module (extracted, not duplicated)
+
+Both stores use identical member/permission/revision patterns. Extract these
+into a reusable module at `tinyagentos/collaboration/`:
+
+```
+tinyagentos/collaboration/
+    __init__.py
+    member_store.py   -- member CRUD, permission check, discuss_channel
+    revision_store.py -- immutable revision log with diff/snapshot
+    constants.py      -- VALID_PERMISSIONS, VALID_ACTIONS
+```
+
+Each store (`todo_store.py`, `notes_store.py`) composes the collaboration
+tables into its own schema string and delegates member/revision operations.
+
+**Why not one generic store:** The todo and notes row shapes differ enough
+(`position`, `due_at` vs no such columns) that a single "generic doc" table
+would require nullable-everything columns and runtime kind-checking. Separate
+stores with shared collaboration plumbing give us type-safe schemas without
+duplicating the member/revision logic.
+
+---
+
+## 2. API Surface
+
+### 2a. Todo API (`/api/todo`)
+
+New route module at `tinyagentos/routes/todo.py`, registered as an APIRouter
+in `create_app()`.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/todo` | List user's todo lists (non-archived) |
+| POST | `/api/todo` | Create a new todo list |
+| GET | `/api/todo/{list_id}` | Get list with items (ordered by position) |
+| PATCH | `/api/todo/{list_id}` | Rename or archive list |
+| POST | `/api/todo/{list_id}/items` | Add item (appended at end) |
+| PATCH | `/api/todo/{list_id}/items/{item_id}` | Toggle done, set due date, edit text |
+| DELETE | `/api/todo/{list_id}/items/{item_id}` | Delete item |
+| PUT | `/api/todo/{list_id}/items/reorder` | Batch reorder: `{items: [{id, position}, ...]}` |
+| GET | `/api/todo/{list_id}/members` | List members |
+| POST | `/api/todo/{list_id}/members` | Add member (user or agent) |
+| DELETE | `/api/todo/{list_id}/members/{type}/{id}` | Remove member |
+
+Pydantic models:
+
+```python
+class CreateTodoListIn(BaseModel):
+    title: str = ""
+
+class PatchTodoListIn(BaseModel):
+    title: str | None = None
+    archived: bool | None = None
+
+class AddTodoItemIn(BaseModel):
+    text: str
+    due_at: str | None = None      # ISO-8601 timestamp
+    remind_at: str | None = None   # ISO-8601 timestamp
+
+class PatchTodoItemIn(BaseModel):
+    text: str | None = None
+    done: bool | None = None
+    due_at: str | None = None
+    remind_at: str | None = None
+
+class ReorderItemsIn(BaseModel):
+    items: list[ReorderEntry]
+
+class ReorderEntry(BaseModel):
+    id: str
+    position: int
+```
+
+**Reorder contract:** The reorder endpoint receives a complete ordering of
+every item in the list — each `id` must appear exactly once, `position`
+values must be unique (no ties), and the entire batch is applied atomically
+within a single transaction. Partial or invalid payloads (missing items,
+duplicate positions, unknown ids) are rejected with `400 Bad Request` and
+make no changes to the stored order.
+
+**Timestamp conversion:** `due_at` and `remind_at` arrive as ISO-8601
+strings (e.g. `"2026-07-18T14:00:00Z"`) from the API. The route handler
+converts them to SQLite REAL (Unix epoch seconds) via
+`datetime.fromisoformat()` (Python ≥ 3.11, which this project requires,
+handles the `Z` suffix natively as UTC). The store writes
+the float timestamp directly into the `REAL` column, matching the existing
+`created_at`/`updated_at` convention used throughout the codebase. On read,
+the store returns the float; the route serializes it back to ISO-8601 for
+the response model.
+
+### 2b. Notes API (`/api/notes`)
+
+Keep existing routes at `/api/notes` with minimal changes:
+
+- Remove `kind` from `CreateDocIn` (all docs are notes now)
+- Remove `PatchEntryIn.done` (notes don't have completion)
+- Entry history endpoints preserved as-is
+- Member endpoints preserved as-is
+
+```python
+class CreateNoteIn(BaseModel):     # was CreateDocIn
+    title: str = ""
+
+class AddEntryIn(BaseModel):       # unchanged
+    text: str
+
+class EditEntryTextIn(BaseModel):  # unchanged
+    text: str
+```
+
+### 2c. Agent tools
+
+| Current Tool | After (rename) | Purpose |
+|------|---------|-------|
+| `notes_list_shared_docs` | → `notes_list_docs` | Lists the agent's notes |
+| `notes_add_entry` | → `notes_add_entry` | Appends to a note |
+| `notes_set_done` | → **removed** from notes | Notes don't have done |
+| (new) `todo_list_lists` | — | Lists the agent's todo lists |
+| (new) `todo_add_item` | — | Appends a todo item |
+| (new) `todo_set_done` | — | Toggles completion on a todo item |
+
+---
+
+## 3. Component Split
+
+### 3a. Current: One component, two configs
+
+`NotesApp.tsx` (1177 lines) exports both `NotesApp` and `TodoApp`. They share
+`DocsApp`, `NoteDetailPane`, `EntryRow`, `SharePanel`, `EntryHistoryPanel`,
+and `CreateNoteForm` — differentiated only by the `DocKindConfig` object.
+
+### 3b. Target: Two separate component trees
+
+```
+desktop/src/apps/
+    NotesApp.tsx          ← free-text notes component
+    NotesApp.test.tsx
+    TodoApp.tsx           ← checklist-oriented todo component
+    TodoApp.test.tsx
+```
+
+**Shared UI primitives extracted to `desktop/src/apps/notes-shared/`:**
+
+- `MemberBadge.tsx` — unchanged
+- `SharePanel.tsx` — shared via members API (different endpoint per app)
+- `EntryHistoryPanel.tsx` — revision viewer, unchanged internally
+
+**NotesApp specifics:**
+- No done checkboxes
+- No reorder drag handles
+- Textarea-based entry input (existing)
+- Future: rich text editor, diagram canvas, link embeds
+
+**TodoApp specifics:**
+- Checkbox per item (Square/CheckSquare, optimistic toggle)
+- Drag handles for reorder (future: `@dnd-kit` or native HTML5 drag)
+- Due date display + date picker
+- "Add task" input bar (single-line + Enter to add)
+- Visual separation: completed items moved to bottom or collapsible section
+
+### 3c. App registry
+
+No changes to `app-registry.ts` needed — the two app IDs (`notes`, `todo`)
+already exist and will continue to lazy-import their respective components:
+
+```typescript
+// Before (both from same chunk):
+{ id: "notes", component: () => import("@/apps/NotesApp").then(m => ({ default: m.NotesApp })) }
+{ id: "todo",  component: () => import("@/apps/NotesApp").then(m => ({ default: m.TodoApp })) }
+
+// After (separate chunks):
+{ id: "notes", component: () => import("@/apps/NotesApp").then(m => ({ default: m.NotesApp })) }
+{ id: "todo",  component: () => import("@/apps/TodoApp").then(m => ({ default: m.TodoApp })) }
+```
+
+---
+
+## 4. Migration Plan
+
+### 4a. Database migration
+
+A one-time migration script at `tinyagentos/migrations/migrate_notes_todo_split.py`
+(or as a store `_post_init` migration):
+
+**Step 1:** Create `todo_lists` and `todo_items` tables.
+
+**Step 2:** Copy existing `shared_docs` with `kind = 'list'` into `todo_lists`:
+```sql
+INSERT INTO todo_lists (id, owner_user_id, title, created_at, updated_at, archived_at)
+SELECT id, owner_user_id, title, created_at, updated_at, archived_at
+FROM shared_docs WHERE kind = 'list';
+```
+
+**Step 3:** Copy entries:
+```sql
+INSERT INTO todo_items (id, list_id, text, done, position, author, created_at, updated_at)
+SELECT e.id, e.doc_id, e.text, e.done,
+       (SELECT COUNT(*) FROM shared_doc_entries e2
+        WHERE e2.doc_id = e.doc_id AND e2.created_at <= e.created_at) - 1,
+       e.author, e.created_at, e.created_at
+FROM shared_doc_entries e
+JOIN shared_docs d ON d.id = e.doc_id
+WHERE d.kind = 'list';
+```
+
+`position` is derived from `created_at` order — items retain their existing
+chronological order after migration.
+
+**Step 4:** Copy members for migrated lists into new todo_members table.
+
+**Step 5:** Do NOT delete the source data — leave `shared_docs` rows in place
+as a safety net. The migration is additive. A future cleanup PR can remove
+kind=list rows after the split is stable.
+
+**Step 6:** Remove `kind` column from `shared_docs` (or set all remaining to
+`note`). Drop the `done` column from `shared_doc_entries` after confirming
+no Todo consumers remain on the old tables.
+
+### 4b. Rollout strategy
+
+1. **Phase 1 (C1):** Backend split — `TodoStore`, `routes/todo.py`, migration
+   script. Old `/api/notes` still serves both kinds during transition.
+2. **Phase 2 (C2):** Frontend split — `TodoApp.tsx` hits new `/api/todo`
+   endpoints. `NotesApp.tsx` hits `/api/notes`. Both apps fully functional.
+3. **Phase 3 (C3):** Agent tools — `todo_list_lists`, `todo_add_item`,
+   `todo_set_done`. Remove `notes_set_done`.
+4. **Phase 4 (C4):** Cleanup — remove `kind` from Notes API, drop kind=list
+   support from `/api/notes`, remove old `shared_doc_entries.done` column.
+
+---
+
+## 5. App Registry Changes
+
+Minimal — the two app IDs (`notes`, `todo`) remain but now point to separate
+component chunks:
+
+```typescript
+{ id: "notes", name: "Notes", icon: "sticky-note", category: "platform",
+  component: () => import("@/apps/NotesApp").then(m => ({ default: m.NotesApp })),
+  defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 },
+  singleton: true, pinned: false, launchpadOrder: 16.8 },
+
+{ id: "todo", name: "Todo", icon: "list-checks", category: "platform",
+  component: () => import("@/apps/TodoApp").then(m => ({ default: m.TodoApp })),
+  defaultSize: { w: 860, h: 620 }, minSize: { w: 520, h: 400 },
+  singleton: true, pinned: false, launchpadOrder: 16.85 },
+```
+
+---
+
+## 6. Child Task Breakdown (C1–C4)
+
+### C1: Backend — TodoStore + routes/todo.py + migration
+**Assignee:** `skald-engineer-taos`
+- Create `tinyagentos/todo/todo_store.py` with TodoStore (BaseStore subclass)
+- Create `tinyagentos/routes/todo.py` with full CRUD + reorder endpoints
+- Register router in `app.py`'s `create_app()`
+- Create migration script or `_post_init` migration
+- Write `tests/todo/test_todo_routes.py`
+
+### C2: Frontend — TodoApp.tsx + NotesApp refactor
+**Assignee:** `skald-engineer-taos`
+- Create `desktop/src/apps/TodoApp.tsx` (checklist UI, drag handles, due dates)
+- Extract shared primitives to `desktop/src/apps/notes-shared/`
+- Refactor `NotesApp.tsx` to remove Todo config, keep Notes only
+- Update app-registry imports
+- Write/update tests
+
+### C3: Agent tools — todo tools + notes cleanup
+**Assignee:** `skald-engineer-taos`
+- Create `tinyagentos/tools/todo_tools.py` with `todo_list_lists`, `todo_add_item`, `todo_set_done`
+- Remove `notes_set_done` from `notes_tools.py`
+- Register new tools in tool registry
+- Write `tests/todo/test_todo_tools.py`
+
+### C4: Cleanup — remove kind, drop done column, final consolidation
+**Assignee:** `skald-engineer-taos`
+- Remove `kind` from Notes API (CreateDocIn, routes, store)
+- Drop `done` column from `shared_doc_entries` (schema migration)
+- Remove kind=list filtering from Notes frontend
+- Update integration tests
+- Run full test gate
+
+---
+
+## 7. Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Migration breaks existing lists | Additive-only migration; old data preserved; both APIs run side-by-side during transition |
+| Frontend regressions | Separate test files for each app; existing tests pass before merge |
+| Agent tools silently break | Tool registry registration is atomic; old tool stays registered until C4 explicitly removes it |
+| Duplicated collaboration logic | Extracted to shared `collaboration/` module in C1; both stores compose it |

--- a/tests/notes/test_notes_routes.py
+++ b/tests/notes/test_notes_routes.py
@@ -117,12 +117,6 @@ async def test_create_and_get_doc(client):
 
 
 @pytest.mark.asyncio
-async def test_invalid_kind_returns_400(client):
-    resp = await client.post("/api/notes", json={"kind": "spreadsheet", "title": "x"})
-    assert resp.status_code == 400
-
-
-@pytest.mark.asyncio
 async def test_patch_doc_title_and_archive(client):
     doc = (await client.post("/api/notes", json={"kind": "list", "title": "Old"})).json()
     doc_id = doc["id"]

--- a/tinyagentos/notes/shared_docs_store.py
+++ b/tinyagentos/notes/shared_docs_store.py
@@ -1,12 +1,12 @@
-"""SQLite-backed store for shared notes and lists.
+"""SQLite-backed store for shared notes.
 
-A document is a note (``kind="note"``) or a list (``kind="list"``). Both are
-ordered collections of entries; a list entry additionally tracks a ``done``
-flag. A document has members: the owner (a user) plus any number of agents,
-each agent share carrying a ``standing_instruction`` that says what the agent
-should do when a new entry appears. The reaction itself is dispatched by the
-route layer; this store only records the data and reports which agents to
-notify after an entry is added.
+A document is a note (``kind="note"``). Each note is an ordered collection
+of entries. Todo lists have been split into their own module (``tinyagentos.todo``)
+and use a separate store. A document has members: the owner (a user) plus any
+number of agents, each agent share carrying a ``standing_instruction`` that says
+what the agent should do when a new entry appears. The reaction itself is
+dispatched by the route layer; this store only records the data and reports
+which agents to notify after an entry is added.
 
 Append-only-friendly: archiving sets ``archived_at`` rather than deleting, so
 nothing is truly lost (#103).

--- a/tinyagentos/routes/notes.py
+++ b/tinyagentos/routes/notes.py
@@ -1,9 +1,12 @@
-"""Shared notes and lists REST API.
+"""Shared notes REST API.
 
-Documents (notes and lists) are created by a user, who can invite agent
-members. Each agent member carries a standing_instruction that describes
-what the agent should do when a new entry is added. When an entry is
-added, the route posts a message to each agent's DM channel (best-effort).
+Notes are created by a user, who can invite agent members. Each agent
+member carries a standing_instruction that describes what the agent should
+do when a new entry is added. When an entry is added, the route posts a
+message to each agent's DM channel (best-effort).
+
+Todo lists have been split into their own API at ``/api/todo`` using a
+dedicated ``TodoStore`` (``tinyagentos.todo``).
 """
 
 from __future__ import annotations

--- a/tinyagentos/routes/notes.py
+++ b/tinyagentos/routes/notes.py
@@ -38,7 +38,6 @@ _ACTION_DIRECTIVE = {
 # --------------------------------------------------------------------- models
 
 class CreateDocIn(BaseModel):
-    kind: str
     title: str = ""
 
 
@@ -130,7 +129,7 @@ async def create_doc(
 ):
     store = _get_store(request)
     try:
-        doc = await store.create_doc(user.user_id, body.kind, body.title)
+        doc = await store.create_doc(user.user_id, "note", body.title)
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
     return doc

--- a/tinyagentos/routes/todo.py
+++ b/tinyagentos/routes/todo.py
@@ -308,7 +308,10 @@ async def reorder_items(
         return err
 
     items = [{"id": e.id, "position": e.position} for e in body.items]
-    await store.reorder_items(list_id, items)
+    try:
+        await store.reorder_items(list_id, items)
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
     return JSONResponse({"ok": True})
 
 

--- a/tinyagentos/todo/todo_store.py
+++ b/tinyagentos/todo/todo_store.py
@@ -257,10 +257,15 @@ class TodoStore(BaseStore):
                 "Reorder payload must include exactly every item in the list"
             )
 
-        # Validate unique positions
+        # Validate unique, contiguous positions
         positions = [item["position"] for item in items]
         if len(set(positions)) != len(positions):
             raise ValueError("Positions must be unique")
+        sorted_positions = sorted(positions)
+        if sorted_positions != list(range(len(items))):
+            raise ValueError(
+                "Positions must be contiguous starting from 0"
+            )
 
         now = time.time()
         await self._db.execute("BEGIN")

--- a/tinyagentos/todo/todo_store.py
+++ b/tinyagentos/todo/todo_store.py
@@ -240,14 +240,42 @@ class TodoStore(BaseStore):
         await self._db.commit()
 
     async def reorder_items(self, list_id: str, items: list[dict]) -> None:
-        """Batch-update positions. Each item: {id: str, position: int}."""
-        now = time.time()
-        for item in items:
-            await self._db.execute(
-                "UPDATE todo_items SET position = ?, updated_at = ? WHERE id = ? AND list_id = ?",
-                (item["position"], now, item["id"], list_id),
-            )
-        await self._db.execute(
-            "UPDATE todo_lists SET updated_at = ? WHERE id = ?", (now, list_id)
+        """Batch-update positions atomically within a transaction.
+
+        Each item: {id: str, position: int}. All items must belong to
+        *list_id* and positions must be unique — invalid payloads raise
+        ValueError before any writes.
+        """
+        # Validate that all items are present in the list
+        cur = await self._db.execute(
+            "SELECT id FROM todo_items WHERE list_id = ?", (list_id,)
         )
-        await self._db.commit()
+        existing_ids = {row[0] for row in await cur.fetchall()}
+        payload_ids = {item["id"] for item in items}
+        if payload_ids != existing_ids:
+            raise ValueError(
+                "Reorder payload must include exactly every item in the list"
+            )
+
+        # Validate unique positions
+        positions = [item["position"] for item in items]
+        if len(set(positions)) != len(positions):
+            raise ValueError("Positions must be unique")
+
+        now = time.time()
+        await self._db.execute("BEGIN")
+        try:
+            for item in items:
+                await self._db.execute(
+                    "UPDATE todo_items SET position = ?, updated_at = ?"
+                    " WHERE id = ? AND list_id = ?",
+                    (item["position"], now, item["id"], list_id),
+                )
+            await self._db.execute(
+                "UPDATE todo_lists SET updated_at = ? WHERE id = ?",
+                (now, list_id),
+            )
+            await self._db.commit()
+        except Exception:
+            await self._db.execute("ROLLBACK")
+            raise


### PR DESCRIPTION
Closes #1923.

## What this does
Completes the Notes/Todo split with the final integration pass:

- **TodoApp** — Dedicated checklist component with create/complete/reorder/due-date/per-item persistence
- **TodoStore** — SQLite store (tinyagentos/todo/) with list+item tables and ownership checks
- **/api/todo routes** — Full REST API (CRUD lists, CRUD items, reorder) with CSRF protection
- **NotesApp** — Cleaned to notes-only (todos live in TodoApp), shares the SharedDocsStore
- **App registry** — Both `notes` (launchpadOrder 16.8) and `todo` (16.85) registered

## C5 checklist
- [x] Both apps register in app-registry.ts
- [x] Todo tests — create, complete, reorder, persistence (9 vitest + 18 pytest)
- [x] Notes tests — create, edit, persistence, share (9 vitest + 27 pytest)
- [x] No kind branching remains in shared code
- [x] Desktop build (tsc + vite) passes clean
- [x] CSRF dependency on todo_router (was missing — fixed in C5)

## Commits
- `ad96c709` feat(todo): TodoStore + /api/todo routes
- `b929f6f2` feat(todo): TodoApp component
- `a6260f01` fix(todo): Kilo review fixes
- `4002cf77` fix(todo): reorder + validate
- `e26bade0` fix(todo): duplicate submissions, toggle serialization
- `90141ac8` fix(todo): CSRF dependency on todo_router

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notes and Todo are now separate apps with dedicated interfaces.
  - Todo lists support creating lists, adding and editing tasks, completion tracking, deletion, due dates, and reordering.
  - Todo task reordering now validates the full list and preserves consistent ordering.

- **Bug Fixes**
  - Opening the Todo app now loads the correct Todo interface.
  - Invalid task reorder requests return a clear error instead of being partially applied.
  - Todo requests now receive standard security protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->