### PR TITLE
chore: move dev deps to [dependency-groups] so uv sync gives a working test env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       # not from a fresh unpinned resolve that can pull in a regressed
       # release (see the fastapi 0.137 incident, #903).
       - name: Install dependencies
-        run: uv sync --frozen --extra dev --python ${{ matrix.python-version }}
+        run: uv sync --frozen --python ${{ matrix.python-version }}
 
       # SPA bundle is stubbed by tests/conftest.py — see pytest_configure.
       # The real build is exercised in the spa-build job below.
@@ -168,7 +168,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv sync --frozen --extra dev --python 3.12
+        run: uv sync --frozen --python 3.12
 
       - name: Check for syntax errors
         run: uv run --no-sync python -m compileall tinyagentos/ -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ To keep this sustainable, **all contributors must agree to the Contributor Licen
 ```bash
 git clone https://github.com/jaylfc/taOS.git
 cd tinyagentos
-uv sync --extra dev
+uv sync
 # Build the desktop SPA - static/desktop/ is gitignored (generated artifact)
 cd desktop && npm install && npm run build && cd ..
 uv run pytest tests/ --ignore=tests/e2e -n auto

--- a/README.md
+++ b/README.md
@@ -686,7 +686,7 @@ uv run exo
 ## Development
 
 ```bash
-uv sync --extra dev
+uv sync
 uv run pytest tests/ --ignore=tests/e2e -n auto   # ~7,400 tests
 cd desktop && npx vitest run                       # ~1,900 desktop tests
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,12 @@ proxy = ["litellm[proxy]>=1.93.0", "prisma>=0.11.0"]
 # dependency or fresh installs abort. torrent_downloader guards the import and
 # falls back to a direct download when it is absent.
 torrent = ["libtorrent>=2.0.9"]
+e2e = [
+    "pytest>=9.1.1",
+    "pytest-playwright>=0.5.0",
+]
+
+[dependency-groups]
 dev = [
     "pytest>=9.1.1",
     "pytest-asyncio>=0.23.0",
@@ -74,10 +80,6 @@ dev = [
     "httpx",
     "respx>=0.21.0",
     "websockets>=12.0",
-]
-e2e = [
-    "pytest>=9.1.1",
-    "pytest-playwright>=0.5.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -3042,16 +3042,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-dev = [
-    { name = "httpx" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-split" },
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
-    { name = "respx" },
-    { name = "websockets" },
-]
 e2e = [
     { name = "pytest" },
     { name = "pytest-playwright" },
@@ -3068,6 +3058,18 @@ worker = [
     { name = "pystray" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-split" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "respx" },
+    { name = "websockets" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
@@ -3077,7 +3079,6 @@ requires-dist = [
     { name = "diff-match-patch", specifier = ">=20230430" },
     { name = "fastapi", specifier = ">=0.115.0,<0.137" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "httpx", marker = "extra == 'dev'" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "libtorrent", marker = "extra == 'torrent'", specifier = ">=2.0.9" },
     { name = "litellm", extras = ["proxy"], marker = "extra == 'proxy'", specifier = ">=1.93.0" },
@@ -3088,26 +3089,31 @@ requires-dist = [
     { name = "prisma", marker = "extra == 'proxy'", specifier = ">=0.11.0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pystray", marker = "extra == 'worker'", specifier = ">=0.19.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest", marker = "extra == 'e2e'", specifier = ">=9.1.1" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-playwright", marker = "extra == 'e2e'", specifier = ">=0.5.0" },
-    { name = "pytest-split", marker = "extra == 'dev'", specifier = ">=0.9.0" },
-    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pywebpush", specifier = ">=1.14" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "readability-lxml", specifier = ">=0.8.1" },
-    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "sqlcipher3", specifier = ">=0.6.2" },
     { name = "taosmd", specifier = "==0.4.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.51.0" },
     { name = "websockets", specifier = ">=12.0" },
-    { name = "websockets", marker = "extra == 'dev'", specifier = ">=12.0" },
     { name = "zeroconf", specifier = ">=0.150.0" },
 ]
-provides-extras = ["worker", "proxy", "torrent", "dev", "e2e"]
+provides-extras = ["worker", "proxy", "torrent", "e2e"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-split", specifier = ">=0.9.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.0" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
+    { name = "respx", specifier = ">=0.21.0" },
+    { name = "websockets", specifier = ">=12.0" },
+]
 
 [[package]]
 name = "tokenizers"


### PR DESCRIPTION
Autonomous build of board card tsk-sz5nvh.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

[project.optional-dependencies] dev is now [dependency-groups] dev (PEP 735),
which uv installs by default. This eliminates the four places that had to
remember --extra dev (ci.yml shards + lint jobs, CONTRIBUTING.md, README.md)
and prevents a fresh clone from silently running zero tests.

worker, proxy, torrent, and e2e remain optional extras. uv.lock regenerated.

Files:
 .github/workflows/ci.yml |  4 ++--
 CONTRIBUTING.md          |  2 +-
 README.md                |  2 +-
 pyproject.toml           | 10 ++++++----
 4 files changed, 10 insertions(+), 8 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor and development setup instructions to use the simpler `uv sync` command.
  * Clarified local development and CI environment setup guidance.

* **Chores**
  * Streamlined automated checks to use the standard dependency synchronization process.
  * Improved organization of end-to-end testing dependencies for more consistent project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->