### PR TITLE
feat(mesh): surface guest peer nodes in mesh_status and add guest-preauth proxy endpoint

### DIFF
--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -85,6 +85,57 @@ class TestMeshStatus:
         assert s["tailnet"] == "jason"
         assert s["node_ip"] == "100.64.0.5"
         assert s["hostname"] == "node-1"
+        assert s["guests"] == []
+
+    async def test_guests_field_present_even_when_no_peers(self):
+        """mesh_status always includes ``guests`` (empty list when no guest peers)."""
+        s = await mesh.mesh_status()
+        # Fast-path: not installed returns joined=False with detail, never raises.
+        assert isinstance(s, dict)
+        if s.get("joined"):
+            assert isinstance(s.get("guests"), list)
+
+    async def test_guest_peer_detected(self):
+        """A peer tagged ``tag:guest`` appears in the guests list."""
+        status = dict(self._STATUS)
+        status["Peer"] = {
+            "nodekey:abc": {
+                "HostName": "hogne-box",
+                "Online": True,
+                "TailscaleIPs": ["100.64.0.6"],
+                "Tags": ["tag:guest"],
+            }
+        }
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out=json.dumps(status))):
+            s = await mesh.mesh_status()
+        assert s["guests"] == [
+            {"hostname": "hogne-box", "node_ip": "100.64.0.6", "online": True}
+        ]
+
+    async def test_non_guest_peers_excluded(self):
+        """Peers without ``tag:guest`` are omitted from the guests list."""
+        status = dict(self._STATUS)
+        status["Peer"] = {
+            "nodekey:a": {"HostName": "host-2", "Online": True,
+                          "TailscaleIPs": ["100.64.0.7"], "Tags": []},
+            "nodekey:b": {"HostName": "guest-1", "Online": False,
+                          "TailscaleIPs": ["100.64.0.8"], "Tags": ["tag:guest"]},
+        }
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out=json.dumps(status))):
+            s = await mesh.mesh_status()
+        assert len(s["guests"]) == 1
+        assert s["guests"][0]["hostname"] == "guest-1"
+
+    async def test_malformed_peer_data_graceful(self):
+        """A peer dict that isn't a dict is silently skipped."""
+        status = dict(self._STATUS)
+        status["Peer"] = {"bad": "not-a-dict"}
+        with patch.object(mesh, "is_tailscale_installed", return_value=True), \
+             patch.object(mesh, "_run", _run_returns(0, out=json.dumps(status))):
+            s = await mesh.mesh_status()
+        assert s["guests"] == []
 
     async def test_not_running_not_joined(self):
         stopped = {"BackendState": "Stopped", "Self": {}}

--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -271,12 +271,15 @@ async def test_cluster_guest_preauth_forwards_and_strips_key(client, monkeypatch
     assert captured["method"] == "POST"
     assert "taos_session" not in captured["cookie"]
     # The preauth key was captured server-side for out-of-band delivery
-    # to the guest instance (D1 delegation-accept handler).
+    # to the guest instance (D1 delegation-accept handler consumes via
+    # _pop_guest_preauth_intent, which is the pop-and-evict accessor).
     from tinyagentos.routes import account_proxy
-    intent = account_proxy._guest_preauth_intents.get("hub:hogne")
+    intent = account_proxy._pop_guest_preauth_intent("hub:hogne")
     assert intent is not None, "guest preauth key was not captured server-side"
     assert intent["preauth_key"] == "guest-key-1"
     assert intent["hostname"] == "guest-node"
+    # Consumed once — a second pop returns None.
+    assert account_proxy._pop_guest_preauth_intent("hub:hogne") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -237,9 +237,9 @@ async def test_cluster_join_503_when_explicitly_blanked(client, monkeypatch):
 
 # --- Guest preauth key minting (cross-user C2) ---
 @pytest.mark.asyncio
-async def test_cluster_guest_preauth_forwards_to_upstream(client, monkeypatch):
-    """POST /api/account/cluster/join/guest-preauth forwards to
-    {base}/api/cluster/join/guest-preauth with the session cookie relayed."""
+async def test_cluster_guest_preauth_forwards_and_strips_key(client, monkeypatch):
+    """POST /api/account/cluster/join/guest-preauth validates contact_id,
+    forwards to upstream, and strips the preauth key from the response."""
     monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
     captured: dict[str, str] = {}
 
@@ -249,7 +249,8 @@ async def test_cluster_guest_preauth_forwards_to_upstream(client, monkeypatch):
         captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
         captured["body"] = (kw.get("content") or b"").decode("utf-8")
         return _FakeResp(
-            content=b'{"preauth_key":"guest-key-1","hostname":"guest-node"}',
+            content=b'{"preauth_key":"guest-key-1","hostname":"guest-node",'
+                    b'"controller_token":"ct-token","headscale_preauth_key":"hs-key"}',
             headers={"content-type": "application/json"},
         )
 
@@ -259,10 +260,43 @@ async def test_cluster_guest_preauth_forwards_to_upstream(client, monkeypatch):
         json={"contact_id": "hub:hogne"},
     )
     assert r.status_code == 200
-    assert r.json()["preauth_key"] == "guest-key-1"
+    body = r.json()
+    # Secrets must be stripped — no credential reaches the browser.
+    assert "preauth_key" not in body
+    assert "headscale_preauth_key" not in body
+    assert "controller_token" not in body
+    # Non-secret fields survive.
+    assert body.get("hostname") == "guest-node"
     assert captured["url"] == "https://taos.my/api/cluster/join/guest-preauth"
     assert captured["method"] == "POST"
     assert "taos_session" not in captured["cookie"]
+
+
+@pytest.mark.asyncio
+async def test_cluster_guest_preauth_rejects_bad_contact_id(client, monkeypatch):
+    """Reject missing, malformed, or non-hub contact_id at the edge."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    called = {"n": 0}
+
+    async def handler(method, url, **kw):
+        called["n"] += 1
+        return _FakeResp()
+
+    _patch_upstream(monkeypatch, handler)
+    for bad_body in [
+        {},
+        {"contact_id": ""},
+        {"contact_id": "   "},
+        {"contact_id": "not-hub-prefix"},
+        {"contact_id": "hub:"},
+        {"contact_id": "hub:x" * 65},
+    ]:
+        r = await client.post(
+            "/api/account/cluster/join/guest-preauth", json=bad_body
+        )
+        assert r.status_code == 400, f"Expected 400 for {bad_body}"
+    # No upstream call was made for any rejected body.
+    assert called["n"] == 0
 
 
 # --- Account subdomain actions (account model slice 3) ---

--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -235,6 +235,36 @@ async def test_cluster_join_503_when_explicitly_blanked(client, monkeypatch):
     assert r.status_code == 503
 
 
+# --- Guest preauth key minting (cross-user C2) ---
+@pytest.mark.asyncio
+async def test_cluster_guest_preauth_forwards_to_upstream(client, monkeypatch):
+    """POST /api/account/cluster/join/guest-preauth forwards to
+    {base}/api/cluster/join/guest-preauth with the session cookie relayed."""
+    monkeypatch.setenv("TAOS_ACCOUNT_BASE_URL", "https://taos.my")
+    captured: dict[str, str] = {}
+
+    async def handler(method, url, **kw):
+        captured["method"] = method
+        captured["url"] = url
+        captured["cookie"] = kw.get("headers", {}).get("Cookie", "")
+        captured["body"] = (kw.get("content") or b"").decode("utf-8")
+        return _FakeResp(
+            content=b'{"preauth_key":"guest-key-1","hostname":"guest-node"}',
+            headers={"content-type": "application/json"},
+        )
+
+    _patch_upstream(monkeypatch, handler)
+    r = await client.post(
+        "/api/account/cluster/join/guest-preauth",
+        json={"contact_id": "hub:hogne"},
+    )
+    assert r.status_code == 200
+    assert r.json()["preauth_key"] == "guest-key-1"
+    assert captured["url"] == "https://taos.my/api/cluster/join/guest-preauth"
+    assert captured["method"] == "POST"
+    assert "taos_session" not in captured["cookie"]
+
+
 # --- Account subdomain actions (account model slice 3) ---
 @pytest.mark.asyncio
 async def test_subdomains_check_forwards_name(client, monkeypatch):

--- a/tests/test_routes_account_proxy.py
+++ b/tests/test_routes_account_proxy.py
@@ -270,6 +270,13 @@ async def test_cluster_guest_preauth_forwards_and_strips_key(client, monkeypatch
     assert captured["url"] == "https://taos.my/api/cluster/join/guest-preauth"
     assert captured["method"] == "POST"
     assert "taos_session" not in captured["cookie"]
+    # The preauth key was captured server-side for out-of-band delivery
+    # to the guest instance (D1 delegation-accept handler).
+    from tinyagentos.routes import account_proxy
+    intent = account_proxy._guest_preauth_intents.get("hub:hogne")
+    assert intent is not None, "guest preauth key was not captured server-side"
+    assert intent["preauth_key"] == "guest-key-1"
+    assert intent["hostname"] == "guest-node"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -449,7 +449,12 @@ async def cluster_guest_preauth(request: Request):
     # _pop_guest_preauth_intent to consume-and-delete).
     stripped, join_intent = _persist_join_credentials(resp)
     if join_intent:
-        _guest_preauth_intents[cid] = (time.monotonic(), join_intent)
+        now = time.monotonic()
+        # Sweep stale entries to bound dict growth even when consumer is inactive.
+        expired = [k for k, (ts, _) in _guest_preauth_intents.items() if now - ts > _GUEST_PREAUTH_TTL_SECONDS]
+        for k in expired:
+            _guest_preauth_intents.pop(k, None)
+        _guest_preauth_intents[cid] = (now, join_intent)
     return stripped
 
 
@@ -533,7 +538,7 @@ def _pop_guest_preauth_intent(cid: str) -> dict | None:
     for k in expired:
         _guest_preauth_intents.pop(k, None)
     entry = _guest_preauth_intents.pop(cid, None)
-    if entry is None or now - entry[0] > _GUEST_PREAUTH_TTL_SECONDS:
+    if entry is None:
         return None
     return entry[1]
 

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -66,6 +66,11 @@ _ACTIONS: dict[str, tuple[str, str]] = {
     "hub_presence_get": ("GET", "/api/hub/presence"),
     # Block asks the hub to sever the accepted edge (no more presence/hints).
     "hub_edge_revoke": ("POST", "/api/hub/edges/revoke"),
+    # Guest preauth key minting (cross-user C2). The host calls same-origin
+    # /api/account/cluster/join/guest-preauth at delegation-accept time to mint
+    # a scoped, ACL-pinned preauth key the guest instance will use to join the
+    # host's mesh. The taos.my side creates the key via the Headscale admin API.
+    "cluster_guest_preauth": ("POST", "/api/cluster/join/guest-preauth"),
 }
 
 _TIMEOUT = httpx.Timeout(15.0)
@@ -404,6 +409,23 @@ async def cluster_join_deny(request: Request, rid: str):
     if not _valid_rid(rid):
         return JSONResponse({"error": "invalid request id"}, status_code=400)
     return await _forward_to(request, "POST", f"{_JOIN_BASE}/requests/{rid}/deny")
+
+
+@router.post("/api/account/cluster/join/guest-preauth")
+async def cluster_guest_preauth(request: Request):
+    """Mint a scoped guest preauth key for a cross-user collaborator instance.
+
+    Called by the host at delegation-accept time (D1). Forwards to taos.my's
+    ``POST /api/cluster/join/guest-preauth``, which creates an ACL-pinned
+    (``tag:guest``) single-use preauth key via the Headscale admin API. The
+    forwarded body carries the guest contact identity; the response carries
+    the preauth key + hostname for the guest instance to join with.
+
+    The preauth key is stripped from any browser-facing response (same security
+    pattern as the host join poll) — the caller (peer channel, D1) delivers it
+    directly to the guest instance out-of-band.
+    """
+    return await _forward(request, "cluster_guest_preauth")
 
 
 def _persist_join_credentials(resp: Response) -> tuple[Response, dict | None]:

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -444,9 +444,11 @@ async def cluster_guest_preauth(request: Request):
                              body=json.dumps({"contact_id": cid}).encode("utf-8"))
 
     # Strip the preauth key from the response so it never reaches the browser.
-    # The caller (peer channel / delegation-accept handler) must capture the key
-    # from the stripped response upstream before returning to the browser.
-    stripped, _ = _persist_join_credentials(resp)
+    # Capture the join_intent for out-of-band delivery to the guest instance
+    # via the peer channel (D1 delegation-accept handler).
+    stripped, join_intent = _persist_join_credentials(resp)
+    if join_intent:
+        _guest_preauth_intents[cid] = join_intent
     return stripped
 
 
@@ -485,7 +487,7 @@ def _persist_join_credentials(resp: Response) -> tuple[Response, dict | None]:
         except Exception as exc:  # noqa: BLE001
             logger.warning("cluster-join: could not persist mesh credentials: %s", exc)
 
-    preauth = body.get("headscale_preauth_key")
+    preauth = body.get("preauth_key") or body.get("headscale_preauth_key")
     join_intent = None
     if preauth:
         # The Headscale node hostname; the exact value taos.my routes on is the
@@ -510,6 +512,12 @@ def _persist_join_credentials(resp: Response) -> tuple[Response, dict | None]:
 # sufficient (a process restart that loses this simply means a fresh join
 # opportunity, and the key is stale by then anyway).
 _attempted_preauth: set[str] = set()
+
+# Guest preauth keys (C2 cross-user transport). Populated by
+# cluster_guest_preauth when taos.my mints a guest preauth key; consumed
+# by the D1 delegation-accept handler for out-of-band delivery to the guest
+# instance via the peer channel.
+_guest_preauth_intents: dict[str, dict] = {}
 
 # Keep a strong reference to in-flight background tasks so they are not
 # garbage-collected mid-run (a bare create_task() can be dropped -> "coroutine

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -69,11 +69,6 @@ _ACTIONS: dict[str, tuple[str, str]] = {
     "hub_presence_get": ("GET", "/api/hub/presence"),
     # Block asks the hub to sever the accepted edge (no more presence/hints).
     "hub_edge_revoke": ("POST", "/api/hub/edges/revoke"),
-    # Guest preauth key minting (cross-user C2). The host calls same-origin
-    # /api/account/cluster/join/guest-preauth at delegation-accept time to mint
-    # a scoped, ACL-pinned preauth key the guest instance will use to join the
-    # host's mesh. The taos.my side creates the key via the Headscale admin API.
-    "cluster_guest_preauth": ("POST", "/api/cluster/join/guest-preauth"),
 }
 
 _TIMEOUT = httpx.Timeout(15.0)

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -417,14 +417,18 @@ async def cluster_guest_preauth(request: Request):
     ``POST /api/cluster/join/guest-preauth``, which creates an ACL-pinned
     (``tag:guest``) single-use preauth key via the Headscale admin API.
 
-    **Security:** validates the ``contact_id`` body field before forwarding,
-    and strips every preauth key from the response so no credential reaches
-    browser JavaScript. The caller (peer channel, D1) must extract the key
-    server-side before the response is sent to the browser, or use an
-    alternative internal delivery path.
+    **Security:** validates the ``contact_id`` *format* at the edge (length,
+    prefix) before forwarding to avoid wasted upstream API calls, but does
+    **not** assert the caller owns that contact — contact-to-caller ownership
+    is enforced by the upstream taos.my service which has access to the
+    contacts database.  Every preauth key is stripped from the response so no
+    credential reaches browser JavaScript. The caller (peer channel, D1) must
+    extract the key server-side before the response is sent to the browser, or
+    use an alternative internal delivery path.
     """
-    # Validate contact_id before forwarding (defense-in-depth: the upstream also
-    # validates, but we reject garbage at the edge to avoid wasted API calls).
+    # Validate contact_id format at the edge (defense-in-depth: the upstream
+    # also validates + enforces ownership, but we reject garbage at the edge
+    # to avoid wasted API calls).
     try:
         body = await request.json()
     except Exception:  # noqa: BLE001

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+import time
 
 import httpx
 from fastapi import APIRouter, Request, Response
@@ -445,10 +446,11 @@ async def cluster_guest_preauth(request: Request):
 
     # Strip the preauth key from the response so it never reaches the browser.
     # Capture the join_intent for out-of-band delivery to the guest instance
-    # via the peer channel (D1 delegation-accept handler).
+    # via the peer channel (D1 delegation-accept handler calls
+    # _pop_guest_preauth_intent to consume-and-delete).
     stripped, join_intent = _persist_join_credentials(resp)
     if join_intent:
-        _guest_preauth_intents[cid] = join_intent
+        _guest_preauth_intents[cid] = (time.monotonic(), join_intent)
     return stripped
 
 
@@ -517,7 +519,24 @@ _attempted_preauth: set[str] = set()
 # cluster_guest_preauth when taos.my mints a guest preauth key; consumed
 # by the D1 delegation-accept handler for out-of-band delivery to the guest
 # instance via the peer channel.
-_guest_preauth_intents: dict[str, dict] = {}
+#
+# Single-use keys are stale after a short window (Headscale rejects them
+# once expired), so entries auto-evict after _GUEST_PREAUTH_TTL_SECONDS.
+_GUEST_PREAUTH_TTL_SECONDS = 300  # 5 min — Headscale default expiry window
+_guest_preauth_intents: dict[str, tuple[float, dict]] = {}
+
+
+def _pop_guest_preauth_intent(cid: str) -> dict | None:
+    """Consume-and-delete a guest preauth intent. Also sweeps stale entries."""
+    now = time.monotonic()
+    # Sweep: delete all expired entries on any access.
+    expired = [k for k, (ts, _) in _guest_preauth_intents.items() if now - ts > _GUEST_PREAUTH_TTL_SECONDS]
+    for k in expired:
+        _guest_preauth_intents.pop(k, None)
+    entry = _guest_preauth_intents.pop(cid, None)
+    if entry is None or now - entry[0] > _GUEST_PREAUTH_TTL_SECONDS:
+        return None
+    return entry[1]
 
 # Keep a strong reference to in-flight background tasks so they are not
 # garbage-collected mid-run (a bare create_task() can be dropped -> "coroutine

--- a/tinyagentos/routes/account_proxy.py
+++ b/tinyagentos/routes/account_proxy.py
@@ -33,8 +33,10 @@ router = APIRouter()
 _JOIN_SERVICE_TOKENS = ("controller_token", "sites_token")
 # Everything stripped from the browser body: the service tokens plus the
 # single-use Headscale preauth key, which the controller consumes server-side to
-# join the mesh (Slice 2). None of these should ever reach browser JavaScript.
-_STRIP_KEYS = _JOIN_SERVICE_TOKENS + ("headscale_preauth_key",)
+# join the mesh (Slice 2). ``headscale_preauth_key`` is the host join key;
+# ``preauth_key`` is the guest preauth key (C2 cross-user transport). None of
+# these should ever reach browser JavaScript.
+_STRIP_KEYS = _JOIN_SERVICE_TOKENS + ("headscale_preauth_key", "preauth_key", "guest_preauth_key")
 
 # Only these account actions are proxied. The upstream base is operator config
 # (env), never user input, so there is no open-proxy / SSRF surface.
@@ -417,15 +419,35 @@ async def cluster_guest_preauth(request: Request):
 
     Called by the host at delegation-accept time (D1). Forwards to taos.my's
     ``POST /api/cluster/join/guest-preauth``, which creates an ACL-pinned
-    (``tag:guest``) single-use preauth key via the Headscale admin API. The
-    forwarded body carries the guest contact identity; the response carries
-    the preauth key + hostname for the guest instance to join with.
+    (``tag:guest``) single-use preauth key via the Headscale admin API.
 
-    The preauth key is stripped from any browser-facing response (same security
-    pattern as the host join poll) — the caller (peer channel, D1) delivers it
-    directly to the guest instance out-of-band.
+    **Security:** validates the ``contact_id`` body field before forwarding,
+    and strips every preauth key from the response so no credential reaches
+    browser JavaScript. The caller (peer channel, D1) must extract the key
+    server-side before the response is sent to the browser, or use an
+    alternative internal delivery path.
     """
-    return await _forward(request, "cluster_guest_preauth")
+    # Validate contact_id before forwarding (defense-in-depth: the upstream also
+    # validates, but we reject garbage at the edge to avoid wasted API calls).
+    try:
+        body = await request.json()
+    except Exception:  # noqa: BLE001
+        return JSONResponse({"error": "invalid body"}, status_code=400)
+    if not isinstance(body, dict) or not isinstance(body.get("contact_id"), str):
+        return JSONResponse({"error": "missing contact_id"}, status_code=400)
+    cid: str = body["contact_id"].strip()
+    if not cid.startswith("hub:") or len(cid) < 5 or len(cid) > 256:
+        return JSONResponse({"error": "invalid contact_id"}, status_code=400)
+
+    # Forward to taos.my with the validated body.
+    resp = await _forward_to(request, "POST", f"{_JOIN_BASE}/guest-preauth",
+                             body=json.dumps({"contact_id": cid}).encode("utf-8"))
+
+    # Strip the preauth key from the response so it never reaches the browser.
+    # The caller (peer channel / delegation-accept handler) must capture the key
+    # from the stripped response upstream before returning to the browser.
+    stripped, _ = _persist_join_credentials(resp)
+    return stripped
 
 
 def _persist_join_credentials(resp: Response) -> tuple[Response, dict | None]:

--- a/tinyagentos/taosnet/mesh.py
+++ b/tinyagentos/taosnet/mesh.py
@@ -100,11 +100,32 @@ async def mesh_up(
     return {"ok": False, "detail": detail}
 
 
+_GUEST_TAG = "tag:guest"
+
+
+def _is_guest_node(node: dict) -> bool:
+    """True when a peer node carries the ``tag:guest`` tag (ACL-pinned guest)."""
+    tags: list[str] = node.get("Tags") or []
+    return _GUEST_TAG in tags
+
+
+def _guest_peer_entry(node: dict) -> dict:
+    """Extract the standard guest-peer summary from a tailscale peer dict."""
+    ips = node.get("TailscaleIPs") or []
+    return {
+        "hostname": node.get("HostName"),
+        "node_ip": ips[0] if ips else None,
+        "online": bool(node.get("Online")),
+    }
+
+
 async def mesh_status() -> dict:
     """Report mesh membership from ``tailscale status --json``. On success:
-    ``{joined, online, tailnet, node_ip, hostname}``. On the not-available /
-    error path: ``{joined: False, detail}``. Fail-soft: not-installed / not-up
-    returns ``joined=False`` with a detail, never raises."""
+    ``{joined, online, tailnet, node_ip, hostname, guests}`` where ``guests``
+    is a list of peer nodes tagged ``tag:guest`` (ACL-pinned guest instances that
+    joined this host's mesh). On the not-available / error path:
+    ``{joined: False, detail}``. Fail-soft: not-installed / not-up returns
+    ``joined=False`` with a detail, never raises."""
     if not is_tailscale_installed():
         return {"joined": False, "detail": "tailscale not installed"}
     rc, out, err = await _run(["tailscale", "status", "--json"], timeout=10.0)
@@ -119,12 +140,25 @@ async def mesh_status() -> dict:
     ips = self_node.get("TailscaleIPs") or []
     # BackendState "Running" + a Self node means we are up on the tailnet.
     joined = data.get("BackendState") == "Running" and bool(self_node)
+
+    # --- guest peer nodes (C2: cross-user guest preauth) -------------------
+    guests: list[dict] = []
+    peers = data.get("Peer") or {}
+    if isinstance(peers, dict):
+        for peer in peers.values():
+            if not isinstance(peer, dict):
+                continue
+            if _is_guest_node(peer):
+                guests.append(_guest_peer_entry(peer))
+    # ------------------------------------------------------------------------
+
     return {
         "joined": joined,
         "online": online,
         "tailnet": (data.get("CurrentTailnet") or {}).get("Name"),
         "node_ip": ips[0] if ips else None,
         "hostname": self_node.get("HostName"),
+        "guests": guests,
     }
 
 

--- a/tinyagentos/taosnet/mesh.py
+++ b/tinyagentos/taosnet/mesh.py
@@ -110,7 +110,14 @@ def _is_guest_node(node: dict) -> bool:
 
 
 def _guest_peer_entry(node: dict) -> dict:
-    """Extract the standard guest-peer summary from a tailscale peer dict."""
+    """Extract the standard guest-peer summary from a tailscale peer dict.
+
+    ``node_ip`` uses ``TailscaleIPs[0]`` (the first address reported), which
+    is consistent with the host's own ``mesh_status`` output. For multi-homed
+    peers this may be an IPv4 or IPv6 address (or ``None`` when the list is
+    empty). Callers that need a specific address family should resolve the
+    hostname, not rely on this field as the sole network identifier.
+    """
     ips = node.get("TailscaleIPs") or []
     return {
         "hostname": node.get("HostName"),


### PR DESCRIPTION
## Summary

Implements the taOS-side pieces of **C2 (guest-preauth mint + ACL automation + mesh-status guest links)** from EPIC #2012.

Closes #2018.

## Changes

### 1. Extend `mesh_status()` to surface guest peer nodes
- Parses the `Peer` map from `tailscale status --json`
- Identifies nodes tagged `tag:guest` (ACL-pinned guest instances)
- Returns them in a `guests` list: `[{hostname, node_ip, online}]`
- Fail-soft: malformed peer data is silently skipped

### 2. Add guest-preauth proxy endpoint
- `POST /api/account/cluster/join/guest-preauth` forwards to taos.my
- Called by the host at delegation-accept time (D1) to mint an ACL-pinned,
  single-use preauth key for the guest collaborator instance
- Same security pattern as the host join poll: preauth key is stripped
  from browser-facing responses, delivered out-of-band via peer channel

### 3. Tests: 16 mesh tests + 1 account_proxy integration test
- Guest peer detection, non-guest exclusion, malformed data handling
- Account proxy guest-preauth forwarding with cookie relay verification

## Files changed (4)
- `tinyagentos/taosnet/mesh.py` — +40/-3
- `tinyagentos/routes/account_proxy.py` — +22
- `tests/test_mesh.py` — +51 (5 new tests)
- `tests/test_routes_account_proxy.py` — +30 (1 new test)

## Test results
```
tests/test_mesh.py .......................... 16 passed
tests/test_routes_account_proxy.py (guest_preauth) .. 1 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /api/account/cluster/join/guest-preauth` to mint and temporarily hold guest join preauthorization intents.
  * Updated mesh status to include a `guests` list for peers tagged as guests (hostname, IP, online state).
* **Bug Fixes**
  * Guest peer handling is fail-safe: malformed peer data is ignored and service/unparseable status responses preserve fail-soft behavior.
* **Tests**
  * Added coverage for guest preauth forwarding, secret-field stripping, one-time intent consumption, and rejection of invalid `contact_id` values.
  * Added coverage for guest list population/omission in mesh status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->