### PR TITLE
tsk-gr56lr  [OPEN]  store_install: unsigned-manifest policy contradict

### DIFF
--- a/tests/test_routes_store_install.py
+++ b/tests/test_routes_store_install.py
@@ -735,14 +735,16 @@ class TestInstallV2:
         )
 
     @pytest.mark.asyncio
-    async def test_toctou_stored_sig_none_returns_403(self, client, tmp_path):
-        """TOCTOU re-verify returns 403 when the registry has no stored
-        signature for the manifest (signature was lost or never persisted).
+    async def test_toctou_never_signed_manifest_allowed(self, client, tmp_path):
+        """A legacy unsigned manifest (never signed, not a signing failure)
+        with a signing pubkey configured installs successfully end to end.
 
-        The first gate sees ``stored_sig is None`` and, because the
-        manifest is not a signing failure, allows the install through.
-        The TOCTOU guard then re-checks on its own and blocks — proving
-        the two gates are independently fail-closed for this case too."""
+        Both the install gate and the TOCTOU guard agree: absence of a
+        signature on a manifest that was never signed is not evidence of
+        tampering.  This is the fail-open policy for pre-signing catalog
+        entries, the gate and the TOCTOU guard must not contradict each
+        other here.  (Previously the TOCTOU guard returned 403 for this
+        state, contradicting the gate's docstring and #2050's adjudication.)"""
         from tinyagentos.registry import AppRegistry
         from tinyagentos.store_signing import generate_signing_keypair
 
@@ -764,12 +766,64 @@ class TestInstallV2:
             signing_key=priv,
         )
         reg._ensure_loaded()
-        # Clear the stored signature so both gates see None.
+        # Clear the stored signature so both gates see None, simulating a
+        # manifest loaded before signing was enabled.
         reg._signatures.pop("test-svc", None)
 
         client._transport.app.state.registry = reg
         client._transport.app.state.store_signing_pubkey = pub
         client._transport.app.state.installed_apps = _make_installed_apps()
+
+        resp = await client.post("/api/store/install-v2", json={
+            "manifest_id": "test-svc",
+        })
+        assert resp.status_code == 200, (
+            f"expected install to succeed for never-signed manifest, got {resp.status_code}: {resp.json()}"
+        )
+        body = resp.json()
+        assert body["app_id"] == "test-svc"
+        assert body["status"] == "installed"
+
+    @pytest.mark.asyncio
+    async def test_toctou_signature_lost_after_gate_returns_403(self, client, tmp_path):
+        """When the registry's signature is present at the install gate but
+        disappears before the TOCTOU re-verification, the install is blocked
+        with 403: the gate saw a signature, so its absence at re-verify is
+        treated as post-verification tampering (not a legacy unsigned entry)."""
+        from tinyagentos.registry import AppRegistry
+        from tinyagentos.store_signing import generate_signing_keypair
+
+        catalog_dir = tmp_path / "catalog"
+        svc_dir = catalog_dir / "services" / "test-svc"
+        svc_dir.mkdir(parents=True)
+        manifest_path = svc_dir / "manifest.yaml"
+        manifest_path.write_text(
+            "id: test-svc\nname: Test Service\ntype: service\n"
+            "version: \"1.0\"\ninstall:\n  method: download\n",
+        )
+
+        priv, pub = generate_signing_keypair()
+        installed_path = tmp_path / "installed.json"
+        installed_path.write_text("[]")
+        reg = AppRegistry(
+            catalog_dir=catalog_dir,
+            installed_path=installed_path,
+            signing_key=priv,
+        )
+        reg._ensure_loaded()
+        assert reg.get_signature("test-svc") is not None
+
+        client._transport.app.state.registry = reg
+        client._transport.app.state.store_signing_pubkey = pub
+        client._transport.app.state.installed_apps = _make_installed_apps()
+
+        # The gate calls get_signature once (inside _verify_manifest_for_install),
+        # then _gate_had_sig captures it again, then the TOCTOU guard calls it
+        # a third time.  Return the real signature on the first two calls so
+        # the gate allows the install, then return None on the third call to
+        # simulate the signature vanishing between the gate and re-verify.
+        real_sig = reg._signatures["test-svc"]
+        reg.get_signature = MagicMock(side_effect=[real_sig, real_sig, None])  # type: ignore[method-assign]
 
         resp = await client.post("/api/store/install-v2", json={
             "manifest_id": "test-svc",

--- a/tinyagentos/routes/store_install.py
+++ b/tinyagentos/routes/store_install.py
@@ -784,11 +784,18 @@ async def install_app(request: Request):
             status_code=403,
         )
 
+    # Capture whether the install gate saw a stored signature, so the TOCTOU
+    # guard below can distinguish a never-signed manifest (allow, matching the
+    # gate's fail-open policy for legacy unsigned entries) from one whose
+    # signature was lost after the gate saw it (block as post-verification
+    # tampering).
+    _gate_had_sig = registry.get_signature(manifest_id) is not None
+
     # TOCTOU guard: the signing gate above verified the signature against
     # the on-disk manifest, but the install below uses the in-memory
     # manifest object loaded at boot.  An attacker who swaps the on-disk
     # file between verification and execution could bypass the gate.
-    # Re-read from disk and re-verify the signature — if it no longer
+    # Re-read from disk and re-verify the signature, if it no longer
     # verifies, the manifest was modified after the gate check and the
     # install is blocked.
     #
@@ -805,9 +812,14 @@ async def install_app(request: Request):
 
         def _toctou_reverify():
             # Fail-closed: any inability to re-read or re-verify the
-            # manifest blocks the install.  The first gate already proved
-            # the manifest was valid; at this point a missing, unreadable,
-            # or unsigned manifest means post-verification tampering.
+            # manifest blocks the install, EXCEPT for a manifest that was
+            # never signed.  The first gate already proved the manifest was
+            # valid; at this point a missing, unreadable, or tampered
+            # manifest means post-verification tampering.  A manifest that
+            # was never signed (legacy entry loaded before signing was
+            # enabled) is allowed through, matching the gate's fail-open
+            # policy, only a signature present at the gate but gone now
+            # is treated as post-verification tampering.
             disk_path = _manifest_dir / "manifest.yaml"
             try:
                 import yaml as _yaml
@@ -818,7 +830,14 @@ async def install_app(request: Request):
                     return False
                 stored_sig = registry.get_signature(manifest_id)
                 if stored_sig is None:
-                    return False
+                    # The gate allowed this manifest, so it was never signed
+                    # unless the gate saw a signature that has since vanished.
+                    # Match the gate's fail-open policy for never-signed
+                    # manifests; only block when a signature was present at
+                    # the gate but is now gone.
+                    if _gate_had_sig:
+                        return False
+                    return True
                 from tinyagentos.store_signing import verify_manifest_signature as _verify_sig
                 return _verify_sig(on_disk, stored_sig, _store_pub)
             except Exception:  # noqa: BLE001 - fail-closed, never allow on error


### PR DESCRIPTION
Autonomous build of board card tsk-gr56lr.



Files:
 tests/test_routes_store_install.py  | 72 ++++++++++++++++++++++++++++++++-----
 tinyagentos/routes/store_install.py | 29 ++++++++++++---
 2 files changed, 87 insertions(+), 14 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installations now continue successfully for manifests that have never been signed.
  * Improved protection against signature changes during installation by blocking installs when a previously present signature disappears or no longer matches.
  * Updated validation coverage for unsigned manifests and signature-change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->