### PR TITLE
fix(library): wire up the unused source ingest option

### DIFF
--- a/desktop/src/lib/library.ts
+++ b/desktop/src/lib/library.ts
@@ -127,7 +127,6 @@ export async function reprocessLibraryItem(itemId: string): Promise<boolean> {
 
 export interface IngestLibraryOptions {
   title?: string;
-  source?: string;
 }
 
 export async function ingestLibraryUrl(
@@ -138,7 +137,7 @@ export async function ingestLibraryUrl(
     const res = await fetch("/api/library/ingest", {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ url, title: opts?.title ?? "", source: opts?.source ?? "" }),
+      body: JSON.stringify({ url, title: opts?.title ?? "" }),
     });
     if (!res.ok) return null;
     const ct = res.headers.get("content-type") ?? "";

--- a/desktop/src/lib/library.ts
+++ b/desktop/src/lib/library.ts
@@ -138,7 +138,7 @@ export async function ingestLibraryUrl(
     const res = await fetch("/api/library/ingest", {
       method: "POST",
       headers: { "Content-Type": "application/json", Accept: "application/json" },
-      body: JSON.stringify({ url, title: opts?.title ?? "" }),
+      body: JSON.stringify({ url, title: opts?.title ?? "", source: opts?.source ?? "" }),
     });
     if (!res.ok) return null;
     const ct = res.headers.get("content-type") ?? "";


### PR DESCRIPTION
Autonomous build of board card tsk-kbcq5o.



Files:
 desktop/src/lib/library.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

----
## Summary by Gitar

- **Library updates:**
    - Passed `source` option from `opts` into the library ingestion API request body in `ingestLibraryUrl`.

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Library ingestion now preserves and sends the optional source information when adding a library URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->