### PR TITLE
test(desktop): add unit tests for AssistantStudioApp

### DIFF
--- a/desktop/src/apps/AssistantStudioApp.test.tsx
+++ b/desktop/src/apps/AssistantStudioApp.test.tsx
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { ReactNode } from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { AssistantStudioApp } from "./AssistantStudioApp";
 
 const mockAgents = [{ name: "hermes" }, { name: "other" }];
+
+const PA_LABEL = "Select the agent to act as your personal assistant";
 
 vi.mock("lucide-react", () => ({
   LayoutDashboard: () => <span />,
@@ -25,7 +28,7 @@ vi.mock("@/components/ui", () => ({
     onClick,
     "aria-label": ariaLabel,
   }: {
-    children: React.ReactNode;
+    children: ReactNode;
     onClick?: () => void;
     "aria-label"?: string;
   }) => (
@@ -35,9 +38,34 @@ vi.mock("@/components/ui", () => ({
   ),
 }));
 
+// The component fetches /api/agents on mount in EVERY test, so every test needs
+// the stub -- without it the others hit jsdom's real fetch and update state
+// outside act(). Stubbing per-test also leaked the mock into whatever ran next,
+// so it is installed and torn down here instead.
 beforeEach(() => {
   localStorage.clear();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(mockAgents) }),
+  );
 });
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Wait until the mount fetch has resolved and defaulted the PA.
+ *
+ * The selector exists on the first render, so waiting for it proves nothing:
+ * the journal and task controls are `disabled={!pa}`, and fireEvent on a
+ * disabled control silently does nothing. Waiting for the PA to actually be
+ * set is what makes those tests deterministic rather than timing-dependent.
+ */
+async function waitForPa() {
+  const select = await screen.findByLabelText(PA_LABEL);
+  await waitFor(() => expect((select as HTMLSelectElement).value).toBe("hermes"));
+  return select;
+}
 
 describe("AssistantStudioApp", () => {
   it("renders all 7 rail sections", () => {
@@ -69,26 +97,33 @@ describe("AssistantStudioApp", () => {
 
   it("the PA selector renders with an accessible label", async () => {
     render(<AssistantStudioApp windowId="win-1" />);
-    await waitFor(() => {
-      expect(
-        screen.getByLabelText("Select the agent to act as your personal assistant")
-      ).toBeInTheDocument();
-    });
+    expect(await screen.findByLabelText(PA_LABEL)).toBeInTheDocument();
+  });
+
+  it("defaults the PA to hermes once the agent list loads", async () => {
+    render(<AssistantStudioApp windowId="win-1" />);
+    const select = await waitForPa();
+    expect((select as HTMLSelectElement).value).toBe("hermes");
   });
 
   it("adding a journal entry shows the text in the list", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(mockAgents) }));
     render(<AssistantStudioApp windowId="win-1" />);
-    await waitFor(() => {
-      expect(screen.getByLabelText("Select the agent to act as your personal assistant")).toBeInTheDocument();
-    });
+    await waitForPa();
     fireEvent.click(screen.getByRole("button", { name: "Journal" }));
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Journal" })).toBeInTheDocument();
     });
-    const textarea = screen.getByLabelText("New journal entry");
+
+    // Assert the controls are live before driving them. Without this the test
+    // can pass on a disabled textarea by accident and stops testing anything.
+    const textarea = screen.getByLabelText("New journal entry") as HTMLTextAreaElement;
+    expect(textarea).not.toBeDisabled();
+
     fireEvent.change(textarea, { target: { value: "Test journal entry text" } });
-    fireEvent.click(screen.getByRole("button", { name: "Add entry" }));
+    const addButton = screen.getByRole("button", { name: "Add entry" });
+    expect(addButton).not.toBeDisabled();
+    fireEvent.click(addButton);
+
     await waitFor(() => {
       expect(screen.getByText("Test journal entry text")).toBeInTheDocument();
     });

--- a/desktop/src/apps/AssistantStudioApp.test.tsx
+++ b/desktop/src/apps/AssistantStudioApp.test.tsx
@@ -1,75 +1,96 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import React from "react";
 import { AssistantStudioApp } from "./AssistantStudioApp";
 
+const mockAgents = [{ name: "hermes" }, { name: "other" }];
+
+vi.mock("lucide-react", () => ({
+  LayoutDashboard: () => <span />,
+  NotebookPen: () => <span />,
+  CalendarDays: () => <span />,
+  ListTodo: () => <span />,
+  MessagesSquare: () => <span />,
+  PenTool: () => <span />,
+  FolderKanban: () => <span />,
+  UserRound: () => <span />,
+  Plus: () => <span />,
+  Check: () => <span />,
+  Trash2: () => <span />,
+  ExternalLink: () => <span />,
+}));
+
+vi.mock("@/components/ui", () => ({
+  Button: ({
+    children,
+    onClick,
+    "aria-label": ariaLabel,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    "aria-label"?: string;
+  }) => (
+    <button onClick={onClick} aria-label={ariaLabel}>
+      {children}
+    </button>
+  ),
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe("AssistantStudioApp", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      ok: true,
-      json: async () => [{ name: "hermes" }, { name: "other" }],
+  it("renders all 7 rail sections", () => {
+    render(<AssistantStudioApp windowId="win-1" />);
+    expect(screen.getByRole("button", { name: "Overview" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Journal" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Calendar" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Tasks" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Comms" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Canvas" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Deliverables" })).toBeInTheDocument();
+  });
+
+  it("clicking a rail button switches the visible panel", async () => {
+    render(<AssistantStudioApp windowId="win-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Journal" }));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Journal" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Calendar" }));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Calendar and time" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Tasks" }));
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Tasks" })).toBeInTheDocument();
     });
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it("the PA selector renders with an accessible label", async () => {
+    render(<AssistantStudioApp windowId="win-1" />);
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Select the agent to act as your personal assistant")
+      ).toBeInTheDocument();
+    });
   });
 
-  it("renders all 7 rail sections", async () => {
+  it("adding a journal entry shows the text in the list", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(mockAgents) }));
     render(<AssistantStudioApp windowId="win-1" />);
-    // Drain the mount-time /api/agents fetch so its setState lands inside act().
-    await waitFor(() =>
-      expect(screen.queryByText("Loading agents...")).not.toBeInTheDocument(),
-    );
-    const nav = document.querySelector("nav[aria-label='Assistant Studio sections']");
-    expect(nav).toBeInTheDocument();
-    const railLabels = [
-      "Overview",
-      "Journal",
-      "Calendar",
-      "Tasks",
-      "Comms",
-      "Canvas",
-      "Deliverables",
-    ];
-    for (const label of railLabels) {
-      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
-    }
-  });
-
-  it("switches visible panel when a rail button is clicked", async () => {
-    render(<AssistantStudioApp windowId="win-1" />);
-    // Drain the mount-time /api/agents fetch so its setState lands inside act().
-    await waitFor(() =>
-      expect(screen.queryByText("Loading agents...")).not.toBeInTheDocument(),
-    );
+    await waitFor(() => {
+      expect(screen.getByLabelText("Select the agent to act as your personal assistant")).toBeInTheDocument();
+    });
     fireEvent.click(screen.getByRole("button", { name: "Journal" }));
-    expect(screen.getByRole("heading", { name: "Journal" })).toBeInTheDocument();
-  });
-
-  it("renders PA selector with accessible label", async () => {
-    render(<AssistantStudioApp windowId="win-1" />);
-    const paSelect = screen.getByLabelText(
-      "Select the agent to act as your personal assistant",
-    );
-    expect(paSelect).toBeInTheDocument();
-    await waitFor(() => expect(paSelect.value).toBe("hermes"));
-  });
-
-  it("adds a journal entry", async () => {
-    render(<AssistantStudioApp windowId="win-1" />);
-    const paSelect = screen.getByLabelText(
-      "Select the agent to act as your personal assistant",
-    );
-    await waitFor(() => expect(paSelect.value).toBe("hermes"));
-
-    fireEvent.click(screen.getByRole("button", { name: "Journal" }));
-    expect(screen.getByRole("heading", { name: "Journal" })).toBeInTheDocument();
-
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Journal" })).toBeInTheDocument();
+    });
     const textarea = screen.getByLabelText("New journal entry");
-    fireEvent.change(textarea, { target: { value: "hello journal" } });
+    fireEvent.change(textarea, { target: { value: "Test journal entry text" } });
     fireEvent.click(screen.getByRole("button", { name: "Add entry" }));
-    expect(screen.getByText("hello journal")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Test journal entry text")).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Autonomous build of board card tsk-hr4zwz.



Files:
 desktop/src/apps/AssistantStudioApp.test.tsx | 131 ++++++++++++++++-----------
 1 file changed, 76 insertions(+), 55 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Assistant Studio tests to improve reliability and isolate UI behavior.
  * Added coverage for switching between Journal, Calendar, and Tasks panels.
  * Verified the journal entry workflow, including adding and displaying new entries.
  * Simplified checks for navigation buttons and the personal assistant selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->