### PR TITLE
feat(providers): add Nous Portal as a cloud model provider

### DIFF
--- a/desktop/src/apps/ProvidersApp.tsx
+++ b/desktop/src/apps/ProvidersApp.tsx
@@ -18,7 +18,7 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 /* ------------------------------------------------------------------ */
 
 /** Fallback constants used before the API call completes. */
-const FALLBACK_CLOUD_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "deepseek", "openai-compatible"] as const;
+const FALLBACK_CLOUD_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "deepseek", "nous", "openai-compatible"] as const;
 const FALLBACK_LOCAL_TYPES = ["rkllama", "ollama", "llama-cpp", "vllm", "exo", "mlx", "sd-cpp"] as const;
 
 /** Active cloud types — seeded with fallback, updated from /api/providers/types.
@@ -35,6 +35,7 @@ const DEFAULT_URLS: Partial<Record<ProviderType, string>> = {
   openrouter: "https://openrouter.ai/api/v1",
   kilocode: "https://api.kilo.ai/api/gateway",
   deepseek: "https://api.deepseek.com",
+  nous: "https://inference-api.nousresearch.com/v1",
   ollama: "http://localhost:11434",
   // taOS default rkllama port since the 7833 migration (adjacent to qmd on
   // 7832) -- see _DEFAULT_RKLLAMA_PORT in rkllama_installer.py. 8080 is the
@@ -82,6 +83,12 @@ const CLOUD_PROVIDER_META: Record<string, CloudProviderMeta> = {
     description: "DeepSeek V4 Pro, Flash, Reasoner",
     url: "https://api.deepseek.com",
     keyPlaceholder: "sk-...",
+  },
+  nous: {
+    label: "Nous Portal",
+    description: "Hermes 4 and frontier models via Nous Research",
+    url: "https://inference-api.nousresearch.com/v1",
+    keyPlaceholder: "your Portal token",
   },
   "openai-compatible": {
     label: "OpenAI-Compatible",

--- a/desktop/src/lib/models.ts
+++ b/desktop/src/lib/models.ts
@@ -127,7 +127,7 @@ export interface CloudProvider {
   source?: string;
 }
 
-export const CLOUD_PROVIDER_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "deepseek", "openai-compatible"] as const;
+export const CLOUD_PROVIDER_TYPES = ["openai", "anthropic", "openrouter", "kilocode", "deepseek", "nous", "openai-compatible"] as const;
 
 /** Flatten /api/providers cloud providers into AggregatedModel entries. */
 export function cloudProvidersToAggregated(providers: CloudProvider[]): AggregatedModel[] {

--- a/tinyagentos/backend_adapters.py
+++ b/tinyagentos/backend_adapters.py
@@ -242,6 +242,7 @@ _ADAPTERS: dict[str, BackendAdapter] = {
     "openrouter": CloudAPIAdapter(),
     "kilocode": CloudAPIAdapter(),
     "deepseek": CloudAPIAdapter(),
+    "nous": CloudAPIAdapter(),
     "openai-compatible": CloudAPIAdapter(),
     "sd-cpp": StableDiffusionCppAdapter(),
     "iopaint": IOPaintAdapter(),

--- a/tinyagentos/providers/__init__.py
+++ b/tinyagentos/providers/__init__.py
@@ -32,6 +32,7 @@ ALL_TYPES: set[str] = {
     "openrouter",
     "kilocode",
     "deepseek",
+    "nous",
     "openai-compatible",
     # -- local image-generation backends --
     "sd-cpp",
@@ -46,6 +47,7 @@ CLOUD_TYPES: set[str] = {
     "openrouter",
     "kilocode",
     "deepseek",
+    "nous",
     "openai-compatible",
 }
 
@@ -74,6 +76,7 @@ BACKEND_TYPE_MAP: dict[str, str] = {
     "openrouter": "openrouter",
     "kilocode": "openai",  # kilocode is OpenAI-compatible; api_base set explicitly
     "deepseek": "deepseek",  # native LiteLLM provider; api_base set to official base
+    "nous": "openai",  # Nous Portal is OpenAI-compatible; api_base set explicitly
     "openai-compatible": "openai",  # user-supplied OpenAI-compatible endpoint
 }
 

--- a/tinyagentos/routes/providers.py
+++ b/tinyagentos/routes/providers.py
@@ -27,6 +27,7 @@ PROVIDER_URL_DEFAULTS: dict[str, str] = {
     "anthropic": "https://api.anthropic.com/v1",
     "openrouter": "https://openrouter.ai/api/v1",
     "deepseek": "https://api.deepseek.com",
+    "nous": "https://inference-api.nousresearch.com/v1",
 }
 
 # Seed model list for cloud providers that don't expose an openly-listable
@@ -45,6 +46,14 @@ PROVIDER_DEFAULT_MODELS: dict[str, list[dict]] = {
         {"id": "deepseek-v4-flash"},
         {"id": "deepseek-chat"},
         {"id": "deepseek-reasoner"},
+    ],
+    # Nous Portal authenticates with an OAuth-minted bearer, so a fresh add
+    # without a working credential can't auto-discover /v1/models. Seed the
+    # flagship Hermes models so the entry registers routable models either way.
+    "nous": [
+        {"id": "Hermes-4-405B"},
+        {"id": "Hermes-4-70B"},
+        {"id": "Hermes-4.3-36B"},
     ],
 }
 


### PR DESCRIPTION
## What

Adds **Nous Portal** (Nous Research) as a first-class cloud model provider so it can be added from the Providers app, instead of a hand-configured openai-compatible endpoint (which is easy to misconfigure).

Nous Portal is an OpenAI-compatible inference API (`https://inference-api.nousresearch.com/v1`) serving the Hermes 4 family and frontier models.

## Changes

Following the `kilocode`/`deepseek` pattern (cloud, OpenAI-compatible, explicit api_base):

- **providers/__init__.py** (single source of truth): `nous` added to `ALL_TYPES` + `CLOUD_TYPES`, mapped to the `openai` LiteLLM prefix. LiteLLM's existing `elif` sets `api_base` for any non-openai/anthropic cloud type with a URL, so no litellm_config change is needed.
- **routes/providers.py**: default base URL + a seed model list (flagship Hermes models) for when `/v1/models` can't be listed without a working credential.
- **backend_adapters.py**: `nous` uses `CloudAPIAdapter`.
- **Frontend** (models.ts, ProvidersApp.tsx): `nous` added to the cloud-type lists and provider metadata (label "Nous Portal", default URL, description, key placeholder).

## Verification

- Base URL + OpenAI-compatibility verified against Nous Portal docs.
- Backend provider suite passes (68 tests); frontend `tsc` clean.
- `nous` resolves through the provider registry (`CLOUD_TYPES`, `BACKEND_TYPE_MAP['nous']=='openai'`).

Note: the Portal authenticates with an OAuth-minted bearer; users supply their Portal token as the provider key.