### PR TITLE
Device token write passthrough for share targets (currently discovery-only)

### DIFF
--- a/tests/test_device_share_write.py
+++ b/tests/test_device_share_write.py
@@ -1,0 +1,176 @@
+"""Tests proving a device token can complete share writes and cannot write elsewhere."""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.app import create_app
+
+
+@pytest.fixture
+def app(tmp_data_dir):
+    return create_app(data_dir=tmp_data_dir)
+
+
+@pytest.mark.asyncio
+class TestDeviceShareWritePassthrough:
+    """Device bearer tokens may write to the three share destinations
+    advertised by /api/share/destinations and cannot reach any other route.
+    """
+
+    async def _register_device(self, client) -> str:
+        reg = await client.post("/api/devices/register", json={"platform": "ios"})
+        assert reg.status_code == 200
+        return reg.json()["scoped_token"]
+
+    async def _device_client(self, app, token):
+        transport = ASGITransport(app=app)
+        return AsyncClient(
+            transport=transport,
+            base_url="http://test",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    async def _user_id(self, app) -> str:
+        primary = app.state.auth.get_primary_user()
+        return primary["id"] if primary else "admin"
+
+    # -- Positive: device token can write to each share destination --
+
+    async def test_device_can_ingest_library_url(self, client, app, tmp_data_dir):
+        token = await self._register_device(client)
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.post("/api/library/ingest", data={"url": "https://example.com/page"})
+            assert resp.status_code == 202
+            body = resp.json()
+            assert "item_id" in body
+            assert body["status"] == "pending"
+
+    async def test_device_can_post_chat_message(self, client, app, tmp_data_dir):
+        token = await self._register_device(client)
+        uid = await self._user_id(app)
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.post(
+                "/api/chat/messages",
+                json={
+                    "channel_id": "general",
+                    "content": "hello from device",
+                    "author_id": uid,
+                    "author_type": "agent",
+                },
+            )
+            assert resp.status_code == 200
+            assert resp.json()["content"] == "hello from device"
+
+    async def test_device_can_upload_project_file(self, client, app, tmp_data_dir):
+        token = await self._register_device(client)
+        uid = await self._user_id(app)
+        await app.state.project_store.create_project(
+            name="Device Project",
+            slug="device-project",
+            created_by=uid,
+            user_id=uid,
+        )
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.post(
+                "/api/projects/device-project/files/upload",
+                files={"file": ("note.txt", b"shared content", "text/plain")},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["name"] == "note.txt"
+            assert body["status"] == "uploaded"
+
+    # -- Negative: device token cannot write to non-share endpoints --
+
+    async def test_device_cannot_list_library_items(self, client, app):
+        token = await self._register_device(client)
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.get("/api/library/items")
+            assert resp.status_code == 401
+
+    async def test_device_cannot_delete_library_item(self, client, app):
+        token = await self._register_device(client)
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.delete("/api/library/items/nonexistent")
+            assert resp.status_code == 401
+
+    async def test_device_cannot_reprocess_library_item(self, client, app):
+        token = await self._register_device(client)
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.post("/api/library/items/abc/reprocess")
+            assert resp.status_code == 401
+
+    async def test_device_cannot_list_chat_channels(self, client, app):
+        token = await self._register_device(client)
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.get("/api/chat/channels")
+            assert resp.status_code == 401
+
+    async def test_device_cannot_access_others_project_files(self, client, app):
+        token = await self._register_device(client)
+        await app.state.project_store.create_project(
+            name="Other Project",
+            slug="other-project",
+            created_by="other-user",
+            user_id="other-user",
+        )
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.get("/api/projects/other-project/files")
+            assert resp.status_code == 401
+
+    async def test_device_cannot_mkdir_others_project(self, client, app):
+        token = await self._register_device(client)
+        await app.state.project_store.create_project(
+            name="Other Project",
+            slug="other-project",
+            created_by="other-user",
+            user_id="other-user",
+        )
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.post("/api/projects/other-project/mkdir", json={"path": "sub"})
+            assert resp.status_code == 401
+
+    async def test_device_cannot_delete_others_project_file(self, client, app):
+        token = await self._register_device(client)
+        await app.state.project_store.create_project(
+            name="Other Project",
+            slug="other-project",
+            created_by="other-user",
+            user_id="other-user",
+        )
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.delete("/api/projects/other-project/files/note.txt")
+            assert resp.status_code == 401
+
+    # -- Chat author_id guard: device must not impersonate another user --
+
+    async def test_device_chat_rejects_mismatched_author_id(self, client, app):
+        token = await self._register_device(client)
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.post(
+                "/api/chat/messages",
+                json={
+                    "channel_id": "general",
+                    "content": "impersonation attempt",
+                    "author_id": "some-other-user",
+                    "author_type": "agent",
+                },
+            )
+            assert resp.status_code == 403
+            assert "author_id must match device owner" in resp.json()["error"]
+
+    async def test_device_chat_accepts_own_author_id(self, client, app, tmp_data_dir):
+        token = await self._register_device(client)
+        uid = await self._user_id(app)
+        async with await self._device_client(app, token) as dc:
+            resp = await dc.post(
+                "/api/chat/messages",
+                json={
+                    "channel_id": "general",
+                    "content": "from my device",
+                    "author_id": uid,
+                    "author_type": "agent",
+                },
+            )
+            assert resp.status_code == 200

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -130,20 +130,25 @@ _AGENT_DECISIONS_ROUTES = (
 )
 
 # Device-bearer self-service paths (lock-screen push-token rotation plus
-# decision list/get/answer). A scoped device token (Bearer taosdev_...) may
-# pass through the auth gate on exactly these routes; the route dependency
-# (current_user_or_device) resolves the device and synthesizes a NON-admin
-# CurrentUser. request.state.user_id is left None on this path so device
-# bearers cannot reach other current_user / request.state consumers (e.g.
-# create_decision which reads uid=request.state.user_id). Session-authenticated
-# calls still work: the session-cookie check runs when no Bearer header is
-# present, so GET/POST without a Bearer reach the guard normally.
+# decision list/get/answer) AND share-write destinations (library ingest,
+# chat messages, project-files upload). A scoped device token (Bearer
+# taosdev_...) may pass through the auth gate on exactly these routes; the
+# route dependency (current_user_or_device) resolves the device and
+# synthesizes a NON-admin CurrentUser. request.state.user_id is left None on
+# this path so device bearers cannot reach other current_user /
+# request.state consumers (e.g. create_decision which reads
+# uid=request.state.user_id). Session-authenticated calls still work: the
+# session-cookie check runs when no Bearer header is present, so POST without
+# a Bearer reaches the guard normally.
 _DEVICE_BEARER_PATHS = (
     ("PATCH", re.compile(r"^/api/devices/[^/]+/push-token$")),
     ("GET", re.compile(r"^/api/decisions$")),
     ("GET", re.compile(r"^/api/decisions/[^/]+$")),
     ("GET", re.compile(r"^/api/decisions/[^/]+/history$")),
     ("POST", re.compile(r"^/api/decisions/[^/]+/answer$")),
+    ("POST", re.compile(r"^/api/library/ingest$")),
+    ("POST", re.compile(r"^/api/chat/messages$")),
+    ("POST", re.compile(r"^/api/projects/[^/]+/files/upload$")),
 )
 
 

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -6,10 +6,12 @@ import logging
 import os
 from pathlib import Path
 
-from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse, Response
 
+from tinyagentos.auth_context import CurrentUser
 from tinyagentos.chat.reactions import maybe_trigger_semantic
+from tinyagentos.device_auth import current_user_or_device
 
 router = APIRouter()
 
@@ -296,8 +298,13 @@ async def chat_ws(websocket: WebSocket):
 
 
 @router.post("/api/chat/messages")
-async def post_message(request: Request):
-    """Send a message via HTTP (used by agents and the agent-bridge)."""
+async def post_message(request: Request, user: CurrentUser = Depends(current_user_or_device)):
+    """Send a message via HTTP (used by agents and the agent-bridge).
+
+    Authenticated via session cookie or device bearer token. When a device
+    bearer is used the author_id in the body must match the device owner's
+    user_id (prevents a compromised device from impersonating another user).
+    """
     body = await request.json()
     msg_store = request.app.state.chat_messages
     ch_store = request.app.state.chat_channels
@@ -305,6 +312,15 @@ async def post_message(request: Request):
 
     channel_id = body["channel_id"]
     content = body.get("content") or ""
+
+    # Device-bearer guard: a scoped device token must not impersonate another
+    # user. The author_id must match the device owner's user_id.
+    device = getattr(request.state, "_device", None)
+    if device is not None and body.get("author_id") != device["user_id"]:
+        return JSONResponse(
+            {"error": "author_id must match device owner"},
+            status_code=403,
+        )
 
     if content.startswith("/help"):
         from tinyagentos.chat.help import handle_help

--- a/tinyagentos/routes/library.py
+++ b/tinyagentos/routes/library.py
@@ -14,9 +14,11 @@ import logging
 import uuid
 from pathlib import Path
 
-from fastapi import APIRouter, Request, UploadFile, File, Form
+from fastapi import APIRouter, Depends, Request, UploadFile, File, Form
 from fastapi.responses import JSONResponse
 
+from tinyagentos.auth_context import CurrentUser
+from tinyagentos.device_auth import current_user_or_device
 from tinyagentos.library_pipeline import run_pipeline
 from tinyagentos.library_collections import handoff_to_collections
 from tinyagentos.task_utils import _create_supervised_task
@@ -99,6 +101,7 @@ async def _get_library_store(request: Request):
 @router.post("/api/library/ingest")
 async def ingest(
     request: Request,
+    user: CurrentUser = Depends(current_user_or_device),
     file: UploadFile | None = File(None),
     url: str | None = Form(None),
     title: str | None = Form(None),
@@ -106,7 +109,8 @@ async def ingest(
     """Ingest a file or URL into the library.
 
     Accepts a file upload (multipart) or a URL string form field. At least one
-    of ``file`` or ``url`` must be provided.
+    of ``file`` or ``url`` must be provided. Authenticated via session cookie
+    or device bearer token.
 
     Returns ``{item_id, status: \"pending\"}`` immediately — pipeline processing
     happens asynchronously in a background task.

--- a/tinyagentos/routes/project_files.py
+++ b/tinyagentos/routes/project_files.py
@@ -5,10 +5,12 @@ import json
 from pathlib import Path
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException, Request, UploadFile, File
+from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile, File
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
+from tinyagentos.auth_context import CurrentUser
+from tinyagentos.device_auth import current_user_or_device
 from tinyagentos.workspace_trash import (
     TrashItemNotFound,
     TrashRestoreConflict,
@@ -44,7 +46,8 @@ async def _authorize_files_actor(
 
     Mirrors ``_authorize_canvas_actor``: accepts EITHER a session owner/admin
     (human behavior unchanged) OR an approved agent's registry JWT holding the
-    matching files scope bound to THIS project:
+    matching files scope bound to THIS project, OR a device bearer token whose
+    owner owns the project:
 
       * read mode  -> ``files_read`` grant on the project
       * write mode -> ``files_write`` grant on the project
@@ -68,6 +71,14 @@ async def _authorize_files_actor(
         if project is not None and not is_admin and project.get("user_id") != uid:
             return JSONResponse({"error": "not found"}, status_code=404)
         return ("user", uid)
+    # Device bearer path: current_user_or_device resolves the device and
+    # stashes it on request.state._device. A device may only write to projects
+    # owned by its user_id (same ownership gate as the session path above).
+    device = getattr(request.state, "_device", None)
+    if device is not None:
+        if project is not None and project.get("user_id") != device["user_id"]:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        return ("device", device["user_id"])
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.lower().startswith("bearer "):
         # Middleware normally 401s unauthenticated requests before the route
@@ -202,8 +213,18 @@ async def api_project_watch_files(request: Request, slug: str, path: str = "", i
 
 
 @router.post("/api/projects/{slug}/files/upload")
-async def api_project_upload_file(request: Request, slug: str, path: str = "", file: UploadFile = File(...)):
-    """Upload a file to the project's files folder."""
+async def api_project_upload_file(
+    request: Request,
+    slug: str,
+    user: CurrentUser = Depends(current_user_or_device),
+    path: str = "",
+    file: UploadFile = File(...),
+):
+    """Upload a file to the project's files folder.
+
+    Authenticated via session cookie, device bearer token, or agent registry
+    JWT with the ``files_write`` scope bound to this project.
+    """
     auth = await _authorize_files_actor(request, slug, "write")
     if isinstance(auth, JSONResponse):
         return auth


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Device token write passthrough for share targets (currently discovery-only)

Autonomous build of board card tsk-avjhlv.



Files:
 tinyagentos/auth_middleware.py             |  21 ++--
 tinyagentos/routes/chat.py                 |  22 +++-
 tinyagentos/routes/decisions.py            |  70 +++---------
 tinyagentos/routes/library.py              |   8 +-
 tinyagentos/routes/project_files.py        |  29 ++++-
 tinyagentos/taosnet/mesh.py                |   3 +-
 tinyagentos/taosnet/mesh_credentials.py    |   3 +-
 12 files changed, 258 insertions(+), 146 deletions(-)