### PR TITLE
fix(hardware): detect Rockchip NPU from device-tree when driver not loaded

### DIFF
--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -130,6 +130,34 @@ class TestDetectNpuRknpuModernPaths:
         npu = hardware_mod._detect_npu()
         assert npu.type == "rknpu"
 
+    def test_device_tree_fallback_no_driver_paths(self, monkeypatch):
+        """When no rknpu driver paths exist but device-tree reports RK3588,
+        _detect_npu still returns an rknpu NpuInfo (fresh flash / early boot)."""
+        # No driver paths exist
+        monkeypatch.setattr(hardware_mod, "_path_exists_safe", lambda p: False)
+        monkeypatch.setattr(hardware_mod, "_drm_has_rknpu", lambda: False)
+        # Neutralise lspci / non-rknpu probes
+        monkeypatch.setattr(hardware_mod, "_run", lambda *a, **k: "")
+        # No /dev/apex_* or hailo* globs
+        monkeypatch.setattr(Path, "glob", lambda self, pattern: iter([]))
+        # Device-tree reports RK3588
+        def fake_read_text(self, *args, **kwargs):
+            if str(self) == "/proc/device-tree/model":
+                return "Orange Pi 5 Plus"
+            if str(self) == "/proc/device-tree/compatible":
+                return "rockchip,rk3588\0rockchip,rk3588-orangepi-5-plus"
+            raise OSError("stubbed")
+        monkeypatch.setattr(Path, "read_text", fake_read_text)
+        monkeypatch.setattr(Path, "exists", lambda self: str(self) in (
+            "/proc/device-tree/model", "/proc/device-tree/compatible",
+        ))
+
+        npu = hardware_mod._detect_npu()
+        assert npu.type == "rknpu"
+        assert npu.device == "rk3588"
+        assert npu.tops == 6
+        assert npu.cores == 3
+
 
 class TestGetHardwareProfile:
     def test_always_reprobes_on_startup(self, tmp_path, monkeypatch):

--- a/tinyagentos/hardware.py
+++ b/tinyagentos/hardware.py
@@ -285,6 +285,25 @@ def _detect_npu() -> NpuInfo:
             pass
         tops = 6 if cores == 3 else (6 if cores == 1 else 1)
         return NpuInfo(type="rknpu", device=soc or "rknpu", tops=tops, cores=cores)
+    # Fallback: detect Rockchip SoC from device-tree even when the rknpu
+    # driver hasn't been loaded yet (fresh flash, early boot, kernel
+    # without the module). The SoC is known from device-tree/model and
+    # device-tree/compatible without any driver — report the NPU so the
+    # setup wizard can offer the backend install step (#1535).
+    try:
+        dt_text = ""
+        for dt in ("/proc/device-tree/model", "/proc/device-tree/compatible"):
+            p = Path(dt)
+            if p.exists():
+                dt_text += " " + p.read_text().replace("\x00", " ").lower()
+        if "rk3588" in dt_text:
+            return NpuInfo(type="rknpu", device="rk3588", tops=6, cores=3)
+        if "rk3576" in dt_text:
+            return NpuInfo(type="rknpu", device="rk3576", tops=6, cores=1)
+        if "rk3568" in dt_text:
+            return NpuInfo(type="rknpu", device="rk3568", tops=1, cores=1)
+    except (OSError, ValueError):
+        pass
     # Hailo — distinguish 8L (13 TOPS, vision only) from 10H (40 TOPS, LLM capable)
     for p in Path("/dev").glob("hailo*"):
         hailo_info = _run(["lspci", "-d", "1e60:"])


### PR DESCRIPTION
## Problem

On a fresh RK3588 board the rknpu kernel module may not be loaded at first boot, leaving all driver-probe paths (/dev/rknpu, debugfs, devfreq, platform-drivers) absent. The NPU goes undetected and the setup wizard never offers the backend install step.

## Fix

Add a device-tree fallback after the driver-path probe fails in `_detect_npu()`.  Read `/proc/device-tree/model` and `/proc/device-tree/compatible` and check for rk3588/rk3576/rk3568.  The SoC is known from device-tree without any driver — report rknpu so the wizard can show the "Install the NPU backend" step even on a cold board.

## Changes

- `tinyagentos/hardware.py`: +19 lines — device-tree fallback in `_detect_npu()`
- `tests/test_hardware.py`: +28 lines — new test `test_device_tree_fallback_no_driver_paths`

## Testing

- `pytest tests/test_hardware.py::TestDetectNpuRknpuModernPaths -v` — 3/3 pass (incl. new test)
- Security scans: no secrets, no injection vectors

Closes #1535