### PR TITLE
tsk-6v5j75  [OPEN]  Fix-forward PR 2190: new-contract tests for A2A stream proxy

### DIFF
--- a/tests/test_routes_a2a_bus_stream.py
+++ b/tests/test_routes_a2a_bus_stream.py
@@ -1,9 +1,12 @@
 """Tests for the authenticated A2A SSE stream proxy (Slice S3).
 
 Covers: an agent-JWT (bound to a project) can open the stream and receives
-forwarded SSE frames relayed from the raw bus; the messages proxy forwards the
-`since` cursor; an unauthenticated request is rejected 401; and the raw :7900
-bus is never exposed directly (the upstream call is made by the proxy only).
+forwarded SSE frames relayed from the raw bus; an omitted or ``*`` channel
+subscribes to ALL threads with NO ``thread`` param forwarded upstream, while a
+named channel maps to ``thread``; the ``since`` cursor is honored in both
+modes; the messages proxy forwards ``since`` and rejects ``*``; an
+unauthenticated request is rejected 401; and the raw :7900 bus is never exposed
+directly (the upstream call is made by the proxy only).
 """
 from __future__ import annotations
 
@@ -139,13 +142,98 @@ class TestBusStreamProxy:
         assert params["thread"] == "general"
         assert float(params["since"]) == 1234.5
 
-    async def test_stream_requires_channel(self, agent_app, client):
-        _, token = await _mint_agent(agent_app, scopes=("a2a_receive",))
-        resp = await client.get(
-            "/api/a2a/bus/stream",
-            headers={"Authorization": f"Bearer {token}"},
+    def _mock_upstream(self, sse_lines=None):
+        """Return a mock httpx.AsyncClient whose .stream() yields *sse_lines*."""
+        sse_lines = sse_lines if sse_lines is not None else []
+        upstream_resp = MagicMock()
+        upstream_resp.aiter_lines = MagicMock(
+            return_value=_fake_sse_lines(sse_lines)
         )
-        assert resp.status_code == 400
+        upstream_ctx = AsyncMock()
+        upstream_ctx.__aenter__ = AsyncMock(return_value=upstream_resp)
+        upstream_ctx.__aexit__ = AsyncMock(return_value=False)
+        client_ctx = AsyncMock()
+        client_ctx.stream = MagicMock(return_value=upstream_ctx)
+        client_ctx.__aenter__ = AsyncMock(return_value=client_ctx)
+        client_ctx.__aexit__ = AsyncMock(return_value=False)
+        return client_ctx
+
+    async def test_stream_no_channel_all_threads(self, agent_app, client):
+        """Omitting channel -> 200 SSE with NO thread param forwarded upstream."""
+        _, token = await _mint_agent(agent_app, scopes=("a2a_receive",))
+        client_ctx = self._mock_upstream([
+            "event: message",
+            'data: {"id":"m1","ts":1,"from":"a","body":"hi"}',
+            "",
+        ])
+        with patch(
+            "tinyagentos.routes.a2a_bus.httpx.AsyncClient",
+            return_value=client_ctx,
+        ):
+            resp = await client.get(
+                "/api/a2a/bus/stream",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert "m1" in resp.text
+        assert client_ctx.stream.called
+        params = client_ctx.stream.call_args.kwargs["params"]
+        assert "thread" not in params
+
+    async def test_stream_wildcard_channel_all_threads(self, agent_app, client):
+        """channel=* -> 200 SSE with NO thread param forwarded upstream."""
+        _, token = await _mint_agent(agent_app, scopes=("a2a_receive",))
+        client_ctx = self._mock_upstream([])
+        with patch(
+            "tinyagentos.routes.a2a_bus.httpx.AsyncClient",
+            return_value=client_ctx,
+        ):
+            resp = await client.get(
+                "/api/a2a/bus/stream",
+                params={"channel": "*"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        assert client_ctx.stream.called
+        params = client_ctx.stream.call_args.kwargs["params"]
+        assert "thread" not in params
+
+    async def test_stream_named_channel_forwards_thread(self, agent_app, client):
+        """Named channel -> thread forwarded upstream."""
+        _, token = await _mint_agent(agent_app, scopes=("a2a_receive",))
+        client_ctx = self._mock_upstream([])
+        with patch(
+            "tinyagentos.routes.a2a_bus.httpx.AsyncClient",
+            return_value=client_ctx,
+        ):
+            resp = await client.get(
+                "/api/a2a/bus/stream",
+                params={"channel": "general"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 200
+        params = client_ctx.stream.call_args.kwargs["params"]
+        assert params["thread"] == "general"
+
+    async def test_stream_since_honored_all_threads(self, agent_app, client):
+        """since cursor forwarded in all-threads (no-channel) mode."""
+        _, token = await _mint_agent(agent_app, scopes=("a2a_receive",))
+        client_ctx = self._mock_upstream([])
+        with patch(
+            "tinyagentos.routes.a2a_bus.httpx.AsyncClient",
+            return_value=client_ctx,
+        ):
+            resp = await client.get(
+                "/api/a2a/bus/stream",
+                params={"since": "1234.5"},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 200
+        params = client_ctx.stream.call_args.kwargs["params"]
+        assert "thread" not in params
+        assert float(params["since"]) == 1234.5
 
     async def test_unauthenticated_stream_is_401(self, noauth_client):
         resp = await noauth_client.get(
@@ -189,6 +277,16 @@ class TestMessagesSincePassthrough:
         call_kwargs = mock_client.get.call_args.kwargs
         assert call_kwargs["params"]["thread"] == "general"
         assert float(call_kwargs["params"]["since"]) == 42.0
+
+    async def test_messages_rejects_wildcard_channel(self, agent_app, client):
+        """bus_messages rejects channel=* (all-threads is stream-only)."""
+        _, token = await _mint_agent(agent_app, scopes=("a2a_receive",))
+        resp = await client.get(
+            "/api/a2a/bus/messages",
+            params={"channel": "*"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -121,8 +121,13 @@ async def bus_messages(
     false`` and HTTP 200.
     """
     await _authorize_bus_read(request)
-    if not channel or channel == "*":
+    if not channel:
         return JSONResponse({"error": "channel required"}, status_code=400)
+    if channel == "*":
+        return JSONResponse(
+            {"error": "wildcard channel not supported here; use /api/a2a/bus/stream for all-threads"},
+            status_code=400,
+        )
 
     limit = max(1, min(500, limit))
     params: dict = {"thread": channel, "limit": limit}

--- a/tinyagentos/routes/a2a_bus.py
+++ b/tinyagentos/routes/a2a_bus.py
@@ -112,14 +112,16 @@ async def bus_messages(
     Authorized readers: an admin session, the host local token, or an active
     agent registry JWT holding the ``a2a_receive`` scope.
 
-    ``channel`` is required and maps to the bus ``thread`` query param. ``limit``
-    is clamped to 1..500. ``since`` is forwarded verbatim to the bus as the
-    cursor (a message ``ts``); the bus replays everything after it, so an agent
-    can resume from the highest ``ts`` it has processed. On a bus error this
-    returns an empty list with ``available: false`` and HTTP 200.
+    ``channel`` is required and maps to the bus ``thread`` query param; ``*`` is
+    rejected here (it is only meaningful as an all-threads selector on the
+    stream endpoint). ``limit`` is clamped to 1..500. ``since`` is forwarded
+    verbatim to the bus as the cursor (a message ``ts``); the bus replays
+    everything after it, so an agent can resume from the highest ``ts`` it has
+    processed. On a bus error this returns an empty list with ``available:
+    false`` and HTTP 200.
     """
     await _authorize_bus_read(request)
-    if not channel:
+    if not channel or channel == "*":
         return JSONResponse({"error": "channel required"}, status_code=400)
 
     limit = max(1, min(500, limit))
@@ -156,12 +158,26 @@ async def bus_stream(
     (fail closed). It holds ONE upstream SSE connection to the bus per client and
     relays events verbatim, injecting a ``: ping`` heartbeat comment every 25s so
     idle streams are distinguishable from dead ones and intermediaries do not reap
-    them. The raw :7900 bus is never exposed directly: ``channel`` maps to the
-    bus ``thread`` query param and ``since`` to the bus cursor.
+    them. The raw :7900 bus is never exposed directly.
+
+    ``channel`` maps to the bus ``thread`` query param. Omitting it (or passing
+    ``channel=*``) subscribes to ALL threads: no ``thread`` param is forwarded
+    upstream, so the bus streams events from every thread. ``since`` maps to the
+    bus cursor.
     """
     await _authorize_bus_read(request)
-    if not channel:
-        return JSONResponse({"error": "channel required"}, status_code=400)
+
+    # An empty channel or "*" means "all threads": omit the thread param
+    # upstream so the bus streams every thread. NOTE: when per-channel bus ACLs
+    # land (card tsk-dp6fyv), an all-threads subscriber must receive ONLY the
+    # threads it is allowed to read, not everything -- filter here, not at the
+    # bus. This is the line a future change will get wrong.
+    all_threads = channel == "" or channel == "*"
+    params: dict = {}
+    if not all_threads:
+        params["thread"] = channel
+    if since is not None:
+        params["since"] = since
 
     bus = _bus_url()
 
@@ -171,7 +187,7 @@ async def bus_stream(
                 async with client.stream(
                     "GET",
                     f"{bus}/a2a/stream",
-                    params={"thread": channel, **({"since": since} if since is not None else {})},
+                    params=params,
                 ) as upstream:
                     heartbeat = asyncio.create_task(
                         _stream_sleep(_STREAM_HEARTBEAT_SEC)


### PR DESCRIPTION
Autonomous build of board card tsk-6v5j75.

Replace the stale test_stream_requires_channel (asserted the old 400 when
channel was omitted) with tests of the new contract: omitting channel (or
channel=*) yields 200 SSE with NO thread param forwarded upstream; a named
channel forwards thread; the since cursor is honored in both modes. Add a
red-first proof in the all-threads no-thread-forwarded assertions. Reject
channel=* in bus_messages (all-threads is stream-only).

On record: the stream proxy has no per-thread authorization today; this PR
widens convenience, not authz (verified by lead review).

Files:
 tests/test_routes_a2a_bus_stream.py | 116 +++++++++++++++++++++++++++++++++---
 tinyagentos/routes/a2a_bus.py       |  38 ++++++++----
 2 files changed, 134 insertions(+), 20 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added all-threads stream subscriptions when no channel is specified or when using `channel="*"`.
  * Preserved support for specific channel subscriptions and forwarding of stream cursors.

* **Bug Fixes**
  * The messages endpoint now rejects wildcard channels with an HTTP 400 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->