### PR TITLE
Observatory follow-ups from #2203 merge review: mint-path regression guard + fleet view for global-grant agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ### Added
 
+- Observatory fleet view for agents holding a global `observatory_control`
+  grant; project-scoped grants see only their granted projects (#2267).
+
+### Added
+
 - Lead agents can edit their own board cards: the seeded internal lead now
   carries the `project_tasks_update` scope (title/body/labels/priority on
   own-or-lead cards; a plain `project_tasks` grant still gets 403 on PATCH,

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -824,3 +824,8 @@ class TestFeedReadScope:
 def test_allowed_scopes_includes_project_doc_review():
     """project_doc_review must be in the mint allowlist so internal agents can be granted it."""
     assert "project_doc_review" in _ALLOWED_SCOPES
+
+
+def test_allowed_scopes_includes_observatory_control():
+    """observatory_control must be in the mint allowlist so internal agents can be granted it."""
+    assert "observatory_control" in _ALLOWED_SCOPES

--- a/tests/test_routes_agent_auth_requests.py
+++ b/tests/test_routes_agent_auth_requests.py
@@ -18,6 +18,10 @@ class TestRequestableScopes:
         from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
         assert "project_tasks" in VALID_SCOPES
 
+    def test_observatory_control_is_a_valid_scope(self):
+        from tinyagentos.routes.agent_auth_requests import VALID_SCOPES
+        assert "observatory_control" in VALID_SCOPES
+
     @pytest.mark.asyncio
     async def test_create_accepts_project_tasks(self, client, monkeypatch):
         class _Store(_FakeAuthRequestsStore):

--- a/tests/test_routes_observatory.py
+++ b/tests/test_routes_observatory.py
@@ -1,5 +1,3 @@
-import asyncio
-from datetime import datetime, timezone
 from httpx import ASGITransport, AsyncClient
 
 import pytest
@@ -27,8 +25,8 @@ async def _non_admin_client(app):
 
 
 async def _make_obs_agent_token(app, *, scopes=("observatory_control",), project_id=None):
-    """Register an agent, add its grants through the public consent-mint path,
-    and return (canonical_id, signed JWT)."""
+    """Register an agent and add grants directly to the store (bypasses the
+    route-layer scope-validation path), then return (canonical_id, signed JWT)."""
     registry = app.state.agent_registry
     grants = app.state.agent_grants
     if registry._db is None:
@@ -555,3 +553,56 @@ class TestObservatoryAgentAuth:
         async with _bare(app) as bare:
             resp = await bare.get("/api/observatory/pause")
         assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_global_grant_agent_sees_fleet(self, app):
+        pstore = app.state.project_store
+        tstore = app.state.project_task_store
+        if pstore._db is None:
+            await pstore.init()
+        if tstore._db is None:
+            await tstore.init()
+        proj = await pstore.create_project(name="ObsG", slug="obs-global", created_by="admin", user_id="admin")
+        task = await tstore.create_task(proj["id"], title="Global card", created_by="admin")
+        await tstore.claim_task(task["id"], "@lane-global")
+
+        _cid, token = await _make_obs_agent_token(app)
+        async with _bare(app) as bare:
+            resp = await bare.get(
+                "/api/observatory/fleet",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 200
+        agents = resp.json()["agents"]
+        mine = [a for a in agents if a["handle"] == "@lane-global"]
+        assert len(mine) == 1
+        assert mine[0]["state"] == "working"
+
+    @pytest.mark.asyncio
+    async def test_project_scoped_agent_does_not_see_other_projects_lanes(self, app):
+        pstore = app.state.project_store
+        tstore = app.state.project_task_store
+        if pstore._db is None:
+            await pstore.init()
+        if tstore._db is None:
+            await tstore.init()
+        proj_a = await pstore.create_project(name="ObsA", slug="obs-a", created_by="admin", user_id="admin")
+        proj_b = await pstore.create_project(name="ObsB", slug="obs-b", created_by="admin", user_id="admin")
+        task_a = await tstore.create_task(proj_a["id"], title="Card A", created_by="admin")
+        task_b = await tstore.create_task(proj_b["id"], title="Card B", created_by="admin")
+        await tstore.claim_task(task_a["id"], "@lane-a")
+        await tstore.claim_task(task_b["id"], "@lane-b")
+
+        _cid, token = await _make_obs_agent_token(
+            app, scopes=("observatory_control",), project_id=proj_a["id"]
+        )
+        async with _bare(app) as bare:
+            resp = await bare.get(
+                "/api/observatory/fleet",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 200
+        agents = resp.json()["agents"]
+        handles = [a["handle"] for a in agents]
+        assert "@lane-a" in handles
+        assert "@lane-b" not in handles

--- a/tinyagentos/cli/taosctl/commands/observatory.py
+++ b/tinyagentos/cli/taosctl/commands/observatory.py
@@ -4,7 +4,8 @@ The Observatory backend exposes the fleet view plus the pause and concurrency
 dials the dispatch loop polls each iteration. This group is the terminal/script
 control surface for them, so steering the queue is a command rather than a hand
 edit of a local dispatch script. Pause/throttle changes are admin-only server
-side; reads are open to any authenticated caller.
+side; reads require an admin session or an agent token holding
+``observatory_control``.
 """
 from __future__ import annotations
 

--- a/tinyagentos/routes/observatory.py
+++ b/tinyagentos/routes/observatory.py
@@ -100,6 +100,7 @@ async def _authorize_observatory_read(request: Request) -> str:
     caller = await check_agent_scope(request, "observatory_control")
     if caller is None:
         raise HTTPException(status_code=403, detail="forbidden")
+    request.state.agent_caller = caller
     return caller
 
 
@@ -328,19 +329,44 @@ async def get_fleet(request: Request):
 
     Derives state from the board: an agent that holds a claimed task is
     'working' on it, and a registered agent that holds none is 'idle'. Admins
-    see every project + agent; other authorized callers see their own. The
-    current pause state is returned alongside so the UI can show both in one
-    read. Trace-timeline and PR-in-review enrichment are phase 2.
+    and agents holding a GLOBAL ``observatory_control`` grant see every project
+    + agent; project-scoped agents see their own granted projects. The current
+    pause state is returned alongside so the UI can show both in one read.
+    Trace-timeline and PR-in-review enrichment are phase 2.
     """
     await _authorize_observatory_read(request)
     is_admin = getattr(request.state, "is_admin", False)
+    caller = getattr(request.state, "agent_caller", None)
     user_id = getattr(request.state, "user_id", None)
+
+    grants_store = _get_grants_store(request)
+    caller_has_global = False
+    caller_project_ids: set[str] = set()
+    if caller and not is_admin:
+        grants = await grants_store.list_grants(caller)
+        now = datetime.now(timezone.utc)
+        caller_has_global = any(
+            g["scope"] == "observatory_control"
+            and g.get("project_id") is None
+            and _grant_unexpired(g.get("expires_at"), now)
+            for g in grants
+        )
+        caller_project_ids = {
+            g["project_id"] for g in grants
+            if g["scope"] == "observatory_control"
+            and g.get("project_id") is not None
+            and _grant_unexpired(g.get("expires_at"), now)
+        }
+
     pstore = request.app.state.project_store
     tstore = request.app.state.project_task_store
-    if is_admin:
+    if is_admin or caller_has_global:
         projects = await pstore.list_projects(status=None)
+    elif caller_project_ids:
+        all_projects = await pstore.list_projects(status=None)
+        projects = [p for p in all_projects if p.get("id") in caller_project_ids]
     else:
-        projects = await pstore.list_for_user(user_id, status=None)
+        projects = await pstore.list_for_user(user_id, status=None) if user_id else []
 
     now = time.time()
     agents: list[dict] = []
@@ -382,10 +408,10 @@ async def get_fleet(request: Request):
     registered: list[dict] = []
     if registry is not None:
         try:
-            if is_admin:
+            if is_admin or caller_has_global:
                 registered = await registry.list_all(status="active")
             else:
-                registered = await registry.list_for_user(user_id, status="active")
+                registered = await registry.list_for_user(user_id, status="active") if user_id else []
         except Exception:
             registered = []
         for rec in registered:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Observatory follow-ups from #2203 merge review: mint-path regression guard + fleet view for global-grant agents

Autonomous build of board card tsk-y5oozq.



Files:
 tests/test_agent_registry.py                    |  5 +++
 tests/test_routes_agent_auth_requests.py        |  4 ++
 tests/test_routes_observatory.py                | 59 +++++++++++++++++++++++--
 tinyagentos/cli/taosctl/commands/observatory.py |  3 +-
 tinyagentos/routes/observatory.py               | 40 ++++++++++++++---
 5 files changed, 99 insertions(+), 12 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `observatory_control` access scope for agent-based Observatory access.
  * Global grants can view all projects and agents, while project-scoped grants remain limited to assigned projects.
  * Agent registry views now follow the same access rules.

* **Documentation**
  * Clarified that Observatory read operations require an admin session or the appropriate agent access scope.

* **Tests**
  * Added coverage for scopes, registry permissions, global grants, and project-scoped visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->