### PR TITLE
pr_watch reports a drafted PR as GONE, then stops tracking it

### DIFF
--- a/pr_watch.py
+++ b/pr_watch.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Realtime PR state watcher: emit ONE line per meaningful STATE TRANSITION.
+
+Jay 2026-07-27: a 2-hourly poll let finished PRs sit green for a day holding
+fleet throttle slots. This watches continuously and speaks only when a PR
+CHANGES to something actionable, so it is quiet by default and loud exactly
+when a decision is needed.
+
+Transitions reported:
+  -> READY      mergeable + all required checks green   (merge it, frees a slot)
+  -> RED        a required check failed                 (fix-forward or close)
+  -> CONFLICT   branch conflicts with base              (rebase needed)
+  -> DRAFTED    PR was drafted                          (keep watching)
+  -> READY-FROM-DRAFT PR was undrafted                  (re-evaluate mergeability)
+  -> GONE       merged or closed                        (slot freed)
+First sighting of a PR is reported as NEW so nothing appears from nowhere.
+Silence = nothing changed. Poll interval is 60s: effectively realtime for CI,
+and ~60 API calls/hour against a 5000/hour budget.
+"""
+import json
+import subprocess
+import sys
+import time
+
+REPO = "jaylfc/taOS"
+AUTHORS = {"jaylfc", "hognek"}      # fleet + collaborator PRs I merge
+REQUIRED = ("test (3.1", "lint", "spa-build", "shards")
+POLL_SECONDS = 60
+
+
+def gh_json(args):
+    try:
+        out = subprocess.run(["gh"] + args, capture_output=True, text=True, timeout=60)
+        if out.returncode != 0:
+            return None
+        return json.loads(out.stdout or "[]")
+    except Exception:
+        return None
+
+
+def classify(pr):
+    """Reduce a PR to one actionable state string."""
+    checks = pr.get("statusCheckRollup") or []
+    required = [c for c in checks
+                if any(str(c.get("name") or c.get("context") or "").startswith(r) for r in REQUIRED)]
+    concl = [str(c.get("conclusion") or c.get("status") or "") for c in required]
+    if any(c in ("FAILURE", "TIMED_OUT", "ACTION_REQUIRED") for c in concl):
+        return "RED"
+    state = pr.get("mergeStateStatus")
+    if state == "DIRTY":
+        return "CONFLICT"
+    if required and all(c == "SUCCESS" for c in concl) and state == "CLEAN":
+        return "READY"
+    return "PENDING"
+
+
+def process_tick(prs, seen, reported, first_pass):
+    messages = []
+    if prs is None:
+        return messages, seen, reported, first_pass
+
+    live = {}
+    for pr in prs:
+        if (pr.get("author") or {}).get("login") not in AUTHORS:
+            continue
+        n = pr["number"]
+        if pr.get("isDraft"):
+            state = "DRAFT"
+        else:
+            state = classify(pr)
+        oid = (pr.get("headRefOid") or "")[:8]
+        live[n] = state
+        title = (pr.get("title") or "")[:60]
+        prev = seen.get(n)
+
+        if prev is None and not first_pass:
+            messages.append(f"PR #{n} NEW [{state}] {title}")
+            reported[n] = (state, oid)
+        elif prev is not None and prev != state and state != "PENDING":
+            if reported.get(n) != (state, oid):
+                if prev != "DRAFT" and state == "DRAFT":
+                    msg = f"PR #{n} DRAFTED | {title}"
+                elif prev == "DRAFT" and state != "DRAFT":
+                    msg = f"PR #{n} READY-FROM-DRAFT | {title}"
+                else:
+                    msg = f"PR #{n} {prev} -> {state} | {title}"
+                messages.append(msg)
+                reported[n] = (state, oid)
+
+    for n, prev in seen.items():
+        if n not in live and prev != "GONE":
+            messages.append(f"PR #{n} GONE (merged or closed) - throttle slot freed")
+            reported.pop(n, None)
+
+    return messages, live, reported, False
+
+
+def main():
+    seen = {}       # number -> last observed state (for GONE detection)
+    reported = {}   # number -> (state, head_oid) of the last line actually EMITTED
+    first_pass = True
+    while True:
+        prs = gh_json([
+            "pr", "list", "--repo", REPO, "--state", "open", "--limit", "100",
+            # headRefOid added 2026-07-28: emission is keyed on (state, commit) so a
+            # CI re-run at the SAME commit is not reported as a new event.
+            "--json", "number,title,author,mergeStateStatus,statusCheckRollup,isDraft,headRefOid",
+        ])
+        messages, seen, reported, first_pass = process_tick(
+            prs, seen, reported, first_pass
+        )
+        for msg in messages:
+            print(msg, flush=True)
+        time.sleep(POLL_SECONDS)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(0)

--- a/tests/test_pr_watch.py
+++ b/tests/test_pr_watch.py
@@ -1,0 +1,176 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+
+import pytest
+
+from pr_watch import classify, process_tick
+
+
+REQUIRED_CHECKS = [
+    {"name": "test (3.1", "conclusion": "SUCCESS"},
+    {"name": "lint", "conclusion": "SUCCESS"},
+    {"name": "spa-build", "conclusion": "SUCCESS"},
+    {"name": "shards", "conclusion": "SUCCESS"},
+]
+
+
+class TestClassify:
+    def test_red_on_failure(self):
+        pr = {
+            "statusCheckRollup": [
+                {"name": "test (3.1", "conclusion": "FAILURE"},
+            ],
+            "mergeStateStatus": "CLEAN",
+        }
+        assert classify(pr) == "RED"
+
+    def test_red_on_timed_out(self):
+        pr = {
+            "statusCheckRollup": [
+                {"name": "test (3.1", "conclusion": "TIMED_OUT"},
+            ],
+            "mergeStateStatus": "CLEAN",
+        }
+        assert classify(pr) == "RED"
+
+    def test_red_on_action_required(self):
+        pr = {
+            "statusCheckRollup": [
+                {"name": "test (3.1", "conclusion": "ACTION_REQUIRED"},
+            ],
+            "mergeStateStatus": "CLEAN",
+        }
+        assert classify(pr) == "RED"
+
+    def test_conflict_on_dirty(self):
+        pr = {
+            "statusCheckRollup": [],
+            "mergeStateStatus": "DIRTY",
+        }
+        assert classify(pr) == "CONFLICT"
+
+    def test_ready_when_all_green(self):
+        pr = {
+            "statusCheckRollup": REQUIRED_CHECKS,
+            "mergeStateStatus": "CLEAN",
+        }
+        assert classify(pr) == "READY"
+
+    def test_pending_when_not_all_green(self):
+        pr = {
+            "statusCheckRollup": [
+                {"name": "test (3.1", "conclusion": "SUCCESS"},
+                {"name": "lint", "conclusion": "PENDING"},
+            ],
+            "mergeStateStatus": "CLEAN",
+        }
+        assert classify(pr) == "PENDING"
+
+    def test_pending_when_no_required_checks(self):
+        pr = {
+            "statusCheckRollup": [
+                {"name": "other-check", "conclusion": "SUCCESS"},
+            ],
+            "mergeStateStatus": "CLEAN",
+        }
+        assert classify(pr) == "PENDING"
+
+
+def make_pr(number, title, login, is_draft, head_oid, checks, merge_state):
+    return {
+        "number": number,
+        "title": title,
+        "author": {"login": login},
+        "isDraft": is_draft,
+        "headRefOid": head_oid,
+        "statusCheckRollup": checks,
+        "mergeStateStatus": merge_state,
+    }
+
+
+class TestDraftTransitions:
+    def test_drafted_instead_of_gone(self):
+        seen = {1: "READY"}
+        reported = {}
+        prs = [make_pr(1, "Add feature", "jaylfc", True, "abc12345", [], "CLEAN")]
+        messages, live, reported, _ = process_tick(prs, seen, reported, False)
+        assert messages == ["PR #1 DRAFTED | Add feature"]
+        assert live == {1: "DRAFT"}
+        assert reported == {1: ("DRAFT", "abc12345")}
+
+    def test_ready_from_draft(self):
+        seen = {1: "DRAFT"}
+        reported = {1: ("DRAFT", "abc12345")}
+        prs = [make_pr(1, "Add feature", "jaylfc", False, "def98765", REQUIRED_CHECKS, "CLEAN")]
+        messages, live, reported, _ = process_tick(prs, seen, reported, False)
+        assert messages == ["PR #1 READY-FROM-DRAFT | Add feature"]
+        assert live == {1: "READY"}
+        assert reported == {1: ("READY", "def98765")}
+
+    def test_gone_when_closed(self):
+        seen = {1: "READY"}
+        reported = {}
+        prs = []
+        messages, live, reported, _ = process_tick(prs, seen, reported, False)
+        assert messages == ["PR #1 GONE (merged or closed) - throttle slot freed"]
+        assert live == {}
+        assert reported == {}
+
+    def test_draft_first_sighting_no_new_on_first_pass(self):
+        seen = {}
+        reported = {}
+        prs = [make_pr(1, "Add feature", "jaylfc", True, "abc12345", [], "CLEAN")]
+        messages, live, reported, _ = process_tick(prs, seen, reported, True)
+        assert messages == []
+        assert live == {1: "DRAFT"}
+        assert reported == {}
+
+    def test_new_message_after_first_pass(self):
+        seen = {}
+        reported = {}
+        prs = [make_pr(1, "Add feature", "jaylfc", False, "abc12345", REQUIRED_CHECKS, "CLEAN")]
+        messages, live, reported, _ = process_tick(prs, seen, reported, False)
+        assert messages == ["PR #1 NEW [READY] Add feature"]
+        assert live == {1: "READY"}
+        assert reported == {1: ("READY", "abc12345")}
+
+    def test_no_duplicate_transition_same_commit(self):
+        seen = {1: "READY"}
+        reported = {1: ("READY", "abc1234")}
+        prs = [make_pr(1, "Add feature", "jaylfc", False, "abc123456789", REQUIRED_CHECKS, "CLEAN")]
+        messages, live, reported, _ = process_tick(prs, seen, reported, False)
+        assert messages == []
+        assert live == {1: "READY"}
+        assert reported == {1: ("READY", "abc1234")}
+
+    def test_draft_remains_draft_silent(self):
+        seen = {1: "DRAFT"}
+        reported = {1: ("DRAFT", "abc1234")}
+        prs = [make_pr(1, "Add feature", "jaylfc", True, "abc123456789", [], "CLEAN")]
+        messages, live, reported, _ = process_tick(prs, seen, reported, False)
+        assert messages == []
+        assert live == {1: "DRAFT"}
+        assert reported == {1: ("DRAFT", "abc1234")}
+
+    def test_author_filter(self):
+        seen = {}
+        reported = {}
+        prs = [make_pr(1, "Add feature", "other-user", False, "abc123456789", REQUIRED_CHECKS, "CLEAN")]
+        messages, live, reported, _ = process_tick(prs, seen, reported, False)
+        assert messages == []
+        assert live == {}
+        assert reported == {}
+
+    def test_normal_red_transition(self):
+        seen = {1: "READY"}
+        reported = {1: ("READY", "abc12345")}
+        prs = [make_pr(1, "Add feature", "jaylfc", False, "def98765", REQUIRED_CHECKS, "CLEAN")]
+        prs[0]["statusCheckRollup"] = [
+            {"name": "test (3.1", "conclusion": "FAILURE"},
+        ]
+        messages, live, reported, _ = process_tick(prs, seen, reported, False)
+        assert messages == ["PR #1 READY -> RED | Add feature"]
+        assert live == {1: "RED"}
+        assert reported == {1: ("RED", "def98765")}


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): pr_watch reports a drafted PR as GONE, then stops tracking it

Autonomous build of board card tsk-xgipqs.



Files:
 pr_watch.py            | 121 ++++++++++++++++++++++++++++++++++
 tests/test_pr_watch.py | 176 +++++++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 297 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous monitoring for GitHub pull requests.
  * Reports meaningful status changes, including new, ready, blocked, conflicting, draft, and closed states.
  * Filters monitored pull requests by configured authors.
  * Suppresses duplicate notifications and handles temporary service or command failures gracefully.

* **Tests**
  * Added comprehensive coverage for pull-request classifications and status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->