### PR TITLE
fix(invites): allow revoking expired invites, 409 for terminal states

### DIFF
--- a/tests/projects/test_invite_store.py
+++ b/tests/projects/test_invite_store.py
@@ -315,6 +315,44 @@ async def test_revoke_nonexistent_returns_false(store):
     assert await store.revoke("000000") is False
 
 
+@pytest.mark.asyncio
+async def test_revoke_expired_invite(store):
+    """An expired invite can still be revoked (cleanup from the pending list)."""
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    await store._db.execute(
+        "UPDATE project_invites SET expires_ts = 1 WHERE invite_id = ?", (iid,)
+    )
+    await store._db.commit()
+    row = await store.get(iid)
+    assert row["status"] == "expired"
+    ok = await store.revoke(iid)
+    assert ok is True
+    row = await store.get(iid)
+    assert row["status"] == "revoked"
+
+
+@pytest.mark.asyncio
+async def test_revoke_redeemed_invite_returns_false(store):
+    result = await store.mint(
+        project_id="prj-1",
+        scopes=[],
+        approval_mode="auto",
+        check_interval_secs=1800,
+        created_by="u",
+    )
+    iid = result["record"]["invite_id"]
+    pin = result["pin"]
+    await store.redeem(iid, pin)
+    assert await store.revoke(iid) is False
+
+
 # ---------------------------------------------------------------------------
 # redeem
 # ---------------------------------------------------------------------------

--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -139,6 +139,37 @@ async def test_revoke_nonexistent_returns_404(client, app):
     assert resp.status_code == 404, resp.text
 
 
+@pytest.mark.asyncio
+async def test_revoke_expired_returns_204(client, app):
+    pid = await _create_project(client)
+    mint_resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto"},
+    )
+    iid = mint_resp.json()["invite_id"]
+    store = app.state.project_invites
+    await store._db.execute(
+        "UPDATE project_invites SET expires_ts = 1 WHERE invite_id = ?", (iid,)
+    )
+    await store._db.commit()
+    resp = await client.delete(f"/api/projects/{pid}/invites/{iid}")
+    assert resp.status_code == 204, resp.text
+
+
+@pytest.mark.asyncio
+async def test_revoke_already_revoked_returns_409(client, app):
+    pid = await _create_project(client)
+    mint_resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto"},
+    )
+    iid = mint_resp.json()["invite_id"]
+    first = await client.delete(f"/api/projects/{pid}/invites/{iid}")
+    assert first.status_code == 204, first.text
+    second = await client.delete(f"/api/projects/{pid}/invites/{iid}")
+    assert second.status_code == 409, second.text
+
+
 # ---------------------------------------------------------------------------
 # Redeem slice (S2): auto + manual approval, handle derivation, bundle, errors
 # ---------------------------------------------------------------------------

--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -652,3 +652,35 @@ async def test_mint_rejects_ttl_over_cap(client, app):
         json={"scopes": [], "approval_mode": "auto", "ttl_secs": 999999},
     )
     assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_revoke_redeemed_returns_409(client, app):
+    pid = await _create_project(client)
+    mint_resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto"},
+    )
+    body = mint_resp.json()
+    store = app.state.project_invites
+    await store.redeem(body["invite_id"], body["pin"])
+    resp = await client.delete(f"/api/projects/{pid}/invites/{body['invite_id']}")
+    assert resp.status_code == 409, resp.text
+
+
+@pytest.mark.asyncio
+async def test_revoke_claimed_returns_409_with_mid_redeem_message(client, app):
+    pid = await _create_project(client)
+    mint_resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto"},
+    )
+    iid = mint_resp.json()["invite_id"]
+    store = app.state.project_invites
+    await store._db.execute(
+        "UPDATE project_invites SET status = 'claimed' WHERE invite_id = ?", (iid,)
+    )
+    await store._db.commit()
+    resp = await client.delete(f"/api/projects/{pid}/invites/{iid}")
+    assert resp.status_code == 409, resp.text
+    assert "mid-redeem" in resp.json()["error"]

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -325,7 +325,8 @@ class ProjectInviteStore(BaseStore):
         if self._db is None:
             raise RuntimeError("ProjectInviteStore not initialised")
         cursor = await self._db.execute(
-            "UPDATE project_invites SET status = 'revoked' WHERE invite_id = ? AND status = 'pending'",
+            "UPDATE project_invites SET status = 'revoked' "
+            "WHERE invite_id = ? AND status IN ('pending', 'expired')",
             (invite_id,),
         )
         await self._db.commit()

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -709,9 +709,13 @@ async def revoke_invite(
     row = await store.get(invite_id)
     if row is None or row.get("project_id") != project_id:
         return JSONResponse({"error": "invite not found"}, status_code=404)
+    if row.get("status") in ("redeemed", "revoked"):
+        return JSONResponse(
+            {"error": f"invite already {row['status']}"}, status_code=409
+        )
     ok = await store.revoke(invite_id)
     if not ok:
-        return JSONResponse({"error": "invite not found or already redeemed"}, status_code=404)
+        return JSONResponse({"error": "invite state changed, retry"}, status_code=409)
     return JSONResponse(content=None, status_code=204)
 
 

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -709,9 +709,15 @@ async def revoke_invite(
     row = await store.get(invite_id)
     if row is None or row.get("project_id") != project_id:
         return JSONResponse({"error": "invite not found"}, status_code=404)
-    if row.get("status") in ("redeemed", "revoked"):
+    status = row.get("status")
+    if status in ("redeemed", "revoked"):
+        return JSONResponse({"error": f"invite already {status}"}, status_code=409)
+    # 'claimed' is the transient mid-redeem state. Revoking it would race the
+    # redeem, so refuse with a message that names the state rather than the
+    # generic retry text.
+    if status == "claimed":
         return JSONResponse(
-            {"error": f"invite already {row['status']}"}, status_code=409
+            {"error": "invite is mid-redeem, retry once it settles"}, status_code=409
         )
     ok = await store.revoke(invite_id)
     if not ok:


### PR DESCRIPTION
## Problem
Live repro from Jay's e2e test: both pending invites hit their 15-minute TTL and lazily flipped to `expired` on read. `store.revoke` only matches `status='pending'`, so the DELETE matched zero rows and the route returned 404 "invite not found" - while the dialog kept listing the rows (it labels everything "Pending" regardless of status, tracked in #2065). Net effect: dead invites, displayed as pending, unrevokable.

## Fix
- `invite_store.revoke`: matches `pending` and `expired` (an expired invite is exactly what a user wants to clean up).
- `revoke_invite` route: `redeemed`/`revoked` now return 409 with the actual state instead of a misleading 404; 404 remains only for genuinely missing or wrong-project invites.

## Testing
- New: revoke-expired returns 204 (store + route), revoke-redeemed returns false, double-revoke returns 409.
- Full invite store + route suites: 71 passed.

## Related
- #2065 dialog rework should render status badges (pending vs expired) rather than one "Pending" list - noted there.
- The 15-minute TTL itself is a separate product decision (human-mediated redeems need longer or a mint-time choice) - raising with Jay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expired project invitations can now be revoked successfully.
* **Bug Fixes**
  * Revocation now returns clearer **409 conflict** responses when an invitation is already **redeemed** or **revoked**.
  * If an invitation is mid-redeem (“claimed”), revocation is blocked with a **409** including a **“mid-redeem”** message.
  * If the invitation changes state during the request, the endpoint returns **409** with a retry guidance response.
* **Tests**
  * Added coverage for revoke behavior across expired, redeemed, claimed, and already-revoked scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->