### PR TITLE
docs(agent-coordination): spend model tokens on judgement, not on waiting

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -180,6 +180,25 @@ I have read the CLA Document and I hereby sign the CLA
 3. Once code is done and local tests pass, `gh pr ready`. Address review feedback with additional
    commits on the same branch. The maintainer merges upstream.
 
+### Do not spend turns waiting
+
+You pay per turn. Spend them on judgement (reading a diff, diagnosing a failure,
+deciding whether a green check is trustworthy), not on waiting or repetition.
+
+- **Do not poll CI in a loop.** `gh pr checks <PR#> --watch` blocks in one call
+  and returns when the run finishes. Re-running `gh pr checks` every minute
+  costs a turn each time and tells you nothing new. (A malformed watch once
+  exited early and reported success while shards were still running, so read
+  the final status rather than trusting that the command returned.)
+- **If you have hand-verified the same property twice, write the test.** Two
+  manual checks is the signal. A test costs nothing per run; re-reading costs
+  every time.
+- **Ask the narrow question.** A targeted `grep` or a symbol-level diff against
+  `origin/dev` usually decides the matter far more cheaply than reading a whole
+  diff. Work out what single fact settles it, then fetch only that.
+- **Do not re-poll a blocked run.** See `action_required` above: surface it and
+  stop. Repeatedly checking a run that is waiting on a human is pure cost.
+
 ## Post-Push Bot Review Cycle
 
 After pushing a PR and marking it ready, automated bots review it. The reliable gate is

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -89,6 +89,47 @@ several threads means one connection each.
   edge-case correctness problem) before merging. Style and preference nits can
   be deferred or taken in a follow-up.
 
+## Spend model tokens on judgement, not on waiting
+
+An agent working this repo pays for every turn it takes. Reserve those turns for
+work only a model can do, and hand the rest to the platform.
+
+- **Judgement is worth a turn**: reviewing a diff, diagnosing a failure, writing
+  the acceptance criteria for a task, deciding whether a green check is
+  trustworthy.
+- **Waiting and mechanics are not**: watching CI finish, merging a PR you have
+  already approved, polling for a state change, re-checking something you have
+  already verified.
+
+**Use auto-merge once you have reviewed.** Rather than waiting for checks and
+coming back to merge, arm it and let GitHub finish the job:
+
+```
+gh pr merge <number> --auto --squash --delete-branch
+```
+
+The PR merges the moment required checks pass. Without this, every approved PR
+costs two extra wake-ups: one when it turns green, one to merge it.
+
+**Only arm auto-merge on a PR you have actually reviewed.** Auto-merge triggers
+on *green*, and green is a claim rather than proof. This repo has merged a
+feature that passed every check and had never once executed, and shipped a
+"10 MB" download cap that buffered the whole body into memory first. Auto-merge
+replaces the *waiting*, never the *reading*.
+
+(The `automerge` check reporting `skipping` on your PR comes from
+`dependabot-automerge.yml` and applies to Dependabot only. It is not general
+auto-merge.)
+
+**If you have hand-checked the same property twice, turn it into a check.** Two
+manual verifications is the signal to write the script or the CI job. A test
+that runs on every PR costs nothing per run; a human re-reading the same thing
+costs every time.
+
+**Ask the narrow question.** Prefer a targeted probe to reading everything: a
+symbol-level diff against the target branch answers "did this PR delete work
+that landed after it was cut?" far more cheaply than reading the whole diff.
+
 ## Keep the shared docs honest
 
 - When you merge something others depend on, update the relevant README or

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -111,6 +111,21 @@ gh pr merge <number> --auto --squash --delete-branch
 The PR merges the moment required checks pass. Without this, every approved PR
 costs two extra wake-ups: one when it turns green, one to merge it.
 
+**Check two things before you rely on it**, because auto-merge is neither
+universally available nor safe by default:
+
+1. **Is it enabled on the repo?** `gh api repos/<owner>/<repo> --jq
+   .allow_auto_merge`. It is a paid feature for private repositories, and on a
+   repo where it is unavailable a `PATCH` to enable it returns `200` and
+   silently changes nothing. Re-read the field afterwards rather than trusting
+   the response.
+2. **Does the base branch have required status checks?** `gh api
+   repos/<owner>/<repo>/branches/<base>/protection`. This is the one that
+   bites: auto-merge waits for the gates a branch actually has, so on a branch
+   with **no** protection there are no required checks, a PR is mergeable the
+   instant it opens, and `--auto` quietly degrades to *merge now, ignore CI*.
+   Never arm it on an unprotected branch.
+
 **Only arm auto-merge on a PR you have actually reviewed.** Auto-merge triggers
 on *green*, and green is a claim rather than proof. This repo has merged a
 feature that passed every check and had never once executed, and shipped a


### PR DESCRIPTION
Adds a token-discipline section to the agent coordination guide, so the practice reaches every agent and contributor working this repo rather than living only in my head.

**The substance:** reserve model turns for judgement (reviewing a diff, diagnosing a failure, writing acceptance criteria, deciding whether a green check is trustworthy) and hand waiting and mechanics to the platform.

**The concrete win:** `allow_auto_merge` is *already* enabled on this repo and was going unused. Every approved PR was costing two extra wake-ups, one when it turned green and one to merge it. `gh pr merge <n> --auto --squash --delete-branch` removes both.

**The constraint, which matters as much:** auto-merge triggers on **green**, and green is a claim rather than proof. This repo has merged a feature that passed every check having never once executed, and shipped a "10 MB" cap that buffered the entire body into memory first. So auto-merge replaces the *waiting*, never the *reading*, and should only be armed on a PR already reviewed.

Also documents a real trap: the `automerge` check that reports `skipping` on human PRs comes from `dependabot-automerge.yml` and fires for Dependabot only. It reads like general auto-merge exists when it does not.

Docs-only change to an existing guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reducing time spent waiting on CI and merge workflows.
  * Added recommendations for focused reviews, targeted checks, and automating repeated verification.
  * Documented best practices for evaluating CI results and using auto-merge after review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->