### PR TITLE
tsk-rll2pj  [OPEN]  Fix-forward PR 2202 (S2A follow-ups): slug fallbac

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -235,6 +235,40 @@ further project via `POST /api/projects/{project_id}/members/assign-agent`
 active identity (the existing canonical_id and token are reused instead of
 409ing).
 
+## Share destinations (device bearer)
+
+`GET /api/share/destinations` lets a paired device DISCOVER share targets. It is
+discovery-only: the response enumerates destinations, but the device scoped
+token itself cannot write to the ingest endpoints behind them (library ingest,
+chat messages, and project-files uploads all require their own session or agent
+auth). Sharing a payload happens through the device share flow, not by the
+device calling those endpoints directly.
+
+**Auth model.** `require_device` only: the caller sends
+`Authorization: Bearer <scoped_token>` (issued at `POST /api/devices/register`).
+Browser sessions and agent JWTs are not accepted. The path is listed in
+`EXEMPT_PATHS` in `tinyagentos/auth_middleware.py` so the session cookie gate
+does not apply; the handler enforces the device token. CSRF is registered on
+the router (`dependencies=_csrf`) so future unsafe-method routes inherit the
+double-submit check; the GET is exempt because safe methods always are.
+
+**Coverage.** `agent_chat` destinations resolve through the agent registry
+(exact canonical_id, then a slug lookup bounded to the canonical
+`-YYYYMMDD-HHMMSS` tail). Only registry-backed agents appear; a plain deployed
+agent with no registry row resolves nothing and its DM is omitted.
+
+**Response shape.**
+
+```json
+{
+  "destinations": [
+    {"kind": "library",       "id": "library",        "label": "Library"},
+    {"kind": "project_files", "id": "<project-slug>", "label": "<project name>"},
+    {"kind": "agent_chat",    "id": "<agent-slug>",   "label": "<display name>"}
+  ]
+}
+```
+
 ## Requesting more scope for an existing identity (scope requests)
 
 The auth-request flow (`POST /api/agents/auth-requests`) MINTS A NEW identity on

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -388,6 +388,75 @@ class TestGet:
 
 
 # ---------------------------------------------------------------------------
+# AgentRegistryStore: get_by_slug
+# ---------------------------------------------------------------------------
+
+
+class TestGetBySlug:
+    @pytest.mark.asyncio
+    async def test_matches_bare_slug(self, store):
+        """A DM member stored as a bare slug resolves via the slug lookup."""
+        agent = await store.register(framework="openclaw", display_name="Alpha")
+        slug = "alpha"
+        fetched = await store.get_by_slug(slug)
+        assert fetched is not None
+        assert fetched["canonical_id"] == agent["canonical_id"]
+        assert fetched["canonical_id"].startswith(f"{slug}-")
+
+    @pytest.mark.asyncio
+    async def test_does_not_prefix_match_longer_slug(self, store):
+        """Slug ``alpha`` must NOT match a sibling slotted ``alpha-beta-...``.
+
+        A plain ``LIKE 'alpha-%'`` prefix would match ``alpha-beta-YYYYMMDD-HHMMSS``
+        because it begins with ``alpha-``; the bounded tail match must not.
+        """
+        wider = await store.register(framework="openclaw", display_name="Alpha Beta")
+        assert wider["canonical_id"].startswith("alpha-beta-")
+        assert await store.get_by_slug("alpha") is None
+        assert await store.get_by_slug("alpha-beta") is not None
+
+    @pytest.mark.asyncio
+    async def test_matches_collision_suffix(self, store):
+        """A canonical_id carrying a 2-hex collision suffix still resolves."""
+        await store._db.execute(
+            "INSERT INTO agent_registry "
+            "(canonical_id, display_name, framework, user_id, origin, handle, "
+            "capabilities, created_ts, status) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "alpha-20260101-000000-01",
+                "Alpha",
+                "openclaw",
+                "user-1",
+                "taos-deployed",
+                "",
+                "[]",
+                "2026-01-01T00:00:00",
+                "active",
+            ),
+        )
+        await store._db.commit()
+        fetched = await store.get_by_slug("alpha")
+        assert fetched is not None
+        assert fetched["canonical_id"] == "alpha-20260101-000000-01"
+
+    @pytest.mark.asyncio
+    async def test_filters_inactive_by_default(self, store):
+        agent = await store.register(framework="openclaw", display_name="Gamma")
+        await store.set_status(agent["canonical_id"], "suspended")
+        assert await store.get_by_slug("gamma") is None
+        fetched = await store.get_by_slug("gamma", status=None)
+        assert fetched is not None
+        assert fetched["canonical_id"] == agent["canonical_id"]
+
+    @pytest.mark.asyncio
+    async def test_not_initialized_raises(self, tmp_path):
+        s = AgentRegistryStore(tmp_path / "not_init.db")
+        with pytest.raises(RuntimeError, match="not initialised"):
+            await s.get_by_slug("anything")
+
+
+# ---------------------------------------------------------------------------
 # AgentRegistryStore: list_all
 # ---------------------------------------------------------------------------
 

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -1252,3 +1252,14 @@ class TestDirectReportsAndOrgTree:
         tree = await store.get_org_tree()
         ids = {node["canonical_id"] for node in tree}
         assert row["canonical_id"] in ids
+
+
+@pytest.mark.asyncio
+async def test_get_by_slug_rejects_glob_metacharacters(store):
+    # A caller-supplied member string with GLOB metachars must not reach the
+    # matcher: it returns None instead of matching or raising.
+    assert await store.get_by_slug("alpha[a-z]") is None
+    assert await store.get_by_slug("alpha*") is None
+    assert await store.get_by_slug("alpha?") is None
+    assert await store.get_by_slug("") is None
+    assert await store.get_by_slug("Alpha") is None

--- a/tests/test_routes_share_destinations.py
+++ b/tests/test_routes_share_destinations.py
@@ -115,3 +115,86 @@ class TestShareDestinations:
         finally:
             await registry.close()
             app.state.agent_registry = registry
+
+    async def _prep_registry_and_device(self, app, client):
+        """Init a fresh registry and register a paired device for *app*.
+
+        Returns (registry, user_id, device_token). Shared by the bare-slug
+        regression tests so they can seed a DM channel member stored as a slug.
+        """
+        registry = app.state.agent_registry
+        if registry._db is not None:
+            await registry.close()
+        await registry.init()
+        primary = app.state.auth.get_primary_user()
+        user_id = primary["id"] if primary else "admin"
+        reg = await client.post("/api/devices/register", json={"platform": "ios"})
+        assert reg.status_code == 200
+        token = reg.json()["scoped_token"]
+        return registry, user_id, token
+
+    async def test_agent_chat_resolves_bare_slug_member(self, client, app):
+        """A DM member stored as a bare slug (not canonical_id) still resolves to
+        an active-agent destination. Storing the canonical_id would make
+        ``registry.get(member)`` succeed and never exercise the ``get_by_slug``
+        fallback, so this pins the fallback path itself."""
+        registry, user_id, token = await self._prep_registry_and_device(app, client)
+        try:
+            agent = await registry.register(
+                framework="openclaw", display_name="Alpha", user_id=user_id
+            )
+            slug = "alpha"
+            assert agent["canonical_id"].startswith(f"{slug}-")
+
+            await app.state.chat_channels.create_channel(
+                name="dm",
+                type="dm",
+                created_by=user_id,
+                members=[user_id, slug],
+            )
+
+            resp = await client.get(
+                "/api/share/destinations",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            chats = [d for d in body["destinations"] if d["kind"] == "agent_chat"]
+            ids = {d["id"] for d in chats}
+            assert slug in ids
+            assert chats[0]["label"] == "Alpha"
+        finally:
+            await registry.close()
+
+    async def test_agent_chat_bare_slug_does_not_match_longer_slug(
+        self, client, app
+    ):
+        """Negative boundary: member ``alpha`` must NOT match a record slotted
+        ``alpha-beta-YYYYMMDD-HHMMSS``. ``get_by_slug('alpha')`` must not
+        prefix-match the longer slug."""
+        registry, user_id, token = await self._prep_registry_and_device(app, client)
+        try:
+            wider = await registry.register(
+                framework="openclaw", display_name="Alpha Beta", user_id=user_id
+            )
+            assert wider["canonical_id"].startswith("alpha-beta-")
+
+            await app.state.chat_channels.create_channel(
+                name="dm2",
+                type="dm",
+                created_by=user_id,
+                members=[user_id, "alpha"],
+            )
+
+            resp = await client.get(
+                "/api/share/destinations",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            chats = [d for d in body["destinations"] if d["kind"] == "agent_chat"]
+            ids = {d["id"] for d in chats}
+            assert "alpha" not in ids
+            assert all(d["id"] != wider["canonical_id"] for d in chats)
+        finally:
+            await registry.close()

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -556,6 +556,11 @@ class AgentRegistryStore(BaseStore):
         """
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised")
+        # Slugs are strictly [a-z0-9-] (see _slugify). Reject anything else
+        # before building the GLOB pattern: bracket/star/question metachars in
+        # a caller-supplied string must not reach the matcher.
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", slug or ""):
+            return None
         # mint_canonical_id yields {slug}-{YYYYMMDD}-{HHMMSS} (and, on a
         # same-second slug collision, a -{2hex} suffix). GLOBing the 8-6 digit
         # tail pins the slug to its own canonical-id boundary.

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -539,6 +539,46 @@ class AgentRegistryStore(BaseStore):
         ).fetchone()
         return _row_to_dict(row) if row else None
 
+    async def get_by_slug(self, slug: str, *, status: str = "active") -> Optional[dict]:
+        """Return the oldest entry whose canonical_id decodes to *slug*, or ``None``.
+
+        DM channels created by the deploy route store the agent slug (not the
+        canonical_id) as the channel member, so callers that need to resolve a
+        channel member back to an agent record look up by slug. Pass
+        ``status=None`` to match any status.
+
+        The match is bounded to a real canonical_id tail
+        ``-{YYYYMMDD}-{HHMMSS}`` (optionally followed by a 2-hex collision
+        suffix) so that slug ``alpha`` does NOT match a sibling agent slotted
+        ``alpha-beta-YYYYMMDD-HHMMSS`` -- a plain ``LIKE 'slug-%'`` would, since
+        it prefix-matches any canonical_id beginning ``alpha-``. The same
+        tail shape is enforced by tinyagentos/chat/orphan_reconcile._CANONICAL_AGENT_ID_RE.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        # mint_canonical_id yields {slug}-{YYYYMMDD}-{HHMMSS} (and, on a
+        # same-second slug collision, a -{2hex} suffix). GLOBing the 8-6 digit
+        # tail pins the slug to its own canonical-id boundary.
+        pattern = (
+            f"{slug}-"
+            "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
+            "-"
+            "[0-9][0-9][0-9][0-9][0-9][0-9]"
+            "*"
+        )
+        if status is None:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry WHERE canonical_id GLOB ? ORDER BY id LIMIT 1",
+                (pattern,),
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry WHERE canonical_id GLOB ? AND status = ? ORDER BY id LIMIT 1",
+                (pattern, status),
+            )
+        row = await cursor.fetchone()
+        return _row_to_dict(row) if row else None
+
     async def get_by_handle(self, handle: str, *, status: str = "active") -> Optional[dict]:
         """Return the oldest entry with *handle* and *status*, or ``None``.
 

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -63,7 +63,7 @@ def register_all_routers(app):
     app.include_router(settings_router, dependencies=_csrf)
 
     from tinyagentos.routes.share import router as share_router
-    app.include_router(share_router)
+    app.include_router(share_router, dependencies=_csrf)
 
     from tinyagentos.routes.store import router as store_router
     app.include_router(store_router, dependencies=_csrf)

--- a/tinyagentos/routes/share.py
+++ b/tinyagentos/routes/share.py
@@ -47,6 +47,16 @@ async def list_share_destinations(request: Request):
             if member in seen:
                 continue
             label = member
+            # A multi-user channel can carry another HUMAN username as a
+            # member; a username that happens to equal an agent slug must not
+            # resolve to that agent's chat. Skip known usernames outright.
+            auth = getattr(request.app.state, "auth", None)
+            if auth is not None:
+                try:
+                    if auth.find_user(member) is not None:
+                        continue
+                except Exception:
+                    pass
             if registry is not None:
                 try:
                     agent = await registry.get(member)

--- a/tinyagentos/routes/share.py
+++ b/tinyagentos/routes/share.py
@@ -50,6 +50,10 @@ async def list_share_destinations(request: Request):
             if registry is not None:
                 try:
                     agent = await registry.get(member)
+                    if agent is None:
+                        # DM channels store the agent slug (not its canonical_id)
+                        # as the member, so slug members need a slug lookup.
+                        agent = await registry.get_by_slug(member)
                     if agent and agent.get("status") == "active":
                         seen.add(member)
                         destinations.append({

--- a/tinyagentos/routes/share.py
+++ b/tinyagentos/routes/share.py
@@ -56,7 +56,9 @@ async def list_share_destinations(request: Request):
                     if auth.find_user(member) is not None:
                         continue
                 except Exception:
-                    pass
+                    # Fail CLOSED: if we cannot verify the member is not a
+                    # human, do not offer it as an agent destination.
+                    continue
             if registry is not None:
                 try:
                     agent = await registry.get(member)


### PR DESCRIPTION
Autonomous build of board card tsk-rll2pj.



Files:
 tests/test_agent_registry_store.py      | 69 +++++++++++++++++++++++++++
 tests/test_routes_share_destinations.py | 83 +++++++++++++++++++++++++++++++++
 tinyagentos/agent_registry_store.py     | 40 ++++++++++++++++
 tinyagentos/routes/share.py             |  4 ++
 4 files changed, 196 insertions(+)

----
## Summary by Gitar

- **Agent Registry:**
    - Added `get_by_slug` lookup method to `AgentRegistryStore` with strict tail matching to prevent false prefix collisions
    - Updated `list_share_destinations` route to fall back to `get_by_slug` when DM channel members are stored as bare slugs
- **Testing:**
    - Added comprehensive unit and integration tests covering slug lookup, collision suffixes, inactive filtering, and boundary constraints

<sub>This will update automatically on new commits.</sub>