### PR TITLE
DO NOT MERGE: verify the sharded aggregate gate reports red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,15 @@ jobs:
   # run at once instead of queueing behind the 2 self-hosted boxes. The VPS +
   # Fedora runners stay free for the kilo lane and GPU/bench work.
 
-  test:
+  # Renamed from "test" to "shards" because sharding changes the check-run names
+  # this job reports. Branch protection matches required checks by NAME, so the
+  # sharded jobs report "test (3.12, 1)" etc and the required contexts
+  # "test (3.12)" / "test (3.13)" would never be reported again. Protection then
+  # waits forever on checks that cannot exist and blocks every PR, including the
+  # one that would fix it. The aggregate "test" job below keeps reporting those
+  # two exact names, so no protection change is needed and there is no window
+  # where dev is wedged.
+  shards:
     runs-on: ubuntu-latest
     # Measured 2026-07-26 over the last 12 job records: 3.13 runs 31-35 min and
     # 3.12 runs 38-41 min. The previous comment claimed "~16 min", which had
@@ -61,7 +69,8 @@ jobs:
         # Cores per job were the bottleneck, not the tests.
         #
         # A public repo gets ~20 concurrent jobs free and we were using 2, so
-        # this costs nothing. 2 versions x 4 shards = 8 jobs.
+        # this costs nothing. 2 versions x 4 shards = 8 jobs on PR/push, and
+        # 12 on the scheduled run that adds 3.11.
         shard: [1, 2, 3, 4]
 
     steps:
@@ -103,11 +112,37 @@ jobs:
           uv run --no-sync pytest tests/ --tb=short --ignore=tests/e2e
           -n auto --splits 4 --group ${{ matrix.shard }}
 
-      # Import smoke check: identical in every shard, so run it once rather
-      # than 8 times.
+      # Import smoke check: identical in every shard, so run it once per Python
+      # version (shard 1 only) rather than in all 4 shards.
       - name: Verify app starts
         if: matrix.shard == 1
         run: uv run --no-sync python -c "from tinyagentos.app import create_app; print('OK')"
+
+  # Aggregate gate. Reports the exact check names branch protection requires
+  # ("test (3.12)", "test (3.13)") so the required-context list does not have to
+  # change when the shard count does. An explicit `name:` is used verbatim by
+  # GitHub rather than having the matrix values appended, which is what makes
+  # reproducing the old names possible at all.
+  #
+  # `if: always()` is load-bearing. Without it this job is SKIPPED when the
+  # shards fail, and GitHub treats a skipped required check as satisfied -- so a
+  # red suite would report a green gate. It must run and fail explicitly.
+  test:
+    name: test (${{ matrix.python-version }})
+    needs: shards
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Gate on shard results
+        run: |
+          echo "shards concluded: ${{ needs.shards.result }}"
+          if [ "${{ needs.shards.result }}" != "success" ]; then
+            echo "::error::test shards did not all pass"
+            exit 1
+          fi
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
         # PR + push runs cover the latest two; the daily cron run
         # below adds 3.11 so the minimum-supported version stays tested.
         python-version: ${{ github.event_name == 'schedule' && fromJSON('["3.11", "3.12", "3.13"]') || fromJSON('["3.12", "3.13"]') }}
+        # Shard the suite across parallel jobs. xdist parallelises WITHIN a job,
+        # but a hosted runner is 2 vCPU, so -n auto caps at 2 workers however
+        # many tests exist -- and the suite has grown 4845 -> 10250 (#2135).
+        # Cores per job were the bottleneck, not the tests.
+        #
+        # A public repo gets ~20 concurrent jobs free and we were using 2, so
+        # this costs nothing. 2 versions x 4 shards = 8 jobs.
+        shard: [1, 2, 3, 4]
 
     steps:
       - uses: actions/checkout@v7
@@ -83,13 +91,22 @@ jobs:
       # SPA bundle is stubbed by tests/conftest.py — see pytest_configure.
       # The real build is exercised in the spa-build job below.
 
-      - name: Run tests
-        # Run across all runner cores. The serial suite (4845 tests) took
-        # ~22 min; -n auto cuts it to a few minutes so "merge on green" is
-        # practical. Dropped -v so xdist worker output stays readable.
-        run: uv run --no-sync pytest tests/ --tb=short --ignore=tests/e2e -n auto
+      - name: Run tests (shard ${{ matrix.shard }}/4)
+        # --splits/--group partition the suite deterministically and exactly:
+        # verified that the 4 groups union to all 10250 collected tests with no
+        # duplicates and, critically, no drops. A sharding bug that silently
+        # skipped tests would leave CI green while testing less, which is the
+        # one failure mode worth checking rather than assuming.
+        #
+        # -n auto still uses both cores inside each shard.
+        run: >-
+          uv run --no-sync pytest tests/ --tb=short --ignore=tests/e2e
+          -n auto --splits 4 --group ${{ matrix.shard }}
 
+      # Import smoke check: identical in every shard, so run it once rather
+      # than 8 times.
       - name: Verify app starts
+        if: matrix.shard == 1
         run: uv run --no-sync python -c "from tinyagentos.app import create_app; print('OK')"
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,14 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     strategy:
+      # Both gates must report their own conclusion. With the default
+      # fail-fast, the first gate to fail CANCELS its sibling, so a red suite
+      # reported "test (3.12) failure, test (3.13) cancelled" -- observed on a
+      # deliberate-failure branch. Cancelled is not success so protection still
+      # blocks, but which version broke becomes a coin flip, and a required
+      # check whose conclusion depends on scheduling order is not a gate worth
+      # trusting.
+      fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,10 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-timeout>=2.3.0",
     "pytest-xdist>=3.5.0",
+    # Shards the suite across parallel CI jobs. xdist parallelises WITHIN a job
+    # and a hosted runner has 2 vCPU, so -n auto caps at 2 workers no matter how
+    # many tests there are; the only remaining lever is more jobs (#2135).
+    "pytest-split>=0.9.0",
     "httpx",
     "respx>=0.21.0",
     "websockets>=12.0",

--- a/tests/tmp_gate_check/test_deliberate_failure.py
+++ b/tests/tmp_gate_check/test_deliberate_failure.py
@@ -1,0 +1,9 @@
+"""Temporary: proves the aggregate gate reports FAILURE when a shard fails.
+
+Deleted immediately after the check. If this file is ever seen on dev, the
+verification branch leaked and it should be removed.
+"""
+
+
+def test_deliberately_fails():
+    assert False, "deliberate failure to verify the CI aggregate gate goes red"

--- a/uv.lock
+++ b/uv.lock
@@ -2399,6 +2399,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
+]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3053,6 +3065,7 @@ dev = [
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-split" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "respx" },
@@ -3098,6 +3111,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-playwright", marker = "extra == 'e2e'", specifier = ">=0.5.0" },
+    { name = "pytest-split", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },


### PR DESCRIPTION
Throwaway branch. Contains one deliberately failing test to prove the aggregate `test (3.12)`/`test (3.13)` jobs report **failure** when a shard fails, rather than being skipped.

This matters because `needs: shards` without `if: always()` would SKIP the gate on shard failure, and GitHub counts a skipped required check as satisfied - a red suite would show a green required check. The success path is already proven on #2137; this proves the half that actually protects us.

Will be closed and the branch deleted as soon as the checks report.