### PR TITLE
feat(feedback): add per-user 24h submission cap

### DIFF
--- a/tests/test_feedback_route.py
+++ b/tests/test_feedback_route.py
@@ -199,3 +199,50 @@ async def test_post_feedback_rate_limit_per_user(client, app):
             json={"type": "feature", "title": "User2 feature", "body": ""},
         )
         assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_concurrent_submissions_cannot_exceed_the_cap(client):
+    """The cap must hold when requests race, not just when they arrive in order.
+
+    Counting and inserting as two separate calls passes every sequential test
+    and still lets N concurrent requests all read the same count, all see room,
+    and all insert. A user with several tabs open hits this without trying.
+    """
+    import asyncio
+
+    # One slot left, then fire more requests at it than can possibly fit.
+    for i in range(MAX_FEEDBACK_PER_USER_PER_DAY - 1):
+        resp = await client.post(
+            "/api/feedback", json={"type": "bug", "title": f"Bug {i}", "body": ""}
+        )
+        assert resp.status_code == 201
+
+    results = await asyncio.gather(*[
+        client.post("/api/feedback", json={"type": "bug", "title": f"Race {i}", "body": ""})
+        for i in range(8)
+    ])
+    created = [r for r in results if r.status_code == 201]
+    limited = [r for r in results if r.status_code == 429]
+
+    assert len(created) == 1, "exactly one racer may take the last slot"
+    assert len(limited) == 7
+    assert len(created) + len(limited) == 8, "every request got a definite answer"
+
+
+@pytest.mark.asyncio
+async def test_rejected_submission_is_not_persisted(client):
+    """A 429 must leave no row behind, or the cap tightens on every retry."""
+    for i in range(MAX_FEEDBACK_PER_USER_PER_DAY):
+        assert (await client.post(
+            "/api/feedback", json={"type": "bug", "title": f"Bug {i}", "body": ""}
+        )).status_code == 201
+
+    assert (await client.post(
+        "/api/feedback", json={"type": "bug", "title": "Rejected", "body": ""}
+    )).status_code == 429
+
+    listed = (await client.get("/api/feedback")).json()
+    items = listed["items"] if isinstance(listed, dict) else listed
+    assert len(items) == MAX_FEEDBACK_PER_USER_PER_DAY
+    assert not any(i["title"] == "Rejected" for i in items)

--- a/tests/test_feedback_route.py
+++ b/tests/test_feedback_route.py
@@ -1,10 +1,12 @@
 """Tests for POST/GET /api/feedback endpoints."""
 from __future__ import annotations
 
+from httpx import ASGITransport, AsyncClient
+
 import pytest
 import pytest_asyncio
 
-from tinyagentos.feedback_store import FeedbackStore, MAX_SCREENSHOT_LEN
+from tinyagentos.feedback_store import FeedbackStore, MAX_FEEDBACK_PER_USER_PER_DAY, MAX_SCREENSHOT_LEN
 
 
 # ---------------------------------------------------------------------------
@@ -153,3 +155,47 @@ async def test_oversized_screenshot_rejected(client):
 async def test_get_unknown_id_returns_404(client):
     resp = await client.get("/api/feedback/does-not-exist")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_post_feedback_rate_limit_exceeded(client):
+    for i in range(MAX_FEEDBACK_PER_USER_PER_DAY):
+        resp = await client.post(
+            "/api/feedback",
+            json={"type": "bug", "title": f"Bug {i}", "body": ""},
+        )
+        assert resp.status_code == 201
+    resp = await client.post(
+        "/api/feedback",
+        json={"type": "bug", "title": "Over limit", "body": ""},
+    )
+    assert resp.status_code == 429
+    assert "Too many" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_post_feedback_rate_limit_per_user(client, app):
+    for i in range(MAX_FEEDBACK_PER_USER_PER_DAY):
+        resp = await client.post(
+            "/api/feedback",
+            json={"type": "bug", "title": f"Admin bug {i}", "body": ""},
+        )
+        assert resp.status_code == 201
+
+    invite_code = app.state.auth.add_user_invite("user2", "admin")
+    app.state.auth.complete_invite("user2", invite_code, "User Two", "", "password")
+    record = app.state.auth.find_user("user2")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        cookies={"taos_session": token},
+    ) as user2_client:
+        resp = await user2_client.post(
+            "/api/feedback",
+            json={"type": "feature", "title": "User2 feature", "body": ""},
+        )
+        assert resp.status_code == 201

--- a/tinyagentos/feedback_store.py
+++ b/tinyagentos/feedback_store.py
@@ -66,16 +66,6 @@ class FeedbackStore(BaseStore):
             "created_at": created_at,
         }
 
-    async def count_recent(self, user_id: str, since: str) -> int:
-        """Return the number of submissions by user_id created since the given ISO timestamp."""
-        assert self._db is not None
-        cursor = await self._db.execute(
-            "SELECT COUNT(*) FROM feedback WHERE user_id = ? AND created_at >= ?",
-            (user_id, since),
-        )
-        row = await cursor.fetchone()
-        return row[0] if row else 0
-
     async def create_within_cap(
         self,
         *,

--- a/tinyagentos/feedback_store.py
+++ b/tinyagentos/feedback_store.py
@@ -76,6 +76,64 @@ class FeedbackStore(BaseStore):
         row = await cursor.fetchone()
         return row[0] if row else 0
 
+    async def create_within_cap(
+        self,
+        *,
+        user_id: str,
+        type: str,
+        title: str,
+        body: str,
+        screenshot: str = "",
+        app: str = "",
+        since: str,
+        cap: int,
+    ) -> dict | None:
+        """Insert only if the user is under `cap` submissions since `since`.
+
+        Returns the created row, or None if the cap was already reached.
+
+        Counting and inserting as two calls looks correct and is not: two
+        concurrent requests both read the same count, both see room, and both
+        insert, so the cap is exceeded by however many requests raced. A user
+        with several tabs open hits this without trying, and a scripted client
+        defeats the limit entirely.
+
+        One INSERT ... SELECT ... WHERE (SELECT COUNT(*) ...) < ? evaluates the
+        count and performs the write inside a single statement, so SQLite's
+        write lock makes the check-and-insert indivisible. rowcount tells us
+        which way it went.
+        """
+        assert self._db is not None
+        item_id = str(uuid.uuid4())
+        created_at = datetime.now(timezone.utc).isoformat()
+        cursor = await self._db.execute(
+            """
+            INSERT INTO feedback (id, user_id, type, title, body, screenshot, app, created_at)
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?
+            WHERE (
+                SELECT COUNT(*) FROM feedback WHERE user_id = ? AND created_at >= ?
+            ) < ?
+            """,
+            (
+                item_id, user_id, type, title, body, screenshot, app, created_at,
+                user_id, since, cap,
+            ),
+        )
+        if not cursor.rowcount:
+            await self._db.rollback()
+            return None
+        await self._db.commit()
+        return {
+            "id": item_id,
+            "user_id": user_id,
+            "type": type,
+            "title": title,
+            "body": body,
+            "screenshot": screenshot,
+            "app": app,
+            "created_at": created_at,
+        }
+
     async def list_for_user(self, user_id: str) -> list[dict]:
         """Return all submissions for a user, most recent first, without screenshot blobs."""
         assert self._db is not None

--- a/tinyagentos/feedback_store.py
+++ b/tinyagentos/feedback_store.py
@@ -14,6 +14,9 @@ MAX_SCREENSHOT_LEN = 4_000_000
 # Maximum body text length.
 MAX_BODY_LEN = 20_000
 
+# Maximum feedback submissions per user in a 24-hour window.
+MAX_FEEDBACK_PER_USER_PER_DAY = 20
+
 
 class FeedbackStore(BaseStore):
     SCHEMA = """
@@ -62,6 +65,16 @@ class FeedbackStore(BaseStore):
             "app": app,
             "created_at": created_at,
         }
+
+    async def count_recent(self, user_id: str, since: str) -> int:
+        """Return the number of submissions by user_id created since the given ISO timestamp."""
+        assert self._db is not None
+        cursor = await self._db.execute(
+            "SELECT COUNT(*) FROM feedback WHERE user_id = ? AND created_at >= ?",
+            (user_id, since),
+        )
+        row = await cursor.fetchone()
+        return row[0] if row else 0
 
     async def list_for_user(self, user_id: str) -> list[dict]:
         """Return all submissions for a user, most recent first, without screenshot blobs."""

--- a/tinyagentos/routes/feedback.py
+++ b/tinyagentos/routes/feedback.py
@@ -6,13 +6,14 @@ GET  /api/feedback/{id} -- fetch a single submission including its screenshot
 """
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, field_validator
 
 from tinyagentos.auth import get_current_user
-from tinyagentos.feedback_store import MAX_BODY_LEN, MAX_SCREENSHOT_LEN
+from tinyagentos.feedback_store import MAX_BODY_LEN, MAX_FEEDBACK_PER_USER_PER_DAY, MAX_SCREENSHOT_LEN
 
 router = APIRouter()
 
@@ -68,6 +69,16 @@ async def submit_feedback(
 ) -> dict:
     """Create a new feedback submission for the authenticated user."""
     store = request.app.state.feedback_store
+    since = datetime.now(timezone.utc) - timedelta(days=1)
+    recent_count = await store.count_recent(current_user["id"], since.isoformat())
+    if recent_count >= MAX_FEEDBACK_PER_USER_PER_DAY:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"Too many feedback submissions. "
+                f"Maximum {MAX_FEEDBACK_PER_USER_PER_DAY} per 24 hours."
+            ),
+        )
     item = await store.create(
         user_id=current_user["id"],
         type=payload.type,

--- a/tinyagentos/routes/feedback.py
+++ b/tinyagentos/routes/feedback.py
@@ -70,16 +70,12 @@ async def submit_feedback(
     """Create a new feedback submission for the authenticated user."""
     store = request.app.state.feedback_store
     since = datetime.now(timezone.utc) - timedelta(days=1)
-    recent_count = await store.count_recent(current_user["id"], since.isoformat())
-    if recent_count >= MAX_FEEDBACK_PER_USER_PER_DAY:
-        raise HTTPException(
-            status_code=429,
-            detail=(
-                f"Too many feedback submissions. "
-                f"Maximum {MAX_FEEDBACK_PER_USER_PER_DAY} per 24 hours."
-            ),
-        )
-    item = await store.create(
+    # Cap enforcement lives in the store as one statement. Counting here and
+    # inserting after would let concurrent requests all read the same count and
+    # all insert, which a user with several tabs open trips without trying.
+    item = await store.create_within_cap(
+        since=since.isoformat(),
+        cap=MAX_FEEDBACK_PER_USER_PER_DAY,
         user_id=current_user["id"],
         type=payload.type,
         title=payload.title,
@@ -87,6 +83,14 @@ async def submit_feedback(
         screenshot=payload.screenshot,
         app=payload.app,
     )
+    if item is None:
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                f"Too many feedback submissions. "
+                f"Maximum {MAX_FEEDBACK_PER_USER_PER_DAY} per 24 hours."
+            ),
+        )
     # Return without the screenshot blob to keep the response light.
     return {
         "id": item["id"],


### PR DESCRIPTION
Autonomous build of board card tsk-tlkemm.



Files:
 tests/test_feedback_route.py   | 48 +++++++++++++++++++++++++++++++++++++++++-
 tinyagentos/feedback_store.py  | 13 ++++++++++++
 tinyagentos/routes/feedback.py | 13 +++++++++++-
 3 files changed, 72 insertions(+), 2 deletions(-)