### PR TITLE
fix(invites): return scopes as a list from invite list endpoints (#2065)

### DIFF
--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -605,6 +605,22 @@ def _build_os_guide_markdown(
     return "\n".join(lines)
 
 
+
+def _scopes_as_list(raw) -> list:
+    """The store keeps scopes as a JSON-encoded TEXT column; the API contract
+    is a list. Parse defensively so a malformed row degrades to [] instead of
+    crashing every client that renders the list."""
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, str):
+        try:
+            import json as _json
+            v = _json.loads(raw)
+            return v if isinstance(v, list) else []
+        except Exception:
+            return []
+    return []
+
 @router.post("/api/projects/{project_id}/invites")
 async def mint_invite(
     project_id: str,
@@ -663,7 +679,7 @@ async def list_invites(
     return [
         {
             "invite_id": i["invite_id"],
-            "scopes": i["scopes"],
+            "scopes": _scopes_as_list(i["scopes"]),
             "status": i["status"],
             "expires_ts": i["expires_ts"],
             "redeemed_by": i.get("redeemed_by"),
@@ -768,7 +784,7 @@ async def list_os_invites(
     return [
         {
             "invite_id": i["invite_id"],
-            "scopes": i["scopes"],
+            "scopes": _scopes_as_list(i["scopes"]),
             "status": i["status"],
             "expires_ts": i["expires_ts"],
             "redeemed_by": i.get("redeemed_by"),


### PR DESCRIPTION
## Problem
Both invite list serializers in `tinyagentos/routes/project_invites.py` passed the raw DB TEXT column through, so the API returned `scopes` as a JSON-encoded **string** (`"[\"project_tasks\"...]"`). The Projects Invite dialog renders `inv.scopes.join(", ")` (InviteAgentDialog.tsx:349) and its type declares `scopes: string[]`, so the first time any pending invite existed the dialog threw and tripped the SPA error boundary (full "something went wrong" crash, reload required).

This is also the real root cause of the #2065 silent dialog close: after a successful mint the dialog refreshes the pending list, hits the same throw, and unmounts before the URL/PIN success view renders. One root cause, three symptoms (crash on open, silent close after mint, empty-list-only survival).

## Fix
Add `_scopes_as_list` and use it in both list serializers: passes lists through, parses JSON strings, degrades malformed rows to `[]` instead of crashing every client.

## Testing
- `tests/projects/test_invite_store.py` + csrf routes: 45 passed
- Verified live repro against the Pi API: both pending invites on prj-qlvxdq return string scopes today

Refs #2065 (crash path; the dialog UX rework remains open there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project and agent invite listings now consistently return scopes as a list.
  * Invalid or malformed scope data is handled safely by returning an empty list instead of causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->