### PR TITLE
Projects app: Notes area for posting ideas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ### Added
 
+- Projects gain a Notes area: title + markdown notes per project, readable and
+  writable by the project owner or by an agent holding a project-bound
+  `project_notes` grant (new requestable scope) (#2285).
 - Chat renders `text` and `thinking` content blocks: thinking is a
   collapsed-by-default disclosure with a proper ARIA expand/collapse contract (#2282).
 - Messages sidebar shows a live "thinking" badge on channels whose bound

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -206,6 +206,14 @@ The surface, by scope:
   (read one), and `PUT /api/projects/{pid}/doc-review/{path}` (set state).
   The route verifies the JWT + grant + project binding; the middleware allowlist
   is closed to these paths only.
+- **project_notes**: read and write a project's persistent idea notes
+  (title + markdown body). `GET /api/projects/{pid}/notes` (list),
+  `POST /api/projects/{pid}/notes` (create), `PATCH /api/projects/{pid}/notes/{nid}`
+  (edit) and `DELETE /api/projects/{pid}/notes/{nid}`. One scope covers read and
+  write, mirroring project_doc_review. The route verifies the JWT + grant +
+  project binding, and a token bound to a DIFFERENT project gets a 404 rather
+  than a 403, so it cannot confirm that another project exists. The note's
+  author is taken from the verified token, never from the request body.
 - **canvas_read**: `GET .../canvas/elements`, `.../canvas/watch-projection`,
   `.../canvas/snapshot.png|.tldr`, `.../canvas/stream`. **canvas_write**: `POST .../canvas/elements`,
   `PATCH|DELETE .../canvas/elements/{id}`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -364,6 +364,10 @@ async def client(app, tmp_data_dir):
     if project_element_store._db is not None:
         await project_element_store.close()
     await project_element_store.init()
+    project_notes_store = app.state.project_notes_store
+    if project_notes_store._db is not None:
+        await project_notes_store.close()
+    await project_notes_store.init()
     routine_store = app.state.routine_store
     if routine_store._db is not None:
         await routine_store.close()
@@ -500,6 +504,7 @@ async def client(app, tmp_data_dir):
     await feedback_store.close()
     await client_log_store.close()
     await project_element_store.close()
+    await project_notes_store.close()
     await app.state.qmd_client.close()
     await app.state.http_client.aclose()
     await _browser_store.close()

--- a/tests/test_project_notes_store.py
+++ b/tests/test_project_notes_store.py
@@ -1,0 +1,134 @@
+"""Project notes store: create/read/list/update/delete + newest-first ordering.
+
+The store (tinyagentos/projects/notes_store.py) is exercised directly.  The
+routes (tinyagentos/routes/project_notes.py) are exercised over HTTP in
+test_routes_project_notes.py to pin the session-or-agent-JWT auth gate.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.projects.notes_store import ProjectNotesStore
+
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ProjectNotesStore(tmp_path / "projects.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_note(store):
+    n = await store.create_note(
+        project_id="prj-aaa", title="Idea", body="a thought", author_id="user-1"
+    )
+    assert n["id"].startswith("note-")
+    assert n["project_id"] == "prj-aaa"
+    assert n["title"] == "Idea"
+    assert n["body"] == "a thought"
+    assert n["author_id"] == "user-1"
+    assert n["author_kind"] == "user"
+    assert n["created_at"] is not None
+    assert n["updated_at"] == n["created_at"]
+
+    again = await store.get_note(n["id"])
+    assert again == n
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(store):
+    assert await store.get_note("note-does-not-exist") is None
+
+
+@pytest.mark.asyncio
+async def test_list_notes_newest_first(store):
+    a = await store.create_note("p", "A", "body-a", "u")
+    b = await store.create_note("p", "B", "body-b", "u")
+    c = await store.create_note("p", "C", "body-c", "u")
+    listed = await store.list_notes("p")
+    # Newest first by created_at DESC.
+    assert [n["id"] for n in listed] == [c["id"], b["id"], a["id"]]
+
+
+@pytest.mark.asyncio
+async def test_list_notes_scoped_to_project(store):
+    n1 = await store.create_note("p1", "one", "b", "u")
+    n2 = await store.create_note("p2", "two", "b", "u")
+    assert [n["id"] for n in await store.list_notes("p1")] == [n1["id"]]
+    assert [n["id"] for n in await store.list_notes("p2")] == [n2["id"]]
+
+
+@pytest.mark.asyncio
+async def test_list_notes_empty(store):
+    assert await store.list_notes("p") == []
+
+
+@pytest.mark.asyncio
+async def test_update_note_title_and_body(store):
+    n = await store.create_note("p", "orig", "orig body", "u")
+    updated = await store.update_note(n["id"], title="new", body="new body")
+    assert updated["title"] == "new"
+    assert updated["body"] == "new body"
+    assert updated["updated_at"] >= n["updated_at"]
+    assert updated["author_id"] == "u"
+
+
+@pytest.mark.asyncio
+async def test_update_note_partial_only_sets_provided_fields(store):
+    n = await store.create_note("p", "keep me", "keep body", "u")
+    updated = await store.update_note(n["id"], title="changed")
+    assert updated["title"] == "changed"
+    assert updated["body"] == "keep body"
+
+
+@pytest.mark.asyncio
+async def test_update_note_noop_returns_existing(store):
+    n = await store.create_note("p", "keep me", "keep body", "u")
+    returned = await store.update_note(n["id"])
+    assert returned == n
+
+
+@pytest.mark.asyncio
+async def test_update_note_missing_returns_none(store):
+    assert await store.update_note("note-missing", title="x") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_note(store):
+    n = await store.create_note("p", "doomed", "body", "u")
+    assert await store.get_note(n["id"]) is not None
+    assert await store.delete_note(n["id"]) is True
+    assert await store.get_note(n["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_note_missing_returns_false(store):
+    assert await store.delete_note("note-missing") is False
+
+
+@pytest.mark.asyncio
+async def test_create_note_agent_author_kind(store):
+    n = await store.create_note("p", "idea", "body", "agent-7", author_kind="agent")
+    assert n["author_kind"] == "agent"
+    assert n["author_id"] == "agent-7"
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_index_on_existing_db(tmp_path):
+    """A notes table on a fresh install carries the created_at DESC index that
+    list_notes relies on for ordering."""
+    import sqlite3
+
+    db = tmp_path / "projects.db"
+    s = ProjectNotesStore(db)
+    await s.init()
+    conn = sqlite3.connect(str(db))
+    idxs = [r[0] for r in conn.execute(
+        "SELECT name, tbl_name FROM sqlite_master WHERE type='index' AND tbl_name='project_notes'"
+    )]
+    conn.close()
+    assert "idx_notes_project_created" in idxs
+    await s.close()

--- a/tests/test_routes_project_notes.py
+++ b/tests/test_routes_project_notes.py
@@ -1,0 +1,259 @@
+"""Project notes routes: session owner/admin and project-bound agent JWT.
+
+Pin the dual-auth contract for /api/projects/{id}/notes (GET/POST/PATCH/DELETE):
+
+  1. A session owner/admin can CRUD notes (regression on the projects
+     ownership pattern).
+  2. An approved agent token (scope project_notes) bound to project A can
+     read + author + edit + delete notes ONLY for project A; a token bound
+     elsewhere collapses into an existence-hiding 404.
+  3. A token missing the project_notes scope is rejected 403; an
+     unauthenticated (no session, no token) request is 401.
+
+The store (tinyagentos/projects/notes_store.py) is exercised directly in
+test_project_notes_store.py; these tests pin the HTTP auth + project scoping.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tinyagentos.agent_registry_store import mint_registry_token
+
+
+@pytest_asyncio.fixture
+async def ctx(client):
+    """Reuse the session-admin `client` app and additionally init the agent
+    registry + grants stores so tokens can be minted against real stores."""
+    app = client._transport.app
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is None:
+            await store.init()
+    uid = app.state.auth.find_user("admin")["id"]
+    yield SimpleNamespace(client=client, app=app, uid=uid)
+    for attr in ("agent_registry", "agent_grants"):
+        store = getattr(app.state, attr)
+        if store._db is not None:
+            await store.close()
+
+
+def _bare(app):
+    """Cookieless client so requests carry only the Bearer header."""
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _new_project(ctx, slug):
+    resp = await ctx.client.post("/api/projects", json={"name": slug, "slug": slug})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["id"]
+
+
+async def _mint_agent(ctx, project_id, scopes=("project_notes",)):
+    registry = ctx.app.state.agent_registry
+    grants = ctx.app.state.agent_grants
+    priv, _pub = ctx.app.state.agent_registry_keypair
+    rec = await registry.register(
+        framework="grok",
+        display_name="Grok",
+        origin="external-selfjoin",
+        handle="@grok",
+    )
+    cid = rec["canonical_id"]
+    await registry.set_status(cid, "active")
+    for scope in scopes:
+        await grants.add_grant(cid, scope, project_id=project_id)
+    token = mint_registry_token(
+        cid, priv, user_id="u", framework="grok", project_id=project_id
+    )
+    return cid, token
+
+
+def _hdr(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+class TestOwnerSessionCRUD:
+    async def test_create_list_update_delete(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/notes", json={"title": "Idea", "body": "thought"}
+        )
+        assert created.status_code == 200, created.text
+        note = created.json()
+        assert note["title"] == "Idea"
+        assert note["body"] == "thought"
+        assert note["author_kind"] == "user"
+
+        listed = await ctx.client.get(f"/api/projects/{pid}/notes")
+        assert listed.status_code == 200
+        assert any(n["id"] == note["id"] for n in listed.json()["items"])
+
+        patched = await ctx.client.patch(
+            f"/api/projects/{pid}/notes/{note['id']}", json={"title": "Renamed"}
+        )
+        assert patched.status_code == 200
+        assert patched.json()["title"] == "Renamed"
+        # Body preserved on partial update.
+        assert patched.json()["body"] == "thought"
+
+        deleted = await ctx.client.delete(f"/api/projects/{pid}/notes/{note['id']}")
+        assert deleted.status_code == 200, deleted.text
+        assert deleted.json()["ok"] is True
+
+        after = await ctx.client.get(f"/api/projects/{pid}/notes")
+        assert not any(n["id"] == note["id"] for n in after.json()["items"])
+
+    async def test_list_newest_first(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        a = await ctx.client.post(
+            f"/api/projects/{pid}/notes", json={"title": "A", "body": ""}
+        )
+        b = await ctx.client.post(
+            f"/api/projects/{pid}/notes", json={"title": "B", "body": ""}
+        )
+        listed = await ctx.client.get(f"/api/projects/{pid}/notes")
+        ids = [n["id"] for n in listed.json()["items"]]
+        assert ids == [b.json()["id"], a.json()["id"]]
+
+    async def test_update_unknown_note_is_404(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        resp = await ctx.client.patch(
+            f"/api/projects/{pid}/notes/note-missing", json={"title": "x"}
+        )
+        assert resp.status_code == 404
+
+    async def test_delete_unknown_note_is_404(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        resp = await ctx.client.delete(f"/api/projects/{pid}/notes/note-missing")
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestAgentScopeGating:
+    async def test_agent_can_read_and_write_own_project(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        # Session owner seeds a note so the agent has something to read.
+        seeded = await ctx.client.post(
+            f"/api/projects/{pid}/notes", json={"title": "seed", "body": "seed"}
+        )
+        seed_id = seeded.json()["id"]
+
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            listed = await bare.get(f"/api/projects/{pid}/notes", headers=_hdr(token))
+            assert listed.status_code == 200
+            ids = [n["id"] for n in listed.json()["items"]]
+            assert seed_id in ids
+
+            post = await bare.post(
+                f"/api/projects/{pid}/notes",
+                json={"title": "agent idea", "body": "posted by agent"},
+                headers=_hdr(token),
+            )
+        assert post.status_code == 200, post.text
+        note = post.json()
+        assert note["author_id"] == cid
+        assert note["author_kind"] == "agent"
+
+    async def test_agent_patch_succeeds(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/notes", json={"title": "orig", "body": "b"}
+        )
+        note_id = created.json()["id"]
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.patch(
+                f"/api/projects/{pid}/notes/{note_id}",
+                json={"title": "agent-edited"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["title"] == "agent-edited"
+
+    async def test_agent_delete_succeeds(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        created = await ctx.client.post(
+            f"/api/projects/{pid}/notes", json={"title": "todelete", "body": "b"}
+        )
+        note_id = created.json()["id"]
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.delete(
+                f"/api/projects/{pid}/notes/{note_id}", headers=_hdr(token)
+            )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+
+    async def test_agent_note_persists(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            await bare.post(
+                f"/api/projects/{pid}/notes",
+                json={"title": "persist", "body": "kept"},
+                headers=_hdr(token),
+            )
+            listed = await bare.get(f"/api/projects/{pid}/notes", headers=_hdr(token))
+        assert listed.status_code == 200
+        titles = [n["title"] for n in listed.json()["items"]]
+        assert "persist" in titles
+        assert listed.json()["items"][0]["author_id"] == cid
+
+    async def test_agent_other_project_is_404(self, ctx):
+        pid_a = await _new_project(ctx, "alpha")
+        pid_b = await _new_project(ctx, "bravo")
+        _cid, token_a = await _mint_agent(ctx, pid_a)
+        async with _bare(ctx.app) as bare:
+            listing = await bare.get(f"/api/projects/{pid_b}/notes", headers=_hdr(token_a))
+            create = await bare.post(
+                f"/api/projects/{pid_b}/notes",
+                json={"title": "x", "body": ""},
+                headers=_hdr(token_a),
+            )
+            patch = await bare.patch(
+                f"/api/projects/{pid_b}/notes/note-x",
+                json={"title": "y"},
+                headers=_hdr(token_a),
+            )
+            delete = await bare.delete(
+                f"/api/projects/{pid_b}/notes/note-x", headers=_hdr(token_a)
+            )
+        # Existence-hiding 404 for every method: indistinguishable from a
+        # non-owner session on a missing project.
+        assert listing.status_code == 404
+        assert create.status_code == 404
+        assert patch.status_code == 404
+        assert delete.status_code == 404
+
+    async def test_agent_missing_scope_is_403(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        _cid, token = await _mint_agent(ctx, pid, scopes=("a2a_receive",))
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/notes", headers=_hdr(token))
+        assert resp.status_code == 403, resp.text
+
+    async def test_unauthenticated_is_401(self, ctx):
+        pid = await _new_project(ctx, "alpha")
+        async with _bare(ctx.app) as bare:
+            resp = await bare.get(f"/api/projects/{pid}/notes")
+        assert resp.status_code == 401, resp.text
+
+    async def test_agent_author_attributed_to_token(self, ctx):
+        """An agent creating a note is always attributed to its own canonical id;
+        the route does not accept a client-supplied author_id."""
+        pid = await _new_project(ctx, "alpha")
+        cid, token = await _mint_agent(ctx, pid)
+        async with _bare(ctx.app) as bare:
+            resp = await bare.post(
+                f"/api/projects/{pid}/notes",
+                json={"title": "idea", "body": "b"},
+                headers=_hdr(token),
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["author_id"] == cid

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -423,6 +423,8 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     routine_store = RoutineStore(data_dir / "routines.db")
     project_canvas_store = ProjectCanvasStoreImpl(data_dir / "projects.db", broker=project_event_broker)
     doc_review_store = DocReviewStore(data_dir / "projects.db")
+    from tinyagentos.projects.notes_store import ProjectNotesStore
+    project_notes_store = ProjectNotesStore(data_dir / "projects.db")
     from tinyagentos.decisions.decision_store import DecisionStore
     decision_store = DecisionStore(data_dir / "decisions.db")
     from tinyagentos.governance.policy_store import ExecutionPolicyStore
@@ -587,6 +589,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await routine_store.init()
         await project_canvas_store.init()
         await doc_review_store.init()
+        await project_notes_store.init()
         await decision_store.init()
         await execution_policy_store.init()
         await shared_docs_store.init()
@@ -1449,6 +1452,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
                 logger.exception("canvas snapshotter stop failed")
         await project_canvas_store.close()
         await doc_review_store.close()
+        await project_notes_store.close()
         await project_invite_store.close()
         await project_task_store.close()
         await project_element_store.close()
@@ -1613,6 +1617,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.desktop_command_broker = desktop_command_broker
     app.state.project_canvas_store = project_canvas_store
     app.state.doc_review_store = doc_review_store
+    app.state.project_notes_store = project_notes_store
     app.state.decision_store = decision_store
     app.state.execution_policies = execution_policy_store
     app.state.shared_docs_store = shared_docs_store

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -102,10 +102,28 @@ _AGENT_DOC_REVIEW_ROUTES = (
     ("PUT", re.compile(rf"^/api/projects/{_SEG}/doc-review/(.+)$")),
 )
 
+# Project notes store routes an agent may reach with its own registry JWT
+# (scope project_notes, verified + project-bound by the route).  The token only
+# reaches the handler, which then verifies the JWT + grant + project binding;
+# nothing else is reachable by the token.  List/create are on the collection
+# segment; patch/delete target a specific note id.
+_AGENT_NOTES_ROUTES = (
+    ("GET", re.compile(rf"^/api/projects/{_SEG}/notes$")),
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/notes$")),
+    ("PATCH", re.compile(rf"^/api/projects/{_SEG}/notes/{_SEG}$")),
+    ("DELETE", re.compile(rf"^/api/projects/{_SEG}/notes/{_SEG}$")),
+)
+
 
 def _is_agent_doc_review_path(method: str, path: str) -> bool:
     """True only for the doc-review routes a project_doc_review token may reach."""
     return any(m == method and rx.match(path) for m, rx in _AGENT_DOC_REVIEW_ROUTES)
+
+
+def _is_agent_notes_path(method: str, path: str) -> bool:
+    """True only for the notes routes a project_notes token may reach.
+    Strict method + anchored-regex match; everything else is excluded."""
+    return any(m == method and rx.match(path) for m, rx in _AGENT_NOTES_ROUTES)
 
 
 _AGENT_CANVAS_ROUTES = (
@@ -458,6 +476,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
             path in _AGENT_TOKEN_PATHS
             or _is_agent_task_path(request.method, path)
             or _is_agent_doc_review_path(request.method, path)
+            or _is_agent_notes_path(request.method, path)
             or _is_agent_canvas_path(request.method, path)
             or _is_agent_decisions_path(request.method, path)
             or _is_agent_files_path(request.method, path)

--- a/tinyagentos/projects/ids.py
+++ b/tinyagentos/projects/ids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import secrets
 
-ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "lst", "rev", "cs", "rtn", "elm")
+ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "lst", "rev", "cs", "rtn", "elm", "note")
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
 
 

--- a/tinyagentos/projects/notes_store.py
+++ b/tinyagentos/projects/notes_store.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import time
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+NOTES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS project_notes (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    body TEXT NOT NULL DEFAULT '',
+    author_id TEXT NOT NULL,
+    author_kind TEXT NOT NULL DEFAULT 'user',
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notes_project ON project_notes(project_id);
+CREATE INDEX IF NOT EXISTS idx_notes_project_created ON project_notes(project_id, created_at DESC);
+"""
+
+
+class ProjectNotesStore(BaseStore):
+    SCHEMA = NOTES_SCHEMA
+
+    async def create_note(
+        self,
+        project_id: str,
+        title: str,
+        body: str,
+        author_id: str,
+        author_kind: str = "user",
+    ) -> dict:
+        note_id = new_id("note")
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO project_notes
+               (id, project_id, title, body, author_id, author_kind, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (note_id, project_id, title, body, author_id, author_kind, now, now),
+        )
+        await self._db.commit()
+        return await self.get_note(note_id)
+
+    async def get_note(self, note_id: str) -> dict | None:
+        async with self._db.execute(
+            "SELECT * FROM project_notes WHERE id = ?", (note_id,)
+        ) as cur:
+            row = await cur.fetchone()
+            if row is None:
+                return None
+            keys = [d[0] for d in cur.description]
+            return dict(zip(keys, row))
+
+    async def list_notes(self, project_id: str) -> list[dict]:
+        async with self._db.execute(
+            "SELECT * FROM project_notes WHERE project_id = ? ORDER BY created_at DESC",
+            (project_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+            keys = [d[0] for d in cur.description]
+            return [dict(zip(keys, r)) for r in rows]
+
+    async def update_note(
+        self,
+        note_id: str,
+        title: str | None = None,
+        body: str | None = None,
+    ) -> dict | None:
+        sets: list[str] = []
+        params: list = []
+        if title is not None:
+            sets.append("title = ?")
+            params.append(title)
+        if body is not None:
+            sets.append("body = ?")
+            params.append(body)
+        if not sets:
+            return await self.get_note(note_id)
+        sets.append("updated_at = ?")
+        params.append(time.time())
+        params.append(note_id)
+        await self._db.execute(
+            f"UPDATE project_notes SET {', '.join(sets)} WHERE id = ?", params
+        )
+        await self._db.commit()
+        return await self.get_note(note_id)
+
+    async def delete_note(self, note_id: str) -> bool:
+        cursor = await self._db.execute(
+            "DELETE FROM project_notes WHERE id = ?", (note_id,)
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0

--- a/tinyagentos/routes/__init__.py
+++ b/tinyagentos/routes/__init__.py
@@ -183,6 +183,9 @@ def register_all_routers(app):
     from tinyagentos.routes.project_doc_review import router as project_doc_review_router
     app.include_router(project_doc_review_router, dependencies=_csrf)
 
+    from tinyagentos.routes.project_notes import router as project_notes_router
+    app.include_router(project_notes_router, dependencies=_csrf)
+
     from tinyagentos.routes.desktop_control import router as desktop_control_router
     app.include_router(desktop_control_router, dependencies=_csrf)
 

--- a/tinyagentos/routes/agent_auth_requests.py
+++ b/tinyagentos/routes/agent_auth_requests.py
@@ -82,6 +82,11 @@ VALID_SCOPES = frozenset({
     # (project-bound like project_tasks). Reconciled from master at beta.45 -
     # the routes shipped on every install while the scope was missing here.
     "project_doc_review",
+    # Project notes: read/write a project's persistent idea notes
+    # (title + markdown body) by a session owner/admin or a project-bound
+    # project_notes grant holder. Mirrors project_doc_review's single-scope
+    # read+write surface for a lightweight persistent notes surface.
+    "project_notes",
     "observatory_control",
 })
 

--- a/tinyagentos/routes/agent_registry.py
+++ b/tinyagentos/routes/agent_registry.py
@@ -95,8 +95,9 @@ _ALLOWED_SCOPES = frozenset({
     "project_tasks",
     "project_tasks_create",
     "project_tasks_update",
-    "project_doc_review",
-    "canvas_read", "canvas_write",
+     "project_doc_review",
+     "project_notes",
+     "canvas_read", "canvas_write",
     "decisions_read", "decisions_write",
     "observatory_control",
 })

--- a/tinyagentos/routes/project_notes.py
+++ b/tinyagentos/routes/project_notes.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from tinyagentos.agent_token_auth import (
+    PROJECT_SCOPE_MISMATCH_DETAIL,
+    check_agent_scope_for_project,
+)
+from tinyagentos.auth_context import CurrentUser
+from tinyagentos.routes.projects import _get_owned_project
+
+router = APIRouter()
+
+# Scope for project-scoped notes: a single scope covers read + write. Notes are
+# a lightweight persistent surface (ideas, not lifecycle-critical cards), so a
+# single project_notes grant lets an approved agent read and post/edit/delete
+# notes on ITS project only. The route verifies the JWT + grant + project binding.
+_NOTES_SCOPE = "project_notes"
+
+
+class CreateNoteIn(BaseModel):
+    title: str
+    body: str = ""
+
+
+class UpdateNoteIn(BaseModel):
+    title: str | None = None
+    body: str | None = None
+
+
+async def _authorize_notes_actor(
+    request: Request, pstore, project_id: str
+) -> "tuple[str, bool, dict] | JSONResponse":
+    """Resolve the actor for a project-notes route that accepts EITHER a session
+    owner/admin OR an approved external agent's registry JWT holding _NOTES_SCOPE
+    bound to THIS project.
+
+    Mirrors ``_authorize_task_actor`` (routes/projects.py): session non-owners
+    and wrong-project tokens both collapse into an existence-hiding 404 so a
+    caller can never confirm another project's existence. The route takes
+    ``request: Request`` and auths INSIDE the handler (not via Depends) because
+    ``Depends(current_user)`` would 401 an agent with no session before it runs.
+
+    Returns ``(actor_id, is_agent, project)`` on success, or a JSONResponse to
+    return directly.
+    """
+    uid = getattr(request.state, "user_id", None)
+    if uid:
+        user = CurrentUser(
+            user_id=uid, is_admin=bool(getattr(request.state, "is_admin", False))
+        )
+        project_or_err = await _get_owned_project(pstore, project_id, user)
+        if isinstance(project_or_err, JSONResponse):
+            return project_or_err
+        return (user.user_id, False, project_or_err)
+
+    try:
+        caller = await check_agent_scope_for_project(request, _NOTES_SCOPE, project_id)
+    except HTTPException as exc:
+        if exc.status_code == 403 and exc.detail == PROJECT_SCOPE_MISMATCH_DETAIL:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        raise
+    if caller is None:
+        # No session and no Bearer token: fail closed with existence-hiding 404.
+        return JSONResponse({"error": "not found"}, status_code=404)
+    project = await pstore.get_project(project_id)
+    if project is None:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    return (caller, True, project)
+
+
+@router.get("/api/projects/{project_id}/notes")
+async def list_notes(project_id: str, request: Request):
+    pstore = request.app.state.project_store
+    auth = await _authorize_notes_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    store = request.app.state.project_notes_store
+    return {"items": await store.list_notes(project_id)}
+
+
+@router.post("/api/projects/{project_id}/notes")
+async def create_note(
+    project_id: str,
+    payload: CreateNoteIn,
+    request: Request,
+):
+    pstore = request.app.state.project_store
+    auth = await _authorize_notes_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, is_agent, _project = auth
+    author_kind = "agent" if is_agent else "user"
+    store = request.app.state.project_notes_store
+    title = payload.title or ""
+    note = await store.create_note(
+        project_id=project_id,
+        title=title,
+        body=payload.body,
+        author_id=actor_id,
+        author_kind=author_kind,
+    )
+    await pstore.log_activity(
+        project_id, actor_id, "note.created", {"note_id": note["id"], "title": note["title"]}
+    )
+    return note
+
+
+@router.patch("/api/projects/{project_id}/notes/{note_id}")
+async def update_note(
+    project_id: str,
+    note_id: str,
+    payload: UpdateNoteIn,
+    request: Request,
+):
+    pstore = request.app.state.project_store
+    auth = await _authorize_notes_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_notes_store
+    existing = await store.get_note(note_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    updated = await store.update_note(
+        note_id,
+        title=payload.title,
+        body=payload.body,
+    )
+    await pstore.log_activity(
+        project_id, actor_id, "note.updated", {"note_id": note_id}
+    )
+    return updated
+
+
+@router.delete("/api/projects/{project_id}/notes/{note_id}")
+async def delete_note(
+    project_id: str,
+    note_id: str,
+    request: Request,
+):
+    pstore = request.app.state.project_store
+    auth = await _authorize_notes_actor(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_notes_store
+    existing = await store.get_note(note_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    await store.delete_note(note_id)
+    await pstore.log_activity(
+        project_id, actor_id, "note.deleted", {"note_id": note_id}
+    )
+    return {"ok": True}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Projects app: Notes area for posting ideas

Autonomous build of board card tsk-ehgzcd.



Files:
 tinyagentos/auth_middleware.py            |  19 +++
 tinyagentos/projects/ids.py               |   2 +-
 tinyagentos/projects/notes_store.py       |  95 +++++++++++
 tinyagentos/routes/__init__.py            |   3 +
 tinyagentos/routes/agent_auth_requests.py |   5 +
 tinyagentos/routes/agent_registry.py      |   5 +-
 tinyagentos/routes/project_notes.py       | 157 ++++++++++++++++++
 11 files changed, 686 insertions(+), 3 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project-scoped notes with create, view, update, and delete support.
  * Notes support titles, body content, timestamps, and author attribution.
  * Added secure access for project owners, administrators, and authorized project agents.
  * Added project activity tracking for note changes.
* **Bug Fixes**
  * Unauthorized or cross-project note access is safely denied without revealing resource existence.
* **Documentation**
  * Documented project note access and agent permissions.
* **Tests**
  * Added comprehensive coverage for note storage, ordering, permissions, authentication, and lifecycle operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->