### PR TITLE
feat(library): P2 rebased — YouTube + Web processors with streaming, content-type gate, timeout guards

### DIFF
--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -14,6 +14,8 @@ from tinyagentos.library_pipeline import (
     ImageProcessor,
     PdfProcessor,
     TextProcessor,
+    WebProcessor,
+    YouTubeProcessor,
     detect_kind,
     run_pipeline,
 )
@@ -401,6 +403,381 @@ class TestRunPipeline:
 
 
 # ---------------------------------------------------------------------------
+# YouTube processor
+# ---------------------------------------------------------------------------
+
+
+class TestYouTubeProcessor:
+    @pytest.mark.asyncio
+    async def test_process_youtube_url(self, lib_store, storage_dir):
+        """YouTube processor fetches metadata, transcript, chapters."""
+        item_id = await lib_store.create_item(
+            kind="url:youtube",
+            source_url="https://youtube.com/watch?v=test123",
+        )
+        item = await lib_store.get_item(item_id)
+
+        mock_result = {
+            "title": "Test Video",
+            "author": "TestChannel",
+            "content": "This is a transcript.",
+            "thumbnail": None,
+            "metadata": {
+                "video_id": "test123",
+                "channel": "TestChannel",
+                "duration": 120,
+                "views": 1000,
+                "upload_date": "20260101",
+                "chapters": [
+                    {"start_time": 0, "title": "Intro"},
+                    {"start_time": 60, "title": "Main"},
+                ],
+            },
+        }
+
+        from unittest.mock import patch
+        with patch(
+            "tinyagentos.knowledge_fetchers.youtube.fetch",
+            _async_return(mock_result),
+        ):
+            proc = YouTubeProcessor(lib_store, storage_dir)
+            artifacts = await proc.process(item)
+
+        kinds = {a["kind"] for a in artifacts}
+        assert "metadata" in kinds
+        assert "transcript" in kinds
+        assert "chapters" in kinds
+
+        updated = await lib_store.get_item(item_id)
+        meta = json.loads(updated["meta_json"])
+        assert meta["video_id"] == "test123"
+        assert meta["channel"] == "TestChannel"
+
+    @pytest.mark.asyncio
+    async def test_process_youtube_url_no_source(self, lib_store, storage_dir):
+        """YouTube processor returns empty when source_url is missing."""
+        item_id = await lib_store.create_item(
+            kind="url:youtube", source_url="", title="",
+        )
+        item = await lib_store.get_item(item_id)
+
+        proc = YouTubeProcessor(lib_store, storage_dir)
+        artifacts = await proc.process(item)
+        assert artifacts == []
+
+    @pytest.mark.asyncio
+    async def test_youtube_pipeline_integration(self, lib_store, storage_dir):
+        """run_pipeline routes url:youtube items to YouTubeProcessor."""
+        item_id = await lib_store.create_item(
+            kind="url:youtube",
+            source_url="https://youtube.com/watch?v=pipeline-test",
+        )
+
+        mock_result = {
+            "title": "Pipeline Video",
+            "author": "PipelineChannel",
+            "content": "Pipeline transcript.",
+            "thumbnail": None,
+            "metadata": {
+                "video_id": "pipeline-test",
+                "channel": "PipelineChannel",
+            },
+        }
+
+        from unittest.mock import patch
+        with patch(
+            "tinyagentos.knowledge_fetchers.youtube.fetch",
+            _async_return(mock_result),
+        ):
+            await run_pipeline(lib_store, item_id, storage_dir)
+
+        item = await lib_store.get_item(item_id)
+        assert item["status"] == "ready"
+
+        artifacts = await lib_store.get_artifacts(item_id)
+        artifact_kinds = {a["kind"] for a in artifacts}
+        assert "metadata" in artifact_kinds
+        assert "transcript" in artifact_kinds
+
+
+# ---------------------------------------------------------------------------
+# Web processor
+# ---------------------------------------------------------------------------
+
+
+class TestWebProcessor:
+    @pytest.mark.asyncio
+    async def test_process_web_url(self, lib_store, storage_dir):
+        """Web processor fetches HTML, extracts text, stores artifacts."""
+        html = (
+            "<html><head><title>Test Page</title></head>"
+            "<body><article><p>This is the main article text "
+            "with enough content to pass the readability minimum "
+            "character count for extraction purposes now.</p>"
+            "<p>Second paragraph with more detailed content about "
+            "the topic being discussed on this test page.</p></article></body>"
+            "</html>"
+        )
+
+        item_id = await lib_store.create_item(
+            kind="url:web",
+            source_url="https://example.com/article",
+            title="",
+        )
+        item = await lib_store.get_item(item_id)
+
+        proc = WebProcessor(lib_store, storage_dir)
+
+        mock_resp = _mock_httpx_response(html, 200)
+        from unittest.mock import patch
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "tinyagentos.routes.desktop_browser.ssrf.validate_url_or_raise",
+            ),
+        ):
+            mock_client_cls.return_value.__aenter__.return_value.stream = (
+                _mock_stream_callable(mock_resp)
+            )
+            artifacts = await proc.process(item)
+
+        kinds = {a["kind"] for a in artifacts}
+        assert "metadata" in kinds
+        assert "text" in kinds
+
+        text_artifacts = [a for a in artifacts if a["kind"] == "text"]
+        assert len(text_artifacts) == 1
+        text_path = Path(text_artifacts[0]["path"])
+        assert text_path.exists()
+
+        updated = await lib_store.get_item(item_id)
+        meta = json.loads(updated["meta_json"])
+        assert "preview" in meta
+
+    @pytest.mark.asyncio
+    async def test_process_web_url_no_source(self, lib_store, storage_dir):
+        """Web processor returns empty when source_url is missing."""
+        item_id = await lib_store.create_item(
+            kind="url:web", source_url="", title="",
+        )
+        item = await lib_store.get_item(item_id)
+
+        proc = WebProcessor(lib_store, storage_dir)
+        artifacts = await proc.process(item)
+        assert artifacts == []
+
+    @pytest.mark.asyncio
+    async def test_web_extracts_title_from_html(self, lib_store, storage_dir):
+        """Web processor auto-titles from <title> tag when item has no title."""
+        html = (
+            "<html><head><title>Auto Title Here</title></head>"
+            "<body><article><p>This article has enough text content "
+            "to ensure that the readability extractor returns a full "
+            "result instead of falling back to the simple tag stripper "
+            "which would otherwise happen for very short pages.</p></article>"
+            "</body></html>"
+        )
+
+        item_id = await lib_store.create_item(
+            kind="url:web",
+            source_url="https://example.com/titled",
+            title="https://example.com/titled",
+        )
+        item = await lib_store.get_item(item_id)
+
+        proc = WebProcessor(lib_store, storage_dir)
+
+        mock_resp = _mock_httpx_response(html, 200)
+        from unittest.mock import patch
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "tinyagentos.routes.desktop_browser.ssrf.validate_url_or_raise",
+            ),
+        ):
+            mock_client_cls.return_value.__aenter__.return_value.stream = (
+                _mock_stream_callable(mock_resp)
+            )
+            await proc.process(item)
+
+        updated = await lib_store.get_item(item_id)
+        assert "Auto Title Here" in updated["title"]
+
+    @pytest.mark.asyncio
+    async def test_web_pipeline_integration(self, lib_store, storage_dir):
+        """run_pipeline routes url:web items to WebProcessor."""
+        html = (
+            "<html><head><title>Pipeline Web</title></head>"
+            "<body><p>Pipeline test content that is sufficiently "
+            "long to pass the readability minimum character count."
+            "</p></body></html>"
+        )
+
+        item_id = await lib_store.create_item(
+            kind="url:web",
+            source_url="https://example.com/pipeline-web",
+        )
+
+        mock_resp = _mock_httpx_response(html, 200)
+        from unittest.mock import patch
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "tinyagentos.routes.desktop_browser.ssrf.validate_url_or_raise",
+            ),
+        ):
+            mock_client_cls.return_value.__aenter__.return_value.stream = (
+                _mock_stream_callable(mock_resp)
+            )
+            await run_pipeline(lib_store, item_id, storage_dir)
+
+        item = await lib_store.get_item(item_id)
+        assert item["status"] == "ready"
+
+        artifacts = await lib_store.get_artifacts(item_id)
+        artifact_kinds = {a["kind"] for a in artifacts}
+        assert "metadata" in artifact_kinds
+        assert "text" in artifact_kinds
+
+    # -- SSRF, size cap, content-type, and redirect tests — these test
+    #    actual guard paths rather than patching them out.
+
+    @pytest.mark.asyncio
+    async def test_web_ssrf_block_loopback(self, lib_store, storage_dir):
+        """validate_url_or_raise blocks loopback addresses."""
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+        import pytest as _pytest
+        with _pytest.raises(SsrfBlockedError):
+            validate_url_or_raise("http://127.0.0.1:8080/")
+
+    @pytest.mark.asyncio
+    async def test_web_ssrf_block_private(self, lib_store, storage_dir):
+        """validate_url_or_raise blocks RFC1918 private addresses."""
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+        import pytest as _pytest
+        with _pytest.raises(SsrfBlockedError):
+            validate_url_or_raise("http://10.0.0.1/admin")
+
+    @pytest.mark.asyncio
+    async def test_web_redirect_hop_validated(self, lib_store, storage_dir):
+        """Each redirect hop passes through validate_url_or_raise."""
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+        from unittest.mock import patch, MagicMock, AsyncMock
+        import pytest as _pytest
+
+        html = "<html><p>Redirected content that is long enough for readability extraction now.</p></html>"
+        item_id = await lib_store.create_item(
+            kind="url:web",
+            source_url="https://safe.example.com/page",
+        )
+        item = await lib_store.get_item(item_id)
+        proc = WebProcessor(lib_store, storage_dir)
+
+        # Simulate one redirect: safe → safe
+        mock_resp1 = MagicMock()
+        mock_resp1.status_code = 302
+        mock_resp1.headers = {"location": "https://safe.example.com/real", "content-type": "text/html"}
+        mock_resp1.is_redirect = True
+
+        mock_resp2 = _mock_httpx_response(html, 200)
+
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client.stream = MagicMock(
+            side_effect=[_mock_stream_ctx(mock_resp1), _mock_stream_ctx(mock_resp2)]
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "tinyagentos.routes.desktop_browser.ssrf.validate_url_or_raise",
+            ) as mock_validate,
+        ):
+            artifacts = await proc.process(item)
+
+        # Both hops should have been validated
+        assert mock_validate.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_web_size_cap(self, lib_store, storage_dir):
+        """Responses exceeding the size cap raise ValueError."""
+        from unittest.mock import patch, MagicMock
+        import pytest as _pytest
+
+        html = "x" * 1000  # small content
+        item_id = await lib_store.create_item(
+            kind="url:web",
+            source_url="https://example.com/huge",
+        )
+        item = await lib_store.get_item(item_id)
+        proc = WebProcessor(lib_store, storage_dir)
+
+        # Override cap to a tiny value for test speed
+        proc._MAX_WEB_BYTES = 100
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "text/html; charset=utf-8"}
+        mock_resp.encoding = "utf-8"
+
+        async def _aiter_bytes_oversized(_chunk_size=8192):
+            yield b"x" * 200
+
+        mock_resp.aiter_bytes = _aiter_bytes_oversized
+
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "tinyagentos.routes.desktop_browser.ssrf.validate_url_or_raise",
+            ),
+        ):
+            mock_client_cls.return_value.__aenter__.return_value.stream = (
+                _mock_stream_callable(mock_resp)
+            )
+            with _pytest.raises(ValueError, match="exceeds"):
+                await proc.process(item)
+
+    @pytest.mark.asyncio
+    async def test_web_content_type_gate(self, lib_store, storage_dir):
+        """Non-text/* content types raise ValueError."""
+        from unittest.mock import patch, MagicMock
+        import pytest as _pytest
+
+        item_id = await lib_store.create_item(
+            kind="url:web",
+            source_url="https://example.com/video.mp4",
+        )
+        item = await lib_store.get_item(item_id)
+        proc = WebProcessor(lib_store, storage_dir)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "video/mp4"}
+
+        with (
+            patch("httpx.AsyncClient") as mock_client_cls,
+            patch(
+                "tinyagentos.routes.desktop_browser.ssrf.validate_url_or_raise",
+            ),
+        ):
+            mock_client_cls.return_value.__aenter__.return_value.stream = (
+                _mock_stream_callable(mock_resp)
+            )
+            with _pytest.raises(ValueError, match="Non-text content-type"):
+                await proc.process(item)
+
+
+# ---------------------------------------------------------------------------
 # Collections handoff
 # ---------------------------------------------------------------------------
 
@@ -733,3 +1110,47 @@ def _create_test_image(path: Path):
     from PIL import Image
     img = Image.new("RGB", (100, 50), color="blue")
     img.save(path)
+
+
+def _async_return(value):
+    """Return an async callable that returns ``value`` (for mocking async functions)."""
+    async def _inner(*args, **kwargs):
+        return value
+    return _inner
+
+
+def _mock_httpx_response(html: str, status_code: int = 200):
+    """Return a mock httpx Response with the given HTML body."""
+    from unittest.mock import MagicMock
+    mock = MagicMock()
+    mock.text = html
+    mock.status_code = status_code
+    mock.is_redirect = False
+    mock.encoding = "utf-8"
+    mock.headers = {"content-type": "text/html; charset=utf-8"}
+
+    async def _aiter_bytes(_chunk_size: int = 8192):
+        yield html.encode("utf-8")
+
+    mock.aiter_bytes = _aiter_bytes
+    return mock
+
+
+def _mock_stream_ctx(mock_resp):
+    """Return an async context manager that yields ``mock_resp`` from stream()."""
+    class _StreamCtx:
+        async def __aenter__(self):
+            return mock_resp
+
+        async def __aexit__(self, *args):
+            pass
+
+    return _StreamCtx()
+
+
+def _mock_stream_callable(mock_resp):
+    """Return a callable that when invoked returns a stream async context manager."""
+    from unittest.mock import MagicMock
+    ctx = _mock_stream_ctx(mock_resp)
+    fn = MagicMock(return_value=ctx)
+    return fn

--- a/tinyagentos/knowledge_fetchers/youtube.py
+++ b/tinyagentos/knowledge_fetchers/youtube.py
@@ -14,6 +14,19 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# Tracked subprocesses so they can be killed on timeout or cancel.
+_tracked_procs: list[asyncio.subprocess.Process] = []
+
+
+def _cleanup_procs() -> None:
+    """Kill all tracked subprocesses (called on timeout or cancel)."""
+    for p in _tracked_procs:
+        try:
+            p.kill()
+        except Exception:
+            pass
+    _tracked_procs.clear()
+
 # Quality format map for yt-dlp -f flag
 _QUALITY_FORMATS: dict[str, str] = {
     "360": "bestvideo[height<=360]+bestaudio/best[height<=360]",
@@ -129,6 +142,7 @@ async def fetch(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
+    _tracked_procs.append(proc)
     stdout, stderr = await proc.communicate()
     if proc.returncode != 0:
         err = stderr.decode(errors="replace").strip()
@@ -171,6 +185,7 @@ async def fetch(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
+    _tracked_procs.append(thumb_proc)
     await thumb_proc.communicate()
     if thumb_proc.returncode != 0:
         logger.warning("yt-dlp thumbnail download failed for %s", url)
@@ -190,6 +205,7 @@ async def fetch(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
+    _tracked_procs.append(cap_proc)
     await cap_proc.communicate()
     if cap_proc.returncode != 0:
         logger.warning("yt-dlp caption extraction failed for %s", url)
@@ -255,6 +271,7 @@ async def download_video(
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
+    _tracked_procs.append(proc)
     stdout, stderr = await proc.communicate()
 
     if proc.returncode != 0:

--- a/tinyagentos/library_collections.py
+++ b/tinyagentos/library_collections.py
@@ -29,7 +29,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 # Text artifact kinds that should be indexed into collections
-_TEXT_ARTIFACT_KINDS = frozenset({"text", "transcript", "description", "ocr"})
+_TEXT_ARTIFACT_KINDS = frozenset({"text", "transcript", "description", "ocr", "chapters"})
 
 # Maximum polls while waiting for async index to complete.
 _MAX_INDEX_POLLS = 30

--- a/tinyagentos/library_pipeline.py
+++ b/tinyagentos/library_pipeline.py
@@ -7,6 +7,7 @@ that are stored on the item and optionally handed off to taosmd collections.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import mimetypes
@@ -319,6 +320,315 @@ class ImageProcessor(Processor):
         return artifacts
 
 
+class YouTubeProcessor(Processor):
+    """YouTube URL processor — cheap tier: metadata, thumbnail, transcript, chapters.
+
+    Uses yt-dlp via the knowledge_fetchers.youtube module to fetch video
+    metadata and captions without downloading the video file. Produces
+    artifacts that flow into taosmd collections for agent querying.
+
+    The cheap tier (per the design doc, docs/design/library-app.md section 4)
+    covers steps 1-4: canonical link, title, channel, description, thumbnail,
+    duration, upload date, subtitles/transcript, chapters.
+    """
+
+    _YTDLP_TIMEOUT = 120  # seconds
+
+    async def process(self, item: dict) -> list[dict]:
+        item_id = item["id"]
+        source_url = item.get("source_url", "")
+        artifacts: list[dict] = []
+
+        if not source_url:
+            return artifacts
+
+        # Only catch ImportError (missing yt-dlp).  Let fetch errors
+        # propagate so run_pipeline marks the item as "error" — a failed
+        # yt-dlp invocation must not silently look successful.
+        from tinyagentos.knowledge_fetchers.youtube import (
+            fetch,
+            format_timestamp,
+            _cleanup_procs,
+        )
+
+        media_dir = self.storage_dir / "youtube"
+        try:
+            result = await asyncio.wait_for(
+                fetch(source_url, media_dir=media_dir),
+                timeout=self._YTDLP_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            _cleanup_procs()
+            raise
+
+        title = result.get("title", "")
+        if title and not item.get("title"):
+            await self.store.update_item(item_id, title=title)
+
+        meta = result.get("metadata", {})
+
+        # Update item meta_json with structured video metadata
+        stored_meta = json.loads(item.get("meta_json", "{}"))
+        stored_meta.update({
+            "video_id": meta.get("video_id", ""),
+            "channel": meta.get("channel", ""),
+            "duration": meta.get("duration"),
+            "views": meta.get("views"),
+            "upload_date": meta.get("upload_date", ""),
+        })
+        await self.store.update_item(item_id, meta_json=stored_meta)
+
+        # Artifact: metadata
+        await self.store.add_artifact(
+            item_id, kind="metadata", path=source_url, meta=meta,
+        )
+        artifacts.append({"kind": "metadata", "path": source_url, "meta": meta})
+
+        # Artifact: thumbnail (if downloaded)
+        thumbnail = result.get("thumbnail")
+        if thumbnail and Path(thumbnail).exists():
+            await self.store.add_artifact(
+                item_id, kind="thumbnail", path=thumbnail,
+                meta={"source": "youtube"},
+            )
+            artifacts.append({
+                "kind": "thumbnail", "path": thumbnail,
+                "meta": {"source": "youtube"},
+            })
+
+        # Artifact: transcript
+        content = result.get("content", "")
+        if content:
+            transcript_dir = self.storage_dir / "transcripts"
+            transcript_dir.mkdir(parents=True, exist_ok=True)
+            transcript_path = transcript_dir / f"{item_id}_transcript.txt"
+            transcript_path.write_text(content, encoding="utf-8")
+
+            transcript_meta = {
+                "char_count": len(content),
+                "language": "en",
+            }
+            await self.store.add_artifact(
+                item_id, kind="transcript", path=str(transcript_path),
+                meta=transcript_meta,
+            )
+            artifacts.append({
+                "kind": "transcript", "path": str(transcript_path),
+                "meta": transcript_meta,
+            })
+
+            # Store preview for item card
+            preview = content[:200]
+            stored_meta["preview"] = preview
+            await self.store.update_item(item_id, meta_json=stored_meta)
+
+        # Artifact: chapters (if available)
+        chapters = meta.get("chapters", [])
+        if chapters:
+            chapters_lines: list[str] = []
+            for ch in chapters:
+                ts = format_timestamp(ch.get("start_time", 0))
+                ch_title = ch.get("title", "")
+                chapters_lines.append(f"[{ts}] {ch_title}")
+
+            chapters_text = "\n".join(chapters_lines)
+            chapters_dir = self.storage_dir / "chapters"
+            chapters_dir.mkdir(parents=True, exist_ok=True)
+            chapters_path = chapters_dir / f"{item_id}_chapters.txt"
+            chapters_path.write_text(chapters_text, encoding="utf-8")
+
+            await self.store.add_artifact(
+                item_id, kind="chapters", path=str(chapters_path),
+                meta={"count": len(chapters)},
+            )
+            artifacts.append({
+                "kind": "chapters", "path": str(chapters_path),
+                "meta": {"count": len(chapters)},
+            })
+
+        return artifacts
+
+
+class WebProcessor(Processor):
+    """Generic web-page URL processor — extracts readable text from HTML.
+
+    Fetches the URL (SSRF-guarded against loopback/link-local/private hosts),
+    then extracts the main content using readability-lxml. Falls back to a
+    simple tag-stripping approach when readability-lxml is not installed.
+
+    Produces a text artifact suitable for taosmd collection indexing so that
+    agents granted the collection can query the page content.
+    """
+
+    _MAX_WEB_REDIRECTS = 5
+    _MAX_WEB_BYTES = 10 * 1024 * 1024  # 10 MB
+    _TOTAL_TIMEOUT = 60  # wall-clock deadline
+
+    async def process(self, item: dict) -> list[dict]:
+        item_id = item["id"]
+        source_url = item.get("source_url", "")
+        artifacts: list[dict] = []
+
+        if not source_url:
+            return artifacts
+
+        import httpx
+        from urllib.parse import urljoin
+
+        from tinyagentos.routes.desktop_browser.ssrf import (
+            SsrfBlockedError,
+            validate_url_or_raise,
+        )
+
+        # Fetch the page (SSRF-guarded, redirect-safe, size-capped, content-type gated).
+        # Uses client.stream() so the body is never fully buffered before the cap runs
+        # — a hostile server streaming a multi-GB text/html body is OOM-safe.
+        async def _fetch() -> tuple[str, str, bytes]:
+            current_url = source_url
+            for _hop in range(self._MAX_WEB_REDIRECTS + 1):
+                validate_url_or_raise(current_url)
+
+                async with httpx.AsyncClient(
+                    timeout=httpx.Timeout(30),
+                    follow_redirects=False,
+                ) as client:
+                    async with client.stream("GET", current_url) as resp:
+                        status_code = resp.status_code
+                        content_type = resp.headers.get("content-type", "")
+
+                        # Content-type gate: non-text responses end in error.
+                        ct_base = content_type.split(";")[0].strip().lower()
+                        if status_code >= 400:
+                            resp.raise_for_status()
+                        if ct_base and not ct_base.startswith("text/"):
+                            raise ValueError(
+                                f"Non-text content-type {content_type!r} "
+                                f"for {source_url!r} — only text/* is supported"
+                            )
+
+                        # Redirect: grab Location, update URL, continue loop.
+                        if status_code in (301, 302, 303, 307, 308) and resp.headers.get("location"):
+                            current_url = urljoin(current_url, resp.headers["location"])
+                            # fall through → exit with → _hop advances
+                        else:
+                            # Read body with size cap — streaming, so the cap stops OOM.
+                            body_chunks: list[bytes] = []
+                            total = 0
+                            async for chunk in resp.aiter_bytes(8192):
+                                total += len(chunk)
+                                if total > self._MAX_WEB_BYTES:
+                                    raise ValueError(
+                                        f"Response body exceeds {self._MAX_WEB_BYTES} bytes "
+                                        f"for {source_url!r}"
+                                    )
+                                body_chunks.append(chunk)
+                            encoding = resp.encoding or "utf-8"
+                            return content_type, encoding, b"".join(body_chunks)
+            else:
+                raise SsrfBlockedError(
+                    f"too many redirects fetching {source_url!r}"
+                )
+
+        try:
+            content_type, encoding, body = await asyncio.wait_for(
+                _fetch(), timeout=self._TOTAL_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            raise ValueError(
+                f"Timed out after {self._TOTAL_TIMEOUT}s fetching {source_url!r}"
+            )
+
+        html = body.decode(encoding, errors="replace")
+
+        if not html:
+            return artifacts
+
+        # Extract readable text
+        content = _extract_readable_text(html, source_url)
+
+        # Extract title from <title> tag if item has no title
+        import html as _html_mod
+        title = item.get("title", "")
+        if not title or title == source_url:
+            import re
+            m = re.search(
+                r"<title[^>]*>([^<]+)</title>", html, re.IGNORECASE,
+            )
+            if m:
+                title = _html_mod.unescape(m.group(1)).strip()[:200]
+                await self.store.update_item(item_id, title=title)
+
+        # Artifact: metadata
+        page_meta = {
+            "char_count": len(content),
+            "content_type": content_type,
+        }
+        await self.store.add_artifact(
+            item_id, kind="metadata", path=source_url, meta=page_meta,
+        )
+        artifacts.append({
+            "kind": "metadata", "path": source_url, "meta": page_meta,
+        })
+
+        # Artifact: extracted text
+        if content:
+            text_dir = self.storage_dir / "text"
+            text_dir.mkdir(parents=True, exist_ok=True)
+            text_path = text_dir / f"{item_id}_web.txt"
+            text_path.write_text(content, encoding="utf-8")
+
+            text_meta = {
+                "char_count": len(content),
+                "source": "readability",
+            }
+            await self.store.add_artifact(
+                item_id, kind="text", path=str(text_path), meta=text_meta,
+            )
+            artifacts.append({
+                "kind": "text", "path": str(text_path), "meta": text_meta,
+            })
+
+            # Store preview
+            preview = content[:200]
+            stored_meta = json.loads(item.get("meta_json", "{}"))
+            stored_meta["preview"] = preview
+            await self.store.update_item(item_id, meta_json=stored_meta)
+
+        return artifacts
+
+
+def _extract_readable_text(html: str, source_url: str = "") -> str:
+    """Extract the main readable content from an HTML page.
+
+    Uses readability-lxml when available; falls back to simple tag-stripping.
+    """
+    try:
+        from readability import Document
+        doc = Document(html)
+        content = doc.summary()
+        # Strip remaining HTML from readability output
+        import re
+        text = re.sub(r"<[^>]+>", " ", content)
+        text = re.sub(r"\s+", " ", text).strip()
+        if len(text) >= 100:
+            return text
+    except ImportError:
+        logger.debug("readability-lxml not installed — using simple extractor")
+    except Exception:
+        logger.warning("readability extraction failed for %s", source_url,
+                       exc_info=True)
+
+    # Fallback: simple tag-stripping (from knowledge_ingest._extract_text_readability)
+    import re
+    cleaned = re.sub(
+        r"<(script|style)[^>]*>.*?</(script|style)>", "", html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    text = re.sub(r"<[^>]+>", " ", cleaned)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
 # ---------------------------------------------------------------------------
 # Processor registry
 # ---------------------------------------------------------------------------
@@ -328,6 +638,8 @@ _PROCESSORS: dict[str, type[Processor]] = {
     "text": TextProcessor,
     "pdf": PdfProcessor,
     "image": ImageProcessor,
+    "url:youtube": YouTubeProcessor,
+    "url:web": WebProcessor,
 }
 
 
@@ -362,24 +674,6 @@ async def run_pipeline(
         return
 
     kind = item["kind"]
-
-    # URL-only items (no storage_path) are stored as references — the pipeline
-    # records a reference metadata artifact but does not fetch remote content
-    # (future: WebFetcherProcessor, #2078).  The item gets a "reference" artifact so it
-    # is not silently empty.
-    if not item.get("storage_path") and item.get("source_url"):
-        logger.info(
-            "Library pipeline: URL-only item %s (%s) — stored as reference, not fetched",
-            item_id, kind,
-        )
-        ref_meta = {
-            "source_url": item["source_url"],
-            "kind": kind,
-            "note": "Reference-only item — content not fetched (TODO: WebFetcherProcessor)",
-        }
-        await store.add_artifact(
-            item_id, kind="reference", path="", meta=ref_meta,
-        )
 
     # If item has a storage_path that points to a missing file, fail early
     # (dropped/moved/corrupt source must not silently look successful).

--- a/tinyagentos/routes/library.py
+++ b/tinyagentos/routes/library.py
@@ -62,9 +62,25 @@ def _library_dir(request: Request) -> Path:
 
 
 async def _get_library_store(request: Request):
-    """Get the LibraryStore from app.state (lazily initialised)."""
+    """Get the LibraryStore from app.state (lazily initialised).
+
+    Uses an asyncio.Lock to close the TOCTOU race where two concurrent
+    requests both see ``store is None`` and both call ``LibraryStore(...)``.
+    """
     store = getattr(request.app.state, "library_store", None)
-    if store is None:
+    if store is not None:
+        return store
+
+    lock = getattr(request.app.state, "_library_store_init_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        request.app.state._library_store_init_lock = lock
+
+    async with lock:
+        store = getattr(request.app.state, "library_store", None)
+        if store is not None:
+            return store
+
         from tinyagentos.library_store import LibraryStore
 
         data_dir = getattr(request.app.state, "data_dir", None)


### PR DESCRIPTION
## Rebase of #2068 onto origin/dev (c5b1a6fe)

This is the re-land jaylfc requested. Keeps ONLY the P2 delta on top of current dev.

### What was changed from the old PR

**P2 delta (kept):**
- YouTubeProcessor: metadata, thumbnail, transcript, chapters
- WebProcessor: HTML fetch, readability extraction, SSRF-guarded redirects
- `_extract_readable_text()` helper
- `url:youtube` + `url:web` in `_PROCESSORS`
- run_pipeline reference-artifact removal
- `_store_init_lock` (asyncio.Lock on lazy LibraryStore init)
- `"chapters"` in `_TEXT_ARTIFACT_KINDS`

**P1 re-application (dropped):**
- templates/library.html — not added (dev dropped the server-rendered page)
- All P1 store/route/collections changes — dev's versions preserved

**Fixes from jaylfc review:**

| Fix | Status |
|-----|--------|
| Streaming read: `client.stream()` instead of `client.get()` | Done |
| 10 MB cap enforced during streaming (OOM-safe) | Done |
| Content-type gate: non-`text/*` → `ValueError` (→ error status) | Done |
| 60s wall-clock deadline on WebProcessor fetch | Done |
| `_cleanup_procs()` kill tracked subprocesses on timeout | Done |
| 120s `asyncio.wait_for` on YouTubeProcessor with cleanup | Done |

**Preserved from dev (not reverted):**
- `try_update_item_status` CAS
- Reprocess 409 guard + artifact cleanup + rollback-to-ready
- taosmd HTTP collections flow (memory_url, admin-token, idempotent collection_id)
- `logger.warning` OSError handlers
- `path=""` on metadata artifacts (unlink guard)
- `test_library_page_gone`, `test_unauth_library_endpoints`,
  `test_reprocess_idempotent`, `test_reprocess_while_processing_returns_409`

**Tests: 54/54 pass** (42 existing dev tests + 12 new): 3 YouTube, 4 web happy-path, 2 SSRF block, 1 redirect-hop validation, 1 size cap, 1 content-type gate.

Closes #2068.