### PR TITLE
chore(release): v1.0.0-beta.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+## [1.0.0-beta.47] - 2026-08-09
+
 ### Added
+
+- **Devices**: pairing requests can be created and tracked via the new device
+  pair-request API, with approval or denial surfaced to the user through the
+  Decisions app (#2233).
 
 - **Docs**: new `taos-agent` OS skill (`.claude/skills/taos-agent/SKILL.md`) that
   consolidates the agent-manual OS-operation content into actionable instructions for
@@ -30,6 +36,27 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 - Chat renders `tool_call` and `status` content blocks: tool calls as a
   collapsible detail with an ARIA disclosure contract, status (and the
   `question` variant) as a muted line with a "reply below" hint (#2275).
+
+### Changed
+
+- Contributors add a `changelog.d/<pr>-<slug>.md` fragment instead of editing
+  `CHANGELOG.md`, so concurrent PRs no longer conflict on the shared
+  `[Unreleased]` anchor; `scripts/collate_changelog.py` folds fragments into a
+  release section at bump time. Editing `CHANGELOG.md` directly still works.
+- The Tasks app is now called Routines in the launcher and window title. The
+  app id is unchanged, so existing layouts and pinned positions are preserved
+  (#2298).
+- Approving an agent auth-request with `defer_binding` now returns 409 when that
+  agent already has an active handle, and the response points the operator at
+  `POST /api/projects/{project_id}/members/assign-agent`. It previously advised
+  minting a second identity, which splits an agent's memory and grants across
+  two canonical ids (#2313).
+
+### Security
+
+- Bumped `cryptography` from 48.0.1 to 50.0.0, picking up the upstream fixes
+  for PYSEC-2026-3552/3553/3554 and CVE-2026-69247 (PKCS#7 EnvelopedData
+  Bleichenbacher). Also updates `uvicorn[standard]` to 0.52.1.
 
 ## [1.0.0-beta.46] - 2026-08-03
 

--- a/changelog.d/2233-device-pair-requests.md
+++ b/changelog.d/2233-device-pair-requests.md
@@ -1,3 +1,0 @@
-- **Devices**: pairing requests can be created and tracked via the new device
-  pair-request API, with approval or denial surfaced to the user through the
-  Decisions app (#2233).

--- a/changelog.d/2290-changelog-fragments.md
+++ b/changelog.d/2290-changelog-fragments.md
@@ -1,6 +1,0 @@
-### Changed
-
-- Contributors add a `changelog.d/<pr>-<slug>.md` fragment instead of editing
-  `CHANGELOG.md`, so concurrent PRs no longer conflict on the shared
-  `[Unreleased]` anchor; `scripts/collate_changelog.py` folds fragments into a
-  release section at bump time. Editing `CHANGELOG.md` directly still works.

--- a/changelog.d/2298-tasks-to-routines.md
+++ b/changelog.d/2298-tasks-to-routines.md
@@ -1,5 +1,0 @@
-### Changed
-
-- The Tasks app is now called Routines in the launcher and window title. The
-  app id is unchanged, so existing layouts and pinned positions are preserved
-  (#2298).

--- a/changelog.d/2313-consent-defer-active-handle.md
+++ b/changelog.d/2313-consent-defer-active-handle.md
@@ -1,7 +1,0 @@
-### Changed
-
-- Approving an agent auth-request with `defer_binding` now returns 409 when that
-  agent already has an active handle, and the response points the operator at
-  `POST /api/projects/{project_id}/members/assign-agent`. It previously advised
-  minting a second identity, which splits an agent's memory and grants across
-  two canonical ids (#2313).

--- a/changelog.d/2314-cryptography-50.md
+++ b/changelog.d/2314-cryptography-50.md
@@ -1,5 +1,0 @@
-### Security
-
-- Bumped `cryptography` from 48.0.1 to 50.0.0, picking up the upstream fixes
-  for PYSEC-2026-3552/3553/3554 and CVE-2026-69247 (PKCS#7 EnvelopedData
-  Bleichenbacher). Also updates `uvicorn[standard]` to 0.52.1.

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tinyagentos-desktop",
   "private": true,
-  "version": "1.0.0-beta.46",
+  "version": "1.0.0-beta.47",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tinyagentos"
-version = "1.0.0-beta.46"
+version = "1.0.0-beta.47"
 description = "Self-hosted AI agent memory system for low-power hardware"
 license = { file = "LICENSE" }
 # Upper-capped at <3.14 because litellm (the proxy extra, the agent/model proxy

--- a/tinyagentos/__init__.py
+++ b/tinyagentos/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.0.0-beta.46"
+__version__ = "1.0.0-beta.47"

--- a/uv.lock
+++ b/uv.lock
@@ -3063,7 +3063,7 @@ wheels = [
 
 [[package]]
 name = "tinyagentos"
-version = "1.0.0b46"
+version = "1.0.0b47"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Release train for beta.47. Collates 5 fragments + direct entries into the changelog section; bumps pyproject, package.json, __init__, and uv.lock (1.0.0b47, lock-sync test green locally).

Contents since beta.46 (all merged today): device pair-requests consent loop wired end-to-end (#2233), device/node block+revoke (#2238), registry token rotation via token_min_iat (#2208, closes #2205), cryptography 50.0.0 + uvicorn bump (#2314, supersedes the closed #2310), auth session pruning (#2316), Library settings pane scaffolding (#2276), doc-gate config-error exits (#2312/#2306) and consent-defer 409 fix (#2313/#2308), SPA deps (#2315), Routines rename (#2298), project Notes (#2285), chat content blocks + thinking badge (#2281/#2282), admin notifications route (#2280), taos-agent OS skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device pair-request creation and tracking with approval or denial through Decisions.
  * Renamed the Tasks app to Routines while preserving existing app identification.
* **Bug Fixes**
  * Deferred agent-auth binding now returns a clear conflict when an active handle already exists, guiding operators to assign the existing handle instead.
* **Documentation**
  * Added contributor guidance for submitting changelog fragments and preparing consolidated release notes.
* **Release**
  * Published version 1.0.0-beta.47.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->