### PR TITLE
Fix decorative test from #2131: rate_limit_per_user passes with no rate limit at all

### DIFF
--- a/tests/test_feedback_route.py
+++ b/tests/test_feedback_route.py
@@ -182,6 +182,12 @@ async def test_post_feedback_rate_limit_per_user(client, app):
         )
         assert resp.status_code == 201
 
+    resp = await client.post(
+        "/api/feedback",
+        json={"type": "bug", "title": "Admin over limit", "body": ""},
+    )
+    assert resp.status_code == 429
+
     invite_code = app.state.auth.add_user_invite("user2", "admin")
     app.state.auth.complete_invite("user2", invite_code, "User Two", "", "password")
     record = app.state.auth.find_user("user2")


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fix decorative test from #2131: rate_limit_per_user passes with no rate limit at all

Autonomous build of board card tsk-p7fity.

The test asserted 201 for every request, so it passed whether or not the
rate limit existed. Add the missing assertion that a further admin post
after hitting the cap returns 429, while user2's first post still returns
201. This pair is the actual per-user scoping claim.

Files:
 tests/test_feedback_route.py | 6 ++++++
 1 file changed, 6 insertions(+)