### PR TITLE
fix(agents): bind project_tasks_create and files scopes to a project on approval

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -68,7 +68,7 @@ git worktree add ../taos-<task> -b feat/<task> origin/dev
 ## Posting to the coordination bus (a2a)
 
 Agents coordinate over the A2A bus. When you post, the send body is
-`{from, thread, body}` — the destination field is **`thread`**, not `channel`:
+`{from, thread, body}`, where the destination field is **`thread`**, not `channel`:
 
 ```
 POST <bus>/a2a/send
@@ -84,7 +84,7 @@ POST <bus>/a2a/send
 The raw bus above is unauthenticated on the LAN and trusts the `from` field, so
 reaching it means either the owner's account or an SSH hop. A registered agent
 should instead post through the controller's authenticated proxy, which forces
-`from` to the agent's own registry handle (no spoofing) — so it posts as itself,
+`from` to the agent's own registry handle (no spoofing), so it posts as itself,
 not the owner:
 
 ```
@@ -153,19 +153,19 @@ it to gain more scopes without duplicating itself. A scope request adds grants t
 that SAME canonical_id instead:
 
 - `POST /api/agents/registry/{canonical_id}/scope-requests`
-  `{requested_scopes, project_id?, reason?}` — create a pending request. Unlike
+  `{requested_scopes, project_id?, reason?}`: create a pending request. Unlike
   the new-agent auth-request (unauthenticated, since the agent has no creds yet),
   this is CREDENTIALLED: the caller must be the agent's OWN registry bearer token
   (`sub` == `canonical_id`) OR the owning user / an admin. An anonymous caller can
   never escalate an existing identity. The middleware allowlist exposes only the
   create path to a registry JWT; the route re-checks identity == canonical_id.
 - `POST /api/agents/registry/{canonical_id}/scope-requests/{req_id}/approve`
-  `{granted_scopes, project_id?}` — owner/admin only. The admin may narrow but
+  `{granted_scopes, project_id?}`: owner/admin only. The admin may narrow but
   never widen the requested scopes; each granted scope is added via
   `add_grant(canonical_id, scope, project_id)` (idempotent on the
   `(canonical_id, scope, project_id)` UNIQUE key, so re-approving is a no-op). No
   new identity is created.
-- `POST /api/agents/registry/{canonical_id}/scope-requests/{req_id}/deny` —
+- `POST /api/agents/registry/{canonical_id}/scope-requests/{req_id}/deny`:
   owner/admin only.
 
 Requested scopes are validated against the same closed `VALID_SCOPES` vocabulary
@@ -184,7 +184,7 @@ possession), added method-sensitively to `tinyagentos/auth_middleware.py` exactl
 like `POST /api/cluster/pairing/claim`, and per-IP rate-limited (20 requests per
 10s, reusing the pairing throttle helper):
 
-- `POST /api/projects/invites/redeem` — body `{invite_id, pin, harness, label?}`.
+- `POST /api/projects/invites/redeem`: body `{invite_id, pin, harness, label?}`.
   Verifies the PIN (wrong PIN / expired / attempt-capped -> 403; already redeemed
   / revoked -> 409), derives the agent handle `{project_slug}-{harness}[-{label}]`
   and de-dupes it against active registry agents in the project, then either
@@ -193,7 +193,7 @@ like `POST /api/cluster/pairing/claim`, and per-IP rate-limited (20 requests per
   fires). Returns a connection bundle plus `{request_id, agent_handle, poll_path}`.
   `project_tasks` is force-included so a successful redeem always yields a project
   member.
-- `GET /i/{invite_id}` — content-negotiated advert. An agent requesting
+- `GET /i/{invite_id}`: content-negotiated advert. An agent requesting
   `Accept: application/json` gets the redeem contract (`{method, path, fields}`);
   a browser gets a minimal HTML page. No PIN check here; it only advertises the
   contract.
@@ -202,19 +202,19 @@ The redeem response carries a **connection bundle** (design section 4 plus the
 Approved-build addendum). It contains NO token or secret (the token still
 arrives via the status poll). The bundle has:
 
-- `controller.endpoints` — the controller's reachable addresses: non-loopback
+- `controller.endpoints`: the controller's reachable addresses: non-loopback
   LAN IPv4s (priority ordered, operator override first) and the mesh (Tailscale)
   node IP when joined. No relay in Phase 1.
-- `apis` — the agent-JWT-reachable surface, scoped EXACTLY to the granted scopes
+- `apis`: the agent-JWT-reachable surface, scoped EXACTLY to the granted scopes
   and mirroring the middleware canvas allowlist so the advertised routes are the
   ones the token can call: task routes when `project_tasks` is granted; canvas
   `GET /canvas/elements` + `/canvas/snapshot.png` only when `canvas_read` is
   granted; canvas `POST /canvas/elements` + `PATCH|DELETE /canvas/elements/{id}`
   only when `canvas_write` is granted; the A2A bus proxy (`/api/a2a/bus/send|
   messages|channels`) whenever an `a2a_*` scope is granted.
-- `delivery` — the timed-check contract (`poll_path`, `stream_path`,
+- `delivery`: the timed-check contract (`poll_path`, `stream_path`,
   `check_interval_secs` from the invite, `cursor: ts`, `filter: mentions+project`).
-- `onboarding` + `guide_markdown` — a personalized capability guide (repo link,
+- `onboarding` + `guide_markdown`: a personalized capability guide (repo link,
   agent manual links, scoped Projects/Canvas summary, the A2A authenticated-proxy
   contract, and explicit instructions to write the identity/project/token-file/bus
   contract into the agent's OWN memory and to poll every `check_interval_secs`).

--- a/tests/test_agent_scope_requests.py
+++ b/tests/test_agent_scope_requests.py
@@ -549,3 +549,51 @@ async def test_approved_scope_grant_unlocks_route_e2e(client, monkeypatch, tmp_p
         assert decision.get("question") == "Should we deploy?"
     finally:
         await env.close()
+
+
+def test_project_scope_set_is_a_single_definition():
+    """Which scopes require a project binding must be defined exactly once.
+
+    This existed as three parallel copies (two function-local, one module-level).
+    Fixing only the module-level one left the auth-request approval path -- the
+    path an invite actually takes -- still granting files_* and
+    project_tasks_create globally: grants written with project_id=None, which
+    check_agent_scope_for_project never matches, so the operator sees a
+    successful approval and the agent silently has no access.
+
+    Aliases are checked by identity, not equality, so a re-introduced copy that
+    happens to agree today still fails here rather than drifting later.
+    """
+    from tinyagentos.routes import agent_auth_requests as mod
+
+    assert mod._PROJECT_SCOPES == {
+        "project_tasks",
+        "project_tasks_create",
+        "canvas_read",
+        "canvas_write",
+        "files_read",
+        "files_write",
+    }
+    assert mod._SCOPE_PROJECT_SCOPES is mod._PROJECT_SCOPES
+    assert mod._SCOPE_CANVAS_SCOPES is mod._CANVAS_SCOPES
+    assert mod._SCOPE_FILES_SCOPES is mod._FILES_SCOPES
+
+    # No shadowing re-definition anywhere in the module source.
+    import inspect
+    import re
+
+    src = inspect.getsource(mod)
+    for name in ("_CANVAS_SCOPES", "_FILES_SCOPES", "_PROJECT_SCOPES"):
+        assigns = re.findall(rf"^\s*{name}\s*=", src, re.MULTILINE)
+        assert len(assigns) == 1, f"{name} is assigned {len(assigns)} times, expected 1"
+
+
+def test_every_project_bound_scope_is_a_valid_scope():
+    """The project-scope set must not name a scope the vocabulary rejects.
+
+    A typo here fails open in the confusing direction: the scope never matches
+    the needs_project check, so it is granted globally without anyone noticing.
+    """
+    from tinyagentos.routes.agent_auth_requests import VALID_SCOPES, _PROJECT_SCOPES
+
+    assert _PROJECT_SCOPES <= set(VALID_SCOPES)

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -667,6 +667,22 @@ async def add_agent_to_project(
                             can_read=("canvas_read" in granted_canvas),
                             can_write=("canvas_write" in granted_canvas),
                         )
+                    # role="lead" above is only a LABEL on the member row. The
+                    # project's actual lead is the projects.lead_member_id
+                    # pointer, and set_lead is its only writer, so without this
+                    # call the member reads as lead in the UI while every
+                    # lead-gated check refuses them (taOS #2113: exactly what
+                    # happened to Hermes on taOSrabbit). Best-effort like the
+                    # rest of this block: the membership + grant already stand.
+                    if is_lead:
+                        try:
+                            await pstore.set_lead(project_id, canonical_id)
+                        except KeyError:
+                            logger.warning(
+                                "add_agent_to_project: could not set %s as lead of %s",
+                                canonical_id, project_id,
+                            )
+
                     if "project_tasks" in granted_scopes:
                         from tinyagentos.projects.a2a import ensure_a2a_channel
 

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -854,7 +854,15 @@ _SCOPE_REQUEST_PENDING_CAP = 10
 # a real project_id is required for them. decisions_read/decisions_write are
 # NOT here: they may be granted globally (project_id=None) or per-project.
 _SCOPE_CANVAS_SCOPES = {"canvas_read", "canvas_write"}
-_SCOPE_PROJECT_SCOPES = {"project_tasks"} | _SCOPE_CANVAS_SCOPES
+_SCOPE_FILES_SCOPES = {"files_read", "files_write"}
+# Every scope whose authority is meaningless without a project binding. Missing
+# one here is not harmless: the approval would succeed with no project_id, the
+# grant would be written global (project_id=None), and check_agent_scope_for_project
+# would then never match it -- so the operator believes they granted access and
+# the agent silently has none.
+_SCOPE_PROJECT_SCOPES = (
+    {"project_tasks", "project_tasks_create"} | _SCOPE_CANVAS_SCOPES | _SCOPE_FILES_SCOPES
+)
 
 
 async def _authorize_scope_request_creation(

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -187,6 +187,16 @@ async def _retire_scope_request_notification(request: Request, request_id: str) 
         pass
 
 
+# Single source of truth for which scopes are meaningless without a project
+# binding. This lived in three places (two function-local copies plus a module
+# one), and fixing only one of them left the auth-request approval path -- the
+# path an invite actually takes -- still granting files_* and
+# project_tasks_create globally. One definition, referenced everywhere.
+_CANVAS_SCOPES = {"canvas_read", "canvas_write"}
+_FILES_SCOPES = {"files_read", "files_write"}
+_PROJECT_SCOPES = {"project_tasks", "project_tasks_create"} | _CANVAS_SCOPES | _FILES_SCOPES
+
+
 def _get_approve_lock(request: Request, request_id: str) -> asyncio.Lock:
     """Per-request-id lock preventing concurrent approve races."""
     locks = getattr(request.app.state, "_approve_locks", None)
@@ -375,8 +385,6 @@ async def approve_request_record(
             ),
         )
 
-    _CANVAS_SCOPES = {"canvas_read", "canvas_write"}
-    _PROJECT_SCOPES = {"project_tasks"} | _CANVAS_SCOPES
 
     # project_tasks and the canvas scopes bind the token to a specific project
     # and add a membership row, so require a real project_id for these grants.
@@ -627,8 +635,6 @@ async def add_agent_to_project(
     grants_store = _get_grants_store(request)
     rel_mgr = _get_relationships(request)
 
-    _CANVAS_SCOPES = {"canvas_read", "canvas_write"}
-    _PROJECT_SCOPES = {"project_tasks"} | _CANVAS_SCOPES
 
     # Write the grants bound to this project and the relationship edge.
     for scope in granted_scopes:
@@ -869,16 +875,16 @@ _SCOPE_REQUEST_PENDING_CAP = 10
 # Scopes that bind a grant to a specific project (and add a membership row), so
 # a real project_id is required for them. decisions_read/decisions_write are
 # NOT here: they may be granted globally (project_id=None) or per-project.
-_SCOPE_CANVAS_SCOPES = {"canvas_read", "canvas_write"}
-_SCOPE_FILES_SCOPES = {"files_read", "files_write"}
-# Every scope whose authority is meaningless without a project binding. Missing
-# one here is not harmless: the approval would succeed with no project_id, the
-# grant would be written global (project_id=None), and check_agent_scope_for_project
-# would then never match it -- so the operator believes they granted access and
-# the agent silently has none.
-_SCOPE_PROJECT_SCOPES = (
-    {"project_tasks", "project_tasks_create"} | _SCOPE_CANVAS_SCOPES | _SCOPE_FILES_SCOPES
-)
+#
+# These are aliases, not copies. Missing a scope here is not harmless: the
+# approval would succeed with no project_id, the grant would be written global
+# (project_id=None), and check_agent_scope_for_project would then never match it
+# -- so the operator believes they granted access and the agent silently has
+# none. Re-listing the members instead of aliasing is how the three earlier
+# copies drifted apart, so keep these as plain aliases.
+_SCOPE_CANVAS_SCOPES = _CANVAS_SCOPES
+_SCOPE_FILES_SCOPES = _FILES_SCOPES
+_SCOPE_PROJECT_SCOPES = _PROJECT_SCOPES
 
 
 async def _authorize_scope_request_creation(

--- a/tinyagentos/routes/project_files.py
+++ b/tinyagentos/routes/project_files.py
@@ -59,6 +59,11 @@ async def _authorize_files_actor(
     if uid:
         # Session path: project visibility gate. A non-owner non-admin human
         # collapses into the SAME existence-hiding 404 the agent path uses.
+        # An UNKNOWN slug is deliberately allowed through for session users:
+        # the project files tree is slug-addressed and lazily created, which
+        # test_list_unknown_slug_returns_empty documents as intended. The agent
+        # path below is strict (unknown slug -> 404) because an agent must not
+        # be able to address a project it was never granted.
         is_admin = bool(getattr(request.state, "is_admin", False))
         if project is not None and not is_admin and project.get("user_id") != uid:
             return JSONResponse({"error": "not found"}, status_code=404)


### PR DESCRIPTION
Findings from reviewing the beta.44 promotion roll-up (#2122) before releasing to master. Three taken, two rejected with reasons.

## Taken

**Bug: project scopes mis-bound (Qodo).** `_SCOPE_PROJECT_SCOPES` listed only `project_tasks` plus the canvas scopes, so `project_tasks_create`, `files_read` and `files_write` could be approved with no `project_id`. The grant was then written global (`project_id=None`), and `check_agent_scope_for_project` only matches a grant bound to that project, so it never authorized anything. It fails closed, but the operator believes they granted access and the agent silently has none. Fixed, with a comment explaining why omitting a scope from this set is not harmless.

**Style: em dashes in public docs (Qodo).** Replaced all 11 in `docs/agent-coordination.md` with commas and colons.

## Rejected, with reasons

**"Orphan project files access" (Qodo, flagged Bug + Security).** I implemented this fix, it broke 10 existing tests, and on inspection the finding is wrong. `test_list_unknown_slug_returns_empty` documents the intent in its docstring: *"Unknown slug auto-creates an empty folder and returns []."* The project files tree is deliberately slug-addressed and lazily created. The slug is already sanitized against `/` and `..`, so the worst case is an authenticated user creating an empty directory, not privilege escalation. Reverted, and left a comment recording why the session path is permissive while the agent path stays strict (unknown slug returns 404, since an agent must not address a project it was never granted). Tightening this would be a deliberate behaviour change with test updates, not something to slip into a release fix.

**"AgentScopeRequestsStore missing MIGRATIONS" (Qodo).** Not a defect. `BaseStore.MIGRATIONS` defaults to `[]` and only runs `if self.MIGRATIONS`, so a brand-new table correctly has none.

## Deferred, filed separately

**CSRF on library.ts mutating calls** is real but pre-existing and file-wide (delete, reprocess and ingest all use raw `fetch`), so it is #2126 rather than scope creep here.

42 tests pass locally (project files, files agent scope, scope requests).