### PR TITLE
fix(notifications): show approve/deny for scope-request notifications in bell

### DIFF
--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -38,11 +38,15 @@ export function ConsentActions({
   scopes,
   requestedProjectId,
   onResolved,
+  source = "auth_requests",
+  canonicalId,
 }: {
   requestId: string;
   scopes: string[];
   requestedProjectId?: string;
   onResolved?: () => void;
+  source?: string;
+  canonicalId?: string;
 }) {
   const needsProject = scopes.some((s) => PROJECT_SCOPES.has(s));
   const [busy, setBusy] = useState(false);
@@ -133,9 +137,10 @@ export function ConsentActions({
       setBusy(false);
       return;
     }
-    const url = approved
-      ? `/api/agents/auth-requests/${encodeURIComponent(requestId)}/approve`
-      : `/api/agents/auth-requests/${encodeURIComponent(requestId)}/deny`;
+    const baseUrl = source === "agent_scope_requests"
+      ? `/api/agents/registry/${encodeURIComponent(canonicalId ?? requestId)}/scope-requests/${encodeURIComponent(requestId)}`
+      : `/api/agents/auth-requests/${encodeURIComponent(requestId)}`;
+    const url = `${baseUrl}/${approved ? "approve" : "deny"}`;
     let body: string | undefined;
     if (approved) {
       const payload: { granted_scopes: string[]; project_id?: string } = { granted_scopes: scopes };
@@ -276,12 +281,13 @@ export function ConsentActions({
  *  is missing. */
 export function consentPayload(
   data: Record<string, unknown> | undefined,
-): { requestId: string; scopes: string[]; projectId?: string } | null {
+): { requestId: string; scopes: string[]; projectId?: string; canonicalId?: string } | null {
   if (!data) return null;
   const requestId = data.request_id;
   if (typeof requestId !== "string") return null;
   const raw = data.requested_scopes;
   const scopes = Array.isArray(raw) ? raw.filter((s): s is string => typeof s === "string") : [];
   const projectId = typeof data.project_id === "string" ? data.project_id : undefined;
-  return { requestId, scopes, projectId };
+  const canonicalId = typeof data.canonical_id === "string" ? data.canonical_id : undefined;
+  return { requestId, scopes, projectId, canonicalId };
 }

--- a/desktop/src/components/ConsentActions.tsx
+++ b/desktop/src/components/ConsentActions.tsx
@@ -137,8 +137,13 @@ export function ConsentActions({
       setBusy(false);
       return;
     }
+    if (source === "agent_scope_requests" && !canonicalId) {
+      setError("Missing agent identifier; cannot process this scope request.");
+      setBusy(false);
+      return;
+    }
     const baseUrl = source === "agent_scope_requests"
-      ? `/api/agents/registry/${encodeURIComponent(canonicalId ?? requestId)}/scope-requests/${encodeURIComponent(requestId)}`
+      ? `/api/agents/registry/${encodeURIComponent(canonicalId!)}/scope-requests/${encodeURIComponent(requestId)}`
       : `/api/agents/auth-requests/${encodeURIComponent(requestId)}`;
     const url = `${baseUrl}/${approved ? "approve" : "deny"}`;
     let body: string | undefined;

--- a/desktop/src/components/NotificationCentre.tsx
+++ b/desktop/src/components/NotificationCentre.tsx
@@ -39,7 +39,7 @@ function NotificationItem({
 }) {
   // Agent access-requests carry inline Allow/Deny actions. These nested buttons
   // live outside the clickable row to keep the markup valid.
-  const consent = n.source === "auth_requests" ? consentPayload(n.data) : null;
+  const consent = (n.source === "auth_requests" || n.source === "agent_scope_requests") ? consentPayload(n.data) : null;
   return (
     <div className={`border-b border-white/5 ${!n.read ? "bg-accent/5" : ""}`}>
       <button
@@ -77,6 +77,8 @@ function NotificationItem({
             requestId={consent.requestId}
             scopes={consent.scopes}
             requestedProjectId={consent.projectId}
+            source={n.source}
+            canonicalId={consent.canonicalId}
             onResolved={() => onResolveConsent(n.id)}
           />
         </div>

--- a/desktop/src/components/NotificationToast.tsx
+++ b/desktop/src/components/NotificationToast.tsx
@@ -270,7 +270,7 @@ function ToastItem({ notif, onExpire }: { notif: Notification; onExpire: () => v
   const archiveRead = useNotificationStore((s) => s.archiveRead);
   const Icon = LEVEL_ICONS[notif.level];
   const isAgentPaused = notif.source === "agent.paused";
-  const consent = notif.source === "auth_requests" ? consentPayload(notif.data) : null;
+  const consent = (notif.source === "auth_requests" || notif.source === "agent_scope_requests") ? consentPayload(notif.data) : null;
   // Stable boolean for the effect dependency — using the `consent` object
   // would recreate the timer on every render because consentPayload() returns
   // a new object reference each time.
@@ -307,6 +307,8 @@ function ToastItem({ notif, onExpire }: { notif: Notification; onExpire: () => v
             requestId={consent.requestId}
             scopes={consent.scopes}
             requestedProjectId={consent.projectId}
+            source={notif.source}
+            canonicalId={consent.canonicalId}
             onResolved={() => archiveRead(notif.id)}
           />
         )}


### PR DESCRIPTION
Fixes scope-request notification UI gap from #1921.

## Problem
PR #1921 (agent scope-requests) emits notifications with `source: "agent_scope_requests"`, but `NotificationCentre` and `NotificationToast` only render `ConsentActions` (approve/deny buttons) for `source === "auth_requests"`. Scope-request approve/deny was invisible in the UI — approving required hand-rolled curl.

## Fix
- Branch the source check in `NotificationCentre.tsx` and `NotificationToast.tsx` to also match `"agent_scope_requests"`
- `ConsentActions` accepts optional `source` (defaults to `"auth_requests"`) and `canonicalId` props; routes approve/deny to the scope-request endpoints (`/api/agents/registry/{id}/scope-requests/{req_id}/approve|deny`) when source is `"agent_scope_requests"`
- `consentPayload()` extracts `canonical_id` from notification data for scope-request endpoint path construction
- Backward compatible: existing callers (DecisionsApp, existing tests) continue to work with `source="auth_requests"` default

## Files
- `desktop/src/components/ConsentActions.tsx` — added source/canonicalId props + URL branching + consentPayload canonicalId extraction
- `desktop/src/components/NotificationCentre.tsx` — branched source check + passes source/canonicalId
- `desktop/src/components/NotificationToast.tsx` — same

## Tests
- `npm run build` passes (tsc + vite build)
- `vitest run ConsentActions.test.tsx` — 7/7 pass (backward compatibility confirmed)

Ref: #1921 — PR adding scope-request flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for approving or denying agent scope requests from notifications and toast messages.
  * Consent actions now handle additional request metadata to route decisions correctly.
  * Expanded consent information to include canonical request identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->