### PR TITLE
doc-gate: accept changelog.d fragments so concurrent PRs stop conflicting

### DIFF
--- a/changelog.d/2290-changelog-fragments.md
+++ b/changelog.d/2290-changelog-fragments.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Contributors add a `changelog.d/<pr>-<slug>.md` fragment instead of editing
+  `CHANGELOG.md`, so concurrent PRs no longer conflict on the shared
+  `[Unreleased]` anchor; `scripts/collate_changelog.py` folds fragments into a
+  release section at bump time. Editing `CHANGELOG.md` directly still works.

--- a/docs/changelog-fragments.md
+++ b/docs/changelog-fragments.md
@@ -1,0 +1,48 @@
+# Changelog fragments
+
+Drop ONE file per pull request into `changelog.d/` instead of editing
+`CHANGELOG.md`:
+
+    changelog.d/2291-notes-area.md
+
+Name it `<pr-number>-<short-slug>.md` and write the bullet exactly as it should
+appear in the changelog, including the trailing `(#PR)`:
+
+    - Projects gain a Notes area: title + markdown notes per project (#2291).
+
+Put `### Added`, `### Fixed`, `### Changed`, `### Removed` or `### Security` on
+its own first line when the section matters; the collator groups by section and
+defaults to `### Added`.
+
+## Why files instead of editing CHANGELOG.md
+
+Every PR that edits `CHANGELOG.md` writes at the same `[Unreleased]` anchor, so
+any two concurrent PRs conflict there by construction, and each merge
+re-conflicts every other open PR. With N PRs open that is O(N^2) rebases which
+touch no real code. On 2026-08-04 that cost seven rebases in one session.
+Distinct filenames cannot conflict.
+
+Editing `CHANGELOG.md` directly still satisfies the doc gate, so nothing breaks
+if you forget; the fragment is simply the path that does not cost anyone a
+rebase.
+
+## Why this file is not in changelog.d/
+
+The doc gate accepts `changelog.d/*.md` as proof that a user-visible change was
+documented. A `README.md` sitting in that directory would match the same glob,
+so a PR could satisfy the changelog rule by touching the readme and shipping no
+changelog at all. That is not hypothetical: it was caught by probing the gate
+during the change that introduced fragments, where the gate went green on a
+route change carrying no changelog entry. `changelog.d/` therefore contains
+nothing but fragments and a `.gitkeep`.
+
+## At release time
+
+The version bump runs:
+
+    python3 scripts/collate_changelog.py <version>
+
+which folds every fragment into a new `## [<version>] - <date>` section beneath
+`[Unreleased]`, groups them by section in Keep-a-Changelog order, and deletes the
+fragments in the same commit. `--dry-run` prints the section without touching
+anything.

--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -49,12 +49,26 @@ require_doc = ["docs/agent-coordination.md"]
 hint = "the agent-token route allowlist changed; update the agent-facing API surface (or add a Docs-Reviewed trailer explaining why not)"
 
 # User-visible behaviour needs a changelog line.
+#
+# EITHER a CHANGELOG.md edit OR a new fragment under changelog.d/ satisfies
+# this; prefer the fragment. Every PR editing CHANGELOG.md writes at the same
+# [Unreleased] anchor, so concurrent PRs conflict there by construction and each
+# merge re-conflicts the next - N open PRs cost O(N^2) rebases touching no real
+# code. A fragment is a new file with a unique name and cannot conflict.
+# scripts/collate_changelog.py folds them in at release time.
+#
+# NOTE the glob is deliberately `changelog.d/*.md` and the directory holds
+# NOTHING but fragments: the convention doc lives at docs/changelog-fragments.md,
+# because a README.md inside changelog.d/ would ITSELF match this glob and let a
+# PR that merely touched the README satisfy the rule. Verified by probe: with the
+# doc inside the directory the gate went green on a change carrying no changelog
+# at all.
 [[rules]]
 name = "user-visible-changelog"
 on_modify = true
 when_changed = ["tinyagentos/routes/*.py", "desktop/src/apps/*/**", "tinyagentos/installers/*"]
-require_doc = ["CHANGELOG.md"]
-hint = "user-visible behaviour changed; add a CHANGELOG.md line (or add a Docs-Reviewed trailer explaining why not)"
+require_doc = ["CHANGELOG.md", "changelog.d/*.md"]
+hint = "user-visible behaviour changed; add a changelog.d/<pr>-<slug>.md fragment (preferred) or a CHANGELOG.md line (or add a Docs-Reviewed trailer explaining why not)"
 
 # Agent-facing behaviour needs the compiled agent manual reviewed.
 [[rules]]

--- a/scripts/collate_changelog.py
+++ b/scripts/collate_changelog.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Fold changelog.d/*.md fragments into a new CHANGELOG.md version section.
+
+Run from the release bump, before tagging:
+
+    python3 scripts/collate_changelog.py 1.0.0-beta.47
+
+Reads every ``changelog.d/*.md``, groups the bullets under their declared
+``### Section`` heading (defaulting to ``### Added``), writes them as a new
+``## [<version>] - <today>`` section directly beneath ``## [Unreleased]`` in
+CHANGELOG.md, and deletes the fragments it consumed.
+
+Fragments exist because every PR editing CHANGELOG.md writes at the same anchor,
+so concurrent PRs conflict there by construction. A fragment is a new file with a
+unique name and cannot conflict. See docs/changelog-fragments.md.
+
+The convention doc deliberately lives OUTSIDE changelog.d/: a README.md in there
+would match the doc-gate's ``changelog.d/*.md`` glob and let a PR satisfy the
+changelog rule by touching the readme.
+
+Exit codes: 0 on success (including "no fragments, nothing to do"), 1 on a
+malformed fragment or a CHANGELOG.md missing its [Unreleased] anchor.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+FRAGMENT_DIR = ROOT / "changelog.d"
+CHANGELOG = ROOT / "CHANGELOG.md"
+UNRELEASED = "## [Unreleased]"
+DEFAULT_SECTION = "### Added"
+# Keep-a-Changelog order, so a release section always reads the same way
+# regardless of the order the fragments happened to land in.
+SECTION_ORDER = ["### Added", "### Changed", "### Fixed", "### Removed", "### Security"]
+
+
+def parse_fragment(path: Path) -> dict[str, list[str]]:
+    """Return {section: [bullet lines]} for one fragment file."""
+    sections: dict[str, list[str]] = {}
+    current = DEFAULT_SECTION
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.rstrip()
+        if not line.strip():
+            continue
+        if line.startswith("### "):
+            current = line.strip()
+            continue
+        # Continuation lines of a wrapped bullet are indented; they stay with
+        # the bullet rather than becoming a new entry.
+        sections.setdefault(current, []).append(line)
+    if not sections:
+        raise ValueError(f"{path.name} contains no changelog bullets")
+    return sections
+
+
+def collect(fragment_dir: Path) -> tuple[dict[str, list[str]], list[Path]]:
+    merged: dict[str, list[str]] = {}
+    consumed: list[Path] = []
+    # Sorted so the output is deterministic: same fragments, same section order.
+    for path in sorted(fragment_dir.glob("*.md")):
+        for section, lines in parse_fragment(path).items():
+            merged.setdefault(section, []).extend(lines)
+        consumed.append(path)
+    return merged, consumed
+
+
+def render(version: str, merged: dict[str, list[str]], today: str) -> str:
+    out = [f"## [{version}] - {today}", ""]
+    ordered = [s for s in SECTION_ORDER if s in merged]
+    ordered += [s for s in sorted(merged) if s not in SECTION_ORDER]
+    for section in ordered:
+        out.append(section)
+        out.append("")
+        out.extend(merged[section])
+        out.append("")
+    return "\n".join(out)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Fold changelog fragments into CHANGELOG.md")
+    ap.add_argument("version", help="release version, e.g. 1.0.0-beta.47")
+    ap.add_argument("--date", default=None, help="release date (YYYY-MM-DD), defaults to today")
+    ap.add_argument("--dry-run", action="store_true", help="print the section, change nothing")
+    args = ap.parse_args(argv)
+
+    if not FRAGMENT_DIR.is_dir():
+        print("collate-changelog: no changelog.d/ directory, nothing to do")
+        return 0
+    merged, consumed = collect(FRAGMENT_DIR)
+    if not consumed:
+        print("collate-changelog: no fragments, nothing to do")
+        return 0
+
+    today = args.date or datetime.date.today().isoformat()
+    section = render(args.version, merged, today)
+
+    if args.dry_run:
+        print(section)
+        return 0
+
+    text = CHANGELOG.read_text(encoding="utf-8")
+    if UNRELEASED not in text:
+        print(f"collate-changelog: {CHANGELOG.name} has no '{UNRELEASED}' anchor", file=sys.stderr)
+        return 1
+    # Insert directly BELOW [Unreleased] so Unreleased stays empty and on top,
+    # which is what the release train expects on the next cycle.
+    anchor = UNRELEASED + "\n"
+    text = text.replace(anchor, anchor + "\n" + section, 1)
+    CHANGELOG.write_text(text, encoding="utf-8")
+
+    for path in consumed:
+        path.unlink()
+    print(f"collate-changelog: folded {len(consumed)} fragment(s) into {CHANGELOG.name} as {args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_collate_changelog.py
+++ b/tests/test_collate_changelog.py
@@ -1,0 +1,116 @@
+"""Tests for scripts/collate_changelog.py.
+
+The collator is what makes changelog fragments safe to adopt: if it loses a
+bullet, drops a section, or leaves fragments behind, the release notes go out
+wrong and nothing else catches it.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(tmp_root: Path):
+    """Import collate_changelog with its paths pointed at a temp repo."""
+    spec = importlib.util.spec_from_file_location(
+        f"collate_changelog_{tmp_root.name}", SCRIPTS / "collate_changelog.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    mod.ROOT = tmp_root
+    mod.FRAGMENT_DIR = tmp_root / "changelog.d"
+    mod.CHANGELOG = tmp_root / "CHANGELOG.md"
+    return mod
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    (tmp_path / "changelog.d").mkdir()
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n## [1.0.0-beta.46] - 2026-08-03\n\n"
+        "### Added\n\n- older thing (#1).\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_folds_fragments_and_deletes_them(repo: Path):
+    mod = _load(repo)
+    (repo / "changelog.d" / "2291-notes.md").write_text("- Notes area (#2291).\n", encoding="utf-8")
+    (repo / "changelog.d" / "2292-fix.md").write_text("### Fixed\n\n- A bug (#2292).\n", encoding="utf-8")
+
+    assert mod.main(["1.0.0-beta.47", "--date", "2026-08-05"]) == 0
+
+    text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "## [1.0.0-beta.47] - 2026-08-05" in text
+    assert "- Notes area (#2291)." in text
+    assert "- A bug (#2292)." in text
+    # Unreleased stays, and stays ABOVE the new section, ready for the next cycle.
+    assert text.index("## [Unreleased]") < text.index("## [1.0.0-beta.47]")
+    # The previous release is untouched and still below the new one.
+    assert text.index("## [1.0.0-beta.47]") < text.index("## [1.0.0-beta.46]")
+    assert "- older thing (#1)." in text
+    # Fragments are consumed.
+    assert not (repo / "changelog.d" / "2291-notes.md").exists()
+    assert not (repo / "changelog.d" / "2292-fix.md").exists()
+
+
+def test_no_fragments_is_a_noop_not_an_error(repo: Path):
+    mod = _load(repo)
+    before = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert mod.main(["1.0.0-beta.47"]) == 0
+    assert (repo / "CHANGELOG.md").read_text(encoding="utf-8") == before
+
+
+def test_sections_are_grouped_and_ordered(repo: Path):
+    mod = _load(repo)
+    (repo / "changelog.d" / "a.md").write_text("### Fixed\n\n- fix one (#1).\n", encoding="utf-8")
+    (repo / "changelog.d" / "b.md").write_text("- add one (#2).\n", encoding="utf-8")
+    (repo / "changelog.d" / "c.md").write_text("### Fixed\n\n- fix two (#3).\n", encoding="utf-8")
+
+    assert mod.main(["9.9.9", "--date", "2026-08-05"]) == 0
+    text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    # Added precedes Fixed (Keep-a-Changelog order), and both Fixed bullets sit
+    # under ONE heading rather than one heading per fragment.
+    assert text.index("### Added") < text.index("### Fixed")
+    assert text.count("### Fixed") == 1
+    assert "- fix one (#1)." in text and "- fix two (#3)." in text
+
+
+def test_wrapped_bullet_continuation_lines_are_kept(repo: Path):
+    mod = _load(repo)
+    (repo / "changelog.d" / "wrap.md").write_text(
+        "- A long entry that wraps across\n  two lines and must stay whole (#4).\n",
+        encoding="utf-8",
+    )
+    assert mod.main(["9.9.9", "--date", "2026-08-05"]) == 0
+    text = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+    assert "- A long entry that wraps across" in text
+    assert "  two lines and must stay whole (#4)." in text
+
+
+def test_dry_run_changes_nothing(repo: Path, capsys):
+    mod = _load(repo)
+    (repo / "changelog.d" / "2294-y.md").write_text("- Y (#2294).\n", encoding="utf-8")
+    before = (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert mod.main(["1.0.0-beta.47", "--dry-run"]) == 0
+    assert (repo / "CHANGELOG.md").read_text(encoding="utf-8") == before
+    assert (repo / "changelog.d" / "2294-y.md").exists()
+    assert "- Y (#2294)." in capsys.readouterr().out
+
+
+def test_missing_unreleased_anchor_fails_loudly_and_keeps_fragments(repo: Path):
+    mod = _load(repo)
+    (repo / "CHANGELOG.md").write_text("# Changelog\n\nno anchor here\n", encoding="utf-8")
+    (repo / "changelog.d" / "2295-z.md").write_text("- Z (#2295).\n", encoding="utf-8")
+
+    assert mod.main(["1.0.0-beta.47"]) == 1
+    # The fragment survives a failed run so nothing is lost.
+    assert (repo / "changelog.d" / "2295-z.md").exists()

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -190,3 +190,69 @@ def test_glob_double_star_matches_bare_parent():
     # A single `*` still does not cross a separator.
     assert _glob_match("tinyagentos/routes/desktop_browser/__init__.py",
                        "tinyagentos/routes/*.py") is False
+
+
+# ---------------------------------------------------------------------------
+# Changelog fragments: a new changelog.d/*.md file satisfies the changelog rule
+# instead of editing CHANGELOG.md, so concurrent PRs cannot conflict on the
+# shared [Unreleased] anchor. The gate must NOT go inert in the process.
+# ---------------------------------------------------------------------------
+
+CHANGELOG_RULE_CONFIG = {
+    "gate": {"trailer": "Docs-Reviewed:"},
+    "rules": [
+        {
+            "name": "user-visible-changelog",
+            "on_modify": True,
+            "when_changed": ["tinyagentos/routes/*.py"],
+            "require_doc": ["CHANGELOG.md", "changelog.d/*.md"],
+            "hint": "user-visible behaviour changed",
+        },
+    ],
+}
+
+
+class TestChangelogFragments:
+    def test_fragment_satisfies_the_changelog_rule(self):
+        changed = [
+            ("M", "tinyagentos/routes/notifications.py"),
+            ("A", "changelog.d/2291-notes.md"),
+        ]
+        assert dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG) == []
+
+    def test_editing_changelog_directly_still_satisfies_it(self):
+        """Additive, not a migration - the old path must keep working."""
+        changed = [
+            ("M", "tinyagentos/routes/notifications.py"),
+            ("M", "CHANGELOG.md"),
+        ]
+        assert dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG) == []
+
+    def test_neither_fragment_nor_changelog_nor_trailer_STILL_FAILS(self):
+        """The point is fewer conflicts, NOT a weaker gate.
+
+        If this ever passes the rule has gone inert and user-visible changes
+        ship undocumented. This is the case that caught a real mistake while
+        the feature was being built: putting the convention README inside
+        changelog.d/ made it match the glob, so the gate went green here.
+        """
+        changed = [("M", "tinyagentos/routes/notifications.py")]
+        failures = dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG)
+        assert len(failures) == 1
+        assert failures[0].startswith("user-visible-changelog -- ")
+
+    def test_fragment_in_a_subdirectory_does_not_count(self):
+        """One segment deep on purpose: a stray markdown file nested under
+        changelog.d/ must not silently satisfy the rule."""
+        changed = [
+            ("M", "tinyagentos/routes/notifications.py"),
+            ("A", "changelog.d/archive/old.md"),
+        ]
+        assert len(dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG)) == 1
+
+    def test_non_markdown_fragment_does_not_count(self):
+        changed = [
+            ("M", "tinyagentos/routes/notifications.py"),
+            ("A", "changelog.d/2291-notes.txt"),
+        ]
+        assert len(dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG)) == 1


### PR DESCRIPTION
Closes the changelog rebase treadmill. Implements tsk-ziomck.

THE PROBLEM, measured rather than assumed: every PR that edits CHANGELOG.md writes at the same [Unreleased] anchor, so any two concurrent PRs conflict there by construction and each merge re-conflicts the next. With N PRs open that is O(N^2) rebases which touch no real code. On 2026-08-04 I rebased #2275, #2281, #2282 and #2283 for changelog-only conflicts - seven rebases in one session, #2283 three times.

THE CHANGE:
- docs/doc-gate.toml: the user-visible-changelog rule now accepts EITHER a CHANGELOG.md edit OR a new changelog.d/*.md fragment. The gate is already data-driven, so this is a config line, not script surgery.
- scripts/collate_changelog.py: folds every fragment into a new '## [version] - date' section beneath [Unreleased], groups by section in Keep-a-Changelog order, deletes the fragments. --dry-run prints without touching anything. Run it from the release bump.
- docs/changelog-fragments.md: the convention.
- Editing CHANGELOG.md directly STILL WORKS. This is additive, not a migration.

PROVEN BOTH DIRECTIONS AGAINST THE REAL GATE, not just unit fixtures:
- A route change carrying a fragment -> doc-gate clean (exit 0).
- The SAME route change with no fragment, no CHANGELOG edit and no trailer -> DOC-GATE FAIL, exit 1. The rule is not inert.

A MISTAKE WORTH RECORDING, because it is exactly the failure this repo keeps hitting: my first version put the convention doc at changelog.d/README.md. That file MATCHES changelog.d/*.md, so the readme satisfied the changelog rule - the probe above went GREEN on a change with no changelog at all. The gate would have shipped looking correct while being permanently satisfiable by touching a readme. The doc now lives at docs/changelog-fragments.md and changelog.d/ holds nothing but fragments and a .gitkeep. Both the config comment and the test name record why.

TESTS: 33 passing across tests/test_doc_gate.py (5 new, including the not-inert case and two glob-precision cases) and tests/test_collate_changelog.py (7, covering fold+delete, section grouping and ordering, wrapped-bullet continuation, dry-run, the no-fragments no-op, and a missing [Unreleased] anchor failing loudly WITHOUT eating the fragments).

Dogfooded: this PR's own changelog entry is a fragment.