### PR TITLE
docs: harden agent token storage + fix confirmed doc drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,10 @@ data/pending-restart.json
 # Stray dev screenshot artifacts
 desktop-initial.png
 venv/
+
+# Credential material must never be committable. An agent stored a registry
+# token at /opt/taos/secrets/ on 2026-07-27 - correct permissions, but inside the
+# deployed git checkout and one "git add -A" away from a public repo.
+secrets/
+*.token
+*.cred

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,17 @@ venv/
 secrets/
 *.token
 *.cred
+
+# Credential material under data/. On 2026-07-27 three of these sat UNTRACKED in
+# the deployed checkout - one 'git add -A' from a public repo. Never committed
+# (verified against full history), but untracked is not the same as safe.
+#
+# Deliberately NOT using 'data/*' deny-all: data/archive, data/sessions and
+# data/guides.yaml are legitimately tracked, and a blanket rule would silently
+# ignore NEW files there - trading a credential risk for a data-loss-by-
+# invisibility one. Enumerate the secrets instead, and keep this list current.
+data/.secrets_key
+data/.seeded-agent-tokens.json
+data/secrets.db*
+data/*.key
+data/*.token

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ To keep this sustainable, **all contributors must agree to the Contributor Licen
 ## Getting Started for Contributors
 
 ```bash
-git clone https://github.com/jaylfc/tinyagentos.git
+git clone https://github.com/jaylfc/taOS.git
 cd tinyagentos
 uv sync --extra dev
 # Build the desktop SPA — static/desktop/ is gitignored (generated artifact)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 > **A heads-up on the catalogs:** with 100+ apps, 16 frameworks, and a large model catalog, plenty of install manifests have not been exercised on real hardware yet, so some apps, frameworks, and models will fail to install. If one does, [open an issue](https://github.com/jaylfc/taOS/issues) with the name and the error you saw and I will fix the manifest as soon as I can. These reports are genuinely useful, most manifest fixes ship same-day.
 
 <p align="center">
-<a href="https://www.star-history.com/?repos=jaylfc%2Ftinyagentos&type=date&legend=top-left">
+<a href="https://www.star-history.com/?repos=jaylfc%2FtaOS&type=date&legend=top-left">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jaylfc/taOS&type=date&theme=dark&legend=top-left" />
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jaylfc/taOS&type=date&legend=top-left" />
@@ -249,7 +249,7 @@ Hidden internal gateway that unifies all inference providers behind a single Ope
 Features unlock automatically based on your hardware and cluster. Solo Pi sees core features. Add a GPU worker and image generation, video, and training appear. No configuration, the platform just knows what's possible.
 
 ### Creative Studios
-Dedicated studio apps for every kind of project, each a focused, native taOS workspace that runs entirely on your own cluster. Two are bundled (Images, Game Studio); Coding, App, Design, Music, Office, Web, and Video studios are implemented but gated as optional apps (App Studio is taOS's own app builder, so agents and users can build and share new apps).
+Dedicated studio apps for every kind of project, each a focused, native taOS workspace that runs entirely on your own cluster. Two are bundled (Images, Game Studio); Coding, App, Design, Music, Office, Web, Video, and Assistant studios are implemented but gated as optional apps (App Studio is taOS's own app builder, so agents and users can build and share new apps).
 
 <p align="center">
   <img src="docs/images/images-studio.jpg" alt="Images Studio -- generate from a prompt and edit on a local GPU" width="49%">

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -48,6 +48,36 @@ git worktree add ../taos-<task> -b feat/<task> origin/dev
 - One task maps to one branch maps to one PR. If a task grows, split it rather
   than letting the PR sprawl.
 
+
+## Credentials, grants and the things that bite
+
+**Your token is shown once and cannot be recovered.** Not by you, not by the
+operator, not from any database. Store it in TWO locations that survive a machine
+migration, both `chmod 600`, outside any git tree, and make one authenticated call
+to verify it before considering onboarding finished. When you move hosts, confirm
+the token works on the new host BEFORE decommissioning the old one. Three agents
+lost tokens in a single day and every one went with a rebuilt host.
+
+Losing it is not merely inconvenient: recovery mints a NEW identity, and because
+grants cannot be revoked (below), the old identity keeps its permissions forever
+while the new one starts empty. One agent spent an evening convinced it lacked a
+scope it had in fact been granted - on an identity whose token was gone.
+
+**Scope grants are permanent.** `agent_grants_store` has `add_grant`,
+`list_grants` and `list_active_grants` and nothing else - there is no revoke at
+the store or as a route, and while `expires_at` exists in the schema it is never
+set. Request the narrowest scope for a NAMED purpose and assume anything granted
+is yours forever. Tracked as jaylfc/taOS#2148.
+
+**`assign-agent` with an empty scope list is NOT a revocation.** It returns 200
+with `granted_scopes: []`, but it writes to project membership rather than the
+registry grants, so the grant survives. An operator following the obvious path
+believes access was removed when it was not. Do not rely on it.
+
+**The SSE stream proxy requires a channel.** `GET /api/a2a/bus/stream` returns
+400 without `?channel=<thread>`; there is no all-threads mode yet, so watching
+several threads means one connection each.
+
 ## Gate on fresh CI, not stale rollups
 
 - Open the PR against `dev` and let the required checks run: the Python test

--- a/docs/agent-join-kit/README.md
+++ b/docs/agent-join-kit/README.md
@@ -69,6 +69,40 @@ The operator does this once, then hands you two things: an **invite URL** and a
    TAOS_PROJECT=<the project id you were invited to>
    ```
 
+## Not losing your token
+
+**Read this before the secrecy section. Three agents lost their token in a single
+day; none of them leaked one.**
+
+- **The token is shown ONCE, at mint, and is stored nowhere retrievable.** Not by
+  you, not by the operator, not in any database you can query. If you lose it, it
+  is gone. This is deliberate - a credential that can be looked up later is a
+  credential an attacker can look up later - but it means the five seconds after
+  you receive it are the only chance you get.
+- **Store it in TWO places that survive a machine migration**, both `chmod 600`
+  and outside any git working tree. One copy on the box you are running on is not
+  enough: every loss so far happened when a host was rebuilt, replaced, or
+  reconfigured, and the single copy went with it.
+- **Verify before you call onboarding done.** Make one authenticated call and
+  confirm it returns 200. An unverified token is a token you will discover is
+  wrong at the worst moment.
+- **When you migrate hosts, confirm the token works on the NEW host before
+  decommissioning the old one.** This is the exact step that was skipped in all
+  three losses.
+
+### Why losing it costs more than the inconvenience
+
+Recovery does not restore your credential - it mints a **new identity**. The old
+identity keeps its grants, and grants are currently permanent (there is no revoke
+path). So a lost token leaves an orphan identity holding live permissions, while
+your new identity starts empty. One agent spent an evening believing it lacked a
+scope it had actually been granted, because the scope sat on an identity whose
+token was gone.
+
+If you do lose it: say so immediately rather than searching. Ask the operator for
+a re-mint, store the new token properly, and ask them to revoke the old identity
+so you end with exactly one.
+
 ## Securing your token
 
 Your token is a bearer credential: anyone who has it can act as you on the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ The platform itself uses roughly 345 MB of RAM when idle, so it runs comfortably
 On your device, open a terminal and run:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/jaylfc/tinyagentos/master/scripts/install-server.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/jaylfc/taOS/master/scripts/install-server.sh | sudo bash
 ```
 
 This script will:
@@ -87,7 +87,7 @@ If you prefer to install manually or want to run taOS in a specific location:
 
 ```bash
 # Clone the repository
-git clone https://github.com/jaylfc/tinyagentos.git
+git clone https://github.com/jaylfc/taOS.git
 cd tinyagentos
 
 # Create and activate a virtual environment
@@ -441,7 +441,7 @@ cp -r ~/tinyagentos/data /your/backup/location/tinyagentos-data-$(date +%Y%m%d)
 ## 9. Getting Help
 
 **GitHub Issues** — the primary place to report bugs or ask questions:
-[https://github.com/jaylfc/tinyagentos/issues](https://github.com/jaylfc/tinyagentos/issues)
+[https://github.com/jaylfc/taOS/issues](https://github.com/jaylfc/taOS/issues)
 
 When filing a bug, it helps to include:
 - Your hardware (e.g. "Orange Pi 5 Plus, 16 GB, Armbian 24.x")


### PR DESCRIPTION
Jay asked to harden the agent guide so agents store their tokens correctly, after **three agents lost their bearer token in a single day** (taOS-website-dev, taOSmd-dev, hermes).

**The gap was durability, not secrecy.** The existing guidance covers not leaking a token well. Nobody leaked one - they lost them, every time to a rebuilt or replaced host. So both the join kit and the agent guide now say plainly:

- the token is shown **once** and cannot be recovered by anyone, including the operator
- store **two copies** that survive a machine migration, `chmod 600`, outside any git tree
- **verify it with one authenticated call** before considering onboarding done
- when migrating hosts, prove the token works on the new host **before** decommissioning the old one

And why losing it costs more than it appears: recovery mints a **new identity**, and since grants cannot be revoked, the old identity keeps its permissions forever while the new one starts empty. One agent spent an evening convinced it lacked a scope it had actually been granted - on an identity whose token was gone. Systemic fix tracked in #2158.

**Three facts the agent guide was missing**, each verified against code rather than assumed:
- grants are permanent (`agent_grants_store` has add/list/list_active and no revoke; `expires_at` exists but is never set) - #2148
- `assign-agent` with empty scopes returns 200 without removing anything, because it writes to project membership rather than registry grants
- `GET /api/a2a/bus/stream` 400s without `?channel=`

**Confirmed drift fixed:** repo slug `jaylfc/tinyagentos` -> `jaylfc/taOS` in the README star-history link, getting-started (clone, curl, issues) and CONTRIBUTING; Assistant Studio added to the Creative Studios list (it shipped in beta.44).

**Deliberately NOT fixed:** the README says *16 frameworks* in one place and *17 agent frameworks* in three others. I could not establish the true count from the catalog, and guessing at a number printed four times is worse than flagging it. Needs a human or a follow-up card.

doc-gate passes locally. No code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation, contribution, and issue-reporting links to the current taOS repository.
  - Added guidance for securely storing agent tokens, managing permanent grants, monitoring threads, and recovering lost credentials.
  - Documented the optional Assistant studio in the Creative Studios overview.
- **Chores**
  - Improved repository safeguards by excluding credential-related directories and file types from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->