### PR TITLE
tsk-glxi4e  [OPEN]  Make 3-strike card QUARANTINE loud (it currently v

### DIFF
--- a/tinyagentos/projects/strike_store.py
+++ b/tinyagentos/projects/strike_store.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import time
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+STRIKE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS task_strikes (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    step TEXT NOT NULL,
+    log_tail TEXT NOT NULL DEFAULT '',
+    actor TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_strikes_task ON task_strikes(task_id);
+"""
+
+
+def _row(r) -> dict:
+    keys = ("id", "task_id", "step", "log_tail", "actor", "created_at")
+    return dict(zip(keys, r))
+
+
+class StrikeStore(BaseStore):
+    """Append-only log of verification strikes per task.
+
+    The dispatch host (taOS-dev) records a strike each time a card fails
+    verification.  When the count reaches ``STRIKE_THRESHOLD`` the task is
+    quarantined (see ``ProjectTaskStore.quarantine_task``) and the lead is
+    notified.  Strikes are auto-cleared when the task closes or its PR
+    merges (see ``ProjectTaskStore.close_task`` and the unquarantine route).
+    """
+
+    SCHEMA = STRIKE_SCHEMA
+
+    # Number of failed verifications before a card is quarantined.
+    STRIKE_THRESHOLD = 3
+
+    async def record_strike(
+        self,
+        task_id: str,
+        step: str,
+        log_tail: str = "",
+        actor: str = "",
+    ) -> int:
+        """Record one verification strike for *task_id*.
+
+        Returns the total strike count for the task after this insert (so the
+        caller can decide whether the threshold was just crossed).
+        """
+        sid = new_id("str")
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO task_strikes
+               (id, task_id, step, log_tail, actor, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (sid, task_id, step, log_tail, actor, now),
+        )
+        await self._db.commit()
+        return await self.count_strikes(task_id)
+
+    async def count_strikes(self, task_id: str) -> int:
+        async with self._db.execute(
+            "SELECT COUNT(*) FROM task_strikes WHERE task_id = ?", (task_id,)
+        ) as cur:
+            row = await cur.fetchone()
+        return row[0] if row else 0
+
+    async def list_strikes(self, task_id: str) -> list[dict]:
+        """All strikes for *task_id*, oldest first."""
+        async with self._db.execute(
+            "SELECT * FROM task_strikes WHERE task_id = ? ORDER BY created_at ASC",
+            (task_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [_row(r) for r in rows]
+
+    async def latest(self, task_id: str) -> dict | None:
+        """The most recent strike for *task_id*, or None."""
+        async with self._db.execute(
+            "SELECT * FROM task_strikes WHERE task_id = ? ORDER BY created_at DESC LIMIT 1",
+            (task_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        return _row(row) if row else None
+
+    async def clear_strikes(self, task_id: str) -> int:
+        """Delete every strike for *task_id*.
+
+        Returns the number of rows deleted (0 when there were none).
+        """
+        cursor = await self._db.execute(
+            "DELETE FROM task_strikes WHERE task_id = ?", (task_id,)
+        )
+        await self._db.commit()
+        return cursor.rowcount

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from tinyagentos.board_audit import BoardAuditLog
     from tinyagentos.projects.events import ProjectEventBroker
     from tinyagentos.projects.project_store import ProjectStore
+    from tinyagentos.projects.strike_store import StrikeStore
 
 logger = logging.getLogger(__name__)
 
@@ -110,11 +111,13 @@ class ProjectTaskStore(BaseStore):
         broker: "ProjectEventBroker | None" = None,
         audit: "BoardAuditLog | None" = None,
         project_store: "ProjectStore | None" = None,
+        strikes: "StrikeStore | None" = None,
     ) -> None:
         super().__init__(db_path)
         self._broker = broker
         self._audit = audit
         self._project_store = project_store
+        self._strikes = strikes
 
     async def _publish(self, project_id: str, kind: str, payload: dict) -> None:
         if self._broker is not None:
@@ -373,6 +376,15 @@ class ProjectTaskStore(BaseStore):
             existing = await self.get_task(task_id)
             if existing is not None:
                 await self._publish(existing["project_id"], "task.closed", {"id": task_id, "closed_by": closed_by})
+            # A closed card can never be re-landed, so any lingering strikes
+            # are stale garbage that would make the dispatch lanes redo landed
+            # work.  Clear them automatically (best-effort; the close itself
+            # has already committed).
+            if self._strikes is not None:
+                try:
+                    await self._strikes.clear_strikes(task_id)
+                except Exception:
+                    logger.warning("clear_strikes failed for task %s on close", task_id, exc_info=True)
             # Derive the pre-close status race-free from the committed row rather
             # than a separate pre-read (which would have a TOCTOU gap). close does
             # not clear claimed_by, so a set claimer means it was 'claimed'.
@@ -403,6 +415,73 @@ class ProjectTaskStore(BaseStore):
                 await self._publish(existing["project_id"], "task.reopened", {"id": task_id, "reopened_by": reopened_by})
             await self._record_audit(
                 task_id, "task.reopened", reopened_by, "closed", "open",
+                project_id=existing["project_id"] if existing else "",
+            )
+        return changed
+
+    async def quarantine_task(self, task_id: str, actor: str) -> bool:
+        """Move a task into the ``quarantined`` status.
+
+        A quarantined card is visible on the board (distinct column) but is
+        removed from the ready pool -- the fleet will not pick it up until a
+        lead explicitly un-quarantines it.  Only acts on a task that is not
+        already closed/cancelled; returns False otherwise.
+        """
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET status = 'quarantined', updated_at = ?
+               WHERE id = ? AND status NOT IN ('closed', 'cancelled', 'quarantined')""",
+            (now, task_id),
+        )
+        await self._db.commit()
+        changed = cursor.rowcount == 1
+        if changed:
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(
+                    existing["project_id"],
+                    "task.quarantined",
+                    {"id": task_id, "actor": actor},
+                )
+            await self._record_audit(
+                task_id, "task.quarantined", actor, "open", "quarantined",
+                project_id=existing["project_id"] if existing else "",
+            )
+        return changed
+
+    async def unquarantine_task(self, task_id: str, actor: str) -> bool:
+        """Return a quarantined task to the open pool and clear its strikes.
+
+        This is the explicit un-quarantine / retry action: the card re-enters
+        the ready pool so the fleet may pick it up again.  Strikes are cleared
+        so a fresh failure count starts from zero.  Only acts on a quarantined
+        task; returns False otherwise.
+        """
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET status = 'open', updated_at = ?
+               WHERE id = ? AND status = 'quarantined'""",
+            (now, task_id),
+        )
+        await self._db.commit()
+        changed = cursor.rowcount == 1
+        if changed:
+            if self._strikes is not None:
+                try:
+                    await self._strikes.clear_strikes(task_id)
+                except Exception:
+                    logger.warning("clear_strikes failed for task %s on unquarantine", task_id, exc_info=True)
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(
+                    existing["project_id"],
+                    "task.unquarantined",
+                    {"id": task_id, "actor": actor},
+                )
+            await self._record_audit(
+                task_id, "task.unquarantined", actor, "quarantined", "open",
                 project_id=existing["project_id"] if existing else "",
             )
         return changed


### PR DESCRIPTION
Autonomous build of board card tsk-glxi4e.



Files:
 tinyagentos/projects/strike_store.py | 98 ++++++++++++++++++++++++++++++++++++
 tinyagentos/projects/task_store.py   | 79 +++++++++++++++++++++++++++++
 2 files changed, 177 insertions(+)

----
## Summary by Gitar

- **New strike tracking:**
    - Added `StrikeStore` to record verification failures and threshold limits
- **Task quarantine management:**
    - Added `quarantine_task` and `unquarantine_task` methods in `ProjectTaskStore`


<sub>This will update automatically on new commits.</sub>