### PR TITLE
tsk-dk5v6d  [OPEN]  PWA install: exempt manifest + icons from auth mid

### DIFF
--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -9,7 +9,11 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey"}
+# PWA manifest + icons: Chrome fetches these before any auth handshake
+# during install, so they must be reachable without a session cookie.
+# Listed individually (not via the /static/ prefix) so only the PWA
+# install surface is public, not every static asset.
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey", "/static/manifest-desktop.json", "/static/icon-192.png", "/static/icon-512.png"}
 
 # Registry feed endpoints accept EITHER an admin session OR a registry JWT.
 # When a Bearer token is present for these paths the request bypasses the


### PR DESCRIPTION
Autonomous build of board card tsk-dk5v6d.



Files:
 tinyagentos/auth_middleware.py | 6 +++++-
 1 file changed, 5 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PWA installation by allowing required desktop manifest and icon assets to load before authentication.
  * Improved access to installation resources for browsers that fetch them during the install process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->