### PR TITLE
docs: write down the verification and collision rules we work by

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -429,6 +429,32 @@ Run `scripts/install-git-hooks.sh` to enable local hooks (`.githooks/pre-commit`
   are available. Most modules use `from __future__ import annotations`.
 - Code style: match surrounding code, one concern per module
 - Use `uv` for dependency management and test running: `uv sync --extra dev`, `uv run pytest`
+- **Read `CONTRIBUTING.md` sections "Verifying your work" and "Avoiding collisions with
+  other contributors".** They are the canonical statement of both; this file does not
+  restate them so the two cannot drift. What follows is only the part specific to
+  working here as an agent.
+
+## Verification (agent specifics)
+
+Green is a claim, not evidence. The repo-level cases are in CONTRIBUTING.md. These are
+the ones that bite agents in particular:
+
+- **Do not report work as done without a PR link.** A branch with commits and no PR is
+  not delivered. A lane once announced completion on an empty branch; the check now runs
+  before any completion is claimed, and the same standard applies to you.
+- **A PR that passes CI can still be empty.** Before saying a card is finished, look at
+  the actual diff and confirm it contains the change described.
+- **Never infer merge conflicts from `git merge-tree`** against branches you have not
+  fetched; it produces confident nonsense. Use GitHub's `mergeable_state`, and treat
+  `unknown` as "not computed yet" and re-query rather than as an answer.
+- **Check the exit status of the command that matters**, not the last one in a pipe.
+  `cmd | tail && echo OK` prints OK when `cmd` failed.
+- **An empty fetch is not a match.** If two files that cannot be identical hash the same,
+  your request failed rather than the contents agreeing.
+- **Verify a bot finding against the code before folding it.** Automated review is often
+  wrong and always confident. Fold what is real, say plainly what is not.
+- **Report honestly.** If tests fail, include the output. If a step was skipped, name it.
+  "Done" means verified.
 
 ## Desktop SPA build + test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,9 +202,34 @@ Run a specific test file:
 pytest tests/test_catalog_sync.py -v
 ```
 
-The project has ~3,590 tests. CI runs against Python 3.12 and 3.13 on every pull request (two matrix jobs). Python 3.11 is added on the nightly scheduled run. A PR cannot be merged until all matrix jobs pass.
+The project has ~10,250 tests. CI runs against Python 3.12 and 3.13 on every pull request. Python 3.11 is added on the nightly scheduled run. A PR cannot be merged until all required checks pass.
 
 When adding a feature, add tests that cover the new behaviour. When fixing a bug, add a regression test.
+
+---
+
+## Verifying your work
+
+**A passing signal is a claim, not evidence.** Most bad merges in this project came from something that looked like success without being one. Before trusting a green tick, ask what would have to be true for it to be lying.
+
+Cases that have actually happened here:
+
+- **A PR passed every required check while containing only a version bump.** Green proves the suite ran, not that the work happened.
+- **A test file reported green while every test in it skipped.** `pytest.importorskip` is the correct way to land tests ahead of the code they cover, and it asserts nothing until that code exists. Once the implementation merges, confirm the skips became real passes. If the import path in the guard does not match what shipped, they skip forever and look identical to passing.
+- **`cmd | tail && echo OK` prints OK when `cmd` failed**, because `&&` sees `tail`'s exit status. Check the exit code of the command that matters.
+- **Green on a branch with conflicts tested the old base**, not the result of merging.
+
+Applied to your own changes:
+
+- **If you add a gate, prove it fails.** A check only ever observed passing is unproven where it counts. Make it go red deliberately once.
+- **Verify a review comment against the code before acting on it**, including automated ones. Bot findings are often wrong, and confidently phrased.
+- **Report honestly.** If tests fail, say so and include the output. If you skipped a step, name it. "Done" should mean verified, not attempted.
+
+## Avoiding collisions with other contributors
+
+- **Check whether an open PR already adds the file you are adding.** Two PRs that both create the same path cannot both merge, and whichever lands first silently decides the design. This has cost duplicated implementations of the same feature more than once.
+- **Renaming a CI job orphans its required check.** Branch protection matches required checks by name, so a rename means the old name is never reported again and later PRs block on a check that can no longer exist. Keep the old name reported (an aggregate job whose explicit `name:` reproduces it) or update protection first.
+- **Stage explicit paths rather than `git add -A`**, which sweeps in untracked files you did not write.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,18 @@ For frontend development, use `cd desktop && npm run dev` — Vite serves with h
 
 ---
 
+## Contributing with an AI coding agent
+
+If you work on taOS through a coding agent (Claude Code, opencode, Cursor, or similar), point it at **[`.claude/skills/taos-development-skill/SKILL.md`](.claude/skills/taos-development-skill/SKILL.md)**. It ships in the repo, so a clone already has it.
+
+It is the operational companion to this file: repository layout, the architectural patterns worth knowing before touching a subsystem, the local test gate to run before marking work ready, the fork PR and CI specifics, and the pitfalls that have actually cost contributors time here. This file states the conventions; the skill states how to apply them without tripping over the setup.
+
+Agents should read both. The skill deliberately does not restate the conventions in this file, so that the two cannot drift out of sync.
+
+**If you are an AI agent reading this:** load that skill before making changes, and pay particular attention to "Verifying your work" and "Avoiding collisions with other contributors" below. Most problems here have come from trusting a signal that looked like success rather than from writing bad code.
+
+---
+
 ## How to Contribute
 
 ### Bug Reports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to taOS
 
-Welcome — and thanks for your interest in contributing. taOS is a self-hosted AI agent platform for low-power hardware. Before diving in, please read the [README](README.md) for a project overview.
+Welcome - and thanks for your interest in contributing. taOS is a self-hosted AI agent platform for low-power hardware. Before diving in, please read the [README](README.md) for a project overview.
 
-> **Note:** The project is in early development. APIs and interfaces may change. That is fine — contributions of all sizes are welcome.
+> **Note:** The project is in early development. APIs and interfaces may change. That is fine - contributions of all sizes are welcome.
 
 ---
 
@@ -10,7 +10,7 @@ Welcome — and thanks for your interest in contributing. taOS is a self-hosted 
 
 taOS is open source under the **GNU Affero General Public License v3.0 or later** (AGPL-3.0-or-later; see [`LICENSE`](LICENSE)). A separate commercial license is available from jaylfc for uses the AGPL does not grant, for example embedding taOS in a proprietary product or offering it as a hosted service without releasing your modifications under the AGPL (see [`COMMERCIAL-LICENSE.md`](COMMERCIAL-LICENSE.md)).
 
-To keep this sustainable, **all contributors must agree to the Contributor License Agreement ([`CLA.md`](CLA.md))** before their contributions are merged. The CLA grants jaylfc the right to include and **relicense** your contributions under the project's licenses; **you keep ownership of your work**. You sign once — on your first pull request, comment **"I have read the CLA Document and I hereby sign the CLA"** and the CLA check turns green; it then covers all your future contributions.
+To keep this sustainable, **all contributors must agree to the Contributor License Agreement ([`CLA.md`](CLA.md))** before their contributions are merged. The CLA grants jaylfc the right to include and **relicense** your contributions under the project's licenses; **you keep ownership of your work**. You sign once - on your first pull request, comment **"I have read the CLA Document and I hereby sign the CLA"** and the CLA check turns green; it then covers all your future contributions.
 
 ---
 
@@ -20,14 +20,14 @@ To keep this sustainable, **all contributors must agree to the Contributor Licen
 git clone https://github.com/jaylfc/tinyagentos.git
 cd tinyagentos
 uv sync --extra dev
-# Build the desktop SPA — static/desktop/ is gitignored (generated artifact)
+# Build the desktop SPA - static/desktop/ is gitignored (generated artifact)
 cd desktop && npm install && npm run build && cd ..
 uv run pytest tests/ --ignore=tests/e2e -n auto
 ```
 
 Python 3.10 or later and Node.js 22 or later are required.
 
-For frontend development, use `cd desktop && npm run dev` — Vite serves with hot reload on port 5173.
+For frontend development, use `cd desktop && npm run dev` - Vite serves with hot reload on port 5173.
 
 ---
 
@@ -75,12 +75,12 @@ Keep pull requests focused. One feature or fix per PR is easier to review.
 
 > **Branches:** `master` is the stable branch that installs track, so it only
 > receives tested changes promoted from `dev`. All contributions target `dev`.
-> If you open a PR against `master` by mistake, no problem — we'll retarget it
+> If you open a PR against `master` by mistake, no problem - we'll retarget it
 > to `dev` (the commits and review carry over).
 
 ### Documentation
 
-Documentation improvements are always welcome — typo fixes, clarifications, better examples. Open a PR directly.
+Documentation improvements are always welcome - typo fixes, clarifications, better examples. Open a PR directly.
 
 The taOS agent manual is compiled: edit `docs/agent-manual/` and run `python3 scripts/build-agent-manual.py` to regenerate `docs/taos-agent-manual.md`.
 
@@ -90,7 +90,7 @@ The taOS agent manual is compiled: edit `docs/agent-manual/` and run `python3 sc
 
 The catalog lives in `app-catalog/`. Each app has its own directory containing a `manifest.yaml`.
 
-### Step 1 — Create the directory
+### Step 1 - Create the directory
 
 ```
 app-catalog/
@@ -106,7 +106,7 @@ Pick the appropriate category and create a directory named after your app's `id`
 mkdir app-catalog/agents/my-framework
 ```
 
-### Step 2 — Write manifest.yaml
+### Step 2 - Write manifest.yaml
 
 Use `app-catalog/agents/langroid/manifest.yaml` as a template:
 
@@ -143,7 +143,7 @@ hardware_tiers:
 
 All fields except `config_schema` are required. The `hardware_tiers` block controls which hardware profiles see the app as recommended.
 
-### Step 3 — Update catalog.yaml
+### Step 3 - Update catalog.yaml
 
 Add an entry to `app-catalog/catalog.yaml` under the appropriate section:
 
@@ -155,7 +155,7 @@ Add an entry to `app-catalog/catalog.yaml` under the appropriate section:
   description: "One-line description matching your manifest"
 ```
 
-### Step 4 — Open a PR
+### Step 4 - Open a PR
 
 Submit a pull request. The CI will run the catalog tests automatically. Include a link to the upstream project in your PR description.
 
@@ -165,7 +165,7 @@ Submit a pull request. The CI will run the catalog tests automatically. Include 
 
 ### Python
 
-- Follow the patterns already in the codebase — there is no strict linter, but keep it readable
+- Follow the patterns already in the codebase - there is no strict linter, but keep it readable
 - One concern per module; avoid cross-importing between route files
 - Use `async def` for route handlers; use `await` for all I/O
 
@@ -173,13 +173,13 @@ Submit a pull request. The CI will run the catalog tests automatically. Include 
 
 The UI is a React SPA (`desktop/`) built with Vite. Static assets are served from `static/desktop/` after `npm run build`. If you are adding a new UI surface:
 
-- Follow existing React patterns in `desktop/src/` — no server-rendered templates for new features
+- Follow existing React patterns in `desktop/src/` - no server-rendered templates for new features
 - ARIA labels are required on interactive elements without visible text labels
 - One concern per component; keep API calls in dedicated hooks or service files
 
 ### Tests
 
-- Use pytest; fixtures live in `tests/conftest.py` — use them
+- Use pytest; fixtures live in `tests/conftest.py` - use them
 - Mirror the module structure: `tinyagentos/routes/agents.py` -> `tests/test_agents.py`
 - All PRs must pass CI before merge
 
@@ -287,7 +287,7 @@ app-catalog/           # YAML manifests for installable apps (108 apps)
 tests/                 # pytest test suite (~3,590 tests)
 ```
 
-Routes are registered in `app.py`. Route modules access stores via `request.app.state` (dependency injection set up in the app lifespan) — they do not import stores directly. The frontend is a React SPA; `templates/` is minimal and only used for the agent debugger page.
+Routes are registered in `app.py`. Route modules access stores via `request.app.state` (dependency injection set up in the app lifespan) - they do not import stores directly. The frontend is a React SPA; `templates/` is minimal and only used for the agent debugger page.
 
 ---
 


### PR DESCRIPTION
Jay asked for our working conventions to be written down so other agents can work the way we have been.

**Where it lives, and why not in three places.** `CONTRIBUTING.md` gets the canonical text, because it applies to every contributor, human or agent. The guest-agent skill (`.claude/skills/taos-development-skill/SKILL.md`) **points at those sections rather than repeating them**, using the "Upstream conventions (from CONTRIBUTING.md)" pattern already established there, and keeps only what is specific to agents. Three copies of the same rules would drift within a fortnight.

Note `CLAUDE.md` is gitignored, so it was not a viable home: anything written there reaches one machine.

**What is captured.** Every recurring problem here has had the same shape, a signal that looked like success without being one:

- a PR passed all five required checks containing only a version bump
- a test file reported green because every test in it skipped behind `pytest.importorskip`, asserting nothing
- `cmd | tail && echo OK` printing OK after `cmd` failed, because `&&` sees `tail`
- green on a conflicted branch, which tested the old base rather than the merge

None of these are fixable by adding another check, because the check is the thing lying. So they are written as habits, with the rule that anything acting as a gate must be proven to fail on purpose before it is trusted.

The second section covers collisions: two PRs that both **add** the same path cannot both merge, and whichever lands first silently decides the design. That has cost duplicate implementations of the same feature twice, both found at merge time rather than when the branches opened. Also documents that renaming a CI job orphans its required check, since protection matches by name.

Some of how we operate is deliberately not public and stays out of this.

Drive-by correction: the test count said ~3,590 against a suite of ~10,250.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contributor guidance for working with AI coding agents.
  * Added clearer instructions for verifying changes, interpreting CI results, and reporting failures or skipped checks.
  * Added guidance to avoid conflicts with other contributors and duplicate CI checks.
  * Updated contribution, testing, architecture, style, and licensing documentation for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->