### PR TITLE
Account model slice 7 (per design doc)

### DIFF
--- a/docs/design/taosgo-mesh-join-foundation.md
+++ b/docs/design/taosgo-mesh-join-foundation.md
@@ -6,7 +6,7 @@ broadly, off-LAN remote access (taOSgo). Author: taOS-dev.
 ## Why this exists
 
 Web Studio v1 is a complete static-site builder (generate -> edit -> preview ->
-install/export). Its one missing feature, publish to `<label>.<handle>.taos.my`,
+install/export). Its one missing feature, publish to `<subdomain>.taos.my`
 is blocked, and so is off-LAN remote access to the desktop. The block is not a
 small wiring gap: the taOS **controller has no mesh-join code at all**. There is
 no `tailscale up`, no preauth-key consumption, no Headscale connection, and no
@@ -119,11 +119,11 @@ Once Units 1+2 land, publishing a Web Studio site is:
    only in v1 (matches Web Studio's stated scope); "dynamic + keep-running"
    containers are a later phase.
 2. **Register the route.** `POST hs.taos.my.../api/sites/publish` with
-   `Authorization: Bearer <sites_token>` and `{label, port, host_id}` -- handle is
-   derived server-side from the token (the anti-spoof we already reviewed in #94).
+   `Authorization: Bearer <sites_token>` and `{subdomain, port, host_id}` -- the
+   subdomain is checked against the account's active claims server-side
    The label is validated client-side against the same reserved rules, but taos.my
    re-validates.
-3. **Web Studio UI.** ShareView gains a "Publish to <handle>.taos.my" action
+3. **Web Studio UI.** ShareView gains a "Publish to <subdomain>.taos.my" action
    (alongside install/export): pick a label, POST, show the resulting FQDN + a
    copy link, and an "unpublish". Gated on the host having joined a mesh
    (`mesh_status().joined`) with a clear "connect your taOS account first" empty

--- a/tinyagentos/taosnet/mesh.py
+++ b/tinyagentos/taosnet/mesh.py
@@ -2,7 +2,8 @@
 
 The always-on host joins the account's Headscale mesh using the single-use
 preauth key from the cluster-join ready payload, so that
-``<label>.<handle>.taos.my`` (Web Studio publish) and off-LAN desktop access can
+``<subdomain>.taos.my`` (a claimed subdomain; see
+``docs/design/account-username-subdomain-model.md``) and off-LAN desktop access can
 route to this host over the tailnet. Jay decided the mechanism is **system
 tailscale** (tailscale + tailscaled managed as a service), not userspace tsnet:
 real kernel networking, boot-persistent, best for the always-on host.

--- a/tinyagentos/taosnet/mesh_credentials.py
+++ b/tinyagentos/taosnet/mesh_credentials.py
@@ -7,7 +7,8 @@ single-scope, host-bound bearer tokens:
 - ``controller_token`` -- scope ``taosnet:passkey`` (fetch the account taOSnet
   passkey; see ``passkey_client.py``)
 - ``sites_token``      -- scope ``sites:publish`` (publish a Web Studio site to
-  ``<label>.<handle>.taos.my``; taos.my #167)
+  a claimed subdomain under ``.taos.my``; see
+  ``docs/design/account-username-subdomain-model.md`` for the namespace model)
 
 This module is the *writer* for the ``get_controller_token()`` seam
 ``passkey_client.py`` documented: it persists those tokens to a single 0600 file


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Account model slice 7 (per design doc)

Autonomous build of board card tsk-7buc5w.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

mesh_credentials.py docstring, mesh.py module docstring, and
taosgo-mesh-join-foundation.md all referenced <label>.<handle>.taos.my.
Per account-username-subdomain-model.md the subdomain namespace is
now a separate claimable namespace decoupled from the username, so
those references become <subdomain>.taos.my / claimed-subdomain
language. No code changes.

Files:
 docs/design/taosgo-mesh-join-foundation.md | 8 ++++----
 tinyagentos/taosnet/mesh.py                | 3 ++-
 tinyagentos/taosnet/mesh_credentials.py    | 3 ++-
 3 files changed, 8 insertions(+), 6 deletions(-)