### PR TITLE
feat(agents): project_tasks_create scope so an external agent can author cards

### DIFF
--- a/desktop/src/apps/ProjectsApp/InviteAgentDialog.tsx
+++ b/desktop/src/apps/ProjectsApp/InviteAgentDialog.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 
 const SCOPE_PRESETS: { value: string; label: string; defaultOn: boolean; disabled?: boolean; hint?: string }[] = [
   { value: "project_tasks", label: "project_tasks", defaultOn: true, disabled: true, hint: "required for project invites" },
+  { value: "project_tasks_create", label: "project_tasks_create", defaultOn: false, hint: "author NEW cards. project_tasks alone is read, lifecycle and comments only" },
   { value: "canvas_read", label: "canvas_read", defaultOn: true },
   { value: "canvas_write", label: "canvas_write", defaultOn: true },
 ];

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -297,7 +297,10 @@ class TestExcludedRoutes:
     """Invariant 2 + 5: project_tasks must NOT reach create-task, members, or
     project-lifecycle routes; the token authenticates nothing off the allowlist."""
 
-    async def test_cannot_create_task(self, ctx):
+    async def test_project_tasks_alone_cannot_create_task(self, ctx):
+        """project_tasks is read + lifecycle + comments. Authoring requires the
+        SEPARATE project_tasks_create grant, so an agent approved only for
+        project_tasks must still be refused (Invariant 2 + 5 preserved)."""
         pid = await _new_project(ctx, "alpha")
         _cid, token = await _mint_agent(ctx, pid)
         async with _bare(ctx.app) as bare:
@@ -516,3 +519,54 @@ class TestLeadAgentMarkClaimable:
         )
         assert resp.status_code == 200, resp.text
         assert "claimable" in resp.json()["labels"]
+
+@pytest.mark.asyncio
+class TestTaskCreationScope:
+    """project_tasks_create is a separate, narrower grant for AUTHORING cards.
+
+    Both halves matter: an agent WITH it can create, an agent WITHOUT it cannot.
+    A test that only asserted the refusal would pass against a route nobody can
+    reach, and one that only asserted success would not prove the scope is
+    enforced at all.
+    """
+
+    async def test_project_tasks_create_allows_authoring(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_create",))
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/tasks",
+                json={"title": "authored by an agent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["title"] == "authored by an agent"
+        # Authorship is attributed to the AGENT, not to the project owner.
+        assert body["created_by"] == cid
+
+    async def test_create_scope_is_project_bound(self, ctx):
+        """A grant on project A must not authorise creation on project B."""
+        pid_a = await _new_project(ctx, "alpha")
+        pid_b = await _new_project(ctx, "beta")
+        _cid, token = await _mint_agent(ctx, pid_a, scopes=("project_tasks_create",))
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid_b}/tasks",
+                json={"title": "cross project"},
+                headers=_hdr(token),
+            )
+        # Existence-hiding: indistinguishable from a project that is not theirs.
+        assert resp.status_code == 404, resp.text
+
+    async def test_create_scope_does_not_widen_other_routes(self, ctx):
+        """project_tasks_create authorises AUTHORING only, not member management."""
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_create",))
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/members",
+                json={"mode": "native", "agent_id": "x"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code in (401, 403, 404)

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -42,14 +42,20 @@ _AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE
 # paths (/api/projects/{pid}/tasks...), so an exact frozenset can't match them;
 # a (method, compiled-regex) allowlist is used instead.  Each pattern is fully
 # anchored and uses a slash-free segment ([^/]+) with an exact segment count, so
-# sibling routes that must stay session-only -- POST .../tasks (create),
-# /members, /relationships, /audit, /activity, project lifecycle -- never match.
+# sibling routes that must stay session-only -- /members, /relationships,
+# /audit, /activity, project lifecycle -- never match. POST .../tasks IS
+# reachable, but only with project_tasks_create, never with project_tasks.
 # This is the project-scoped analogue of the exact _AGENT_TOKEN_PATHS contract:
 # the token only reaches the handler, which then verifies the JWT + grant +
 # project binding.  Anything not listed here is NOT reachable by a registry JWT.
 _SEG = r"[^/]+"
 _AGENT_TASK_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks$")),
+    # Task CREATION, gated by the SEPARATE project_tasks_create scope (not
+    # project_tasks, which stays read + lifecycle + comments per Invariant 2+5).
+    # Reaching the handler is not authorisation: it then verifies the JWT, the
+    # project binding, and that narrower scope.
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks$")),
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/ready$")),
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
     ("GET", re.compile(rf"^/api/projects/tasks/{_SEG}/context$")),

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -55,6 +55,13 @@ VALID_SCOPES = frozenset({
     # agent's OWN project only (bound by the token's project_id claim). Does NOT
     # grant task create, member management, or project lifecycle.
     "project_tasks",
+    # Authoring cards, deliberately SEPARATE from project_tasks. project_tasks
+    # is documented and tested as read + lifecycle + comments only ("Invariant
+    # 2 + 5"), so widening it would retroactively grant authoring to every agent
+    # already approved for it, invisibly to whoever approved them. A distinct
+    # scope keeps an existing approval meaning exactly what it meant when it was
+    # given, and makes authoring an explicit per-agent opt-in.
+    "project_tasks_create",
     # Canvas access: read and write on a specific project's canvas. Like
     # project_tasks, a project_id is required so the token is bound to the
     # operator-validated project rather than whatever the unauthenticated agent

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -93,6 +93,7 @@ _ALLOWED_SCOPES = frozenset({
     "files_read", "files_write",
     "tools_execute", "registry_feeds_read",
     "project_tasks",
+    "project_tasks_create",
     "canvas_read", "canvas_write",
     "decisions_read", "decisions_write",
 })

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -452,11 +452,15 @@ async def _require_task_in_project(
 
 
 async def _authorize_task_actor(
-    request: Request, pstore, project_id: str
+    request: Request, pstore, project_id: str, scope: str = "project_tasks"
 ) -> "tuple[str, bool, dict] | JSONResponse":
     """Resolve the actor for a task route that accepts EITHER a session
-    owner/admin OR an approved external agent's registry JWT (scope
-    project_tasks) bound to THIS project.
+    owner/admin OR an approved external agent's registry JWT holding ``scope``
+    (default ``project_tasks``) bound to THIS project.
+
+    ``scope`` is a parameter because authoring uses a SEPARATE, narrower grant
+    (``project_tasks_create``): project_tasks is documented and tested as read
+    plus lifecycle plus comments, so creation must not ride on it.
 
     Returns ``(actor_id, is_agent, project)`` on success, or a JSONResponse to
     return directly.  These routes take ``request: Request`` and auth INSIDE the
@@ -482,7 +486,7 @@ async def _authorize_task_actor(
 
     try:
         caller = await check_agent_scope_for_project(
-            request, "project_tasks", project_id
+            request, scope, project_id
         )
     except HTTPException as exc:
         if exc.status_code == 403 and exc.detail == PROJECT_SCOPE_MISMATCH_DETAIL:
@@ -588,14 +592,25 @@ async def create_task(
     project_id: str,
     payload: CreateTaskIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
+    """Create a task as a session owner/admin, or as an approved external agent
+    holding ``project_tasks_create`` on THIS project.
+
+    Authoring is a SEPARATE scope from ``project_tasks`` on purpose: that scope
+    is documented and tested as read + lifecycle + comments ("Invariant 2 + 5"),
+    so widening it would retroactively grant authoring to every agent already
+    approved for it. Existence-hiding 404 behaviour matches the other task
+    routes.
+    """
     store = request.app.state.project_task_store
     pstore = request.app.state.project_store
     estore = request.app.state.project_element_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    actor_or_err = await _authorize_task_actor(
+        request, pstore, project_id, scope="project_tasks_create"
+    )
+    if isinstance(actor_or_err, JSONResponse):
+        return actor_or_err
+    actor_id, _is_agent, _project = actor_or_err
     if payload.parent_task_id is not None:
         parent = await store.get_task(payload.parent_task_id)
         if parent is None or parent["project_id"] != project_id:
@@ -614,10 +629,10 @@ async def create_task(
         assignee_id=payload.assignee_id,
         parent_task_id=payload.parent_task_id,
         element_id=element_id,
-        created_by=user.user_id,
+        created_by=actor_id,
     )
     _beads_mark_dirty(request, project_id)
-    await pstore.log_activity(project_id, user.user_id, "task.created", {"task_id": t["id"], "title": t["title"]})
+    await pstore.log_activity(project_id, actor_id, "task.created", {"task_id": t["id"], "title": t["title"]})
     return t
 
 


### PR DESCRIPTION
Closes the gap in #2095, by Jay's decision, without changing what any existing grant means.

## The problem

An external agent holding `project_tasks` can claim, close, reopen and comment on existing cards but **cannot create one**. Two independent blocks: `create_task` authorised via `_get_owned_project` (owner or admin only), and the middleware allowlist deliberately excluded `POST .../tasks`.

## Why a new scope rather than widening the old one

The exclusion is **deliberate and tested**: `tests/test_routes_projects_agent_tasks.py` states it as "Invariant 2 + 5: project_tasks must NOT reach create-task, members, or project-lifecycle routes", and the scope is documented as read plus lifecycle plus comments.

Widening `project_tasks` would retroactively grant authoring to **every agent already approved for it**, invisibly to whoever approved them. The point of a consent flow is that an approval means a specific thing, so authoring becomes a separate opt-in instead.

## Changes

- `project_tasks_create` added to `VALID_SCOPES` and mirrored into `_ALLOWED_SCOPES` (kept in sync, no drift).
- `_authorize_task_actor` parameterised on scope, defaulting to `project_tasks`, so the ten existing routes are untouched.
- `create_task` uses it with `project_tasks_create`; existence-hiding 404 behaviour is identical to its siblings.
- Middleware admits `POST .../tasks`. Reaching the handler is not authorisation: it still verifies JWT, project binding and the narrower scope.
- Authorship is attributed to the **agent**, not the project owner, in both `created_by` and the activity log.
- The invite dialog offers the scope, default OFF, with a hint explaining the difference.

## Tests

The original invariant test is kept and renamed to say why it exists, plus the halves that make it meaningful:
- an agent **with** the scope can author (and `created_by` is the agent)
- a grant on project A **cannot** create on project B (404, existence-hiding)
- the scope does **not** widen member management

33 passing in that file, 47 across the invite and agent-token suites.