### PR TITLE
fix(store): fail-closed canonicalisation + TOCTOU re-verify hardening

### DIFF
--- a/tests/test_routes_store_install.py
+++ b/tests/test_routes_store_install.py
@@ -646,7 +646,7 @@ class TestInstallV2:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(os.geteuid() == 0, reason="chmod 0o000 is a no-op for root")
+    @pytest.mark.skipif(getattr(os, 'geteuid', lambda: -1)() == 0, reason="chmod 0o000 is a no-op for root")
     async def test_toctou_manifest_unreadable_returns_403(self, client, tmp_path):
         """TOCTOU re-verify returns 403 when manifest.yaml cannot be read
         (permissions revoked) between the initial gate and the install."""
@@ -840,7 +840,7 @@ class TestInstallV2:
         svc_dir.mkdir(parents=True)
         manifest_path = svc_dir / "manifest.yaml"
         # Load the catalog with a manifest that CAN be signed (no date
-        # fields — _canonical_manifest_bytes succeeds on dicts without
+        # fields - _canonical_manifest_bytes succeeds on dicts without
         # non-JSON-serialisable values).
         manifest_path.write_text(
             "id: test-svc\nname: Test Service\ntype: service\n"
@@ -855,7 +855,7 @@ class TestInstallV2:
             installed_path=installed_path,
             signing_key=priv,
         )
-        reg._ensure_loaded()  # signing succeeds — no date fields yet
+        reg._ensure_loaded()  # signing succeeds - no date fields yet
 
         client._transport.app.state.registry = reg
         client._transport.app.state.store_signing_pubkey = pub

--- a/tests/test_routes_store_install.py
+++ b/tests/test_routes_store_install.py
@@ -827,6 +827,64 @@ class TestInstallV2:
         )
 
     @pytest.mark.asyncio
+    async def test_toctou_date_field_fails_closed_returns_403(self, client, tmp_path):
+        """TOCTOU re-verify returns 403 (not 500) when the manifest contains
+        a YAML date field that ``json.dumps`` cannot serialise without
+        ``default=str``.  Proves the canonicalisation fix is fail-closed:
+        TypeError → return False → 403, consistent with the PR's thesis."""
+        from tinyagentos.registry import AppRegistry
+        from tinyagentos.store_signing import generate_signing_keypair
+
+        catalog_dir = tmp_path / "catalog"
+        svc_dir = catalog_dir / "services" / "test-svc"
+        svc_dir.mkdir(parents=True)
+        manifest_path = svc_dir / "manifest.yaml"
+        # Load the catalog with a manifest that CAN be signed (no date
+        # fields — _canonical_manifest_bytes succeeds on dicts without
+        # non-JSON-serialisable values).
+        manifest_path.write_text(
+            "id: test-svc\nname: Test Service\ntype: service\n"
+            "version: \"1.0\"\ninstall:\n  method: download\n",
+        )
+
+        priv, pub = generate_signing_keypair()
+        installed_path = tmp_path / "installed.json"
+        installed_path.write_text("[]")
+        reg = AppRegistry(
+            catalog_dir=catalog_dir,
+            installed_path=installed_path,
+            signing_key=priv,
+        )
+        reg._ensure_loaded()  # signing succeeds — no date fields yet
+
+        client._transport.app.state.registry = reg
+        client._transport.app.state.store_signing_pubkey = pub
+        client._transport.app.state.installed_apps = _make_installed_apps()
+
+        # Now tamper the manifest to include a YAML date field.
+        # yaml.safe_load parses the unquoted 2026-01-01 into a
+        # datetime.date, which json.dumps cannot serialise without
+        # default=str.  The TypeError from _canonical_manifest_bytes
+        # is caught by verify_manifest_signature's except Exception →
+        # returns False → TOCTOU returns False → 403.
+        manifest_path.write_text(
+            "id: test-svc\nname: Test Service\ntype: service\n"
+            "version: \"1.0\"\nrelease_date: 2026-01-01\n"
+            "install:\n  method: download\n",
+        )
+
+        # Make the first gate pass so the TOCTOU guard runs.
+        reg.verify_manifest_signature = lambda aid, pem: True  # type: ignore[method-assign]
+
+        resp = await client.post("/api/store/install-v2", json={
+            "manifest_id": "test-svc",
+        })
+        assert resp.status_code == 403
+        assert resp.json()["error"] == (
+            "manifest signature re-verification failed"
+        )
+
+    @pytest.mark.asyncio
     async def test_no_signing_key_skips_verification(self, client):
         """When store_signing_pubkey is not set, the signing gate is
         skipped and the install proceeds normally."""

--- a/tests/test_routes_store_install.py
+++ b/tests/test_routes_store_install.py
@@ -589,7 +589,7 @@ class TestInstallV2:
             f"expected 403 after tampering, got {resp.status_code}: {resp.json()}"
         )
         body = resp.json()
-        assert body["error"] == "manifest modified between signature verification and install"
+        assert body["error"] == "manifest signature re-verification failed"
         assert "install_id" in body
 
         # Restore the original so teardown is clean.
@@ -642,10 +642,11 @@ class TestInstallV2:
         })
         assert resp.status_code == 403
         assert resp.json()["error"] == (
-            "manifest modified between signature verification and install"
+            "manifest signature re-verification failed"
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(os.geteuid() == 0, reason="chmod 0o000 is a no-op for root")
     async def test_toctou_manifest_unreadable_returns_403(self, client, tmp_path):
         """TOCTOU re-verify returns 403 when manifest.yaml cannot be read
         (permissions revoked) between the initial gate and the install."""
@@ -685,7 +686,7 @@ class TestInstallV2:
             })
             assert resp.status_code == 403
             assert resp.json()["error"] == (
-                "manifest modified between signature verification and install"
+                "manifest signature re-verification failed"
             )
         finally:
             os.chmod(manifest_path, 0o644)  # restore so tmp_path can clean up
@@ -730,7 +731,7 @@ class TestInstallV2:
         })
         assert resp.status_code == 403
         assert resp.json()["error"] == (
-            "manifest modified between signature verification and install"
+            "manifest signature re-verification failed"
         )
 
     @pytest.mark.asyncio
@@ -775,7 +776,7 @@ class TestInstallV2:
         })
         assert resp.status_code == 403
         assert resp.json()["error"] == (
-            "manifest modified between signature verification and install"
+            "manifest signature re-verification failed"
         )
 
     @pytest.mark.asyncio
@@ -822,7 +823,7 @@ class TestInstallV2:
         })
         assert resp.status_code == 403
         assert resp.json()["error"] == (
-            "manifest modified between signature verification and install"
+            "manifest signature re-verification failed"
         )
 
     @pytest.mark.asyncio

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -814,15 +814,15 @@ async def install_app(request: Request):
                 if not disk_path.exists():
                     return False
                 on_disk = _yaml.safe_load(disk_path.read_text())
+                if not on_disk:
+                    return False
+                stored_sig = registry.get_signature(manifest_id)
+                if stored_sig is None:
+                    return False
+                from tinyagentos.store_signing import verify_manifest_signature as _verify_sig
+                return _verify_sig(on_disk, stored_sig, _store_pub)
             except Exception:
                 return False
-            if not on_disk:
-                return False
-            stored_sig = registry.get_signature(manifest_id)
-            if stored_sig is None:
-                return False
-            from tinyagentos.store_signing import verify_manifest_signature as _verify_sig
-            return _verify_sig(on_disk, stored_sig, _store_pub)
 
         if not await asyncio.to_thread(_toctou_reverify):
             progress.finish(

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -814,15 +814,15 @@ async def install_app(request: Request):
                 if not disk_path.exists():
                     return False
                 on_disk = _yaml.safe_load(disk_path.read_text())
-                if not on_disk:
-                    return False
-                stored_sig = registry.get_signature(manifest_id)
-                if stored_sig is None:
-                    return False
-                from tinyagentos.store_signing import verify_manifest_signature as _verify_sig
-                return _verify_sig(on_disk, stored_sig, _store_pub)
             except Exception:
                 return False
+            if not on_disk:
+                return False
+            stored_sig = registry.get_signature(manifest_id)
+            if stored_sig is None:
+                return False
+            from tinyagentos.store_signing import verify_manifest_signature as _verify_sig
+            return _verify_sig(on_disk, stored_sig, _store_pub)
 
         if not await asyncio.to_thread(_toctou_reverify):
             progress.finish(

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -821,22 +821,23 @@ async def install_app(request: Request):
                     return False
                 from tinyagentos.store_signing import verify_manifest_signature as _verify_sig
                 return _verify_sig(on_disk, stored_sig, _store_pub)
-            except Exception:
+            except Exception:  # noqa: BLE001 — fail-closed, never allow on error
                 return False
 
         if not await asyncio.to_thread(_toctou_reverify):
             progress.finish(
                 install_id, success=False,
-                error="manifest modified between signature verification and install",
+                error="manifest signature re-verification failed",
             )
             return JSONResponse(
                 {
-                    "error": "manifest modified between signature verification and install",
+                    "error": "manifest signature re-verification failed",
                     "detail": (
-                        "The manifest on disk was modified after the initial "
-                        "signature verification. This may indicate post-verification "
-                        "tampering. Rebuild the catalog or reinstall the app from "
-                        "a trusted source."
+                        "The manifest signature could not be re-verified at "
+                        "install time. This may indicate post-load tampering, "
+                        "a missing or unreadable manifest file, or a lost "
+                        "signature. Rebuild the catalog or reinstall the app "
+                        "from a trusted source."
                     ),
                     "install_id": install_id,
                 },

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -821,7 +821,8 @@ async def install_app(request: Request):
                     return False
                 from tinyagentos.store_signing import verify_manifest_signature as _verify_sig
                 return _verify_sig(on_disk, stored_sig, _store_pub)
-            except Exception:  # noqa: BLE001 — fail-closed, never allow on error
+            except Exception:  # noqa: BLE001 - fail-closed, never allow on error
+                logger.exception("TOCTOU manifest re-verification failed")
                 return False
 
         if not await asyncio.to_thread(_toctou_reverify):


### PR DESCRIPTION
Follow-up to #2050.

**Changes:**
- `32041496`: Drop `default=str` from `_canonical_manifest_bytes` — fail-closed on TypeError (YAML date fields etc.)
- `7a4e867e`: Address CodeRabbit BLE001, unified error message, root guard
- `2f559234`: Resolve Kilo WARNING+SUGGESTION — date-safe canonicalisation + async TOCTOU
- `29679d5e`: Add TOCTOU date-field fail-closed regression test

**Tests:** 6 new TOCTOU tests + 13 store_signing tests — all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened package installation safeguards by re-checking manifest signatures immediately before installation.
  * Installations are now blocked with a 403 error if the manifest is missing, unreadable, empty, altered, unsigned, or otherwise fails verification.
  * Improved protection against files changing between security checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->