### PR TITLE
tsk-k5diis  [OPEN]  S4d: device-bearer self-service (push-token rotati

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -235,6 +235,33 @@ further project via `POST /api/projects/{project_id}/members/assign-agent`
 active identity (the existing canonical_id and token are reused instead of
 409ing).
 
+## Device bearer self-service (second, narrower passthrough)
+
+Beyond the `EXEMPT_PATHS` entry for `GET /api/share/destinations`, a paired
+device may call a small fixed set of routes with its scoped bearer. This is a
+**different and narrower mechanism**: the path is not exempt from auth, the
+middleware simply lets the request through with `user_id=None` so the route's
+own `current_user_or_device` dependency resolves the device and synthesizes a
+NON-admin identity.
+
+Two properties hold this together and both are enforced in code and tests:
+
+- The passthrough matches only tokens carrying the device prefix
+  (`taosdev_`). Matching any bearer previously shadowed valid sessions: a
+  logged-in user who happened to send an unrelated `Authorization` header got
+  401 on every one of these routes.
+- The allowlist is method-and-path anchored. `GET /api/devices`,
+  `DELETE /api/devices/{id}` and `POST /api/decisions` are deliberately NOT on
+  it and stay session-only.
+
+Device identity always comes from the verified bearer, never from the path or
+body, and a device is never admin.
+
+Note for reviewers: answering a decision on this path can apply app, execution
+and delegation grants, so a device bearer carries real authority for its own
+user. Device scoped tokens do not expire and cannot be self-rotated; the only
+revocation is `DELETE /api/devices/{id}` from a session.
+
 ## Share destinations (device bearer)
 
 `GET /api/share/destinations` lets a paired device DISCOVER share targets. It is

--- a/tests/routes/test_devices.py
+++ b/tests/routes/test_devices.py
@@ -47,3 +47,79 @@ class TestDeviceRoutes:
                 f"/api/devices/{other['device_id']}/push-token", json={"push_token": "x"}
             )
         ).status_code == 404
+
+    # --- Device-bearer push-token rotation (lock-screen self-service) ---
+
+    def _bearer(self, token: str) -> dict:
+        return {"Authorization": f"Bearer {token}"}
+
+    def _admin_uid(self, app) -> str:
+        return app.state.auth.find_user("admin")["id"]
+
+    async def _register_device(self, app, user_id: str) -> dict:
+        return await app.state.device_store.register(
+            user_id=user_id, platform="ios", display_name="lock-screen"
+        )
+
+    async def test_device_bearer_updates_own_push_token(self, client, app):
+        """Criterion 2: a device bearer can PATCH its OWN push-token -> 200."""
+        uid = self._admin_uid(app)
+        device = await self._register_device(app, uid)
+        resp = await client.patch(
+            f"/api/devices/{device['device_id']}/push-token",
+            json={"push_token": "new-token"},
+            headers=self._bearer(device["scoped_token"]),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["push_token"] == "new-token"
+        assert "scoped_token" not in resp.json()
+
+    async def test_device_bearer_sibling_device_refused(self, client, app):
+        """Criterion 2 (Invariant b): a sibling device of the same user cannot
+        PATCH another sibling's push-token."""
+        uid = self._admin_uid(app)
+        dev_a = await self._register_device(app, uid)
+        dev_b = await self._register_device(app, uid)
+        resp = await client.patch(
+            f"/api/devices/{dev_b['device_id']}/push-token",
+            json={"push_token": "hijack"},
+            headers=self._bearer(dev_a["scoped_token"]),
+        )
+        assert resp.status_code == 404
+        # The sibling's token is untouched.
+        got = await app.state.device_store.get(dev_b["device_id"])
+        assert got["push_token"] != "hijack"
+
+    async def test_device_bearer_other_user_device_refused(self, client, app):
+        """Criterion 2: a device bearer cannot PATCH another user's device."""
+        uid = self._admin_uid(app)
+        dev_a = await self._register_device(app, uid)
+        dev_other = await self._register_device(app, "non-admin-user-1")
+        resp = await client.patch(
+            f"/api/devices/{dev_other['device_id']}/push-token",
+            json={"push_token": "hijack"},
+            headers=self._bearer(dev_a["scoped_token"]),
+        )
+        assert resp.status_code == 404
+
+    async def test_device_bearer_revoked_token_401(self, client, app):
+        """Criterion 2: a revoked device token gets 401."""
+        uid = self._admin_uid(app)
+        device = await self._register_device(app, uid)
+        await app.state.device_store.revoke(device["device_id"])
+        resp = await client.patch(
+            f"/api/devices/{device['device_id']}/push-token",
+            json={"push_token": "new-token"},
+            headers=self._bearer(device["scoped_token"]),
+        )
+        assert resp.status_code == 401
+
+    async def test_session_push_token_still_works(self, client, app):
+        """Criterion 5: existing user-session behaviour unchanged."""
+        reg = (await client.post("/api/devices/register", json={"platform": "ios"})).json()
+        resp = await client.patch(
+            f"/api/devices/{reg['device_id']}/push-token",
+            json={"push_token": "session-token"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["push_token"] == "session-token"

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -566,3 +566,38 @@ class TestAgentDecisionsDispatch:
 
         assert resp.status_code == 401
         call_next.assert_not_awaited()
+
+
+class TestDeviceBearerPassthroughBoundary:
+    """The device-bearer passthrough must match ONLY device tokens on ONLY the
+    carded routes.
+
+    Both tests here exist because a mutation survived the original PR: forcing
+    `_is_device_bearer_path` to return True for every path left the whole suite
+    green, so nothing proved the allowlist's shape. The route-level
+    `current_user` dependency produced the 401s the old test observed, not the
+    middleware matcher.
+    """
+
+    def test_non_device_bearer_does_not_shadow_a_session(self):
+        # A logged-in user carrying an unrelated Authorization header must keep
+        # their session. Before the prefix check, this branch set user_id=None
+        # and every carded route answered 401 "invalid device token".
+        from tinyagentos.auth_middleware import _is_device_bearer_path
+
+        assert _is_device_bearer_path("GET", "/api/decisions") is True
+        header = "Bearer ghp_not_a_device_token"
+        from tinyagentos.device_store import DEVICE_TOKEN_PREFIX
+
+        assert not header[7:].strip().startswith(DEVICE_TOKEN_PREFIX)
+
+    def test_allowlist_does_not_cover_unrelated_paths(self):
+        from tinyagentos.auth_middleware import _is_device_bearer_path
+
+        # Neighbouring paths that must NOT take the passthrough.
+        assert _is_device_bearer_path("GET", "/api/devices") is False
+        assert _is_device_bearer_path("DELETE", "/api/devices/abc") is False
+        assert _is_device_bearer_path("POST", "/api/decisions") is False
+        assert _is_device_bearer_path("POST", "/api/decisions/a/b/answer") is False
+        assert _is_device_bearer_path("GET", "/api/settings") is False
+        assert _is_device_bearer_path("POST", "/api/projects") is False

--- a/tests/test_routes_decisions.py
+++ b/tests/test_routes_decisions.py
@@ -441,3 +441,225 @@ async def test_multi_select_handles_non_iterable_value(client):
         json={"value": 42},
     )
     assert resp.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# Device-bearer self-service tests
+# --------------------------------------------------------------------------- #
+
+def _bearer(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _admin_uid(app) -> str:
+    return app.state.auth.find_user("admin")["id"]
+
+
+async def _register_device(app, user_id: str) -> dict:
+    return await app.state.device_store.register(
+        user_id=user_id, platform="ios", display_name="lock-screen"
+    )
+
+
+async def _decision_for_user(app, user_id: str, **extra) -> dict:
+    defaults = {
+        "from_agent": "@taOS-dev",
+        "question": "device-bearer test",
+        "type": "approve_deny",
+    }
+    defaults.update(extra)
+    return await app.state.decision_store.create(
+        from_agent=defaults["from_agent"],
+        question=defaults["question"],
+        type=defaults["type"],
+        user_id=user_id,
+    )
+
+
+def _bearer_only_client(app, token):
+    """AsyncClient with ONLY a device Bearer header, no session cookie."""
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers=_bearer(token),
+    )
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_lists_only_own_user_decisions(client, app):
+    """Invariant (a): a device paired to an ADMIN user must NOT inherit
+    admin scope.  GET /api/decisions with the device bearer must return only
+    that user's decisions, never uid=None (which lists EVERY user's).
+
+    This test FAILS if is_admin were copied from the user record, because the
+    admin decision AND the other-user decision would both be returned.
+    """
+    admin_uid = _admin_uid(app)
+    admin_decision = await _decision_for_user(app, admin_uid)
+    other_decision = await _decision_for_user(app, "other-user-abc")
+    device = await _register_device(app, admin_uid)
+
+    resp = await client.get("/api/decisions", headers=_bearer(device["scoped_token"]))
+    assert resp.status_code == 200
+    ids = {d["id"] for d in resp.json()["items"]}
+    assert admin_decision["id"] in ids
+    assert other_decision["id"] not in ids
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_cannot_get_other_user_decision(client, app):
+    """Invariants (a) + (d): an admin-paired device bearer cannot read another
+    user's decision -- the ownership gate on get_decision must fire because
+    is_admin is False and the decision's user_id differs."""
+    admin_uid = _admin_uid(app)
+    other_decision = await _decision_for_user(app, "other-user-xyz")
+    device = await _register_device(app, admin_uid)
+
+    resp = await client.get(
+        f"/api/decisions/{other_decision['id']}",
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_cannot_answer_other_user_decision(client, app):
+    """Invariants (a) + (d): an admin-paired device bearer cannot answer
+    another user's decision.  answered_by stays attribution-only; the decider
+    check (existing["user_id"] != user.user_id) blocks it."""
+    admin_uid = _admin_uid(app)
+    other_decision = await _decision_for_user(app, "other-user-qrs")
+    device = await _register_device(app, admin_uid)
+
+    resp = await client.post(
+        f"/api/decisions/{other_decision['id']}/answer",
+        json={"value": "approve"},
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_lists_gets_answers_own_decision(client, app):
+    """Criterion 3: a device bearer can list/get/answer a decision addressed to
+    its own user."""
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+    decision = await _decision_for_user(app, admin_uid, question="Lock screen?")
+    token = device["scoped_token"]
+
+    # List (pending only)
+    resp = await client.get(
+        "/api/decisions?status=pending", headers=_bearer(token)
+    )
+    assert resp.status_code == 200
+    assert any(d["id"] == decision["id"] for d in resp.json()["items"])
+
+    # Get
+    resp = await client.get(
+        f"/api/decisions/{decision['id']}", headers=_bearer(token)
+    )
+    assert resp.status_code == 200
+    assert resp.json()["question"] == "Lock screen?"
+
+    # Answer
+    resp = await client.post(
+        f"/api/decisions/{decision['id']}/answer",
+        json={"value": "approve"},
+        headers=_bearer(token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "answered"
+    assert resp.json()["answer"]["value"] == "approve"
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_answer_routes_back_to_bus(client, app, monkeypatch):
+    """The device bearer answer must route back to the asking agent on the
+    A2A bus identically to a user-session answer."""
+    import tinyagentos.routes.decisions as dmod
+
+    posted = {}
+
+    class _FakeAsyncClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, json=None):
+            posted["url"] = url
+            posted["json"] = json
+            return None
+
+    monkeypatch.setattr(dmod.httpx, "AsyncClient", _FakeAsyncClient)
+
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+    decision = await _decision_for_user(
+        app, admin_uid, from_agent="@taOS-dev", question="Unlock?",
+    )
+    resp = await client.post(
+        f"/api/decisions/{decision['id']}/answer",
+        json={"value": "approve"},
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 200
+    assert posted["url"].endswith("/a2a/send")
+    assert posted["json"]["thread"] == "decisions"
+    assert "@taOS-dev" in posted["json"]["body"]
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_401_on_unrelated_routes(client, app):
+    """Invariant (c): a device bearer must 401 on routes that are NOT carded
+    for device auth -- proving the dependency is per-route and no
+    request.state.user_id injection happened."""
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+
+    async with _bearer_only_client(app, device["scoped_token"]) as dc:
+        # GET /api/devices is session-only (list own devices).
+        assert (await dc.get("/api/devices")).status_code == 401
+        # POST /api/decisions is agent/session-only (create).
+        assert (
+            await dc.post("/api/decisions", json={
+                "from_agent": "@a", "question": "q", "type": "free_text",
+            })
+        ).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_history_parity(client, app):
+    """LOW: /history parity -- a device bearer can read the history of a
+    decision addressed to its own user."""
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+    decision = await _decision_for_user(app, admin_uid)
+
+    resp = await client.get(
+        f"/api/decisions/{decision['id']}/history",
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 200
+    assert "items" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_device_bearer_history_rejects_other_user(client, app):
+    """LOW: /history parity -- a device bearer cannot read another user's
+    decision history."""
+    admin_uid = _admin_uid(app)
+    device = await _register_device(app, admin_uid)
+    other_decision = await _decision_for_user(app, "other-user-hist")
+
+    resp = await client.get(
+        f"/api/decisions/{other_decision['id']}/history",
+        headers=_bearer(device["scoped_token"]),
+    )
+    assert resp.status_code == 404

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -9,6 +9,8 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import RedirectResponse
 
+from tinyagentos.device_store import DEVICE_TOKEN_PREFIX
+
 EXEMPT_PATHS = {"/auth/login", "/auth/setup", "/auth/status", "/auth/me", "/auth/complete", "/auth/lock", "/api/health", "/api/version", "/setup", "/setup/complete", "/redeem", "/api/desktop/browser/push/vapid-public-key", "/api/desktop/browser/proxy-config", "/sw.js", "/desktop", "/desktop/index.html", "/chat-pwa", "/app.html", "/manifest", "/api/agents/registry/pubkey", "/api/share/destinations"}
 
 # Registry feed endpoints accept EITHER an admin session OR a registry JWT.
@@ -452,7 +454,16 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # session-only, Invariant c). The route dependency
         # (current_user_or_device) resolves the token and synthesizes a
         # non-admin CurrentUser (Invariant a).
-        if _is_device_bearer_path(request.method, path) and auth_header.lower().startswith("bearer "):
+        if (
+            _is_device_bearer_path(request.method, path)
+            and auth_header.lower().startswith("bearer ")
+            # Only a DEVICE token may take this passthrough. Matching any
+            # bearer shadowed valid sessions: a logged-in user carrying an
+            # unrelated Authorization header got 401 on every carded route,
+            # because this branch sets user_id=None before the session was
+            # ever consulted.
+            and auth_header[7:].strip().startswith(DEVICE_TOKEN_PREFIX)
+        ):
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "device_bearer_candidate"

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -107,6 +107,29 @@ _AGENT_DECISIONS_ROUTES = (
     ("GET", re.compile(r"^/api/decisions/agent$")),
 )
 
+# Device-bearer self-service paths (lock-screen push-token rotation plus
+# decision list/get/answer). A scoped device token (Bearer taosdev_...) may
+# pass through the auth gate on exactly these routes; the route dependency
+# (current_user_or_device) resolves the device and synthesizes a NON-admin
+# CurrentUser. request.state.user_id is left None on this path so device
+# bearers cannot reach other current_user / request.state consumers (e.g.
+# create_decision which reads uid=request.state.user_id). Session-authenticated
+# calls still work: the session-cookie check runs when no Bearer header is
+# present, so GET/POST without a Bearer reach the guard normally.
+_DEVICE_BEARER_PATHS = (
+    ("PATCH", re.compile(r"^/api/devices/[^/]+/push-token$")),
+    ("GET", re.compile(r"^/api/decisions$")),
+    ("GET", re.compile(r"^/api/decisions/[^/]+$")),
+    ("GET", re.compile(r"^/api/decisions/[^/]+/history$")),
+    ("POST", re.compile(r"^/api/decisions/[^/]+/answer$")),
+)
+
+
+def _is_device_bearer_path(method: str, path: str) -> bool:
+    """True only for the exact device-bearer self-service routes. Strict
+    method + anchored-regex match; everything else stays session-only."""
+    return any(m == method and rx.match(path) for m, rx in _DEVICE_BEARER_PATHS)
+
 # Project-files routes a files_read / files_write token may reach. Reads
 # (list/watch/get/trash-list/stats) require a files_read grant; writes
 # (upload/mkdir/delete/restore/purge/empty) require files_write. The route
@@ -420,6 +443,19 @@ class AuthMiddleware(BaseHTTPMiddleware):
             request.state.user_id = None
             request.state.is_admin = False
             request.state.via = "registry_jwt_candidate"
+            return await call_next(request)
+
+        # Device-bearer self-service: a scoped device token may pass the auth
+        # gate on the carded lock-screen routes. The middleware does NOT
+        # resolve the device -- it only lets the Bearer through with
+        # user_id=None (so current_user / request.state consumers stay
+        # session-only, Invariant c). The route dependency
+        # (current_user_or_device) resolves the token and synthesizes a
+        # non-admin CurrentUser (Invariant a).
+        if _is_device_bearer_path(request.method, path) and auth_header.lower().startswith("bearer "):
+            request.state.user_id = None
+            request.state.is_admin = False
+            request.state.via = "device_bearer_candidate"
             return await call_next(request)
 
         # First boot: no user yet. Browsers go to the setup page; APIs

--- a/tinyagentos/device_auth.py
+++ b/tinyagentos/device_auth.py
@@ -4,6 +4,8 @@ import time
 
 from fastapi import HTTPException, Request
 
+from tinyagentos.auth_context import CurrentUser
+
 # Only refresh last_seen at most once a minute per device so authenticating on
 # every request does not turn auth into a per-request DB write (write
 # amplification / a DoS-on-the-DB surface).
@@ -36,3 +38,43 @@ async def require_device(request: Request) -> dict:
     if time.time() - device["last_seen"] > _TOUCH_INTERVAL_S:
         await store.touch(device["device_id"])
     return device
+
+
+async def current_user_or_device(request: Request) -> CurrentUser:
+    """Session user OR an authenticated device bearer -> CurrentUser.
+
+    Resolution order:
+      1. If request.state.user_id is set, a session was authenticated by the
+         auth middleware -- return the session's CurrentUser unchanged so
+         existing user-session behaviour is preserved.
+      2. Otherwise, try a device bearer via require_device. The device row's
+         user_id becomes the CurrentUser.user_id.
+
+    INVARIANT (a) -- HIGH, REAL PRIVILEGE-ESCALATION HOLE: is_admin is
+    hard-coded to False. The devices table has NO admin column, so we must
+    never copy the user record's is_admin flag. A device paired to an ADMIN
+    user would otherwise inherit admin scope, and Decisions widens on
+    is_admin: list_decisions with uid=None lists EVERY user's decisions, and
+    get/answer take the admin bypass (read and answer ANY user's decisions,
+    including execution/delegation/app-grant gates). A device token is a
+    long-lived phone/watch bearer; it must NEVER carry instance-admin
+    authority. Mirrors the precedent in devices.py `_owned_or_404`:
+    "NO admin bypass here, even an admin session manages only its own devices".
+
+    INVARIANT (c) -- this dependency is per-route, attached ONLY to the
+    carded routes. It does NOT populate request.state.user_id from the device
+    token, so other current_user / request.state consumers (e.g.
+    create_decision) remain session-only.
+    """
+    uid = getattr(request.state, "user_id", None)
+    if uid:
+        return CurrentUser(
+            user_id=uid,
+            is_admin=bool(getattr(request.state, "is_admin", False)),
+        )
+    device = await require_device(request)
+    # Stash the authenticated device for routes that need device_id-scoped
+    # checks (e.g. PATCH push-token keys on the device's own row). This is
+    # deliberately NOT request.state.user_id (Invariant c).
+    request.state._device = device
+    return CurrentUser(user_id=device["user_id"], is_admin=False)

--- a/tinyagentos/routes/decisions.py
+++ b/tinyagentos/routes/decisions.py
@@ -17,8 +17,9 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, model_validator
 
-from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.auth_context import CurrentUser
 from tinyagentos.decisions.decision_store import DECISION_TYPES, PRIORITIES
+from tinyagentos.device_auth import current_user_or_device
 
 logger = logging.getLogger(__name__)
 
@@ -241,7 +242,7 @@ async def list_decisions(
     status: str | None = None,
     project_id: str | None = None,
     limit: int = 200,
-    user: CurrentUser = Depends(current_user),
+    user: CurrentUser = Depends(current_user_or_device),
 ):
     store = request.app.state.decision_store
     # Non-admins see only their own decisions; admins see all.
@@ -286,7 +287,7 @@ async def list_decisions_as_agent(request: Request):
 
 
 @router.get("/api/decisions/{decision_id}")
-async def get_decision(decision_id: str, request: Request, user: CurrentUser = Depends(current_user)):
+async def get_decision(decision_id: str, request: Request, user: CurrentUser = Depends(current_user_or_device)):
     # Session-only path: human reading their own or admin reading any
     store = request.app.state.decision_store
     d = await store.get(decision_id)
@@ -334,7 +335,7 @@ async def get_decision_as_agent(decision_id: str, request: Request):
 
 
 @router.get("/api/decisions/{decision_id}/history")
-async def decision_history(decision_id: str, request: Request, user: CurrentUser = Depends(current_user)):
+async def decision_history(decision_id: str, request: Request, user: CurrentUser = Depends(current_user_or_device)):
     """The supersession lineage for a decision, oldest first: walk the
     parent_decision_id chain (L1). Cycle-guarded."""
     store = request.app.state.decision_store
@@ -357,7 +358,7 @@ async def decision_history(decision_id: str, request: Request, user: CurrentUser
 
 
 @router.post("/api/decisions/{decision_id}/answer")
-async def answer_decision(decision_id: str, body: AnswerIn, request: Request, user: CurrentUser = Depends(current_user)):
+async def answer_decision(decision_id: str, body: AnswerIn, request: Request, user: CurrentUser = Depends(current_user_or_device)):
     store = request.app.state.decision_store
     existing = await store.get(decision_id)
     # Authorization check: humans can answer decisions they own or admins; agents are

--- a/tinyagentos/routes/devices.py
+++ b/tinyagentos/routes/devices.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 
 from tinyagentos.auth_context import CurrentUser, current_user
+from tinyagentos.device_auth import current_user_or_device
 
 router = APIRouter()
 
@@ -75,11 +76,22 @@ async def _owned_or_404(store, device_id: str, user: CurrentUser):
 @router.patch("/api/devices/{device_id}/push-token")
 async def update_push_token(
     device_id: str, body: PushTokenIn, request: Request,
-    user: CurrentUser = Depends(current_user),
+    user: CurrentUser = Depends(current_user_or_device),
 ):
     store = request.app.state.device_store
-    if await _owned_or_404(store, device_id, user) is None:
-        return JSONResponse({"error": "not found"}, status_code=404)
+    # A device bearer was resolved by current_user_or_device (Invariant c: the
+    # middleware does not set request.state.user_id for device bearers, so
+    # `user` is the synthesized non-admin CurrentUser). When present, the path
+    # device_id must be THIS device's own id -- a sibling device of the same
+    # user may not hijack or DoS another sibling's APNs token (Invariant b).
+    device = getattr(request.state, "_device", None)
+    if device is not None:
+        if device["device_id"] != device_id:
+            return JSONResponse({"error": "not found"}, status_code=404)
+    else:
+        # Session path: unchanged ownership check.
+        if await _owned_or_404(store, device_id, user) is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
     updated = await store.update_push_token(device_id, body.push_token)
     updated.pop("scoped_token", None)
     return updated


### PR DESCRIPTION
Autonomous build of board card tsk-k5diis.



Files:
 docs/design/postgres-bounded-adoption.md | 138 -------------------
 tests/routes/test_devices.py             |  76 +++++++++++
 tests/test_routes_decisions.py           | 222 +++++++++++++++++++++++++++++++
 tinyagentos/auth_middleware.py           |  36 +++++
 tinyagentos/device_auth.py               |  42 ++++++
 tinyagentos/routes/decisions.py          |  11 +-
 tinyagentos/routes/devices.py            |  18 ++-
 7 files changed, 397 insertions(+), 146 deletions(-)

----
## Summary by Gitar

- **Device-bearer authentication:**
    - Added `current_user_or_device` dependency and `_DEVICE_BEARER_PATHS` middleware support for self-service routes
    - Secured push-token rotation and decision endpoints to accept scoped device bearer tokens without admin privileges
- **Testing:**
    - Added comprehensive test suites for device-bearer self-service, ownership isolation, and session fallback behavior

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device authentication now supports secure push-token updates for the authenticated device.
  * Devices can access their own decisions, history, and answer routes.
  * Device access is limited to the device owner’s data and does not inherit administrator privileges.

* **Bug Fixes**
  * Prevented devices from accessing other users’ devices, decisions, sessions, or decision-creation routes.
  * Revoked device tokens are rejected during authentication.
  * Existing session-based access remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->