### PR TITLE
tsk-x46zyb  [OPEN]  Observatory queue/throttle routes reject the agent

### DIFF
--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -1,6 +1,67 @@
 import pytest
+from httpx import ASGITransport, AsyncClient
 
-from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.agent_registry_store import mint_registry_token
+
+
+# --- helpers ------------------------------------------------------------------
+
+
+async def _mint_agent(app, project_id, scopes, handle="@taOS-dev"):
+    """Register an active agent, grant it *scopes* for *project_id*, return
+    (canonical_id, bearer_token). project_id=None grants globally."""
+    registry = app.state.agent_registry
+    grants = app.state.agent_grants
+    for store in (registry, grants):
+        if store._db is None:
+            await store.init()
+    priv, _pub = app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="claude-code",
+        display_name="taOS dev",
+        origin="internal",
+        handle=handle,
+    )
+    cid = rec["canonical_id"]
+    if rec.get("status") != "active":
+        await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="claude-code", project_id=project_id
+    )
+    return cid, token
+
+
+def _agent_client(app, token):
+    """Cookieless client that authenticates only via the agent bearer token."""
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def _non_admin_client(app, username="bob"):
+    """Client authenticated as a non-admin human user."""
+    invite = app.state.auth.add_user_invite(username, "admin")
+    app.state.auth.complete_invite(username, invite, username.title(), "", "testpass1")
+    user = app.state.auth.find_user(username)
+    token = app.state.auth.create_session(user_id=user["id"], long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+async def _new_project(client, name="alpha", slug="alpha"):
+    resp = await client.post("/api/projects", json={"name": name, "slug": slug})
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+# --- pause --------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -42,13 +103,12 @@ async def test_empty_scope_rejected(client):
 
 @pytest.mark.asyncio
 async def test_non_admin_cannot_pause(app, client):
-    # Override the auth dependency to a non-admin user for this request.
-    app.dependency_overrides[current_user] = lambda: CurrentUser(user_id="bob", is_admin=False)
-    try:
-        resp = await client.post("/api/observatory/pause", json={"scope": "global", "paused": True})
-        assert resp.status_code == 403
-    finally:
-        app.dependency_overrides.pop(current_user, None)
+    async with _non_admin_client(app) as ac:
+        resp = await ac.post("/api/observatory/pause", json={"scope": "global", "paused": True})
+    assert resp.status_code == 403
+
+
+# --- throttle -----------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -89,12 +149,126 @@ async def test_throttle_empty_scope_rejected(client):
 
 @pytest.mark.asyncio
 async def test_non_admin_cannot_throttle(app, client):
-    app.dependency_overrides[current_user] = lambda: CurrentUser(user_id="bob", is_admin=False)
-    try:
-        resp = await client.post("/api/observatory/throttle", json={"scope": "global", "max_concurrent": 1})
-        assert resp.status_code == 403
-    finally:
-        app.dependency_overrides.pop(current_user, None)
+    async with _non_admin_client(app) as ac:
+        resp = await ac.post("/api/observatory/throttle", json={"scope": "global", "max_concurrent": 1})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_agent_with_observatory_control_can_set_throttle(app, client):
+    """An agent JWT with the observatory_control scope can PATCH the throttle dial."""
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, pid, ("observatory_control",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/observatory/throttle", json={"scope": "global", "max_concurrent": 4})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["global"] == 4
+    # Value persists across a fresh read.
+    resp = await client.get("/api/observatory/throttle")
+    assert resp.json()["global"] == 4
+
+
+@pytest.mark.asyncio
+async def test_agent_without_observatory_control_cannot_set_throttle(app, client):
+    """An agent JWT without the observatory_control scope gets 403 on throttle writes."""
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, pid, ("project_tasks",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/observatory/throttle", json={"scope": "global", "max_concurrent": 1})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_agent_can_read_throttle(app, client):
+    """Any active agent token can read throttle state."""
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, pid, ("project_tasks",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get("/api/observatory/throttle")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"global": None, "lanes": {}}
+
+
+# --- queue --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_queue_defaults_to_empty(client):
+    resp = await client.get("/api/observatory/queue")
+    assert resp.status_code == 200
+    assert resp.json() == {"global": None, "lanes": {}}
+
+
+@pytest.mark.asyncio
+async def test_global_queue_round_trips(client):
+    resp = await client.post("/api/observatory/queue", json={"scope": "global", "max_queue": 2})
+    assert resp.status_code == 200
+    assert resp.json()["global"] == 2
+    resp = await client.get("/api/observatory/queue")
+    assert resp.json()["global"] == 2
+    resp = await client.post("/api/observatory/queue", json={"scope": "global", "max_queue": 0})
+    assert resp.json()["global"] is None
+
+
+@pytest.mark.asyncio
+async def test_per_lane_queue_set_and_clear(client):
+    lane = "@taOS-dev-kilo-owl-alpha"
+    resp = await client.post("/api/observatory/queue", json={"scope": lane, "max_queue": 3})
+    assert resp.json()["lanes"].get(lane) == 3
+    assert resp.json()["global"] is None
+    resp = await client.post("/api/observatory/queue", json={"scope": lane, "max_queue": None})
+    assert lane not in resp.json()["lanes"]
+
+
+@pytest.mark.asyncio
+async def test_queue_empty_scope_rejected(client):
+    resp = await client.post("/api/observatory/queue", json={"scope": "  ", "max_queue": 2})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_set_queue(app, client):
+    async with _non_admin_client(app) as ac:
+        resp = await ac.post("/api/observatory/queue", json={"scope": "global", "max_queue": 1})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_agent_with_observatory_control_can_set_queue(app, client):
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, pid, ("observatory_control",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/observatory/queue", json={"scope": "global", "max_queue": 4})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["global"] == 4
+
+
+@pytest.mark.asyncio
+async def test_agent_without_observatory_control_cannot_set_queue(app, client):
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, pid, ("project_tasks",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.post("/api/observatory/queue", json={"scope": "global", "max_queue": 1})
+    assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.asyncio
+async def test_agent_can_read_queue(app, client):
+    pid = await _new_project(client)
+    _cid, token = await _mint_agent(app, pid, ("project_tasks",))
+
+    async with _agent_client(app, token) as ac:
+        resp = await ac.get("/api/observatory/queue")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"global": None, "lanes": {}}
+
+
+# --- approval-mode (session-only, unchanged) ----------------------------------
 
 
 @pytest.mark.asyncio
@@ -157,12 +331,12 @@ async def test_approval_mode_empty_scope_rejected(client):
 
 @pytest.mark.asyncio
 async def test_non_admin_cannot_set_approval_mode(app, client):
-    app.dependency_overrides[current_user] = lambda: CurrentUser(user_id="bob", is_admin=False)
-    try:
-        resp = await client.post("/api/observatory/approval-mode", json={"scope": "global", "mode": "dont_ask"})
-        assert resp.status_code == 403
-    finally:
-        app.dependency_overrides.pop(current_user, None)
+    async with _non_admin_client(app) as ac:
+        resp = await ac.post("/api/observatory/approval-mode", json={"scope": "global", "mode": "dont_ask"})
+    assert resp.status_code == 403
+
+
+# --- fleet (session-only, unchanged) ------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -361,9 +535,9 @@ async def test_fleet_idle_agent_carries_its_framework(app, client):
     await reg.register(framework="hermes", display_name="Idle Fw",
                        handle="@lane-fw-idle", user_id="admin")
     agents = (await client.get("/api/observatory/fleet")).json()["agents"]
-    mine = [a for a in agents if a["handle"] == "@lane-fw-idle"]
-    assert len(mine) == 1
-    assert mine[0]["framework"] == "hermes"
+    idle = [a for a in agents if a["handle"] == "@lane-fw-idle"]
+    assert len(idle) == 1
+    assert idle[0]["framework"] == "hermes"
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -32,10 +32,19 @@ _A2A_BUS_READ_PATHS = frozenset({
 _A2A_BUS_WRITE_PATHS = frozenset({
     "/api/a2a/bus/send",
 })
+# Observatory OS-control routes an agent may reach with its own registry JWT.
+# Reads accept any active agent token; writes require the observatory_control
+# scope (verified by the route, which also accepts an admin session). Exact
+# path allowlist, closed to everything else.
+_AGENT_OBSERVATORY_PATHS = frozenset({
+    "/api/observatory/throttle",
+    "/api/observatory/queue",
+    "/api/observatory/pause",
+})
 # Every path that accepts a registry JWT in place of the admin session.  The
 # passthrough is allowlisted to exactly these paths -- a registry JWT must never
 # authenticate an arbitrary route (no skeleton key).
-_AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE_PATHS
+_AGENT_TOKEN_PATHS = _REGISTRY_FEED_PATHS | _A2A_BUS_READ_PATHS | _A2A_BUS_WRITE_PATHS | _AGENT_OBSERVATORY_PATHS
 
 # Project kanban routes an agent may reach with its own registry JWT (scope
 # project_tasks, verified + project-bound by the route).  These are DYNAMIC

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -32,7 +32,7 @@ _DEFAULT_STATE: dict = {"global": False, "lanes": {}}
 # no-trace-progress check is phase 2 once the lane->trace-slug mapping is wired.
 STALE_CLAIM_SECONDS = 1800
 
-# Serialise read-modify-write of the pause/throttle state files so two
+# Serialise read-modify-write of the pause/throttle/queue state files so two
 # concurrent admin POSTs cannot lose an update (each reads the same prior
 # state and the second os.replace clobbers the first). The writes are
 # infrequent admin actions, so a single in-process lock is sufficient.
@@ -85,19 +85,45 @@ class PauseBody(BaseModel):
     paused: bool
 
 
+# --- Observatory auth resolver -------------------------------------------------
+# Read routes accept any active agent token or a logged-in human session.
+# Write routes accept an admin session or an agent JWT that holds the
+# observatory_control scope grant.
+# Never session-only: the registry JWT path is the primary agent control surface.
+
+async def _require_observatory_read(request: Request) -> None:
+    from tinyagentos.agent_token_auth import check_agent_identity
+    cid = await check_agent_identity(request)
+    if cid is not None:
+        return
+    uid = getattr(request.state, "user_id", None)
+    if not uid:
+        raise HTTPException(status_code=401, detail="authentication required")
+
+
+async def _require_observatory_write(request: Request) -> str:
+    from tinyagentos.agent_token_auth import check_agent_scope
+    cid = await check_agent_scope(request, "observatory_control")
+    if cid is not None:
+        return cid
+    uid = getattr(request.state, "user_id", None)
+    if uid and getattr(request.state, "is_admin", False):
+        return uid
+    raise HTTPException(status_code=403, detail="forbidden")
+
+
 @router.get("/api/observatory/pause")
-async def get_pause(request: Request, user: CurrentUser = Depends(current_user)):
+async def get_pause(request: Request, _auth: None = Depends(_require_observatory_read)):
     """Current pause state. Any authenticated caller (and the dispatch loop,
     which polls this each iteration) may read it."""
     return _read_state(request)
 
 
 @router.post("/api/observatory/pause")
-async def set_pause(body: PauseBody, request: Request, user: CurrentUser = Depends(current_user)):
-    """Pause or resume the queue globally or for a single lane. Admin only,
-    since it steers the whole fleet."""
-    if not user.is_admin:
-        raise HTTPException(status_code=403, detail="forbidden")
+async def set_pause(body: PauseBody, request: Request, _actor: str = Depends(_require_observatory_write)):
+    """Pause or resume the queue globally or for a single lane. Admin session
+    or agent JWT with observatory_control scope only, since it steers the
+    whole fleet."""
     scope = body.scope.strip()
     if not scope:
         return JSONResponse({"error": "scope required"}, status_code=400)
@@ -154,16 +180,15 @@ class ThrottleBody(BaseModel):
 
 
 @router.get("/api/observatory/throttle")
-async def get_throttle(request: Request, user: CurrentUser = Depends(current_user)):
+async def get_throttle(request: Request, _auth: None = Depends(_require_observatory_read)):
     """Current concurrency caps. The dispatch loop polls this each iteration."""
     return _read_throttle(request)
 
 
 @router.post("/api/observatory/throttle")
-async def set_throttle(body: ThrottleBody, request: Request, user: CurrentUser = Depends(current_user)):
-    """Set or clear a concurrency cap globally or for a single lane. Admin only."""
-    if not user.is_admin:
-        raise HTTPException(status_code=403, detail="forbidden")
+async def set_throttle(body: ThrottleBody, request: Request, _actor: str = Depends(_require_observatory_write)):
+    """Set or clear a concurrency cap globally or for a single lane. Admin session
+    or agent JWT with observatory_control scope only."""
     scope = body.scope.strip()
     if not scope:
         return JSONResponse({"error": "scope required"}, status_code=400)
@@ -177,6 +202,63 @@ async def set_throttle(body: ThrottleBody, request: Request, user: CurrentUser =
         else:
             state["lanes"].pop(scope, None)
         _atomic_write(_throttle_path(request), state)
+    return state
+
+
+# --- Dispatch queue control (read + write). Agents drive the queue through
+# this endpoint; reads are open to any active agent, writes require the
+# observatory_control scope just like throttle/pause. State is a JSON file in
+# data_dir so it survives restarts. ---
+
+
+def _queue_path(request: Request) -> Path:
+    return Path(request.app.state.data_dir) / "observatory_queue.json"
+
+
+def _read_queue(request: Request) -> dict:
+    p = _queue_path(request)
+    if not p.exists():
+        return {"global": None, "lanes": {}}
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, ValueError):
+        return {"global": None, "lanes": {}}
+    lanes = {}
+    for k, v in (data.get("lanes") or {}).items():
+        lim = _coerce_limit(v)
+        if lim is not None:
+            lanes[str(k)] = lim
+    return {"global": _coerce_limit(data.get("global")), "lanes": lanes}
+
+
+class QueueBody(BaseModel):
+    scope: str  # "global" or a lane handle
+    max_queue: int | None = None  # None or <= 0 clears the cap
+
+
+@router.get("/api/observatory/queue")
+async def get_queue(request: Request, _auth: None = Depends(_require_observatory_read)):
+    """Current dispatch queue caps."""
+    return _read_queue(request)
+
+
+@router.post("/api/observatory/queue")
+async def set_queue(body: QueueBody, request: Request, _actor: str = Depends(_require_observatory_write)):
+    """Set or clear a dispatch queue cap globally or for a single lane. Admin session
+    or agent JWT with observatory_control scope only."""
+    scope = body.scope.strip()
+    if not scope:
+        return JSONResponse({"error": "scope required"}, status_code=400)
+    limit = _coerce_limit(body.max_queue)
+    async with _write_lock:
+        state = _read_queue(request)
+        if scope == "global":
+            state["global"] = limit
+        elif limit is not None:
+            state["lanes"][scope] = limit
+        else:
+            state["lanes"].pop(scope, None)
+        _atomic_write(_queue_path(request), state)
     return state
 
 


### PR DESCRIPTION
Autonomous build of board card tsk-x46zyb.



Files:
 tests/test_routes_observatory.py  | 222 +++++++++++++++++++++++++++++++++-----
 tinyagentos/auth_middleware.py    |  11 +-
 tinyagentos/routes/observatory.py | 106 +++++++++++++++---
 3 files changed, 302 insertions(+), 37 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Observatory dispatch queue controls for viewing and setting queue limits.
  - Agents with Observatory control permissions can manage pause settings, throttling, and queue limits.
  - Authenticated agents can read Observatory pause, throttle, and queue status.

- **Bug Fixes**
  - Improved reliability when multiple Observatory settings are updated concurrently.
  - Restricted control updates for agents without the required permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->