### PR TITLE
finish theme-token migration in MessagesApp, add shell-scrim and shell-subtle tokens

### DIFF
--- a/desktop/src/apps/MessagesApp.palette.test.ts
+++ b/desktop/src/apps/MessagesApp.palette.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "MessagesApp.tsx"), "utf-8");
+
+const HARDCODED = /\b(bg|text|border)-(white|black)(\/\d+|\/\[\d+\.\d+\])/g;
+
+describe("MessagesApp palette token regression", () => {
+  it("contains no hardcoded white/black palette utilities", () => {
+    const hits: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = HARDCODED.exec(source)) !== null) {
+      hits.push(m[0]);
+    }
+    expect(hits, `hardcoded palette utilities found: ${hits.join(", ")}`).toEqual([]);
+  });
+});

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1938,11 +1938,11 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
     <div className="relative flex flex-col h-full bg-shell-base text-white overflow-hidden">
       {/* Toolbar — hidden on mobile when a channel is selected */}
       {showToolbar && (
-        <div className="relative flex items-center px-3 py-2.5 border-b border-white/[0.06] shrink-0">
+        <div className="relative flex items-center px-3 py-2.5 border-b border-shell-border shrink-0">
           {title ? (
             <>
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                <span className="text-sm font-semibold text-white/90">{title}</span>
+                <span className="text-sm font-semibold text-shell-text">{title}</span>
               </div>
               <div className="ml-auto">
                 <Button
@@ -1958,7 +1958,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
             </>
           ) : (
             <>
-              <div className="flex items-center gap-2 text-sm font-medium text-white/80">
+              <div className="flex items-center gap-2 text-sm font-medium text-shell-text">
                 <MessageCircle size={15} />
                 {!isMobile && "Messages"}
               </div>
@@ -2193,7 +2193,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
         <div
           role="dialog"
           aria-label={`Agent info for @${agentInfoPopover.slug}`}
-          className="fixed z-50 bg-shell-surface border border-white/10 rounded-lg shadow-xl p-3 text-xs min-w-[200px]"
+          className="fixed z-50 bg-shell-surface border border-shell-border rounded-lg shadow-xl p-3 text-xs min-w-[200px]"
           style={{ top: agentInfoPopover.y, left: agentInfoPopover.x }}
           onMouseLeave={() => setAgentInfoPopover(null)}
         >
@@ -2207,18 +2207,18 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
       {/* ---- Canvas Viewer ---- */}
       {viewingCanvas && (
         <div
-          className="fixed inset-0 z-[10002] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          className="fixed inset-0 z-[10002] flex items-center justify-center bg-shell-scrim backdrop-blur-sm"
           onClick={() => setViewingCanvas(null)}
           role="dialog"
           aria-modal="true"
           aria-label="Canvas viewer"
         >
           <div
-            className="w-[90vw] h-[85vh] max-w-5xl rounded-xl border border-white/10 overflow-hidden bg-shell-bg flex flex-col"
+            className="w-[90vw] h-[85vh] max-w-5xl rounded-xl border border-shell-border overflow-hidden bg-shell-bg flex flex-col"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="flex items-center justify-between px-4 py-2 border-b border-white/10 shrink-0">
-              <div className="flex items-center gap-2 text-sm text-white/80">
+            <div className="flex items-center justify-between px-4 py-2 border-b border-shell-border shrink-0">
+              <div className="flex items-center gap-2 text-sm text-shell-text">
                 <PanelRight size={14} />
                 <span>{viewingCanvas.title ?? "Canvas"}</span>
               </div>
@@ -2252,7 +2252,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
             aria-label="New channel"
           >
             <div
-              className="absolute bottom-0 left-0 right-0 bg-shell-bg border-t border-white/[0.08] rounded-t-2xl p-4 space-y-3"
+              className="absolute bottom-0 left-0 right-0 bg-shell-bg border-t border-shell-border rounded-t-2xl p-4 space-y-3"
               onClick={(e) => e.stopPropagation()}
             >
               <div className="flex items-center justify-between mb-1">
@@ -2277,7 +2277,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
                   id="new-channel-type-mobile"
                   value={newChannel.type}
                   onChange={(e) => setNewChannel((s) => ({ ...s, type: e.target.value as "topic" | "group" }))}
-                  className="w-full bg-white/[0.06] border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-accent-line"
+                  className="w-full bg-shell-subtle border border-shell-border rounded-lg px-3 py-2 text-sm text-shell-text outline-none focus:border-accent-line"
                   aria-label="Channel type"
                 >
                   <option value="topic">Topic</option>
@@ -2300,9 +2300,9 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
             </div>
           </div>
         ) : (
-          <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+          <div className="absolute inset-0 bg-shell-scrim flex items-center justify-center z-50 p-4">
             <Card className="w-full max-w-[380px] max-h-full flex flex-col shadow-2xl bg-shell-bg">
-              <CardHeader className="flex flex-row items-center justify-between gap-2 p-0 px-4 py-3 border-b border-white/[0.06]">
+              <CardHeader className="flex flex-row items-center justify-between gap-2 p-0 px-4 py-3 border-b border-shell-border">
                 <CardTitle className="text-sm font-medium">New Channel</CardTitle>
                 <Button
                   variant="ghost"
@@ -2331,7 +2331,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
                     id="new-channel-type"
                     value={newChannel.type}
                     onChange={(e) => setNewChannel((s) => ({ ...s, type: e.target.value as "topic" | "group" }))}
-                    className="w-full bg-white/[0.06] border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-accent-line"
+                    className="w-full bg-shell-subtle border border-shell-border rounded-lg px-3 py-2 text-sm text-shell-text outline-none focus:border-accent-line"
                     aria-label="Channel type"
                   >
                     <option value="topic">Topic</option>

--- a/desktop/src/theme/builtin-themes.ts
+++ b/desktop/src/theme/builtin-themes.ts
@@ -29,6 +29,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
         "--color-shell-surface-active": "rgba(0, 0, 0, 0.08)",
         "--color-shell-border": "rgba(0, 0, 0, 0.09)",
         "--color-shell-border-strong": "rgba(0, 0, 0, 0.15)",
+        "--color-shell-scrim": "rgba(0, 0, 0, 0.45)",
+        "--color-shell-subtle": "rgba(0, 0, 0, 0.055)",
         // Near-black ink: 14:1 / 6.4:1 / 4.0:1 on the #f4f5f7 body.
         "--color-shell-text": "rgba(0, 0, 0, 0.85)",
         "--color-shell-text-secondary": "rgba(0, 0, 0, 0.55)",

--- a/desktop/src/theme/theme-config.ts
+++ b/desktop/src/theme/theme-config.ts
@@ -15,6 +15,7 @@ export const ALLOWED_TOKENS = new Set<string>([
   "--color-shell-surface-hover","--color-shell-surface-active",
   "--color-shell-border","--color-shell-border-strong",
   "--color-shell-text","--color-shell-text-secondary","--color-shell-text-tertiary",
+  "--color-shell-scrim","--color-shell-subtle",
   "--color-traffic-close","--color-traffic-minimize","--color-traffic-maximize",
   "--color-accent","--color-accent-glow",
   "--color-accent-soft","--color-accent-line","--color-accent-strong",

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -40,6 +40,12 @@
   --color-dock-border: rgba(255, 255, 255, 0.08);
   --color-topbar-bg: rgba(29, 29, 31, 0.92);
 
+  /* Modal / overlay */
+  --color-shell-scrim: rgba(0, 0, 0, 0.6);
+
+  /* Subtle surface fills — input backgrounds, faint raised surfaces */
+  --color-shell-subtle: rgba(255, 255, 255, 0.06);
+
   /* Snap zones */
   --color-snap-preview: rgba(139, 146, 163, 0.15);
   --color-snap-border: rgba(139, 146, 163, 0.4);


### PR DESCRIPTION
Autonomous build of board card tsk-4nwxif.



Files:
 desktop/src/apps/MessagesApp.palette.test.ts | 20 ++++++++++++++++++++
 desktop/src/apps/MessagesApp.tsx             | 26 +++++++++++++-------------
 desktop/src/theme/builtin-themes.ts          |  2 ++
 desktop/src/theme/theme-config.ts            |  1 +
 desktop/src/theme/tokens.css                 |  6 ++++++
 5 files changed, 42 insertions(+), 13 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated message app panels, dialogs, headers, and channel creation screens to use consistent theme-based colors.
  * Improved overlay, border, text, and subtle-surface styling across light and dark themes.

* **Bug Fixes**
  * Prevented hardcoded black and white utility colors from being reintroduced in the Messages app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->