### PR TITLE
Task PATCH route rejects the agent registry JWT, so agents cannot edit card bodies/priority

### DIFF
--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -117,20 +117,141 @@ class TestAgentCanDriveOwnBoard:
         assert resp.status_code == 200
         assert resp.json()["id"] == tid
 
-    async def test_patch_task_is_session_only(self, ctx):
-        """PATCH free-mutates task fields (title/assignee_id/parent), broader than
-        the project_tasks scope, so it is NOT on the agent allowlist: an agent
-        token is rejected. Lifecycle is driven via claim/close/reopen instead."""
+    async def test_lead_agent_patch_body_succeeds(self, ctx):
+        """An agent holding project_tasks may PATCH a card body on a board it
+        leads -> 200 and the change is reflected in the response."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"body": "revised body"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["body"] == "revised body"
+
+    async def test_lead_agent_patch_body_persists(self, ctx):
+        """The patched body survives a fresh read."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"body": "persisted body"},
+                headers=_hdr(token),
+            )
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/{tid}", headers=_hdr(token)
+            )
+        assert resp.status_code == 200
+        assert resp.json()["body"] == "persisted body"
+
+    async def test_lead_agent_patch_priority_succeeds(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"priority": 7},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["priority"] == 7
+
+    async def test_lead_agent_patch_labels_succeeds(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"labels": ["bug", "urgent"]},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["labels"] == ["bug", "urgent"]
+
+    async def test_lead_agent_patch_title_succeeds(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"title": "renamed by agent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["title"] == "renamed by agent"
+
+    async def test_agent_patch_assignee_id_rejected(self, ctx):
+        """assignee_id stays human-only: an agent PATCH of it -> 403."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"assignee_id": "someone-else"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+    async def test_agent_patch_parent_task_id_rejected(self, ctx):
+        """parent_task_id stays human-only: an agent PATCH of it -> 403."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"parent_task_id": "some-parent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+    async def test_non_lead_agent_patch_rejected(self, ctx):
+        """An agent that neither created nor leads the project cannot PATCH
+        its cards -> 403."""
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
         _cid, token = await _mint_agent(ctx, pid)
         async with _bare(ctx.app) as bare:
             resp = await bare.patch(
                 f"/api/projects/{pid}/tasks/{tid}",
-                json={"priority": 5},
+                json={"body": "hacked"},
                 headers=_hdr(token),
             )
-        assert resp.status_code in (401, 403, 404)
+        assert resp.status_code == 403
+
+    async def test_admin_patch_assignee_id_unchanged(self, ctx):
+        """Human session path unchanged: admin may still patch assignee_id."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        resp = await ctx.client.patch(
+            f"/api/projects/{pid}/tasks/{tid}",
+            json={"assignee_id": "worker-1"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["assignee_id"] == "worker-1"
 
     async def test_claim_own_task_as_self(self, ctx):
         pid = await _new_project(ctx, "alpha")

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -74,12 +74,12 @@ _AGENT_TASK_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
-    # PATCH (free task-field mutation) was intentionally NOT here: it is broader
-    # than the "read + lifecycle + comments" the project_tasks scope documents.
-    # It is now reachable by a project_tasks_update-bound agent token, but the
-    # route enforces the narrower scope + authorship/lead gate + a field
-    # whitelist (title, body, labels, status, priority) before any mutation, so
-    # a project_tasks worker still cannot rewrite fields it was never meant to.
+    # PATCH (task field mutation) is reachable by a project_tasks-bound agent
+    # token (the same scope the claim/close/release lifecycle routes use). The
+    # route enforces an authorship/lead gate + a field whitelist (title, body,
+    # labels, priority) before any mutation, so a project_tasks worker can amend
+    # its own cards or those it leads, but cannot reassign assignee_id or
+    # rewire parent_task_id (human-only fields).
     ("PATCH", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
     # Mark-claimable curation: reachable by a Bearer token, but the handler
     # (_authorize_project_lead) then restricts it to THIS project's LEAD agent --

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -769,11 +769,11 @@ async def get_task(
     return t
 
 
-# Fields an agent holding project_tasks_update may PATCH. Everything else in
-# UpdateTaskIn (assignee_id, parent_task_id, element_id, and any future field)
-# is rejected 400 for agents so the surface stays minimal and future task
-# fields are protected by default. Session owner/admin is unaffected.
-_AGENT_EDITABLE_FIELDS = frozenset({"title", "body", "labels", "status", "priority"})
+# Fields an agent holding project_tasks may PATCH. Everything else in
+# UpdateTaskIn (assignee_id, parent_task_id, element_id, status, and any
+# future field) is rejected 403 for agents so the surface stays minimal and
+# future task fields are protected by default. Session owner/admin is unaffected.
+_AGENT_EDITABLE_FIELDS = frozenset({"title", "body", "labels", "priority"})
 
 
 @router.patch("/api/projects/{project_id}/tasks/{task_id}")
@@ -783,12 +783,13 @@ async def update_task(
     payload: UpdateTaskIn,
     request: Request,
 ):
-    # Dual-auth: session owner/admin OR an agent holding project_tasks_update
-    # bound to THIS project. The agent gate (authorship/lead) and field
-    # whitelist are enforced below.
+    # Dual-auth: session owner/admin OR an agent holding project_tasks bound
+    # to THIS project (the same scope the claim/close/release lifecycle routes
+    # require). The agent gate (authorship/lead) and field whitelist are
+    # enforced below.
     pstore = request.app.state.project_store
     auth = await _authorize_task_actor(
-        request, pstore, project_id, scope="project_tasks_update"
+        request, pstore, project_id, scope="project_tasks"
     )
     if isinstance(auth, JSONResponse):
         return auth
@@ -810,14 +811,17 @@ async def update_task(
                 status_code=403,
             )
 
-    # Field whitelist for agents: title, body, labels, status, priority ONLY.
-    # Any other field that is set is rejected 400 (future fields included).
+    # Field whitelist for agents: title, body, labels, priority ONLY.
+    # Any other field that is set is rejected 403 (future fields included)
+    # so the surface stays minimal and future task fields are protected by
+    # default. assignee_id and parent_task_id stay human-only: an agent may
+    # not reassign work to itself or rewire hierarchies.
     if is_agent:
         for f in payload.model_fields:
             if f not in _AGENT_EDITABLE_FIELDS and getattr(payload, f) is not None:
                 return JSONResponse(
                     {"error": f"field {f!r} is not editable by agents"},
-                    status_code=400,
+                    status_code=403,
                 )
 
     if payload.parent_task_id is not None:
@@ -912,10 +916,10 @@ async def mark_task_claimable(
 
     LEAD-only curation: a project LEAD (session owner/admin, or the lead agent's
     ``project_tasks`` token) flags which cards the build fleet may pick up. This
-    is deliberately narrower than PATCH ``update_task`` (which stays session-only
-    per #1774): it touches ONLY the ``claimable`` label and preserves every other
-    label, so granting it to the lead agent does not widen the ``project_tasks``
-    scope into free field edits.
+    is deliberately narrower than PATCH ``update_task``: it toggles ONLY the
+    ``claimable`` label and preserves every other label, so granting it to the
+    lead agent does not widen the ``project_tasks`` scope beyond a single-label
+    toggle.
     """
     pstore = request.app.state.project_store
     auth = await _authorize_project_lead(request, pstore, project_id)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Task PATCH route rejects the agent registry JWT, so agents cannot edit card bodies/priority

Autonomous build of board card tsk-2bkd56.



Files:
 tests/test_routes_projects_agent_tasks.py | 133 ++++++++++++++++++++++++++++--
 tinyagentos/auth_middleware.py            |  12 +--
 tinyagentos/routes/projects.py            |  36 ++++----
 3 files changed, 153 insertions(+), 28 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Project task agents can update task titles, descriptions, labels, and priorities when authorized.
  * Task status and other restricted fields remain protected from agent edits.
  * Unauthorized or unsupported field changes now return a consistent forbidden response.
  * Project leads retain broader task-editing capabilities, while assignee and parent-task restrictions remain enforced.
  * Claimable-task updates remain limited to toggling the `claimable` label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->