### PR TITLE
feat(invites): 1 hour default TTL + optional per-mint ttl_secs

### DIFF
--- a/tests/test_routes_project_invites.py
+++ b/tests/test_routes_project_invites.py
@@ -585,3 +585,39 @@ async def test_guide_markdown_contains_required_instructions(client, app, monkey
     # Timed-check instruction mentions the interval value.
     assert "1800" in guide
 
+
+
+@pytest.mark.asyncio
+async def test_mint_default_ttl_is_one_hour(client, app):
+    pid = await _create_project(client)
+    before = time.time()
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto"},
+    )
+    assert resp.status_code == 200, resp.text
+    ttl = resp.json()["expires_ts"] - before
+    assert 3500 < ttl <= 3610
+
+
+@pytest.mark.asyncio
+async def test_mint_honours_ttl_secs(client, app):
+    pid = await _create_project(client)
+    before = time.time()
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto", "ttl_secs": 86400},
+    )
+    assert resp.status_code == 200, resp.text
+    ttl = resp.json()["expires_ts"] - before
+    assert 86300 < ttl <= 86410
+
+
+@pytest.mark.asyncio
+async def test_mint_rejects_ttl_over_cap(client, app):
+    pid = await _create_project(client)
+    resp = await client.post(
+        f"/api/projects/{pid}/invites",
+        json={"scopes": [], "approval_mode": "auto", "ttl_secs": 999999},
+    )
+    assert resp.status_code == 422, resp.text

--- a/tinyagentos/projects/invite_store.py
+++ b/tinyagentos/projects/invite_store.py
@@ -10,7 +10,7 @@ import aiosqlite
 
 from tinyagentos.base_store import BaseStore
 
-_EXPIRY_SECS = 15 * 60
+_EXPIRY_SECS = 60 * 60
 _MAX_ATTEMPTS = 5
 _PENDING_CAP = 10
 
@@ -131,7 +131,8 @@ class ProjectInviteStore(BaseStore):
                    display_name: str | None = None,
                    kind: str = "agent",
                    pin_required: bool = True,
-                   contact_id: str | None = None) -> dict:
+                   contact_id: str | None = None,
+                   ttl_secs: int | None = None) -> dict:
         if self._db is None:
             raise RuntimeError("ProjectInviteStore not initialised")
 
@@ -180,7 +181,9 @@ class ProjectInviteStore(BaseStore):
         pin = self._generate_pin()
         pin_hash = hashlib.sha256(pin.encode()).hexdigest()
         now = _now()
-        expires_ts = now + _EXPIRY_SECS
+        if ttl_secs is not None and ttl_secs <= 0:
+            raise ValueError("ttl_secs must be positive")
+        expires_ts = now + (ttl_secs if ttl_secs is not None else _EXPIRY_SECS)
 
         # 6-digit invite IDs have a non-trivial collision chance under load
         # (~12 % at 500 pending).  Retry on UNIQUE constraint violation so a

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -30,6 +30,10 @@ class MintInviteIn(BaseModel):
     scopes: list[str] = Field(default_factory=list)
     approval_mode: str = Field(default="auto", pattern="^(auto|manual)$")
     check_interval_secs: int = Field(default=1800, ge=60)
+    # How long the invite stays redeemable. Omitted means the store default
+    # (1 hour). Capped at 24 hours: the PIN is the security gate, expiry is
+    # hygiene, but an indefinitely live link is not a state we want.
+    ttl_secs: int | None = Field(default=None, ge=60, le=86400)
 
 
 class MintOsInviteIn(BaseModel):
@@ -649,6 +653,7 @@ async def mint_invite(
             approval_mode=payload.approval_mode,
             check_interval_secs=payload.check_interval_secs,
             created_by=user.user_id,
+            ttl_secs=payload.ttl_secs,
         )
     except InvitePendingCapError as exc:
         return JSONResponse({"error": str(exc)}, status_code=429)


### PR DESCRIPTION
Follow-up to #2071, from the same live-test session: both invites expired before they could be redeemed because the TTL was 15 minutes.

## Change
- Default invite TTL 15 minutes to **1 hour**.
- `POST /api/projects/{id}/invites` accepts optional `ttl_secs` (60s to 24h, validated); omitted uses the default.
- `ProjectInviteStore.mint` takes `ttl_secs=None` and falls back to the default, so every other call site is unchanged.

## Rationale
Handing an invite URL + PIN to a human who then configures an agent is not a 15 minute flow. The PIN (plus the pending cap and single-use redeem) is the actual security control; expiry is hygiene, so an hour by default with an explicit opt-in up to a day is the right balance. 24h is a hard cap so no invite lives indefinitely.

## Testing
- New: default TTL lands at 1 hour, `ttl_secs` honoured at the 24h bound, over-cap rejected 422.
- Invite store + route suites: 70 passed.

## Follow-up
The mint dialog gets a TTL picker (15m / 1h / 24h) as part of the #2065 rework - the backend contract lands here first so the UI has something to call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project invites now default to a one-hour expiration.
  * Invite creators can set a custom expiration period from 60 seconds up to 24 hours.
  * Invalid expiration values are rejected with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->