### PR TITLE
docs(agent-manual): document the project Files API for agents

### DIFF
--- a/docs/agent-manual/04-apps.md
+++ b/docs/agent-manual/04-apps.md
@@ -17,4 +17,13 @@
 - **Activity**: live feed of everything agents do (tool calls, model calls, errors).
 - **Decisions**: your inbox for agent approvals and questions.
 - **Observatory**: watch the agent fleet; pause or throttle work lanes.
-- Other bundled apps (Library, Channels, Secrets, Tasks, Images, MCP, Guides and more); if you do not know one, guess from its name and point to Guides.
+## Project Files
+
+An agent with the appropriate scopes can read and write files in a project.
+
+- `GET /api/projects/{slug}/files?path=<subdir>` list files in a subdirectory (requires `files_read`)
+- `GET /api/projects/{slug}/files/{path}` download a single file (requires `files_read`)
+- `POST /api/projects/{slug}/files/upload?path=<subdir>` upload a file using multipart form field `file` (requires `files_write`)
+- `POST /api/projects/{mkdir}` with body `{"path": "<subdir>"}` create a subdirectory (requires `files_write`)
+
+Routes key on the project SLUG, not the internal project id. Authenticate with the registry JWT: `Authorization: Bearer <token>`. A token for a different project returns 404. Access is granted per project.


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): docs(agent-manual): document the project Files API for agents

Autonomous build of board card tsk-ue56cp.



Files:
 docs/agent-manual/04-apps.md | 11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for accessing, listing, downloading, uploading, and organizing project files.
  * Documented required permissions, authentication, project-specific access, and slug-based routing.
  * Removed an outdated generic note about bundled apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->