### PR TITLE
fix(shortcuts): resolve container's real incus project + start it for terminal shortcuts

### DIFF
--- a/tests/containers/test_lxc_pty.py
+++ b/tests/containers/test_lxc_pty.py
@@ -68,3 +68,87 @@ def test_spawn_pty_integration():
         assert b"hello-from-pty" in output
     except Exception as exc:
         pytest.skip(f"Container taos-agent-test-pty not available: {exc}")
+
+
+def test_open_incus_pty_resolves_project_and_starts(monkeypatch):
+    """_open_incus_pty must target the container's ACTUAL project and start it
+    if stopped, so a shortcut works for a container in `default` while the
+    incus client default project is a per-user one (e.g. user-999)."""
+    import json as _json
+    from tinyagentos.containers import lxc as lxcmod
+
+    run_calls = []
+    popen_calls = []
+
+    class FakeCompleted:
+        def __init__(self, rc, out):
+            self.returncode = rc
+            self.stdout = out
+
+    def fake_run(args, **kw):
+        run_calls.append(args)
+        if "list" in args:
+            return FakeCompleted(0, _json.dumps([
+                {"name": "taos-agent-naira", "project": "default", "status": "Stopped"},
+            ]))
+        return FakeCompleted(0, "")
+
+    class FakePopen:
+        def __init__(self, args, **kw):
+            popen_calls.append(args)
+            self.pid = 4321
+
+    monkeypatch.setattr(lxcmod.subprocess, "run", fake_run)
+    monkeypatch.setattr(lxcmod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(lxcmod.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(lxcmod.os, "close", lambda fd: None)
+
+    lxcmod._open_incus_pty("taos-agent-naira", "exec bash -l")
+
+    # The exec targets the resolved project, not the client default.
+    exec_cmd = popen_calls[0]
+    assert "--project" in exec_cmd
+    assert "default" in exec_cmd
+    assert "taos-agent-naira" in exec_cmd
+    # A stopped container was started first, in the same resolved project.
+    start_cmds = [c for c in run_calls if "start" in c]
+    assert start_cmds, "stopped container should be started before exec"
+    assert "--project" in start_cmds[0] and "default" in start_cmds[0]
+
+
+def test_open_incus_pty_running_container_not_restarted(monkeypatch):
+    """A running container is exec'd directly, with no start call."""
+    import json as _json
+    from tinyagentos.containers import lxc as lxcmod
+
+    run_calls = []
+    popen_calls = []
+
+    class FakeCompleted:
+        def __init__(self, rc, out):
+            self.returncode = rc
+            self.stdout = out
+
+    def fake_run(args, **kw):
+        run_calls.append(args)
+        if "list" in args:
+            return FakeCompleted(0, _json.dumps([
+                {"name": "taos-agent-naira", "project": "user-999", "status": "Running"},
+            ]))
+        return FakeCompleted(0, "")
+
+    class FakePopen:
+        def __init__(self, args, **kw):
+            popen_calls.append(args)
+            self.pid = 4321
+
+    monkeypatch.setattr(lxcmod.subprocess, "run", fake_run)
+    monkeypatch.setattr(lxcmod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(lxcmod.pty, "openpty", lambda: (10, 11))
+    monkeypatch.setattr(lxcmod.os, "close", lambda fd: None)
+
+    lxcmod._open_incus_pty("taos-agent-naira", "exec bash -l")
+
+    exec_cmd = popen_calls[0]
+    assert "user-999" in exec_cmd
+    assert not [c for c in run_calls if "start" in c], "running container must not be started"

--- a/tinyagentos/containers/lxc.py
+++ b/tinyagentos/containers/lxc.py
@@ -65,14 +65,60 @@ class _IncusPtyHandle(PtyHandle):
                 pass
 
 
+def _resolve_project_and_state_sync(container: str) -> tuple[str | None, str | None]:
+    """Return (project, state) for *container* by searching ALL incus projects.
+
+    ``incus exec`` targets the client's default project only, so a container
+    that lives in ``default`` while the client default is a per-user project
+    (e.g. ``user-999``) would be reported as "Instance not found". The async
+    path uses ``_resolve_container_project``; this is the synchronous sibling
+    the PTY path needs. Returns (None, None) if the container is not found or
+    the lookup fails, so the caller falls back to the default project.
+    """
+    try:
+        result = subprocess.run(
+            ["incus", "list", "--all-projects", "-f", "json"],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode != 0:
+            return (None, None)
+        for inst in json.loads(result.stdout or "[]"):
+            if inst.get("name") == container:
+                return (inst.get("project"), inst.get("status"))
+    except Exception:
+        logger.debug("resolve project for %s failed", container, exc_info=True)
+    return (None, None)
+
+
 def _open_incus_pty(container: str, shell_cmd: str) -> _IncusPtyHandle:
-    """Open an incus exec session with a real PTY."""
+    """Open an incus exec session with a real PTY.
+
+    Resolves the container's actual project (agents may live in a per-user
+    project like ``user-999`` or, for legacy containers, ``default``) and
+    starts it if it is stopped, so the shortcut works regardless of project or
+    run state instead of erroring with "Instance not found" / "not running".
+    """
+    project, state = _resolve_project_and_state_sync(container)
+    proj_args = ["--project", project] if project else []
+
+    # A dev-access terminal on a stopped container should just start it; incus
+    # exec fails on a non-running instance. Best effort: ignore an "already
+    # running" race and let the exec below surface any real failure.
+    if state is not None and state.lower() != "running":
+        try:
+            subprocess.run(
+                ["incus", "start", *proj_args, container],
+                capture_output=True, text=True, timeout=60,
+            )
+        except Exception:
+            logger.debug("start %s before pty failed", container, exc_info=True)
+
     master_fd, slave_fd = pty.openpty()
     # `incus exec` has no --tty/--interactive flags; -t/--force-interactive
     # forces pseudo-terminal allocation. stdin/stdout are wired to the PTY slave
     # below, so this gives a real interactive terminal in the container.
     proc = subprocess.Popen(
-        ["incus", "exec", "--force-interactive", container, "--",
+        ["incus", "exec", *proj_args, "--force-interactive", container, "--",
          "bash", "-lc", shell_cmd],
         stdin=slave_fd,
         stdout=slave_fd,


### PR DESCRIPTION
Agent terminal/TUI shortcuts opened an incus PTY with no `--project`, so incus used the client default project (a per-user one like `user-999`). A container in another project (e.g. a legacy one in `default`) failed with "Failed to fetch instance ... in project user-999: Instance not found" even though it exists. Every other container op already resolves the real project via `_resolve_container_project` (--all-projects); the PTY path was the exception.

Fix: `_open_incus_pty` resolves the container's actual project and passes `--project`, and starts the container if stopped (incus exec fails on a non-running instance). Adds a sync resolver sibling + 2 tests. Unblocks the Hermes TUI / container-shell shortcuts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PTY sessions now locate containers across all Incus projects.
  * Stopped containers are started automatically before opening a session.
  * Running containers are accessed without unnecessary restarts.
  * Commands consistently use the container’s resolved project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->