### PR TITLE
fix(apps): register assistant-studio as an installable optional app

### DIFF
--- a/tinyagentos/routes/apps.py
+++ b/tinyagentos/routes/apps.py
@@ -34,7 +34,7 @@ OPTIONAL_FRONTEND_APPS = {
     # Creative Studios: a frontend-only optional app whose install row just
     # flips the launcher visibility, no service spawned.
     "coding-studio", "design-studio", "music-studio", "app-studio", "office-studio",
-    "web-studio", "video-studio",
+    "web-studio", "video-studio", "assistant-studio",
 }
 _FRONTEND_APP_KIND = "frontend-app"
 
@@ -48,6 +48,7 @@ APP_VERSIONS: dict[str, str] = {
     "office-studio": "1.0.0",
     "web-studio": "1.0.0",
     "video-studio": "1.0.0",
+    "assistant-studio": "1.0.0",
 }
 
 # Trust level for each optional app (all current optional apps are first-party).
@@ -59,6 +60,7 @@ APP_TRUST: dict[str, str] = {
     "office-studio": "first-party",
     "web-studio": "first-party",
     "video-studio": "first-party",
+    "assistant-studio": "first-party",
 }
 
 # Provenance tier for each optional app (see tinyagentos/userspace/capabilities.py
@@ -74,6 +76,7 @@ APP_PROVENANCE: dict[str, str] = {
     "app-studio": "first-party",
     "office-studio": "first-party",
     "web-studio": "first-party",
+    "assistant-studio": "first-party",
 }
 
 


### PR DESCRIPTION
Assistant Studio (#2103) shipped in the frontend registry as `optional` but was missing from the server-side optional-app catalog, so `getLaunchableApps` hid it and install returned "not an optional app". Adds it to `OPTIONAL_FRONTEND_APPS` + version/trust/provenance dicts, matching the other Creative Studios. Unblocks installing/showing Assistant Studio in the launchpad.