### PR TITLE
doc-gate: user-visible-changelog misses desktop shell changes (App.tsx, components/, stores/)

### DIFF
--- a/docs/doc-gate.toml
+++ b/docs/doc-gate.toml
@@ -66,7 +66,7 @@ hint = "the agent-token route allowlist changed; update the agent-facing API sur
 [[rules]]
 name = "user-visible-changelog"
 on_modify = true
-when_changed = ["tinyagentos/routes/*.py", "desktop/src/apps/*/**", "tinyagentos/installers/*"]
+when_changed = ["tinyagentos/routes/*.py", "desktop/src/apps/*/**", "desktop/src/App.tsx", "desktop/src/components/**", "desktop/src/stores/**", "tinyagentos/installers/*"]
 require_doc = ["CHANGELOG.md", "changelog.d/*.md"]
 hint = "user-visible behaviour changed; add a changelog.d/<pr>-<slug>.md fragment (preferred) or a CHANGELOG.md line (or add a Docs-Reviewed trailer explaining why not)"
 

--- a/tests/test_doc_gate.py
+++ b/tests/test_doc_gate.py
@@ -204,7 +204,14 @@ CHANGELOG_RULE_CONFIG = {
         {
             "name": "user-visible-changelog",
             "on_modify": True,
-            "when_changed": ["tinyagentos/routes/*.py"],
+            "when_changed": [
+                "tinyagentos/routes/*.py",
+                "desktop/src/apps/*/**",
+                "desktop/src/App.tsx",
+                "desktop/src/components/**",
+                "desktop/src/stores/**",
+                "tinyagentos/installers/*",
+            ],
             "require_doc": ["CHANGELOG.md", "changelog.d/*.md"],
             "hint": "user-visible behaviour changed",
         },
@@ -256,3 +263,35 @@ class TestChangelogFragments:
             ("A", "changelog.d/2291-notes.txt"),
         ]
         assert len(dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG)) == 1
+
+    def test_desktop_app_shell_triggers_changelog_rule(self):
+        changed = [("M", "desktop/src/App.tsx")]
+        failures = dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG)
+        assert len(failures) == 1
+        assert failures[0].startswith("user-visible-changelog -- ")
+
+    def test_desktop_component_triggers_changelog_rule(self):
+        changed = [("M", "desktop/src/components/Desktop.tsx")]
+        failures = dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG)
+        assert len(failures) == 1
+        assert failures[0].startswith("user-visible-changelog -- ")
+
+    def test_desktop_store_triggers_changelog_rule(self):
+        changed = [("M", "desktop/src/stores/theme-store.ts")]
+        failures = dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG)
+        assert len(failures) == 1
+        assert failures[0].startswith("user-visible-changelog -- ")
+
+    def test_desktop_shell_fragment_satisfies_rule(self):
+        changed = [
+            ("M", "desktop/src/App.tsx"),
+            ("A", "changelog.d/2303-reduce-effects.md"),
+        ]
+        assert dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG) == []
+
+    def test_desktop_shell_test_file_does_not_trigger(self):
+        changed = [
+            ("A", "desktop/src/components/__tests__/Desktop.test.tsx"),
+            ("A", "desktop/src/stores/__tests__/theme-store.test.ts"),
+        ]
+        assert dg.evaluate_rules(changed, [], CHANGELOG_RULE_CONFIG) == []


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): doc-gate: user-visible-changelog misses desktop shell changes (App.tsx, components/, stores/)

Autonomous build of board card tsk-wnqh3d.

Add desktop/src/App.tsx, desktop/src/components/**, and desktop/src/stores/**
to the when_changed glob for the user-visible-changelog rule so modifications
to the desktop shell require a changelog entry, matching the existing coverage
for desktop/src/apps/*/**.

Files:
 docs/doc-gate.toml     |  2 +-
 tests/test_doc_gate.py | 41 ++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 41 insertions(+), 2 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved release documentation checks to cover changes across the desktop app, components, stores, and installer files.
  * Added validation to ensure applicable desktop updates include user-visible changelog entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->