### PR TITLE
taOStalk s1: TextBlock + ThinkingBlock renderers (cards 3+4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ### Added
 
+- Chat renders `text` and `thinking` content blocks: thinking is a
+  collapsed-by-default disclosure with a proper ARIA expand/collapse contract (#2282).
 - Messages sidebar shows a live "thinking" badge on channels whose bound
   taOStalk agent is currently working, on desktop and mobile (#2281).
 - Admin-only `POST /api/notifications` so orchestrators and lead agents can

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -416,7 +416,7 @@ export function ThinkingBlock({ block, index }: { block: ThinkingContentBlock; i
         aria-controls={contentAria}
         aria-label={open ? "Collapse thinking" : "Expand thinking"}
         onClick={() => setOpen((o) => !o)}
-        className="flex w-full items-center gap-2 px-3 py-2 text-[12px] font-semibold text-shell-text-tertiary hover:text-shell-text-secondary hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+        className="flex w-full items-center gap-2 px-3 py-2 text-[12px] font-semibold text-shell-text-tertiary hover:text-shell-text-secondary hover:bg-shell-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
       >
         <ChevronDown
           size={14}

--- a/desktop/src/apps/MessagesApp.tsx
+++ b/desktop/src/apps/MessagesApp.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useId } from "react";
 import {
   MessageCircle,
   Hash,
@@ -263,14 +263,21 @@ export function relativeTime(ts: number | string, nowMs: number = Date.now()): s
 }
 
 /**
- * Dispatch a single content block to its renderer. Tool call, status, and
- * question blocks render through their dedicated card components; text and
- * thinking blocks land as separate cards (slice 1 #1953 sect 4) and currently
- * fall through to the unknown-block fallback below. Any other/unrecognized
- * kind also falls through -- the slice-2 seam for the renderer registry.
+ * Dispatch a single content block to its renderer. All four slice-1 kinds now
+ * have dedicated components: text and thinking (cards 3+4), tool call and
+ * status/question (cards 5+6). Any unrecognised kind still falls through to
+ * the unknown-block fallback -- the slice-2 seam for the renderer registry.
  */
 function renderContentBlock(block: ContentBlock, index: number): React.ReactElement {
   switch (block.kind) {
+    case "text": {
+      const textBlock = block as TextContentBlock;
+      return <TextBlock block={textBlock} index={index} key={`block-${index}`} />;
+    }
+    case "thinking": {
+      const thinkingBlock = block as ThinkingContentBlock;
+      return <ThinkingBlock block={thinkingBlock} index={index} key={`block-${index}`} />;
+    }
     case "tool_call":
       return (
         <ToolCallBlock block={block as ToolCallContentBlock} key={`block-${index}`} />
@@ -283,8 +290,6 @@ function renderContentBlock(block: ContentBlock, index: number): React.ReactElem
       return (
         <StatusBlock block={block as QuestionContentBlock} key={`block-${index}`} />
       );
-    case "text":
-    case "thinking":
     default:
       return (
         <div key={`block-${index}`} className="text-shell-text-tertiary text-[12px]">
@@ -373,6 +378,64 @@ export function renderInline(text: string, keyPrefix: string) {
       </ReactMarkdown>
     </div>,
   ];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Content block renderers (taOStalk session turns)                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * TextBlock -- renders a {kind:"text"} content block by reusing the existing
+ * inline markdown renderer (renderInline), so a text block renders
+ * identically to a plain message's markdown body.
+ */
+export function TextBlock({ block, index }: { block: TextContentBlock; index: number }): React.ReactElement {
+  return <>{renderInline(block.text, `text-block-${index}`)}</>;
+}
+
+/**
+ * ThinkingBlock -- renders a {kind:"thinking"} content block as a
+ * collapsed-by-default disclosure. The toggle button carries the ARIA
+ * disclosure contract (aria-expanded / aria-controls) and a chevron; the
+ * panel is dim-styled to de-emphasize the agent's internal reasoning. The
+ * container matches the Store/Images card bar (rounded border, shell
+ * surface background, dim tertiary text).
+ */
+export function ThinkingBlock({ block, index }: { block: ThinkingContentBlock; index: number }): React.ReactElement {
+  const [open, setOpen] = useState(block.collapsed === false);
+  const summaryRef = useId();
+  const contentId = useId();
+  const summaryAria = `taostalk-thinking-summary-${summaryRef}`;
+  const contentAria = `taostalk-thinking-content-${contentId}`;
+  return (
+    <div className="rounded-2xl border border-shell-border bg-shell-surface/60 shadow-card overflow-hidden">
+      <button
+        type="button"
+        id={summaryAria}
+        aria-expanded={open}
+        aria-controls={contentAria}
+        aria-label={open ? "Collapse thinking" : "Expand thinking"}
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-[12px] font-semibold text-shell-text-tertiary hover:text-shell-text-secondary hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+      >
+        <ChevronDown
+          size={14}
+          aria-hidden={true}
+          className="transition-transform duration-150"
+          style={{ transform: open ? "rotate(0deg)" : "rotate(-90deg)" }}
+        />
+        <span>Thinking</span>
+      </button>
+      <div
+        id={contentAria}
+        aria-labelledby={summaryAria}
+        hidden={!open}
+        className="px-3 py-2 text-[13px] text-shell-text-tertiary"
+      >
+        {renderInline(block.text, `thinking-${index}`)}
+      </div>
+    </div>
+  );
 }
 
 

--- a/desktop/src/apps/chat/__tests__/content-blocks.test.tsx
+++ b/desktop/src/apps/chat/__tests__/content-blocks.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { TextBlock, ThinkingBlock } from "../../MessagesApp";
+
+describe("TextBlock", () => {
+  it("renders the block text through the markdown renderer", () => {
+    const { container } = render(
+      <TextBlock block={{ kind: "text", text: "hello **bold** world" }} index={0} />,
+    );
+    expect(container.textContent).toContain("hello");
+    expect(container.textContent).toContain("bold");
+    expect(container.textContent).toContain("world");
+    expect(container.querySelector("strong")?.textContent).toBe("bold");
+  });
+
+  it("renders inline code with the dim code styling", () => {
+    const { container } = render(
+      <TextBlock block={{ kind: "text", text: "see `code` here" }} index={0} />,
+    );
+    const code = container.querySelector("code");
+    expect(code?.textContent).toBe("code");
+  });
+
+  it("renders markdown lists", () => {
+    const { container } = render(
+      <TextBlock block={{ kind: "text", text: "- one\n- two\n- three" }} index={0} />,
+    );
+    expect(container.querySelectorAll("li").length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("ThinkingBlock", () => {
+  it("is collapsed by default and hides its content", () => {
+    render(
+      <ThinkingBlock block={{ kind: "thinking", text: "deep thoughts", collapsed: true }} index={0} />,
+    );
+    const button = screen.getByRole("button", { name: /thinking/i });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    const controlsId = button.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    const panel = document.getElementById(controlsId!);
+    expect(panel).not.toBeNull();
+    expect(panel?.hasAttribute("hidden")).toBe(true);
+    expect(panel?.getAttribute("aria-labelledby")).toBe(button.getAttribute("id"));
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+  });
+
+  it("starts collapsed even when collapsed is not specified", () => {
+    render(
+      <ThinkingBlock block={{ kind: "thinking", text: "hidden" }} index={0} />,
+    );
+    const button = screen.getByRole("button", { name: /thinking/i });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(document.getElementById(button.getAttribute("aria-controls")!)?.hasAttribute("hidden")).toBe(true);
+  });
+
+  it("starts open only when collapsed is explicitly false", () => {
+    render(
+      <ThinkingBlock block={{ kind: "thinking", text: "visible thoughts", collapsed: false }} index={0} />,
+    );
+    const button = screen.getByRole("button", { name: /thinking/i });
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(document.getElementById(button.getAttribute("aria-controls")!)?.hasAttribute("hidden")).toBe(false);
+    expect(screen.getByText("visible thoughts")).toBeInTheDocument();
+  });
+
+  it("toggles open and updates ARIA + hidden state", () => {
+    render(
+      <ThinkingBlock block={{ kind: "thinking", text: "deep thoughts" }} index={0} />,
+    );
+    const button = screen.getByRole("button", { name: /thinking/i });
+    const controlsId = button.getAttribute("aria-controls")!;
+
+    // collapsed -> content hidden
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(document.getElementById(controlsId)?.hasAttribute("hidden")).toBe(true);
+
+    // expand
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(document.getElementById(controlsId)?.hasAttribute("hidden")).toBe(false);
+    expect(screen.getByText("deep thoughts")).toBeInTheDocument();
+
+    // collapse again
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(document.getElementById(controlsId)?.hasAttribute("hidden")).toBe(true);
+  });
+
+  it("renders the thinking body as markdown once expanded", () => {
+    render(
+      <ThinkingBlock block={{ kind: "thinking", text: "a **bold** plan" }} index={0} />,
+    );
+    const button = screen.getByRole("button", { name: /thinking/i });
+    fireEvent.click(button);
+    const strong = screen.getByText("bold");
+    expect(strong.tagName).toBe("STRONG");
+  });
+
+  it("uses distinct ids per instance and links via aria-labelledby", () => {
+    render(
+      <div>
+        <ThinkingBlock block={{ kind: "thinking", text: "first" }} index={0} />
+        <ThinkingBlock block={{ kind: "thinking", text: "second" }} index={1} />
+      </div>,
+    );
+    const buttons = screen.getAllByRole("button", { name: /thinking/i });
+    const controls = buttons.map((b) => b.getAttribute("aria-controls")!);
+    expect(controls[0]).not.toBe(controls[1]);
+    buttons.forEach((b) => {
+      const panel = document.getElementById(b.getAttribute("aria-controls")!);
+      expect(panel).not.toBeNull();
+      expect(panel?.getAttribute("aria-labelledby")).toBe(b.getAttribute("id"));
+    });
+  });
+
+  it("has dim styling on the toggle and container", () => {
+    const { container } = render(
+      <ThinkingBlock block={{ kind: "thinking", text: "x" }} index={0} />,
+    );
+    const button = screen.getByRole("button", { name: /thinking/i });
+    expect(button.className).toMatch(/text-shell-text-tertiary/);
+    const card = container.firstElementChild;
+    expect(card?.className).toMatch(/border-shell-border/);
+    expect(card?.className).toMatch(/bg-shell-surface/);
+  });
+});

--- a/desktop/src/apps/chat/__tests__/render-helpers.test.tsx
+++ b/desktop/src/apps/chat/__tests__/render-helpers.test.tsx
@@ -59,8 +59,8 @@ describe("renderContent", () => {
   });
 
   it("dispatches to content_blocks when non-empty", () => {
-    const { container } = render(<div>{renderContent("", [{ kind: "text", text: "hello" }])}</div>);
-    expect(container.textContent).toContain("unsupported block: text");
+    const { container } = render(<div>{renderContent("", [{ kind: "text", text: "hello world" }])}</div>);
+    expect(container.textContent).toContain("hello world");
   });
 
   it("falls through to markdown when content_blocks is empty", () => {
@@ -99,26 +99,30 @@ describe("renderContent", () => {
     expect(container.textContent).toContain("unsupported block: mystery");
   });
 
-  it("renders unknown fallback for text and thinking (separate cards)", () => {
+  it("renders all four slice-1 kinds with no fallback", () => {
     const { container } = render(
       <div>{renderContent("", [
         { kind: "text", text: "hi" },
-        { kind: "thinking", text: "thinking...", collapsed: true },
-      ])}</div>,
-    );
-    expect(container.textContent).toContain("unsupported block: text");
-    expect(container.textContent).toContain("unsupported block: thinking");
-  });
-
-  it("renders one fallback line per block for stub kinds", () => {
-    const { container } = render(
-      <div>{renderContent("", [
-        { kind: "text", text: "a" },
-        { kind: "thinking", text: "b" },
+        { kind: "thinking", text: "pondering" },
+        { kind: "tool_call", name: "grep", args: {} },
+        { kind: "status", text: "done" },
       ])}</div>,
     );
     const text = container.textContent || "";
-    expect(text.match(/unsupported block/g)?.length).toBe(2);
+    expect(text).toContain("hi");
+    expect(text).toContain("Thinking");
+    expect(text).toContain("done");
+    expect(text).not.toContain("unsupported block");
+  });
+
+  it("still falls back once for a single unrecognised block", () => {
+    const { container } = render(
+      <div>{renderContent("", [
+        { kind: "mystery", text: "a" },
+      ])}</div>,
+    );
+    const text = container.textContent || "";
+    expect(text.match(/unsupported block/g)?.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): taOStalk s1: TextBlock + ThinkingBlock renderers (cards 3+4)

Autonomous build of board card tsk-6ylbbx.



Files:
 desktop/src/apps/MessagesApp.tsx                   |  79 +++++++++++--
 .../apps/chat/__tests__/content-blocks.test.tsx    | 127 +++++++++++++++++++++
 .../apps/chat/__tests__/render-helpers.test.tsx    |  16 +--
 3 files changed, 207 insertions(+), 15 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Chat messages now render text content with inline Markdown formatting.
  - Thinking content appears in a collapsible panel that is closed by default and can be expanded when needed.
  - Added accessible expand/collapse controls with appropriate labels and relationships.

- **Bug Fixes**
  - Supported text and thinking content blocks no longer display as unsupported content.
  - Improved rendering consistency for chat content blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->