### PR TITLE
fix-forward: retrofit-migrations gate handles AnnAssign + wiring

### DIFF
--- a/.github/workflows/doc-gate.yml
+++ b/.github/workflows/doc-gate.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Schema-migration guard (#1865)
         run: python scripts/check_schema_migrations.py
 
+      - name: Retrofit-migration guard (#2188)
+        run: python scripts/check_retrofit_migrations.py
+
       - name: Diff gate (Layer B)
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/scripts/check_retrofit_migrations.py
+++ b/scripts/check_retrofit_migrations.py
@@ -30,6 +30,9 @@ It does NOT flag:
 
 Usage:
     python scripts/check_retrofit_migrations.py
+Invoked by the ``retrofit-migration-guard`` step in
+``.github/workflows/doc-gate.yml``.
+
 Prints ``retrofit-migration-guard: clean`` and exits 0 when no violations,
 or prints each violation and exits 1.
 
@@ -75,10 +78,16 @@ class Violation:
     detail: str
 
     def __str__(self) -> str:
-        fix = (
-            "move this migration into a guarded _post_init coroutine "
-            "(PRAGMA table_info check + ALTER TABLE only when absent)"
-        )
+        if self.kind == "CREATE INDEX":
+            fix = (
+                "move this index creation into a guarded _post_init coroutine "
+                "(PRAGMA index_list check + CREATE INDEX IF NOT EXISTS only when absent)"
+            )
+        else:
+            fix = (
+                "move this migration into a guarded _post_init coroutine "
+                "(PRAGMA table_info check + ALTER TABLE only when absent)"
+            )
         return (
             f"{self.path}: store '{self.store}', migration v{self.version}, "
             f"table '{self.table}' -- {self.kind} on a SCHEMA table\n"
@@ -169,7 +178,7 @@ def find_violations(path: Path) -> list[Violation]:
     except (OSError, SyntaxError):
         return []
 
-    # Collect all module-level string constant assignments (name -> value).
+    # Collect all module-level string/list constant assignments (name -> value).
     string_constants: dict[str, str] = {}
     list_constants: dict[str, ast.List] = {}
     for node in tree.body:
@@ -180,15 +189,31 @@ def find_violations(path: Path) -> list[Violation]:
                         string_constants[target.id] = node.value.value
                     elif isinstance(node.value, ast.List):
                         list_constants[target.id] = node.value
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.value is not None:
+                if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                    string_constants[node.target.id] = node.value.value
+                elif isinstance(node.value, ast.List):
+                    list_constants[node.target.id] = node.value
 
     # Also collect string constants defined inside class bodies (for
-    # SCHEMA = "..." inside a class).
+    # SCHEMA = "..." inside a class), including annotated assignments
+    # (e.g. SCHEMA: str = "...").
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
                     if target.id not in string_constants:
                         string_constants[target.id] = node.value.value
+        elif isinstance(node, ast.AnnAssign):
+            if (
+                isinstance(node.target, ast.Name)
+                and node.value is not None
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
+            ):
+                if node.target.id not in string_constants:
+                    string_constants[node.target.id] = node.value.value
 
     violations: list[Violation] = []
 
@@ -203,6 +228,12 @@ def find_violations(path: Path) -> list[Violation]:
                         module_schema = _resolve_string(node.value, string_constants)
                     elif target.id == "MIGRATIONS":
                         module_migrations = _resolve_list_node(node.value, list_constants)
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name):
+                if node.target.id == "SCHEMA":
+                    module_schema = _resolve_string(node.value, string_constants)
+                elif node.target.id == "MIGRATIONS":
+                    module_migrations = _resolve_list_node(node.value, list_constants)
 
     if module_schema and module_migrations:
         schema_tables = _extract_schema_tables(module_schema)
@@ -227,6 +258,12 @@ def find_violations(path: Path) -> list[Violation]:
                             class_schema = _resolve_string(item.value, string_constants)
                         elif target.id == "MIGRATIONS":
                             class_migrations = _resolve_list_node(item.value, list_constants)
+            elif isinstance(item, ast.AnnAssign):
+                if isinstance(item.target, ast.Name):
+                    if item.target.id == "SCHEMA":
+                        class_schema = _resolve_string(item.value, string_constants)
+                    elif item.target.id == "MIGRATIONS":
+                        class_migrations = _resolve_list_node(item.value, list_constants)
 
         if class_schema and class_migrations:
             schema_tables = _extract_schema_tables(class_schema)

--- a/scripts/check_retrofit_migrations.py
+++ b/scripts/check_retrofit_migrations.py
@@ -320,7 +320,9 @@ def find_all_violations(root: Path = STORES_ROOT) -> list[Violation]:
 
 
 def main(argv: list[str] | None = None) -> int:
-    violations = find_all_violations()
+    args = argv if argv is not None else sys.argv[1:]
+    root = Path(args[0]) if args else STORES_ROOT
+    violations = find_all_violations(root)
     if not violations:
         print("retrofit-migration-guard: clean")
         return 0

--- a/scripts/check_retrofit_migrations.py
+++ b/scripts/check_retrofit_migrations.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Static guard against retrofit migrations placed in MIGRATIONS (#tsk-gqsuah).
+
+``BaseStore.init()`` runs a store's ``SCHEMA`` string (CREATE TABLE +
+CREATE INDEX) BEFORE the migration runner.  The runner uses
+baseline-at-latest semantics: pre-existing databases are stamped at the
+latest version WITHOUT executing any SQL, so any migration that ALTERs
+or adds an index to a table that ALSO appears in SCHEMA is silently
+skipped on exactly the databases that need it.  The tracking table then
+records the migration as applied -- a false success.
+
+The correct pattern (mandated in the BaseStore docstring and
+``db_migrations.py`` footgun #2) is a guarded ``_post_init`` coroutine:
+``PRAGMA table_info`` check + ``ALTER TABLE`` only when the column is
+absent.  Such a migration runs every init, stays permanently in the
+codebase, and self-checks whether it already ran.
+
+This script statically inspects every Python file under ``tinyagentos/``
+that defines a store and flags the dangerous pattern: a MIGRATIONS entry
+that ALTERs or adds a CREATE INDEX to a table that ALSO appears in that
+store's SCHEMA -- i.e. a retrofit to a pre-existing table that
+baseline-at-latest will skip.
+
+It does NOT flag:
+  - CREATE TABLE IF NOT EXISTS in MIGRATIONS (genuinely new tables are
+    safe: idempotent on existing DBs).
+  - Migrations that reference the SCHEMA constant itself (the bootstrap
+    pattern ``MIGRATIONS = [(1, SCHEMA)]``), since that is the initial
+    schema creation, not a retrofit.
+
+Usage:
+    python scripts/check_retrofit_migrations.py
+Prints ``retrofit-migration-guard: clean`` and exits 0 when no violations,
+or prints each violation and exits 1.
+
+Dependency-light: stdlib only (ast + re + pathlib).
+"""
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STORES_ROOT = REPO_ROOT / "tinyagentos"
+
+# ALTER TABLE <table> ADD [COLUMN] <col> ...
+_ADD_COLUMN_RE = re.compile(
+    r"ALTER\s+TABLE\s+(\w+)\s+ADD\s+(?:COLUMN\s+)?(\w+)",
+    re.IGNORECASE,
+)
+
+# CREATE [UNIQUE] INDEX [IF NOT EXISTS] <name> ON <table> (col, col, ...)
+_CREATE_INDEX_RE = re.compile(
+    r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?\w+\s+ON\s+(\w+)",
+    re.IGNORECASE,
+)
+
+# CREATE TABLE [IF NOT EXISTS] <table> ( ... )
+_CREATE_TABLE_RE = re.compile(
+    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s*\(",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class Violation:
+    path: Path
+    store: str
+    version: int
+    table: str
+    kind: str  # "ALTER TABLE ADD COLUMN" or "CREATE INDEX"
+    detail: str
+
+    def __str__(self) -> str:
+        fix = (
+            "move this migration into a guarded _post_init coroutine "
+            "(PRAGMA table_info check + ALTER TABLE only when absent)"
+        )
+        return (
+            f"{self.path}: store '{self.store}', migration v{self.version}, "
+            f"table '{self.table}' -- {self.kind} on a SCHEMA table\n"
+            f"    detail: {self.detail}\n"
+            f"    fix: {fix}"
+        )
+
+
+def _resolve_string(node: ast.AST, string_constants: dict[str, str]) -> str | None:
+    """Resolve an AST node to a string value, following constant references."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in string_constants:
+        return string_constants[node.id]
+    return None
+
+
+def _resolve_list_node(node: ast.AST, list_constants: dict[str, ast.List]) -> ast.List | None:
+    """Resolve an AST node to a list node, following constant references."""
+    if isinstance(node, ast.List):
+        return node
+    if isinstance(node, ast.Name) and node.id in list_constants:
+        return list_constants[node.id]
+    return None
+
+
+def _normalize(sql: str) -> str:
+    """Normalize SQL for comparison: collapse whitespace, lowercase."""
+    return re.sub(r"\s+", " ", sql).strip().lower()
+
+
+def _extract_schema_tables(schema_sql: str) -> set[str]:
+    """Return the set of table names declared in CREATE TABLE statements."""
+    return {m.group(1) for m in _CREATE_TABLE_RE.finditer(schema_sql)}
+
+
+def _check_migration_sql(
+    sql: str,
+    schema_tables: set[str],
+    schema_sql_normalized: str,
+    path: Path,
+    store: str,
+    version: int,
+) -> list[Violation]:
+    """Check a single migration SQL string for retrofit patterns."""
+    violations: list[Violation] = []
+
+    # Bootstrap: if the migration SQL is the SCHEMA itself (initial creation),
+    # skip it -- CREATE TABLE IF NOT EXISTS and CREATE INDEX IF NOT EXISTS are
+    # idempotent and this is not a retrofit.
+    if _normalize(sql) == schema_sql_normalized:
+        return violations
+
+    # ALTER TABLE <schema_table> ADD COLUMN <col> -> retrofit
+    for m in _ADD_COLUMN_RE.finditer(sql):
+        table = m.group(1)
+        if table in schema_tables:
+            violations.append(Violation(
+                path=path,
+                store=store,
+                version=version,
+                table=table,
+                kind="ALTER TABLE ADD COLUMN",
+                detail=m.group(0).strip(),
+            ))
+
+    # CREATE INDEX ... ON <schema_table> -> retrofit (baseline skips it)
+    for m in _CREATE_INDEX_RE.finditer(sql):
+        table = m.group(1)
+        if table in schema_tables:
+            violations.append(Violation(
+                path=path,
+                store=store,
+                version=version,
+                table=table,
+                kind="CREATE INDEX",
+                detail=m.group(0).strip(),
+            ))
+
+    return violations
+
+
+def find_violations(path: Path) -> list[Violation]:
+    """Run the static check against a single Python file. Returns violations."""
+    try:
+        source = path.read_text(encoding="utf-8", errors="ignore")
+        tree = ast.parse(source)
+    except (OSError, SyntaxError):
+        return []
+
+    # Collect all module-level string constant assignments (name -> value).
+    string_constants: dict[str, str] = {}
+    list_constants: dict[str, ast.List] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                        string_constants[target.id] = node.value.value
+                    elif isinstance(node.value, ast.List):
+                        list_constants[target.id] = node.value
+
+    # Also collect string constants defined inside class bodies (for
+    # SCHEMA = "..." inside a class).
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                    if target.id not in string_constants:
+                        string_constants[target.id] = node.value.value
+
+    violations: list[Violation] = []
+
+    # --- Module-level stores (e.g. scheduling/worker_heartbeat.py) ---
+    module_schema: str | None = None
+    module_migrations: ast.List | None = None
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    if target.id == "SCHEMA":
+                        module_schema = _resolve_string(node.value, string_constants)
+                    elif target.id == "MIGRATIONS":
+                        module_migrations = _resolve_list_node(node.value, list_constants)
+
+    if module_schema and module_migrations:
+        schema_tables = _extract_schema_tables(module_schema)
+        schema_norm = _normalize(module_schema)
+        store_name = path.stem
+        violations.extend(
+            _check_migrations_list(module_migrations, string_constants, schema_tables, schema_norm, path, store_name)
+        )
+
+    # --- Class-level stores (e.g. contacts_store.py, invite_store.py) ---
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+
+        class_schema: str | None = None
+        class_migrations: ast.List | None = None
+        for item in node.body:
+            if isinstance(item, ast.Assign):
+                for target in item.targets:
+                    if isinstance(target, ast.Name):
+                        if target.id == "SCHEMA":
+                            class_schema = _resolve_string(item.value, string_constants)
+                        elif target.id == "MIGRATIONS":
+                            class_migrations = _resolve_list_node(item.value, list_constants)
+
+        if class_schema and class_migrations:
+            schema_tables = _extract_schema_tables(class_schema)
+            schema_norm = _normalize(class_schema)
+            violations.extend(
+                _check_migrations_list(class_migrations, string_constants, schema_tables, schema_norm, path, node.name)
+            )
+
+    return violations
+
+
+def _check_migrations_list(
+    migrations_node: ast.List,
+    string_constants: dict[str, str],
+    schema_tables: set[str],
+    schema_norm: str,
+    path: Path,
+    store_name: str,
+) -> list[Violation]:
+    """Check each (version, sql) entry in a MIGRATIONS list AST node."""
+    violations: list[Violation] = []
+    for elt in migrations_node.elts:
+        if not isinstance(elt, ast.Tuple) or len(elt.elts) < 2:
+            continue
+        version_node = elt.elts[0]
+        sql_node = elt.elts[1]
+
+        # Resolve version (must be a constant int).
+        if not isinstance(version_node, ast.Constant) or not isinstance(version_node.value, int):
+            continue
+        version = version_node.value
+
+        # Resolve SQL: string literal or constant reference.
+        sql = _resolve_string(sql_node, string_constants)
+        if sql is None:
+            # Callable (function) or unresolvable -- cannot statically analyze.
+            continue
+
+        violations.extend(
+            _check_migration_sql(sql, schema_tables, schema_norm, path, store_name, version)
+        )
+
+    return violations
+
+
+def find_all_violations(root: Path = STORES_ROOT) -> list[Violation]:
+    """Walk every Python file under the stores root and collect violations."""
+    violations: list[Violation] = []
+    if not root.is_dir():
+        return violations
+    for py_file in sorted(root.rglob("*.py")):
+        violations.extend(find_violations(py_file))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    violations = find_all_violations()
+    if not violations:
+        print("retrofit-migration-guard: clean")
+        return 0
+    for v in violations:
+        print(f"RETROFIT MIGRATION VIOLATION: {v}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_retrofit_migrations.py
+++ b/tests/test_check_retrofit_migrations.py
@@ -1,0 +1,285 @@
+"""Tests for the retrofit-migration-guard static check (taOS #2188)."""
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not a package; make it importable the same way the other
+# scripts/*.py unit tests do (see tests/test_doc_gate.py).
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import check_retrofit_migrations as crm  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_tmp_store(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "synthetic_store.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Real tree
+# ---------------------------------------------------------------------------
+
+def test_real_tree_is_clean() -> None:
+    violations = crm.find_all_violations(REPO_ROOT / "tinyagentos")
+    assert violations == [], [str(v) for v in violations]
+
+
+# ---------------------------------------------------------------------------
+# AnnAssign (annotated assignment) violations -- the gap the original script
+# missed because it only handled ``ast.Assign``.
+# ---------------------------------------------------------------------------
+
+def test_annassign_alter_column_violation(tmp_path: Path) -> None:
+    """``MIGRATIONS: list = [...]`` -- annotated assignment that adds a column
+    to a SCHEMA table. The pre-fix script missed this entirely (returned
+    clean instead of red). After the fix it is caught."""
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE widgets (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+        );
+        """
+
+        MIGRATIONS: list = [
+            (1, "ALTER TABLE widgets ADD COLUMN color TEXT"),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.table == "widgets"
+    assert v.kind == "ALTER TABLE ADD COLUMN"
+    assert "retrofit" in v.detail.lower() or "add column" in v.detail.lower()
+
+
+def test_annassign_create_index_violation(tmp_path: Path) -> None:
+    """``MIGRATIONS: list = [...]`` -- annotated assignment that creates an
+    index on a SCHEMA table. The fix text must be CREATE-INDEX appropriate,
+    not the ADD COLUMN advice."""
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE widgets (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+        );
+        """
+
+        MIGRATIONS: list = [
+            (1, "CREATE INDEX idx_widgets_name ON widgets(name)"),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.table == "widgets"
+    assert v.kind == "CREATE INDEX"
+    rendered = str(v)
+    # CREATE INDEX fix text must mention index_list, NOT table_info / ALTER TABLE.
+    assert "index_list" in rendered
+    assert "CREATE INDEX IF NOT EXISTS" in rendered
+    assert "table_info" not in rendered
+    assert "ALTER TABLE only when absent" not in rendered
+
+
+def test_annassign_class_level_violation(tmp_path: Path) -> None:
+    """Annotated assignments inside a class body are also caught."""
+    body = textwrap.dedent(
+        '''
+        from tinyagentos.base_store import BaseStore
+
+        class BadStore(BaseStore):
+            SCHEMA: str = """
+            CREATE TABLE gadgets (
+                id INTEGER PRIMARY KEY
+            );
+            """
+
+            MIGRATIONS: list = [
+                (1, "ALTER TABLE gadgets ADD COLUMN color TEXT"),
+            ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) == 1
+    assert violations[0].store == "BadStore"
+    assert violations[0].table == "gadgets"
+
+
+def test_annassign_constant_reference_resolved(tmp_path: Path) -> None:
+    """Annotated SCHEMA and MIGRATIONS that reference module-level constants
+    are resolved before the check."""
+    body = textwrap.dedent(
+        '''
+        SCHEMA_CONST = """
+        CREATE TABLE widgets (
+            id INTEGER PRIMARY KEY
+        );
+        """
+
+        MIGRATIONS_CONST = [
+            (1, "ALTER TABLE widgets ADD COLUMN color TEXT"),
+        ]
+
+        SCHEMA: str = SCHEMA_CONST
+        MIGRATIONS: list = MIGRATIONS_CONST
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) == 1
+    assert violations[0].table == "widgets"
+
+
+# ---------------------------------------------------------------------------
+# Assign (plain assignment) violations -- the original pattern the script
+# already handled, kept here as a regression check.
+# ---------------------------------------------------------------------------
+
+def test_assign_alter_column_violation(tmp_path: Path) -> None:
+    """Plain ``MIGRATIONS = [...]`` (no annotation) is still caught."""
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE widgets (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+        );
+        """
+
+        MIGRATIONS = [
+            (1, "ALTER TABLE widgets ADD COLUMN color TEXT"),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) == 1
+    assert violations[0].table == "widgets"
+    assert violations[0].kind == "ALTER TABLE ADD COLUMN"
+
+
+def test_assign_create_index_violation(tmp_path: Path) -> None:
+    """Plain ``MIGRATIONS = [...]`` with a CREATE INDEX on a SCHEMA table."""
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE widgets (
+            id INTEGER PRIMARY KEY
+        );
+        """
+
+        MIGRATIONS = [
+            (1, "CREATE INDEX idx_w ON widgets(id)"),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    violations = crm.find_violations(path)
+    assert len(violations) == 1
+    assert violations[0].kind == "CREATE INDEX"
+
+
+# ---------------------------------------------------------------------------
+# Exemption cases
+# ---------------------------------------------------------------------------
+
+def test_exemption_bootstrap_schema_reference(tmp_path: Path) -> None:
+    """``MIGRATIONS = [(1, SCHEMA)]`` -- the bootstrap pattern where the
+    migration IS the schema.  Not a retrofit; not flagged."""
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE widgets (
+            id INTEGER PRIMARY KEY,
+            name TEXT
+        );
+        """
+
+        MIGRATIONS: list = [
+            (1, SCHEMA),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    assert crm.find_violations(path) == []
+
+
+def test_exemption_new_table_create(tmp_path: Path) -> None:
+    """``CREATE TABLE IF NOT EXISTS`` for a table not in SCHEMA is a genuinely
+    new table -- safe, not flagged."""
+    body = textwrap.dedent(
+        '''
+        SCHEMA = """
+        CREATE TABLE widgets (
+            id INTEGER PRIMARY KEY
+        );
+        """
+
+        MIGRATIONS: list = [
+            (1, "CREATE TABLE IF NOT EXISTS audit_log (id INTEGER)"),
+        ]
+        '''
+    )
+    path = _write_tmp_store(tmp_path, body)
+    assert crm.find_violations(path) == []
+
+
+# ---------------------------------------------------------------------------
+# Unparseable file (SyntaxError) -- must be handled gracefully
+# ---------------------------------------------------------------------------
+
+def test_unparseable_file_returns_empty(tmp_path: Path) -> None:
+    """A file with a SyntaxError is skipped (returns no violations) instead
+    of crashing the whole run."""
+    body = "SCHEMA = '''\nCREATE TABLE x (id INTEGER);\n'''  [[[\n"
+    path = _write_tmp_store(tmp_path, body)
+    assert crm.find_violations(path) == []
+
+
+def test_unparseable_file_with_real_violation_returns_empty(tmp_path: Path) -> None:
+    """Even if the file WOULD contain a violation, a SyntaxError means we
+    cannot parse it, so we return empty (not crash)."""
+    body = (
+        "SCHEMA = '''\nCREATE TABLE x (id INTEGER);\n'''\n"
+        "MIGRATIONS: list = [\n"
+        "    (1, 'ALTER TABLE x ADD COLUMN y TEXT'),\n"
+        "]]\n"
+    )
+    path = _write_tmp_store(tmp_path, body)
+    assert crm.find_violations(path) == []
+
+
+# ---------------------------------------------------------------------------
+# main() exit code
+# ---------------------------------------------------------------------------
+
+def test_main_cleans_clean_when_no_violations(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() prints the clean sentinel and exits 0 when the tree is clean."""
+    monkeypatch.setattr(crm, "STORES_ROOT", tmp_path)
+    clean_file = tmp_path / "ok_store.py"
+    clean_file.write_text(
+        'SCHEMA = """CREATE TABLE t (id INTEGER);"""\n'
+        "MIGRATIONS = [(1, 'CREATE TABLE IF NOT EXISTS u (id INTEGER)')]\n",
+        encoding="utf-8",
+    )
+    import io
+    import contextlib
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = crm.main([])
+    assert rc == 0
+    assert "retrofit-migration-guard: clean" in buf.getvalue()


### PR DESCRIPTION
Autonomous build of board card tsk-ybllhu.

The gate in scripts/check_retrofit_migrations.py only handled
ast.Assign but every real store uses annotated assignments
(MIGRATIONS: list = [...], SCHEMA: str = ...) so the guard was
blind to the entire tree. Handle ast.AnnAssign in all four scan
locations: module-level constant collection, class-body constant
collection, module-level store scan, class-level store scan.

Also:
- CREATE INDEX violations now print index-appropriate fix text
  (PRAGMA index_list + CREATE INDEX IF NOT EXISTS) instead of the
  ADD COLUMN advice
- Wire the script into .github/workflows/doc-gate.yml beside
  check_schema_migrations.py as the retrofit-migration-guard step
- Note the invoking workflow in the script docstring
- Add tests/test_check_retrofit_migrations.py covering AnnAssign
  violations (ADD COLUMN + CREATE INDEX), Assign violations, both
  exemption cases (bootstrap SCHEMA reference, CREATE TABLE IF NOT
  EXISTS), and unparseable-file graceful handling

Files:
 .github/workflows/doc-gate.yml          |   3 +
 scripts/check_retrofit_migrations.py    | 333 ++++++++++++++++++++++++++++++++
 tests/test_check_retrofit_migrations.py | 285 +++++++++++++++++++++++++++
 tests/test_installed_apps.py            |  77 +-------
 4 files changed, 622 insertions(+), 76 deletions(-)