### PR TITLE
feat(library): item card component with thumbnail, status, artifacts, collection link

### DIFF
--- a/desktop/src/components/LibraryItemCard.test.tsx
+++ b/desktop/src/components/LibraryItemCard.test.tsx
@@ -1,0 +1,397 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { LibraryItemCard } from "./LibraryItemCard";
+import type { LibraryItem, LibraryArtifact, LibraryJob } from "@/lib/library";
+
+/* ------------------------------------------------------------------ */
+/*  Fixtures                                                           */
+/* ------------------------------------------------------------------ */
+
+function makeItem(overrides: Partial<LibraryItem> = {}): LibraryItem {
+  return {
+    id: "item-1",
+    kind: "text",
+    source_url: "",
+    title: "Test Item",
+    status: "pending",
+    storage_path: "",
+    bytes: 0,
+    meta_json: "{}",
+    created_at: 1000,
+    updated_at: 1000,
+    ...overrides,
+  };
+}
+
+function makeArtifact(overrides: Partial<LibraryArtifact> = {}): LibraryArtifact {
+  return {
+    id: "art-1",
+    item_id: "item-1",
+    kind: "text",
+    path: "/tmp/test.txt",
+    meta_json: "{}",
+    created_at: 1000,
+    ...overrides,
+  };
+}
+
+function makeJob(overrides: Partial<LibraryJob> = {}): LibraryJob {
+  return {
+    id: "job-1",
+    item_id: "item-1",
+    stage: "metadata",
+    state: "queued",
+    error: "",
+    created_at: 1000,
+    updated_at: 1000,
+    ...overrides,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("LibraryItemCard", () => {
+  /* ---------------------------------------------------------------- */
+  /*  Pending                                                          */
+  /* ---------------------------------------------------------------- */
+
+  describe("pending state", () => {
+    it("renders the title, kind badge, and pending status", () => {
+      render(<LibraryItemCard item={makeItem({ title: "My Video", kind: "url:youtube" })} />);
+      expect(screen.getByText("My Video")).toBeInTheDocument();
+      expect(screen.getByText("YouTube")).toBeInTheDocument();
+      expect(screen.getByText("pending")).toBeInTheDocument();
+    });
+
+    it("shows a thumbnail placeholder when no thumbnail artifact exists", () => {
+      render(<LibraryItemCard item={makeItem()} />);
+      expect(screen.getByText("No thumbnail")).toBeInTheDocument();
+      expect(screen.queryByAltText(/Thumbnail/)).not.toBeInTheDocument();
+    });
+
+    it("shows the no-pipeline-stages message", () => {
+      render(<LibraryItemCard item={makeItem()} />);
+      expect(screen.getByText("No pipeline stages")).toBeInTheDocument();
+    });
+
+    it("shows the no-artifacts message", () => {
+      render(<LibraryItemCard item={makeItem()} />);
+      expect(screen.getByText("No artifacts")).toBeInTheDocument();
+    });
+
+    it("disables the download button", () => {
+      render(<LibraryItemCard item={makeItem()} />);
+      const downloadBtn = screen.getByLabelText("Download (not available yet)");
+      expect(downloadBtn).toBeDisabled();
+    });
+
+    it("renders the link-to-collection button", () => {
+      render(<LibraryItemCard item={makeItem()} />);
+      expect(screen.getByLabelText("Link to collection")).toBeInTheDocument();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Processing                                                       */
+  /* ---------------------------------------------------------------- */
+
+  describe("processing state", () => {
+    const processingItem = makeItem({
+      id: "item-2",
+      kind: "text",
+      title: "notes.txt",
+      status: "processing",
+      bytes: 2048,
+      meta_json: JSON.stringify({}),
+    });
+    const processingJobs = [
+      makeJob({ id: "job-a", item_id: "item-2", stage: "metadata", state: "done" }),
+      makeJob({ id: "job-b", item_id: "item-2", stage: "text", state: "processing" }),
+    ];
+
+    it("renders the processing status", () => {
+      render(
+        <LibraryItemCard
+          item={processingItem}
+          jobs={processingJobs}
+        />,
+      );
+      expect(screen.getByText("processing")).toBeInTheDocument();
+    });
+
+    it("shows pipeline stages with their states", () => {
+      render(
+        <LibraryItemCard
+          item={processingItem}
+          jobs={processingJobs}
+        />,
+      );
+      expect(screen.getByText("metadata: done")).toBeInTheDocument();
+      expect(screen.getByText("text: processing")).toBeInTheDocument();
+    });
+
+    it("disables the download button", () => {
+      render(
+        <LibraryItemCard
+          item={processingItem}
+          jobs={processingJobs}
+        />,
+      );
+      expect(screen.getByLabelText("Download (not available yet)")).toBeDisabled();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Done (ready)                                                     */
+  /* ---------------------------------------------------------------- */
+
+  describe("done (ready) state", () => {
+    const doneItem = makeItem({
+      id: "item-3",
+      kind: "text",
+      title: "notes.txt",
+      status: "ready",
+      bytes: 1024,
+      meta_json: JSON.stringify({
+        preview: "This is the preview text of the document content.",
+        duration: 120,
+      }),
+    });
+    const doneArtifacts = [
+      makeArtifact({
+        id: "art-t",
+        item_id: "item-3",
+        kind: "thumbnail",
+        path: "/tmp/thumb.jpg",
+        meta_json: JSON.stringify({ width: 320, height: 240 }),
+      }),
+      makeArtifact({
+        id: "art-x",
+        item_id: "item-3",
+        kind: "text",
+        path: "/tmp/notes.txt",
+        meta_json: JSON.stringify({ char_count: 1024, line_count: 20 }),
+      }),
+    ];
+    const doneJobs = [
+      makeJob({ id: "job-a", item_id: "item-3", stage: "metadata", state: "done" }),
+      makeJob({ id: "job-b", item_id: "item-3", stage: "text", state: "done" }),
+    ];
+
+    it("renders the ready status", () => {
+      render(
+        <LibraryItemCard
+          item={doneItem}
+          artifacts={doneArtifacts}
+          jobs={doneJobs}
+        />,
+      );
+      expect(screen.getByText("ready")).toBeInTheDocument();
+    });
+
+    it("renders the thumbnail image", () => {
+      render(
+        <LibraryItemCard
+          item={doneItem}
+          artifacts={doneArtifacts}
+          jobs={doneJobs}
+        />,
+      );
+      const img = screen.getByAltText("Thumbnail for notes.txt") as HTMLImageElement;
+      expect(img).toBeInTheDocument();
+      expect(img.src).toContain("/tmp/thumb.jpg");
+    });
+
+    it("shows the duration for media items", () => {
+      render(
+        <LibraryItemCard
+          item={doneItem}
+          artifacts={doneArtifacts}
+          jobs={doneJobs}
+        />,
+      );
+      expect(screen.getByText("2:00")).toBeInTheDocument();
+    });
+
+    it("shows artifacts with their preview text", () => {
+      render(
+        <LibraryItemCard
+          item={doneItem}
+          artifacts={doneArtifacts}
+          jobs={doneJobs}
+        />,
+      );
+      expect(screen.getByText("text")).toBeInTheDocument();
+      expect(screen.getByText("1024 chars")).toBeInTheDocument();
+      expect(
+        screen.getByText("This is the preview text of the document content."),
+      ).toBeInTheDocument();
+    });
+
+    it("shows pipeline stages as done", () => {
+      render(
+        <LibraryItemCard
+          item={doneItem}
+          artifacts={doneArtifacts}
+          jobs={doneJobs}
+        />,
+      );
+      expect(screen.getByText("metadata: done")).toBeInTheDocument();
+      expect(screen.getByText("text: done")).toBeInTheDocument();
+    });
+
+    it("calls onLinkToCollection when the link button is clicked", () => {
+      const onLinkToCollection = vi.fn();
+      render(
+        <LibraryItemCard
+          item={doneItem}
+          artifacts={doneArtifacts}
+          jobs={doneJobs}
+          onLinkToCollection={onLinkToCollection}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText("Link to collection"));
+      expect(onLinkToCollection).toHaveBeenCalledTimes(1);
+      expect(onLinkToCollection).toHaveBeenCalledWith(doneItem);
+    });
+
+    it("disables the download button", () => {
+      render(
+        <LibraryItemCard
+          item={doneItem}
+          artifacts={doneArtifacts}
+          jobs={doneJobs}
+        />,
+      );
+      expect(screen.getByLabelText("Download (not available yet)")).toBeDisabled();
+    });
+
+    it("shows the source URL button when source_url is set", () => {
+      const youtubeItem = makeItem({
+        id: "item-yt",
+        kind: "url:youtube",
+        title: "YouTube Video",
+        status: "ready",
+        source_url: "https://youtube.com/watch?v=abc",
+        meta_json: JSON.stringify({}),
+      });
+      render(<LibraryItemCard item={youtubeItem} />);
+      expect(screen.getByLabelText("Open source https://youtube.com/watch?v=abc")).toBeInTheDocument();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Failed (error)                                                   */
+  /* ---------------------------------------------------------------- */
+
+  describe("failed (error) state", () => {
+    const failedItem = makeItem({
+      id: "item-4",
+      kind: "pdf",
+      title: "broken.pdf",
+      status: "error",
+      bytes: 512,
+      meta_json: JSON.stringify({
+        error: "Source file not found: /tmp/broken.pdf",
+      }),
+    });
+    const failedJobs = [
+      makeJob({
+        id: "job-a",
+        item_id: "item-4",
+        stage: "metadata",
+        state: "failed",
+        error: "Source file not found",
+      }),
+    ];
+
+    it("renders the error status", () => {
+      render(
+        <LibraryItemCard
+          item={failedItem}
+          jobs={failedJobs}
+        />,
+      );
+      expect(screen.getByText("error")).toBeInTheDocument();
+    });
+
+    it("shows the error message in an alert", () => {
+      render(
+        <LibraryItemCard
+          item={failedItem}
+          jobs={failedJobs}
+        />,
+      );
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveTextContent("Source file not found: /tmp/broken.pdf");
+    });
+
+    it("shows the failed pipeline stage", () => {
+      render(
+        <LibraryItemCard
+          item={failedItem}
+          jobs={failedJobs}
+        />,
+      );
+      expect(screen.getByText("metadata: failed")).toBeInTheDocument();
+    });
+
+    it("disables the download button", () => {
+      render(
+        <LibraryItemCard
+          item={failedItem}
+          jobs={failedJobs}
+        />,
+      );
+      expect(screen.getByLabelText("Download (not available yet)")).toBeDisabled();
+    });
+
+    it("shows a default error message when meta_json has no error field", () => {
+      const itemNoError = makeItem({
+        id: "item-5",
+        status: "error",
+        meta_json: "{}",
+      });
+      render(<LibraryItemCard item={itemNoError} />);
+      const alert = screen.getByRole("alert");
+      expect(alert).toHaveTextContent("Processing failed");
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  Edge cases                                                       */
+  /* ---------------------------------------------------------------- */
+
+  describe("edge cases", () => {
+    it("renders Untitled when title is empty", () => {
+      render(<LibraryItemCard item={makeItem({ title: "" })} />);
+      expect(screen.getByText("Untitled")).toBeInTheDocument();
+    });
+
+    it("shows no preview available when item has no preview in meta_json", () => {
+      const item = makeItem({
+        status: "ready",
+        meta_json: JSON.stringify({}),
+      });
+      const artifacts = [makeArtifact({ kind: "text" })];
+      render(<LibraryItemCard item={item} artifacts={artifacts} />);
+      expect(screen.getByText("No preview available")).toBeInTheDocument();
+    });
+
+    it("renders transcript and ocr artifacts in the list", () => {
+      const item = makeItem({
+        status: "ready",
+        meta_json: JSON.stringify({ preview: "preview text" }),
+      });
+      const artifacts = [
+        makeArtifact({ id: "a1", kind: "transcript" }),
+        makeArtifact({ id: "a2", kind: "ocr" }),
+      ];
+      render(<LibraryItemCard item={item} artifacts={artifacts} />);
+      expect(screen.getByText("transcript")).toBeInTheDocument();
+      expect(screen.getByText("ocr")).toBeInTheDocument();
+    });
+  });
+});

--- a/desktop/src/components/LibraryItemCard.tsx
+++ b/desktop/src/components/LibraryItemCard.tsx
@@ -1,0 +1,267 @@
+import { Download, Link, AlertCircle, Image as ImageIcon, ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui";
+import type { LibraryItem, LibraryArtifact, LibraryJob } from "@/lib/library";
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const KIND_LABELS: Record<string, string> = {
+  text: "Text",
+  pdf: "PDF",
+  image: "Image",
+  archive: "Archive",
+  file: "File",
+  "url:youtube": "YouTube",
+  "url:web": "Web",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "bg-amber-500/15 text-amber-400 border-amber-500/30",
+  processing: "bg-amber-500/15 text-amber-400 border-amber-500/30",
+  ready: "bg-green-500/15 text-green-400 border-green-500/30",
+  error: "bg-red-500/15 text-red-400 border-red-500/30",
+};
+
+const JOB_STATE_COLORS: Record<string, string> = {
+  queued: "bg-white/10 text-shell-text-tertiary border-white/10",
+  processing: "bg-amber-500/15 text-amber-400 border-amber-500/30",
+  done: "bg-green-500/15 text-green-400 border-green-500/30",
+  failed: "bg-red-500/15 text-red-400 border-red-500/30",
+};
+
+const TEXT_ARTIFACT_KINDS = ["text", "transcript", "description", "ocr"];
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function parseMeta(metaJson: string): Record<string, unknown> {
+  try {
+    return JSON.parse(metaJson || "{}") as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function formatDuration(seconds: number): string {
+  if (!seconds || seconds <= 0) return "";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (!bytes || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function kindLabel(kind: string): string {
+  return KIND_LABELS[kind] ?? kind;
+}
+
+function statusColor(status: string): string {
+  return STATUS_COLORS[status] ?? STATUS_COLORS.pending ?? "";
+}
+
+function jobStateColor(state: string): string {
+  return JOB_STATE_COLORS[state] ?? JOB_STATE_COLORS.queued ?? "";
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export interface LibraryItemCardProps {
+  item: LibraryItem;
+  artifacts?: LibraryArtifact[];
+  jobs?: LibraryJob[];
+  onLinkToCollection?: (item: LibraryItem) => void;
+  onDownload?: (item: LibraryItem) => void;
+  onOpenSource?: (item: LibraryItem) => void;
+}
+
+export function LibraryItemCard({
+  item,
+  artifacts = [],
+  jobs = [],
+  onLinkToCollection,
+  onDownload,
+  onOpenSource,
+}: LibraryItemCardProps) {
+  const itemMeta = parseMeta(item.meta_json);
+  const duration = itemMeta.duration ? Number(itemMeta.duration) : 0;
+  const durationStr = formatDuration(duration);
+  const preview = itemMeta.preview ? String(itemMeta.preview) : null;
+  const error =
+    item.status === "error"
+      ? (String(itemMeta.error || "") || "Processing failed")
+      : null;
+
+  const thumbnailArtifact = artifacts.find((a) => a.kind === "thumbnail");
+  const textArtifacts = artifacts.filter((a) => TEXT_ARTIFACT_KINDS.includes(a.kind));
+
+  return (
+    <Card className="w-full max-w-sm">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-sm font-medium leading-snug line-clamp-1">
+            {item.title || "Untitled"}
+          </CardTitle>
+          <span
+            className={cn(
+              "shrink-0 text-[10px] px-1.5 py-0.5 rounded border",
+              statusColor(item.status),
+            )}
+          >
+            {item.status}
+          </span>
+        </div>
+        <CardDescription className="flex flex-wrap items-center gap-1.5 text-[11px]">
+          <span
+            className={cn(
+              "px-1.5 py-0.5 rounded bg-accent/10 text-accent border border-accent/20",
+            )}
+          >
+            {kindLabel(item.kind)}
+          </span>
+          {durationStr && <span>{durationStr}</span>}
+          <span>{formatBytes(item.bytes)}</span>
+          {item.source_url && (
+            <button
+              type="button"
+              onClick={() => onOpenSource?.(item)}
+              aria-label={`Open source ${item.source_url}`}
+              className="underline decoration-accent/40 hover:decoration-accent"
+            >
+              <ExternalLink size={10} className="inline align-middle" />
+            </button>
+          )}
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        {/* Thumbnail */}
+        {thumbnailArtifact ? (
+          <img
+            src={thumbnailArtifact.path}
+            alt={`Thumbnail for ${item.title || "item"}`}
+            className="w-full aspect-video object-cover rounded-lg bg-shell-surface"
+            onError={(e) => {
+              const target = e.target as HTMLImageElement;
+              target.style.display = "none";
+            }}
+          />
+        ) : (
+          <div className="flex flex-col items-center justify-center w-full aspect-video rounded-lg bg-shell-surface text-shell-text-tertiary">
+            <ImageIcon size={20} />
+            <span className="text-[10px] mt-1">No thumbnail</span>
+          </div>
+        )}
+
+        {/* Error state -- failure must be visible, never silent */}
+        {error && (
+          <div role="alert" className="flex items-start gap-2 text-xs text-red-400">
+            <AlertCircle size={14} className="shrink-0 mt-0.5" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {/* Pipeline stages (jobs shape from spec section 2) */}
+        {jobs.length > 0 ? (
+          <div className="space-y-1">
+            <div className="text-[10px] text-shell-text-tertiary uppercase">
+              Pipeline
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {jobs.map((job) => (
+                <span
+                  key={job.id}
+                  className={cn(
+                    "text-[10px] px-1.5 py-0.5 rounded border",
+                    jobStateColor(job.state),
+                  )}
+                  title={job.error || undefined}
+                >
+                  {job.stage}: {job.state}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="text-[10px] text-shell-text-tertiary">
+            No pipeline stages
+          </div>
+        )}
+
+        {/* Artifacts with preview */}
+        {textArtifacts.length > 0 ? (
+          <div className="space-y-2">
+            <div className="text-[10px] text-shell-text-tertiary uppercase">
+              Artifacts
+            </div>
+            {textArtifacts.map((art) => {
+              const artMeta = parseMeta(art.meta_json);
+              const charCount = artMeta.char_count
+                ? `${Number(artMeta.char_count)} chars`
+                : "";
+              return (
+                <div key={art.id} className="text-xs">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium text-shell-text-secondary">
+                      {art.kind}
+                    </span>
+                    {charCount && (
+                      <span className="text-shell-text-tertiary">{charCount}</span>
+                    )}
+                  </div>
+                  {preview ? (
+                    <p className="text-[11px] text-shell-text-secondary line-clamp-3 mt-1 leading-relaxed">
+                      {preview}
+                    </p>
+                  ) : (
+                    <p className="text-[11px] text-shell-text-tertiary mt-1">
+                      No preview available
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="text-[10px] text-shell-text-tertiary">
+            No artifacts
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-2 pt-2 border-t border-white/[0.06]">
+          <button
+            type="button"
+            onClick={() => onLinkToCollection?.(item)}
+            className="text-xs px-2 py-1 rounded hover:bg-white/[0.05] transition-colors flex items-center gap-1"
+            aria-label="Link to collection"
+          >
+            <Link size={12} />
+            Link to collection
+          </button>
+          <button
+            type="button"
+            onClick={() => onDownload?.(item)}
+            disabled
+            className="text-xs px-2 py-1 rounded text-shell-text-tertiary cursor-not-allowed flex items-center gap-1"
+            aria-label="Download (not available yet)"
+          >
+            <Download size={12} />
+            Download
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/desktop/src/lib/library.ts
+++ b/desktop/src/lib/library.ts
@@ -1,0 +1,150 @@
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export type LibraryItemStatus = "pending" | "processing" | "ready" | "error";
+
+export interface LibraryItem {
+  id: string;
+  kind: string;
+  source_url: string;
+  title: string;
+  status: LibraryItemStatus;
+  storage_path: string;
+  bytes: number;
+  meta_json: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface LibraryArtifact {
+  id: string;
+  item_id: string;
+  kind: string;
+  path: string;
+  meta_json: string;
+  created_at: number;
+}
+
+export interface LibraryJob {
+  id: string;
+  item_id: string;
+  stage: string;
+  state: string;
+  error: string;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface LibraryItemDetail {
+  item: LibraryItem;
+  artifacts: LibraryArtifact[];
+  jobs: LibraryJob[];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+async function fetchJson<T>(url: string, fallback: T, init?: RequestInit): Promise<T> {
+  try {
+    const res = await fetch(url, { ...init, headers: { Accept: "application/json", ...init?.headers } });
+    if (!res.ok) return fallback;
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("application/json")) return fallback;
+    return await res.json();
+  } catch {
+    return fallback;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Items                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface ListLibraryItemsParams {
+  kind?: string;
+  status?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listLibraryItems(
+  params?: ListLibraryItemsParams,
+): Promise<{ items: LibraryItem[]; count: number }> {
+  const qs = new URLSearchParams();
+  if (params?.kind) qs.set("kind", params.kind);
+  if (params?.status) qs.set("status", params.status);
+  if (params?.limit != null) qs.set("limit", String(params.limit));
+  if (params?.offset != null) qs.set("offset", String(params.offset));
+  const query = qs.toString();
+  const url = `/api/library/items${query ? `?${query}` : ""}`;
+  const data = await fetchJson<{ items: LibraryItem[]; count: number }>(url, { items: [], count: 0 });
+  return { items: Array.isArray(data.items) ? data.items : [], count: data.count ?? 0 };
+}
+
+export async function getLibraryItem(itemId: string): Promise<LibraryItemDetail | null> {
+  try {
+    const res = await fetch(`/api/library/items/${encodeURIComponent(itemId)}`, {
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("application/json")) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteLibraryItem(itemId: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/library/items/${encodeURIComponent(itemId)}`, {
+      method: "DELETE",
+      headers: { Accept: "application/json" },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function reprocessLibraryItem(itemId: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/library/items/${encodeURIComponent(itemId)}/reprocess`, {
+      method: "POST",
+      headers: { Accept: "application/json" },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Ingest                                                             */
+/* ------------------------------------------------------------------ */
+
+export interface IngestLibraryOptions {
+  title?: string;
+  source?: string;
+}
+
+export async function ingestLibraryUrl(
+  url: string,
+  opts?: IngestLibraryOptions,
+): Promise<{ item_id: string; status: string } | null> {
+  try {
+    const res = await fetch("/api/library/ingest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ url, title: opts?.title ?? "" }),
+    });
+    if (!res.ok) return null;
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("application/json")) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Autonomous build of board card tsk-cpgdhh.

Add LibraryItemCard component per docs/design/library-app.md sections 2-4.
Card shows thumbnail (or placeholder), title, kind badge, media duration,
pipeline status per stage (jobs shape), artifact list (text, transcript,
description, ocr) with preview, link-to-collection action, and a disabled
Download stub until P3. Failure states are always visible -- no silent
empties for missing thumbnails, pipeline stages, artifacts, or errors.

Includes lib/library.ts with types and API client for the library store
(items, artifacts, jobs) and 25 component tests covering pending,
processing, ready, and error states.

Files:
 desktop/src/components/LibraryItemCard.test.tsx | 397 ++++++++++++++++++++++++
 desktop/src/components/LibraryItemCard.tsx      | 267 ++++++++++++++++
 desktop/src/lib/library.ts                      | 150 +++++++++
 3 files changed, 814 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added library item cards displaying titles, types, statuses, thumbnails, previews, processing stages, errors, durations, and file sizes.
  * Added actions to link items to collections, open source URLs, and download items.
  * Added library browsing, item details, deletion, reprocessing, and URL ingestion capabilities.
  * Added filtering and pagination support for library items.

* **Tests**
  * Added comprehensive coverage for item statuses, previews, artifacts, actions, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->