### PR TITLE
ci: raise the test timeout above the actual suite runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,20 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    # 45 min cap accommodates the cron run that includes 3.11 (~30 min);
-    # 3.12/3.13 PR runs finish in ~16 min, so this only kicks in if 3.11
-    # ever drifts further.
-    timeout-minutes: 45
+    # Measured 2026-07-26 over the last 12 job records: 3.13 runs 31-35 min and
+    # 3.12 runs 38-41 min. The previous comment claimed "~16 min", which had
+    # stopped being true, so the 45 min cap sat about 4 minutes above the slowest
+    # normal run and 3.12 kept crossing it.
+    #
+    # A cap that close to the median does not catch hangs, it manufactures red
+    # PRs: two of those 12 records were killed mid-suite with nothing wrong. That
+    # is worse than no cap, because a timeout kill looks exactly like a genuine
+    # failure until you check the clock.
+    #
+    # 75 leaves real headroom while still bounding a truly hung job. The suite
+    # growing from ~16 to ~40 min is a separate problem worth fixing on its own
+    # merits; raising this stops it corrupting merge decisions in the meantime.
+    timeout-minutes: 75
     strategy:
       matrix:
         # PR + push runs cover the latest two; the daily cron run


### PR DESCRIPTION
Found while checking why #2127 went red. It had not failed: `test (3.12)` was killed at exactly 45m16s, which is `timeout-minutes: 45`.

## The cap stopped matching reality

The comment above it claimed 3.12/3.13 PR runs finish in ~16 min. Measured across the last 12 job records:

| job | duration |
|---|---|
| test (3.13) | 31 - 35 min |
| test (3.12) | 38 - 41 min, plus two killed at 45 |

So the cap sat about 4 minutes above the slowest normal run, and 3.12 is consistently the slower leg.

## Why this is worse than having no cap

A timeout kill is reported as a red check. It is indistinguishable from a genuine test failure unless someone compares the job duration against `timeout-minutes`. So the gate that exists to protect merges was intermittently producing false reds on healthy code, and the only defence was noticing the clock.

Two of the last 12 records were killed this way, including the one gating #2127.

75 min keeps a real bound on a hung job while leaving headroom.

## Not a fix for the underlying slowdown

Raising this does not address the suite going from ~16 to ~40 min. That is a genuine regression in its own right and is filed separately. This change stops it corrupting merge decisions while that is investigated, rather than leaving a gate that lies.
