### PR TITLE
Lists store hardening: list-scoped reorder + atomic position allocation

### DIFF
--- a/tests/projects/test_lists_store.py
+++ b/tests/projects/test_lists_store.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 
 import pytest
@@ -168,6 +169,7 @@ async def test_reorder_entries(entries_store):
     )
     await entries_store.reorder_entries(
         project_id="prj-1",
+        list_id="lst-1",
         entries=[
             {"id": c["id"], "position": 0},
             {"id": a["id"], "position": 1},
@@ -250,3 +252,73 @@ async def test_add_entries_without_positions_gets_ascending(entries_store):
     assert positions == [0, 1, 2], (
         f"Expected [0, 1, 2] but got {positions}"
     )
+
+
+@pytest.mark.asyncio
+async def test_reorder_entries_does_not_corrupt_sibling_list(entries_store):
+    """A reorder scoped to one list must not reposition an entry that belongs
+    to a different list in the same project, and must signal the mismatch."""
+    a = await entries_store.add_entry(
+        list_id="lst-A",
+        project_id="prj-1",
+        text="A",
+        original_text="A",
+        author_kind="agent",
+        author_id="agent-1",
+        position=0,
+    )
+    b = await entries_store.add_entry(
+        list_id="lst-B",
+        project_id="prj-1",
+        text="B",
+        original_text="B",
+        author_kind="agent",
+        author_id="agent-1",
+        position=0,
+    )
+
+    result = await entries_store.reorder_entries(
+        project_id="prj-1",
+        list_id="lst-A",
+        entries=[{"id": b["id"], "position": 99}],
+    )
+
+    b_after = await entries_store.get_entry(b["id"])
+    assert b_after["position"] == 0, "sibling-list entry must not be moved"
+    assert result is False, "reorder should signal that id does not belong to list"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_add_entry_distinct_positions(entries_store, monkeypatch):
+    """Two concurrent add_entry calls without explicit positions must not
+    persist duplicate positions."""
+    original = entries_store._get_next_position
+
+    async def slow_next_position(project_id, list_id):
+        val = await original(project_id, list_id)
+        await asyncio.sleep(0)
+        return val
+
+    monkeypatch.setattr(entries_store, "_get_next_position", slow_next_position)
+
+    e1, e2 = await asyncio.gather(
+        entries_store.add_entry(
+            list_id="lst-1",
+            project_id="prj-1",
+            text="First",
+            original_text="First",
+            author_kind="agent",
+            author_id="agent-1",
+        ),
+        entries_store.add_entry(
+            list_id="lst-1",
+            project_id="prj-1",
+            text="Second",
+            original_text="Second",
+            author_kind="agent",
+            author_id="agent-1",
+        ),
+    )
+
+    positions = {e1["position"], e2["position"]}
+    assert len(positions) == 2, f"expected distinct positions, got {positions}"

--- a/tests/projects/test_lists_store.py
+++ b/tests/projects/test_lists_store.py
@@ -280,10 +280,15 @@ async def test_reorder_entries_does_not_corrupt_sibling_list(entries_store):
     result = await entries_store.reorder_entries(
         project_id="prj-1",
         list_id="lst-A",
-        entries=[{"id": b["id"], "position": 99}],
+        entries=[
+            {"id": a["id"], "position": 5},
+            {"id": b["id"], "position": 99},
+        ],
     )
 
+    a_after = await entries_store.get_entry(a["id"])
     b_after = await entries_store.get_entry(b["id"])
+    assert a_after["position"] == 0, "valid update before the mismatch must be rolled back"
     assert b_after["position"] == 0, "sibling-list entry must not be moved"
     assert result is False, "reorder should signal that id does not belong to list"
 

--- a/tinyagentos/projects/lists_store.py
+++ b/tinyagentos/projects/lists_store.py
@@ -138,17 +138,32 @@ class ProjectListEntriesStore(BaseStore):
         entry_id = new_id("ent")
         now = time.time()
 
-        await self._db.execute(
-            "INSERT INTO project_list_entries "
-            "(id, list_id, project_id, text, original_text, category, status, "
-            "done, author_kind, author_id, position, created_at, updated_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                entry_id, list_id, project_id, text, original_text,
-                category, "new", 0, author_kind, author_id,
-                position if position is not None else await self._get_next_position(project_id, list_id), now, now,
-            ),
-        )
+        if position is not None:
+            await self._db.execute(
+                "INSERT INTO project_list_entries "
+                "(id, list_id, project_id, text, original_text, category, status, "
+                "done, author_kind, author_id, position, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    entry_id, list_id, project_id, text, original_text,
+                    category, "new", 0, author_kind, author_id,
+                    position, now, now,
+                ),
+            )
+        else:
+            await self._db.execute(
+                "INSERT INTO project_list_entries "
+                "(id, list_id, project_id, text, original_text, category, status, "
+                "done, author_kind, author_id, position, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, "
+                "COALESCE((SELECT MAX(position) + 1 FROM project_list_entries "
+                "WHERE list_id = ? AND project_id = ?), 0), ?, ?)",
+                (
+                    entry_id, list_id, project_id, text, original_text,
+                    category, "new", 0, author_kind, author_id,
+                    list_id, project_id, now, now,
+                ),
+            )
         await self._db.commit()
         return await self.get_entry(entry_id)
 
@@ -243,14 +258,18 @@ class ProjectListEntriesStore(BaseStore):
         await self._db.commit()
         return cursor.rowcount == 1
 
-    async def reorder_entries(self, project_id: str, entries: list[dict]) -> None:
+    async def reorder_entries(self, project_id: str, list_id: str, entries: list[dict]) -> bool:
         for entry in entries:
-            await self._db.execute(
+            cursor = await self._db.execute(
                 "UPDATE project_list_entries SET position = ?, updated_at = ? "
-                "WHERE id = ? AND project_id = ?",
-                (entry["position"], time.time(), entry["id"], project_id),
+                "WHERE id = ? AND project_id = ? AND list_id = ?",
+                (entry["position"], time.time(), entry["id"], project_id, list_id),
             )
+            if cursor.rowcount == 0:
+                await self._db.rollback()
+                return False
         await self._db.commit()
+        return True
 
     async def _get_next_position(self, project_id: str, list_id: str) -> int:
         async with self._db.execute(


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Lists store hardening: list-scoped reorder + atomic position allocation

Autonomous build of board card tsk-237k2v.

reorder_entries now requires list_id, scopes UPDATE by list_id,
and returns False (rolling back) when any supplied entry id does
not belong to that list, preventing silent corruption of sibling
lists in the same project.

add_entry allocates position atomically inside the INSERT via
COALESCE((SELECT MAX(position)+1 ...), 0) when position is None,
eliminating the concurrent-duplicate-position race that occurred
when MAX(position)+1 was read in a separate query.

Files:
 tests/projects/test_lists_store.py  | 72 +++++++++++++++++++++++++++++++++++++
 tinyagentos/projects/lists_store.py | 49 +++++++++++++++++--------
 2 files changed, 106 insertions(+), 15 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reordering entries is now limited to the selected list, preventing changes to entries in other lists.
  * Reordering safely rolls back when an invalid entry is provided.
  * Concurrently added entries now receive distinct positions.

* **Improvements**
  * Entries added without an explicit position are automatically placed at the end of their list.
  * Reordering now reports whether the operation succeeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->