### PR TITLE
tsk-gp5xrq  [OPEN]  S2A: GET /api/share/destinations (authorization-fi

### DIFF
--- a/tests/test_routes_share_destinations.py
+++ b/tests/test_routes_share_destinations.py
@@ -1,0 +1,117 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+from tinyagentos.device_store import DeviceStore
+from tinyagentos.agent_registry_store import AgentRegistryStore
+
+
+@pytest.fixture
+def app(tmp_data_dir):
+    return create_app(data_dir=tmp_data_dir)
+
+
+@pytest.mark.asyncio
+class TestShareDestinations:
+    async def test_unauthenticated_returns_401(self, app, tmp_data_dir):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/share/destinations")
+            assert resp.status_code == 401
+
+    async def test_library_always_present_for_paired_device(self, client, app):
+        reg = await client.post("/api/devices/register", json={"platform": "ios"})
+        assert reg.status_code == 200
+        token = reg.json()["scoped_token"]
+
+        resp = await client.get(
+            "/api/share/destinations",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "destinations" in body
+        kinds = {d["kind"] for d in body["destinations"]}
+        assert "library" in kinds
+        lib = next(d for d in body["destinations"] if d["kind"] == "library")
+        assert lib["id"] == "library"
+        assert lib["label"] == "Library"
+
+    async def test_project_filtering_excludes_other_user_projects(self, client, app):
+        await app.state.project_store.create_project(
+            name="Other Project",
+            slug="other-project",
+            created_by="other-user",
+            user_id="other-user",
+        )
+
+        reg = await client.post("/api/devices/register", json={"platform": "ios"})
+        token = reg.json()["scoped_token"]
+
+        resp = await client.get(
+            "/api/share/destinations",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        slugs = {d["id"] for d in body["destinations"] if d["kind"] == "project_files"}
+        assert "other-project" not in slugs
+
+    async def test_response_shape_and_correct_kinds(self, client, app):
+        reg = await client.post("/api/devices/register", json={"platform": "ios"})
+        token = reg.json()["scoped_token"]
+
+        resp = await client.get(
+            "/api/share/destinations",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "destinations" in body
+        assert isinstance(body["destinations"], list)
+
+        for entry in body["destinations"]:
+            assert "kind" in entry
+            assert "id" in entry
+            assert "label" in entry
+            assert entry["kind"] in ("library", "project_files", "agent_chat")
+
+    async def test_agent_chat_includes_active_agents_in_user_channels(self, client, app):
+        registry = app.state.agent_registry
+        if registry._db is not None:
+            await registry.close()
+        await registry.init()
+
+        try:
+            primary = app.state.auth.get_primary_user()
+            user_id = primary["id"] if primary else "admin"
+
+            agent_record = await registry.register(
+                display_name="Test Agent",
+                framework="test",
+                user_id=user_id,
+            )
+            canonical_id = agent_record["canonical_id"]
+
+            await app.state.chat_channels.create_channel(
+                name="dm",
+                type="dm",
+                created_by=user_id,
+                members=[user_id, canonical_id],
+            )
+
+            reg = await client.post("/api/devices/register", json={"platform": "ios"})
+            token = reg.json()["scoped_token"]
+
+            resp = await client.get(
+                "/api/share/destinations",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            agents = [d for d in body["destinations"] if d["kind"] == "agent_chat"]
+            agent_ids = {a["id"] for a in agents}
+            assert canonical_id in agent_ids
+        finally:
+            await registry.close()
+            app.state.agent_registry = registry

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
-EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey"}
+EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey", "/api/share/destinations"}
 
 # Registry feed endpoints accept EITHER an admin session OR a registry JWT.
 # When a Bearer token is present for these paths the request bypasses the

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -62,6 +62,9 @@ def register_all_routers(app):
     from tinyagentos.routes.settings import router as settings_router
     app.include_router(settings_router, dependencies=_csrf)
 
+    from tinyagentos.routes.share import router as share_router
+    app.include_router(share_router)
+
     from tinyagentos.routes.store import router as store_router
     app.include_router(store_router, dependencies=_csrf)
 

--- a/tinyagentos/routes/share.py
+++ b/tinyagentos/routes/share.py
@@ -1,0 +1,63 @@
+"""Share destinations - discover ingest endpoints the calling device can write to."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from tinyagentos.device_auth import require_device
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/api/share/destinations")
+async def list_share_destinations(request: Request):
+    device = await require_device(request)
+    user_id = device.get("user_id", "")
+    destinations = []
+
+    destinations.append({
+        "kind": "library",
+        "id": "library",
+        "label": "Library",
+    })
+
+    pstore = request.app.state.project_store
+    for project in await pstore.list_for_user(user_id):
+        destinations.append({
+            "kind": "project_files",
+            "id": project["slug"],
+            "label": project["name"],
+        })
+
+    ch_store = request.app.state.chat_channels
+    seen = set()
+    registry = getattr(request.app.state, "agent_registry", None)
+    user_id_str = str(user_id)
+    for ch in await ch_store.list_channels():
+        members = ch.get("members") or []
+        if user_id_str not in members and "user" not in members:
+            continue
+        for member in members:
+            if member in (user_id_str, "user"):
+                continue
+            if member in seen:
+                continue
+            label = member
+            if registry is not None:
+                try:
+                    agent = await registry.get(member)
+                    if agent and agent.get("status") == "active":
+                        seen.add(member)
+                        destinations.append({
+                            "kind": "agent_chat",
+                            "id": member,
+                            "label": agent.get("display_name") or member,
+                        })
+                except RuntimeError:
+                    pass
+
+    return {"destinations": destinations}


### PR DESCRIPTION
Autonomous build of board card tsk-gp5xrq.



Files:
 tests/test_routes_share_destinations.py | 117 ++++++++++++++++++++++++++++++++
 tinyagentos/auth_middleware.py          |   2 +-
 tinyagentos/routes/__init__.py          |   3 +
 tinyagentos/routes/share.py             |  63 +++++++++++++++++
 4 files changed, 184 insertions(+), 1 deletion(-)