### PR TITLE
Admin endpoint: POST /api/notifications (create) for review-request notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Added
+
+- Admin-only `POST /api/notifications` so orchestrators and lead agents can
+  raise review-request notifications through the store (and therefore through
+  SSE and web push) instead of a raw database insert (#2280).
+
 ## [1.0.0-beta.46] - 2026-08-03
 
 ### Fixed

--- a/tests/test_routes_notifications.py
+++ b/tests/test_routes_notifications.py
@@ -1,4 +1,6 @@
 import pytest
+from httpx import ASGITransport, AsyncClient
+
 from tinyagentos.notifications import NotificationStore
 
 
@@ -55,3 +57,67 @@ class TestNotificationStore:
             assert items[0]["title"] == "Backend online"
         finally:
             await store.close()
+
+
+@pytest.mark.asyncio
+class TestNotificationCreateRoutes:
+    """Route tests for the admin-gated POST /api/notifications endpoint."""
+
+    async def _member_client(self, app) -> AsyncClient:
+        """Cookie'd client for a non-admin member session.
+
+        Reuses the admin created by the ``client`` fixture (add_user_invite
+        requires an inviter) to issue an invite, then completes it as a plain
+        non-admin user so the admin gate can be exercised.
+        """
+        auth_mgr = app.state.auth
+        invite_code = auth_mgr.add_user_invite("member", "admin")
+        auth_mgr.complete_invite(
+            "member", invite_code, "Test Member", "", "memberpass1234"
+        )
+        member = auth_mgr.find_user("member")
+        token = auth_mgr.create_session(user_id=member["id"], long_lived=True)
+        return AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            cookies={"taos_session": token},
+        )
+
+    async def test_non_admin_is_forbidden(self, client, app):
+        """A non-admin session is rejected with 403 on POST /api/notifications."""
+        member_client = await self._member_client(app)
+        try:
+            resp = await member_client.post(
+                "/api/notifications",
+                json={"title": "review me", "message": "a doc is ready"},
+            )
+        finally:
+            await member_client.aclose()
+        assert resp.status_code == 403
+
+    async def test_admin_create_appears_in_list(self, client):
+        """An admin-created notification shows up in GET /api/notifications."""
+        resp = await client.post(
+            "/api/notifications",
+            json={
+                "title": "PR ready for review",
+                "message": "tinyagentos/routes/notifications.py needs review",
+                "level": "info",
+                "source": "review-request",
+                "data": {"pr": 42},
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        listing = await client.get("/api/notifications")
+        assert listing.status_code == 200
+        items = listing.json()
+        matches = [i for i in items if i["title"] == "PR ready for review"]
+        assert len(matches) == 1
+        created = matches[0]
+        assert created["message"] == "tinyagentos/routes/notifications.py needs review"
+        assert created["level"] == "info"
+        assert created["source"] == "review-request"
+        assert created["data"] == {"pr": 42}
+        assert created["read"] is False

--- a/tinyagentos/routes/notifications.py
+++ b/tinyagentos/routes/notifications.py
@@ -9,6 +9,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from pydantic import BaseModel, field_validator
 
 from tinyagentos.auth import get_current_user
+from tinyagentos.routes.auth import _require_admin
 
 router = APIRouter()
 
@@ -45,6 +46,35 @@ async def list_notifications(request: Request, unread_only: bool = False):
             )
         return HTMLResponse("".join(html_parts))
     return items
+
+
+class CreateNotificationRequest(BaseModel):
+    title: str
+    message: str
+    level: str = "info"
+    source: str = "system"
+    data: dict | None = None
+
+
+@router.post("/api/notifications")
+async def create_notification(request: Request, body: CreateNotificationRequest):
+    """Admin-only: create a notification through the internal store.
+
+    Lets orchestrators and lead agents signal that a doc or PR is ready for
+    review without a raw DB insert, which would skip SSE and web-push delivery.
+    """
+    ok, err = _require_admin(request)
+    if not ok:
+        return err
+    store = request.app.state.notifications
+    await store.add(
+        title=body.title,
+        message=body.message,
+        level=body.level,
+        source=body.source,
+        data=body.data,
+    )
+    return {"ok": True}
 
 
 @router.get("/api/notifications/count", response_class=HTMLResponse)


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Admin endpoint: POST /api/notifications (create) for review-request notifications

Autonomous build of board card tsk-ei47at.

Add an ADMIN-gated POST /api/notifications accepting
{title, message, level=info, source, data} that calls
NotificationStore.add() so SSE and PWA web-push fire for review-request
notifications. Previously notifications were only creatable via the
internal store, forcing orchestrators and lead agents to do raw DB
inserts that skip SSE and web-push.

Includes a test asserting non-admin sessions get 403 and that an
admin-created notification appears in GET /api/notifications.

Files:
 tests/test_routes_notifications.py  | 66 +++++++++++++++++++++++++++++++++++++
 tinyagentos/routes/notifications.py | 30 +++++++++++++++++
 2 files changed, 96 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only API endpoint for creating notifications.
  * Supports notification titles, messages, levels, sources, and optional additional data.
  * Newly created notifications appear in notification listings and can be delivered through supported notification channels.

* **Bug Fixes**
  * Unauthorized requests to create notifications now receive a forbidden response.

* **Documentation**
  * Documented the new notification creation endpoint in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->