### PR TITLE
fix-forward PR 2219 (theme tokens): backend schema + root text-white

### DIFF
--- a/desktop/src/apps/MessagesApp.palette.test.ts
+++ b/desktop/src/apps/MessagesApp.palette.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "MessagesApp.tsx"), "utf-8");
+
+const HARDCODED = /\b(bg|text|border)-(white|black)(?:\/(?:\d+|\[[\d.]+\]))?\b/g;
+
+describe("MessagesApp palette token regression", () => {
+  it("contains no hardcoded white/black palette utilities", () => {
+    const hits: string[] = [];
+    for (const line of source.split("\n")) {
+      if (line.includes("palette-ok")) continue;
+      let m: RegExpExecArray | null;
+      while ((m = HARDCODED.exec(line)) !== null) {
+        hits.push(m[0]);
+      }
+      HARDCODED.lastIndex = 0;
+    }
+    expect(hits, `hardcoded palette utilities found: ${hits.join(", ")}`).toEqual([]);
+  });
+});

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1935,14 +1935,14 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
   /* ---------------------------------------------------------------- */
 
   return (
-    <div className="relative flex flex-col h-full bg-shell-base text-white overflow-hidden">
+    <div className="relative flex flex-col h-full bg-shell-base text-shell-text overflow-hidden">
       {/* Toolbar — hidden on mobile when a channel is selected */}
       {showToolbar && (
-        <div className="relative flex items-center px-3 py-2.5 border-b border-white/[0.06] shrink-0">
+        <div className="relative flex items-center px-3 py-2.5 border-b border-shell-border shrink-0">
           {title ? (
             <>
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                <span className="text-sm font-semibold text-white/90">{title}</span>
+                <span className="text-sm font-semibold text-shell-text">{title}</span>
               </div>
               <div className="ml-auto">
                 <Button
@@ -1958,7 +1958,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
             </>
           ) : (
             <>
-              <div className="flex items-center gap-2 text-sm font-medium text-white/80">
+              <div className="flex items-center gap-2 text-sm font-medium text-shell-text">
                 <MessageCircle size={15} />
                 {!isMobile && "Messages"}
               </div>
@@ -2193,7 +2193,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
         <div
           role="dialog"
           aria-label={`Agent info for @${agentInfoPopover.slug}`}
-          className="fixed z-50 bg-shell-surface border border-white/10 rounded-lg shadow-xl p-3 text-xs min-w-[200px]"
+          className="fixed z-50 bg-shell-surface border border-shell-border rounded-lg shadow-xl p-3 text-xs min-w-[200px]"
           style={{ top: agentInfoPopover.y, left: agentInfoPopover.x }}
           onMouseLeave={() => setAgentInfoPopover(null)}
         >
@@ -2207,18 +2207,18 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
       {/* ---- Canvas Viewer ---- */}
       {viewingCanvas && (
         <div
-          className="fixed inset-0 z-[10002] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          className="fixed inset-0 z-[10002] flex items-center justify-center bg-shell-scrim backdrop-blur-sm"
           onClick={() => setViewingCanvas(null)}
           role="dialog"
           aria-modal="true"
           aria-label="Canvas viewer"
         >
           <div
-            className="w-[90vw] h-[85vh] max-w-5xl rounded-xl border border-white/10 overflow-hidden bg-shell-bg flex flex-col"
+            className="w-[90vw] h-[85vh] max-w-5xl rounded-xl border border-shell-border overflow-hidden bg-shell-bg flex flex-col"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="flex items-center justify-between px-4 py-2 border-b border-white/10 shrink-0">
-              <div className="flex items-center gap-2 text-sm text-white/80">
+            <div className="flex items-center justify-between px-4 py-2 border-b border-shell-border shrink-0">
+              <div className="flex items-center gap-2 text-sm text-shell-text">
                 <PanelRight size={14} />
                 <span>{viewingCanvas.title ?? "Canvas"}</span>
               </div>
@@ -2234,7 +2234,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
             </div>
             <iframe
               src={viewingCanvas.url}
-              className="flex-1 w-full border-none bg-white"
+              className="flex-1 w-full border-none bg-white" // palette-ok: canvas iframe document background is legitimately white
               title="Canvas"
             />
           </div>
@@ -2252,7 +2252,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
             aria-label="New channel"
           >
             <div
-              className="absolute bottom-0 left-0 right-0 bg-shell-bg border-t border-white/[0.08] rounded-t-2xl p-4 space-y-3"
+              className="absolute bottom-0 left-0 right-0 bg-shell-bg border-t border-shell-border rounded-t-2xl p-4 space-y-3"
               onClick={(e) => e.stopPropagation()}
             >
               <div className="flex items-center justify-between mb-1">
@@ -2277,7 +2277,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
                   id="new-channel-type-mobile"
                   value={newChannel.type}
                   onChange={(e) => setNewChannel((s) => ({ ...s, type: e.target.value as "topic" | "group" }))}
-                  className="w-full bg-white/[0.06] border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-accent-line"
+                  className="w-full bg-shell-subtle border border-shell-border rounded-lg px-3 py-2 text-sm text-shell-text outline-none focus:border-accent-line"
                   aria-label="Channel type"
                 >
                   <option value="topic">Topic</option>
@@ -2300,9 +2300,9 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
             </div>
           </div>
         ) : (
-          <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
+          <div className="absolute inset-0 bg-shell-scrim flex items-center justify-center z-50 p-4">
             <Card className="w-full max-w-[380px] max-h-full flex flex-col shadow-2xl bg-shell-bg">
-              <CardHeader className="flex flex-row items-center justify-between gap-2 p-0 px-4 py-3 border-b border-white/[0.06]">
+              <CardHeader className="flex flex-row items-center justify-between gap-2 p-0 px-4 py-3 border-b border-shell-border">
                 <CardTitle className="text-sm font-medium">New Channel</CardTitle>
                 <Button
                   variant="ghost"
@@ -2331,7 +2331,7 @@ className="shrink-0 p-0.5 rounded hover:bg-shell-surface-active transition-color
                     id="new-channel-type"
                     value={newChannel.type}
                     onChange={(e) => setNewChannel((s) => ({ ...s, type: e.target.value as "topic" | "group" }))}
-                    className="w-full bg-white/[0.06] border border-white/10 rounded-lg px-3 py-2 text-sm text-white outline-none focus:border-accent-line"
+                    className="w-full bg-shell-subtle border border-shell-border rounded-lg px-3 py-2 text-sm text-shell-text outline-none focus:border-accent-line"
                     aria-label="Channel type"
                   >
                     <option value="topic">Topic</option>

--- a/desktop/src/theme/builtin-themes.ts
+++ b/desktop/src/theme/builtin-themes.ts
@@ -29,6 +29,8 @@ export const BUILTIN_THEMES: BuiltinTheme[] = [
         "--color-shell-surface-active": "rgba(0, 0, 0, 0.08)",
         "--color-shell-border": "rgba(0, 0, 0, 0.09)",
         "--color-shell-border-strong": "rgba(0, 0, 0, 0.15)",
+        "--color-shell-scrim": "rgba(0, 0, 0, 0.45)",
+        "--color-shell-subtle": "rgba(0, 0, 0, 0.055)",
         // Near-black ink: 14:1 / 6.4:1 / 4.0:1 on the #f4f5f7 body.
         "--color-shell-text": "rgba(0, 0, 0, 0.85)",
         "--color-shell-text-secondary": "rgba(0, 0, 0, 0.55)",

--- a/desktop/src/theme/theme-config.ts
+++ b/desktop/src/theme/theme-config.ts
@@ -15,6 +15,7 @@ export const ALLOWED_TOKENS = new Set<string>([
   "--color-shell-surface-hover","--color-shell-surface-active",
   "--color-shell-border","--color-shell-border-strong",
   "--color-shell-text","--color-shell-text-secondary","--color-shell-text-tertiary",
+  "--color-shell-scrim","--color-shell-subtle",
   "--color-traffic-close","--color-traffic-minimize","--color-traffic-maximize",
   "--color-accent","--color-accent-glow",
   "--color-accent-soft","--color-accent-line","--color-accent-strong",

--- a/desktop/src/theme/tokens.css
+++ b/desktop/src/theme/tokens.css
@@ -40,6 +40,12 @@
   --color-dock-border: rgba(255, 255, 255, 0.08);
   --color-topbar-bg: rgba(29, 29, 31, 0.92);
 
+  /* Modal / overlay */
+  --color-shell-scrim: rgba(0, 0, 0, 0.6);
+
+  /* Subtle surface fills -- input backgrounds, faint raised surfaces */
+  --color-shell-subtle: rgba(255, 255, 255, 0.06);
+
   /* Snap zones */
   --color-snap-preview: rgba(139, 146, 163, 0.15);
   --color-snap-border: rgba(139, 146, 163, 0.4);

--- a/tests/test_theme_token_sync.py
+++ b/tests/test_theme_token_sync.py
@@ -1,0 +1,37 @@
+"""Backend/frontend theme-token allowlist drift guard.
+
+The original shell-scrim/shell-subtle defect (#2219 review): tokens were added
+to the client ALLOWED_TOKENS but not to the backend _COLOR_TOKENS, so valid
+theme packages passed the client and were rejected server-side. This test pins
+the two lists together: every color token the client allows must be accepted
+by the backend schema, and vice versa.
+"""
+import re
+from pathlib import Path
+
+from tinyagentos.themes.schema import _COLOR_TOKENS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+THEME_CONFIG = REPO_ROOT / "desktop" / "src" / "theme" / "theme-config.ts"
+
+
+def _client_color_tokens() -> set[str]:
+    src = THEME_CONFIG.read_text(encoding="utf-8")
+    m = re.search(r"ALLOWED_TOKENS[^=]*=\s*new Set<string>\(\[(.*?)\]\)", src, re.S)
+    assert m, "ALLOWED_TOKENS literal not found in theme-config.ts"
+    tokens = set(re.findall(r"[\"']([^\"']+)[\"']", m.group(1)))
+    return {t for t in tokens if t.startswith("--color-")}
+
+
+def test_backend_accepts_every_client_color_token():
+    missing = _client_color_tokens() - set(_COLOR_TOKENS)
+    assert not missing, (
+        f"client-allowed color tokens rejected by backend schema: {sorted(missing)}"
+    )
+
+
+def test_client_allows_every_backend_color_token():
+    missing = set(_COLOR_TOKENS) - _client_color_tokens()
+    assert not missing, (
+        f"backend-accepted color tokens missing from client allowlist: {sorted(missing)}"
+    )

--- a/tinyagentos/themes/schema.py
+++ b/tinyagentos/themes/schema.py
@@ -9,6 +9,7 @@ _COLOR_TOKENS = {
     "--color-shell-surface-hover", "--color-shell-surface-active",
     "--color-shell-border", "--color-shell-border-strong",
     "--color-shell-text", "--color-shell-text-secondary", "--color-shell-text-tertiary",
+    "--color-shell-scrim", "--color-shell-subtle",
     "--color-traffic-close", "--color-traffic-minimize", "--color-traffic-maximize",
     "--color-accent", "--color-accent-glow",
     "--color-accent-soft", "--color-accent-line", "--color-accent-strong",


### PR DESCRIPTION
Autonomous build of board card tsk-s274hj.

Add --color-shell-scrim and --color-shell-subtle to the backend theme
schema so packages using the new tokens are accepted, mirror them in the
frontend token lists (ALLOWED_TOKENS, tokens.css, builtin light theme),
migrate hardcoded white/black utilities in MessagesApp to shell tokens,
and add a palette regression test with an allowlist for the canvas
iframe bg-white line.

Files:
 desktop/src/apps/MessagesApp.palette.test.ts | 24 ++++++++++++++++++
 desktop/src/apps/MessagesApp.tsx             | 30 +++++++++++-----------
 desktop/src/theme/builtin-themes.ts          |  2 ++
 desktop/src/theme/theme-config.ts            |  1 +
 desktop/src/theme/tokens.css                 |  6 +++++
 tests/test_theme_token_sync.py               | 37 ++++++++++++++++++++++++++++
 tinyagentos/themes/schema.py                 |  1 +
 7 files changed, 86 insertions(+), 15 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Messages interface to use theme-aware colors across toolbars, popovers, canvas viewing, and channel creation dialogs.
  - Improved visual consistency between light and dark themes.
  - Added dedicated theme colors for modal overlays and subtle surfaces.
  - Preserved the canvas viewer’s intentional white background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->