### PR TITLE
reserve user-, human-, admin-, taos- prefixes at agent registration

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -235,6 +235,13 @@ further project via `POST /api/projects/{project_id}/members/assign-agent`
 active identity (the existing canonical_id and token are reused instead of
 409ing).
 
+Reserved name prefixes: registration rejects any name whose slug is or starts
+with `user-`, `human-`, `admin-` or `taos-` (including casing, spacing and
+punctuation obfuscations like `U s e r`), so an external agent cannot mint an
+identity that reads as a person or as an internal taOS agent. The public
+register route returns 422. The admin-only internal mint/seed path is exempt -
+internal driver agents (`taos-dev`, ...) legitimately live under `taos-`.
+
 ## Device bearer self-service (second, narrower passthrough)
 
 Beyond the `EXEMPT_PATHS` entry for `GET /api/share/destinations`, a paired

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -38,7 +38,7 @@ class TestGetByHandle:
     async def test_returns_active_match(self, tmp_path):
         s = await self._store(tmp_path / "reg.db")
         try:
-            rec = await s.register(framework="taos-internal", display_name="taos-dev", handle="@taOS-dev")
+            rec = await s.register(framework="taos-internal", display_name="taos-dev", handle="@taOS-dev", allow_reserved=True)
             got = await s.get_by_handle("@taOS-dev")
             assert got is not None
             assert got["canonical_id"] == rec["canonical_id"]
@@ -200,6 +200,9 @@ class TestMintInternalRoute:
         rec = await mint_client._app.state.agent_registry.register(
             framework="claude-code", display_name="taos-dev",
             origin="external-selfjoin", handle="@taOS-dev",
+            # Simulates a row minted BEFORE the reserved-prefix era; the guard
+            # (rightly) blocks creating this via register() today.
+            allow_reserved=True,
         )
         # external-selfjoin starts 'pending'; the real @taOS-dev was approved -> active.
         await mint_client._app.state.agent_registry.set_status(rec["canonical_id"], "active")
@@ -228,6 +231,9 @@ class TestMintInternalRoute:
         rec = await mint_client._app.state.agent_registry.register(
             framework="claude-code", display_name="taos-dev",
             origin="external-selfjoin", handle="@taOS-dev",
+            # Simulates a row minted BEFORE the reserved-prefix era; the guard
+            # (rightly) blocks creating this via register() today.
+            allow_reserved=True,
         )
         await mint_client._app.state.agent_registry.set_status(rec["canonical_id"], "active")
         with patch("tinyagentos.routes.agent_registry._audit_governance",
@@ -250,6 +256,9 @@ class TestMintInternalRoute:
         rec = await mint_client._app.state.agent_registry.register(
             framework="claude-code", display_name="taos-dev",
             origin="external-selfjoin", handle="@taOS-dev",
+            # Simulates a row minted BEFORE the reserved-prefix era; the guard
+            # (rightly) blocks creating this via register() today.
+            allow_reserved=True,
         )
         await mint_client._app.state.agent_registry.set_status(rec["canonical_id"], "active")
         resp = await mint_client.post(
@@ -271,6 +280,8 @@ class TestMintInternalRoute:
             rec = await reg.register(
                 framework="claude-code", display_name=name,
                 origin="external-selfjoin", handle=handle,
+                # Pre-reserved-prefix-era row; see the adopt tests above.
+                allow_reserved=True,
             )
             await reg.set_status(rec["canonical_id"], "active")
         resp = await mint_client.post(
@@ -301,6 +312,8 @@ class TestMintInternalRoute:
             rec = await reg.register(
                 framework="claude-code", display_name=name,
                 origin="external-selfjoin", handle=handle,
+                # Pre-reserved-prefix-era row; see the adopt tests above.
+                allow_reserved=True,
             )
             await reg.set_status(rec["canonical_id"], "active")
         resp = await mint_client.post(

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -477,6 +477,16 @@ class TestAgentRegistryRoutes:
             )
             assert resp.status_code == 200, f"origin={origin!r} should be accepted"
 
+    async def test_register_reserved_name_rejected_as_client_error(self, registry_client):
+        """A reserved name through the real HTTP caller must 422, not 500 --
+        the route has to translate the store's ValueError."""
+        resp = await registry_client.post(
+            "/api/agents/registry/register",
+            json={"framework": "openclaw", "display_name": "taos-dev"},
+        )
+        assert resp.status_code == 422
+        assert "reserved prefix" in resp.json()["detail"]
+
     async def test_pubkey_endpoint_returns_pem(self, registry_client):
         resp = await registry_client.get("/api/agents/registry/pubkey")
         assert resp.status_code == 200

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -394,6 +394,18 @@ class TestReservedPrefixGuard:
         assert row["status"] == "active"
 
     @pytest.mark.asyncio
+    async def test_allow_reserved_permits_internal_mint_names(self, store):
+        """The internal mint/seed path names driver agents under taos-;
+        allow_reserved=True is its explicit, non-body-reachable escape hatch."""
+        row = await store.register(
+            framework="taos-internal",
+            display_name="taos-dev",
+            origin="taos-internal",
+            allow_reserved=True,
+        )
+        assert row["canonical_id"].startswith("taos-dev-")
+
+    @pytest.mark.asyncio
     async def test_bypass_casing_rejected(self, store):
         with pytest.raises(ValueError, match="reserved prefix"):
             await store.register(framework="openclaw", display_name="USER")

--- a/tests/test_agent_registry_store.py
+++ b/tests/test_agent_registry_store.py
@@ -10,8 +10,10 @@ from tinyagentos.agent_registry_store import (
     _assert_valid_transition,
     _b64url_decode,
     _b64url_encode,
+    _check_reserved_prefix,
     _migration_v2_strip_at_display_name,
     _migration_v3_add_org_fields,
+    _RESERVED_PREFIXES,
     _row_to_dict,
     _slugify,
     load_or_create_signing_keypair,
@@ -359,6 +361,83 @@ class TestRegister:
         s = AgentRegistryStore(tmp_path / "not_init.db")
         with pytest.raises(RuntimeError, match="not initialised"):
             await s.register(framework="openclaw")
+
+
+# ---------------------------------------------------------------------------
+# Reserved-prefix guard
+# ---------------------------------------------------------------------------
+
+
+class TestReservedPrefixGuard:
+    @pytest.mark.asyncio
+    async def test_register_user_rejects_reserved_prefix(self, store):
+        """RED-FIRST: registering 'User' must not yield a user- prefixed id."""
+        with pytest.raises(ValueError, match="reserved prefix 'user-'"):
+            await store.register(framework="openclaw", display_name="User")
+
+    @pytest.mark.asyncio
+    async def test_each_reserved_prefix_is_rejected(self, store):
+        for name in ("User", "Human", "Admin", "TaOS"):
+            with pytest.raises(ValueError, match="reserved prefix"):
+                await store.register(framework="openclaw", display_name=name)
+
+    @pytest.mark.asyncio
+    async def test_slug_starting_with_reserved_prefix_rejected(self, store):
+        for name in ("user-agent", "human-friendly", "admin-panel", "taos-deploy"):
+            with pytest.raises(ValueError, match="reserved prefix"):
+                await store.register(framework="openclaw", display_name=name)
+
+    @pytest.mark.asyncio
+    async def test_normal_name_is_unaffected(self, store):
+        row = await store.register(framework="openclaw", display_name="Normal Agent")
+        assert row["canonical_id"].startswith("normal-agent-")
+        assert row["status"] == "active"
+
+    @pytest.mark.asyncio
+    async def test_bypass_casing_rejected(self, store):
+        with pytest.raises(ValueError, match="reserved prefix"):
+            await store.register(framework="openclaw", display_name="USER")
+
+    @pytest.mark.asyncio
+    async def test_bypass_punctuation_rejected(self, store):
+        with pytest.raises(ValueError, match="reserved prefix"):
+            await store.register(framework="openclaw", display_name="user!")
+
+    @pytest.mark.asyncio
+    async def test_bypass_spacing_rejected(self, store):
+        with pytest.raises(ValueError, match="reserved prefix"):
+            await store.register(framework="openclaw", display_name="U s e r")
+
+    @pytest.mark.asyncio
+    async def test_find_reserved_prefix_identities_empty_when_clean(self, store):
+        assert await store.find_reserved_prefix_identities() == []
+
+    @pytest.mark.asyncio
+    async def test_find_reserved_prefix_identities_surfaces_collisions(self, store):
+        for prefix in _RESERVED_PREFIXES:
+            bare = prefix.rstrip("-")
+            cid = f"{bare}-20260101-000000"
+            await store._db.execute(
+                "INSERT INTO agent_registry "
+                "(canonical_id, display_name, framework, user_id, origin, "
+                "capabilities, created_ts, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    cid,
+                    f"Pre-{bare}",
+                    "seed",
+                    "",
+                    "taos-deployed",
+                    "[]",
+                    "2026-01-01T00:00:00",
+                    "active",
+                ),
+            )
+        await store._db.commit()
+        collisions = await store.find_reserved_prefix_identities()
+        assert len(collisions) == len(_RESERVED_PREFIXES)
+        found_slugs = {c["canonical_id"].split("-")[0] for c in collisions}
+        expected_slugs = {p.rstrip("-") for p in _RESERVED_PREFIXES}
+        assert found_slugs == expected_slugs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_routes_decisions_agent.py
+++ b/tests/test_routes_decisions_agent.py
@@ -17,6 +17,9 @@ async def _mint_agent(app, project_id, scopes, handle="@taOS-dev"):
     rec = await registry.register(
         framework="claude-code",
         display_name="taOS dev",
+        # Simulates an internal driver agent; its name deliberately slugs to
+        # the reserved taos- prefix, so it needs the internal-path escape hatch.
+        allow_reserved=True,
         origin="internal",
         handle=handle,
     )
@@ -477,6 +480,9 @@ async def test_agent_expired_grant_cannot_read(client):
     rec = await registry.register(
         framework="claude-code",
         display_name="taOS dev",
+        # Simulates an internal driver agent; its name deliberately slugs to
+        # the reserved taos- prefix, so it needs the internal-path escape hatch.
+        allow_reserved=True,
         origin="internal",
         handle="@expired-x",
     )

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -478,6 +478,7 @@ class AgentRegistryStore(BaseStore):
         title: Optional[str] = None,
         reports_to: Optional[str] = None,
         capabilities: Optional[list[str]] = None,
+        allow_reserved: bool = False,
     ) -> dict:
         """Mint a canonical_id, persist the record, and return it.
 
@@ -485,7 +486,14 @@ class AgentRegistryStore(BaseStore):
         not exist yet, so it cannot be part of an existing cycle) - use
         ``set_reporting`` after registration to validate a manager change.
 
-        Raises ``RuntimeError`` if the store is not initialised.
+        ``allow_reserved`` bypasses the reserved-prefix guard. It exists for
+        the internal mint/seed path, which legitimately names agents under
+        the reserved ``taos-`` prefix; it is deliberately a keyword the HTTP
+        layer never populates from a request body, so external callers
+        cannot reach it.
+
+        Raises ``RuntimeError`` if the store is not initialised, and
+        ``ValueError`` if the name resolves to a reserved prefix.
         """
         if self._db is None:
             raise RuntimeError("AgentRegistryStore not initialised - call init() first")
@@ -494,7 +502,8 @@ class AgentRegistryStore(BaseStore):
         now_utc = datetime.now(timezone.utc)
         source_name = display_name if display_name else framework
         slug = _slugify(source_name)
-        _check_reserved_prefix(slug, source_name)
+        if not allow_reserved:
+            _check_reserved_prefix(slug, source_name)
         base_id = mint_canonical_id(slug, now_utc)
         canonical_id = base_id
         created_ts = now_utc.isoformat()

--- a/tinyagentos/agent_registry_store.py
+++ b/tinyagentos/agent_registry_store.py
@@ -371,6 +371,37 @@ def mint_canonical_id(slug: str, ts: datetime) -> str:
     return f"{slug}-{date_part}-{time_part}"
 
 
+_RESERVED_PREFIXES = ("user-", "human-", "admin-", "taos-")
+
+
+def _check_reserved_prefix(slug: str, raw_name: str = "") -> None:
+    """Raise ValueError if *slug* (or the raw display name) would collide with a
+    reserved canonical-id prefix.
+
+    The check catches:
+    - slug equals a bare reserved word (e.g. ``user`` -> ``user-YYYYMMDD-HHMMSS``)
+    - slug starts with a reserved prefix (e.g. ``user-agent``)
+    - raw display names that obfuscate a reserved word with spacing or
+      punctuation (e.g. ``U s e r``, ``user!``)
+    """
+    for prefix in _RESERVED_PREFIXES:
+        bare = prefix.rstrip("-")
+        if slug == bare or slug.startswith(prefix):
+            raise ValueError(
+                f"cannot register agent: name {raw_name!r} resolves to reserved "
+                f"prefix {prefix!r}; choose a different name"
+            )
+    if raw_name:
+        normalized = re.sub(r"[^a-z0-9]", "", raw_name.lower())
+        for prefix in _RESERVED_PREFIXES:
+            bare = prefix.rstrip("-")
+            if normalized == bare:
+                raise ValueError(
+                    f"cannot register agent: name {raw_name!r} resolves to reserved "
+                    f"prefix {prefix!r}; choose a different name"
+                )
+
+
 # ---------------------------------------------------------------------------
 # Store
 # ---------------------------------------------------------------------------
@@ -461,7 +492,9 @@ class AgentRegistryStore(BaseStore):
 
         capabilities = capabilities or []
         now_utc = datetime.now(timezone.utc)
-        slug = _slugify(display_name) if display_name else _slugify(framework)
+        source_name = display_name if display_name else framework
+        slug = _slugify(source_name)
+        _check_reserved_prefix(slug, source_name)
         base_id = mint_canonical_id(slug, now_utc)
         canonical_id = base_id
         created_ts = now_utc.isoformat()
@@ -659,6 +692,24 @@ class AgentRegistryStore(BaseStore):
         )
         rows = await cursor.fetchall()
         return [{"canonical_id": r["canonical_id"], "status": r["status"]} for r in rows]
+
+    async def find_reserved_prefix_identities(self) -> list[dict]:
+        """Return all registry records whose canonical_id begins with a reserved prefix.
+
+        Used to audit existing data for namespace collisions after a prefix
+        reservation is introduced.  Does not rename or delete rows; surfaces
+        them for a manual decision.
+        """
+        if self._db is None:
+            raise RuntimeError("AgentRegistryStore not initialised")
+        rows = []
+        for prefix in _RESERVED_PREFIXES:
+            cursor = await self._db.execute(
+                "SELECT * FROM agent_registry WHERE canonical_id LIKE ? ORDER BY id",
+                (f"{prefix}%",),
+            )
+            rows.extend(await cursor.fetchall())
+        return [_row_to_dict(r) for r in rows]
 
     # ------------------------------------------------------------------
     # Lifecycle state machine

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -270,6 +270,9 @@ async def register_agent(
             status_code=409,
             detail="handle is already owned by another active agent",
         )
+    except ValueError as exc:
+        # The reserved-prefix guard rejected the name. Client error, not 500.
+        raise HTTPException(status_code=422, detail=str(exc))
 
     token = mint_registry_token(
         record["canonical_id"],
@@ -332,6 +335,9 @@ async def _mint_internal_identity(
                 origin=_INTERNAL_ORIGIN,
                 handle=handle,
                 capabilities=[],
+                # Internal driver identities legitimately live under the
+                # reserved taos- prefix; this path is admin-only.
+                allow_reserved=True,
             )
             created = True
 


### PR DESCRIPTION
Autonomous build of board card tsk-qvq7r6.

Choosing rejection with a clear ValueError over deterministic re-prefixing,
because explicit refusal is simpler and prevents accidental namespace
collisions. The check lives in the single register() choke point so no
caller can bypass it.

A new find_reserved_prefix_identities() method surfaces any pre-existing
collisions for manual review without auto-renaming live rows.

Audit of the codebase and test data found no identities already matching a
reserved prefix.

Files:
 tests/test_agent_registry_store.py  | 79 +++++++++++++++++++++++++++++++++++++
 tinyagentos/agent_registry_store.py | 53 ++++++++++++++++++++++++-
 2 files changed, 131 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration now blocks names using reserved identity prefixes, including names that normalize to those prefixes.
  * Added an audit capability to identify existing records with reserved-prefix identities without modifying them.

* **Bug Fixes**
  * Improved registration consistency by validating the canonical identifier derived from the agent’s display name or framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->