### PR TITLE
Unit tests for base_store

### DIFF
--- a/tests/test_base_store.py
+++ b/tests/test_base_store.py
@@ -1,6 +1,7 @@
-"""Tests for BaseStore — init, schema, connection, close, migrations."""
+"""Tests for BaseStore -- init, schema, connection, close, migrations."""
 import aiosqlite
 import pytest
+import sqlite3
 
 from tinyagentos.base_store import BaseStore
 
@@ -149,5 +150,228 @@ class TestBaseStore:
             )
             versions = [row[0] for row in await cursor.fetchall()]
             assert 1 in versions
+        finally:
+            await store.close()
+
+
+# ---------------------------------------------------------------------------
+# CRUD coverage: BaseStore exposes no CRUD itself, so a concrete subclass with a
+# real schema is exercised end-to-end against a tmp_path database.  This pins
+# the BaseStore plumbing (init -> connection -> commit/rollback -> close) that
+# every CRUD subclass depends on, plus the per-row / owner-scoping semantics
+# those subclasses build on top of it.
+# ---------------------------------------------------------------------------
+
+_COLUMNS = ["id", "owner", "key", "value"]
+
+
+def _row_to_dict(row) -> dict | None:
+    return dict(zip(_COLUMNS, row)) if row is not None else None
+
+
+class CrudStore(BaseStore):
+    """Minimal concrete store exercising BaseStore's connection lifecycle."""
+
+    SCHEMA = """
+    CREATE TABLE IF NOT EXISTS items (
+        id    INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT,
+        key   TEXT NOT NULL,
+        value TEXT,
+        UNIQUE(owner, key)
+    );
+    """
+
+    async def create_item(self, owner: str | None, key: str, value: str) -> int:
+        cursor = await self._db.execute(
+            "INSERT INTO items (owner, key, value) VALUES (?, ?, ?)",
+            (owner, key, value),
+        )
+        await self._db.commit()
+        return cursor.lastrowid
+
+    async def get_item(self, item_id: int) -> dict | None:
+        cursor = await self._db.execute(
+            "SELECT id, owner, key, value FROM items WHERE id = ?", (item_id,)
+        )
+        return _row_to_dict(await cursor.fetchone())
+
+    async def list_items(self, owner: str | None = None) -> list[dict]:
+        if owner is None:
+            cursor = await self._db.execute(
+                "SELECT id, owner, key, value FROM items ORDER BY id"
+            )
+        else:
+            cursor = await self._db.execute(
+                "SELECT id, owner, key, value FROM items WHERE owner = ? ORDER BY id",
+                (owner,),
+            )
+        return [_row_to_dict(row) for row in await cursor.fetchall()]
+
+    async def update_item(self, item_id: int, value: str) -> int:
+        cursor = await self._db.execute(
+            "UPDATE items SET value = ? WHERE id = ?", (value, item_id)
+        )
+        await self._db.commit()
+        return cursor.rowcount
+
+    async def delete_item(self, item_id: int) -> int:
+        cursor = await self._db.execute(
+            "DELETE FROM items WHERE id = ?", (item_id,)
+        )
+        await self._db.commit()
+        return cursor.rowcount
+
+
+@pytest.mark.asyncio
+class TestCrudStore:
+
+    async def _make_store(self, tmp_path) -> CrudStore:
+        store = CrudStore(tmp_path / "crud.db")
+        await store.init()
+        return store
+
+    async def test_create_returns_id_and_persists_row(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            item_id = await store.create_item("alice", "k1", "v1")
+            assert item_id == 1
+            row = await store.get_item(item_id)
+            assert row == {"id": 1, "owner": "alice", "key": "k1", "value": "v1"}
+        finally:
+            await store.close()
+
+    async def test_create_assigns_increasing_ids(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            first = await store.create_item("alice", "k1", "v1")
+            second = await store.create_item("bob", "k2", "v2")
+            assert second == first + 1
+        finally:
+            await store.close()
+
+    async def test_read_missing_id_returns_none(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            assert await store.get_item(999) is None
+        finally:
+            await store.close()
+
+    async def test_empty_list_returns_empty(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            assert await store.list_items() == []
+            assert await store.list_items("alice") == []
+        finally:
+            await store.close()
+
+    async def test_update_modifies_value_and_returns_rowcount(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            item_id = await store.create_item("alice", "k1", "v1")
+            affected = await store.update_item(item_id, "v2")
+            assert affected == 1
+            row = await store.get_item(item_id)
+            assert row["value"] == "v2"
+            assert row["key"] == "k1"
+        finally:
+            await store.close()
+
+    async def test_update_missing_id_affects_zero_rows(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            affected = await store.update_item(999, "v")
+            assert affected == 0
+            assert await store.get_item(999) is None
+        finally:
+            await store.close()
+
+    async def test_delete_removes_row_and_returns_rowcount(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            item_id = await store.create_item("alice", "k1", "v1")
+            affected = await store.delete_item(item_id)
+            assert affected == 1
+            assert await store.get_item(item_id) is None
+            assert await store.list_items() == []
+        finally:
+            await store.close()
+
+    async def test_delete_missing_id_affects_zero_rows(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            affected = await store.delete_item(999)
+            assert affected == 0
+            assert await store.get_item(999) is None
+        finally:
+            await store.close()
+
+    async def test_duplicate_owner_key_raises_integrity(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            await store.create_item("alice", "k1", "v1")
+            with pytest.raises(sqlite3.IntegrityError):
+                await store.create_item("alice", "k1", "v2")
+            # The failed insert must leave no partial row; the original survives.
+            await store._db.rollback()
+            rows = await store.list_items()
+            assert len(rows) == 1
+            assert rows[0]["value"] == "v1"
+        finally:
+            await store.close()
+
+    async def test_duplicate_key_allowed_across_owners(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            alice_id = await store.create_item("alice", "k1", "v1")
+            bob_id = await store.create_item("bob", "k1", "v2")
+            assert bob_id != alice_id
+            rows = await store.list_items()
+            assert len(rows) == 2
+            values_by_owner = {r["owner"]: r["value"] for r in rows}
+            assert values_by_owner == {"alice": "v1", "bob": "v2"}
+        finally:
+            await store.close()
+
+    async def test_scoping_by_owner_isolates_rows(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            await store.create_item("alice", "a1", "1")
+            await store.create_item("alice", "a2", "2")
+            await store.create_item("bob", "b1", "3")
+            alice = await store.list_items("alice")
+            assert [r["key"] for r in alice] == ["a1", "a2"]
+            bob = await store.list_items("bob")
+            assert [r["key"] for r in bob] == ["b1"]
+            all_rows = await store.list_items()
+            assert len(all_rows) == 3
+        finally:
+            await store.close()
+
+    async def test_delete_is_scoped_by_id_not_owner(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            alice_id = await store.create_item("alice", "a1", "1")
+            bob_id = await store.create_item("bob", "b1", "3")
+            affected = await store.delete_item(alice_id)
+            assert affected == 1
+            assert await store.get_item(alice_id) is None
+            # Bob's row must be untouched by alice's delete.
+            bob_row = await store.get_item(bob_id)
+            assert bob_row is not None
+            assert bob_row["owner"] == "bob"
+            assert len(await store.list_items()) == 1
+        finally:
+            await store.close()
+
+    async def test_update_is_scoped_by_id_not_owner(self, tmp_path):
+        store = await self._make_store(tmp_path)
+        try:
+            alice_id = await store.create_item("alice", "a1", "1")
+            bob_id = await store.create_item("bob", "b1", "3")
+            affected = await store.update_item(alice_id, "updated")
+            assert affected == 1
+            assert (await store.get_item(bob_id))["value"] == "3"
+            assert (await store.get_item(alice_id))["value"] == "updated"
         finally:
             await store.close()


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Unit tests for base_store

Autonomous build of board card tsk-k44oda.



Files:
 tests/test_base_store.py | 226 ++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 225 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive end-to-end coverage for creating, reading, listing, updating, and deleting stored items.
  - Verified persistence, generated IDs, missing records, row counts, owner filtering, uniqueness constraints, rollback behavior, and ID-scoped operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->