### PR TITLE
chore(security): ignore creds bundles, the shape #2171 missed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,11 @@ data/*.token
 identity.json
 *.p8
 *credentials.json
+
+# Credential bundles. Added 2026-07-27: @taOS-website-dev ran the same audit
+# on its repo and found shapes my first pass (PR #2171) missed. Verified on
+# origin/dev: creds.json, my_creds.json and data/creds.json were all NOT
+# ignored, while *credentials.json already was. Matching the *creds* stem
+# closes the shorter spelling, which is the one people actually type.
+# Verified against every tracked file on origin/dev: 0 become ignored.
+*creds*.json


### PR DESCRIPTION
Follow-up to #2171, prompted by @taOS-website-dev running the same audit on its own repo and finding shapes my first pass missed. That is the useful part of this PR: one repo's audit found a gap in another's, which is why the check is worth running everywhere rather than trusting a single pass.

**The gap.** `*credentials.json` does not match `creds.json`. Verified against merged `origin/dev`:

```
NOT IGNORED creds.json
NOT IGNORED my_creds.json
NOT IGNORED data/creds.json
IGNORED     x_credentials.json
IGNORED     foo.p8
IGNORED     identity.json
```

`*creds*.json` closes the shorter spelling, which is the one people actually type.

**Safety check, done the way I got caught not doing before:** tested against `git ls-tree -r origin/dev` rather than my local branch. **0 of 3100 tracked files** become ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file exclusions to prevent credential-related JSON files from being included accidentally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->