### PR TITLE
fix(tasks): add ownership guard to close_task

### DIFF
--- a/tests/projects/test_task_store.py
+++ b/tests/projects/test_task_store.py
@@ -341,3 +341,53 @@ async def test_get_task_context_project_falls_back_without_project_store(store):
     t = await store.create_task(project_id="p", title="T", created_by="u")
     ctx = await store.get_task_context(t["id"])
     assert ctx["project"]["id"] == "p"
+
+
+# ── close_task ownership guard ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_close_by_claimer_passes(store):
+    """Claim holder can close their own claimed card."""
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(t["id"], claimer_id="agent-1")
+    ok = await store.close_task(t["id"], closed_by="agent-1", reason="done")
+    assert ok is True
+    again = await store.get_task(t["id"])
+    assert again["status"] == "closed"
+    assert again["closed_by"] == "agent-1"
+
+
+@pytest.mark.asyncio
+async def test_close_by_stranger_rejected(store):
+    """A non-claimer cannot close a claimed card (ownership guard)."""
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(t["id"], claimer_id="agent-1")
+    ok = await store.close_task(t["id"], closed_by="agent-2", reason="intruder")
+    assert ok is False
+    again = await store.get_task(t["id"])
+    assert again["status"] == "claimed"
+    assert again["claimed_by"] == "agent-1"
+
+
+@pytest.mark.asyncio
+async def test_close_by_lead_passes(store):
+    """Lead/curator can force-close a card claimed by someone else."""
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    await store.claim_task(t["id"], claimer_id="agent-1")
+    ok = await store.close_task(t["id"], closed_by="lead", reason="escalation", force=True)
+    assert ok is True
+    again = await store.get_task(t["id"])
+    assert again["status"] == "closed"
+    assert again["closed_by"] == "lead"
+
+
+@pytest.mark.asyncio
+async def test_close_unclaimed_unchanged(store):
+    """Unclaimed cards can still be closed by any authorised caller."""
+    t = await store.create_task(project_id="p", title="A", created_by="u")
+    ok = await store.close_task(t["id"], closed_by="reviewer", reason="stale")
+    assert ok is True
+    again = await store.get_task(t["id"])
+    assert again["status"] == "closed"
+    assert again["closed_by"] == "reviewer"

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -361,14 +361,25 @@ class ProjectTaskStore(BaseStore):
         task_id: str,
         closed_by: str,
         reason: str | None = None,
+        *,
+        force: bool = False,
     ) -> bool:
         now = time.time()
-        cursor = await self._db.execute(
-            """UPDATE project_tasks
-               SET status = 'closed', closed_by = ?, closed_at = ?, close_reason = ?, updated_at = ?
-               WHERE id = ? AND status NOT IN ('closed', 'cancelled')""",
-            (closed_by, now, reason, now, task_id),
-        )
+        if force:
+            cursor = await self._db.execute(
+                """UPDATE project_tasks
+                   SET status = 'closed', closed_by = ?, closed_at = ?, close_reason = ?, updated_at = ?
+                   WHERE id = ? AND status NOT IN ('closed', 'cancelled')""",
+                (closed_by, now, reason, now, task_id),
+            )
+        else:
+            cursor = await self._db.execute(
+                """UPDATE project_tasks
+                   SET status = 'closed', closed_by = ?, closed_at = ?, close_reason = ?, updated_at = ?
+                   WHERE id = ? AND status NOT IN ('closed', 'cancelled')
+                     AND (claimed_by IS NULL OR claimed_by = ?)""",
+                (closed_by, now, reason, now, task_id, closed_by),
+            )
         await self._db.commit()
         changed = cursor.rowcount == 1
         if changed:

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -955,8 +955,11 @@ async def close_task(
     existing = await store.get_task(task_id)
     if existing is None or existing["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
-    ok = await store.close_task(task_id, closed_by=closed_by, reason=payload.reason)
+    force = project.get("lead_member_id") == actor_id
+    ok = await store.close_task(task_id, closed_by=closed_by, reason=payload.reason, force=force)
     if not ok:
+        if existing.get("claimed_by") and existing["claimed_by"] != closed_by:
+            return JSONResponse({"error": "not claimed by you"}, status_code=409)
         return JSONResponse({"error": "cannot close"}, status_code=409)
     _beads_mark_dirty(request, project_id)
     await pstore.log_activity(project_id, closed_by, "task.closed", {"task_id": task_id})


### PR DESCRIPTION
Fixes #2191.

Add claim-holder ownership guard to `close_task` in the store, mirroring the
release guard pattern: the SQL now requires `claimed_by IS NULL OR claimed_by = ?`.
The route handler passes `force=True` when the caller is the project lead/curator,
allowing leads to close cards claimed by others.

### Changes
- **task_store.py**: `close_task` gains a `force` kwarg. Non-force path
  enforces `claimed_by IS NULL OR claimed_by = closed_by`.
- **routes/projects.py**: Close handler resolves lead bypass:
  `force = project.get("lead_member_id") == actor_id`.
- **test_task_store.py**: 4 new tests:
  - `test_close_by_claimer_passes` — claimer closes own claimed card
  - `test_close_by_stranger_rejected` — non-claimer blocked (returns False)
  - `test_close_by_lead_passes` — lead force-closes another's claimed card
  - `test_close_unclaimed_unchanged` — unclaimed cards still closeable by anyone

Tests: 29/29 task_store, 68/68 projects-integration pass.