### PR TITLE
Auth sessions never pruned: 37,077 entries, 4.8MB and growing

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -188,6 +188,24 @@ class TestAuthManager:
         assert token1 in mgr2._sessions
         assert mgr2._sessions[token1]["long_lived"] is True
 
+    def test_prune_at_startup_shrinks_the_file(self, tmp_path):
+        """Startup pruning must persist: the sessions FILE shrinks at init,
+        not merely the in-memory view (which _load() already prunes)."""
+        expired = {
+            f"tok{i}": {"user_id": "u", "expires_at": time.time() - 10, "long_lived": False}
+            for i in range(50)
+        }
+        expired["live"] = {"user_id": "u", "expires_at": time.time() + 3600, "long_lived": False}
+        sessions_file = tmp_path / ".auth_sessions"
+        sessions_file.write_text(json.dumps(expired))
+        size_before = sessions_file.stat().st_size
+
+        AuthManager(tmp_path)
+
+        on_disk = json.loads(sessions_file.read_text())
+        assert list(on_disk) == ["live"]
+        assert sessions_file.stat().st_size < size_before
+
     def test_prune_already_clean_is_noop(self, tmp_path):
         """Pruning an already-clean store (no expired entries) is a no-op."""
         # Create a file with no expired entries (simulating clean state)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import stat
 import time
 
@@ -134,6 +135,70 @@ class TestAuthManager:
         mgr.cleanup_sessions()
         assert t1 not in mgr._sessions
         assert t2 in mgr._sessions
+
+    def test_prune_expired_sessions_at_startup(self, tmp_path):
+        """Expired entries are pruned when AuthManager is initialized."""
+        mgr = AuthManager(tmp_path)
+        # Create an expired session (will be written to file)
+        token = mgr.create_session(user_id="uid1")
+        # Manually expire it and force prune
+        mgr._sessions[token] = {"user_id": "uid1", "expires_at": time.time() - 1, "long_lived": False}
+        mgr.cleanup_sessions()
+        assert token not in mgr._sessions
+        
+        # Create a valid session
+        token2 = mgr.create_session(user_id="uid2")
+        # Verify it's still valid
+        assert mgr.validate_session(token2) is not None
+
+    def test_prune_at_startup_removes_expired(self, tmp_path):
+        """Expired sessions from previous run are pruned at startup."""
+        # Create a file with expired session content (simulating previous run)
+        session_data = {"expired_token": {"user_id": "uid1", "expires_at": time.time() - 3600, "long_lived": False}}
+        sessions_file = tmp_path / ".auth_sessions"
+        sessions_file.write_text(json.dumps(session_data))
+        
+        # Now create a new manager - should prune the expired session
+        mgr2 = AuthManager(tmp_path)
+        # The expired token should be removed
+        assert "expired_token" not in mgr2._sessions
+
+    def test_prune_at_startup_preserves_unexpired(self, tmp_path):
+        """Unexpired sessions survive startup pruning."""
+        # Create a file with valid session content (simulating previous run)
+        token1 = "valid_token_123"
+        session_data = {token1: {"user_id": "uid1", "expires_at": time.time() + 3600, "long_lived": False}}
+        sessions_file = tmp_path / ".auth_sessions"
+        sessions_file.write_text(json.dumps(session_data))
+        
+        # New manager should preserve it
+        mgr2 = AuthManager(tmp_path)
+        assert token1 in mgr2._sessions
+
+    def test_prune_long_lived_unexpired_survives(self, tmp_path):
+        """Long-lived sessions survive pruning when unexpired."""
+        # Create a file with long-lived valid session (simulating previous run)
+        token1 = "long_lived_token_456"
+        session_data = {token1: {"user_id": "uid1", "expires_at": time.time() + 3600, "long_lived": True}}
+        sessions_file = tmp_path / ".auth_sessions"
+        sessions_file.write_text(json.dumps(session_data))
+        
+        # New manager should preserve it
+        mgr2 = AuthManager(tmp_path)
+        assert token1 in mgr2._sessions
+        assert mgr2._sessions[token1]["long_lived"] is True
+
+    def test_prune_already_clean_is_noop(self, tmp_path):
+        """Pruning an already-clean store (no expired entries) is a no-op."""
+        # Create a file with no expired entries (simulating clean state)
+        token1 = "valid_token_789"
+        session_data = {token1: {"user_id": "uid1", "expires_at": time.time() + 3600, "long_lived": False}}
+        sessions_file = tmp_path / ".auth_sessions"
+        sessions_file.write_text(json.dumps(session_data))
+        
+        # Create new manager - should preserve the valid session
+        mgr2 = AuthManager(tmp_path)
+        assert token1 in mgr2._sessions
 
 
 # --- Integration tests for routes ---

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -43,13 +43,28 @@ class _PersistentSessions:
         if not self._path.exists():
             return {}
         try:
-            return json.loads(self._path.read_text())
+            data = json.loads(self._path.read_text())
         except (json.JSONDecodeError, OSError):
             return {}
+        self._prune_expired(data)
+        return data
 
     def _save(self, data: dict) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._save_pruned(data)
+
+    def _save_pruned(self, data: dict) -> None:
+        self._prune_expired(data)
         self._path.write_text(json.dumps(data))
+
+    def _prune_expired(self, data: dict) -> None:
+        now = time.time()
+        expired_keys = [
+            token for token, entry in data.items()
+            if isinstance(entry, dict) and entry.get("expires_at") is not None and now >= entry.get("expires_at")
+        ]
+        for token in expired_keys:
+            del data[token]
 
     def __getitem__(self, key: str):
         return self._load()[key]
@@ -84,6 +99,28 @@ class _PersistentSessions:
 
     def items(self):
         return list(self._load().items())
+
+    def _prune_sessions_on_startup(self) -> None:
+        """Prune expired sessions at startup and opportunistically on writes."""
+        if self._sessions_file.exists():
+            try:
+                data = json.loads(self._sessions_file.read_text())
+                before = len(data)
+                self._prune_expired(data)
+                after = len(data)
+                removed = before - after
+                if removed:
+                    logger.info(
+                        "Pruned %s expired auth sessions at startup (%s -> %s live)",
+                        removed, after, after
+                    )
+                if after > 50000:
+                    logger.warning(
+                        "Auth sessions count %s after pruning is still excessive; "
+                        "sessions are being minted faster than they expire", after
+                    )
+            except (json.JSONDecodeError, OSError):
+                pass
 
 
 def hash_password(password: str, salt: str = "") -> str:
@@ -177,6 +214,39 @@ class AuthManager:
         self._sessions = _PersistentSessions(self._sessions_file)
         self.session_ttl = 86400 * 7  # 7 days, default
         self.long_session_ttl = 86400 * 30  # 30 days for "stay signed in"
+        self._prune_sessions_on_startup()
+
+    def _prune_expired(self, data: dict) -> None:
+        """Remove expired sessions from the data dict in place."""
+        now = time.time()
+        expired_keys = [
+            token for token, entry in data.items()
+            if isinstance(entry, dict) and entry.get("expires_at") is not None and now >= entry.get("expires_at")
+        ]
+        for token in expired_keys:
+            del data[token]
+
+    def _prune_sessions_on_startup(self) -> None:
+        """Prune expired sessions at startup and opportunistically on writes."""
+        if self._sessions_file.exists():
+            try:
+                data = json.loads(self._sessions_file.read_text())
+                before = len(data)
+                self._prune_expired(data)
+                after = len(data)
+                removed = before - after
+                if removed:
+                    logger.info(
+                        "Pruned %s expired auth sessions at startup (%s -> %s live)",
+                        removed, after, after
+                    )
+                if after > 50000:
+                    logger.warning(
+                        "Auth sessions count %s after pruning is still excessive; "
+                        "sessions are being minted faster than they expire", after
+                    )
+            except (json.JSONDecodeError, OSError):
+                pass
 
     # ------------------------------------------------------------------ #
     #  Profile storage helpers                                             #

--- a/tinyagentos/auth.py
+++ b/tinyagentos/auth.py
@@ -100,28 +100,6 @@ class _PersistentSessions:
     def items(self):
         return list(self._load().items())
 
-    def _prune_sessions_on_startup(self) -> None:
-        """Prune expired sessions at startup and opportunistically on writes."""
-        if self._sessions_file.exists():
-            try:
-                data = json.loads(self._sessions_file.read_text())
-                before = len(data)
-                self._prune_expired(data)
-                after = len(data)
-                removed = before - after
-                if removed:
-                    logger.info(
-                        "Pruned %s expired auth sessions at startup (%s -> %s live)",
-                        removed, after, after
-                    )
-                if after > 50000:
-                    logger.warning(
-                        "Auth sessions count %s after pruning is still excessive; "
-                        "sessions are being minted faster than they expire", after
-                    )
-            except (json.JSONDecodeError, OSError):
-                pass
-
 
 def hash_password(password: str, salt: str = "") -> str:
     """Hash a password with argon2id.
@@ -216,37 +194,32 @@ class AuthManager:
         self.long_session_ttl = 86400 * 30  # 30 days for "stay signed in"
         self._prune_sessions_on_startup()
 
-    def _prune_expired(self, data: dict) -> None:
-        """Remove expired sessions from the data dict in place."""
-        now = time.time()
-        expired_keys = [
-            token for token, entry in data.items()
-            if isinstance(entry, dict) and entry.get("expires_at") is not None and now >= entry.get("expires_at")
-        ]
-        for token in expired_keys:
-            del data[token]
-
     def _prune_sessions_on_startup(self) -> None:
-        """Prune expired sessions at startup and opportunistically on writes."""
-        if self._sessions_file.exists():
-            try:
-                data = json.loads(self._sessions_file.read_text())
-                before = len(data)
-                self._prune_expired(data)
-                after = len(data)
-                removed = before - after
-                if removed:
-                    logger.info(
-                        "Pruned %s expired auth sessions at startup (%s -> %s live)",
-                        removed, after, after
-                    )
-                if after > 50000:
-                    logger.warning(
-                        "Auth sessions count %s after pruning is still excessive; "
-                        "sessions are being minted faster than they expire", after
-                    )
-            except (json.JSONDecodeError, OSError):
-                pass
+        """Prune expired sessions at startup AND persist the shrunk file.
+
+        _load() prunes in memory on every read and _save() prunes on every
+        write, so correctness never depends on this -- but without a write-back
+        here, a grown sessions file only shrinks on the next session mint.
+        Load (which prunes) then save once, so startup leaves the file small."""
+        if not self._sessions_file.exists():
+            return
+        try:
+            before = len(json.loads(self._sessions_file.read_text()))
+        except (json.JSONDecodeError, OSError):
+            return
+        data = self._sessions._load()
+        self._sessions._save(data)
+        removed = before - len(data)
+        if removed:
+            logger.info(
+                "Pruned %s expired auth sessions at startup (%s -> %s live)",
+                removed, before, len(data),
+            )
+        if len(data) > 50000:
+            logger.warning(
+                "Auth sessions count %s after pruning is still excessive; "
+                "sessions are being minted faster than they expire", len(data),
+            )
 
     # ------------------------------------------------------------------ #
     #  Profile storage helpers                                             #


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Auth sessions never pruned: 37,077 entries, 4.8MB and growing

Autonomous build of board card tsk-7i3lsx.



Files:
 tests/test_auth.py  | 65 +++++++++++++++++++++++++++++++++++++++++++++++
 tinyagentos/auth.py | 72 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 136 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired sessions are now automatically removed during session storage reads, writes, and application startup.
  * Session cleanup safely handles malformed or unreadable session data.
  * Valid and long-lived sessions are preserved during cleanup.
  * Administrators are warned when the active session count exceeds 50,000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->