### PR TITLE
Fold tsk-2bkd56: lead card-edit via project_tasks_update, not scope collapse (PR 2240 remainder)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Added
+
+- Lead agents can edit their own board cards: the seeded internal lead now
+  carries the `project_tasks_update` scope (title/body/labels/priority on
+  own-or-lead cards; a plain `project_tasks` grant still gets 403 on PATCH,
+  pinned by a regression test) (#2244).
+
 ## [1.0.0-beta.45] - 2026-08-02
 
 ### Added

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -196,6 +196,11 @@ The surface, by scope:
 - **project_tasks_create**: `POST /api/projects/{pid}/tasks` (author new cards).
   This is a SEPARATE scope from project_tasks and is off by default; grant it
   explicitly when an agent needs to create cards.
+- **project_tasks_update**: `PATCH /api/projects/{pid}/tasks/{tid}` on the
+  whitelisted fields (title, body, labels, priority), own-or-lead cards only.
+  Also SEPARATE from project_tasks - a plain project_tasks token gets 403 on
+  PATCH. The seeded internal lead (@taOS-dev) carries it by default so it can
+  edit its own board's cards; assignee_id and parent_task_id stay human-only.
 - **canvas_read**: `GET .../canvas/elements`, `.../canvas/watch-projection`,
   `.../canvas/snapshot.png|.tldr`, `.../canvas/stream`. **canvas_write**: `POST .../canvas/elements`,
   `PATCH|DELETE .../canvas/elements/{id}`.

--- a/tests/test_agent_internal_mint.py
+++ b/tests/test_agent_internal_mint.py
@@ -344,18 +344,22 @@ class TestMintInternalRoute:
             assert s["created"] is True
             assert s["token"]
             if s["handle"] == "@taOS-dev":
-                # Lead curator: gets project_tasks + canvas on prj-5y722y
-                # in addition to the baseline a2a scopes (#1968 C1).
+                # Lead curator: gets project_tasks + project_tasks_update +
+                # canvas on prj-5y722y in addition to the baseline a2a scopes
+                # (#1968 C1). project_tasks_update is what authorizes PATCH
+                # field mutation on the lead's own board (tsk-b6ugu5).
                 assert set(s["scopes"]) == {
                     "a2a_send", "a2a_receive",
-                    "project_tasks", "canvas_read", "canvas_write",
+                    "project_tasks", "project_tasks_update",
+                    "canvas_read", "canvas_write",
                 }
                 # Grants should be project-scoped.
                 grants = await mint_client._app.state.agent_grants.list_grants(
                     s["canonical_id"]
                 )
                 for g in grants:
-                    if g["scope"] in ("project_tasks", "canvas_read", "canvas_write"):
+                    if g["scope"] in ("project_tasks", "project_tasks_update",
+                                      "canvas_read", "canvas_write"):
                         assert g.get("project_id") == "prj-5y722y", (
                             f"scope {g['scope']!r} not bound to prj-5y722y"
                         )
@@ -370,6 +374,32 @@ class TestMintInternalRoute:
         rows = await mint_client._app.state.agent_registry.list_all()
         internal = [r for r in rows if r["origin"] == "taos-internal"]
         assert len(internal) == 4
+
+    async def test_seed_internal_reseed_reasserts_lead_grant(self, mint_client):
+        """seed-internal is idempotent per handle: re-seeding an EXISTING lead
+        identity does not create a duplicate row, and re-asserts the lead's
+        grants (add_grant is idempotent). After a second seed, @taOS-dev must
+        still hold project_tasks_update bound to prj-5y722y (tsk-b6ugu5)."""
+        r1 = await mint_client.post("/api/agents/registry/seed-internal")
+        assert r1.status_code == 200, r1.text
+        lead1 = next(s for s in r1.json()["seeded"] if s["handle"] == "@taOS-dev")
+        cid = lead1["canonical_id"]
+
+        # Re-seed: same canonical_id, created=False.
+        r2 = await mint_client.post("/api/agents/registry/seed-internal")
+        assert r2.status_code == 200
+        lead2 = next(s for s in r2.json()["seeded"] if s["handle"] == "@taOS-dev")
+        assert lead2["canonical_id"] == cid
+        assert lead2["created"] is False
+
+        # The project_tasks_update grant survives re-seed (re-asserted by add_grant).
+        grants = await mint_client._app.state.agent_grants.list_grants(cid)
+        scopes = {g["scope"] for g in grants}
+        assert "project_tasks_update" in scopes
+        update_grant = next(
+            g for g in grants if g["scope"] == "project_tasks_update"
+        )
+        assert update_grant.get("project_id") == "prj-5y722y"
 
     async def test_minted_token_reads_the_bus(self, mint_client):
         """End to end: a token from seed-internal reads the A2A bus (a2a_receive)."""

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -13,6 +13,9 @@ the five non-negotiable security invariants:
   4. Session owner/admin behavior is unchanged (regression).
   5. The token is not a skeleton key: it authenticates no route off the
      allowlist.
+
+PATCH field mutation (title/body/labels/priority) is gated by the NARROWER
+project_tasks_update scope, not the read+lifecycle project_tasks scope (tsk-b6ugu5).
 """
 from __future__ import annotations
 
@@ -118,11 +121,11 @@ class TestAgentCanDriveOwnBoard:
         assert resp.json()["id"] == tid
 
     async def test_lead_agent_patch_body_succeeds(self, ctx):
-        """An agent holding project_tasks may PATCH a card body on a board it
-        leads -> 200 and the change is reflected in the response."""
+        """An agent holding project_tasks_update may PATCH a card body on a board
+        it leads -> 200 and the change is reflected in the response."""
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:
@@ -138,7 +141,9 @@ class TestAgentCanDriveOwnBoard:
         """The patched body survives a fresh read."""
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(
+            ctx, pid, scopes=("project_tasks", "project_tasks_update")
+        )
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:
@@ -156,7 +161,7 @@ class TestAgentCanDriveOwnBoard:
     async def test_lead_agent_patch_priority_succeeds(self, ctx):
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:
@@ -171,7 +176,7 @@ class TestAgentCanDriveOwnBoard:
     async def test_lead_agent_patch_labels_succeeds(self, ctx):
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:
@@ -186,7 +191,7 @@ class TestAgentCanDriveOwnBoard:
     async def test_lead_agent_patch_title_succeeds(self, ctx):
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:
@@ -202,7 +207,7 @@ class TestAgentCanDriveOwnBoard:
         """assignee_id stays human-only: an agent PATCH of it -> 403."""
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:
@@ -217,7 +222,7 @@ class TestAgentCanDriveOwnBoard:
         """parent_task_id stays human-only: an agent PATCH of it -> 403."""
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:
@@ -233,11 +238,31 @@ class TestAgentCanDriveOwnBoard:
         its cards -> 403."""
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
-        _cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks_update",))
         async with _bare(ctx.app) as bare:
             resp = await bare.patch(
                 f"/api/projects/{pid}/tasks/{tid}",
                 json={"body": "hacked"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+    async def test_project_tasks_only_token_cannot_patch(self, ctx):
+        """Regression pin (tsk-b6ugu5): a plain project_tasks grant (read +
+        lifecycle + comments) must NOT authorize PATCH field mutation -- that
+        requires the narrower project_tasks_update scope. A lead agent carrying
+        only project_tasks must be refused 403, not allowed to edit card
+        bodies/priority. This fails RED against the PR 2240 branch (which
+        collapsed the PATCH scope to project_tasks) and passes after the fix."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid, scopes=("project_tasks",))
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"body": "hacked by read-only token"},
                 headers=_hdr(token),
             )
         assert resp.status_code == 403
@@ -582,7 +607,7 @@ class TestLeadAgentMarkClaimable:
     async def test_lead_agent_marks_and_unmarks_claimable(self, ctx):
         pid = await _new_project(ctx, "claimable-lead")
         tid = await _new_task(ctx, pid)
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)  # project_tasks (claimable route scope)
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:
@@ -619,7 +644,7 @@ class TestLeadAgentMarkClaimable:
         await ctx.client.patch(
             f"/api/projects/{pid}/tasks/{tid}", json={"labels": ["urgent"]}
         )
-        cid, token = await _mint_agent(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)  # project_tasks (claimable route scope)
         await ctx.app.state.project_store.add_member(pid, cid, "native")
         await ctx.app.state.project_store.set_lead(pid, cid)
         async with _bare(ctx.app) as bare:

--- a/tests/test_routes_projects_agent_tasks.py
+++ b/tests/test_routes_projects_agent_tasks.py
@@ -117,20 +117,141 @@ class TestAgentCanDriveOwnBoard:
         assert resp.status_code == 200
         assert resp.json()["id"] == tid
 
-    async def test_patch_task_is_session_only(self, ctx):
-        """PATCH free-mutates task fields (title/assignee_id/parent), broader than
-        the project_tasks scope, so it is NOT on the agent allowlist: an agent
-        token is rejected. Lifecycle is driven via claim/close/reopen instead."""
+    async def test_lead_agent_patch_body_succeeds(self, ctx):
+        """An agent holding project_tasks may PATCH a card body on a board it
+        leads -> 200 and the change is reflected in the response."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"body": "revised body"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["body"] == "revised body"
+
+    async def test_lead_agent_patch_body_persists(self, ctx):
+        """The patched body survives a fresh read."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"body": "persisted body"},
+                headers=_hdr(token),
+            )
+            resp = await bare.get(
+                f"/api/projects/{pid}/tasks/{tid}", headers=_hdr(token)
+            )
+        assert resp.status_code == 200
+        assert resp.json()["body"] == "persisted body"
+
+    async def test_lead_agent_patch_priority_succeeds(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"priority": 7},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["priority"] == 7
+
+    async def test_lead_agent_patch_labels_succeeds(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"labels": ["bug", "urgent"]},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["labels"] == ["bug", "urgent"]
+
+    async def test_lead_agent_patch_title_succeeds(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"title": "renamed by agent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["title"] == "renamed by agent"
+
+    async def test_agent_patch_assignee_id_rejected(self, ctx):
+        """assignee_id stays human-only: an agent PATCH of it -> 403."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"assignee_id": "someone-else"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+    async def test_agent_patch_parent_task_id_rejected(self, ctx):
+        """parent_task_id stays human-only: an agent PATCH of it -> 403."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        cid, token = await _mint_agent(ctx, pid)
+        await ctx.app.state.project_store.add_member(pid, cid, "native")
+        await ctx.app.state.project_store.set_lead(pid, cid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/tasks/{tid}",
+                json={"parent_task_id": "some-parent"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 403
+
+    async def test_non_lead_agent_patch_rejected(self, ctx):
+        """An agent that neither created nor leads the project cannot PATCH
+        its cards -> 403."""
         pid = await _new_project(ctx, "alpha")
         tid = await _new_task(ctx, pid)
         _cid, token = await _mint_agent(ctx, pid)
         async with _bare(ctx.app) as bare:
             resp = await bare.patch(
                 f"/api/projects/{pid}/tasks/{tid}",
-                json={"priority": 5},
+                json={"body": "hacked"},
                 headers=_hdr(token),
             )
-        assert resp.status_code in (401, 403, 404)
+        assert resp.status_code == 403
+
+    async def test_admin_patch_assignee_id_unchanged(self, ctx):
+        """Human session path unchanged: admin may still patch assignee_id."""
+        pid = await _new_project(ctx, "alpha")
+        tid = await _new_task(ctx, pid)
+        resp = await ctx.client.patch(
+            f"/api/projects/{pid}/tasks/{tid}",
+            json={"assignee_id": "worker-1"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["assignee_id"] == "worker-1"
 
     async def test_claim_own_task_as_self(self, ctx):
         pid = await _new_project(ctx, "alpha")

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -74,12 +74,12 @@ _AGENT_TASK_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
-    # PATCH (free task-field mutation) was intentionally NOT here: it is broader
-    # than the "read + lifecycle + comments" the project_tasks scope documents.
-    # It is now reachable by a project_tasks_update-bound agent token, but the
-    # route enforces the narrower scope + authorship/lead gate + a field
-    # whitelist (title, body, labels, status, priority) before any mutation, so
-    # a project_tasks worker still cannot rewrite fields it was never meant to.
+    # PATCH (task field mutation) is reachable by a project_tasks-bound agent
+    # token (the same scope the claim/close/release lifecycle routes use). The
+    # route enforces an authorship/lead gate + a field whitelist (title, body,
+    # labels, priority) before any mutation, so a project_tasks worker can amend
+    # its own cards or those it leads, but cannot reassign assignee_id or
+    # rewire parent_task_id (human-only fields).
     ("PATCH", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
     # Mark-claimable curation: reachable by a Bearer token, but the handler
     # (_authorize_project_lead) then restricts it to THIS project's LEAD agent --

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -74,12 +74,12 @@ _AGENT_TASK_ROUTES = (
     ("GET", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/comments$")),
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/(claim|release|close|reopen)$")),
-    # PATCH (task field mutation) is reachable by a project_tasks-bound agent
-    # token (the same scope the claim/close/release lifecycle routes use). The
-    # route enforces an authorship/lead gate + a field whitelist (title, body,
-    # labels, priority) before any mutation, so a project_tasks worker can amend
-    # its own cards or those it leads, but cannot reassign assignee_id or
-    # rewire parent_task_id (human-only fields).
+    # PATCH (free task-field mutation) was intentionally NOT here: it is broader
+    # than the "read + lifecycle + comments" the project_tasks scope documents.
+    # It is now reachable by a project_tasks_update-bound agent token, but the
+    # route enforces the narrower scope + authorship/lead gate + a field
+    # whitelist (title, body, labels, priority) before any mutation, so
+    # a project_tasks worker still cannot rewrite fields it was never meant to.
     ("PATCH", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}$")),
     # Mark-claimable curation: reachable by a Bearer token, but the handler
     # (_authorize_project_lead) then restricts it to THIS project's LEAD agent --

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -178,13 +178,15 @@ _INTERNAL_AGENTS = (
     {
         "handle": "@taOS-dev",
         "slug": "taos-dev",
-        # Lead curator: needs project-task + canvas access on the build fleet project
-        # so it can curate the board (mark cards claimable) and read/write the
-        # project canvas — all via Bearer auth (CSRF-exempt).  Bound to prj-5y722y
-        # (the fleet project) per #1968 C1.
+        # Lead curator: needs project_tasks + project_tasks_update + canvas
+        # access on the build fleet project so it can curate the board (mark
+        # cards claimable) and read/write the project canvas -- all via Bearer
+        # auth (CSRF-exempt). project_tasks_update is required to PATCH card
+        # bodies/priority (project_tasks alone is read + lifecycle + comments).
+        # Bound to prj-5y722y (the fleet project) per #1968 C1.
         "scopes": [
             "a2a_send", "a2a_receive",
-            "project_tasks", "canvas_read", "canvas_write",
+            "project_tasks", "project_tasks_update", "canvas_read", "canvas_write",
         ],
         "project_id": "prj-5y722y",
     },
@@ -411,15 +413,16 @@ async def seed_internal_agents(
 ):
     """Idempotently mint the four internal driver agents and return their tokens.
 
-    Admin only.  Each of @taOS-dev, @taOS-website-dev, @taOSmd-dev, @Hermes is
-    minted with the a2a_send + a2a_receive scopes.  Re-running creates no
-    duplicate rows.  ``adopt`` (query param) is a comma-separated list of the
-    specific handles to vouch for when they already exist under a non-internal
-    origin (e.g. ``?adopt=@taOS-dev``); each adoption grants driver scopes and
-    a token to a pre-existing identity, so it must name each handle explicitly
-    rather than blanket-vouch for all four (a driver handle claimed by someone
-    else via the consent flow must not be adopted as a side effect).  A bare
-    ``adopt=true`` is rejected.  Response: {"seeded": [{handle, canonical_id,
+    Admin only.  Each of the four agents is minted with the baseline a2a_send +
+    a2a_receive scopes; @taOS-dev (the fleet lead) additionally receives
+    project_tasks + project_tasks_update + canvas_read + canvas_write bound to
+    prj-5y722y.  Re-running creates no duplicate rows.  ``adopt`` (query param)
+    is a comma-separated list of the specific handles to vouch for when they
+    already exist under a non-internal origin (e.g. ``?adopt=@taOS-dev``); each
+    adoption grants driver scopes and a token to a pre-existing identity, so it
+    must name each handle explicitly rather than blanket-vouch for all four (a
+    driver handle claimed by someone else via the consent flow must not be
+    adopted as a side effect).  Response: {"seeded": [{handle, canonical_id,
     created, adopted, scopes, token}, ...]}.
     """
     if not user.is_admin:

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -769,7 +769,7 @@ async def get_task(
     return t
 
 
-# Fields an agent holding project_tasks may PATCH. Everything else in
+# Fields an agent holding project_tasks_update may PATCH. Everything else in
 # UpdateTaskIn (assignee_id, parent_task_id, element_id, status, and any
 # future field) is rejected 403 for agents so the surface stays minimal and
 # future task fields are protected by default. Session owner/admin is unaffected.
@@ -783,13 +783,12 @@ async def update_task(
     payload: UpdateTaskIn,
     request: Request,
 ):
-    # Dual-auth: session owner/admin OR an agent holding project_tasks bound
-    # to THIS project (the same scope the claim/close/release lifecycle routes
-    # require). The agent gate (authorship/lead) and field whitelist are
-    # enforced below.
+    # Dual-auth: session owner/admin OR an agent holding project_tasks_update
+    # bound to THIS project. The agent gate (authorship/lead) and field
+    # whitelist are enforced below.
     pstore = request.app.state.project_store
     auth = await _authorize_task_actor(
-        request, pstore, project_id, scope="project_tasks"
+        request, pstore, project_id, scope="project_tasks_update"
     )
     if isinstance(auth, JSONResponse):
         return auth

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -769,11 +769,11 @@ async def get_task(
     return t
 
 
-# Fields an agent holding project_tasks_update may PATCH. Everything else in
-# UpdateTaskIn (assignee_id, parent_task_id, element_id, and any future field)
-# is rejected 400 for agents so the surface stays minimal and future task
-# fields are protected by default. Session owner/admin is unaffected.
-_AGENT_EDITABLE_FIELDS = frozenset({"title", "body", "labels", "status", "priority"})
+# Fields an agent holding project_tasks may PATCH. Everything else in
+# UpdateTaskIn (assignee_id, parent_task_id, element_id, status, and any
+# future field) is rejected 403 for agents so the surface stays minimal and
+# future task fields are protected by default. Session owner/admin is unaffected.
+_AGENT_EDITABLE_FIELDS = frozenset({"title", "body", "labels", "priority"})
 
 
 @router.patch("/api/projects/{project_id}/tasks/{task_id}")
@@ -783,12 +783,13 @@ async def update_task(
     payload: UpdateTaskIn,
     request: Request,
 ):
-    # Dual-auth: session owner/admin OR an agent holding project_tasks_update
-    # bound to THIS project. The agent gate (authorship/lead) and field
-    # whitelist are enforced below.
+    # Dual-auth: session owner/admin OR an agent holding project_tasks bound
+    # to THIS project (the same scope the claim/close/release lifecycle routes
+    # require). The agent gate (authorship/lead) and field whitelist are
+    # enforced below.
     pstore = request.app.state.project_store
     auth = await _authorize_task_actor(
-        request, pstore, project_id, scope="project_tasks_update"
+        request, pstore, project_id, scope="project_tasks"
     )
     if isinstance(auth, JSONResponse):
         return auth
@@ -810,14 +811,17 @@ async def update_task(
                 status_code=403,
             )
 
-    # Field whitelist for agents: title, body, labels, status, priority ONLY.
-    # Any other field that is set is rejected 400 (future fields included).
+    # Field whitelist for agents: title, body, labels, priority ONLY.
+    # Any other field that is set is rejected 403 (future fields included)
+    # so the surface stays minimal and future task fields are protected by
+    # default. assignee_id and parent_task_id stay human-only: an agent may
+    # not reassign work to itself or rewire hierarchies.
     if is_agent:
         for f in payload.model_fields:
             if f not in _AGENT_EDITABLE_FIELDS and getattr(payload, f) is not None:
                 return JSONResponse(
                     {"error": f"field {f!r} is not editable by agents"},
-                    status_code=400,
+                    status_code=403,
                 )
 
     if payload.parent_task_id is not None:
@@ -912,10 +916,10 @@ async def mark_task_claimable(
 
     LEAD-only curation: a project LEAD (session owner/admin, or the lead agent's
     ``project_tasks`` token) flags which cards the build fleet may pick up. This
-    is deliberately narrower than PATCH ``update_task`` (which stays session-only
-    per #1774): it touches ONLY the ``claimable`` label and preserves every other
-    label, so granting it to the lead agent does not widen the ``project_tasks``
-    scope into free field edits.
+    is deliberately narrower than PATCH ``update_task``: it toggles ONLY the
+    ``claimable`` label and preserves every other label, so granting it to the
+    lead agent does not widen the ``project_tasks`` scope beyond a single-label
+    toggle.
     """
     pstore = request.app.state.project_store
     auth = await _authorize_project_lead(request, pstore, project_id)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fold tsk-2bkd56: lead card-edit via project_tasks_update, not scope collapse (PR 2240 remainder)

Autonomous build of board card tsk-b6ugu5.



Files:
 pyproject.toml                            |   2 +-
 tests/test_agent_internal_mint.py         |  38 ++++++-
 tests/test_routes_projects_agent_tasks.py | 164 ++++++++++++++++++++++++++++--
 tinyagentos/__init__.py                   |   2 +-
 tinyagentos/auth_middleware.py            |   2 +-
 tinyagentos/routes/agent_registry.py      |  31 +++---
 tinyagentos/routes/projects.py            |  25 +++--
 9 files changed, 225 insertions(+), 118 deletions(-)

Removes-Intentionally: tests/test_routes_projects_agent_tasks.py:TestAgentCanDriveOwnBoard.test_patch_task_is_session_only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lead agents can update their own or lead-owned project cards.
  * Updates support card titles, descriptions, labels, and priority.
  * The seeded lead agent now includes the required project-scoped update access.

* **Bug Fixes**
  * Agents can no longer modify card status or other protected fields.
  * Unauthorized or unsupported updates now receive a clear permission response.

* **Documentation**
  * Documented the new access scope, ownership rules, permissions, and human-only fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->