### PR TITLE
fix(security): install auth guard in all SPA entry points

### DIFF
--- a/desktop/src/app-standalone-main.tsx
+++ b/desktop/src/app-standalone-main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { AppStandalone } from "./AppStandalone";
 import { AppShell } from "./components/AppShell";
+import { installAuthGuard } from "./lib/auth-guard";
 import { restoreActiveTheme, installWebkitRepaintGuards } from "./stores/theme-store";
 import { getApp } from "./registry/app-registry";
 import "./theme/tokens.css";
+
+installAuthGuard();
 
 // Apply the user's persisted theme on boot, same as chat-main.tsx.
 void restoreActiveTheme();

--- a/desktop/src/chat-main.tsx
+++ b/desktop/src/chat-main.tsx
@@ -2,8 +2,11 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ChatStandalone } from "./ChatStandalone";
 import { AppShell } from "./components/AppShell";
+import { installAuthGuard } from "./lib/auth-guard";
 import { restoreActiveTheme, installWebkitRepaintGuards } from "./stores/theme-store";
 import "./theme/tokens.css";
+
+installAuthGuard();
 
 // Apply the user's persisted theme (light/dark/etc.) on boot, the same as the
 // desktop shell does in App.tsx. Without this the standalone chat PWA always

--- a/desktop/src/lib/__tests__/auth-guard.test.ts
+++ b/desktop/src/lib/__tests__/auth-guard.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
 import { installAuthGuard, SESSION_EXPIRED_EVENT } from "../auth-guard";
 
 describe("auth-guard", () => {
@@ -6,7 +8,7 @@ describe("auth-guard", () => {
 
   beforeEach(() => {
     originalFetch = window.fetch;
-    // Reset the module-level `installed` flag by re-importing — Vitest
+    // Reset the module-level `installed` flag by re-importing -- Vitest
     // caches the module, so each test starts with the wrapper already
     // potentially installed from a previous test. We work around that
     // by resetting the modules. Cheaper alternative for this single
@@ -49,7 +51,7 @@ describe("auth-guard", () => {
 
   it("does not dispatch on 401 from /api/account/* paths", async () => {
     // The account proxy (taos.my cloud account) is a separate auth boundary
-    // and returns 401 when the user simply is not signed into the cloud —
+    // and returns 401 when the user simply is not signed into the cloud --
     // account-client maps that to a signed-out state. Treating it as a
     // controller-session expiry flashed the login gate and bounced the user
     // out of the Account pane. Reported by jay 2026-07-01.
@@ -96,5 +98,26 @@ describe("auth-guard", () => {
     window.removeEventListener(SESSION_EXPIRED_EVENT, handler);
 
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("every SPA entry module installs the auth guard", () => {
+    const viteConfig = readFileSync(join(process.cwd(), "vite.config.ts"), "utf-8");
+    const htmlPaths = Array.from(viteConfig.matchAll(/path\.resolve\(__dirname,\s*"([^"]+\.html)"\)/g)).map(
+      (m) => join(process.cwd(), m[1]),
+    );
+
+    const scriptRegex = /<script[^>]*type="module"[^>]*src="([^"]+)"/g;
+
+    for (const htmlPath of htmlPaths) {
+      const html = readFileSync(htmlPath, "utf-8");
+      const match = html.match(scriptRegex);
+      expect(match, `no module script found in ${htmlPath}`).toBeTruthy();
+
+      const scriptSrc = match![0].match(/src="([^"]+)"/)![1];
+      const entryModule = join(dirname(htmlPath), scriptSrc.replace(/^\//, ""));
+      const entrySource = readFileSync(entryModule, "utf-8");
+
+      expect(entrySource, `installAuthGuard missing in ${entryModule}`).toContain("installAuthGuard()");
+    }
   });
 });

--- a/desktop/src/lib/__tests__/auth-guard.test.ts
+++ b/desktop/src/lib/__tests__/auth-guard.test.ts
@@ -106,6 +106,17 @@ describe("auth-guard", () => {
       (m) => join(process.cwd(), m[1]),
     );
 
+    // The list is derived by regex over vite.config.ts, so a reformat, a
+    // variable, or different quoting there yields an EMPTY array -- the loop
+    // below would never run and this test would PASS while checking nothing.
+    // That is precisely the failure it exists to catch (the gap it guards
+    // existed because the suite was green with the guard in 1 of 3 entries).
+    // Assert the discovery worked before asserting anything about what it found.
+    expect(
+      htmlPaths.length,
+      "no HTML entrypoints parsed out of vite.config.ts - the discovery regex has drifted, so this test would pass vacuously",
+    ).toBeGreaterThanOrEqual(3);
+
     const scriptRegex = /<script[^>]*type="module"[^>]*src="([^"]+)"/g;
 
     for (const htmlPath of htmlPaths) {


### PR DESCRIPTION
Autonomous build of board card tsk-l5wf6k.



Files:
 desktop/src/app-standalone-main.tsx          |  3 +++
 desktop/src/chat-main.tsx                    |  3 +++
 desktop/src/lib/__tests__/auth-guard.test.ts | 27 +++++++++++++++++++++++++--
 3 files changed, 31 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added authentication protection during application startup across standalone and chat entry points.
  * Ensures authentication checks run before restoring themes and rendering the application.

* **Tests**
  * Added coverage verifying that all single-page application entry points install authentication protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->