### PR TITLE
tsk-xocdcd  [OPEN]  taOStalk s1: content_blocks types + renderContent

### DIFF
--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -158,12 +158,50 @@ export function resolveAuthorDisplayState(
   return "removed";
 }
 
+export interface TextContentBlock {
+  kind: "text";
+  text: string;
+}
+
+export interface ThinkingContentBlock {
+  kind: "thinking";
+  text: string;
+  collapsed?: boolean;
+}
+
+export interface ToolCallContentBlock {
+  kind: "tool_call";
+  call_id: string;
+  name: string;
+  input_preview?: string;
+  status: "running" | "done" | "error";
+  result_preview?: string;
+}
+
+export interface StatusContentBlock {
+  kind: "status";
+  text: string;
+}
+
+export interface UnknownContentBlock {
+  kind: "unknown";
+  [key: string]: unknown;
+}
+
+export type ContentBlock =
+  | TextContentBlock
+  | ThinkingContentBlock
+  | ToolCallContentBlock
+  | StatusContentBlock
+  | UnknownContentBlock;
+
 interface Message {
   id: string;
   channel_id: string;
   author_id: string;
   author_type: "user" | "agent";
   content: string;
+  content_blocks?: ContentBlock[];
   /** Parent message id when this message is a thread reply. */
   thread_id?: string;
   content_type?: "text" | "canvas" | string;
@@ -217,7 +255,26 @@ export function relativeTime(ts: number | string, nowMs: number = Date.now()): s
   return new Date(ms).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
 }
 
-export function renderContent(text: string) {
+function renderContentBlock(block: ContentBlock, index: number): React.ReactElement {
+  switch (block.kind) {
+    case "text":
+    case "thinking":
+    case "tool_call":
+    case "status":
+    case "unknown":
+    default:
+      return (
+        <div key={`block-${index}`} className="text-shell-text-tertiary text-xs italic">
+          unsupported block: {block.kind}
+        </div>
+      );
+  }
+}
+
+export function renderContent(text: string, content_blocks?: ContentBlock[]) {
+  if (content_blocks && content_blocks.length > 0) {
+    return content_blocks.map((block, i) => renderContentBlock(block, i));
+  }
   // Split on fenced code blocks first, then apply inline markdown to non-code segments.
   const result: (string | React.ReactElement)[] = [];
   const fenceRegex = /```(?:[^\n]*)?\n([\s\S]*?)```/g;

--- a/desktop/src/apps/chat/MessageList.tsx
+++ b/desktop/src/apps/chat/MessageList.tsx
@@ -27,6 +27,7 @@ import { ReactionBar } from "./ReactionBar";
 import { resolveAgentEmoji } from "@/lib/agent-emoji";
 import { startDrag, endDrag } from "@/shell/dnd/dnd-bus";
 import { renderContent, dayLabel, relativeTime, toMs, resolveAuthorDisplayState } from "../MessagesApp";
+import type { ContentBlock } from "../MessagesApp";
 import type { AttachmentRecord } from "@/lib/chat-attachments-api";
 import { displayAuthor } from "./format-author";
 import type { LiveAgent, ArchivedAgentEntry, Channel } from "./types";
@@ -39,6 +40,7 @@ export interface MessageRow {
   author_id: string;
   author_type: "user" | "agent";
   content: string;
+  content_blocks?: ContentBlock[];
   thread_id?: string;
   content_type?: "text" | "canvas" | string;
   metadata?: {
@@ -538,7 +540,7 @@ export const MessageList = forwardRef<MessageListHandle, MessageListProps>(funct
                             : "text-shell-text"
                         }`}
                       >
-                        {renderContent(msg.content)}
+                        {renderContent(msg.content, msg.content_blocks)}
                         {msg.state === "pending" && (
                           <span className="ml-1 text-shell-text-tertiary">
                             ...

--- a/desktop/src/apps/chat/__tests__/render-helpers.test.tsx
+++ b/desktop/src/apps/chat/__tests__/render-helpers.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { renderContent, dayLabel } from "../../MessagesApp";
+import type { ContentBlock } from "../../MessagesApp";
 
 describe("renderContent", () => {
   it("passes plain text through", () => {
@@ -56,6 +57,44 @@ describe("renderContent", () => {
     const a = link.querySelector("a");
     expect(a?.getAttribute("href")).toBe("https://example.com");
     expect(a?.getAttribute("target")).toBe("_blank");
+  });
+});
+
+describe("renderContent with content_blocks", () => {
+  it("renders unknown-kind fallback for every block kind", () => {
+    const blocks: ContentBlock[] = [
+      { kind: "text", text: "hello" },
+      { kind: "thinking", text: "thinking...", collapsed: true },
+      { kind: "tool_call", call_id: "c1", name: "bash", status: "running" },
+      { kind: "status", text: "done" },
+      { kind: "unknown" },
+    ];
+    const { container } = render(<div>{renderContent("", blocks)}</div>);
+    const text = container.textContent || "";
+    expect(text).toContain("unsupported block: text");
+    expect(text).toContain("unsupported block: thinking");
+    expect(text).toContain("unsupported block: tool_call");
+    expect(text).toContain("unsupported block: status");
+    expect(text).toContain("unsupported block: unknown");
+  });
+
+  it("falls through to markdown when content_blocks is empty", () => {
+    const { container } = render(<div>{renderContent("hello world", [])}</div>);
+    expect(container.textContent).toContain("hello world");
+  });
+
+  it("falls through to markdown when content_blocks is undefined", () => {
+    const { container } = render(<div>{renderContent("hello world")}</div>);
+    expect(container.textContent).toContain("hello world");
+  });
+
+  it("renders one fallback line per block", () => {
+    const blocks: ContentBlock[] = [
+      { kind: "text", text: "a" },
+      { kind: "status", text: "b" },
+    ];
+    const { container } = render(<div>{renderContent("", blocks)}</div>);
+    expect(container.querySelectorAll("div").length).toBeGreaterThanOrEqual(2);
   });
 });
 


### PR DESCRIPTION
Autonomous build of board card tsk-xocdcd.



Files:
 desktop/src/apps/MessagesApp.tsx                   | 59 +++++++++++++++++++++-
 desktop/src/apps/chat/MessageList.tsx              |  4 +-
 .../apps/chat/__tests__/render-helpers.test.tsx    | 39 ++++++++++++++
 3 files changed, 100 insertions(+), 2 deletions(-)

----
## Summary by Gitar

- **New features:**
    - Added `ContentBlock` types and `renderContent` support in `MessagesApp.tsx`
- **Tests:**
    - Added unit tests for `renderContent` with `content_blocks` in `render-helpers.test.tsx`

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages can now display structured content, including text, thinking, tool activity, and status updates.
  * Unsupported message content types show a clear fallback instead of failing silently.
  * Existing Markdown and code-block rendering remains supported for standard messages.

* **Bug Fixes**
  * Improved message rendering consistency when structured content is missing or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->