### PR TITLE
tsk-midukh  [OPEN]  Add vitest coverage for the Crosswords app

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.41",
+  "version": "1.0.0-beta.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.41",
+      "version": "1.0.0-beta.42",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.1",
         "@codemirror/language-data": "^6.5.2",
@@ -5325,9 +5325,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5345,9 +5342,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5365,9 +5359,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5385,9 +5376,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5405,9 +5393,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5425,9 +5410,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5654,9 +5636,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5674,9 +5653,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5694,9 +5670,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5714,9 +5687,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/desktop/src/apps/CrosswordsApp.test.tsx
+++ b/desktop/src/apps/CrosswordsApp.test.tsx
@@ -66,7 +66,7 @@ describe("CrosswordsApp", () => {
     expect(within(firstCell).queryByText("S")).toBeNull();
   });
 
-  it("navigates to a clue's starting cell and direction when the clue is clicked", async () => {
+  it("navigates to a clue\'s starting cell and direction when the clue is clicked", async () => {
     render(<CrosswordsApp windowId="win-cw-4" />);
     await flush();
 
@@ -81,5 +81,27 @@ describe("CrosswordsApp", () => {
 
     const activeClueItem = screen.getByRole("button", { name: /1 across: celestial objects/i });
     expect(activeClueItem).toHaveStyle({ background: "rgba(251, 191, 36, 0.25)" });
+  });
+
+  it("clicks check answers button to enter check mode", async () => {
+    render(<CrosswordsApp windowId="win-cw-5" />);
+    await flush();
+
+    const checkButton = screen.getByRole("button", { name: /check answers/i });
+    fireEvent.click(checkButton);
+    await flush();
+
+    expect(checkButton).toBeInTheDocument();
+  });
+
+  it("switches to next puzzle", async () => {
+    render(<CrosswordsApp windowId="win-cw-6" />);
+    await flush();
+
+    const newPuzzleButton = screen.getByRole("button", { name: /new puzzle/i });
+    fireEvent.click(newPuzzleButton);
+    await flush();
+
+    expect(screen.getByText(/crossword #2/i)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Autonomous build of board card tsk-midukh.



Files:
 desktop/package-lock.json               | 34 ++-------------------------------
 desktop/src/apps/CrosswordsApp.test.tsx | 24 ++++++++++++++++++++++-
 2 files changed, 25 insertions(+), 33 deletions(-)

----
## Summary by Gitar

- **Test coverage:**
    - Added test case for checking answers in `CrosswordsApp` using `checkButton` interaction.
    - Implemented test for switching puzzles by triggering the `new puzzle` button.

<sub>This will update automatically on new commits.</sub>