### PR TITLE
chore(release): v1.0.0-beta.43 version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.43] - 2026-07-21
+
+### Added
+
+- **Library app P1**: LibraryStore, ingest pipeline, cheap-tier processors (file,
+  text, PDF, image) and the collections handoff to taOSmd. Ingested items are
+  copied into a per-item directory and registered as a taOSmd collection over the
+  live Collections API, with async index polling and typed link rows (#2062).
+- Invite mint accepts an optional `ttl_secs` (60s to 24h) so a longer-lived
+  invite is a deliberate choice rather than a code change (#2072).
+
+### Fixed
+
+- **Invite dialog crashed the desktop.** The invite list endpoints returned
+  `scopes` as a JSON-encoded string while the UI typed it as an array, so the
+  dialog threw and tripped the SPA error boundary whenever any pending invite
+  existed. This also caused the post-mint refresh to unmount the dialog before
+  the URL and PIN were shown (#2066).
+- **Expired invites could not be revoked.** `revoke` only matched `pending`, so an
+  invite that lazily flipped to `expired` returned 404 while still listed, leaving
+  dead rows against the pending cap. Revoke now covers expired, and terminal
+  states return 409 with the actual state (#2071).
+- Default invite TTL raised from 15 minutes to 1 hour. Handing a URL and PIN to a
+  human who then configures an agent is not a 15 minute flow (#2072).
+
+### Changed
+
+- `docs/getting-started.md` documents the Hailo-10H AI HAT+2 and the Raspberry Pi
+  5 M.2 slot conflict: the HAT occupies the only M.2 slot, so it cannot be used
+  alongside an NVMe boot drive (#2075).
+- Contributor docs gained seven new defect classes drawn from real review
+  findings, covering runtime state in commits, mobile view registries, retrofit
+  migrations on shipped stores, scope honesty, tolerance assertions, shell
+  snippets in template literals, conflict resolution, and how an external
+  contributor reaches another team's agent (#2069, #2079).
+
 ## [1.0.0-beta.42] - 2026-07-20
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.42",
+  "version": "1.0.0-beta.43",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.42"
+version = "1.0.0-beta.43"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.42"
+__version__ = "1.0.0-beta.43"

--- a/uv.lock
+++ b/uv.lock
@@ -3022,7 +3022,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b42"
+version = "1.0.0b43"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump across the four tracked files (`pyproject.toml`, `tinyagentos/__init__.py`, `desktop/package.json`, and the normalized `1.0.0b43` in `uv.lock`) plus the changelog section. `test_version_lock_sync` passes locally.

## What ships in beta.43

**Library app P1** (#2062): store, ingest pipeline, cheap-tier processors and the collections handoff to taOSmd over the live Collections API, with async index polling and typed link rows. This one went through three review rounds, including a reprocess bug that deleted the user's original uploaded file and a test whose tolerance kept it green.

**Three invite fixes**, all found by live use rather than tests:
- The dialog crashed the whole desktop whenever a pending invite existed, because the list endpoints returned `scopes` as a JSON string while the UI typed it as an array (#2066). This also explains the post-mint dialog closing without showing the URL and PIN.
- Expired invites could not be revoked, returning 404 while still listed and still counting against the pending cap (#2071).
- Default TTL raised from 15 minutes to 1 hour, with an optional per-mint `ttl_secs` (#2072). Handing a URL and PIN to a human who then configures an agent is not a 15 minute flow.

**Docs**: the Hailo-10H AI HAT+2 entry including the Pi 5 M.2 slot conflict (#2075), and seven new contributor defect classes distilled from this cycle's reviews (#2069, #2079).

Cut deliberately from what has landed rather than holding for the wider open-PR set: most of those are held on unaddressed folds, conflicts, or the gated arbiter series, and forcing them in is how the Library data-loss bug would have shipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Library app ingest pipeline and Collections API handoff.
  * Invite creation now supports an optional expiration duration.

* **Bug Fixes**
  * Fixed desktop invite dialog crashes and handling of invite permissions.
  * Expired invites are now revoked correctly.
  * Increased the default invite expiration period.

* **Documentation**
  * Updated Raspberry Pi Hailo-10 AI HAT+2 slot guidance.
  * Expanded contributor guidance for troubleshooting common defect types.

* **Release**
  * Updated the application to version **1.0.0-beta.43**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->