### PR TITLE
Tests: ConfirmDialog focus-trap + ProjectMembers rename vitest coverage

### DIFF
--- a/desktop/src/apps/ProjectsApp/ProjectMembers.test.tsx
+++ b/desktop/src/apps/ProjectsApp/ProjectMembers.test.tsx
@@ -259,6 +259,136 @@ describe("ProjectMembers rename external agent", () => {
       }),
     );
   });
+
+  it("disables Save and ignores Enter while the rename request is in flight", async () => {
+    let resolveRename!: (value: { ok: boolean }) => void;
+    const renamePromise = new Promise<{ ok: boolean }>((resolve) => {
+      resolveRename = resolve;
+    });
+
+    const fetchMock = vi.fn().mockImplementation((input: string, init?: RequestInit) => {
+      if (input === "/api/agents/registry/grok-taos-20260711-000736" && init?.method === "PATCH") {
+        return renamePromise.then(() => ({
+          ok: true,
+          json: async () => ({ ok: true }),
+          text: async () => "",
+        }));
+      }
+      if (input === "/api/projects/prj-test/members") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [externalMember] }),
+          text: async () => "",
+        });
+      }
+      if (input === "/api/agents") {
+        return Promise.resolve({ ok: true, json: async () => [], text: async () => "" });
+      }
+      if (input === "/api/agents/registry") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [registryEntry],
+          text: async () => "",
+        });
+      }
+      throw new Error(`Unmocked fetch: ${input}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ProjectMembers project={project} onChanged={vi.fn()} />);
+    await flush();
+
+    fireEvent.click(screen.getByLabelText("Rename grok-taOS"));
+    const input = screen.getByLabelText("New name for grok-taOS");
+    fireEvent.change(input, { target: { value: "hy3 (grok)" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const saveButton = screen.getByRole("button", { name: "Saving..." });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    resolveRename({ ok: true });
+    await flush();
+
+    const patchCalls = fetchMock.mock.calls.filter(
+      (c: [string, RequestInit]) => c[1]?.method === "PATCH",
+    );
+    expect(patchCalls).toHaveLength(1);
+  });
+
+  it("shows an error when the rename PATCH rejects", async () => {
+    const fetchMock = mockFetch({
+      "/api/projects/prj-test/members": { ok: true, body: { items: [externalMember] } },
+      "/api/agents": { ok: true, body: [] },
+      "/api/agents/registry": { ok: true, body: [registryEntry] },
+      "/api/agents/registry/grok-taos-20260711-000736": { ok: false, status: 400, body: { error: "Bad request" } },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ProjectMembers project={project} onChanged={vi.fn()} />);
+    await flush();
+
+    fireEvent.click(screen.getByLabelText("Rename grok-taOS"));
+    const input = screen.getByLabelText("New name for grok-taOS");
+    fireEvent.change(input, { target: { value: "new-name" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await flush();
+    });
+
+    expect(screen.getByText("Bad request")).toBeInTheDocument();
+  });
+
+  it("reloads the registry and refreshes the label after a successful rename", async () => {
+    const registryCalls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation((input: string) => {
+      if (input === "/api/projects/prj-test/members") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ items: [externalMember] }),
+          text: async () => "",
+        });
+      }
+      if (input === "/api/agents") {
+        return Promise.resolve({ ok: true, json: async () => [], text: async () => "" });
+      }
+      if (input === "/api/agents/registry") {
+        registryCalls.push(input);
+        const displayName = registryCalls.filter((c) => c === input).length === 1
+          ? "grok-taOS"
+          : "hy3 (grok)";
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ ...registryEntry, display_name: displayName }],
+          text: async () => "",
+        });
+      }
+      if (input === "/api/agents/registry/grok-taos-20260711-000736") {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }), text: async () => "" });
+      }
+      throw new Error(`Unmocked fetch: ${input}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+    render(<ProjectMembers project={project} onChanged={vi.fn()} />);
+    await flush();
+
+    const externalSection = screen.getByText("External / Connected agents").closest("section")!;
+    expect(within(externalSection).getByText("grok-taOS")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Rename grok-taOS"));
+    const input = screen.getByLabelText("New name for grok-taOS");
+    fireEvent.change(input, { target: { value: "hy3 (grok)" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+      await flush();
+    });
+
+    expect(registryCalls.filter((c) => c === "/api/agents/registry").length).toBeGreaterThanOrEqual(2);
+    expect(within(externalSection).getByText("hy3 (grok)")).toBeInTheDocument();
+  });
 });
 
 const project = { id: "prj-test", name: "taOS", slug: "taos" } as unknown as Project;

--- a/desktop/src/components/__tests__/ConfirmDialog.test.tsx
+++ b/desktop/src/components/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ConfirmDialog } from "../ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  it("focuses the confirm button when opened", async () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Confirm?"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Confirm" })).toHaveFocus();
+  });
+
+  it("closes on Escape", async () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Confirm?"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("closes on backdrop click", async () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Confirm?"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    const dialog = screen.getByRole("dialog", { name: "Confirm?" });
+    fireEvent.click(dialog);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("traps Tab focus inside the panel", async () => {
+    render(
+      <ConfirmDialog
+        open={true}
+        title="Confirm?"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    const confirmBtn = screen.getByRole("button", { name: "Confirm" });
+    const cancelBtn = screen.getByRole("button", { name: "Cancel" });
+
+    expect(confirmBtn).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(cancelBtn).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(confirmBtn).toHaveFocus();
+  });
+});


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Tests: ConfirmDialog focus-trap + ProjectMembers rename vitest coverage

Autonomous build of board card tsk-5nzjsn.



Files:
 .../src/apps/ProjectsApp/ProjectMembers.test.tsx   | 130 +++++++++++++++++++++
 .../components/__tests__/ConfirmDialog.test.tsx    |  67 +++++++++++
 2 files changed, 197 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for rename requests, including preventing duplicate submissions while saving.
  * Verified that rename errors are displayed and successful changes refresh the displayed project name.
  * Added coverage for confirmation dialog focus behavior, keyboard cancellation, backdrop cancellation, and focus trapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->