### PR TITLE
desktop/src/lib/projects.ts: same Headers-spread bug + init overwrites merged headers

### DIFF
--- a/desktop/src/lib/projects.test.ts
+++ b/desktop/src/lib/projects.test.ts
@@ -609,3 +609,50 @@ describe("projectsApi.activity", () => {
     await expect(projectsApi.activity("p-1")).rejects.toThrow("500");
   });
 });
+
+describe("projectsApi.http CSRF + header merge (Headers-spread regression)", () => {
+  const originalDocument = global.document;
+
+  afterEach(() => {
+    vi.stubGlobal("document", originalDocument);
+  });
+
+  const headerValue = (opts: unknown, name: string): string | null => {
+    const headers = (opts as { headers?: Headers | Record<string, string> }).headers;
+    if (headers instanceof Headers) return headers.get(name);
+    return headers ? (headers as Record<string, string>)[name] ?? null : null;
+  };
+
+  it("attaches X-CSRF-Token and preserves Content-Type on POST", async () => {
+    vi.stubGlobal("document", { cookie: "csrf_token=hdr-token" } as unknown as Document);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "p-1", name: "New", slug: "new", description: "", status: "active", created_by: "u-1", created_at: 1, updated_at: 1 }),
+      text: async () => "",
+      statusText: "OK",
+    });
+    global.fetch = fetchMock;
+    await projectsApi.create({ name: "New", slug: "new" });
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(opts.method).toBe("POST");
+    expect(headerValue(opts, "X-CSRF-Token")).toBe("hdr-token");
+    expect(headerValue(opts, "Content-Type")).toBe("application/json");
+  });
+
+  it("does not add X-CSRF-Token on non-mutating GET", async () => {
+    vi.stubGlobal("document", { cookie: "csrf_token=hdr-token" } as unknown as Document);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+      text: async () => "",
+      statusText: "OK",
+    });
+    global.fetch = fetchMock;
+    await projectsApi.list();
+    const [, opts] = fetchMock.mock.calls[0];
+    expect(headerValue(opts, "X-CSRF-Token")).toBe(null);
+    expect(headerValue(opts, "Content-Type")).toBe("application/json");
+  });
+});

--- a/desktop/src/lib/projects.ts
+++ b/desktop/src/lib/projects.ts
@@ -159,10 +159,12 @@ async function http<T>(path: string, init?: RequestInit): Promise<T> {
   // withCsrf attaches X-CSRF-Token on mutating methods (POST/PUT/PATCH/DELETE);
   // without it, cookie-authenticated project create/update/delete 403 with
   // "CSRF token missing". Non-mutating GETs pass through unchanged.
+  const headers = new Headers(init?.headers);
+  headers.set("Content-Type", "application/json");
   const r = await fetch(path, withCsrf({
     credentials: "include",
-    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
     ...init,
+    headers,
   }));
   if (!r.ok) {
     const text = await r.text().catch(() => r.statusText);


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): desktop/src/lib/projects.ts: same Headers-spread bug + init overwrites merged headers

Autonomous build of board card tsk-ux4a7q.

projectsApi.http built its default headers with a plain-object spread
(...(init?.headers || {})). When init.headers was a Headers instance
(as returned by withCsrf downstream), the spread silently dropped every
entry, and the trailing ...init spread overwrote the merged headers key
entirely, clobbering Content-Type. Mirror the x-monitor/library fix:
build a fresh Headers via new Headers(init?.headers), set Content-Type
on it, and spread ...init before headers so merged headers win.

Files:
 desktop/src/lib/projects.test.ts | 47 ++++++++++++++++++++++++++++++++++++++++
 desktop/src/lib/projects.ts      |  4 +++-
 2 files changed, 50 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request handling to consistently preserve custom headers and JSON content-type settings.
  * Ensured CSRF protection is correctly applied to mutating requests without adding unnecessary headers to read-only requests.

* **Tests**
  * Added regression coverage for CSRF behavior and header preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->