### PR TITLE
fix(canvas): make the .tldr export a file tldraw can actually open

### DIFF
--- a/tests/projects/test_canvas_integration.py
+++ b/tests/projects/test_canvas_integration.py
@@ -133,7 +133,8 @@ async def test_post_then_snapshot_then_sse(app_env):
         await asyncio.sleep(0.05)
     assert target.exists(), f"snapshot not written to {target}"
     body = json.loads(target.read_text())
-    assert any(k.startswith("shape:") for k in body["store"].keys())
+    # Shapes live in the records array, not a store dict keyed by id.
+    assert any(r["typeName"] == "shape" for r in body["records"])
 
 
 @pytest.mark.asyncio

--- a/tests/projects/test_canvas_snapshotter.py
+++ b/tests/projects/test_canvas_snapshotter.py
@@ -49,9 +49,12 @@ async def test_add_element_writes_tldr_within_debounce(env):
         await asyncio.sleep(0.05)
     assert target.exists()
     body = json.loads(target.read_text())
-    assert "store" in body
-    shape_keys = [k for k in body["store"].keys() if k.startswith("shape:")]
-    assert len(shape_keys) == 1
+    # A .tldr file is {tldrawFileFormatVersion, schema, records[]}. The old
+    # {schema, store{}} shape asserted here was an in-memory store snapshot,
+    # which tldraw rejects outright as notATldrawFile.
+    assert body["tldrawFileFormatVersion"] == 1
+    shapes = [r for r in body["records"] if r["typeName"] == "shape"]
+    assert len(shapes) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_canvas_tldr_export.py
+++ b/tests/test_canvas_tldr_export.py
@@ -1,0 +1,159 @@
+"""The .tldr export is a data-recovery escape hatch, so it must open in a STOCK
+tldraw -- one that has never heard of taOS.
+
+Nothing pinned that before, and the export had silently drifted into a file
+tldraw refuses to open at all: it emitted the in-memory {schema, store{}} store
+snapshot instead of the {tldrawFileFormatVersion, schema, records[]} file
+envelope tldraw's parseTldrawJsonFile validates, and typed most shapes as our
+own taos-note/taos-link/taos-image utils, which no stock tldraw can render.
+
+These assertions encode the two properties that failure violated. They are
+structural on purpose: the real parser lives in the npm package we are removing
+(#2132), so a test that imported tldraw would die with the dependency, exactly
+when this guarantee starts mattering most.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tinyagentos.projects.canvas.snapshotter import (
+    _TLDRAW_FILE_FORMAT_VERSION,
+    _build_tldraw_snapshot,
+    _index_key,
+)
+
+# Every kind the canvas can hold, plus one it cannot, since an unknown kind must
+# still export rather than raise mid-recovery.
+ALL_KINDS = [
+    "note",
+    "text",
+    "link",
+    "image",
+    "mermaid",
+    "flowchart",
+    "user_shape",
+    "kind_from_a_future_version",
+]
+
+
+def _element(id_: str, kind: str, **over):
+    el = {
+        "id": id_,
+        "kind": kind,
+        "x": 10.0,
+        "y": 20.0,
+        "w": 200.0,
+        "h": 100.0,
+        "rotation": 0.0,
+        "z_index": 0,
+        "payload": {"text": f"content of {id_}"},
+        "author_id": "jay",
+        "author_kind": "user",
+    }
+    el.update(over)
+    return el
+
+
+def test_export_uses_the_file_envelope_not_a_store_snapshot():
+    """tldraw rejects anything without these three keys as notATldrawFile."""
+    snap = _build_tldraw_snapshot([_element("a", "note")])
+
+    assert snap["tldrawFileFormatVersion"] == _TLDRAW_FILE_FORMAT_VERSION
+    assert isinstance(snap["records"], list)
+    # The old bug: a "store" dict instead of a "records" list.
+    assert "store" not in snap
+
+    # schemaV2 validation requires a sequences dict; without it the file is
+    # refused even though the envelope looks right.
+    assert snap["schema"]["schemaVersion"] == 2
+    assert isinstance(snap["schema"]["sequences"], dict)
+    assert snap["schema"]["sequences"]
+
+
+@pytest.mark.parametrize("kind", ALL_KINDS)
+def test_no_taos_shape_types_reach_the_export(kind):
+    """A stock tldraw has no util for taos-*, so exporting one loses the shape."""
+    snap = _build_tldraw_snapshot([_element("a", kind)])
+    shapes = [r for r in snap["records"] if r["typeName"] == "shape"]
+
+    assert len(shapes) == 1
+    assert not shapes[0]["type"].startswith("taos")
+    assert shapes[0]["type"] in {"note", "text", "geo"}
+
+
+def test_taos_metadata_rides_in_meta_not_props():
+    """tldraw validates props per shape type and rejects unknown keys.
+
+    Provenance therefore has to live in meta, which tldraw carries through
+    untouched. Putting it in props is what made every geo shape invalid.
+    """
+    snap = _build_tldraw_snapshot([_element("a", "mermaid")])
+    shape = next(r for r in snap["records"] if r["typeName"] == "shape")
+
+    assert shape["meta"]["taos_kind"] == "mermaid"
+    assert not any(k.startswith("taos_") for k in shape["props"])
+
+
+def test_every_element_survives_the_export():
+    """The load-bearing rule: a board of N must not come back emptier."""
+    elements = [_element(f"e{i}", ALL_KINDS[i % len(ALL_KINDS)]) for i in range(40)]
+    snap = _build_tldraw_snapshot(elements)
+
+    shapes = [r for r in snap["records"] if r["typeName"] == "shape"]
+    assert len(shapes) == len(elements)
+    assert {s["id"] for s in shapes} == {f"shape:e{i}" for i in range(40)}
+
+
+def test_a_corrupt_tldraw_blob_cannot_reject_the_whole_file():
+    """One bad record makes tldraw refuse the ENTIRE file (invalidRecords).
+
+    So user_shape payloads are converted like everything else rather than passed
+    through. Passing through would risk costing the user their whole board in
+    the one file whose only job is recovery.
+    """
+    corrupt = _element(
+        "u", "user_shape", payload={"tldraw_shape": {"type": "draw", "props": {"nonsense": 1}}}
+    )
+    shape = next(
+        r for r in _build_tldraw_snapshot([corrupt])["records"] if r["typeName"] == "shape"
+    )
+
+    assert shape["type"] == "geo"
+    assert "nonsense" not in shape["props"]
+
+
+def test_elements_with_missing_fields_still_export():
+    """A recovery path must not raise on the ragged rows it exists to rescue."""
+    bare = _element(
+        "bare", "note", payload=None, author_id=None, author_kind=None,
+        z_index=None, w=0.0, h=0.0, rotation=None,
+    )
+    shapes = [r for r in _build_tldraw_snapshot([bare])["records"] if r["typeName"] == "shape"]
+
+    assert len(shapes) == 1
+    assert shapes[0]["rotation"] == 0
+
+
+def test_index_keys_are_valid_and_ascending_past_the_first_62():
+    """tldraw validates index keys, so "a10" is rejected (a fraction may not end
+    in 0). Keys must also sort in z-order, which naive counters break at 62."""
+    keys = [_index_key(i) for i in range(200)]
+
+    assert keys == sorted(keys), "index keys must sort into the intended z-order"
+    assert len(set(keys)) == len(keys)
+    assert keys[:3] == ["a0", "a1", "a2"]
+    # The rollover that a naive "a" + str(i) scheme gets wrong.
+    assert keys[61] == "az"
+    assert keys[62] == "b00"
+
+
+def test_z_index_drives_export_order():
+    elements = [
+        _element("top", "note", z_index=5),
+        _element("bottom", "note", z_index=1),
+    ]
+    shapes = [
+        r for r in _build_tldraw_snapshot(elements)["records"] if r["typeName"] == "shape"
+    ]
+
+    assert [s["id"] for s in shapes] == ["shape:bottom", "shape:top"]

--- a/tests/test_canvas_tldr_export.py
+++ b/tests/test_canvas_tldr_export.py
@@ -157,3 +157,61 @@ def test_z_index_drives_export_order():
     ]
 
     assert [s["id"] for s in shapes] == ["shape:bottom", "shape:top"]
+
+
+# A recovery export runs precisely on boards whose rows are already damaged, so
+# every read has to survive garbage. Both CodeRabbit and Qodo caught that the
+# original raised on a non-dict payload: one bad row aborted the export for the
+# entire project, losing everything the user was trying to rescue.
+HOSTILE_ROWS = [
+    {"id": "list-payload", "kind": "note", "payload": ["not", "a", "dict"]},
+    {"id": "str-payload", "kind": "note", "payload": "bare string"},
+    {"id": "int-payload", "kind": "note", "payload": 42},
+    {"id": "no-kind"},
+    {"kind": "text"},  # no id
+    {"id": "bad-types", "kind": "note", "x": "oops", "y": None,
+     "w": True, "h": [], "rotation": "x", "payload": {}},
+]
+
+
+def test_export_survives_every_malformed_row():
+    snap = _build_tldraw_snapshot(HOSTILE_ROWS)
+    shapes = [r for r in snap["records"] if r["typeName"] == "shape"]
+
+    assert len(shapes) == len(HOSTILE_ROWS), "a damaged row must degrade, not vanish"
+    for s in shapes:
+        assert isinstance(s["x"], float)
+        assert isinstance(s["y"], float)
+        assert isinstance(s["rotation"], float)
+        assert not s["type"].startswith("taos")
+
+
+def test_non_dict_payload_does_not_raise():
+    """The specific crash both bots found: payload.get on a non-mapping."""
+    for payload in (["a"], "text", 42, 3.5, True):
+        row = {"id": "x", "kind": "note", "payload": payload}
+        shapes = [
+            r for r in _build_tldraw_snapshot([row])["records"]
+            if r["typeName"] == "shape"
+        ]
+        assert len(shapes) == 1
+
+
+def test_a_string_payload_is_used_as_the_label():
+    """If the payload is just text, that text is the most useful thing to show."""
+    row = {"id": "x", "kind": "note", "payload": "recover me"}
+    shape = next(
+        r for r in _build_tldraw_snapshot([row])["records"] if r["typeName"] == "shape"
+    )
+    text = shape["props"]["richText"]["content"][0]["content"][0]["text"]
+    assert text == "recover me"
+
+
+def test_bool_dimensions_do_not_pass_as_numbers():
+    """bool is an int subclass, so True would silently become a width of 1.0."""
+    from tinyagentos.projects.canvas.snapshotter import _num_or
+
+    assert _num_or(True, 200.0) == 200.0
+    assert _num_or(False, 200.0) == 200.0
+    assert _num_or(7, 200.0) == 7.0
+    assert _num_or("x", 200.0) == 200.0

--- a/tinyagentos/projects/canvas/snapshotter.py
+++ b/tinyagentos/projects/canvas/snapshotter.py
@@ -17,7 +17,48 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 _STOP_DRAIN_TIMEOUT = 2.0
-_TLDRAW_SCHEMA_VERSION = 1
+
+# .tldr export format. Kept as plain data so this module stays pure Python and
+# survives removing the tldraw npm package (see #2132) -- the export is exactly
+# the escape hatch users need AFTER we stop shipping tldraw, so it must not
+# depend on it.
+#
+# Captured from tldraw 4.5.12 via createTLSchema().serialize(). tldraw migrates
+# older schemas forward on open, so this staying fixed is fine; refresh it only
+# if an export stops opening in a current tldraw.
+_TLDRAW_FILE_FORMAT_VERSION = 1
+_TLDRAW_SERIALIZED_SCHEMA = {
+    "schemaVersion": 2,
+    "sequences": {
+        "com.tldraw.store": 5,
+        "com.tldraw.asset": 1,
+        "com.tldraw.camera": 1,
+        "com.tldraw.document": 2,
+        "com.tldraw.instance": 26,
+        "com.tldraw.instance_page_state": 5,
+        "com.tldraw.page": 1,
+        "com.tldraw.instance_presence": 6,
+        "com.tldraw.pointer": 1,
+        "com.tldraw.shape": 4,
+        "com.tldraw.asset.bookmark": 2,
+        "com.tldraw.asset.image": 6,
+        "com.tldraw.asset.video": 5,
+        "com.tldraw.shape.arrow": 8,
+        "com.tldraw.shape.bookmark": 2,
+        "com.tldraw.shape.draw": 4,
+        "com.tldraw.shape.embed": 4,
+        "com.tldraw.shape.frame": 1,
+        "com.tldraw.shape.geo": 11,
+        "com.tldraw.shape.group": 0,
+        "com.tldraw.shape.highlight": 3,
+        "com.tldraw.shape.image": 5,
+        "com.tldraw.shape.line": 5,
+        "com.tldraw.shape.note": 10,
+        "com.tldraw.shape.text": 4,
+        "com.tldraw.shape.video": 4,
+        "com.tldraw.binding.arrow": 1,
+    },
+}
 
 
 class CanvasSnapshotter:
@@ -172,52 +213,196 @@ class CanvasSnapshotter:
 
 
 def _build_tldraw_snapshot(elements: list[dict]) -> dict:
-    store: dict[str, dict] = {
-        "document:document": {
+    """Build a genuine .tldr file for export to someone else's tldraw.
+
+    This is a data-recovery escape hatch, so it must open in a STOCK tldraw --
+    one that has never heard of taOS. Two rules follow from that, and both were
+    violated by the earlier version of this function:
+
+    1. The envelope is a *file*, not a store snapshot. tldraw's
+       parseTldrawJsonFile validates {tldrawFileFormatVersion, schema, records[]}
+       and rejects anything else as "notATldrawFile". Emitting the in-memory
+       {schema, store{}} shape produced a file tldraw refused to open at all.
+    2. Only NATIVE shape types. taos-note/taos-link/taos-image are our own shape
+       utils; a stock tldraw has no util for them and cannot render or validate
+       them. They were the majority of every real board.
+
+    Lossy by nature: this translates into a foreign format we do not control.
+    The lossless copy is the canonical element JSON exported alongside it.
+    """
+    records: list[dict] = [
+        {
             "id": "document:document",
             "typeName": "document",
+            "gridSize": 10,
             "name": "",
+            "meta": {},
         },
-        "page:page": {
+        {
             "id": "page:page",
             "typeName": "page",
             "name": "Page 1",
             "index": "a1",
+            "meta": {},
+        },
+    ]
+
+    # Preserve z-order in the export: tldraw sorts by index, we sort by z_index.
+    ordered = sorted(elements, key=lambda e: (e.get("z_index") or 0))
+    for i, el in enumerate(ordered):
+        records.append(_tldraw_shape_record(el, _index_key(i)))
+
+    return {
+        "tldrawFileFormatVersion": _TLDRAW_FILE_FORMAT_VERSION,
+        "schema": _TLDRAW_SERIALIZED_SCHEMA,
+        "records": records,
+    }
+
+
+def _tldraw_shape_record(el: dict, index: str) -> dict:
+    """One canvas element as a native tldraw shape record."""
+    # Deliberately NOT passing through a user_shape's literal tldraw_shape blob,
+    # even though it would be the highest-fidelity translation available.
+    #
+    # tldraw validates every record on open and a single failure rejects the
+    # WHOLE file with invalidRecords -- so one stale blob would cost the user
+    # their entire board, in the one file whose only job is disaster recovery.
+    # That risk is not hypothetical here: we declare a fixed schema constant, so
+    # tldraw sees records already claiming the current version and runs no
+    # migration on a blob actually written by an older tldraw.
+    #
+    # So this file optimises for "always opens" and the canonical JSON export
+    # keeps the lossless copy. Splitting the two jobs is what makes each reliable;
+    # asking one file to be both is how you get neither. The raw blob also stays
+    # in the DB payload untouched (#2132's append-only rule).
+    base = {
+        "id": f"shape:{el['id']}",
+        "typeName": "shape",
+        "x": el["x"],
+        "y": el["y"],
+        "rotation": el["rotation"] or 0,
+        "index": index,
+        "parentId": "page:page",
+        "isLocked": False,
+        "opacity": 1,
+        # taOS provenance rides in meta, which tldraw carries through untouched.
+        # It must not go in props: tldraw validates props per shape type and
+        # rejects unknown keys.
+        "meta": {
+            "taos_kind": el["kind"],
+            "taos_author_id": el.get("author_id"),
+            "taos_author_kind": el.get("author_kind"),
         },
     }
-    for el in elements:
-        store[f"shape:{el['id']}"] = {
-            "id": f"shape:{el['id']}",
-            "typeName": "shape",
-            "type": _tldraw_shape_type(el["kind"]),
-            "x": el["x"],
-            "y": el["y"],
-            "rotation": el["rotation"],
-            "index": "a1",
-            "parentId": "page:page",
-            "isLocked": False,
-            "opacity": 1,
-            "props": {
-                "w": el["w"],
-                "h": el["h"],
-                "taos_kind": el["kind"],
-                "taos_payload": el["payload"],
-                "taos_author_id": el["author_id"],
-                "taos_author_kind": el["author_kind"],
-            },
-            "meta": {},
-        }
+
+    kind = el["kind"]
+    if kind == "note":
+        base["type"] = "note"
+        base["props"] = _note_props(_element_text(el))
+    elif kind == "text":
+        base["type"] = "text"
+        base["props"] = _text_props(_element_text(el), el["w"])
+    else:
+        # Everything else (link, image, mermaid, flowchart, unknown kinds) becomes
+        # a labelled rectangle. It is not the original rendering, but it is
+        # visible and carries the content as text, which beats vanishing.
+        base["type"] = "geo"
+        base["props"] = _geo_props(_element_text(el), el["w"], el["h"])
+    return base
+
+
+def _element_text(el: dict) -> str:
+    """Best-effort human-readable content for an element, for the export label."""
+    payload = el.get("payload") or {}
+    for key in ("text", "title", "label", "source", "url", "caption"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return el["kind"]
+
+
+def _rich_text(text: str) -> dict:
+    """tldraw 4.x stores labels as TipTap rich text, not a plain string."""
     return {
-        "schema": {"schemaVersion": 2, "storeVersion": _TLDRAW_SCHEMA_VERSION},
-        "store": store,
+        "type": "doc",
+        "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": text}]}
+        ],
     }
 
 
-def _tldraw_shape_type(kind: str) -> str:
-    if kind == "note":
-        return "taos-note"
-    if kind == "link":
-        return "taos-link"
-    if kind == "image":
-        return "taos-image"
-    return "geo"
+def _note_props(text: str) -> dict:
+    return {
+        "color": "yellow",
+        "labelColor": "black",
+        "size": "m",
+        "font": "draw",
+        "fontSizeAdjustment": 0,
+        "align": "middle",
+        "verticalAlign": "middle",
+        "growY": 0,
+        "url": "",
+        "richText": _rich_text(text),
+        "scale": 1,
+    }
+
+
+def _text_props(text: str, w: float) -> dict:
+    return {
+        "color": "black",
+        "size": "m",
+        "font": "draw",
+        "textAlign": "start",
+        "w": w or 200,
+        "richText": _rich_text(text),
+        "scale": 1,
+        "autoSize": False,
+    }
+
+
+def _geo_props(text: str, w: float, h: float) -> dict:
+    return {
+        "geo": "rectangle",
+        "dash": "draw",
+        "url": "",
+        "w": w or 200,
+        "h": h or 100,
+        "growY": 0,
+        "scale": 1,
+        "labelColor": "black",
+        "color": "black",
+        "fill": "none",
+        "size": "m",
+        "font": "draw",
+        "align": "middle",
+        "verticalAlign": "middle",
+        "richText": _rich_text(text),
+    }
+
+
+# Fractional-index alphabet, matching tldraw's. tldraw validates every index with
+# validateIndexKey, so an arbitrary string like "a10" is rejected (a fraction may
+# not end in "0"). Generating proper integer keys keeps every shape valid however
+# many are on the board -- "a0".."az", then "b00".."bzz", and so on.
+_B62 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+_HEADS = "abcdefghijklmnopqrstuvwxyz"
+
+
+def _index_key(n: int) -> str:
+    """The nth ascending tldraw index key.
+
+    Head "a" means one base62 digit follows, "b" means two, and so on, so the
+    keys stay in ascending lexicographic order as they widen.
+    """
+    for head_ord, head in enumerate(_HEADS):
+        capacity = len(_B62) ** (head_ord + 1)
+        if n < capacity:
+            digits = ""
+            for _ in range(head_ord + 1):
+                digits = _B62[n % len(_B62)] + digits
+                n //= len(_B62)
+            return head + digits
+        n -= capacity
+    # 62 + 62^2 + ... + 62^26 shapes on one board is not reachable in practice;
+    # fall back to the last valid key rather than raise during a data export.
+    return _HEADS[-1] + _B62[-1] * len(_HEADS)

--- a/tinyagentos/projects/canvas/snapshotter.py
+++ b/tinyagentos/projects/canvas/snapshotter.py
@@ -275,12 +275,18 @@ def _tldraw_shape_record(el: dict, index: str) -> dict:
     # keeps the lossless copy. Splitting the two jobs is what makes each reliable;
     # asking one file to be both is how you get neither. The raw blob also stays
     # in the DB payload untouched (#2132's append-only rule).
+    # Read every field defensively. This is the recovery path, so it runs
+    # precisely on the boards whose rows are already ragged, and one raised
+    # KeyError/AttributeError aborts the export for the WHOLE project -- the
+    # user loses everything because one row was odd. Missing or wrong-typed
+    # fields degrade to a placeholder shape instead.
+    kind = _str_or(el.get("kind"), "unknown")
     base = {
-        "id": f"shape:{el['id']}",
+        "id": f"shape:{el.get('id') or 'unknown'}",
         "typeName": "shape",
-        "x": el["x"],
-        "y": el["y"],
-        "rotation": el["rotation"] or 0,
+        "x": _num_or(el.get("x"), 0.0),
+        "y": _num_or(el.get("y"), 0.0),
+        "rotation": _num_or(el.get("rotation"), 0.0),
         "index": index,
         "parentId": "page:page",
         "isLocked": False,
@@ -289,36 +295,60 @@ def _tldraw_shape_record(el: dict, index: str) -> dict:
         # It must not go in props: tldraw validates props per shape type and
         # rejects unknown keys.
         "meta": {
-            "taos_kind": el["kind"],
+            "taos_kind": kind,
             "taos_author_id": el.get("author_id"),
             "taos_author_kind": el.get("author_kind"),
         },
     }
 
-    kind = el["kind"]
+    w = _num_or(el.get("w"), 200.0)
+    h = _num_or(el.get("h"), 100.0)
     if kind == "note":
         base["type"] = "note"
         base["props"] = _note_props(_element_text(el))
     elif kind == "text":
         base["type"] = "text"
-        base["props"] = _text_props(_element_text(el), el["w"])
+        base["props"] = _text_props(_element_text(el), w)
     else:
         # Everything else (link, image, mermaid, flowchart, unknown kinds) becomes
         # a labelled rectangle. It is not the original rendering, but it is
         # visible and carries the content as text, which beats vanishing.
         base["type"] = "geo"
-        base["props"] = _geo_props(_element_text(el), el["w"], el["h"])
+        base["props"] = _geo_props(_element_text(el), w, h)
     return base
 
 
+def _num_or(value, default: float) -> float:
+    """Coerce a stored coordinate to a float, or fall back.
+
+    bool is excluded deliberately: it is an int subclass, so True would sail
+    through as 1.0 and silently place a shape at the wrong coordinate.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    return float(value)
+
+
+def _str_or(value, default: str) -> str:
+    return value if isinstance(value, str) and value else default
+
+
 def _element_text(el: dict) -> str:
-    """Best-effort human-readable content for an element, for the export label."""
-    payload = el.get("payload") or {}
-    for key in ("text", "title", "label", "source", "url", "caption"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value
-    return el["kind"]
+    """Best-effort human-readable content for an element, for the export label.
+
+    payload is whatever JSON was stored, which is not guaranteed to be an
+    object: a list or bare string decodes truthy and would make .get() raise,
+    taking the whole export down over one odd row.
+    """
+    payload = el.get("payload")
+    if isinstance(payload, dict):
+        for key in ("text", "title", "label", "source", "url", "caption"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    elif isinstance(payload, str) and payload.strip():
+        return payload
+    return _str_or(el.get("kind"), "unknown")
 
 
 def _rich_text(text: str) -> dict:

--- a/tinyagentos/routes/project_canvas.py
+++ b/tinyagentos/routes/project_canvas.py
@@ -334,7 +334,13 @@ async def get_canvas_tldr(project_id: str, request: Request):
     path = await snap.export_now(project_id)
     if path is None or not path.exists():
         return JSONResponse({"error": "project not found"}, status_code=404)
-    return FileResponse(path, media_type="application/json")
+    # This is a recovery download, not a page: without the attachment
+    # disposition the browser renders the JSON inline and the user has no file.
+    return FileResponse(
+        path,
+        media_type="application/json",
+        filename=f"{project_id}-canvas.tldr",
+    )
 
 
 @router.patch("/api/projects/{project_id}/canvas/permissions/{agent_id}")


### PR DESCRIPTION
Slice 1 of #2132, and the precondition for everything else in it: users must be able to get their canvas out **before** the renderer changes.

It did not work. Found by checking rather than trusting the issue write-up, which had assumed this came free because the snapshotter is pure Python.

## What was broken

Verified against tldraw 4.5.12 in our own node_modules.

**Wrong container.** We emitted `{schema, store{}}` -- an in-memory store snapshot. A `.tldr` *file* is `{tldrawFileFormatVersion, schema, records[]}`. tldraw's validator requires all three, so `parseTldrawJsonFile` threw and returned `notATldrawFile`. A flat refusal to open, before it ever looked at the content.

**Shapes nobody else can render.** note/link/image were typed `taos-note` / `taos-link` / `taos-image` -- our own shape utils, which only exist inside our `CanvasBoard`. That is 55 of the 64 live elements on the Pi. The remaining `geo` shapes carried `taos_*` keys in `props`, which tldraw rejects as unknown props.

Either fault alone makes the export worthless. Together they meant the recovery path had never worked, and nothing tested it.

## Deliberate call: no raw blob pass-through

A `user_shape` carries the literal `tldraw_shape` it was drawn as, and passing it through would be the highest-fidelity translation available. This does not do that.

A single invalid record makes tldraw reject the **entire file** with `invalidRecords`. One stale blob would cost the user their whole board, in the one file whose only job is disaster recovery. Not hypothetical: we declare a fixed schema constant, so tldraw runs no migration on a blob written by an older version.

So the `.tldr` optimises for **always opens**, and the lossless copy belongs in the canonical JSON export. Splitting the two jobs is what makes each reliable. The raw blob stays untouched in the DB payload regardless.

## Verified on real data

Not just fixtures. All three live Pi boards were exported and loaded into a stock tldraw with every shape intact:

```
prj-5y722y: 22 shapes loaded OK
prj-qigv7w: 25 shapes loaded OK
prj-utbsh7: 17 shapes loaded OK
```

Jay's boards are also backed up off-box (both DB copy and lossless JSON, 80/80 rows verified) before any migration work proceeds.

## Note on the test

Structural rather than a real `parseTldrawJsonFile` call, on purpose: the parser lives in the npm package #2132 removes, so a test importing tldraw would die with the dependency -- exactly when this guarantee starts mattering most. The end-to-end check against the real parser was run manually here and is recorded above.

## Still open in #2132

- Expose the download in the Projects UI. The endpoint exists but nothing in `desktop/src` links to it, so no user can reach it today.
- Export the canonical JSON alongside, as the actual lossless guarantee.
- Then S2 onward (renderer swap).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Canvas recovery downloads now use the filename `{project_id}-canvas.tldr`.
  - Exported `.tldr` files now follow the standard tldraw file format and preserve canvas elements, ordering, metadata, and supported text/note content.

- **Bug Fixes**
  - Improved compatibility with tldraw by normalizing shape types, properties, indexes, and schema data.
  - Corrupt or incomplete canvas elements no longer prevent the full export from completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->