### PR TITLE
chore(security): ignore key material so an identity file cannot be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,7 @@ data/secrets.db*
 data/*.key
 data/*.token
 
-# Key material and secrets. Added 2026-07-28 after data/hub/identity.json was
+# Key material and secrets. Added 2026-07-27 after data/hub/identity.json was
 # committed to PR #2043 with signing_private and encryption_private in
 # PLAINTEXT. It was removed before merge and the repo squash-merges, so it never
 # reached dev, but nothing STOPPED it. The data/ rules above are a per-file

--- a/.gitignore
+++ b/.gitignore
@@ -155,11 +155,11 @@ data/*.token
 
 # Key material and secrets. Added 2026-07-27 after data/hub/identity.json was
 # committed to PR #2043 with signing_private and encryption_private in
-# PLAINTEXT. It was removed before merge and the repo squash-merges, so it never
-# reached dev, but nothing STOPPED it. The data/ rules above are a per-file
-# allowlist, so any new data file slips through; these are pattern-based so a
-# future one cannot. Verified against every tracked file: none become ignored.
-data/hub/
+# PLAINTEXT. data/hub/ is already covered above; these patterns close the REST
+# of the surface, which was open: an identity.json or a *.key written anywhere
+# outside data/hub/ had nothing stopping it. Pattern-based on purpose, since a
+# per-file allowlist cannot catch a file that does not exist yet.
+# Verified against every tracked file: none become ignored.
 *.key
 *_private.*
 *_private_key*

--- a/.gitignore
+++ b/.gitignore
@@ -161,7 +161,9 @@ data/*.token
 # per-file allowlist cannot catch a file that does not exist yet.
 # Verified against every tracked file: none become ignored.
 *.key
-*_private.*
+*_private.pem
+*_private.key
+*_private.json
 *_private_key*
 identity.json
 *.p8

--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,17 @@ data/.seeded-agent-tokens.json
 data/secrets.db*
 data/*.key
 data/*.token
+
+# Key material and secrets. Added 2026-07-28 after data/hub/identity.json was
+# committed to PR #2043 with signing_private and encryption_private in
+# PLAINTEXT. It was removed before merge and the repo squash-merges, so it never
+# reached dev, but nothing STOPPED it. The data/ rules above are a per-file
+# allowlist, so any new data file slips through; these are pattern-based so a
+# future one cannot. Verified against every tracked file: none become ignored.
+data/hub/
+*.key
+*_private.*
+*_private_key*
+identity.json
+*.p8
+*credentials.json


### PR DESCRIPTION
Follows the leak found during the #2043 deep review: `data/hub/identity.json` was committed with `signing_private` and `encryption_private` in plaintext. It was removed before merge and the repo squash-merges, so it never reached dev, but nothing stopped it going in.

The existing `data/` rules are a per-file allowlist (`data/config.yaml`, `data/agents.json`, and so on), so any NEW data file slips straight through. That is what happened. These replacements are pattern-based, so a future identity file cannot.

Verified before committing that no currently tracked file becomes ignored by the new patterns (checked all of `git ls-files`, zero hits). `tinyagentos/taosnet/mesh_credentials.py` and its test are source files and stay tracked.

taOS-website-dev found and closed the same gap in its repo (PR #121). This is the core half.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved protection against accidentally committing credentials and private key material.
  * Added ignore rules for sensitive files and data directories, including common key, identity, and credentials formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->