### PR TITLE
fix(desktop): dialogs render above windows, and mint shows the invite URL and PIN

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.tsx
@@ -571,7 +571,12 @@ export function ProjectMembers({ project, onChanged }: { project: Project; onCha
           projectId={project.id}
           onClose={() => setInviteOpen(false)}
           onMinted={() => {
-            setInviteOpen(false);
+            // Do NOT close the dialog here. The mint succeeds and the dialog
+            // then renders the invite URL and PIN, which are shown exactly
+            // once and cannot be recovered afterwards. Closing on mint threw
+            // that away and the user saw a dialog that vanished on success
+            // (reported 2026-07-21). Refresh the member list only; the user
+            // closes the dialog themselves once they have copied the details.
             onChanged();
           }}
         />

--- a/desktop/src/apps/ProjectsApp/__tests__/ProjectMembers.invite.test.tsx
+++ b/desktop/src/apps/ProjectsApp/__tests__/ProjectMembers.invite.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { InviteAgentDialog } from "../InviteAgentDialog";
+
+// The invite URL and PIN are shown EXACTLY ONCE and cannot be recovered.
+// ProjectMembers used to close the dialog in its onMinted handler, unmounting
+// it before the credentials rendered, so a successful mint looked like a
+// silent failure (reported 2026-07-21).
+describe("mint result survives onMinted", () => {
+  it("renders the invite URL and PIN after a successful mint", async () => {
+    const mint = { invite_id: "123456", pin: "4321", expires_ts: Date.now() / 1000 + 3600, scopes: [] };
+    vi.stubGlobal("fetch", vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return { ok: true, json: async () => mint } as Response;
+      }
+      return { ok: true, json: async () => [] } as Response;
+    }));
+
+    // onMinted must NOT unmount the dialog: the parent only refreshes its list.
+    const onMinted = vi.fn();
+    render(<InviteAgentDialog projectId="prj-x" onClose={() => {}} onMinted={onMinted} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /mint invite/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("4321")).toBeInTheDocument();
+    });
+    expect(onMinted).toHaveBeenCalled();
+    expect(screen.getByLabelText(/invite result/i)).toBeInTheDocument();
+    vi.unstubAllGlobals();
+  });
+});

--- a/desktop/src/stores/__tests__/process-store-zindex.test.ts
+++ b/desktop/src/stores/__tests__/process-store-zindex.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useProcessStore } from "../process-store";
+
+// Overlays (dialogs, menus) portal to document.body at a FIXED z such as
+// z-[10001]. Window z must therefore stay bounded, or a long session pushes
+// windows above modals. Reported 2026-07-21: the invite dialog rendered behind
+// the Projects window.
+const OVERLAY_Z = 10001;
+
+describe("window z-index stays below the overlay layer", () => {
+  beforeEach(() => {
+    useProcessStore.setState({ windows: [], nextZIndex: 1 });
+  });
+
+  it("does not grow z without bound as windows are focused", () => {
+    const s = useProcessStore.getState();
+    const a = s.openWindow("files");
+    const b = s.openWindow("chat");
+
+    // Simulate a long session: thousands of focus switches.
+    for (let i = 0; i < 5000; i++) {
+      useProcessStore.getState().focusWindow(i % 2 === 0 ? a : b);
+    }
+
+    const maxZ = Math.max(...useProcessStore.getState().windows.map((w) => w.zIndex));
+    expect(maxZ).toBeLessThan(OVERLAY_Z);
+    // With two windows the stack is 1..2 regardless of focus count.
+    expect(maxZ).toBeLessThanOrEqual(2);
+  });
+
+  it("preserves relative stacking order after normalisation", () => {
+    const s = useProcessStore.getState();
+    const a = s.openWindow("files");
+    const b = s.openWindow("chat");
+    useProcessStore.getState().focusWindow(a);
+
+    const wins = useProcessStore.getState().windows;
+    const za = wins.find((w) => w.id === a)!.zIndex;
+    const zb = wins.find((w) => w.id === b)!.zIndex;
+    // The most recently focused window is on top.
+    expect(za).toBeGreaterThan(zb);
+  });
+
+  it("keeps z bounded as many windows open", () => {
+    const s = useProcessStore.getState();
+    for (let i = 0; i < 40; i++) s.openWindow(`app-${i}`);
+    const maxZ = Math.max(...useProcessStore.getState().windows.map((w) => w.zIndex));
+    expect(maxZ).toBeLessThan(OVERLAY_Z);
+  });
+});

--- a/desktop/src/stores/process-store.ts
+++ b/desktop/src/stores/process-store.ts
@@ -82,6 +82,25 @@ function safeBounds(
 
 let idCounter = 0;
 
+// Window z-indexes are a bounded stacking ORDER, not an ever-growing counter.
+//
+// Every open, focus, restore and recenter used to increment `nextZIndex`
+// forever. Portal overlays (dialogs, menus) sit at a FIXED z such as
+// `z-[10001]`, so once a long session pushed the window counter past that
+// constant, windows rendered ON TOP of modal dialogs. Reported 2026-07-21:
+// the invite dialog appeared behind the Projects window after a day of use.
+//
+// Renumbering the stack to 1..N after each change keeps window z far below the
+// overlay layer no matter how long the session runs, and preserves relative
+// order because the existing values are sorted first.
+function normaliseStack(windows: WindowState[]): WindowState[] {
+  const rank = new Map<string, number>();
+  [...windows]
+    .sort((a, b) => a.zIndex - b.zIndex)
+    .forEach((w, i) => rank.set(w.id, i + 1));
+  return windows.map((w) => ({ ...w, zIndex: rank.get(w.id) ?? 1 }));
+}
+
 export const useProcessStore = create<ProcessStore>((set, get) => ({
   windows: [],
   nextZIndex: 1,
@@ -123,8 +142,10 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
       launchNonce: 0,
     };
     set((s) => ({
-      windows: s.windows.map((w) => ({ ...w, focused: false })).concat(win),
-      nextZIndex: z + 1,
+      windows: normaliseStack(
+        s.windows.map((w) => ({ ...w, focused: false })).concat(win),
+      ),
+      nextZIndex: s.windows.length + 2,
     }));
     return id;
   },
@@ -147,12 +168,14 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
   focusWindow(id) {
     const z = get().nextZIndex;
     set((s) => ({
-      windows: s.windows.map((w) => ({
-        ...w,
-        focused: w.id === id,
-        zIndex: w.id === id ? z : w.zIndex,
-      })),
-      nextZIndex: z + 1,
+      windows: normaliseStack(
+        s.windows.map((w) => ({
+          ...w,
+          focused: w.id === id,
+          zIndex: w.id === id ? z : w.zIndex,
+        })),
+      ),
+      nextZIndex: s.windows.length + 1,
     }));
   },
 
@@ -167,15 +190,15 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
   restoreWindow(id) {
     const z = get().nextZIndex;
     set((s) => ({
-      windows: s.windows.map((w) => {
+      windows: normaliseStack(s.windows.map((w) => {
         if (w.id !== id) return { ...w, focused: false };
         // Showing a window again: if it drifted off-screen while hidden, pull
         // it back into view. A maximized window keeps its stored bounds for
         // when it is later un-maximized.
         const safe = w.maximized ? {} : safeBounds(w.position, w.size);
         return { ...w, ...safe, minimized: false, focused: true, zIndex: z };
-      }),
-      nextZIndex: z + 1,
+      })),
+      nextZIndex: s.windows.length + 1,
     }));
   },
 
@@ -197,15 +220,15 @@ export const useProcessStore = create<ProcessStore>((set, get) => ({
   recenterWindow(id) {
     const z = get().nextZIndex;
     set((s) => ({
-      windows: s.windows.map((w) => {
+      windows: normaliseStack(s.windows.map((w) => {
         if (w.id !== id) return { ...w, focused: false };
         // Force a recenter (far-off position guarantees safeBounds recenters),
         // and ensure the window is shown and not maximized so the user can see
         // and move it. The recovery path for a window lost off-screen.
         const safe = safeBounds({ x: -1e6, y: -1e6 }, w.size);
         return { ...w, ...safe, minimized: false, maximized: false, focused: true, zIndex: z };
-      }),
-      nextZIndex: z + 1,
+      })),
+      nextZIndex: s.windows.length + 1,
     }));
   },
 


### PR DESCRIPTION
Two bugs on the Projects members screen, both found by using it rather than by tests.

## 1. Modal dialogs rendered behind windows

`nextZIndex` in `process-store.ts` was an **unbounded counter**: every window open, focus, restore and recenter incremented it and nothing ever reset it. Portal overlays sit at a fixed `z-[10001]`. So after enough focus switches in a single session the window counter passed that constant and windows began rendering **on top of modal dialogs**.

This is not specific to the invite dialog. It affects every portal overlay, and it gets worse the longer a session runs, which is why it showed up on a heavily used instance rather than in testing.

**Fix:** renumber the stack to 1..N after each change. Window z now stays far below the overlay layer no matter how long the session runs, and relative order is preserved because the existing values are sorted first.

## 2. A successful mint showed no URL or PIN

`ProjectMembers.tsx` passed an `onMinted` handler that called `setInviteOpen(false)`, so the dialog **unmounted the instant the mint succeeded**. The invite was created correctly every time, but the credentials are rendered by that dialog and are shown exactly once, so the user saw a dialog that vanished on success.

**Fix:** `onMinted` refreshes the member list only. The user closes the dialog once they have copied the URL and PIN.

Note this is a different fault from #2066, which fixed a crash on the same screen. That is why this survived: two independent bugs produced a similar symptom.

## Tests

- `process-store-zindex.test.ts`: 5,000 simulated focus switches keep max z below the overlay constant, relative order is preserved, and 40 open windows stay bounded.
- `ProjectMembers.invite.test.tsx`: a successful mint renders the PIN and the result region, and still calls `onMinted`.

Typecheck clean, all four tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invite dialogs now remain open after a successful invite is created, allowing the one-time PIN and invite URL to be viewed and copied.
  * Window stacking remains stable during extended use, preventing window layers from growing indefinitely and staying below overlay elements.

* **Tests**
  * Added coverage for displaying invite details after minting.
  * Added coverage for bounded window stacking and focus order preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->