### PR TITLE
Add project_tasks_update agent scope so leads can edit their own board

### DIFF
--- a/tests/test_agent_scope_requests.py
+++ b/tests/test_agent_scope_requests.py
@@ -569,6 +569,7 @@ def test_project_scope_set_is_a_single_definition():
     assert mod._PROJECT_SCOPES == {
         "project_tasks",
         "project_tasks_create",
+        "project_tasks_update",
         "canvas_read",
         "canvas_write",
         "files_read",

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -61,9 +61,14 @@ _AGENT_TASK_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/tasks/{_SEG}/context$")),
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
-    # PATCH (free task-field mutation) is intentionally NOT here: it is broader
-    # than the "read + lifecycle + comments" the project_tasks scope documents.
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
+    # PATCH (free task-field mutation) was intentionally NOT here: it is broader
+    # than the "read + lifecycle + comments" the project_tasks scope documents.
+    # It is now reachable by a project_tasks_update-bound agent token, but the
+    # route enforces the narrower scope + authorship/lead gate + a field
+    # whitelist (title, body, labels, status, priority) before any mutation, so
+    # a project_tasks worker still cannot rewrite fields it was never meant to.
+    ("PATCH", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
     # Mark-claimable curation: reachable by a Bearer token, but the handler
     # (_authorize_project_lead) then restricts it to THIS project's LEAD agent --
     # a plain project_tasks worker is refused. Toggles only the "claimable"

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -250,6 +250,7 @@ class ProjectTaskStore(BaseStore):
         body: str | None = None,
         priority: int | None = None,
         labels: list[str] | None = None,
+        status: str | None = None,
         assignee_id: str | None = None,
         parent_task_id: str | None = None,
         element_id: object = _ELEMENT_UNCHANGED,
@@ -259,6 +260,7 @@ class ProjectTaskStore(BaseStore):
             ("body", body, body),
             ("priority", priority, priority),
             ("labels", labels, json.dumps(labels) if labels is not None else None),
+            ("status", status, status),
             ("assignee_id", assignee_id, assignee_id),
             ("parent_task_id", parent_task_id, parent_task_id),
         ]

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -62,6 +62,11 @@ VALID_SCOPES = frozenset({
     # scope keeps an existing approval meaning exactly what it meant when it was
     # given, and makes authoring an explicit per-agent opt-in.
     "project_tasks_create",
+    # Editing a card's own fields (title, body, labels, status, priority).
+    # Distinct from project_tasks (read + lifecycle + comments) and
+    # project_tasks_create (authoring): an agent may PATCH only its OWN cards or
+    # those on a project it leads, and only the whitelisted fields.
+    "project_tasks_update",
     # Canvas access: read and write on a specific project's canvas. Like
     # project_tasks, a project_id is required so the token is bound to the
     # operator-validated project rather than whatever the unauthenticated agent
@@ -194,7 +199,7 @@ async def _retire_scope_request_notification(request: Request, request_id: str) 
 # project_tasks_create globally. One definition, referenced everywhere.
 _CANVAS_SCOPES = {"canvas_read", "canvas_write"}
 _FILES_SCOPES = {"files_read", "files_write"}
-_PROJECT_SCOPES = {"project_tasks", "project_tasks_create"} | _CANVAS_SCOPES | _FILES_SCOPES
+_PROJECT_SCOPES = {"project_tasks", "project_tasks_create", "project_tasks_update"} | _CANVAS_SCOPES | _FILES_SCOPES
 
 
 def _get_approve_lock(request: Request, request_id: str) -> asyncio.Lock:

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -94,6 +94,7 @@ _ALLOWED_SCOPES = frozenset({
     "tools_execute", "registry_feeds_read",
     "project_tasks",
     "project_tasks_create",
+    "project_tasks_update",
     "canvas_read", "canvas_write",
     "decisions_read", "decisions_write",
 })

--- a/tinyagentos/routes/project_invites.py
+++ b/tinyagentos/routes/project_invites.py
@@ -84,7 +84,7 @@ class RedeemInviteIn(BaseModel):
 # (project-less) invite has no project to bind them to, so they are stripped
 # before minting rather than granted verbatim: an OS invite must never hand out
 # project-scoped authority that resolves to no project.
-_PROJECT_SCOPED = {"project_tasks", "canvas_read", "canvas_write"}
+_PROJECT_SCOPED = {"project_tasks", "project_tasks_create", "project_tasks_update", "canvas_read", "canvas_write"}
 
 
 def _derive_handle(project_slug: str, harness: str, label: str | None) -> str:

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -451,6 +451,7 @@ class UpdateTaskIn(BaseModel):
     body: str | None = None
     priority: int | None = None
     labels: list[str] | None = None
+    status: str | None = None
     assignee_id: str | None = None
     parent_task_id: str | None = None
     # Omit to leave the element tag unchanged; send "none" to clear it to
@@ -736,26 +737,56 @@ async def get_task(
     return t
 
 
+# Fields an agent holding project_tasks_update may PATCH. Everything else in
+# UpdateTaskIn (assignee_id, parent_task_id, element_id, and any future field)
+# is rejected 400 for agents so the surface stays minimal and future task
+# fields are protected by default. Session owner/admin is unaffected.
+_AGENT_EDITABLE_FIELDS = frozenset({"title", "body", "labels", "status", "priority"})
+
+
 @router.patch("/api/projects/{project_id}/tasks/{task_id}")
 async def update_task(
     project_id: str,
     task_id: str,
     payload: UpdateTaskIn,
     request: Request,
-    user: CurrentUser = Depends(current_user),
 ):
-    # Session owner/admin only. A project_tasks agent drives its board through
-    # read + the lifecycle actions (claim/release/close/reopen) + comments; free
-    # PATCH of title/body/assignee_id/parent is a broader mutation than that
-    # scope grants, so it stays off the agent allowlist (Kilo review on #1774).
+    # Dual-auth: session owner/admin OR an agent holding project_tasks_update
+    # bound to THIS project. The agent gate (authorship/lead) and field
+    # whitelist are enforced below.
     pstore = request.app.state.project_store
-    project_or_err = await _get_owned_project(pstore, project_id, user)
-    if isinstance(project_or_err, JSONResponse):
-        return project_or_err
+    auth = await _authorize_task_actor(
+        request, pstore, project_id, scope="project_tasks_update"
+    )
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, project = auth
     store = request.app.state.project_task_store
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
+
+    # Agent gate: an agent may PATCH only its OWN cards or cards on a project it
+    # leads. A non-author non-lead agent is refused 403 (it has the scope, so the
+    # project is not hidden; the refusal is an authorization failure, not a
+    # scope mismatch).
+    if is_agent:
+        lead_id = project.get("lead_member_id")
+        if existing.get("created_by") != actor_id and lead_id != actor_id:
+            return JSONResponse(
+                {"error": "agent may only edit its own cards or those it leads"},
+                status_code=403,
+            )
+
+    # Field whitelist for agents: title, body, labels, status, priority ONLY.
+    # Any other field that is set is rejected 400 (future fields included).
+    if is_agent:
+        for f in payload.model_fields:
+            if f not in _AGENT_EDITABLE_FIELDS and getattr(payload, f) is not None:
+                return JSONResponse(
+                    {"error": f"field {f!r} is not editable by agents"},
+                    status_code=400,
+                )
 
     if payload.parent_task_id is not None:
         if payload.parent_task_id == task_id:
@@ -774,7 +805,7 @@ async def update_task(
 
     estore = request.app.state.project_element_store
     update_fields: dict = {}
-    for f in ("title", "body", "priority", "labels", "assignee_id", "parent_task_id"):
+    for f in ("title", "body", "priority", "labels", "status", "assignee_id", "parent_task_id"):
         v = getattr(payload, f)
         if v is not None:
             update_fields[f] = v


### PR DESCRIPTION
Autonomous build of board card tsk-chzj5y.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 tinyagentos/auth_middleware.py            |  9 ++++--
 tinyagentos/projects/task_store.py        |  2 ++
 tinyagentos/routes/agent_auth_requests.py |  7 ++++-
 tinyagentos/routes/agent_registry.py      |  1 +
 tinyagentos/routes/project_invites.py     |  2 +-
 tinyagentos/routes/projects.py            | 49 +++++++++++++++++++++++++------
 6 files changed, 57 insertions(+), 13 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating project task status.
  * Agents with the appropriate project permission can update their own tasks or tasks they lead.
  * Agent task edits support title, description, labels, status, and priority.

* **Security**
  * Restricted agent task updates to approved fields and project-scoped permissions.
  * Added project-task update permissions to authorization and invitation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->