### PR TITLE
ci: run the dependency audit on dev pull requests

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,6 +15,15 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+# Mirror ci.yml: this now runs on every dev PR update, so superseded runs must
+# cancel or each push leaves an orphaned audit burning runner minutes. Pushes to
+# master and dev are deliberately NOT cancelled, so the branch record stays
+# complete. (qodo on #2189, verified: ci.yml carries this block and security.yml
+# did not, which only started to matter once the dev trigger was added.)
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/dev' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,15 @@ name: Security
 on:
   push:
     branches: [master]
+  # dev is where work actually lands: every exec PR targets dev, and master only
+  # receives it later at a release promotion. Auditing master-only meant the
+  # dependency audit NEVER ran on a pull request, so a vulnerable dependency
+  # could merge into dev and ship in a beta without anything looking at it. The
+  # weekly cron still covers master, but that is after the fact and on the wrong
+  # branch. Verified clean on dev before enabling: pip-audit reports no known
+  # vulnerabilities, so this does not block the open queue.
   pull_request:
-    branches: [master]
+    branches: [master, dev]
   schedule:
     - cron: "0 6 * * 1"
 


### PR DESCRIPTION
## The gap

`security.yml` triggers on `push` and `pull_request` to **master only**. Every exec PR targets **dev**, and master receives the work later at a release promotion.

So the dependency audit has never run on a pull request. Confirmed against the live queue rather than inferred:

- all 23 open PRs target `dev`
- no audit or security check is reported on #2188 or #2183

A vulnerable dependency introduced in a PR could merge into dev and ship in a beta with nothing having looked at it. The weekly cron still covers master, but after the fact and on the branch the work has already left.

## The change

One line: `pull_request.branches` becomes `[master, dev]`. Nothing is renamed, so no required-context is orphaned, and the `dependency-audit` job itself is untouched.

## Verified before enabling

`pip-audit --ignore-vuln CVE-2026-3219` against the dev environment reports **no known vulnerabilities**, so this goes green on dev today and does not block the open queue.

## Why now

`taos-website` hit the same class from the other direction: its audit read `requirements.txt` and missed the file that actually carried the test dependency, and the pinned pytest turned out to carry PYSEC-2026-1845.

taOS is **not** exposed to that CVE (pytest pinned `>=9.1.1`, above the 9.0.3 fix) and its audit does install the dev extras via `pip install -e ".[dev,proxy,worker]"`. So our gap is the trigger, not the coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded security auditing so pull requests targeting both the `master` and `dev` branches are covered.
  * Improved workflow documentation to clarify branch-specific security expectations and the intended auditing coverage across development and releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->