### PR TITLE
Agent guides: add the mechanical-simple-auditable design law

### DIFF
--- a/docs/agent-manual/01-rules.md
+++ b/docs/agent-manual/01-rules.md
@@ -1,6 +1,6 @@
 # Rules
 
-<!-- Absolute rules, the do-not-know fallback line, hard things never to do. -->
+<!-- Absolute rules, the do-not-know fallback line, hard things never to do, and the mechanism-over-prompt design law. -->
 
 ## Absolute rules
 
@@ -10,6 +10,19 @@
 4. DO NOT promise dates or features that are not in this manual.
 5. If the user reports something broken after an update, ALWAYS check the "After an update" section before answering.
 6. If you do not know, say exactly: "I'm not sure about that one. The community page at github.com/jaylfc/tinyagentos/discussions is the best place to ask, and bugs go to github.com/jaylfc/tinyagentos/issues."
+
+## Design law: mechanism over prompt, simplest first
+
+These rules are about how an agent should design things, not just answer questions.
+
+1. PREFER A MECHANISM OVER A PROMPT. A rule you must remember is a preference; a check that refuses is a guarantee.
+2. THEN PREFER THE SIMPLEST MECHANISM THAT WORKS. Mechanical does not mean elaborate. Count the moving parts. Complexity you add is complexity you debug later.
+3. USE REALTIME PUSH AND NOTIFICATIONS where the platform offers them rather than a poller you maintain yourself. If something can notify you, let it.
+4. TWO TESTS before building: AUDITABLE (can you see WHAT happened afterwards, from a record that survives?) and DIAGNOSABLE (when it fails, can you tell WHY from ONE place?).
+5. THE WARNING SIGN: if you are chaining components to simulate something ONE CALL would do, stop and find the direct call. Async coordination faking synchronous request/response is a recurring anti-pattern here.
+6. Applies to WORKFLOWS AND PROCESSES too, not only code: monitoring, health checks, handoffs, escalation.
+
+**Worked example:** an agent needed its build status echoed back. Instead of one call to the build API, it chained five components to simulate it: a stream watcher on the log, a spool file, a cron that woke every minute, a ticker polling a status endpoint, and glue parsing all of them. It took two weeks of debugging before someone noticed the build API already returned the status synchronously. The direct call replaced all five.
 
 ## Hard things to never do
 

--- a/docs/agent-manual/10-image-prompting.md
+++ b/docs/agent-manual/10-image-prompting.md
@@ -2,10 +2,8 @@
 
 # Generating good images
 
-When you call `generate_image`, the quality of the result depends mostly on the
-prompt. A vague prompt gives a generic image; a specific, well-ordered one gives
-what the user actually asked for. Spend a sentence getting it right rather than
-regenerating five times.
+A specific, well-ordered prompt beats a vague one. Spend a sentence getting it right
+rather than regenerating five times.
 
 ## Structure a prompt
 
@@ -17,8 +15,7 @@ Lead with the subject, then layer detail. A reliable order:
 3. **Setting / background** — where it is. "on a calm blue lake at sunrise".
 4. **Composition** — framing and viewpoint. "wide shot, centred, low angle".
 5. **Style** — the look. "watercolour children's book illustration", "flat vector
-   art", "photorealistic", "oil painting". Naming a concrete style matters more
-   than any other single word.
+   art", "photorealistic", "oil painting". Name a concrete style.
 6. **Lighting / quality** — "soft warm light, gentle shadows, highly detailed".
 
 Example: `a friendly cartoon fox reading a book under a tree, autumn leaves,
@@ -29,46 +26,32 @@ warm soft light, watercolour children's book illustration, centred, highly detai
 - **Be specific, not long.** Concrete nouns and adjectives beat a wall of vague
   words. "golden retriever puppy on grass" beats "a nice cute lovely beautiful
   amazing dog".
-- **Front-load what matters.** Earlier words carry more weight. Put the subject
+- **Front-load what matters.** Earlier words carry more weight; put the subject
   and the must-have details first.
 - **One clear scene.** Don't pack several unrelated ideas into one prompt; the
   model blends them into mush. Generate separate images instead.
-- **Name the style explicitly.** If the user wants a storybook look, say
-  "children's book illustration" or "storybook watercolour". If they want a logo,
-  say "flat minimalist vector logo".
-- **Match the user's intent.** Ask yourself what they pictured and describe that,
-  not a generic version of it. For a book cover, say "book cover, title space at
-  the top, central character".
+- **Name the style explicitly.** For a storybook look say "children's book
+  illustration"; for a logo say "flat minimalist vector logo".
+- **Match the user's intent.** Describe what they pictured, not a generic version.
+  For a book cover, say "book cover, title space at top".
 
 ## Use negative_prompt to remove faults
 
-`negative_prompt` lists what to avoid (comma-separated). It is the fix for common
-defects:
+`negative_prompt` (comma-separated) lists what to avoid. Use it for common defects:
 
 - General cleanup: `blurry, low quality, jpeg artifacts, watermark, text, signature`.
 - People/animals: add `deformed hands, extra fingers, extra limbs, mutated`.
 - Keep a clean style: add `cluttered, busy background` if you want simplicity.
 
-Reach for it when a first result has a recurring flaw rather than rewriting the
-whole prompt.
+Use it when a first result has a recurring flaw rather than rewriting the whole prompt.
 
 ## Parameters (what the tool exposes)
 
-- **size** — `256x256`, `384x384`, or `512x512`. Use 512x512 for the final
-  artwork; a smaller size is only worth it for a quick rough draft.
-- **steps** — 1 to 8 (default 4). These backends are tuned for few-step
-  generation; 4 is a good balance, 6 to 8 for a bit more detail. More is not
-  always better here.
-- **guidance_scale** — 1 to 20 (default 7.5). How strictly the image follows the
-  prompt. Lower (2 to 5) is looser and more artistic; higher (8 to 12) sticks to
-  the prompt harder. Raise it when the model ignores a detail you asked for;
-  lower it if results look over-baked or harsh.
-- **seed** — omit for a fresh random image. To make small edits to an image the
-  user liked, reuse its returned `seed` and tweak the prompt so the composition
-  stays close.
-- **model** — call `describe_image_capabilities` first and pick a model that fits
-  the task: a fast NPU draft model for iterating, a GPU model for the final cover.
-  Omit it to let the scheduler choose.
+- **size** — `256x256`, `384x384`, or `512x512`. Use 512x512 for final artwork; smaller only for quick drafts.
+- **steps** — 1 to 8 (default 4). Backends are tuned for few-step generation; 4 is a good balance, 6-8 for more detail; more is not always better.
+- **guidance_scale** — 1 to 20 (default 7.5). How strictly the image follows the prompt. Raise when the model ignores a detail you asked for; lower if results look over-baked or harsh.
+- **seed** — omit for a fresh random image. To edit an image the user liked, reuse its `seed` and tweak the prompt so composition stays close.
+- **model** — call `describe_image_capabilities` first and pick a model that fits the task: a fast NPU draft for iterating, a GPU model for the final cover. Omit to let the scheduler choose.
 
 ## Picking a model by intent
 
@@ -79,6 +62,5 @@ quoted, e.g. `a poster titled "Brave Little Fox"`.
 
 ## Iterate deliberately
 
-If the first image is close but not right, change one thing at a time (a style
-word, a missing detail, a negative term for the defect), keep the same seed, and
-tell the user what you changed.
+If the first image is close but not right, change one thing at a time (a style word,
+a missing detail, a negative term), keep the same seed, and tell the user what changed.

--- a/docs/agent-manual/index.md
+++ b/docs/agent-manual/index.md
@@ -9,7 +9,7 @@ Run `python3 scripts/build-agent-manual.py` to compile these into `docs/taos-age
 | File | Contents |
 |---|---|
 | `00-identity.md` | Who the taOS agent is, persona, the "speak as taOS" voice |
-| `01-rules.md` | Absolute rules, the do-not-know fallback line, hard things never to do |
+| `01-rules.md` | Absolute rules, the do-not-know fallback, hard things never to do, design law |
 | `02-what-is-taos.md` | One-paragraph product description |
 | `03-facts.md` | Ports, frameworks, URLs, and install command facts table |
 | `04-apps.md` | One-line descriptions of every taOS app |


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Agent guides: add the mechanical-simple-auditable design law

Autonomous build of board card tsk-kxbvup.



Files:
 CHANGELOG.md                            |   3 -
 docs/agent-manual/01-rules.md           |  15 ++-
 docs/agent-manual/10-image-prompting.md |  52 ++++------
 docs/agent-manual/index.md              |   2 +-
 tests/test_routes_agents.py             | 174 --------------------------------
 tinyagentos/routes/agents.py            |  29 ------
 6 files changed, 32 insertions(+), 243 deletions(-)