### PR TITLE
taOStalk s1: live badge on bound session channels (card 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ### Added
 
+- Messages sidebar shows a live "thinking" badge on channels whose bound
+  taOStalk agent is currently working, on desktop and mobile (#2281).
 - Admin-only `POST /api/notifications` so orchestrators and lead agents can
   raise review-request notifications through the store (and therefore through
   SSE and web push) instead of a raw database insert (#2280).

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -105,6 +105,7 @@ interface Channel {
     archived_agent_slug?: string;
     muted?: string[];
     kind?: string;
+    taostalk_agent?: string;
   };
 }
 
@@ -1626,6 +1627,13 @@ export function MessagesApp({
     archivedChannels.length === 0 &&
     projectGroups.length === 0;
 
+  const thinkingChannelIds: string[] = channels
+    .filter((ch) => {
+      const bound = (ch.settings as { taostalk_agent?: string } | undefined)?.taostalk_agent;
+      return bound && typingAgents.some((a) => a.slug === bound);
+    })
+    .map((ch) => ch.id);
+
   /* ---------------------------------------------------------------- */
   /*  Channel list — iOS 26 grouped on mobile, flat sidebar on desktop */
   /* ---------------------------------------------------------------- */
@@ -1663,6 +1671,7 @@ export function MessagesApp({
       busSelected={busSelected}
       onSelectBusChannel={selectBusChannel}
       formatRelativeTime={relativeTime}
+      thinkingChannelIds={thinkingChannelIds}
     />
   );
 

--- a/desktop/src/apps/chat/ChannelSidebar.tsx
+++ b/desktop/src/apps/chat/ChannelSidebar.tsx
@@ -274,8 +274,8 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                                {thinkingChannelIds.includes(ch.id) && (
                                  <span
                                    className="relative inline-flex h-1.5 w-1.5 shrink-0"
-                                   aria-hidden="true"
-                                   title="thinking"
+                                   role="img"
+                                   aria-label="Agent is thinking"
                                  >
                                    <span className="taos-status-pulse absolute inset-0 rounded-full bg-amber-400" />
                                    <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-400" />
@@ -501,8 +501,8 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                        {thinkingChannelIds.includes(ch.id) && (
                          <span
                            className="relative inline-flex h-1.5 w-1.5 shrink-0"
-                           aria-hidden="true"
-                           title="thinking"
+                           role="img"
+                           aria-label="Agent is thinking"
                          >
                            <span className="taos-status-pulse absolute inset-0 rounded-full bg-amber-400" />
                            <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-400" />

--- a/desktop/src/apps/chat/ChannelSidebar.tsx
+++ b/desktop/src/apps/chat/ChannelSidebar.tsx
@@ -61,6 +61,8 @@ export interface ChannelSidebarProps {
   onSelectBusChannel: (channel: string) => void;
   /** Relative time formatter. */
   formatRelativeTime: (ts: number | string, nowMs: number) => string;
+  /** Channel ids whose bound taostalk_agent is currently thinking (live badge). */
+  thinkingChannelIds: string[];
 }
 
 /* ------------------------------------------------------------------ */
@@ -96,6 +98,7 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
     busSelected,
     onSelectBusChannel,
     formatRelativeTime,
+    thinkingChannelIds,
   } = props;
 
   if (isMobile) {
@@ -255,20 +258,30 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                                 gap: 8,
                               }}
                             >
-                              <span
-                                style={{
-                                  flex: 1,
-                                  fontSize: 15,
-                                  fontWeight: count > 0 ? 700 : 600,
-                                  color: "var(--color-shell-text)",
-                                  overflow: "hidden",
-                                  textOverflow: "ellipsis",
-                                  whiteSpace: "nowrap",
-                                }}
-                              >
-                                {ch.name}
-                              </span>
-                              {ch.last_message_at && (
+                               <span
+                                 style={{
+                                   flex: 1,
+                                   fontSize: 15,
+                                   fontWeight: count > 0 ? 700 : 600,
+                                   color: "var(--color-shell-text)",
+                                   overflow: "hidden",
+                                   textOverflow: "ellipsis",
+                                   whiteSpace: "nowrap",
+                                 }}
+                               >
+                                 {ch.name}
+                               </span>
+                               {thinkingChannelIds.includes(ch.id) && (
+                                 <span
+                                   className="relative inline-flex h-1.5 w-1.5 shrink-0"
+                                   aria-hidden="true"
+                                   title="thinking"
+                                 >
+                                   <span className="taos-status-pulse absolute inset-0 rounded-full bg-amber-400" />
+                                   <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-400" />
+                                 </span>
+                               )}
+                               {ch.last_message_at && (
                                 <span
                                   style={{
                                     fontSize: 11,
@@ -476,16 +489,26 @@ export function ChannelSidebar(props: ChannelSidebarProps) {
                           )}
                         </span>
                       )}
-                      <span
-                        className={`truncate flex-1 text-[14px] tracking-tight ${
-                          count > 0
-                            ? "font-bold text-shell-text"
-                            : "font-semibold text-shell-text"
-                        }`}
-                      >
-                        {ch.name}
-                      </span>
-                      {count > 0 && (
+                       <span
+                         className={`truncate flex-1 text-[14px] tracking-tight ${
+                           count > 0
+                             ? "font-bold text-shell-text"
+                             : "font-semibold text-shell-text"
+                         }`}
+                       >
+                         {ch.name}
+                       </span>
+                       {thinkingChannelIds.includes(ch.id) && (
+                         <span
+                           className="relative inline-flex h-1.5 w-1.5 shrink-0"
+                           aria-hidden="true"
+                           title="thinking"
+                         >
+                           <span className="taos-status-pulse absolute inset-0 rounded-full bg-amber-400" />
+                           <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-amber-400" />
+                         </span>
+                       )}
+                       {count > 0 && (
                         <span className="shrink-0 bg-unread text-white text-[10px] font-bold rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 tabular-nums">
                           {count}
                         </span>

--- a/desktop/src/apps/chat/__tests__/ChannelSidebar.test.tsx
+++ b/desktop/src/apps/chat/__tests__/ChannelSidebar.test.tsx
@@ -81,6 +81,7 @@ function buildProps(overrides: Partial<ChannelSidebarProps> = {}): ChannelSideba
     busSelected: null,
     onSelectBusChannel: vi.fn(),
     formatRelativeTime: (ts) => String(ts),
+    thinkingChannelIds: [],
     ...overrides,
   };
 }
@@ -709,5 +710,71 @@ describe("ChannelSidebar — edge cases", () => {
     render(<ChannelSidebar {...buildProps({ sections })} />);
     const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
     expect(btn).not.toHaveAttribute("title");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Live thinking badge                                                 */
+/* ------------------------------------------------------------------ */
+
+describe("ChannelSidebar — thinking badge", () => {
+  it("shows a pulsing amber dot on a thinking channel (desktop)", () => {
+    const ch = makeChannel({ id: "ch-1", name: "session-alice" });
+    const sections = [makeSection("Live", [ch])];
+    const { container } = render(
+      <ChannelSidebar
+        {...buildProps({ sections, thinkingChannelIds: ["ch-1"] })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    const dot = btn.querySelector(".taos-status-pulse");
+    expect(dot).toBeTruthy();
+    expect(dot).toHaveClass("bg-amber-400");
+  });
+
+  it("does not show thinking dot on non-thinking channels (desktop)", () => {
+    const ch = makeChannel({ id: "ch-1", name: "general" });
+    const sections = [makeSection("Topics", [ch])];
+    render(
+      <ChannelSidebar
+        {...buildProps({ sections, thinkingChannelIds: [] })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.querySelector(".taos-status-pulse")).toBeNull();
+  });
+
+  it("shows thinking dot on mobile when channel is thinking", () => {
+    const ch = makeChannel({ id: "ch-1", name: "session-bob" });
+    const sections = [makeSection("Live", [ch])];
+    const { container } = render(
+      <ChannelSidebar
+        {...buildProps({ isMobile: true, sections, thinkingChannelIds: ["ch-1"] })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    const dot = btn.querySelector(".taos-status-pulse");
+    expect(dot).toBeTruthy();
+    expect(dot).toHaveClass("bg-amber-400");
+  });
+
+  it("clears thinking dot when channel leaves thinkingChannelIds", () => {
+    const ch = makeChannel({ id: "ch-1", name: "session-carol" });
+    const sections = [makeSection("Live", [ch])];
+    const { rerender } = render(
+      <ChannelSidebar
+        {...buildProps({ sections, thinkingChannelIds: ["ch-1"] })}
+      />,
+    );
+    let btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.querySelector(".taos-status-pulse")).toBeTruthy();
+
+    rerender(
+      <ChannelSidebar
+        {...buildProps({ sections, thinkingChannelIds: [] })}
+      />,
+    );
+    btn = screen.getByRole("button", { name: `Channel ${ch.name}` });
+    expect(btn.querySelector(".taos-status-pulse")).toBeNull();
   });
 });


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taOStalk s1: live badge on bound session channels (card 8)

Autonomous build of board card tsk-txlfr5.

- add taostalk_agent to Channel settings type
- compute thinkingChannelIds from channels whose taostalk_agent matches
  a currently thinking agent in the existing typingAgents state
- pass thinkingChannelIds to ChannelSidebar
- render a pulsing amber dot next to thinking session channels in both
  mobile and desktop sidebar rows
- tests: badge appears on thinking start, absent otherwise, clears on end

Files:
 desktop/src/apps/MessagesApp.tsx                   |  9 +++
 desktop/src/apps/chat/ChannelSidebar.tsx           | 71 ++++++++++++++--------
 .../apps/chat/__tests__/ChannelSidebar.test.tsx    | 67 ++++++++++++++++++++
 3 files changed, 123 insertions(+), 24 deletions(-)