### PR TITLE
chore(release): v1.0.0-beta.46 version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.46] - 2026-08-03
+
 ### Fixed
 
 - Decisions API: authentication now runs before request-body validation, so an
@@ -20,9 +22,6 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - Deployed agents are registered into the agent registry at deploy time, each
   minting its own canonical identity; names that resolve to a reserved prefix
   are rejected with a 400 (#2266).
-
-### Added
-
 - Lead agents can edit their own board cards: the seeded internal lead now
   carries the `project_tasks_update` scope (title/body/labels/priority on
   own-or-lead cards; a plain `project_tasks` grant still gets 403 on PATCH,

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.44",
+  "version": "1.0.0-beta.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.44",
+      "version": "1.0.0-beta.46",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.1",
         "@codemirror/language-data": "^6.5.2",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.45",
+  "version": "1.0.0-beta.46",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.45"
+version = "1.0.0-beta.46"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.45"
+__version__ = "1.0.0-beta.46"

--- a/uv.lock
+++ b/uv.lock
@@ -3053,7 +3053,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b45"
+version = "1.0.0b46"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Version bump for the beta.46 release train. Moves CHANGELOG [Unreleased] -> [1.0.0-beta.46] (2026-08-03) with the merged decisions/observatory/registry work (#2266 #2267 #2268 #2244 + doc-review reconciliation), and bumps pyproject/init/uv.lock to 1.0.0-beta.46 / 1.0.0b46 (uv.lock normalized form per the release-train convention). Promote to master follows once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the project to version **1.0.0-beta.46**.
  * Added release notes dated **2026-08-03**.
  * Cleaned up duplicate changelog headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->