### PR TITLE
fix: resolve watch projection issues

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -196,8 +196,8 @@ The surface, by scope:
 - **project_tasks_create**: `POST /api/projects/{pid}/tasks` (author new cards).
   This is a SEPARATE scope from project_tasks and is off by default; grant it
   explicitly when an agent needs to create cards.
-- **canvas_read**: `GET .../canvas/elements`, `.../canvas/snapshot.png|.tldr`,
-  `.../canvas/stream`. **canvas_write**: `POST .../canvas/elements`,
+- **canvas_read**: `GET .../canvas/elements`, `.../canvas/watch-projection`,
+  `.../canvas/snapshot.png|.tldr`, `.../canvas/stream`. **canvas_write**: `POST .../canvas/elements`,
   `PATCH|DELETE .../canvas/elements/{id}`.
 - **files_read**: `GET /api/projects/{slug}/files` (list), `.../files/watch`,
   `GET .../files/{path}` (download), `.../trash`, `.../stats`. **files_write**:

--- a/tests/test_routes_project_canvas.py
+++ b/tests/test_routes_project_canvas.py
@@ -970,6 +970,65 @@ class TestCanvasStreamSnapshotSessionUnchanged:
         )
         assert resp.status_code == 200
 
+    async def test_owner_watch_projection_allowed(self, ctx):
+        pid = await _new_project(ctx, "owner-watch")
+        resp = await ctx.client.get(f"/api/projects/{pid}/canvas/watch-projection")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "version" in data
+        assert "elements" in data
+
+
+@pytest.mark.asyncio
+class TestWatchProjectionAgentGating:
+    async def test_watch_projection_allowed_with_scope_and_flag(self, ctx):
+        pid = await _new_project(ctx, "watch-read")
+        cid, token = await _mint_agent(ctx, pid, ("canvas_read",))
+        await _add_member(ctx, pid, cid)
+        await _grant_canvas(ctx, pid, cid, read=True)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/canvas/watch-projection",
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200
+
+    async def test_watch_projection_without_scope_is_403(self, ctx):
+        pid = await _new_project(ctx, "watch-noscope")
+        cid, token = await _mint_agent(ctx, pid, ("canvas_write",))
+        await _add_member(ctx, pid, cid)
+        await _grant_canvas(ctx, pid, cid, read=True)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/canvas/watch-projection",
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+    async def test_watch_projection_without_flag_is_403(self, ctx):
+        pid = await _new_project(ctx, "watch-noflag")
+        cid, token = await _mint_agent(ctx, pid, ("canvas_read",))
+        await _add_member(ctx, pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid}/canvas/watch-projection",
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+    async def test_watch_projection_wrong_project_is_404(self, ctx):
+        pid_a = await _new_project(ctx, "watch-alpha")
+        pid_b = await _new_project(ctx, "watch-beta")
+        cid, token_a = await _mint_agent(ctx, pid_a, ("canvas_read",))
+        await _add_member(ctx, pid_a, cid)
+        await _grant_canvas(ctx, pid_a, cid, read=True)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(
+                f"/api/projects/{pid_b}/canvas/watch-projection",
+                headers=_hdr(token_a),
+            )
+        assert resp.status_code == 404
+
     async def test_session_gating_uses_project_visibility(self, ctx):
         """A non-owner human session still collapses into 404 (D3 matrix),
         so agent gating did not change session semantics."""

--- a/tests/test_routes_project_canvas.py
+++ b/tests/test_routes_project_canvas.py
@@ -970,6 +970,16 @@ class TestCanvasStreamSnapshotSessionUnchanged:
         )
         assert resp.status_code == 200
 
+    async def test_session_gating_uses_project_visibility(self, ctx):
+        """A non-owner human session still collapses into 404 (D3 matrix),
+        so agent gating did not change session semantics."""
+        pid = await _new_project(ctx, "nonowner-snap")
+        async with _non_owner_client(ctx.app) as other:
+            resp = await other.get(
+                f"/api/projects/{pid}/canvas/snapshot.png"
+            )
+        assert resp.status_code == 404
+
     async def test_owner_watch_projection_allowed(self, ctx):
         pid = await _new_project(ctx, "owner-watch")
         resp = await ctx.client.get(f"/api/projects/{pid}/canvas/watch-projection")
@@ -1029,15 +1039,6 @@ class TestWatchProjectionAgentGating:
             )
         assert resp.status_code == 404
 
-    async def test_session_gating_uses_project_visibility(self, ctx):
-        """A non-owner human session still collapses into 404 (D3 matrix),
-        so agent gating did not change session semantics."""
-        pid = await _new_project(ctx, "nonowner-snap")
-        async with _non_owner_client(ctx.app) as other:
-            resp = await other.get(
-                f"/api/projects/{pid}/canvas/snapshot.png"
-            )
-        assert resp.status_code == 404
 
 
 def _stream_req(app, *, token=None, user_id=None, is_admin=False):

--- a/tests/test_watch_projection.py
+++ b/tests/test_watch_projection.py
@@ -1,0 +1,140 @@
+"""Tests for tinyagentos/projects/canvas/watch_projection.py.
+
+Cover: empty list, each kind mapping, non-dict row, non-dict payload, bool z_index,
+z ordering, creds-URL domain (red-first vs item 2), file_id inclusion.
+"""
+from __future__ import annotations
+
+import pytest
+from tinyagentos.projects.canvas.watch_projection import build_watch_projection
+
+
+def test_empty_list():
+    assert build_watch_projection([]) == {"version": 1, "elements": []}
+
+
+def test_text_card():
+    el = {"kind": "note", "payload": {"text": "hello"}, "z_index": 10}
+    result = build_watch_projection([el])
+    assert result["version"] == 1
+    assert len(result["elements"]) == 1
+    e = result["elements"][0]
+    assert e["kind"] == "note"
+    assert e["type"] == "text_card"
+    assert e["text"] == "hello"
+    assert e["z_index"] == 10
+
+
+def test_text_card_bare_string_payload():
+    el = {"kind": "text", "payload": "bare text", "z_index": 5}
+    result = build_watch_projection([el])
+    assert result["elements"][0]["text"] == "bare text"
+
+
+def test_text_card_no_text():
+    el = {"kind": "note", "payload": {"color": "yellow"}}
+    result = build_watch_projection([el])
+    assert result["elements"][0]["text"] == ""
+
+
+def test_link_row():
+    el = {
+        "kind": "link",
+        "payload": {"title": "Example", "url": "https://example.com"},
+        "z_index": 3,
+    }
+    result = build_watch_projection([el])
+    e = result["elements"][0]
+    assert e["kind"] == "link"
+    assert e["type"] == "link_row"
+    assert e["title"] == "Example"
+    assert e["domain"] == "example.com"
+    assert e["z_index"] == 3
+
+
+def test_link_row_no_url():
+    el = {"kind": "link", "payload": {"title": "No URL"}}
+    result = build_watch_projection([el])
+    assert result["elements"][0]["domain"] == ""
+
+
+def test_link_row_creds_url():
+    # credentials in URL should be stripped (urlparse().hostname, not netloc)
+    el = {"kind": "link", "payload": {"url": "https://user:pass@example.com"}}
+    result = build_watch_projection([el])
+    assert result["elements"][0]["domain"] == "example.com"
+
+
+def test_image_thumbnail():
+    el = {
+        "kind": "image",
+        "payload": {"alt": "photo", "file_id": "file123"},
+        "z_index": 7,
+    }
+    result = build_watch_projection([el])
+    e = result["elements"][0]
+    assert e["type"] == "thumbnail"
+    assert e["alt"] == "photo"
+    assert e["file_id"] == "file123"
+    assert e["z_index"] == 7
+
+
+def test_image_thumbnail_no_file_id():
+    el = {"kind": "image", "payload": {"alt": "no file id"}}
+    result = build_watch_projection([el])
+    assert result["elements"][0]["file_id"] == ""
+
+
+def test_malformed_row_not_dict():
+    result = build_watch_projection(["not a dict"])
+    e = result["elements"][0]
+    assert e["kind"] == "unknown"
+    assert e["type"] == "placeholder"
+    assert e["label"] == "malformed element"
+    assert e["z_index"] == 0
+
+
+def test_malformed_payload_dict():
+    el = {"kind": "note", "payload": "not a dict"}
+    result = build_watch_projection([el])
+    # Payload as string is valid - treated as text content
+    e = result["elements"][0]
+    assert e["type"] == "text_card"
+    assert e["text"] == "not a dict"
+
+
+def test_bool_z_index():
+    el = {"kind": "note", "z_index": True}
+    result = build_watch_projection([el])
+    assert result["elements"][0]["z_index"] == 0
+
+
+def test_z_ordering():
+    el1 = {"kind": "note", "z_index": 20}
+    el2 = {"kind": "note", "z_index": 5}
+    el3 = {"kind": "note", "z_index": 15}
+    result = build_watch_projection([el1, el2, el3])
+    assert [e["z_index"] for e in result["elements"]] == [5, 15, 20]
+
+
+def test_kind_mermaid():
+    el = {"kind": "mermaid", "payload": {"source": "graph TD"}}
+    result = build_watch_projection([el])
+    e = result["elements"][0]
+    assert e["kind"] == "mermaid"
+    assert e["type"] == "placeholder"
+    assert e["label"] == "diagram - open on phone"
+
+
+def test_kind_user_shape():
+    el = {"kind": "user_shape", "payload": {"shape": "circle"}}
+    result = build_watch_projection([el])
+    e = result["elements"][0]
+    assert e["label"] == "user shape"
+
+
+def test_unknown_kind():
+    el = {"kind": "ghost", "payload": {"x": 1}}
+    result = build_watch_projection([el])
+    e = result["elements"][0]
+    assert e["label"] == "ghost"

--- a/tests/test_watch_projection.py
+++ b/tests/test_watch_projection.py
@@ -94,7 +94,7 @@ def test_malformed_row_not_dict():
     assert e["z_index"] == 0
 
 
-def test_malformed_payload_dict():
+def test_string_payload_degrades_to_placeholder():
     el = {"kind": "note", "payload": "not a dict"}
     result = build_watch_projection([el])
     # Payload as string is valid - treated as text content

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -84,6 +84,7 @@ _AGENT_CANVAS_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/{_SEG}/canvas/snapshot\.png$")),
     ("GET", re.compile(rf"^/api/projects/{_SEG}/canvas/snapshot\.tldr$")),
     ("GET", re.compile(rf"^/api/projects/{_SEG}/canvas/stream$")),
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/canvas/watch-projection$")),
 )
 
 # Decisions route an agent may reach with its own registry JWT (scope

--- a/tinyagentos/projects/canvas/watch_projection.py
+++ b/tinyagentos/projects/canvas/watch_projection.py
@@ -17,9 +17,11 @@ Design rules (bus 1319):
 from __future__ import annotations
 
 from typing import Any
+import logging
 from urllib.parse import urlparse
 
 _VERSION = 1
+logger = logging.getLogger(__name__)
 
 _TEXT_CARD_KINDS = ("note", "text")
 _DIAGRAM_KINDS = ("mermaid", "flowchart")
@@ -38,6 +40,7 @@ def build_watch_projection(elements: list[dict]) -> dict:
         try:
             projected.append(_project_element(el))
         except Exception:
+            logger.debug("watch projection: element degraded to placeholder", exc_info=True)
             projected.append(_placeholder_entry(el, "malformed element"))
     projected.sort(key=lambda e: (e.get("z_index") or 0))
     return {"version": _VERSION, "elements": projected}

--- a/tinyagentos/projects/canvas/watch_projection.py
+++ b/tinyagentos/projects/canvas/watch_projection.py
@@ -1,0 +1,155 @@
+"""Watch projection for project canvas elements.
+
+A versioned, renderer-neutral projection of ``project_canvas_elements`` for
+watch clients (S7a).  Pure data: takes a list of element dicts (as returned by
+``ProjectCanvasStore.list_elements``) and returns a JSON-serializable dict.
+
+Design rules (bus 1319):
+
+* ``payload`` is freeform JSON, NOT guaranteed to be a dict.  Every read is
+  defensive, so one hostile row degrades to a placeholder rather than raising
+  and aborting the whole projection.
+* No coupling to renderer-specific payload shapes (tldraw OR Excalidraw; #2132
+  migration in flight).  Only generic keys are consulted.
+* Follows the ``tinyagentos/projects/canvas/snapshotter.py`` precedent: a
+  standalone module of pure functions, no DB, no async, no broker.
+"""
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+_VERSION = 1
+
+_TEXT_CARD_KINDS = ("note", "text")
+_DIAGRAM_KINDS = ("mermaid", "flowchart")
+
+
+def build_watch_projection(elements: list[dict]) -> dict:
+    """Build a versioned watch projection from canvas elements.
+
+    Returns ``{"version": 1, "elements": [...]}`` where each entry is a
+    renderer-neutral mapping of one canvas element.  Rows are ordered by
+    ``z_index``.  Any row that cannot be projected degrades to a placeholder
+    entry, so one bad row never drops the good rows.
+    """
+    projected: list[dict] = []
+    for el in elements:
+        try:
+            projected.append(_project_element(el))
+        except Exception:
+            projected.append(_placeholder_entry(el, "malformed element"))
+    projected.sort(key=lambda e: (e.get("z_index") or 0))
+    return {"version": _VERSION, "elements": projected}
+
+
+def _project_element(el: dict) -> dict:
+    if not isinstance(el, dict):
+        return _placeholder_entry(el, "malformed element")
+    kind = _str_or(el.get("kind"), "unknown")
+    if kind in _TEXT_CARD_KINDS:
+        return _text_card(el, kind)
+    if kind == "image":
+        return _thumbnail(el)
+    if kind == "link":
+        return _link_row(el)
+    if kind in _DIAGRAM_KINDS:
+        return _placeholder_entry(el, "diagram - open on phone")
+    if kind == "user_shape":
+        return _placeholder_entry(el, "user shape")
+    return _placeholder_entry(el, kind)
+
+
+def _base_entry(el: dict, kind: str, entry_type: str) -> dict:
+    if not isinstance(el, dict):
+        return {"id": "", "kind": kind, "type": entry_type, "z_index": 0}
+    return {
+        "id": _str_or(el.get("id"), ""),
+        "kind": kind,
+        "type": entry_type,
+        "z_index": _int_or(el.get("z_index"), 0),
+    }
+
+
+def _text_card(el: dict, kind: str) -> dict:
+    entry = _base_entry(el, kind, "text_card")
+    entry["text"] = _payload_text(el)
+    return entry
+
+
+def _thumbnail(el: dict) -> dict:
+    entry = _base_entry(el, "image", "thumbnail")
+    entry["alt"] = _payload_str(el, "alt")
+    return entry
+
+
+def _link_row(el: dict) -> dict:
+    entry = _base_entry(el, "link", "link_row")
+    payload = el.get("payload")
+    if isinstance(payload, dict):
+        title = payload.get("title")
+        url = payload.get("url")
+    else:
+        title = None
+        url = None
+    entry["title"] = _str_or(title, "")
+    entry["domain"] = _domain_of(url)
+    return entry
+
+
+def _placeholder_entry(el: dict, label: str) -> dict:
+    kind = _str_or(el.get("kind"), "unknown") if isinstance(el, dict) else "unknown"
+    entry = _base_entry(el, kind, "placeholder")
+    entry["label"] = label
+    return entry
+
+
+def _payload_text(el: dict) -> str:
+    """Best-effort text content from an element's payload.
+
+    ``payload`` is whatever JSON was stored, which is not guaranteed to be an
+    object: a list or bare string decodes truthy and would make ``.get()``
+    raise, taking the whole projection down over one odd row.
+    """
+    payload = el.get("payload")
+    if isinstance(payload, dict):
+        for key in ("text", "title", "label", "source", "url", "caption"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    elif isinstance(payload, str) and payload.strip():
+        return payload
+    return ""
+
+
+def _payload_str(el: dict, key: str) -> str:
+    payload = el.get("payload")
+    if isinstance(payload, dict):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _domain_of(url: Any) -> str:
+    if not isinstance(url, str) or not url.strip():
+        return ""
+    try:
+        return urlparse(url).netloc or ""
+    except Exception:
+        return ""
+
+
+def _str_or(value: Any, default: str) -> str:
+    return value if isinstance(value, str) and value else default
+
+
+def _int_or(value: Any, default: int) -> int:
+    """Coerce a stored z_index to an int, or fall back.
+
+    ``bool`` is excluded deliberately: it is an ``int`` subclass, so ``True``
+    would sail through as ``1`` and silently reorder a shape.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    return value

--- a/tinyagentos/projects/canvas/watch_projection.py
+++ b/tinyagentos/projects/canvas/watch_projection.py
@@ -80,6 +80,7 @@ def _text_card(el: dict, kind: str) -> dict:
 def _thumbnail(el: dict) -> dict:
     entry = _base_entry(el, "image", "thumbnail")
     entry["alt"] = _payload_str(el, "alt")
+    entry["file_id"] = _payload_str(el, "file_id")
     return entry
 
 
@@ -135,7 +136,7 @@ def _domain_of(url: Any) -> str:
     if not isinstance(url, str) or not url.strip():
         return ""
     try:
-        return urlparse(url).netloc or ""
+        return urlparse(url).hostname or ""
     except Exception:
         return ""
 

--- a/tinyagentos/routes/project_canvas.py
+++ b/tinyagentos/routes/project_canvas.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 from tinyagentos.projects.canvas.store import CanvasPermissionError
 from tinyagentos.projects.canvas.unfurl import fetch_link_metadata
 from tinyagentos.projects.canvas.render import render_snapshot_png
+from tinyagentos.projects.canvas.watch_projection import build_watch_projection
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -195,6 +196,16 @@ async def list_canvas_elements(
     cs = request.app.state.project_canvas_store
     elements = await cs.list_elements(project_id, element_id=element_id)
     return {"elements": elements}
+
+
+@router.get("/api/projects/{project_id}/canvas/watch-projection")
+async def watch_project_canvas(project_id: str, request: Request):
+    auth = await _authorize_canvas_actor(request, project_id, "read")
+    if isinstance(auth, JSONResponse):
+        return auth
+    cs = request.app.state.project_canvas_store
+    elements = await cs.list_elements(project_id)
+    return build_watch_projection(elements)
 
 
 @router.post("/api/projects/{project_id}/canvas/elements", status_code=201)


### PR DESCRIPTION
Autonomous build of board card tsk-iehi7t.

- _thumbnail: include file_id for renderable thumbnails
- _domain_of: use parsed.hostname to avoid credential leakage in URL netloc
- add watch-projection to canvas_read route enumeration
- add comprehensive watch projection tests

Files:
 docs/agent-coordination.md                      |   4 +-
 tests/test_routes_project_canvas.py             |  59 +++++++++
 tests/test_watch_projection.py                  | 140 +++++++++++++++++++++
 tinyagentos/auth_middleware.py                  |   1 +
 tinyagentos/projects/canvas/watch_projection.py | 156 ++++++++++++++++++++++++
 tinyagentos/routes/project_canvas.py            |  11 ++
 6 files changed, 369 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a canvas watch-projection endpoint that returns versioned, ordered representations of project canvas elements.
  * Supports text, images, links, diagrams, user shapes, and unknown elements with graceful placeholders.
  * Link data safely exposes titles and domains without URL credentials.
  * Authorized agent access now requires canvas read scope and project permissions.

* **Documentation**
  * Updated agent API scope documentation for the new canvas endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->