### PR TITLE
Log unknown task request-body keys (observation phase, tsk-kqzpjt)

### DIFF
--- a/tests/test_routes_projects.py
+++ b/tests/test_routes_projects.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -776,4 +778,68 @@ async def test_old_per_member_lead_route_removed(client):
         f"/api/projects/{pid}/members/agent-a/lead", json={"is_lead": True}
     )
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# tsk-kqzpjt: observation phase for silent key-drops on task request models.
+# Unknown keys are accepted (extra="allow") but logged as a warning. These
+# tests pin: (a) a wrong key still returns 200 and emits the warning naming
+# the unknown key; (b) the correct key logs nothing and persists; (c) create
+# with a wrong key (tags) emits the warning naming tags.
+# ---------------------------------------------------------------------------
+
+_LOGGER = "tinyagentos.routes.projects"
+
+
+@pytest.mark.asyncio
+async def test_close_with_unknown_key_warns_and_succeeds(client, caplog):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    t = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "A"})).json()
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        resp = await client.post(
+            f"/api/projects/{pid}/tasks/{t['id']}/close",
+            json={"closed_by": "agent-1", "close_reason": "done"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "closed"
+    warns = [r for r in caplog.records if "unknown keys" in r.message]
+    assert warns, "expected a warning for unknown key close_reason"
+    msg = warns[0].message
+    assert "CloseIn" in msg
+    assert "close_reason" in msg
+
+
+@pytest.mark.asyncio
+async def test_close_with_correct_key_no_warning_and_persists(client, caplog):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+    t = (await client.post(f"/api/projects/{pid}/tasks", json={"title": "A"})).json()
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        resp = await client.post(
+            f"/api/projects/{pid}/tasks/{t['id']}/close",
+            json={"closed_by": "agent-1", "reason": "done"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "closed"
+    assert resp.json()["close_reason"] == "done"
+    warns = [r for r in caplog.records if "unknown keys" in r.message]
+    assert not warns, "no warning expected for the correct key reason"
+
+
+@pytest.mark.asyncio
+async def test_create_with_unknown_key_tags_warns(client, caplog):
+    pid = (await client.post("/api/projects", json={"name": "A", "slug": "a"})).json()["id"]
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        resp = await client.post(
+            f"/api/projects/{pid}/tasks",
+            json={"title": "T", "tags": ["bug"]},
+        )
+    assert resp.status_code == 200
+    warns = [r for r in caplog.records if "unknown keys" in r.message]
+    assert warns, "expected a warning for unknown key tags"
+    msg = warns[0].message
+    assert "CreateTaskIn" in msg
+    assert "tags" in msg
 

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -10,7 +10,7 @@ import json as _json
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from tinyagentos.agent_token_auth import (
     PROJECT_SCOPE_MISMATCH_DETAIL,
@@ -436,7 +436,31 @@ async def remove_member(
 # Task models
 # ---------------------------------------------------------------------------
 
-class CreateTaskIn(BaseModel):
+class _TaskRequestModelMixin:
+    """Shared base for task request models (tsk-kqzpjt).
+
+    Observation phase: unknown request-body keys are silently accepted
+    (extra="allow") but logged as a single warning so bad clients can be
+    detected before a future flip to extra="forbid". No behaviour change for
+    any caller; every currently-working request keeps working.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    @model_validator(mode="after")
+    def _log_unknown_keys(self):
+        extra = self.model_extra
+        if extra:
+            logger.warning(
+                "%s received unknown keys %s; valid fields are %s",
+                type(self).__name__,
+                sorted(extra.keys()),
+                sorted(type(self).model_fields.keys()),
+            )
+        return self
+
+
+class CreateTaskIn(_TaskRequestModelMixin, BaseModel):
     title: str
     body: str = ""
     priority: int = 0
@@ -446,7 +470,7 @@ class CreateTaskIn(BaseModel):
     element_id: str | None = None
 
 
-class UpdateTaskIn(BaseModel):
+class UpdateTaskIn(_TaskRequestModelMixin, BaseModel):
     title: str | None = None
     body: str | None = None
     priority: int | None = None
@@ -459,24 +483,24 @@ class UpdateTaskIn(BaseModel):
     element_id: str | None = None
 
 
-class ClaimIn(BaseModel):
+class ClaimIn(_TaskRequestModelMixin, BaseModel):
     claimer_id: str
 
 
-class ReleaseIn(BaseModel):
+class ReleaseIn(_TaskRequestModelMixin, BaseModel):
     releaser_id: str
 
 
-class CloseIn(BaseModel):
+class CloseIn(_TaskRequestModelMixin, BaseModel):
     closed_by: str
     reason: str | None = None
 
 
-class ReopenIn(BaseModel):
+class ReopenIn(_TaskRequestModelMixin, BaseModel):
     reopened_by: str | None = None
 
 
-class AddRelIn(BaseModel):
+class AddRelIn(_TaskRequestModelMixin, BaseModel):
     to_task_id: str
     kind: str
 
@@ -865,7 +889,7 @@ async def claim_task(
     return await store.get_task(task_id)
 
 
-class MarkClaimableIn(BaseModel):
+class MarkClaimableIn(_TaskRequestModelMixin, BaseModel):
     claimable: bool
 
 
@@ -1100,7 +1124,7 @@ async def add_relationship(
     return rel
 
 
-class AddCommentIn(BaseModel):
+class AddCommentIn(_TaskRequestModelMixin, BaseModel):
     body: str
     # Optional: an agent caller may omit it and the route pins it to the token
     # canonical_id. A session caller must still supply it (route enforces).


### PR DESCRIPTION
Autonomous build of board card tsk-kqzpjt.

Add a shared _TaskRequestModelMixin to task request models
(CreateTaskIn, UpdateTaskIn, ClaimIn, ReleaseIn, CloseIn, ReopenIn,
AddRelIn, MarkClaimableIn, AddCommentIn) with extra='allow' and a
model_validator that logs one warning when unknown keys are present,
naming the model class, the unknown keys, and the sorted valid field
names. No behaviour change for any caller; every currently-working
request keeps working. The flip to extra='forbid' is a follow-up.

Files:
 tests/test_routes_projects.py  | 66 ++++++++++++++++++++++++++++++++++++++++++
 tinyagentos/routes/projects.py | 44 +++++++++++++++++++++-------
 2 files changed, 100 insertions(+), 10 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Task-related project requests now tolerate unrecognized fields instead of failing validation.
  - Unsupported fields generate warning logs while valid request data continues to be processed normally.
  - Task closing and creation continue to preserve and return expected values.

- **Tests**
  - Added coverage for accepted unknown fields, warning messages, valid fields, and persisted task-closing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->