### PR TITLE
chore(release): v1.0.0-beta.44 version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
-## [1.0.0-beta.44] - 2026-07-22
+## [1.0.0-beta.44] - 2026-07-26
 
 ### Added
 
@@ -20,10 +20,18 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - **Nous Portal** as a first-class cloud model provider (#2102).
 - **Scope requests**: an existing agent (or its owner/admin) can request
   additional scope grants on the same identity, owner/admin approved (#1921).
+- **`project_tasks_create` scope**, so an external agent can author board cards.
+  Deliberately separate from `project_tasks`, which stays read plus lifecycle
+  plus comments, so an existing approval keeps meaning what it meant when it was
+  given (#2098).
 - Library item-card component with thumbnail, status, and artifacts (#2097).
 
 ### Fixed
 
+- **Dialogs rendered behind windows, and minting an invite never showed the URL
+  and PIN.** The window z-index counter grew unbounded until it passed the
+  overlay layer, and the mint dialog unmounted before it could render the
+  result (#2092).
 - **Agent terminal/TUI shortcuts failed with "Instance not found."** The PTY
   path opened `incus exec` with no `--project`, so it used the client default
   project and could not reach a container in another project (e.g. a legacy one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.44] - 2026-07-22
+
+### Added
+
+- **Assistant Studio**: a workspace app for a personal-assistant agent. Pick a
+  registered agent as your PA, then work out of one hub with Overview, Journal,
+  Calendar/time, Tasks, Comms, Canvas, and a Deliverables area (#2103, #2104).
+- **Agent project-file access**: the `files_read` / `files_write` scopes are now
+  enforced on the project-files routes, and the invite bundle surfaces the Files
+  API, so a member agent can read and add project files (#2100).
+- **Nous Portal** as a first-class cloud model provider (#2102).
+- **Scope requests**: an existing agent (or its owner/admin) can request
+  additional scope grants on the same identity, owner/admin approved (#1921).
+- Library item-card component with thumbnail, status, and artifacts (#2097).
+
+### Fixed
+
+- **Agent terminal/TUI shortcuts failed with "Instance not found."** The PTY
+  path opened `incus exec` with no `--project`, so it used the client default
+  project and could not reach a container in another project (e.g. a legacy one
+  in `default`). It now resolves the container's real project and starts it if
+  stopped (#2105).
+- Scope-request approval security fixes: global-capable scopes no longer bind to
+  an agent-supplied `project_id`, approval/deny take the per-request lock, and
+  create authorizes before scope-vocabulary validation (#1921).
+
 ## [1.0.0-beta.43] - 2026-07-21
 
 ### Added

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.43",
+  "version": "1.0.0-beta.44",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.43"
+version = "1.0.0-beta.44"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.43"
+__version__ = "1.0.0-beta.44"

--- a/uv.lock
+++ b/uv.lock
@@ -3022,7 +3022,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b43"
+version = "1.0.0b44"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump to 1.0.0-beta.44 across the four version files plus the normalized `1.0.0b44` in uv.lock (gated by `test_version_lock_sync`), and the changelog entry for the 12 commits on dev since beta.43.

Changelog covers: Assistant Studio (#2103/#2104), agent project-file access (#2100), Nous Portal provider (#2102), scope requests (#1921), `project_tasks_create` (#2098), library item card (#2097), the dialog-behind-window and mint URL/PIN fixes (#2092), the shortcut project-resolution fix (#2105), and the scope-request approval security fixes (#1921).