### PR TITLE
add route tests for canvas endpoints

### DIFF
--- a/tests/test_routes_canvas.py
+++ b/tests/test_routes_canvas.py
@@ -2,32 +2,64 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
-
 import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(tmp_path):
+    from tinyagentos.app import create_app
+
+    config = {
+        "server": {"host": "0.0.0.0", "port": 6969},
+        "backends": [],
+        "qmd": {"url": "http://localhost:7832"},
+        "agents": [],
+        "metrics": {"poll_interval": 30, "retention_days": 30},
+    }
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    (tmp_path / ".setup_complete").touch()
+    app = create_app(data_dir=tmp_path)
+    app.state.auth.setup_user("admin", "Admin", "", "adminpass")
+    return app
+
+
+@pytest.fixture()
+def ws_app(tmp_path):
+    return _make_client(tmp_path)
+
+
+@pytest.fixture()
+def unauthed_client(ws_app):
+    with TestClient(ws_app, raise_server_exceptions=False) as c:
+        yield c
+
+
+@pytest.fixture()
+def authed_client(ws_app):
+    record = ws_app.state.auth.find_user("admin")
+    token = ws_app.state.auth.create_session(user_id=record["id"], long_lived=True)
+    with TestClient(ws_app, raise_server_exceptions=False) as c:
+        c.cookies.set("taos_session", token)
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# POST /api/canvas/generate
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_create_canvas_returns_200(client):
-    resp = await client.post("/api/canvas/generate", json={
-        "title": "Test Canvas",
-        "content": "# Hello",
-        "style": "dark",
-        "format": "markdown",
-        "agent_name": "tester",
-    })
+    resp = await client.post("/api/canvas/generate", json={"title": "Test"})
     assert resp.status_code == 200
-
-
-@pytest.mark.asyncio
-async def test_create_canvas_response_shape(client):
-    resp = await client.post("/api/canvas/generate", json={
-        "title": "Test Canvas",
-        "content": "# Hello",
-        "style": "dark",
-        "format": "markdown",
-        "agent_name": "tester",
-    })
     data = resp.json()
     assert "canvas_id" in data
     assert "canvas_url" in data
@@ -36,161 +68,156 @@ async def test_create_canvas_response_shape(client):
 
 
 @pytest.mark.asyncio
-async def test_create_canvas_defaults(client):
-    resp = await client.post("/api/canvas/generate", json={})
+async def test_create_canvas_stores_values(client):
+    resp = await client.post(
+        "/api/canvas/generate",
+        json={"title": "My Canvas", "content": "hello", "style": "dark", "format": "html"},
+    )
     assert resp.status_code == 200
     data = resp.json()
-    assert "canvas_id" in data
-    assert "edit_token" in data
+    canvas_id = data["canvas_id"]
+    edit_token = data["edit_token"]
+
+    fetched = await client.get(f"/api/canvas/{canvas_id}/data")
+    assert fetched.status_code == 200
+    stored = fetched.json()
+    assert stored["title"] == "My Canvas"
+    assert stored["content"] == "hello"
+    assert stored["style"] == "dark"
+    assert stored["format"] == "html"
+    assert stored["edit_token"] == edit_token
+
+
+# ---------------------------------------------------------------------------
+# GET /api/canvas/{canvas_id}/data
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_get_canvas_data_returns_200(client):
-    created = (await client.post("/api/canvas/generate", json={
-        "title": "Fetch Me",
-        "content": "some content",
-    })).json()
-    resp = await client.get(f"/api/canvas/{created['canvas_id']}/data")
-    assert resp.status_code == 200
-
-
-@pytest.mark.asyncio
-async def test_get_canvas_data_shape(client):
-    created = (await client.post("/api/canvas/generate", json={
-        "title": "Fetch Me",
-        "content": "some content",
-    })).json()
-    data = (await client.get(f"/api/canvas/{created['canvas_id']}/data")).json()
-    assert data["id"] == created["canvas_id"]
-    assert data["title"] == "Fetch Me"
-    assert data["content"] == "some content"
-    assert "edit_token" in data
-    assert "created_at" in data
-    assert "updated_at" in data
-
-
-@pytest.mark.asyncio
-async def test_get_canvas_not_found(client):
-    resp = await client.get("/api/canvas/nonexistent/data")
+async def test_get_canvas_data_404_for_missing(client):
+    resp = await client.get("/api/canvas/does-not-exist/data")
     assert resp.status_code == 404
-    assert resp.json()["error"] == "Canvas not found"
+    assert "error" in resp.json()
 
 
 @pytest.mark.asyncio
-async def test_update_canvas_returns_200(client):
-    created = (await client.post("/api/canvas/generate", json={
-        "title": "Update Me",
-        "content": "old content",
-    })).json()
-    hub = client._transport.app.state.chat_hub
-    with patch.object(hub, "broadcast", new_callable=AsyncMock):
-        resp = await client.post(f"/api/canvas/{created['canvas_id']}/update", json={
-            "edit_token": created["edit_token"],
-            "content": "new content",
-        })
+async def test_get_canvas_data_returns_fields(client):
+    created = await client.post("/api/canvas/generate", json={"title": "T"})
+    canvas_id = created.json()["canvas_id"]
+    resp = await client.get(f"/api/canvas/{canvas_id}/data")
+    assert resp.status_code == 200
+    data = resp.json()
+    for key in ("id", "title", "content", "style", "format", "created_by", "edit_token"):
+        assert key in data, f"missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/canvas/{canvas_id}/update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_canvas_happy_path(client):
+    created = await client.post("/api/canvas/generate", json={"title": "Old"})
+    canvas_id = created.json()["canvas_id"]
+    edit_token = created.json()["edit_token"]
+
+    resp = await client.post(
+        f"/api/canvas/{canvas_id}/update",
+        json={"edit_token": edit_token, "content": "new content", "title": "New"},
+    )
     assert resp.status_code == 200
     assert resp.json()["status"] == "updated"
 
-
-@pytest.mark.asyncio
-async def test_update_canvas_reflects_changes(client):
-    created = (await client.post("/api/canvas/generate", json={
-        "title": "Update Me",
-        "content": "old content",
-    })).json()
-    hub = client._transport.app.state.chat_hub
-    with patch.object(hub, "broadcast", new_callable=AsyncMock):
-        await client.post(f"/api/canvas/{created['canvas_id']}/update", json={
-            "edit_token": created["edit_token"],
-            "content": "new content",
-            "title": "Updated Title",
-        })
-    data = (await client.get(f"/api/canvas/{created['canvas_id']}/data")).json()
-    assert data["content"] == "new content"
-    assert data["title"] == "Updated Title"
+    fetched = await client.get(f"/api/canvas/{canvas_id}/data")
+    assert fetched.json()["content"] == "new content"
+    assert fetched.json()["title"] == "New"
 
 
 @pytest.mark.asyncio
-async def test_update_canvas_invalid_token(client):
-    created = (await client.post("/api/canvas/generate", json={
-        "title": "Protected",
-        "content": "secret",
-    })).json()
-    resp = await client.post(f"/api/canvas/{created['canvas_id']}/update", json={
-        "edit_token": "wrong-token",
-        "content": "hacked",
-    })
-    assert resp.status_code == 403
-    assert resp.json()["error"] == "Invalid edit token or canvas not found"
+async def test_update_canvas_wrong_token_returns_403(client):
+    created = await client.post("/api/canvas/generate", json={"title": "T"})
+    canvas_id = created.json()["canvas_id"]
 
-
-@pytest.mark.asyncio
-async def test_update_canvas_not_found(client):
-    resp = await client.post("/api/canvas/nonexistent/update", json={
-        "edit_token": "some-token",
-        "content": "new",
-    })
+    resp = await client.post(
+        f"/api/canvas/{canvas_id}/update",
+        json={"edit_token": "wrong-token", "content": "x"},
+    )
     assert resp.status_code == 403
 
 
 @pytest.mark.asyncio
-async def test_delete_canvas_returns_200(client):
-    created = (await client.post("/api/canvas/generate", json={
-        "title": "Delete Me",
-        "content": "bye",
-    })).json()
-    resp = await client.delete(f"/api/canvas/{created['canvas_id']}")
+async def test_update_canvas_missing_canvas_returns_403(client):
+    resp = await client.post(
+        "/api/canvas/does-not-exist/update",
+        json={"edit_token": "some-token", "content": "x"},
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/canvas/{canvas_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_canvas_happy_path(client):
+    created = await client.post("/api/canvas/generate", json={"title": "ToDelete"})
+    canvas_id = created.json()["canvas_id"]
+
+    resp = await client.delete(f"/api/canvas/{canvas_id}")
     assert resp.status_code == 200
     assert resp.json()["status"] == "deleted"
 
-
-@pytest.mark.asyncio
-async def test_delete_canvas_not_found(client):
-    resp = await client.delete("/api/canvas/nonexistent")
-    assert resp.status_code == 404
-    assert resp.json()["error"] == "Canvas not found"
+    follow_up = await client.get(f"/api/canvas/{canvas_id}/data")
+    assert follow_up.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_delete_canvas_removes_data(client):
-    created = (await client.post("/api/canvas/generate", json={
-        "title": "Delete Me",
-        "content": "bye",
-    })).json()
-    await client.delete(f"/api/canvas/{created['canvas_id']}")
-    resp = await client.get(f"/api/canvas/{created['canvas_id']}/data")
+async def test_delete_canvas_missing_returns_404(client):
+    resp = await client.delete("/api/canvas/does-not-exist")
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
-async def test_list_canvases_returns_200(client):
-    resp = await client.get("/api/canvas")
-    assert resp.status_code == 200
+# ---------------------------------------------------------------------------
+# GET /api/canvas
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_list_canvases_shape(client):
-    created = (await client.post("/api/canvas/generate", json={
-        "title": "Listed",
-        "content": "in list",
-    })).json()
-    data = (await client.get("/api/canvas")).json()
-    assert "canvases" in data
-    assert isinstance(data["canvases"], list)
-    ids = [c["id"] for c in data["canvases"]]
-    assert created["canvas_id"] in ids
-
-
-@pytest.mark.asyncio
-async def test_list_canvases_empty(client):
-    """Before creating any canvases the list may be empty or contain items from
-    other tests; just verify the response structure is correct."""
+async def test_list_canvases_empty_by_default(client):
     resp = await client.get("/api/canvas")
     assert resp.status_code == 200
     data = resp.json()
-    assert isinstance(data["canvases"], list)
+    assert "canvases" in data
+    assert data["canvases"] == []
 
 
-# WebSocket endpoint (/ws/canvas/{canvas_id}) requires a live WebSocket
-# connection and real-time hub interaction; skipped as it needs an external
-# transport not available through the async HTTP client fixture.
+@pytest.mark.asyncio
+async def test_list_canvases_returns_created(client):
+    created = await client.post("/api/canvas/generate", json={"title": "A"})
+    cid = created.json()["canvas_id"]
+
+    resp = await client.get("/api/canvas")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["canvases"]) == 1
+    assert data["canvases"][0]["id"] == cid
+
+
+# ---------------------------------------------------------------------------
+# WS /ws/canvas/{canvas_id}
+# ---------------------------------------------------------------------------
+
+
+def test_ws_canvas_unauthenticated_rejected(unauthed_client):
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with unauthed_client.websocket_connect("/ws/canvas/test-canvas-id") as ws:
+            ws.receive_text()
+    assert exc_info.value.code == 1008
+
+
+def test_ws_canvas_authenticated_accepted(authed_client):
+    with authed_client.websocket_connect("/ws/canvas/test-canvas-id") as ws:
+        ws.send_text("ping")
+        # Connection staying open means auth passed and hub.join succeeded.


### PR DESCRIPTION
Autonomous build of board card tsk-6pf7bz.



Files:
 tests/test_routes_canvas.py | 285 ++++++++++++++++++++++++--------------------
 1 file changed, 156 insertions(+), 129 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for canvas creation, retrieval, updates, deletion, and listing.
  * Added validation for canvas field persistence and edit-token handling.
  * Added authorization checks for protected canvas operations.
  * Added coverage for missing canvases and unauthenticated WebSocket connections.
  * Verified authenticated WebSocket connections remain active after joining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->