### PR TITLE
test(desktop): add unit tests for AssistantStudioApp

### DIFF
--- a/desktop/src/apps/AssistantStudioApp.test.tsx
+++ b/desktop/src/apps/AssistantStudioApp.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { AssistantStudioApp } from "./AssistantStudioApp";
+
+describe("AssistantStudioApp", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => [{ name: "hermes" }, { name: "other" }],
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders all 7 rail sections", () => {
+    render(<AssistantStudioApp windowId="win-1" />);
+    const nav = document.querySelector("nav[aria-label='Assistant Studio sections']");
+    expect(nav).toBeInTheDocument();
+    const railLabels = [
+      "Overview",
+      "Journal",
+      "Calendar",
+      "Tasks",
+      "Comms",
+      "Canvas",
+      "Deliverables",
+    ];
+    for (const label of railLabels) {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("switches visible panel when a rail button is clicked", async () => {
+    render(<AssistantStudioApp windowId="win-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Journal" }));
+    expect(screen.getByRole("heading", { name: "Journal" })).toBeInTheDocument();
+  });
+
+  it("renders PA selector with accessible label", async () => {
+    render(<AssistantStudioApp windowId="win-1" />);
+    const paSelect = screen.getByLabelText(
+      "Select the agent to act as your personal assistant",
+    );
+    expect(paSelect).toBeInTheDocument();
+    await waitFor(() => expect(paSelect.value).toBe("hermes"));
+  });
+
+  it("adds a journal entry", async () => {
+    render(<AssistantStudioApp windowId="win-1" />);
+    const paSelect = screen.getByLabelText(
+      "Select the agent to act as your personal assistant",
+    );
+    await waitFor(() => expect(paSelect.value).toBe("hermes"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Journal" }));
+    expect(screen.getByRole("heading", { name: "Journal" })).toBeInTheDocument();
+
+    const textarea = screen.getByLabelText("New journal entry");
+    fireEvent.change(textarea, { target: { value: "hello journal" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add entry" }));
+    expect(screen.getByText("hello journal")).toBeInTheDocument();
+  });
+});

--- a/desktop/src/apps/AssistantStudioApp.test.tsx
+++ b/desktop/src/apps/AssistantStudioApp.test.tsx
@@ -16,8 +16,12 @@ describe("AssistantStudioApp", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders all 7 rail sections", () => {
+  it("renders all 7 rail sections", async () => {
     render(<AssistantStudioApp windowId="win-1" />);
+    // Drain the mount-time /api/agents fetch so its setState lands inside act().
+    await waitFor(() =>
+      expect(screen.queryByText("Loading agents...")).not.toBeInTheDocument(),
+    );
     const nav = document.querySelector("nav[aria-label='Assistant Studio sections']");
     expect(nav).toBeInTheDocument();
     const railLabels = [
@@ -36,6 +40,10 @@ describe("AssistantStudioApp", () => {
 
   it("switches visible panel when a rail button is clicked", async () => {
     render(<AssistantStudioApp windowId="win-1" />);
+    // Drain the mount-time /api/agents fetch so its setState lands inside act().
+    await waitFor(() =>
+      expect(screen.queryByText("Loading agents...")).not.toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Journal" }));
     expect(screen.getByRole("heading", { name: "Journal" })).toBeInTheDocument();
   });


### PR DESCRIPTION
Autonomous build of board card tsk-hr4zwz.



Files:
 desktop/src/apps/AssistantStudioApp.test.tsx | 67 ++++++++++++++++++++++++++++
 1 file changed, 67 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the Assistant Studio interface, including navigation between sections.
  * Verified personal-assistant selection and default loading behavior.
  * Added coverage for creating and displaying new journal entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->