### PR TITLE
fix(github): resolve #2009/#1932 semantic conflict on App private key source

### DIFF
--- a/tests/test_routes_github.py
+++ b/tests/test_routes_github.py
@@ -341,18 +341,23 @@ def _build_app_with_app_config(
     app = FastAPI()
     app.include_router(github_router)
 
-    # SecretsStore (PAT)
+    # SecretsStore: PAT under ``github_token``, App key under
+    # ``github-app-private-key`` (moved out of config by #2009).
     mock_secrets = MagicMock()
-    if token:
-        mock_secrets.get = AsyncMock(return_value={"value": token})
-    else:
-        mock_secrets.get = AsyncMock(return_value=None)
+
+    async def _secrets_get(name):
+        if name == "github_token":
+            return {"value": token} if token else None
+        if name == "github-app-private-key":
+            return {"value": "fake-private-key"}
+        return None
+
+    mock_secrets.get = AsyncMock(side_effect=_secrets_get)
     app.state.secrets = mock_secrets
 
-    # App config
+    # App config (private key no longer lives here after #2009)
     mock_config = MagicMock()
     mock_config.github_app_id = "123456"
-    mock_config.github_app_private_key = "fake-private-key"
     app.state.config = mock_config
 
     # App installations store

--- a/tinyagentos/routes/github.py
+++ b/tinyagentos/routes/github.py
@@ -120,7 +120,7 @@ async def _get_app_installation_token(
         from tinyagentos.github_app import get_installation_token
 
         token = await get_installation_token(
-            cfg.github_app_id, cfg.github_app_private_key, installation_id,
+            cfg.github_app_id, private_key, installation_id,
             http_client,
         )
         if token:


### PR DESCRIPTION
Dev is red: test_repo_endpoint_still_uses_app_token fails 401 at the #1932 merge commit. Root cause is a semantic conflict between two individually green PRs: #2009 moved the App private key from config to SecretsStore; #1932 landed with a test helper still stubbing the key on config and a route branch still reading cfg.github_app_private_key.

Fixes:
1. routes/github.py explicit-installation branch now uses the SecretsStore-fetched private_key (the config attribute no longer exists after the #2009 migration strips it).
2. Test helper serves secrets by name (github_token PAT, github-app-private-key App key) matching the live contract.

Verified locally: tests/test_routes_github.py + tests/test_github_app.py 31/31 pass on 3.12.

Process note: #1932 was merged on a green computed before #2009 changed its base; pitfall 14 in docs/contributor-pitfalls.md (#2040) gets a follow-up line about stale-base greens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub App installation tokens now use the configured application private key when accessing non-user-scoped endpoints.
  * Improved token selection to ensure user credentials are not used for app-level GitHub requests.
* **Tests**
  * Updated endpoint validation to reflect the revised GitHub credential configuration and token behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->