### PR TITLE
Deploy route registers deployed agents into agent_registry (dec-h3jlcy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 - Observatory fleet view for agents holding a global `observatory_control`
   grant; project-scoped grants see only their granted projects (#2267).
+- Deployed agents are registered into the agent registry at deploy time, each
+  minting its own canonical identity; names that resolve to a reserved prefix
+  are rejected with a 400 (#2266).
 
 ### Added
 

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -620,6 +620,179 @@ class TestDeployPersistence:
 
 
 @pytest.mark.asyncio
+class TestDeployRegistryRegistration:
+    """Deploy endpoint must mint an agent_registry canonical_id on first deploy
+    and skip re-registration on redeploy / model swap."""
+
+    async def test_deploy_creates_registry_row(self, client, app, monkeypatch):
+        import re
+        import taosmd.agents as tm_agents
+        from unittest.mock import AsyncMock, MagicMock
+
+        app.state.archive = MagicMock(
+            record=AsyncMock(), query=AsyncMock(return_value=[{}])
+        )
+
+        register_calls = []
+        canonical_ids = []
+
+        async def fake_register(*, framework, display_name, **kw):
+            register_calls.append((framework, display_name))
+            cid = f"{display_name.lower().replace(' ', '-')}-20260101-000000"
+            canonical_ids.append(cid)
+            return {"canonical_id": cid, "framework": framework, "display_name": display_name}
+
+        mock_registry = MagicMock()
+        mock_registry.register = fake_register
+        mock_registry.get = AsyncMock(return_value=None)
+        app.state.agent_registry = mock_registry
+
+        def fake_register_agent(name, **kwargs):
+            pass
+        monkeypatch.setattr(tm_agents, "register_agent", fake_register_agent)
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        resp = await client.post("/api/agents/deploy", json={
+            "name": "RegistryTest",
+            "framework": "none",
+            "model": "test-model",
+        })
+        assert resp.status_code == 200
+        import asyncio
+        await asyncio.sleep(0.2)
+
+        assert len(register_calls) == 1
+        assert re.match(r"^[a-z0-9-]+-\d{8}-\d{6}(-\\d{2})?$", canonical_ids[0])
+        agent = next(a for a in app.state.config.agents if a["name"] == resp.json()["name"])
+        assert agent["registry_canonical_id"] == canonical_ids[0]
+
+    async def test_redeploy_does_not_create_duplicate_registry_row(self, client, app, monkeypatch):
+        import taosmd.agents as tm_agents
+        from unittest.mock import AsyncMock, MagicMock
+
+        app.state.archive = MagicMock(
+            record=AsyncMock(), query=AsyncMock(return_value=[{}])
+        )
+
+        canonical_id = "registrytest-20260101-000000"
+        register_calls = []
+
+        async def fake_register(*, framework, display_name, **kw):
+            register_calls.append((framework, display_name))
+            return {"canonical_id": canonical_id, "framework": framework, "display_name": display_name}
+
+        mock_registry = MagicMock()
+        mock_registry.register = fake_register
+        mock_registry.get = AsyncMock(return_value={"canonical_id": canonical_id})
+        app.state.agent_registry = mock_registry
+
+        def fake_register_agent(name, **kwargs):
+            pass
+        monkeypatch.setattr(tm_agents, "register_agent", fake_register_agent)
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}]
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        resp1 = await client.post("/api/agents/deploy", json={
+            "name": "RegistryRedeploy",
+            "framework": "none",
+            "model": "test-model",
+        })
+        assert resp1.status_code == 200
+        import asyncio
+        await asyncio.sleep(0.2)
+
+        assert len(register_calls) == 1
+
+        resp2 = await client.post("/api/agents/deploy", json={
+            "name": "RegistryRedeploy",
+            "framework": "none",
+            "model": "test-model",
+        })
+        assert resp2.status_code == 200
+        await asyncio.sleep(0.2)
+
+        assert len(register_calls) == 1
+
+    async def test_model_swap_does_not_re_register(self, client, app, monkeypatch):
+        import taosmd.agents as tm_agents
+        from unittest.mock import AsyncMock, MagicMock
+
+        app.state.archive = MagicMock(
+            record=AsyncMock(), query=AsyncMock(return_value=[{}])
+        )
+
+        canonical_id = "registryswap-20260101-000000"
+        register_calls = []
+
+        async def fake_register(*, framework, display_name, **kw):
+            register_calls.append((framework, display_name))
+            return {"canonical_id": canonical_id, "framework": framework, "display_name": display_name}
+
+        mock_registry = MagicMock()
+        mock_registry.register = fake_register
+        mock_registry.get = AsyncMock(return_value={"canonical_id": canonical_id})
+        app.state.agent_registry = mock_registry
+
+        def fake_register_agent(name, **kwargs):
+            pass
+        monkeypatch.setattr(tm_agents, "register_agent", fake_register_agent)
+
+        async def fake_deploy(req):
+            return {"success": True, "name": req.name, "ip": "10.0.0.42",
+                    "llm_key": "sk-test", "steps": ["deployment_complete"],
+                    "container": f"taos-agent-{req.name}"}
+        monkeypatch.setattr("tinyagentos.deployer.deploy_agent", fake_deploy)
+
+        class _FakeCatalog:
+            def all_models(self, capability=None):
+                return [{"name": "test-model", "id": "test-model"}, {"name": "other-model", "id": "other-model"}]
+        app.state.backend_catalog = _FakeCatalog()
+        app.state.cluster_manager._workers.clear()
+
+        resp1 = await client.post("/api/agents/deploy", json={
+            "name": "RegistrySwap",
+            "framework": "none",
+            "model": "test-model",
+        })
+        assert resp1.status_code == 200
+        import asyncio
+        await asyncio.sleep(0.2)
+
+        assert len(register_calls) == 1
+
+        resp2 = await client.post("/api/agents/deploy", json={
+            "name": "RegistrySwap",
+            "framework": "none",
+            "model": "other-model",
+        })
+        assert resp2.status_code == 200
+        await asyncio.sleep(0.2)
+
+        assert len(register_calls) == 1
+
+
+@pytest.mark.asyncio
 class TestAgentArchiveLifecycle:
     async def test_archive_creates_snapshot_not_rename(self, client, monkeypatch):
         """DELETE /api/agents/{name} archives via snapshot; no rename called."""

--- a/tests/test_routes_agents.py
+++ b/tests/test_routes_agents.py
@@ -621,8 +621,9 @@ class TestDeployPersistence:
 
 @pytest.mark.asyncio
 class TestDeployRegistryRegistration:
-    """Deploy endpoint must mint an agent_registry canonical_id on first deploy
-    and skip re-registration on redeploy / model swap."""
+    """Deploy endpoint must mint a fresh agent_registry canonical_id for every
+    deployed agent - identities are minted once per agent and never shared,
+    even between agents with the same display name."""
 
     async def test_deploy_creates_registry_row(self, client, app, monkeypatch):
         import re
@@ -673,11 +674,14 @@ class TestDeployRegistryRegistration:
         await asyncio.sleep(0.2)
 
         assert len(register_calls) == 1
-        assert re.match(r"^[a-z0-9-]+-\d{8}-\d{6}(-\\d{2})?$", canonical_ids[0])
+        assert re.match(r"^[a-z0-9-]+-\d{8}-\d{6}(-[0-9a-f]{2})?$", canonical_ids[0])
         agent = next(a for a in app.state.config.agents if a["name"] == resp.json()["name"])
         assert agent["registry_canonical_id"] == canonical_ids[0]
 
-    async def test_redeploy_does_not_create_duplicate_registry_row(self, client, app, monkeypatch):
+    async def test_same_display_name_deploys_mint_distinct_identities(self, client, app, monkeypatch):
+        """Display names are not unique; a second deploy with the same name is
+        a NEW agent (suffixed slug) and must get its own canonical_id, never
+        inherit the first agent's identity."""
         import taosmd.agents as tm_agents
         from unittest.mock import AsyncMock, MagicMock
 
@@ -685,16 +689,20 @@ class TestDeployRegistryRegistration:
             record=AsyncMock(), query=AsyncMock(return_value=[{}])
         )
 
-        canonical_id = "registrytest-20260101-000000"
         register_calls = []
 
         async def fake_register(*, framework, display_name, **kw):
             register_calls.append((framework, display_name))
-            return {"canonical_id": canonical_id, "framework": framework, "display_name": display_name}
+            cid = f"registrytwin-20260101-{len(register_calls):06d}"
+            return {"canonical_id": cid, "framework": framework, "display_name": display_name}
 
         mock_registry = MagicMock()
         mock_registry.register = fake_register
-        mock_registry.get = AsyncMock(return_value={"canonical_id": canonical_id})
+        # get() resolves any id to a live row: reusing an existing entry's
+        # identity would therefore succeed if the route ever tried it.
+        async def fake_get(cid):
+            return {"canonical_id": cid}
+        mock_registry.get = fake_get
         app.state.agent_registry = mock_registry
 
         def fake_register_agent(name, **kwargs):
@@ -713,28 +721,33 @@ class TestDeployRegistryRegistration:
         app.state.backend_catalog = _FakeCatalog()
         app.state.cluster_manager._workers.clear()
 
+        import asyncio
         resp1 = await client.post("/api/agents/deploy", json={
-            "name": "RegistryRedeploy",
+            "name": "RegistryTwin",
             "framework": "none",
             "model": "test-model",
         })
         assert resp1.status_code == 200
-        import asyncio
         await asyncio.sleep(0.2)
 
-        assert len(register_calls) == 1
-
         resp2 = await client.post("/api/agents/deploy", json={
-            "name": "RegistryRedeploy",
+            "name": "RegistryTwin",
             "framework": "none",
             "model": "test-model",
         })
         assert resp2.status_code == 200
         await asyncio.sleep(0.2)
 
-        assert len(register_calls) == 1
+        assert len(register_calls) == 2
+        twins = [a for a in app.state.config.agents
+                 if a.get("display_name") == "RegistryTwin"]
+        assert len(twins) == 2
+        ids = {a["registry_canonical_id"] for a in twins}
+        assert len(ids) == 2, f"identities must be distinct, got {ids}"
 
-    async def test_model_swap_does_not_re_register(self, client, app, monkeypatch):
+    async def test_reserved_name_registration_rejected_as_400(self, client, app, monkeypatch):
+        """A name the registry rejects (reserved prefix) is a user error: the
+        deploy must return 400 with the registry's message and add no agent."""
         import taosmd.agents as tm_agents
         from unittest.mock import AsyncMock, MagicMock
 
@@ -742,16 +755,15 @@ class TestDeployRegistryRegistration:
             record=AsyncMock(), query=AsyncMock(return_value=[{}])
         )
 
-        canonical_id = "registryswap-20260101-000000"
-        register_calls = []
-
         async def fake_register(*, framework, display_name, **kw):
-            register_calls.append((framework, display_name))
-            return {"canonical_id": canonical_id, "framework": framework, "display_name": display_name}
+            raise ValueError(
+                f"cannot register agent: name {display_name!r} resolves to "
+                "reserved prefix 'admin-'; choose a different name"
+            )
 
         mock_registry = MagicMock()
         mock_registry.register = fake_register
-        mock_registry.get = AsyncMock(return_value={"canonical_id": canonical_id})
+        mock_registry.get = AsyncMock(return_value=None)
         app.state.agent_registry = mock_registry
 
         def fake_register_agent(name, **kwargs):
@@ -766,30 +778,19 @@ class TestDeployRegistryRegistration:
 
         class _FakeCatalog:
             def all_models(self, capability=None):
-                return [{"name": "test-model", "id": "test-model"}, {"name": "other-model", "id": "other-model"}]
+                return [{"name": "test-model", "id": "test-model"}]
         app.state.backend_catalog = _FakeCatalog()
         app.state.cluster_manager._workers.clear()
 
-        resp1 = await client.post("/api/agents/deploy", json={
-            "name": "RegistrySwap",
+        resp = await client.post("/api/agents/deploy", json={
+            "name": "Admin",
             "framework": "none",
             "model": "test-model",
         })
-        assert resp1.status_code == 200
-        import asyncio
-        await asyncio.sleep(0.2)
-
-        assert len(register_calls) == 1
-
-        resp2 = await client.post("/api/agents/deploy", json={
-            "name": "RegistrySwap",
-            "framework": "none",
-            "model": "other-model",
-        })
-        assert resp2.status_code == 200
-        await asyncio.sleep(0.2)
-
-        assert len(register_calls) == 1
+        assert resp.status_code == 400
+        assert "reserved prefix" in resp.json()["error"]
+        assert not any(a.get("display_name") == "Admin"
+                       for a in app.state.config.agents)
 
 
 @pytest.mark.asyncio

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -577,34 +577,32 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
             return JSONResponse(err_body, status_code=500)
 
         # Register the agent in the agent registry, minting a canonical_id.
-        # Idempotent on redeploy: if the agent record already carries a
-        # registry_canonical_id and that exact row still exists, skip.
+        # Every deploy creates a NEW agent entry (slugs are made unique above),
+        # so every deploy mints a fresh identity. Never reuse another config
+        # entry's canonical_id by display_name: display names are not unique,
+        # and two agents sharing a canonical identity would cross-wire token
+        # subjects and memory namespaces.
         ar = getattr(request.app.state, "agent_registry", None)
         canonical_id = None
         if ar is not None and getattr(ar, "_db", None) is not None:
-            existing = next(
-                (a for a in config.agents if a.get("display_name") == display_name),
-                None,
-            )
-            if existing is not None:
-                canonical_id = existing.get("registry_canonical_id")
-            if canonical_id:
-                row = await ar.get(canonical_id)
-                if row is None:
-                    canonical_id = None
-            if canonical_id is None:
-                try:
-                    rec = await ar.register(
-                        framework=body.framework,
-                        display_name=display_name,
-                    )
-                    canonical_id = rec.get("canonical_id")
-                except Exception as e:
-                    logger.exception("agent_registry.register(%s) failed", unique_slug)
-                    err_body = {"error": f"Could not register agent in registry: {e}"}
-                    if scoped_key and idempotency_cache is not None:
-                        idempotency_cache.set(scoped_key, err_body)
-                    return JSONResponse(err_body, status_code=500)
+            try:
+                rec = await ar.register(
+                    framework=body.framework,
+                    display_name=display_name,
+                )
+                canonical_id = rec.get("canonical_id")
+            except ValueError as e:
+                # Reserved-prefix names are a user error, not a server fault.
+                err_body = {"error": str(e)}
+                if scoped_key and idempotency_cache is not None:
+                    idempotency_cache.set(scoped_key, err_body)
+                return JSONResponse(err_body, status_code=400)
+            except Exception as e:
+                logger.exception("agent_registry.register(%s) failed", unique_slug)
+                err_body = {"error": f"Could not register agent in registry: {e}"}
+                if scoped_key and idempotency_cache is not None:
+                    idempotency_cache.set(scoped_key, err_body)
+                return JSONResponse(err_body, status_code=500)
 
         # Add agent entry immediately with deploying status. qmd_url has
         # been removed from the agent schema — every agent reads and writes

--- a/tinyagentos/routes/agents.py
+++ b/tinyagentos/routes/agents.py
@@ -576,6 +576,36 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
                 idempotency_cache.set(scoped_key, err_body)
             return JSONResponse(err_body, status_code=500)
 
+        # Register the agent in the agent registry, minting a canonical_id.
+        # Idempotent on redeploy: if the agent record already carries a
+        # registry_canonical_id and that exact row still exists, skip.
+        ar = getattr(request.app.state, "agent_registry", None)
+        canonical_id = None
+        if ar is not None and getattr(ar, "_db", None) is not None:
+            existing = next(
+                (a for a in config.agents if a.get("display_name") == display_name),
+                None,
+            )
+            if existing is not None:
+                canonical_id = existing.get("registry_canonical_id")
+            if canonical_id:
+                row = await ar.get(canonical_id)
+                if row is None:
+                    canonical_id = None
+            if canonical_id is None:
+                try:
+                    rec = await ar.register(
+                        framework=body.framework,
+                        display_name=display_name,
+                    )
+                    canonical_id = rec.get("canonical_id")
+                except Exception as e:
+                    logger.exception("agent_registry.register(%s) failed", unique_slug)
+                    err_body = {"error": f"Could not register agent in registry: {e}"}
+                    if scoped_key and idempotency_cache is not None:
+                        idempotency_cache.set(scoped_key, err_body)
+                    return JSONResponse(err_body, status_code=500)
+
         # Add agent entry immediately with deploying status. qmd_url has
         # been removed from the agent schema — every agent reads and writes
         # through the shared host qmd.service, addressed by agent name and
@@ -603,6 +633,7 @@ async def deploy_agent_endpoint(request: Request, body: DeployAgentRequest):
         new_agent["memory_config"] = body.memory_config
         new_agent["source_persona_id"] = body.source_persona_id
         new_agent["migrated_to_v2_personas"] = True
+        new_agent["registry_canonical_id"] = canonical_id
         # Apply KV-cache quantisation choices from the deploy wizard.
         new_agent["kv_cache_quant_k"] = body.kv_cache_quant_k
         new_agent["kv_cache_quant_v"] = body.kv_cache_quant_v


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Deploy route registers deployed agents into agent_registry (dec-h3jlcy)

Autonomous build of board card tsk-qdvfg4.



Files:
 tests/test_routes_agents.py  | 173 +++++++++++++++++++++++++++++++++++++++++++
 tinyagentos/routes/agents.py |  31 ++++++++
 2 files changed, 204 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed agents are now registered with the agent registry and assigned a persistent canonical identity.
  * Agents with duplicate display names receive distinct identities.

* **Bug Fixes**
  * Deployments using reserved names now return a clear HTTP 400 error without creating an agent.
  * Other registry failures return an appropriate server error while allowing pending deployment requests to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->