### PR TITLE
tsk-mz3diu  [OPEN]  Project create: name uniqueness + dup auto-reject

### DIFF
--- a/tests/projects/test_project_store.py
+++ b/tests/projects/test_project_store.py
@@ -1,7 +1,7 @@
 import pytest
 import pytest_asyncio
 
-from tinyagentos.projects.project_store import ProjectStore
+from tinyagentos.projects.project_store import ProjectConflict, ProjectStore
 
 
 @pytest_asyncio.fixture

--- a/tinyagentos/projects/project_store.py
+++ b/tinyagentos/projects/project_store.py
@@ -10,6 +10,19 @@ from tinyagentos.projects.ids import new_id
 
 logger = logging.getLogger(__name__)
 
+
+class ProjectConflict(ValueError):
+    """Raised when a project name or slug collides with an existing one.
+
+    Carries the collided ``field`` ('name' or 'slug') and the ``taken`` value
+    so the route can build an actionable 409 with suggestions.
+    """
+
+    def __init__(self, field: str, taken: str) -> None:
+        self.field = field
+        self.taken = taken
+        super().__init__(f"{field} already used: {taken}")
+
 PROJECTS_SCHEMA = """
 CREATE TABLE IF NOT EXISTS projects (
     id TEXT PRIMARY KEY,
@@ -147,6 +160,12 @@ class ProjectStore(BaseStore):
     ) -> dict:
         pid = new_id("prj")
         now = time.time()
+        # Enforce case-insensitive name uniqueness via a query check (not a
+        # schema constraint) so existing duplicate names are not destructively
+        # rejected on upgrade. A UNIQUE(slug) constraint remains as the
+        # backstop for slug collisions caught via IntegrityError below.
+        if await self.get_project_by_name(name) is not None:
+            raise ProjectConflict("name", name)
         try:
             await self._db.execute(
                 """INSERT INTO projects
@@ -156,9 +175,10 @@ class ProjectStore(BaseStore):
             )
             await self._db.commit()
         except sqlite3.IntegrityError as exc:
-            # UNIQUE(slug) is the only uniqueness constraint a caller can trigger.
+            # UNIQUE(slug) is the only schema-level uniqueness a caller can
+            # trigger here; the name check above guards name collisions.
             if "slug" in str(exc).lower():
-                raise ValueError(f"slug already used: {slug}") from exc
+                raise ProjectConflict("slug", slug) from exc
             raise
         return await self.get_project(pid)
 
@@ -174,6 +194,15 @@ class ProjectStore(BaseStore):
     async def get_project_by_slug(self, slug: str) -> dict | None:
         async with self._db.execute(
             "SELECT * FROM projects WHERE slug = ?", (slug,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            return _row_to_project(row, cur.description)
+
+    async def get_project_by_name(self, name: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM projects WHERE LOWER(name) = LOWER(?)", (name,)
         ) as cur:
             row = await cur.fetchone()
             if row is None:

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import time as _time
+import uuid
 
 import asyncio as _asyncio
 import json as _json
@@ -21,12 +22,54 @@ from tinyagentos.projects.folders import (
     ensure_project_layout,
     write_project_yaml,
 )
+from tinyagentos.projects.project_store import ProjectConflict
 from tinyagentos.projects.task_store import _ELEMENT_CLEAR
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+
+async def _is_field_free(store, field: str, value: str) -> bool:
+    """Return True when no project uses ``value`` for ``field``."""
+    if field == "name":
+        return await store.get_project_by_name(value) is None
+    return await store.get_project_by_slug(value) is None
+
+
+async def _free_suggestions(store, field: str, taken: str) -> list[str]:
+    """Generate 2-3 free suggestions for a collided name or slug.
+
+    Each candidate is verified against the store so it is genuinely free.
+    Formats: numeric suffix (<value>-2), prefixed (<prefix>-<value>),
+    and short random suffix (<value>-<shortid>).
+    """
+    suggestions: list[str] = []
+
+    # 1. Numeric suffix: <value>-2, <value>-3, ...
+    for i in range(2, 10):
+        cand = f"{taken}-{i}"
+        if await _is_field_free(store, field, cand):
+            suggestions.append(cand)
+            break
+
+    # 2. Prefixed: <prefix>-<value>
+    for prefix in ("team", "new", "app"):
+        cand = f"{prefix}-{taken}"
+        if await _is_field_free(store, field, cand):
+            suggestions.append(cand)
+            break
+
+    # 3. Short random suffix: <value>-<shortid>
+    for _ in range(20):
+        shortid = uuid.uuid4().hex[:5]
+        cand = f"{taken}-{shortid}"
+        if await _is_field_free(store, field, cand):
+            suggestions.append(cand)
+            break
+
+    return suggestions
 
 
 class CreateProjectIn(BaseModel):
@@ -91,6 +134,17 @@ async def create_project(
             settings=payload.settings,
             created_by=user.user_id,
             user_id=user.user_id,
+        )
+    except ProjectConflict as e:
+        suggestions = await _free_suggestions(store, e.field, e.taken)
+        return JSONResponse(
+            {
+                "error": str(e),
+                "field": e.field,
+                "taken": e.taken,
+                "suggestions": suggestions,
+            },
+            status_code=409,
         )
     except ValueError as e:
         return JSONResponse({"error": str(e)}, status_code=409)


### PR DESCRIPTION
Autonomous build of board card tsk-mz3diu.



Files:
 tests/projects/test_project_store.py  |  2 +-
 tinyagentos/projects/project_store.py | 33 +++++++++++++++++++--
 tinyagentos/routes/projects.py        | 54 +++++++++++++++++++++++++++++++++++
 3 files changed, 86 insertions(+), 3 deletions(-)

----
## Summary by Gitar

- **Project uniqueness:**
    - Added case-insensitive name uniqueness check and `ProjectConflict` exception in `ProjectStore`
    - Implemented 409 conflict response with free name/slug suggestions in project creation route

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project creation now detects duplicate names and slugs, including case-insensitive name matches.
  * Conflict responses identify the conflicting field and value and provide alternative suggestions.

* **Bug Fixes**
  * Replaced generic project creation errors with clearer conflict handling for duplicate names and slugs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->