### PR TITLE
check_doc_gate: add opt-in on_modify per-rule and extend tests

### DIFF
--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -4,10 +4,10 @@
 # entries here to cover new feature areas without touching the script.
 #
 # Precision over recall: `when_changed` only triggers a rule on a structural
-# change (a file added or deleted), never a plain modification, and every
-# glob below is scoped to the specific tree it names. This is deliberate --
-# a noisy gate gets disabled, so false positives are worse than an occasional
-# missed doc update.
+# change (a file added or deleted, or a plain modification when the rule sets
+# `on_modify = true`), and every glob below is scoped to the specific tree it
+# names. This is deliberate -- a noisy gate gets disabled, so false positives
+# are worse than an occasional missed doc update.
 
 [gate]
 trailer = "Docs-Reviewed:"
@@ -47,3 +47,23 @@ name = "agent-api"
 when_changed = ["tinyagentos/auth_middleware.py"]
 require_doc = ["docs/agent-coordination.md"]
 hint = "the agent-token route allowlist changed; update the agent-facing API surface (or add a Docs-Reviewed trailer explaining why not)"
+
+# User-visible behaviour needs a changelog line.
+[[rules]]
+on_modify = true
+when_changed = ["tinyagentos/routes/*.py", "desktop/src/apps/*/**", "tinyagentos/installers/*"]
+require_doc = ["CHANGELOG.md"]
+
+# Agent-facing behaviour needs the compiled agent manual reviewed.
+[[rules]]
+on_modify = true
+when_changed = ["tinyagentos/agent_registry*.py", "tinyagentos/agent_token_auth.py", "tinyagentos/routes/agent_*.py", "tinyagentos/mcp/**"]
+require_doc = ["docs/agent-manual/*.md", "docs/agent-coordination.md"]
+
+# The contributor skill documents how to contribute, test and ship. When CI,
+# packaging or the contribution rules move, it goes stale silently because
+# nothing imports it.
+[[rules]]
+on_modify = true
+when_changed = [".github/workflows/*.yml", "pyproject.toml", "CONTRIBUTING.md"]
+require_doc = [".claude/skills/taos-development-skill/*.md", "docs/*.md"]

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -50,20 +50,26 @@ hint = "the agent-token route allowlist changed; update the agent-facing API sur
 
 # User-visible behaviour needs a changelog line.
 [[rules]]
+name = "user-visible-changelog"
 on_modify = true
 when_changed = ["tinyagentos/routes/*.py", "desktop/src/apps/*/**", "tinyagentos/installers/*"]
 require_doc = ["CHANGELOG.md"]
+hint = "user-visible behaviour changed; add a CHANGELOG.md line (or add a Docs-Reviewed trailer explaining why not)"
 
 # Agent-facing behaviour needs the compiled agent manual reviewed.
 [[rules]]
+name = "agent-manual"
 on_modify = true
 when_changed = ["tinyagentos/agent_registry*.py", "tinyagentos/agent_token_auth.py", "tinyagentos/routes/agent_*.py", "tinyagentos/mcp/**"]
 require_doc = ["docs/agent-manual/*.md", "docs/agent-coordination.md"]
+hint = "agent-facing behaviour changed; review the agent manual or coordination doc (or add a Docs-Reviewed trailer explaining why not)"
 
 # The contributor skill documents how to contribute, test and ship. When CI,
 # packaging or the contribution rules move, it goes stale silently because
 # nothing imports it.
 [[rules]]
+name = "contributor-skill"
 on_modify = true
 when_changed = [".github/workflows/*.yml", "pyproject.toml", "CONTRIBUTING.md"]
 require_doc = [".claude/skills/taos-development-skill/*.md", "docs/*.md"]
+hint = "CI, packaging or contribution rules changed; review the contributor skill and docs (or add a Docs-Reviewed trailer explaining why not)"

--- a/scripts/check_doc_gate.py
+++ b/scripts/check_doc_gate.py
@@ -9,12 +9,12 @@ Two layers:
                  scripts/, tinyagentos/, docs/, desktop/ path mentioned in the
                  configured doc set actually exists on disk.
   diff-gate   -- path -> doc rule engine (Layer B). A configured rule fires
-                 when a *structural* change (a file added or deleted, never a
-                 plain modification) matches one of its `when_changed` globs.
-                 A fired rule is satisfied by either editing one of its
-                 `require_doc` files in the same changeset, or by a commit
-                 message trailer line starting with the configured trailer
-                 (default "Docs-Reviewed:") with non-empty text after it.
+                when a *structural* change matches one of its `when_changed`
+                globs. By default only added/deleted files (status A/D) are
+                structural; set `on_modify = true` on a rule to also count
+                plain modifications (status M) for that rule. Any changed
+                file (any status) can *satisfy* a rule if it matches a
+                require_doc glob.
 
 Config lives in docs/doc-gate.toml. Rules are data, not code: add more by
 editing the TOML, no changes to this file required.
@@ -162,10 +162,12 @@ def evaluate_rules(
 
     changed_status: list of (status, path) pairs as from `git diff
     --name-status`, e.g. [("A", "desktop/src/apps/Foo/Foo.tsx"), ("M", "x")].
-    Only status "A" (added) or "D" (deleted) files count as structural change
-    for the purposes of *triggering* a rule; plain modifications ("M") are
-    ignored to keep the gate precise. Any changed file (any status) can
-    *satisfy* a rule if it matches a require_doc glob.
+    By default only status "A" (added) or "D" (deleted) files count as
+    structural change for triggering a rule. When a rule sets `on_modify =
+    true`, status "M" (plain modification) also counts for that rule.
+    Any changed file (any status) can satisfy a rule if it matches a
+    require_doc glob. Test paths are never structural and are always
+    excluded.
     commit_messages: full text of each commit message in range (empty list
     when there is no finalized commit yet, i.e. --staged mode).
     """
@@ -173,10 +175,6 @@ def evaluate_rules(
     rules = config.get("rules", [])
 
     all_paths = [path for _status, path in changed_status]
-    structural_paths = [
-        path for status, path in changed_status
-        if status in ("A", "D") and not _is_test_path(path)
-    ]
 
     trailer_present = any(
         line.strip().startswith(trailer) and line.strip()[len(trailer):].strip()
@@ -190,8 +188,15 @@ def evaluate_rules(
         when_changed = rule.get("when_changed", [])
         require_doc = rule.get("require_doc", [])
         hint = rule.get("hint", "")
+        on_modify = rule.get("on_modify", False)
 
-        triggered = any(_match_any(p, when_changed) for p in structural_paths)
+        rule_structural_paths = [
+            path for status, path in changed_status
+            if (status in ("A", "D") or (on_modify and status == "M"))
+            and not _is_test_path(path)
+        ]
+
+        triggered = any(_match_any(p, when_changed) for p in rule_structural_paths)
         if not triggered:
             continue
 

--- a/tests/test_check_doc_gate.py
+++ b/tests/test_check_doc_gate.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_doc_gate",
+    REPO_ROOT / "scripts" / "check_doc_gate.py",
+)
+_MOD = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MOD)
+evaluate_rules = _MOD.evaluate_rules
+
+
+def _base_config() -> dict:
+    return {
+        "gate": {"trailer": "Docs-Reviewed:"},
+        "rules": [
+            {
+                "name": "test_route",
+                "on_modify": True,
+                "when_changed": ["tinyagentos/routes/themes.py"],
+                "require_doc": ["CHANGELOG.md"],
+                "hint": "a route module was modified",
+            }
+        ],
+    }
+
+
+class TestEvaluateRulesOnModify:
+    """Five cases required by the task."""
+
+    def test_m_only_no_doc_fails(self):
+        """(a) An M-only change matching an on_modify rule with no doc edit FAILS."""
+        config = _base_config()
+        changed = [("M", "tinyagentos/routes/themes.py")]
+        commit_messages: list[str] = []
+        failures = evaluate_rules(changed, commit_messages, config)
+        assert len(failures) == 1
+        assert "CHANGELOG.md" in failures[0]
+
+    def test_m_only_with_doc_passes(self):
+        """(b) The same change WITH the required doc edited PASSES."""
+        config = _base_config()
+        changed = [
+            ("M", "tinyagentos/routes/themes.py"),
+            ("M", "CHANGELOG.md"),
+        ]
+        commit_messages: list[str] = []
+        failures = evaluate_rules(changed, commit_messages, config)
+        assert failures == []
+
+    def test_m_only_with_trailer_passes(self):
+        """(c) The same change with a Docs-Reviewed trailer PASSES."""
+        config = _base_config()
+        changed = [("M", "tinyagentos/routes/themes.py")]
+        commit_messages = ["Fix themes\n\nDocs-Reviewed: reviewed the change"]
+        failures = evaluate_rules(changed, commit_messages, config)
+        assert failures == []
+
+    def test_m_only_without_on_modify_passes(self):
+        """(d) An M-only change matching a rule WITHOUT on_modify still passes,
+        proving the default did not change."""
+        config = {
+            "gate": {"trailer": "Docs-Reviewed:"},
+            "rules": [
+                {
+                    "name": "test_route_default",
+                    "when_changed": ["tinyagentos/routes/themes.py"],
+                    "require_doc": ["CHANGELOG.md"],
+                    "hint": "a route module was modified",
+                }
+            ],
+        }
+        changed = [("M", "tinyagentos/routes/themes.py")]
+        commit_messages: list[str] = []
+        failures = evaluate_rules(changed, commit_messages, config)
+        assert failures == []
+
+    def test_ad_triggering_still_works(self):
+        """(e) A/D triggering still works as before."""
+        config = _base_config()
+        # A triggers
+        failures = evaluate_rules([("A", "tinyagentos/routes/themes.py")], [], config)
+        assert len(failures) == 1
+        # D triggers
+        failures = evaluate_rules([("D", "tinyagentos/routes/themes.py")], [], config)
+        assert len(failures) == 1
+        # A with doc edited passes
+        failures = evaluate_rules(
+            [("A", "tinyagentos/routes/themes.py"), ("A", "CHANGELOG.md")],
+            [],
+            config,
+        )
+        assert failures == []
+
+
+class TestEvaluateRulesEdgeCases:
+    """Additional coverage for the on_modify implementation."""
+
+    def test_test_paths_excluded_even_with_on_modify(self):
+        """Test paths must stay excluded from triggering, as now."""
+        config = _base_config()
+        changed = [("M", "tests/routes/test_themes.py")]
+        commit_messages: list[str] = []
+        failures = evaluate_rules(changed, commit_messages, config)
+        assert failures == []
+
+    def test_multiple_rules_mixed_on_modify(self):
+        """Only rules with on_modify=true fire on M; others do not."""
+        config = {
+            "gate": {"trailer": "Docs-Reviewed:"},
+            "rules": [
+                {
+                    "name": "route_mod",
+                    "on_modify": True,
+                    "when_changed": ["tinyagentos/routes/themes.py"],
+                    "require_doc": ["CHANGELOG.md"],
+                    "hint": "route modified",
+                },
+                {
+                    "name": "catalog_add",
+                    "when_changed": ["app-catalog/**"],
+                    "require_doc": ["README.md"],
+                    "hint": "catalog added",
+                },
+            ],
+        }
+        changed = [("M", "tinyagentos/routes/themes.py")]
+        failures = evaluate_rules(changed, [], config)
+        assert len(failures) == 1
+        assert "route_mod" in failures[0]
+
+    def test_on_modify_false_explicit_still_default(self):
+        """Explicit on_modify = false behaves the same as omitting it."""
+        config = {
+            "gate": {"trailer": "Docs-Reviewed:"},
+            "rules": [
+                {
+                    "name": "route_explicit_false",
+                    "on_modify": False,
+                    "when_changed": ["tinyagentos/routes/themes.py"],
+                    "require_doc": ["CHANGELOG.md"],
+                    "hint": "route modified",
+                }
+            ],
+        }
+        changed = [("M", "tinyagentos/routes/themes.py")]
+        failures = evaluate_rules(changed, [], config)
+        assert failures == []

--- a/tests/test_check_doc_gate.py
+++ b/tests/test_check_doc_gate.py
@@ -106,8 +106,14 @@ class TestEvaluateRulesEdgeCases:
     """Additional coverage for the on_modify implementation."""
 
     def test_test_paths_excluded_even_with_on_modify(self):
-        """Test paths must stay excluded from triggering, as now."""
+        """Test paths must stay excluded from triggering, as now.
+
+        The rule glob deliberately MATCHES the test path, so only the
+        test-path exclusion keeps it from firing -- without that exclusion
+        this test goes red.
+        """
         config = _base_config()
+        config["rules"][0]["when_changed"] = ["tests/routes/*.py"]
         changed = [("M", "tests/routes/test_themes.py")]
         commit_messages: list[str] = []
         failures = evaluate_rules(changed, commit_messages, config)
@@ -133,7 +139,12 @@ class TestEvaluateRulesEdgeCases:
                 },
             ],
         }
-        changed = [("M", "tinyagentos/routes/themes.py")]
+        changed = [
+            ("M", "tinyagentos/routes/themes.py"),
+            # Matches catalog_add's glob, so that rule is genuinely exercised:
+            # it must NOT fire on a plain modification without on_modify.
+            ("M", "app-catalog/foo/app.yml"),
+        ]
         failures = evaluate_rules(changed, [], config)
         assert len(failures) == 1
         assert "route_mod" in failures[0]


### PR DESCRIPTION
Autonomous build of board card tsk-sxuexd.

evaluate_rules now honours an optional on_modify flag on each rule
(default false) so plain modifications can trigger the gate without
changing the behaviour of existing rules. Added three rules covering
user-visible behaviour, agent-facing behaviour, and CI/packaging
documentation, each with on_modify = true. Covered the five required
test cases (M-only fail, M-only with doc pass, M-only with trailer
pass, M-only default-still-pass, A/D still-work) plus edge cases
for test-path exclusion and mixed rules.

Files:
 docs/doc-gate.toml           |  28 ++++++--
 scripts/check_doc_gate.py    |  35 +++++-----
 tests/test_check_doc_gate.py | 157 +++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 201 insertions(+), 19 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation requirements to cover user-facing changes, agent-facing components, CI and packaging updates, and contribution rules.
  * Documentation checks now recognize relevant modified files and accept corresponding documentation or changelog entries.
* **Bug Fixes**
  * Improved consistency in documentation validation while preserving exclusions for test-only changes.
* **Tests**
  * Expanded coverage for documentation checks involving modified, added, and deleted files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->