### PR TITLE
ci(coderabbit): stop spending the review quota on generated diffs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -29,4 +29,8 @@ reviews:
     - "!**/package-lock.json"
     - "!**/uv.lock"
     - "!desktop/dist/**"
-    - "!static/**"
+    # Only the BUILT desktop bundle under static/, not all of static/: sw.js and
+    # the PWA manifests there are human-authored runtime behaviour and exactly
+    # the kind of change a reviewer should see (Qodo caught the over-broad
+    # original).
+    - "!static/desktop/**"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,3 +9,24 @@ reviews:
     base_branches:
       - master
       - dev
+    # The plan has a finite review quota, and it was being spent in the wrong
+    # places: repeatedly "review limit reached" on real code PRs while lockfile
+    # bumps consumed reviews. #2127 and #2131 both went unreviewed for this
+    # reason on the day this was written.
+    #
+    # Dependabot PRs are version bumps plus a regenerated lockfile. There is no
+    # human-authored logic for a reviewer to reason about, and CI already gates
+    # them, so they are the cheapest thing to stop spending quota on.
+    ignore_usernames:
+      - dependabot
+      - dependabot[bot]
+    # A draft is explicitly not ready. Reviewing it burns a review that will be
+    # burned again when it is marked ready.
+    drafts: false
+  # Generated artefacts dominate the diff without carrying reviewable intent.
+  # A single spa-deps bump is a 2000+ line package-lock diff.
+  path_filters:
+    - "!**/package-lock.json"
+    - "!**/uv.lock"
+    - "!desktop/dist/**"
+    - "!static/**"


### PR DESCRIPTION
CodeRabbit was already enabled on `master` and `dev`, so the repeated "review limit reached" was never configuration. It is quota, and it was being spent in the wrong places.

On 2026-07-26 both #2127 and #2131 went unreviewed with "review limit reached" while a spa-deps bump carrying a 2180-line `package-lock.json` diff consumed a review.

That is the wrong way round. The PRs that most need a second reader get skipped, and a rate-limited CodeRabbit renders as a green check unless someone opens the comment body to see it never ran.

## Changes

- **Skip dependabot.** A version bump plus a regenerated lockfile has no human-authored logic to reason about, and CI already gates it.
- **Skip drafts.** A draft is explicitly not ready, and it is reviewed again when marked ready, so the first review is paid for twice.
- **Filter generated artefacts** out of the reviewed diff: lockfiles, built desktop output, `static/`.

Net effect is not less review, it is the same quota aimed at human-written code.

## Note

Config keys were checked against the published `schema.v2.json` (`ignore_usernames`, `drafts`, `path_filters` all exist and mean what is assumed here) rather than written from memory.

Related: Gitar's free plan performs no code review at all, so the effective bot gate on most PRs has been Qodo alone. Worth deciding separately.