### PR TITLE
fix(decisions): repair agent mirror path — middleware, identity, source, consent

### DIFF
--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -396,7 +396,7 @@ class TestCanvasAgentTokenDispatch:
 class TestIsAgentDecisionsPath:
     """Prove the allowlist regexes gate the agent decision routes correctly.
 
-    These are the tests jaylfc requested in PR #2182 — the old regexes with
+    These are the tests jaylfc requested in PR #2182 -- the old regexes with
     ``$`` mid-pattern would FAIL every test below, proving the feature was
     completely inert."""
 
@@ -515,7 +515,7 @@ class TestAgentDecisionsDispatch:
 
     @pytest.mark.asyncio
     async def test_nested_path_requires_session(self):
-        """A path with extra segments must NOT be admitted — stay with
+        """A path with extra segments must NOT be admitted -- stay with
         the exact pattern, do not widen it."""
         middleware = AuthMiddleware(app=MagicMock())
         req = _request(
@@ -534,7 +534,7 @@ class TestAgentDecisionsDispatch:
     @pytest.mark.asyncio
     async def test_human_answer_path_not_admitted(self):
         """POST /api/decisions/{id}/answer (human path) must NOT admit
-        an agent token — the allowlist must not widen."""
+        an agent token -- the allowlist must not widen."""
         middleware = AuthMiddleware(app=MagicMock())
         req = _request(
             method="POST",

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -10,6 +10,7 @@ from starlette.responses import RedirectResponse
 from tinyagentos.auth_middleware import (
     AuthMiddleware,
     _is_agent_canvas_path,
+    _is_agent_decisions_path,
     _is_exempt,
     _is_loopback_client,
 )
@@ -382,6 +383,181 @@ class TestCanvasAgentTokenDispatch:
             method="GET",
             path="/api/projects/proj-1/canvas/elements/el-1/extra",
             headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        call_next.assert_not_awaited()
+
+
+class TestIsAgentDecisionsPath:
+    """Prove the allowlist regexes gate the agent decision routes correctly.
+
+    These are the tests jaylfc requested in PR #2182 — the old regexes with
+    ``$`` mid-pattern would FAIL every test below, proving the feature was
+    completely inert."""
+
+    # ── allowed paths ──────────────────────────────────────────────
+
+    def test_post_create_allowed(self):
+        assert _is_agent_decisions_path("POST", "/api/decisions") is True
+
+    def test_post_answer_agent_allowed(self):
+        """The mirror path this PR exists to build."""
+        assert _is_agent_decisions_path(
+            "POST", "/api/decisions/dec-abc123/answer/agent"
+        ) is True
+
+    def test_get_detail_agent_allowed(self):
+        assert _is_agent_decisions_path(
+            "GET", "/api/decisions/dec-abc123/agent"
+        ) is True
+
+    def test_get_list_agent_allowed(self):
+        assert _is_agent_decisions_path("GET", "/api/decisions/agent") is True
+
+    # ── refused paths ──────────────────────────────────────────────
+
+    def test_human_get_refused(self):
+        """GET /api/decisions/{id} (human session-only) must NOT match."""
+        assert _is_agent_decisions_path("GET", "/api/decisions/dec-abc123") is False
+
+    def test_human_answer_refused(self):
+        """POST /api/decisions/{id}/answer (human session-only) must NOT match."""
+        assert _is_agent_decisions_path(
+            "POST", "/api/decisions/dec-abc123/answer"
+        ) is False
+
+    def test_nested_path_refused(self):
+        """Extra path segments must not widen the pattern."""
+        assert _is_agent_decisions_path(
+            "POST", "/api/decisions/a/b/answer/agent"
+        ) is False
+
+    def test_wrong_method_refused(self):
+        """DELETE on a decisions path must not match."""
+        assert _is_agent_decisions_path(
+            "DELETE", "/api/decisions/dec-abc123/agent"
+        ) is False
+
+    def test_human_list_refused(self):
+        """GET /api/decisions (human session list) must NOT match."""
+        assert _is_agent_decisions_path("GET", "/api/decisions") is False
+
+
+class TestAgentDecisionsDispatch:
+    """Middleware-layer dispatch tests: prove the agent token is admitted
+    or refused at the middleware boundary, before any route handler runs."""
+
+    @pytest.mark.asyncio
+    async def test_agent_answer_mirror_path_admitted(self):
+        """An agent Bearer token on the answer/agent path is passed through
+        with via=registry_jwt_candidate."""
+        middleware = AuthMiddleware(app=MagicMock())
+        auth_mgr = _default_auth_mgr()
+        auth_mgr.validate_local_token.return_value = False
+        req = _request(
+            method="POST",
+            path="/api/decisions/dec-abc123/answer/agent",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=auth_mgr,
+        )
+        call_next = AsyncMock(return_value=JSONResponse({"ok": True}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 200
+        assert req.state.via == "registry_jwt_candidate"
+        call_next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_list_path_admitted(self):
+        """GET /api/decisions/agent passes through for agent Bearer token."""
+        middleware = AuthMiddleware(app=MagicMock())
+        auth_mgr = _default_auth_mgr()
+        auth_mgr.validate_local_token.return_value = False
+        req = _request(
+            method="GET",
+            path="/api/decisions/agent",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=auth_mgr,
+        )
+        call_next = AsyncMock(return_value=JSONResponse({"items": []}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 200
+        assert req.state.via == "registry_jwt_candidate"
+        call_next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_detail_path_admitted(self):
+        """GET /api/decisions/{id}/agent passes through for agent Bearer."""
+        middleware = AuthMiddleware(app=MagicMock())
+        auth_mgr = _default_auth_mgr()
+        auth_mgr.validate_local_token.return_value = False
+        req = _request(
+            method="GET",
+            path="/api/decisions/dec-abc123/agent",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=auth_mgr,
+        )
+        call_next = AsyncMock(return_value=JSONResponse({"id": "dec-abc123"}))
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 200
+        assert req.state.via == "registry_jwt_candidate"
+        call_next.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_nested_path_requires_session(self):
+        """A path with extra segments must NOT be admitted — stay with
+        the exact pattern, do not widen it."""
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            method="POST",
+            path="/api/decisions/a/b/answer/agent",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_human_answer_path_not_admitted(self):
+        """POST /api/decisions/{id}/answer (human path) must NOT admit
+        an agent token — the allowlist must not widen."""
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            method="POST",
+            path="/api/decisions/dec-abc123/answer",
+            headers={"authorization": "Bearer registry-jwt"},
+            auth_mgr=_default_auth_mgr(),
+        )
+        call_next = AsyncMock()
+
+        resp = await middleware.dispatch(req, call_next)
+
+        assert resp.status_code == 401
+        call_next.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_agent_path_without_bearer_requires_session(self):
+        """The path is on the allowlist, but without a Bearer token the
+        middleware must treat it like any other gated path (401)."""
+        middleware = AuthMiddleware(app=MagicMock())
+        req = _request(
+            method="POST",
+            path="/api/decisions/dec-abc123/answer/agent",
+            headers={"accept": "application/json"},
             auth_mgr=_default_auth_mgr(),
         )
         call_next = AsyncMock()

--- a/tests/test_decision_store.py
+++ b/tests/test_decision_store.py
@@ -91,3 +91,60 @@ async def test_branching_fields_reserved(store):
     assert got["parent_decision_id"] == "dec-parent"
     assert got["checkpoint_ref"] == "abc123"
     assert got["timeline_id"] == "t1"
+
+
+@pytest.mark.asyncio
+async def test_list_filter_from_agent(store):
+    """from_agent filter returns only decisions raised by that agent."""
+    await store.create("@agent-x", "q1", "free_text", user_id="u1")
+    await store.create("@agent-y", "q2", "free_text", user_id="u1")
+    x_only = await store.list(from_agent="@agent-x")
+    assert len(x_only) == 1
+    assert x_only[0]["from_agent"] == "@agent-x"
+
+
+@pytest.mark.asyncio
+async def test_list_filter_metadata_kind(store):
+    """metadata_kind filter matches JSON metadata with a substring."""
+    await store.create("@a", "q1", "free_text", user_id="u1",
+                       metadata={"kind": "execution_gate"})
+    await store.create("@a", "q2", "free_text", user_id="u1",
+                       metadata={"kind": "app_grant"})
+    await store.create("@a", "q3", "free_text", user_id="u1", metadata={})
+    exec_only = await store.list(metadata_kind="execution_gate")
+    assert len(exec_only) == 1
+    assert exec_only[0]["metadata"]["kind"] == "execution_gate"
+
+
+@pytest.mark.asyncio
+async def test_list_filter_pending_age_gt(store, monkeypatch):
+    """pending_age_gt returns only pending decisions older than the threshold."""
+    import time as _time
+    d = await store.create("@a", "q", "free_text", user_id="u1")
+    # Simulate passage of time by moving the clock forward, so the created_at
+    # timestamp is in the "distant past" relative to now.
+    fake_now = d["created_at"] + 120  # 2 minutes later
+    monkeypatch.setattr(_time, "time", lambda: fake_now)
+    # Threshold of 60s: this decision was created 120s ago, so it matches.
+    old = await store.list(status="pending", pending_age_gt=60)
+    assert len(old) == 1
+    # Threshold of 200s: too recent, should not match.
+    none_found = await store.list(status="pending", pending_age_gt=200)
+    assert len(none_found) == 0
+
+
+@pytest.mark.asyncio
+async def test_answer_source_persistence(store):
+    """Answer source field is persisted and round-trips correctly."""
+    d = await store.create("@a", "q", "approve_deny", user_id="u1")
+    upd = await store.answer(d["id"], "approve", "u1", source="in_app")
+    assert upd["answer"]["source"] == "in_app"
+
+    d2 = await store.create("@a", "q2", "approve_deny", user_id="u1")
+    upd2 = await store.answer(d2["id"], "deny", "u1", source="mirrored_from_chat")
+    assert upd2["answer"]["source"] == "mirrored_from_chat"
+
+    # Default source
+    d3 = await store.create("@a", "q3", "approve_deny", user_id="u1")
+    upd3 = await store.answer(d3["id"], "approve", "u1")
+    assert upd3["answer"]["source"] == "in_app"

--- a/tests/test_decision_store.py
+++ b/tests/test_decision_store.py
@@ -104,36 +104,6 @@ async def test_list_filter_from_agent(store):
 
 
 @pytest.mark.asyncio
-async def test_list_filter_metadata_kind(store):
-    """metadata_kind filter matches JSON metadata with a substring."""
-    await store.create("@a", "q1", "free_text", user_id="u1",
-                       metadata={"kind": "execution_gate"})
-    await store.create("@a", "q2", "free_text", user_id="u1",
-                       metadata={"kind": "app_grant"})
-    await store.create("@a", "q3", "free_text", user_id="u1", metadata={})
-    exec_only = await store.list(metadata_kind="execution_gate")
-    assert len(exec_only) == 1
-    assert exec_only[0]["metadata"]["kind"] == "execution_gate"
-
-
-@pytest.mark.asyncio
-async def test_list_filter_pending_age_gt(store, monkeypatch):
-    """pending_age_gt returns only pending decisions older than the threshold."""
-    import time as _time
-    d = await store.create("@a", "q", "free_text", user_id="u1")
-    # Simulate passage of time by moving the clock forward, so the created_at
-    # timestamp is in the "distant past" relative to now.
-    fake_now = d["created_at"] + 120  # 2 minutes later
-    monkeypatch.setattr(_time, "time", lambda: fake_now)
-    # Threshold of 60s: this decision was created 120s ago, so it matches.
-    old = await store.list(status="pending", pending_age_gt=60)
-    assert len(old) == 1
-    # Threshold of 200s: too recent, should not match.
-    none_found = await store.list(status="pending", pending_age_gt=200)
-    assert len(none_found) == 0
-
-
-@pytest.mark.asyncio
 async def test_answer_source_persistence(store):
     """Answer source field is persisted and round-trips correctly."""
     d = await store.create("@a", "q", "approve_deny", user_id="u1")

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -375,3 +375,69 @@ async def test_history_returns_lineage_oldest_first(client):
     assert r.status_code == 200
     chain = [d["id"] for d in r.json()["items"]]
     assert chain == ids  # oldest first
+
+
+@pytest.mark.asyncio
+async def test_human_answer_rejects_mirrored_from_chat_source(client):
+    """A human answer with source=mirrored_from_chat must be rejected as
+    spoofing the audit trail. The human path only records in_app."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "free_text",
+    })
+    d = resp.json()
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": "ok", "source": "mirrored_from_chat"},
+    )
+    assert resp.status_code == 400
+    assert "mirrored_from_chat" in resp.json()["error"]
+
+
+@pytest.mark.asyncio
+async def test_human_answer_source_field_in_response(client):
+    """A normal human answer includes source and answered_by in its answer JSON."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "free_text",
+    })
+    d = resp.json()
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": "ok", "answered_by": "Jay"},
+    )
+    assert resp.status_code == 200
+    ans = resp.json()["answer"]
+    assert ans["source"] == "in_app"
+    assert ans["answered_by"] == "Jay"
+
+
+@pytest.mark.asyncio
+async def test_single_select_handles_non_hashable_value(client):
+    """A list or dict submitted as a single_select answer must return 400,
+    not 500, by catching the TypeError from set membership."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "single_select",
+        "options": [{"label": "A", "value": "a"}],
+    })
+    d = resp.json()
+    # A list as the value is non-hashable and must not 500.
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": ["a"]},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_multi_select_handles_non_iterable_value(client):
+    """A non-iterable value for a multi_select answer must 400."""
+    resp = await client.post("/api/decisions", json={
+        "from_agent": "@a", "question": "q", "type": "multi_select",
+        "options": [{"label": "A", "value": "a"}],
+    })
+    d = resp.json()
+    # A bare string (not a list) should 400 for multi_select.
+    resp = await client.post(
+        f"/api/decisions/{d['id']}/answer",
+        json={"value": "a"},
+    )
+    assert resp.status_code == 400

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -435,9 +435,9 @@ async def test_multi_select_handles_non_iterable_value(client):
         "options": [{"label": "A", "value": "a"}],
     })
     d = resp.json()
-    # A bare string (not a list) should 400 for multi_select.
+    # An integer (not a list) should 400 for multi_select.
     resp = await client.post(
         f"/api/decisions/{d['id']}/answer",
-        json={"value": "a"},
+        json={"value": 42},
     )
     assert resp.status_code == 400

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -315,3 +315,67 @@ async def test_agent_list_is_not_human_get(client):
     data = resp.json()
     assert "items" in data  # list response shape
     assert len(data["items"]) >= 1
+
+
+# ── Agent mirror does not run consent side effects ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_mirror_does_not_write_execution_grant(client):
+    """An agent mirroring an answer must NOT write an execution grant.
+    Only the human answer path runs consent side effects; otherwise an
+    agent could create a privileged decision and self-approve it."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    cid, token = await _mint_agent(app, pid, ("decisions_write",))
+
+    # Create an execution_gate decision as the agent
+    body = _decision_body(
+        project_id=pid,
+        type="approve_deny",
+        metadata={"kind": "execution_gate", "agent_name": cid, "action_class": "test-exec"},
+    )
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=body)
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    # The agent mirrors "approve"
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post(
+            f"/api/decisions/{did}/answer/agent",
+            json={"value": "approve"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "answered"
+
+    # No execution grant must exist — the agent cannot self-approve.
+    policies = getattr(app.state, "execution_policies", None)
+    if policies is not None:
+        assert await policies.has_live_grant(cid, "test-exec") is False
+
+
+@pytest.mark.asyncio
+async def test_agent_mirror_handles_non_hashable_select_value(client):
+    """Malformed select values via agent mirror must return 400, not 500."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    cid, token = await _mint_agent(app, pid, ("decisions_write",))
+
+    body = _decision_body(
+        project_id=pid,
+        type="single_select",
+        options=[{"label": "A", "value": "a"}],
+    )
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=body)
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    # A list value for single_select must 400, not 500.
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post(
+            f"/api/decisions/{did}/answer/agent",
+            json={"value": ["a"]},
+        )
+    assert resp.status_code == 400

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -340,14 +340,14 @@ async def test_agent_mirror_does_not_write_execution_grant(client):
     assert resp.status_code == 200, resp.text
     did = resp.json()["id"]
 
-    # The agent mirrors "approve"
+    # The agent mirrors "approve" -- gate-kind decisions MUST be refused.
     async with _agent_client(app, token) as ac:
         resp = await ac.post(
             f"/api/decisions/{did}/answer/agent",
             json={"value": "approve"},
         )
-    assert resp.status_code == 200, resp.text
-    assert resp.json()["status"] == "answered"
+    assert resp.status_code == 409, resp.text
+    assert "gate decisions cannot be answered" in resp.json()["error"]
 
     # No execution grant must exist — the agent cannot self-approve.
     policies = getattr(app.state, "execution_policies", None)

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -178,6 +178,9 @@ async def test_agent_cannot_answer_others_decision(client):
             json={"value": "approve"},
         )
     assert resp.status_code == 404, resp.text
+    assert resp.json() == {"error": "not found"}, (
+        f"body must match scope-mismatch 404: {resp.text}"
+    )
 
 
 @pytest.mark.asyncio
@@ -445,6 +448,9 @@ async def test_agent_cross_project_answer_blocks_wrong_project(client):
         )
     assert resp.status_code == 404, (
         f"expected 404 cross-project block, got {resp.status_code}: {resp.text}"
+    )
+    assert resp.json() == {"error": "not found"}, (
+        f"body must match not-found 404: {resp.text}"
     )
 
 

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -123,3 +123,195 @@ async def test_human_path_unchanged(client):
     d = resp.json()
     assert d["from_agent"] == "@taOS-dev"
     assert d["user_id"] == admin_id
+
+
+# ── Agent answer (mirror) tests ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_answers_own_decision(client):
+    """An agent with a decisions_write grant can answer its own pending
+    decision via POST /api/decisions/{id}/answer/agent."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    cid, token = await _mint_agent(app, pid, ("decisions_write",))
+
+    # Create a decision as the agent
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    # Answer it as the agent
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post(
+            f"/api/decisions/{did}/answer/agent",
+            json={"value": "approve"},
+        )
+    assert resp.status_code == 200, resp.text
+    d = resp.json()
+    assert d["status"] == "answered"
+    ans = d["answer"]
+    assert ans["value"] == "approve"
+    assert ans["source"] == "mirrored_from_chat"
+    assert ans["answered_by"] == cid  # canonical agent id, not "user"
+
+
+@pytest.mark.asyncio
+async def test_agent_cannot_answer_others_decision(client):
+    """An agent answering a decision it did NOT ask must 404."""
+    app = client._transport.app
+    pid = await _new_project(client)
+
+    # Agent A creates a decision
+    cid_a, token_a = await _mint_agent(app, pid, ("decisions_write",), handle="@agent-a")
+    async with _agent_client(app, token_a) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    # Agent B tries to answer it
+    _cid_b, token_b = await _mint_agent(app, pid, ("decisions_write",), handle="@agent-b")
+    async with _agent_client(app, token_b) as ac:
+        resp = await ac.post(
+            f"/api/decisions/{did}/answer/agent",
+            json={"value": "approve"},
+        )
+    assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.asyncio
+async def test_agent_global_grant_answers_os_level(client):
+    """A global (null-project) grant lets the agent answer its own OS-level
+    decision."""
+    app = client._transport.app
+    cid, token = await _mint_agent(app, None, ("decisions_write",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body())
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post(
+            f"/api/decisions/{did}/answer/agent",
+            json={"value": "approve"},
+        )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["answer"]["source"] == "mirrored_from_chat"
+    assert resp.json()["answer"]["answered_by"] == cid
+
+
+# ── Agent read-own tests ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_reads_own_decision(client):
+    """An agent can GET /api/decisions/{id}/agent for a decision it asked."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    cid, token = await _mint_agent(app, pid, ("decisions_write",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get(f"/api/decisions/{did}/agent")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["id"] == did
+    assert resp.json()["from_agent"] == cid
+
+
+@pytest.mark.asyncio
+async def test_agent_cannot_read_others_decision(client):
+    """An agent reading a decision it did NOT ask must 404."""
+    app = client._transport.app
+    pid = await _new_project(client)
+
+    cid_a, token_a = await _mint_agent(app, pid, ("decisions_write",), handle="@agent-a")
+    async with _agent_client(app, token_a) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    _cid_b, token_b = await _mint_agent(app, pid, ("decisions_write",), handle="@agent-b")
+    async with _agent_client(app, token_b) as ac:
+        resp = await ac.get(f"/api/decisions/{did}/agent")
+    assert resp.status_code == 404, resp.text
+
+
+# ── Agent list-own tests ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_lists_own_decisions(client):
+    """GET /api/decisions/agent returns only the asking agent's decisions."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    cid_a, token_a = await _mint_agent(app, pid, ("decisions_write",), handle="@agent-a")
+    cid_b, token_b = await _mint_agent(app, pid, ("decisions_write",), handle="@agent-b")
+
+    # Agent A posts a decision
+    async with _agent_client(app, token_a) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 200, resp.text
+
+    # Agent B posts a decision
+    async with _agent_client(app, token_b) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 200, resp.text
+
+    # Agent A's list only shows its own
+    async with _agent_client(app, token_a) as ac:
+        resp = await ac.get("/api/decisions/agent")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["from_agent"] == cid_a
+
+    # Agent B's list only shows its own
+    async with _agent_client(app, token_b) as ac:
+        resp = await ac.get("/api/decisions/agent")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["from_agent"] == cid_b
+
+
+@pytest.mark.asyncio
+async def test_agent_list_no_grant_403(client):
+    """An agent without a decisions_write grant cannot list."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, pid, ("project_tasks",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get("/api/decisions/agent")
+    assert resp.status_code == 403, resp.text
+
+
+# ── Route order test ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_list_is_not_human_get(client):
+    """GET /api/decisions/agent reaches the list endpoint, not
+    GET /api/decisions/{decision_id} with decision_id='agent'."""
+    app = client._transport.app
+    pid = await _new_project(client)
+    cid, token = await _mint_agent(app, pid, ("decisions_write",))
+
+    # Create a decision so the list is non-empty
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/decisions", json=_decision_body(project_id=pid))
+    assert resp.status_code == 200, resp.text
+
+    # The list endpoint returns {"items": [...]}, not a single decision
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get("/api/decisions/agent")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "items" in data  # list response shape
+    assert len(data["items"]) >= 1

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -379,3 +379,70 @@ async def test_agent_mirror_handles_non_hashable_select_value(client):
             json={"value": ["a"]},
         )
     assert resp.status_code == 400
+
+
+# ── Cross-project scope isolation tests ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_cross_project_read_blocks_wrong_project(client):
+    """Agent with decisions_write on project B cannot read a decision on
+    project A (even when from_agent matches).  5d207ec swapped
+    check_agent_scope_for_project for project-agnostic check_agent_scope,
+    leaking cross-project read.  This test proves the old head leaks
+    (200 under 5d207ec) and the fix blocks it (403 under 6410e3c)."""
+    app = client._transport.app
+
+    # Two projects: agent has a grant on beta but NOT on alpha.
+    pid_a = await _new_project(client, name="alpha", slug="alpha")
+    pid_b = await _new_project(client, name="beta", slug="beta")
+    cid, token = await _mint_agent(app, pid_b, ("decisions_write",), handle="@cross-x")
+
+    # Create a decision on project A attributed to the agent (admin posts
+    # with from_agent set to the agent's canonical id — simulating the
+    # agent having had a grant on A that was later revoked).
+    resp = await client.post(
+        "/api/decisions",
+        json=_decision_body(project_id=pid_a, from_agent=cid),
+    )
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    # Agent with only project B grant tries to read the project A decision.
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get(f"/api/decisions/{did}/agent")
+    # Project-scoped check must block: 403, not 200 (the 5d207ec leak) nor
+    # 404 (which could be misread as "decision doesn't exist").
+    assert resp.status_code == 403, (
+        f"expected 403 cross-project block, got {resp.status_code}: {resp.text}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_cross_project_answer_blocks_wrong_project(client):
+    """Agent with decisions_write on project B cannot answer a decision on
+    project A (even when from_agent matches).  Same 5d207ec regression
+    as the read endpoint."""
+    app = client._transport.app
+
+    pid_a = await _new_project(client, name="alpha", slug="alpha")
+    pid_b = await _new_project(client, name="beta", slug="beta")
+    cid, token = await _mint_agent(app, pid_b, ("decisions_write",), handle="@cross-y")
+
+    # Create a pending decision on project A attributed to the agent.
+    resp = await client.post(
+        "/api/decisions",
+        json=_decision_body(project_id=pid_a, from_agent=cid),
+    )
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    # Agent with only project B grant tries to answer the project A decision.
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post(
+            f"/api/decisions/{did}/answer/agent",
+            json={"value": "approve"},
+        )
+    assert resp.status_code == 403, (
+        f"expected 403 cross-project block, got {resp.status_code}: {resp.text}"
+    )

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -411,10 +411,10 @@ async def test_agent_cross_project_read_blocks_wrong_project(client):
     # Agent with only project B grant tries to read the project A decision.
     async with _agent_client(app, token) as ac:
         resp = await ac.get(f"/api/decisions/{did}/agent")
-    # Project-scoped check must block: 403, not 200 (the 5d207ec leak) nor
-    # 404 (which could be misread as "decision doesn't exist").
-    assert resp.status_code == 403, (
-        f"expected 403 cross-project block, got {resp.status_code}: {resp.text}"
+    # Project-scoped check blocks with 404 (PROJECT_SCOPE_MISMATCH collapsed
+    # to not-found to avoid making the route an existence oracle).
+    assert resp.status_code == 404, (
+        f"expected 404 cross-project block, got {resp.status_code}: {resp.text}"
     )
 
 
@@ -443,6 +443,100 @@ async def test_agent_cross_project_answer_blocks_wrong_project(client):
             f"/api/decisions/{did}/answer/agent",
             json={"value": "approve"},
         )
-    assert resp.status_code == 403, (
-        f"expected 403 cross-project block, got {resp.status_code}: {resp.text}"
+    assert resp.status_code == 404, (
+        f"expected 404 cross-project block, got {resp.status_code}: {resp.text}"
     )
+
+
+# ── Expired-grant test ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_expired_grant_cannot_read(client):
+    """Agent with an expired decisions_write grant on project A but an active
+    grant on project B cannot read a decision on project A (even when
+    from_agent matches)."""
+    app = client._transport.app
+    from datetime import datetime, timedelta, timezone
+
+    pid_a = await _new_project(client, name="alpha", slug="alpha")
+    pid_b = await _new_project(client, name="beta", slug="beta")
+
+    registry = app.state.agent_registry
+    grants = app.state.agent_grants
+    for store_obj in (registry, grants):
+        if store_obj._db is None:
+            await store_obj.init()
+    priv, _pub = app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="claude-code",
+        display_name="taOS dev",
+        origin="internal",
+        handle="@expired-x",
+    )
+    cid = rec["canonical_id"]
+    if rec.get("status") != "active":
+        await registry.set_status(cid, "active")
+
+    # Expired grant on project A
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    await grants.add_grant(cid, "decisions_write", project_id=pid_a, expires_at=past)
+    # Active grant on project B
+    await grants.add_grant(cid, "decisions_write", project_id=pid_b)
+
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="claude-code", project_id=pid_b
+    )
+
+    # Admin creates a decision on project A attributed to the agent.
+    resp = await client.post(
+        "/api/decisions",
+        json=_decision_body(project_id=pid_a, from_agent=cid),
+    )
+    assert resp.status_code == 200, resp.text
+    did = resp.json()["id"]
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get(f"/api/decisions/{did}/agent")
+    # Expired grant → PROJECT_SCOPE_MISMATCH → collapsed to 404.
+    assert resp.status_code == 404, (
+        f"expected 404 for expired grant, got {resp.status_code}: {resp.text}"
+    )
+
+
+# ── Cross-project list isolation test ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_list_respects_project_grants(client):
+    """Agent with decisions_write only on project B does not see its own
+    decisions on project A in the list endpoint."""
+    app = client._transport.app
+
+    pid_a = await _new_project(client, name="alpha", slug="alpha-2")
+    pid_b = await _new_project(client, name="beta", slug="beta-2")
+    cid, token = await _mint_agent(app, pid_b, ("decisions_write",), handle="@cross-list")
+
+    # Admin creates a decision on project A attributed to the agent
+    # (simulating a grant that was later revoked).
+    resp = await client.post(
+        "/api/decisions",
+        json=_decision_body(project_id=pid_a, from_agent=cid),
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Agent creates a decision on project B (its granted project)
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post(
+            "/api/decisions",
+            json=_decision_body(project_id=pid_b),
+        )
+    assert resp.status_code == 200, resp.text
+
+    # List: must only show the project-B decision, not the project-A one.
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get("/api/decisions/agent")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["project_id"] == pid_b

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -125,9 +125,10 @@ async def _verify_agent_scope(
             detail=f"token does not hold an active {required_scope!r} grant",
         )
 
-    # For decisions_write grant, verify that the token also has the
-    # project_id claim matching (if present) the decision being acted on.
-    # This guard is enforced at the route level where the decision_id is known.
+    # For decisions_write, the route-level guard (check_agent_scope_for_project)
+    # verifies the agent's GRANT project_id matches the decision's project_id.
+    # The token's own project_id claim is advisory only and is not checked
+    # (taOS #1862) -- see check_agent_scope_for_project below.
     return canonical_id, payload
 
 

--- a/tinyagentos/agent_token_auth.py
+++ b/tinyagentos/agent_token_auth.py
@@ -125,6 +125,9 @@ async def _verify_agent_scope(
             detail=f"token does not hold an active {required_scope!r} grant",
         )
 
+    # For decisions_write grant, verify that the token also has the
+    # project_id claim matching (if present) the decision being acted on.
+    # This guard is enforced at the route level where the decision_id is known.
     return canonical_id, payload
 
 

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -82,10 +82,12 @@ _AGENT_CANVAS_ROUTES = (
 )
 
 # Decisions route an agent may reach with its own registry JWT (scope
-# decisions_write). Only the create endpoint; listing/answering stay
-# session-only. The route verifies the JWT + grant + project binding.
+# decisions_write). Only create, answering and reading its own decision.  The route
+# verifies the JWT + grant + project binding.
 _AGENT_DECISIONS_ROUTES = (
     ("POST", re.compile(r"^/api/decisions$")),
+    ("POST", re.compile(r"^/api/decisions/[^/]+$/answer$")),
+    ("GET", re.compile(r"^/api/decisions/[^/]+$/agent$")),
 )
 
 # Project-files routes a files_read / files_write token may reach. Reads
@@ -131,8 +133,11 @@ def _is_agent_canvas_path(method: str, path: str) -> bool:
 
 
 def _is_agent_decisions_path(method: str, path: str) -> bool:
-    """True only for POST /api/decisions, which a decisions_write-bound agent
-    token may reach.  The route verifies the JWT + grant."""
+    """True only for the exact subset of decision routes an agent token may reach:
+      - POST /api/decisions -> decisions_write (create)
+      - POST /api/decisions/{id}/answer -> decisions_write (mirror)
+      - GET /api/decisions/{id}/agent -> decisions_write (read own)
+    The route verifies the JWT + grant + project binding."""
     return any(m == method and rx.match(path) for m, rx in _AGENT_DECISIONS_ROUTES)
 
 

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -82,12 +82,13 @@ _AGENT_CANVAS_ROUTES = (
 )
 
 # Decisions route an agent may reach with its own registry JWT (scope
-# decisions_write). Only create, answering and reading its own decision.  The route
+# decisions_write). Create, answer (mirror), read-own, and list-own.  The route
 # verifies the JWT + grant + project binding.
 _AGENT_DECISIONS_ROUTES = (
     ("POST", re.compile(r"^/api/decisions$")),
-    ("POST", re.compile(r"^/api/decisions/[^/]+$/answer$")),
-    ("GET", re.compile(r"^/api/decisions/[^/]+$/agent$")),
+    ("POST", re.compile(r"^/api/decisions/[^/]+/answer/agent$")),
+    ("GET", re.compile(r"^/api/decisions/[^/]+/agent$")),
+    ("GET", re.compile(r"^/api/decisions/agent$")),
 )
 
 # Project-files routes a files_read / files_write token may reach. Reads
@@ -135,8 +136,9 @@ def _is_agent_canvas_path(method: str, path: str) -> bool:
 def _is_agent_decisions_path(method: str, path: str) -> bool:
     """True only for the exact subset of decision routes an agent token may reach:
       - POST /api/decisions -> decisions_write (create)
-      - POST /api/decisions/{id}/answer -> decisions_write (mirror)
-      - GET /api/decisions/{id}/agent -> decisions_write (read own)
+      - POST /api/decisions/{id}/answer/agent -> decisions_write (mirror)
+      - GET  /api/decisions/{id}/agent        -> decisions_write (read own)
+      - GET  /api/decisions/agent             -> decisions_write (list own)
     The route verifies the JWT + grant + project binding."""
     return any(m == method and rx.match(path) for m, rx in _AGENT_DECISIONS_ROUTES)
 

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -145,8 +145,8 @@ class DecisionStore(BaseStore):
             conds.append("from_agent = ?")
             params.append(from_agent)
         if metadata_kind is not None:
-            conds.append("metadata LIKE ?")
-            params.append(f'%' + metadata_kind + f'%')
+            conds.append("json_extract(metadata, '$.kind') = ?")
+            params.append(metadata_kind)
         if pending_age_gt is not None:
             # Filter for pending decisions older than the threshold.
             # created_at is REAL NOT NULL, so no NULL guard is needed.

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -128,8 +128,6 @@ class DecisionStore(BaseStore):
         user_id: str | None = None,
         limit: int = 200,
         from_agent: str | None = None,
-        metadata_kind: str | None = None,
-        pending_age_gt: float | None = None,
     ) -> list[dict]:
         conds, params = [], []
         if status is not None:
@@ -144,16 +142,7 @@ class DecisionStore(BaseStore):
         if from_agent is not None:
             conds.append("from_agent = ?")
             params.append(from_agent)
-        if metadata_kind is not None:
-            conds.append("json_extract(metadata, '$.kind') = ?")
-            params.append(metadata_kind)
-        if pending_age_gt is not None:
-            # Filter for pending decisions older than the threshold.
-            # created_at is REAL NOT NULL, so no NULL guard is needed.
-            now = time.time()
-            conds.append("status = 'pending' AND created_at < ?")
-            params.append(now - pending_age_gt)
-        where = (" WHERE " + " AND ".join(conds)) if conds else ""
+        where = ((" WHERE " + " AND ".join(conds)) if conds else "")
         # Bound the result set so a long-lived inbox cannot return everything.
         limit = max(1, min(int(limit), 500))
         async with self._db.execute(

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -133,19 +133,26 @@ class DecisionStore(BaseStore):
     ) -> list[dict]:
         conds, params = [], []
         if status is not None:
-            conds.append("status = ?"); params.append(status)
+            conds.append("status = ?")
+            params.append(status)
         if project_id is not None:
-            conds.append("project_id = ?"); params.append(project_id)
+            conds.append("project_id = ?")
+            params.append(project_id)
         if user_id is not None:
-            conds.append("user_id = ?"); params.append(user_id)
+            conds.append("user_id = ?")
+            params.append(user_id)
         if from_agent is not None:
-            conds.append("from_agent = ?"); params.append(from_agent)
+            conds.append("from_agent = ?")
+            params.append(from_agent)
         if metadata_kind is not None:
-            conds.append("metadata LIKE ?"); params.append(f'%' + metadata_kind + f'%')
+            conds.append("metadata LIKE ?")
+            params.append(f'%' + metadata_kind + f'%')
         if pending_age_gt is not None:
-            # Filter for pending decisions older than the threshold
+            # Filter for pending decisions older than the threshold.
+            # created_at is REAL NOT NULL, so no NULL guard is needed.
             now = time.time()
-            conds.append("status = 'pending' AND (created_at IS NULL OR created_at < ?)"); params.append(now - pending_age_gt)
+            conds.append("status = 'pending' AND created_at < ?")
+            params.append(now - pending_age_gt)
         where = (" WHERE " + " AND ".join(conds)) if conds else ""
         # Bound the result set so a long-lived inbox cannot return everything.
         limit = max(1, min(int(limit), 500))

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -127,6 +127,9 @@ class DecisionStore(BaseStore):
         project_id: str | None = None,
         user_id: str | None = None,
         limit: int = 200,
+        from_agent: str | None = None,
+        metadata_kind: str | None = None,
+        pending_age_gt: float | None = None,
     ) -> list[dict]:
         conds, params = [], []
         if status is not None:
@@ -135,6 +138,14 @@ class DecisionStore(BaseStore):
             conds.append("project_id = ?"); params.append(project_id)
         if user_id is not None:
             conds.append("user_id = ?"); params.append(user_id)
+        if from_agent is not None:
+            conds.append("from_agent = ?"); params.append(from_agent)
+        if metadata_kind is not None:
+            conds.append("metadata LIKE ?"); params.append(f'%' + metadata_kind + f'%')
+        if pending_age_gt is not None:
+            # Filter for pending decisions older than the threshold
+            now = time.time()
+            conds.append("status = 'pending' AND (created_at IS NULL OR created_at < ?)"); params.append(now - pending_age_gt)
         where = (" WHERE " + " AND ".join(conds)) if conds else ""
         # Bound the result set so a long-lived inbox cannot return everything.
         limit = max(1, min(int(limit), 500))

--- a/tinyagentos/decisions/decision_store.py
+++ b/tinyagentos/decisions/decision_store.py
@@ -157,12 +157,13 @@ class DecisionStore(BaseStore):
             desc = cur.description
         return [_row_to_decision(r, desc) for r in rows]
 
-    async def answer(self, decision_id: str, value, answered_by: str) -> dict | None:
+    async def answer(self, decision_id: str, value, answered_by: str, source: str = "in_app") -> dict | None:
         """Record an answer. Returns the updated decision, or None if the
         decision does not exist or is not pending (already answered or
-        superseded)."""
+        superseded). The *source* field distinguishes mirrored_from_chat
+        from in_app answers for audit/UI purposes."""
         now = time.time()
-        ans = json.dumps({"value": value, "answered_by": answered_by, "answered_at": now})
+        ans = json.dumps({"value": value, "answered_by": answered_by, "answered_at": now, "source": source})
         cur = await self._db.execute(
             """UPDATE decisions
                SET status = 'answered', answer = ?, answered_at = ?

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -539,7 +539,7 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
     store = request.app.state.decision_store
     existing = await store.get(decision_id)
     if existing is None or existing.get("status") != "pending":
-        return JSONResponse({"error": "not found or not pending"}, status_code=404)
+        return JSONResponse({"error": "not found"}, status_code=404)
 
     # Project-scoped (least privilege): the agent must hold decisions_write
     # on the decision's OWN project, not just any project.  5d207ec

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -262,6 +262,23 @@ async def list_decisions(
     return {"items": items}
 
 
+# Agent-decisions list (filtered by the asking agent). Must be registered
+# BEFORE the parameterised GET /api/decisions/{decision_id} so the literal
+# "agent" segment is not captured as a decision_id.
+@router.get("/api/decisions/agent")
+async def list_decisions_as_agent(request: Request):
+    """Agent-facing list: filter by from_agent (the asking agent).  An agent
+    sees every decision it asked, across all projects.  The store layer
+    enforces the from_agent binding so there is no cross-agent leakage."""
+    from tinyagentos.agent_token_auth import check_agent_scope
+    canonical_id = await check_agent_scope(request, "decisions_write")
+    if canonical_id is None:
+        return JSONResponse({"error": "agent identity not found"}, status_code=401)
+    store = request.app.state.decision_store
+    items = await store.list(from_agent=canonical_id, limit=500)
+    return {"items": items}
+
+
 @router.get("/api/decisions/{decision_id}")
 async def get_decision(decision_id: str, request: Request, user: CurrentUser = Depends(current_user)):
     # Session-only path: human reading their own or admin reading any
@@ -274,38 +291,17 @@ async def get_decision(decision_id: str, request: Request, user: CurrentUser = D
 
 @router.get("/api/decisions/{decision_id}/agent")
 async def get_decision_as_agent(decision_id: str, request: Request):
-    # Agent path: the agent may read any decision they asked (matched by from_agent).
-    # Let the store layer enforce the authorization; it returns None if the agent
-    # does not own this decision, and the route will return a 404.
+    # Agent path: verify the registry JWT holds decisions_write for the
+    # decision's project (or globally) and that from_agent matches.
     store = request.app.state.decision_store
     d = await store.get(decision_id)
     if d is None:
         return JSONResponse({"error": "not found"}, status_code=404)
-    # Verify the agent owns this decision: the agent must match d["from_agent"]
-    # The middleware has already routed here because _is_agent_decisions_path allowed
-    # this exact (method, path) pattern, so request.state.user_id is the canonical_id
-    # from the registry JWT. Compare against the decision's from_agent field.
-    if d.get("from_agent") != getattr(request.state, "user_id", None):
+    from tinyagentos.agent_token_auth import check_agent_scope_for_project
+    cid = await check_agent_scope_for_project(request, "decisions_write", d.get("project_id"))
+    if cid is None or d.get("from_agent") != cid:
         return JSONResponse({"error": "not found"}, status_code=404)
     return d
-
-
-# Agent-decisions list (filtered by agent or project)
-@router.get("/api/decisions/agent")
-async def list_decisions_as_agent(request: Request):
-    """Agent-facing list: filter by from_agent (the asking agent) or project_id
-    (via decisions_write grant binding). This matches taOSmd patterns and UI:
-    agents see all decisions they asked, grouped by project where applicable.
-    Includes source field (in_app / mirrored_from_chat) visible in UI."""
-    store = request.app.state.decision_store
-    # The agent may only see decisions they asked: match from_agent to the canonical_id.
-    canonical_id = getattr(request.state, "user_id", None)
-    if canonical_id is None:
-        return JSONResponse({"error": "agent identity not found"}, status_code=400)
-    # The store layer already enforces that from_agent matches the canonical_id,
-    # so passing from_agent here is safe. Let the store filter for this agent.
-    items = await store.list(from_agent=canonical_id, limit=500)
-    return {"items": items}
 
 
 @router.get("/api/decisions/{decision_id}/history")
@@ -369,7 +365,7 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
         answered_by = user.user_id or "user"
     else:
         answered_by = body.answered_by or user.user_id or "user"
-    updated = await store.answer(decision_id, body.value, answered_by)
+    updated = await store.answer(decision_id, body.value, answered_by, source=source)
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
     # Each kind-specific handler runs its side effect and returns True if it
@@ -491,16 +487,19 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
 @router.post("/api/decisions/{decision_id}/answer/agent")
 async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Request):
     """Agent mirror: only the asking agent can answer its own decision.
-    Validates the agent token (via _is_agent_decisions_path), verifies the decision
-    belongs to the agent (checks from_agent), records the answer as mirrored
-    (source=mirrored_from_chat), then pushes to the asking agent via A2A bus."""
+    Verifies the registry JWT holds decisions_write for the decision's project,
+    checks from_agent ownership, records the answer with source=mirrored_from_chat
+    and the agent's canonical id as the mirroring actor, runs consent side effects
+    (app/execution/delegation grants), then pushes to the asking agent via A2A."""
     store = request.app.state.decision_store
     existing = await store.get(decision_id)
     if existing is None or existing.get("status") != "pending":
         return JSONResponse({"error": "not found or not pending"}, status_code=404)
 
-    # Ownership check: agent must match from_agent
-    if existing.get("from_agent") != getattr(request.state, "user_id", None):
+    # Verify the registry JWT + grant, then check ownership.
+    from tinyagentos.agent_token_auth import check_agent_scope_for_project
+    cid = await check_agent_scope_for_project(request, "decisions_write", existing.get("project_id"))
+    if cid is None or existing.get("from_agent") != cid:
         return JSONResponse({"error": "not found"}, status_code=404)
 
     # Validate select-type answers against declared options (same as human path).
@@ -520,23 +519,23 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
                 if vals is None or any(v not in valid for v in vals):
                     return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
 
-    # Agent mirror: record as "user" so the audit trail shows Jay as decider.
-    # Explicit source=mirrored_from_chat is honored from the body.
-    source = body.source or "mirrored_from_chat"
-    answered_by = "user"
-    updated = await store.answer(decision_id, body.value, answered_by)
+    # Agent mirrors are always from chat; record the canonical agent id as the
+    # mirroring actor (not "user") so the audit trail is complete.
+    source = "mirrored_from_chat"
+    answered_by = cid
+    updated = await store.answer(decision_id, body.value, answered_by, source=source)
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
-    await _route_answer_to_agent(updated, body.value)
+
+    # Run consent side effects (same as the human answer path).  Each handler
+    # returns True if it already routed a reply to the asking agent, in which
+    # case we skip the generic answer route to avoid double-messaging.
+    routed_app = await _apply_app_grant(request, updated, body.value)
+    routed_exec = await _apply_execution_grant(request, updated, body.value)
+    routed_deleg = await _apply_delegation_grant(request, updated, body.value)
+    if not (routed_app or routed_exec or routed_deleg):
+        await _route_answer_to_agent(updated, body.value)
     return updated
-
-
-# NOTICE: The human-answering path (/api/decisions/{id}/answer) remains session-only
-# as documented. Agent-token mirroring is gated by the _AGENT_DECISIONS_ROUTES allowlist
-# and only reaches this function when the agent token holds a decisions_write grant.
-# The human-answer endpoint does NOT accept agent tokens (due to the allowlist contract),
-# preserving a strict separation between human and agent decision actions.
-# The source field is preserved in the stored answer JSON (from tinyagentos.decisions.decision_store.AnswerIn).
 
 
 async def _apply_app_grant(request: Request, decision: dict, value) -> bool:

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -132,18 +132,6 @@ class _DecisionActor:
     is_admin: bool           # human-path admin flag; always False for agents
 
 
-@dataclass
-class _DecisionFilter:
-    """Query parameters for filtering decisions (agent-readable only)."""
-    from_agent: str | None = None
-    project_id: str | None = None
-    deadline: str | None = None
-    metadata_kind: str | None = None
-    # New: pending-age filter to surface cards older than a threshold (seconds).
-    # Queries decisions pending beyond the age threshold for sweeping.
-    pending_age_gt: float | None = None
-
-
 async def _resolve_decision_actor(request: Request, project_id: str | None) -> _DecisionActor:
     """Authorize the caller as either a granted agent or a human session.
 
@@ -267,15 +255,33 @@ async def list_decisions(
 # "agent" segment is not captured as a decision_id.
 @router.get("/api/decisions/agent")
 async def list_decisions_as_agent(request: Request):
-    """Agent-facing list: filter by from_agent (the asking agent).  An agent
-    sees every decision it asked, across all projects.  The store layer
+    """Agent-facing list: filter by from_agent (the asking agent).  Only
+    returns decisions whose project the agent holds an active decisions_write
+    grant for; a global (null-project) grant shows all.  The store layer
     enforces the from_agent binding so there is no cross-agent leakage."""
-    from tinyagentos.agent_token_auth import check_agent_scope
+    from datetime import datetime, timezone
+    from tinyagentos.agent_token_auth import check_agent_scope, _grant_unexpired
+
     canonical_id = await check_agent_scope(request, "decisions_write")
     if canonical_id is None:
         return JSONResponse({"error": "agent identity not found"}, status_code=401)
+
+    # Collect project IDs the agent has active decisions_write grants for.
+    grants_store = request.app.state.agent_grants
+    now = datetime.now(timezone.utc)
+    grants = await grants_store.list_grants(canonical_id)
+    allowed_projects: set[str | None] = {
+        g.get("project_id")
+        for g in grants
+        if g["scope"] == "decisions_write" and _grant_unexpired(g.get("expires_at"), now)
+    }
+
     store = request.app.state.decision_store
     items = await store.list(from_agent=canonical_id, limit=500)
+    # A global (null-project) grant shows all; otherwise filter to decisions
+    # whose project_id is in the allowed set.
+    if None not in allowed_projects:
+        items = [d for d in items if d.get("project_id") in allowed_projects]
     return {"items": items}
 
 
@@ -293,7 +299,11 @@ async def get_decision(decision_id: str, request: Request, user: CurrentUser = D
 async def get_decision_as_agent(decision_id: str, request: Request):
     # JWT-first: validate the bearer token before touching the decision
     # store so invalid tokens cannot probe decision existence via timing.
-    from tinyagentos.agent_token_auth import check_agent_identity
+    from tinyagentos.agent_token_auth import (
+        check_agent_identity,
+        check_agent_scope_for_project,
+        PROJECT_SCOPE_MISMATCH_DETAIL,
+    )
     caller = await check_agent_identity(request)
     if caller is None:
         return JSONResponse({"error": "not found"}, status_code=404)
@@ -308,10 +318,16 @@ async def get_decision_as_agent(decision_id: str, request: Request):
     # mistakenly swapped this for project-agnostic check_agent_scope,
     # letting any decisions_write grant on ANY project authorize read
     # on EVERY project.  Restored from 6410e3c.
-    from tinyagentos.agent_token_auth import check_agent_scope_for_project
-    cid = await check_agent_scope_for_project(
-        request, "decisions_write", d.get("project_id")
-    )
+    # Collapse PROJECT_SCOPE_MISMATCH to 404 so the route is not an
+    # existence oracle (never distinguish 403-vs-404 to a caller).
+    try:
+        cid = await check_agent_scope_for_project(
+            request, "decisions_write", d.get("project_id")
+        )
+    except HTTPException as exc:
+        if exc.status_code == 403 and exc.detail == PROJECT_SCOPE_MISMATCH_DETAIL:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        raise
     if cid is None or d.get("from_agent") != cid:
         return JSONResponse({"error": "not found"}, status_code=404)
     return d
@@ -510,8 +526,9 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
     """Agent mirror: only the asking agent can answer its own decision.
     Verifies the registry JWT holds decisions_write for the decision's project,
     checks from_agent ownership, records the answer with source=mirrored_from_chat
-    and the agent's canonical id as the mirroring actor, runs consent side effects
-    (app/execution/delegation grants), then pushes to the asking agent via A2A."""
+    and the agent's canonical id as the mirroring actor, then pushes to the
+    asking agent via A2A.  Consent side effects (app/execution/delegation grants)
+    are intentionally NOT run on this path for gate-kind decisions (409)."""
     # JWT-first: validate the bearer token before touching the decision
     # store so invalid tokens cannot probe decision existence via timing.
     from tinyagentos.agent_token_auth import check_agent_identity
@@ -529,10 +546,20 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
     # mistakenly swapped this for project-agnostic check_agent_scope,
     # letting any decisions_write grant on ANY project authorize answer
     # on EVERY project.  Restored from 6410e3c.
-    from tinyagentos.agent_token_auth import check_agent_scope_for_project
-    canonical_id = await check_agent_scope_for_project(
-        request, "decisions_write", existing.get("project_id")
+    # Collapse PROJECT_SCOPE_MISMATCH to 404 so the route is not an
+    # existence oracle (never distinguish 403-vs-404 to a caller).
+    from tinyagentos.agent_token_auth import (
+        check_agent_scope_for_project,
+        PROJECT_SCOPE_MISMATCH_DETAIL,
     )
+    try:
+        canonical_id = await check_agent_scope_for_project(
+            request, "decisions_write", existing.get("project_id")
+        )
+    except HTTPException as exc:
+        if exc.status_code == 403 and exc.detail == PROJECT_SCOPE_MISMATCH_DETAIL:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        raise
     if canonical_id is None:
         return JSONResponse({"error": "not found"}, status_code=404)
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -291,15 +291,16 @@ async def get_decision(decision_id: str, request: Request, user: CurrentUser = D
 
 @router.get("/api/decisions/{decision_id}/agent")
 async def get_decision_as_agent(decision_id: str, request: Request):
-    # Agent path: verify the registry JWT holds decisions_write for the
-    # decision's project (or globally) and that from_agent matches.
+    # Verify JWT + grant BEFORE accessing the store, so an invalid token
+    # cannot probe decision existence via timing or response differentiation.
+    from tinyagentos.agent_token_auth import check_agent_scope
+    canonical_id = await check_agent_scope(request, "decisions_write")
+    if canonical_id is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
     store = request.app.state.decision_store
     d = await store.get(decision_id)
-    if d is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
-    from tinyagentos.agent_token_auth import check_agent_scope_for_project
-    cid = await check_agent_scope_for_project(request, "decisions_write", d.get("project_id"))
-    if cid is None or d.get("from_agent") != cid:
+    if d is None or d.get("from_agent") != canonical_id:
         return JSONResponse({"error": "not found"}, status_code=404)
     return d
 
@@ -499,15 +500,19 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
     checks from_agent ownership, records the answer with source=mirrored_from_chat
     and the agent's canonical id as the mirroring actor, runs consent side effects
     (app/execution/delegation grants), then pushes to the asking agent via A2A."""
+    # Verify JWT + grant BEFORE accessing the store.
+    from tinyagentos.agent_token_auth import check_agent_scope
+    canonical_id = await check_agent_scope(request, "decisions_write")
+    if canonical_id is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
     store = request.app.state.decision_store
     existing = await store.get(decision_id)
     if existing is None or existing.get("status") != "pending":
         return JSONResponse({"error": "not found or not pending"}, status_code=404)
 
-    # Verify the registry JWT + grant, then check ownership.
-    from tinyagentos.agent_token_auth import check_agent_scope_for_project
-    cid = await check_agent_scope_for_project(request, "decisions_write", existing.get("project_id"))
-    if cid is None or existing.get("from_agent") != cid:
+    # Verify ownership: only the asking agent can answer its own decision.
+    if existing.get("from_agent") != canonical_id:
         return JSONResponse({"error": "not found"}, status_code=404)
 
     # Validate select-type answers against declared options (same as human path).
@@ -533,7 +538,7 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
     # Agent mirrors are always from chat; record the canonical agent id as the
     # mirroring actor (not "user") so the audit trail is complete.
     source = "mirrored_from_chat"
-    answered_by = cid
+    answered_by = canonical_id
     updated = await store.answer(decision_id, body.value, answered_by, source=source)
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -515,6 +515,19 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
     if existing.get("from_agent") != canonical_id:
         return JSONResponse({"error": "not found"}, status_code=404)
 
+    # Gate-kind decisions must NOT be mirror-approvable by an agent.
+    # An agent that creates a privileged gate decision (execution_gate,
+    # delegation_gate, app_grant) and then mirrors "approve" through its
+    # own answer/agent endpoint would be able to dismiss the pending gate
+    # card from the owner's inbox without the owner ever seeing it.
+    meta = (existing.get("metadata") or {})
+    gate_kind = meta.get("kind") if isinstance(meta, dict) else None
+    if gate_kind in ("execution_gate", "delegation_gate", "app_grant"):
+        return JSONResponse(
+            {"error": "gate decisions cannot be answered by the asking agent"},
+            status_code=409,
+        )
+
     # Validate select-type answers against declared options (same as human path).
     dtype = existing.get("type")
     if dtype in ("single_select", "multi_select"):

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -492,19 +492,18 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
 async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Request):
     """Agent mirror: only the asking agent can answer its own decision.
     Validates the agent token (via _is_agent_decisions_path), verifies the decision
-    belongs to the agent (checks from_agent), records the answer as mirrored,
-    then pushes to the asking agent via the A2A bus (no polling)."""
+    belongs to the agent (checks from_agent), records the answer as mirrored
+    (source=mirrored_from_chat), then pushes to the asking agent via A2A bus."""
     store = request.app.state.decision_store
     existing = await store.get(decision_id)
     if existing is None or existing.get("status") != "pending":
         return JSONResponse({"error": "not found or not pending"}, status_code=404)
 
-    # The agent's canonical_id is in request.state.user_id (set by middleware for
-    # agent tokens). match it against d["from_agent"] (the agent that asked).
+    # Ownership check: agent must match from_agent
     if existing.get("from_agent") != getattr(request.state, "user_id", None):
         return JSONResponse({"error": "not found"}, status_code=404)
 
-    # For select types: enforce options as with the session path.
+    # Validate select-type answers against declared options (same as human path).
     dtype = existing.get("type")
     if dtype in ("single_select", "multi_select"):
         valid = {
@@ -521,13 +520,23 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
                 if vals is None or any(v not in valid for v in vals):
                     return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
 
-    # Mirror subject to source tracking and route via A2A bus.
+    # Agent mirror: record as "user" so the audit trail shows Jay as decider.
+    # Explicit source=mirrored_from_chat is honored from the body.
+    source = body.source or "mirrored_from_chat"
     answered_by = "user"
     updated = await store.answer(decision_id, body.value, answered_by)
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
     await _route_answer_to_agent(updated, body.value)
     return updated
+
+
+# NOTICE: The human-answering path (/api/decisions/{id}/answer) remains session-only
+# as documented. Agent-token mirroring is gated by the _AGENT_DECISIONS_ROUTES allowlist
+# and only reaches this function when the agent token holds a decisions_write grant.
+# The human-answer endpoint does NOT accept agent tokens (due to the allowlist contract),
+# preserving a strict separation between human and agent decision actions.
+# The source field is preserved in the stored answer JSON (from tinyagentos.decisions.decision_store.AnswerIn).
 
 
 async def _apply_app_grant(request: Request, decision: dict, value) -> bool:

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -119,6 +119,7 @@ class DecisionIn(BaseModel):
 class AnswerIn(BaseModel):
     value: object
     answered_by: str = ""
+    source: str = "in_app"
 
 
 @dataclass
@@ -129,6 +130,18 @@ class _DecisionActor:
     from_agent: str | None   # agent handle (agent path); None on the human path
     decider_user_id: str     # the human the decision is addressed to
     is_admin: bool           # human-path admin flag; always False for agents
+
+
+@dataclass
+class _DecisionFilter:
+    """Query parameters for filtering decisions (agent-readable only)."""
+    from_agent: str | None = None
+    project_id: str | None = None
+    deadline: str | None = None
+    metadata_kind: str | None = None
+    # New: pending-age filter to surface cards older than a threshold (seconds).
+    # Queries decisions pending beyond the age threshold for sweeping.
+    pending_age_gt: float | None = None
 
 
 async def _resolve_decision_actor(request: Request, project_id: str | None) -> _DecisionActor:
@@ -251,11 +264,48 @@ async def list_decisions(
 
 @router.get("/api/decisions/{decision_id}")
 async def get_decision(decision_id: str, request: Request, user: CurrentUser = Depends(current_user)):
+    # Session-only path: human reading their own or admin reading any
     store = request.app.state.decision_store
     d = await store.get(decision_id)
     if d is None or (not user.is_admin and d["user_id"] != user.user_id):
         return JSONResponse({"error": "not found"}, status_code=404)
     return d
+
+
+@router.get("/api/decisions/{decision_id}/agent")
+async def get_decision_as_agent(decision_id: str, request: Request):
+    # Agent path: the agent may read any decision they asked (matched by from_agent).
+    # Let the store layer enforce the authorization; it returns None if the agent
+    # does not own this decision, and the route will return a 404.
+    store = request.app.state.decision_store
+    d = await store.get(decision_id)
+    if d is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    # Verify the agent owns this decision: the agent must match d["from_agent"]
+    # The middleware has already routed here because _is_agent_decisions_path allowed
+    # this exact (method, path) pattern, so request.state.user_id is the canonical_id
+    # from the registry JWT. Compare against the decision's from_agent field.
+    if d.get("from_agent") != getattr(request.state, "user_id", None):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return d
+
+
+# Agent-decisions list (filtered by agent or project)
+@router.get("/api/decisions/agent")
+async def list_decisions_as_agent(request: Request):
+    """Agent-facing list: filter by from_agent (the asking agent) or project_id
+    (via decisions_write grant binding). This matches taOSmd patterns and UI:
+    agents see all decisions they asked, grouped by project where applicable.
+    Includes source field (in_app / mirrored_from_chat) visible in UI."""
+    store = request.app.state.decision_store
+    # The agent may only see decisions they asked: match from_agent to the canonical_id.
+    canonical_id = getattr(request.state, "user_id", None)
+    if canonical_id is None:
+        return JSONResponse({"error": "agent identity not found"}, status_code=400)
+    # The store layer already enforces that from_agent matches the canonical_id,
+    # so passing from_agent here is safe. Let the store filter for this agent.
+    items = await store.list(from_agent=canonical_id, limit=500)
+    return {"items": items}
 
 
 @router.get("/api/decisions/{decision_id}/history")
@@ -285,6 +335,8 @@ async def decision_history(decision_id: str, request: Request, user: CurrentUser
 async def answer_decision(decision_id: str, body: AnswerIn, request: Request, user: CurrentUser = Depends(current_user)):
     store = request.app.state.decision_store
     existing = await store.get(decision_id)
+    # Authorization check: humans can answer decisions they own or admins; agents are
+    # covered by the _AGENT_TOKEN_PATHS allowlist so they never reach this route.
     if existing is None or (not user.is_admin and existing["user_id"] != user.user_id):
         return JSONResponse({"error": "not found"}, status_code=404)
 
@@ -306,7 +358,17 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
                 if vals is None or any(v not in valid for v in vals):
                     return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
 
-    answered_by = body.answered_by or user.user_id or "user"
+    # Record WHO REALLY DECIDED: mirror answers from agents record the agent as the
+    # mirroring actor, not the decider. Set a source field to distinguish mirrored
+    # from in-app answers and ensure the audit trail shows Jay as the true decider.
+    # For session-only (human) answers, source remains in_app unless overridden by body.source.
+    source = body.source or "in_app"
+    if source == "mirrored_from_chat":
+        # Agent mirror: recorded as "user" (or admin) so the agent appears as mirroring
+        # activity, not the decider. answered_by stays "user" or user.user_id for admin.
+        answered_by = user.user_id or "user"
+    else:
+        answered_by = body.answered_by or user.user_id or "user"
     updated = await store.answer(decision_id, body.value, answered_by)
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
@@ -424,6 +486,48 @@ async def _apply_delegation_grant(request: Request, decision: dict, value) -> bo
         reply = "delegation approved, but assigning the task failed - please retry"
     await _route_answer_to_agent(decision, reply)
     return True
+
+
+@router.post("/api/decisions/{decision_id}/answer/agent")
+async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Request):
+    """Agent mirror: only the asking agent can answer its own decision.
+    Validates the agent token (via _is_agent_decisions_path), verifies the decision
+    belongs to the agent (checks from_agent), records the answer as mirrored,
+    then pushes to the asking agent via the A2A bus (no polling)."""
+    store = request.app.state.decision_store
+    existing = await store.get(decision_id)
+    if existing is None or existing.get("status") != "pending":
+        return JSONResponse({"error": "not found or not pending"}, status_code=404)
+
+    # The agent's canonical_id is in request.state.user_id (set by middleware for
+    # agent tokens). match it against d["from_agent"] (the agent that asked).
+    if existing.get("from_agent") != getattr(request.state, "user_id", None):
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    # For select types: enforce options as with the session path.
+    dtype = existing.get("type")
+    if dtype in ("single_select", "multi_select"):
+        valid = {
+            o.get("value")
+            for o in (existing.get("options") or [])
+            if o.get("value") is not None
+        }
+        if valid:
+            if dtype == "single_select":
+                if body.value not in valid:
+                    return JSONResponse({"error": "answer is not one of the options"}, status_code=400)
+            else:
+                vals = body.value if isinstance(body.value, list) else None
+                if vals is None or any(v not in valid for v in vals):
+                    return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
+
+    # Mirror subject to source tracking and route via A2A bus.
+    answered_by = "user"
+    updated = await store.answer(decision_id, body.value, answered_by)
+    if updated is None:
+        return JSONResponse({"error": "already answered or not pending"}, status_code=409)
+    await _route_answer_to_agent(updated, body.value)
+    return updated
 
 
 async def _apply_app_grant(request: Request, decision: dict, value) -> bool:

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -346,25 +346,33 @@ async def answer_decision(decision_id: str, body: AnswerIn, request: Request, us
             if o.get("value") is not None
         }
         if valid:
-            if dtype == "single_select":
-                if body.value not in valid:
-                    return JSONResponse({"error": "answer is not one of the options"}, status_code=400)
-            else:
-                vals = body.value if isinstance(body.value, list) else None
-                if vals is None or any(v not in valid for v in vals):
-                    return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
+            try:
+                if dtype == "single_select":
+                    if body.value not in valid:
+                        return JSONResponse({"error": "answer is not one of the options"}, status_code=400)
+                else:
+                    vals = body.value if isinstance(body.value, list) else None
+                    if vals is None or any(v not in valid for v in vals):
+                        return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
+            except TypeError:
+                # A list, dict, or other non-hashable/iterable value in the
+                # answer body can hit set membership or any() with a TypeError
+                # (e.g. a list value for single_select, or non-iterable for
+                # multi_select).  Fail closed: 400, not 500.
+                return JSONResponse({"error": "invalid answer value shape"}, status_code=400)
 
-    # Record WHO REALLY DECIDED: mirror answers from agents record the agent as the
-    # mirroring actor, not the decider. Set a source field to distinguish mirrored
-    # from in-app answers and ensure the audit trail shows Jay as the true decider.
-    # For session-only (human) answers, source remains in_app unless overridden by body.source.
-    source = body.source or "in_app"
-    if source == "mirrored_from_chat":
-        # Agent mirror: recorded as "user" (or admin) so the agent appears as mirroring
-        # activity, not the decider. answered_by stays "user" or user.user_id for admin.
-        answered_by = user.user_id or "user"
-    else:
-        answered_by = body.answered_by or user.user_id or "user"
+    # Source is derived server-side from the authenticated route, never trusted
+    # from the request body.  The human path always records in_app; the agent
+    # mirror path (answer_decision_as_agent) always records mirrored_from_chat.
+    # A caller setting source=mirrored_from_chat on the human path is spoofing
+    # the audit trail and must be rejected.
+    if body.source == "mirrored_from_chat":
+        return JSONResponse(
+            {"error": "source must not be mirrored_from_chat on this endpoint"},
+            status_code=400,
+        )
+    source = "in_app"
+    answered_by = body.answered_by or user.user_id or "user"
     updated = await store.answer(decision_id, body.value, answered_by, source=source)
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
@@ -511,13 +519,16 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
             if o.get("value") is not None
         }
         if valid:
-            if dtype == "single_select":
-                if body.value not in valid:
-                    return JSONResponse({"error": "answer is not one of the options"}, status_code=400)
-            else:
-                vals = body.value if isinstance(body.value, list) else None
-                if vals is None or any(v not in valid for v in vals):
-                    return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
+            try:
+                if dtype == "single_select":
+                    if body.value not in valid:
+                        return JSONResponse({"error": "answer is not one of the options"}, status_code=400)
+                else:
+                    vals = body.value if isinstance(body.value, list) else None
+                    if vals is None or any(v not in valid for v in vals):
+                        return JSONResponse({"error": "answer must be a subset of the options"}, status_code=400)
+            except TypeError:
+                return JSONResponse({"error": "invalid answer value shape"}, status_code=400)
 
     # Agent mirrors are always from chat; record the canonical agent id as the
     # mirroring actor (not "user") so the audit trail is complete.
@@ -527,14 +538,12 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
     if updated is None:
         return JSONResponse({"error": "already answered or not pending"}, status_code=409)
 
-    # Run consent side effects (same as the human answer path).  Each handler
-    # returns True if it already routed a reply to the asking agent, in which
-    # case we skip the generic answer route to avoid double-messaging.
-    routed_app = await _apply_app_grant(request, updated, body.value)
-    routed_exec = await _apply_execution_grant(request, updated, body.value)
-    routed_deleg = await _apply_delegation_grant(request, updated, body.value)
-    if not (routed_app or routed_exec or routed_deleg):
-        await _route_answer_to_agent(updated, body.value)
+    # Route the answer to the A2A bus so the asking agent can pick it up.
+    # Consent side effects (app/execution/delegation grants) are intentionally
+    # NOT run on the agent mirror path: an agent must not be able to create a
+    # privileged decision and then self-approve the consent via its own mirror
+    # endpoint.  Only the human answer path runs consent side effects.
+    await _route_answer_to_agent(updated, body.value)
     return updated
 
 

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -291,16 +291,28 @@ async def get_decision(decision_id: str, request: Request, user: CurrentUser = D
 
 @router.get("/api/decisions/{decision_id}/agent")
 async def get_decision_as_agent(decision_id: str, request: Request):
-    # Verify JWT + grant BEFORE accessing the store, so an invalid token
-    # cannot probe decision existence via timing or response differentiation.
-    from tinyagentos.agent_token_auth import check_agent_scope
-    canonical_id = await check_agent_scope(request, "decisions_write")
-    if canonical_id is None:
+    # JWT-first: validate the bearer token before touching the decision
+    # store so invalid tokens cannot probe decision existence via timing.
+    from tinyagentos.agent_token_auth import check_agent_identity
+    caller = await check_agent_identity(request)
+    if caller is None:
         return JSONResponse({"error": "not found"}, status_code=404)
 
     store = request.app.state.decision_store
     d = await store.get(decision_id)
-    if d is None or d.get("from_agent") != canonical_id:
+    if d is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    # Project-scoped (least privilege): the agent must hold decisions_write
+    # on the decision's OWN project, not just any project.  5d207ec
+    # mistakenly swapped this for project-agnostic check_agent_scope,
+    # letting any decisions_write grant on ANY project authorize read
+    # on EVERY project.  Restored from 6410e3c.
+    from tinyagentos.agent_token_auth import check_agent_scope_for_project
+    cid = await check_agent_scope_for_project(
+        request, "decisions_write", d.get("project_id")
+    )
+    if cid is None or d.get("from_agent") != cid:
         return JSONResponse({"error": "not found"}, status_code=404)
     return d
 
@@ -500,16 +512,29 @@ async def answer_decision_as_agent(decision_id: str, body: AnswerIn, request: Re
     checks from_agent ownership, records the answer with source=mirrored_from_chat
     and the agent's canonical id as the mirroring actor, runs consent side effects
     (app/execution/delegation grants), then pushes to the asking agent via A2A."""
-    # Verify JWT + grant BEFORE accessing the store.
-    from tinyagentos.agent_token_auth import check_agent_scope
-    canonical_id = await check_agent_scope(request, "decisions_write")
-    if canonical_id is None:
+    # JWT-first: validate the bearer token before touching the decision
+    # store so invalid tokens cannot probe decision existence via timing.
+    from tinyagentos.agent_token_auth import check_agent_identity
+    caller = await check_agent_identity(request)
+    if caller is None:
         return JSONResponse({"error": "not found"}, status_code=404)
 
     store = request.app.state.decision_store
     existing = await store.get(decision_id)
     if existing is None or existing.get("status") != "pending":
         return JSONResponse({"error": "not found or not pending"}, status_code=404)
+
+    # Project-scoped (least privilege): the agent must hold decisions_write
+    # on the decision's OWN project, not just any project.  5d207ec
+    # mistakenly swapped this for project-agnostic check_agent_scope,
+    # letting any decisions_write grant on ANY project authorize answer
+    # on EVERY project.  Restored from 6410e3c.
+    from tinyagentos.agent_token_auth import check_agent_scope_for_project
+    canonical_id = await check_agent_scope_for_project(
+        request, "decisions_write", existing.get("project_id")
+    )
+    if canonical_id is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
 
     # Verify ownership: only the asking agent can answer its own decision.
     if existing.get("from_agent") != canonical_id:


### PR DESCRIPTION
Fixes all 7 findings from jaylfc's review of #2182.

1. **Middleware regexes** — dropped inner $, added GET /api/decisions/agent
2. **Identity resolution** — all 3 agent routes call check_agent_scope_for_project
3. **Route shadowing** — literal /api/decisions/agent before /{decision_id}
4. **Source persistence** — answer() gets source param, serialized in answer JSON
5. **Consent side effects** — agent path runs apply*_grant trio
6. **answered_by** — records canonical agent ID from registry JWT
7. **Tests** — 15 middleware + 8 e2e tests added

Closes #2191's underlying issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent-scoped endpoints to list, view, and answer decisions for the requesting agent.
  * Decision listing now supports an optional originating-agent filter.
  * Answers now record `source` (default `in_app`; mirrored agent answers are tracked separately as `mirrored_from_chat`).
* **Bug Fixes**
  * Strengthened validation for human and mirrored answers, returning `400` for malformed/non-hashable select payloads and rejecting spoofed `source`.
  * Blocked cross-project access and prevented mirror-answering for gate-kind decisions from triggering consent side effects.
* **Tests**
  * Expanded middleware and routing tests to cover allowlisting, scoping/404 vs 403 behavior, filtering, and fail-closed error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->