### PR TITLE
Agent-as-a-Model: implement the TURN in POST /v1/chat/completions (opencode host-server seam)

### DIFF
--- a/tests/test_routes_agent_model_api.py
+++ b/tests/test_routes_agent_model_api.py
@@ -1,5 +1,9 @@
 """Endpoint tests for the Agent-as-a-Model /v1 surface (decision 19)."""
+from __future__ import annotations
+
 import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -22,6 +26,21 @@ def _ensure_amk_store(client, tmp_path_factory):
         asyncio.get_event_loop().run_until_complete(store.close())
     except Exception:
         pass
+
+
+def _ensure_agent_in_config(state, agent_id: str, model: str = "test-model", llm_key: str = "sk-test-key"):
+    """Inject a fake agent into app.state.config for tests."""
+    state.config.agents.append({
+        "id": agent_id,
+        "name": agent_id,
+        "model": model,
+        "llm_key": llm_key,
+    })
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/models
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
@@ -59,7 +78,9 @@ async def test_models_revoked_key_is_rejected(client):
     assert resp.status_code == 401
 
 
-# --- POST /v1/chat/completions: the consent contract (turn execution pending) ---
+# ---------------------------------------------------------------------------
+# POST /v1/chat/completions
+# ---------------------------------------------------------------------------
 
 
 def _chat_body(model="agent-a"):
@@ -99,19 +120,6 @@ async def test_chat_rejects_empty_messages(client):
 
 
 @pytest.mark.asyncio
-async def test_chat_contract_valid_returns_501_until_turn_implemented(client):
-    store = client._transport.app.state.agent_model_keys
-    token, _ = await store.mint("u1", ["agent-a"], [])
-    resp = await client.post(
-        "/v1/chat/completions",
-        json=_chat_body(model="agent-a"),
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    assert resp.status_code == 501
-    assert resp.json()["error"]["code"] == "not_implemented"
-
-
-@pytest.mark.asyncio
 async def test_chat_revoked_key_is_rejected(client):
     store = client._transport.app.state.agent_model_keys
     token, rec = await store.mint("u1", ["agent-a"], [])
@@ -126,8 +134,6 @@ async def test_chat_revoked_key_is_rejected(client):
 
 @pytest.mark.asyncio
 async def test_chat_auth_precedes_body_validation(client):
-    # An unauthenticated caller with a malformed body must get 401 (auth first),
-    # never a 422 that leaks the schema.
     resp = await client.post("/v1/chat/completions", json={"bogus": True})
     assert resp.status_code == 401
     assert resp.json()["error"]["code"] == "invalid_api_key"
@@ -143,5 +149,168 @@ async def test_chat_missing_model_is_openai_shaped_400(client):
         headers={"Authorization": f"Bearer {token}"},
     )
     assert resp.status_code == 400
-    # OpenAI envelope, not FastAPI's default {"detail": [...]} 422.
     assert resp.json()["error"]["type"] == "invalid_request_error"
+
+
+# ---------------------------------------------------------------------------
+# Happy path: mocked adapter returns text -> OpenAI ChatCompletion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_happy_path_returns_openai_response(client, monkeypatch):
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    _ensure_agent_in_config(client._transport.app.state, "agent-a", model="gpt-4o", llm_key="sk-agent-key")
+
+    fake_server = SimpleNamespace(base_url="http://127.0.0.1:9999")
+
+    async def fake_ensure_server(state, agent_id, model, llm_key=None):
+        return fake_server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.agent_model_api.ensure_agent_opencode_server",
+        fake_ensure_server,
+    )
+
+    class _FakeAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_123"
+
+        async def prompt(self, text, trace_id=None, attachments=None):
+            self._sink({"kind": "delta", "content": "Hello"})
+            self._sink({"kind": "delta", "content": " world"})
+            self._sink({"kind": "final", "content": "Hello world"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.agent_model_api.OpenCodeAdapter",
+        _FakeAdapter,
+    )
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        json=_chat_body(model="agent-a"),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "chat.completion"
+    assert data["model"] == "agent-a"
+    assert data["choices"][0]["message"]["role"] == "assistant"
+    assert data["choices"][0]["message"]["content"] == "Hello world"
+    assert data["choices"][0]["finish_reason"] == "stop"
+    assert "id" in data
+    assert "created" in data
+
+
+@pytest.mark.asyncio
+async def test_chat_uses_agent_model_when_agent_has_one(client, monkeypatch):
+    """The adapter should be configured with the agent's model, not the agent_id."""
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    _ensure_agent_in_config(client._transport.app.state, "agent-a", model="gpt-4o", llm_key="sk-agent-key")
+
+    seen_cfgs = []
+
+    class _FakeAdapter:
+        def __init__(self, cfg, sink):
+            seen_cfgs.append(cfg)
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_123"
+
+        async def prompt(self, text, trace_id=None, attachments=None):
+            self._sink({"kind": "final", "content": "ok"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.agent_model_api.OpenCodeAdapter",
+        _FakeAdapter,
+    )
+
+    fake_server = SimpleNamespace(base_url="http://127.0.0.1:9999")
+
+    async def fake_ensure_server(state, agent_id, model, llm_key=None):
+        return fake_server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.agent_model_api.ensure_agent_opencode_server",
+        fake_ensure_server,
+    )
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        json=_chat_body(model="agent-a"),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert len(seen_cfgs) == 1
+    assert seen_cfgs[0].model_id == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_chat_returns_404_when_agent_not_in_config(client):
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["missing-agent"], [])
+    resp = await client.post(
+        "/v1/chat/completions",
+        json=_chat_body(model="missing-agent"),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "model_not_found"
+
+
+@pytest.mark.asyncio
+async def test_chat_adapter_error_returns_500(client, monkeypatch):
+    store = client._transport.app.state.agent_model_keys
+    token, _ = await store.mint("u1", ["agent-a"], [])
+    _ensure_agent_in_config(client._transport.app.state, "agent-a", model="gpt-4o", llm_key="sk-agent-key")
+
+    fake_server = SimpleNamespace(base_url="http://127.0.0.1:9999")
+
+    async def fake_ensure_server(state, agent_id, model, llm_key=None):
+        return fake_server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.agent_model_api.ensure_agent_opencode_server",
+        fake_ensure_server,
+    )
+
+    class _ErrorAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_err"
+
+        async def prompt(self, text, trace_id=None, attachments=None):
+            self._sink({"kind": "error", "error": "adapter boom"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.agent_model_api.OpenCodeAdapter",
+        _ErrorAdapter,
+    )
+
+    resp = await client.post(
+        "/v1/chat/completions",
+        json=_chat_body(model="agent-a"),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 500
+    assert resp.json()["error"]["code"] == "service_unavailable"

--- a/tinyagentos/routes/agent_model_api.py
+++ b/tinyagentos/routes/agent_model_api.py
@@ -7,21 +7,29 @@ consent flow) and gets THEIR agent(s) exposed as models. The key maps to
 
 GET /v1/models lists the agents the caller's key is consented for, each as an
 OpenAI model entry. POST /v1/chat/completions enforces the same consent contract
-(valid key, requested model in the key's agent_ids) but does NOT yet run the
-agent turn: that step drives the agent's harness and is the next slice, pending
-the turn-seam choice (see ~/.taos-team/pending-decisions.md), so a valid request
-returns 501. Scope (per-capability) enforcement and rate limiting also build on
-this binding. Per the spec, the endpoint must never resolve a model without a
-valid consent key, so the auth + scope contract lands first.
+(valid key, requested model in the key's agent_ids) and runs ONE non-streaming
+turn through the agent's host opencode server, translating the result into an
+OpenAI ChatCompletion response.  The agent keeps its memory, tools and identity
+because the turn runs through the same opencode harness the local taOS agent
+uses, not through a lightweight direct LiteLLM call.
 """
 from __future__ import annotations
 
+import asyncio
+import logging
+import time
+import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
+from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
+from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
+from tinyagentos.taos_agent_runtime import ensure_agent_opencode_server
+
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def _openai_error(message: str, *, type: str, code: str, status: int) -> JSONResponse:
@@ -58,6 +66,17 @@ async def resolve_consent_key(request: Request) -> dict | None:
     return await store.resolve(token)
 
 
+def _resolve_agent(config, agent_ref: str) -> dict | None:
+    """Return the agent dict for *agent_ref* (matched by name first, then id) or None."""
+    for agent in config.agents:
+        if agent.get("name") == agent_ref:
+            return agent
+    for agent in config.agents:
+        if agent.get("id") == agent_ref:
+            return agent
+    return None
+
+
 @router.get("/v1/models")
 async def list_models(request: Request):
     """OpenAI /v1/models: the agents this consent key may address, as models."""
@@ -80,9 +99,9 @@ async def chat_completions(request: Request):
     """OpenAI /v1/chat/completions for an agent-as-a-model.
 
     Enforces the consent contract: a valid key is required, and the requested
-    model must be one of the agents that key is consented for. Running the turn
-    through the agent's harness is the next slice (pending the seam choice), so a
-    contract-valid request returns 501 rather than a fabricated completion.
+    model must be one of the agents that key is consented for.  The turn runs
+    through the agent's host opencode server (reusing the same harness the
+    local taOS agent uses) so the agent keeps its memory, tools and identity.
 
     The body is parsed manually AFTER the auth check (not via a Pydantic
     parameter) for two reasons: auth must take precedence so an unauthenticated
@@ -125,10 +144,116 @@ async def chat_completions(request: Request):
             code="model_not_found",
             status=404,
         )
-    # Contract satisfied; the turn execution is the next slice.
-    return _openai_error(
-        "agent turn execution is not yet implemented for this surface",
-        type="server_error",
-        code="not_implemented",
-        status=501,
+
+    agent = _resolve_agent(request.app.state.config, model)
+    if agent is None:
+        return _openai_error(
+            f"the model '{model}' does not exist or you do not have access to it",
+            type="invalid_request_error",
+            code="model_not_found",
+            status=404,
+        )
+
+    agent_model = agent.get("model") or model
+    llm_key = agent.get("llm_key")
+
+    try:
+        server = await ensure_agent_opencode_server(
+            request.app.state, model, agent_model, llm_key,
+        )
+    except OpenCodeBinaryNotFoundError as exc:
+        logger.error("agent_model_api: opencode binary not found: %s", exc)
+        return _openai_error(
+            "opencode is not installed. Install it with: "
+            "curl -fsSL https://opencode.ai/install | bash -- then restart taOS.",
+            type="server_error",
+            code="service_unavailable",
+            status=503,
+        )
+    except Exception as exc:
+        logger.exception("agent_model_api: opencode server failed to start")
+        return _openai_error(
+            f"agent runtime failed to start: {exc}",
+            type="server_error",
+            code="service_unavailable",
+            status=503,
+        )
+
+    app_state = request.app.state
+    password = getattr(app_state, "opencode_server_passwords", {}).get(model, "")
+
+    cfg = OpenCodeConfig(
+        base_url=server.base_url,
+        server_password=password,
+        model_provider_id="litellm",
+        model_id=agent_model,
     )
+
+    result: dict = {"content": "", "error": None}
+
+    def sink(reply: dict) -> None:
+        kind = reply.get("kind")
+        if kind == "delta":
+            result["content"] += reply.get("content", "")
+        elif kind == "final":
+            result["content"] = reply.get("content", result["content"])
+        elif kind == "error":
+            result["error"] = reply.get("error")
+
+    adapter = OpenCodeAdapter(cfg, sink)
+    session_ids = getattr(app_state, "opencode_server_session_ids", {})
+    adapter.session_id = session_ids.get(model)
+
+    async def _drive() -> None:
+        try:
+            await adapter.ensure_session()
+            session_ids[model] = adapter.session_id
+            trace_id = uuid.uuid4().hex
+            await adapter.prompt(messages[-1].get("content", ""), trace_id=trace_id)
+            await adapter.close()
+        except Exception as exc:
+            logger.exception("agent_model_api: drive task error")
+            result["error"] = str(exc)
+
+    drive_task = asyncio.create_task(_drive())
+
+    try:
+        await asyncio.wait_for(drive_task, timeout=300.0)
+    except asyncio.TimeoutError:
+        if not drive_task.done():
+            drive_task.cancel()
+            try:
+                await drive_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        result["error"] = "agent turn timed out (limit: 300s)"
+
+    if result["error"]:
+        return _openai_error(
+            result["error"],
+            type="server_error",
+            code="service_unavailable",
+            status=500,
+        )
+
+    return {
+        "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": result["content"],
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+    }

--- a/tinyagentos/taos_agent_runtime.py
+++ b/tinyagentos/taos_agent_runtime.py
@@ -157,6 +157,98 @@ async def ensure_taos_opencode_server(app_state, model: str) -> OpenCodeServer:
     return server
 
 
+async def ensure_agent_opencode_server(
+    app_state,
+    agent_id: str,
+    model: str,
+    llm_key: str | None = None,
+) -> OpenCodeServer:
+    """Ensure an opencode server is running for the given agent.
+
+    Per-agent version of :func:`ensure_taos_opencode_server`.  Each agent gets
+    its own server with its own home directory, port, password, and LiteLLM
+    key so conversation history, memory, and identity are isolated per agent.
+    """
+    if not hasattr(app_state, "opencode_servers"):
+        app_state.opencode_servers = {}
+    if not hasattr(app_state, "opencode_server_passwords"):
+        app_state.opencode_server_passwords = {}
+    if not hasattr(app_state, "opencode_server_keys"):
+        app_state.opencode_server_keys = {}
+    if not hasattr(app_state, "opencode_server_models"):
+        app_state.opencode_server_models = {}
+    if not hasattr(app_state, "opencode_server_session_ids"):
+        app_state.opencode_server_session_ids = {}
+
+    if agent_id not in app_state.opencode_server_passwords:
+        app_state.opencode_server_passwords[agent_id] = secrets.token_hex(16)
+    password = app_state.opencode_server_passwords[agent_id]
+
+    existing = app_state.opencode_servers.get(agent_id)
+    existing_model = app_state.opencode_server_models.get(agent_id)
+
+    if existing is not None and existing.is_running() and existing_model == model:
+        return existing
+
+    if existing is not None:
+        try:
+            await existing.stop()
+        except Exception:
+            logger.debug("taos_agent_runtime: error stopping agent server", exc_info=True)
+
+    if llm_key is None:
+        llm_key = get_litellm_master_key(getattr(app_state, "data_dir", None))
+
+    from tinyagentos.installers.port_allocator import allocate_host_port
+
+    data_dir = getattr(app_state, "data_dir", None)
+    home = str(data_dir / f"{agent_id}-opencode") if data_dir else f"{agent_id}-opencode"
+    port = allocate_host_port(f"opencode-{agent_id}")
+
+    llm_proxy = getattr(app_state, "llm_proxy", None)
+    litellm_base_url = (
+        f"http://127.0.0.1:{llm_proxy.port}/v1"
+        if llm_proxy is not None
+        else "http://127.0.0.1:7834/v1"
+    )
+
+    cfg = OpenCodeServerConfig(
+        home=home,
+        port=port,
+        server_password=password,
+        litellm_base_url=litellm_base_url,
+        litellm_key=llm_key,
+        model_ids=[model],
+    )
+    server = OpenCodeServer(cfg)
+    app_state.opencode_servers[agent_id] = server
+    app_state.opencode_server_models[agent_id] = model
+    app_state.opencode_server_keys[agent_id] = llm_key
+    app_state.opencode_server_session_ids[agent_id] = None
+
+    await server.ensure_running(deadline_s=180.0)
+    return server
+
+
+async def stop_agent_opencode_server(app_state, agent_id: str) -> None:
+    """Stop the opencode server for a single agent.
+
+    Safe to call even if the server was never created.
+    """
+    servers = getattr(app_state, "opencode_servers", {})
+    server = servers.get(agent_id)
+    if server is None:
+        return
+    try:
+        await server.stop()
+    except Exception:
+        logger.debug("taos_agent_runtime: error during agent server stop", exc_info=True)
+    finally:
+        servers.pop(agent_id, None)
+        session_ids = getattr(app_state, "opencode_server_session_ids", {})
+        session_ids.pop(agent_id, None)
+
+
 async def stop_taos_opencode_server(app_state) -> None:
     """Stop the taOS agent opencode server if it was started.
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Agent-as-a-Model: implement the TURN in POST /v1/chat/completions (opencode host-server seam)

Autonomous build of board card tsk-gkh4mi.



Files:
 tests/test_routes_agent_model_api.py  | 203 +++++++++++++++++++++++++++++++---
 tinyagentos/routes/agent_model_api.py | 155 +++++++++++++++++++++++---
 tinyagentos/taos_agent_runtime.py     |  92 +++++++++++++++
 3 files changed, 418 insertions(+), 32 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat requests can now be processed through configured agents and return OpenAI-compatible completions.
  * Agent sessions are preserved across requests for more consistent conversations.
  * Agents can use isolated runtimes with configurable models and credentials.
* **Bug Fixes**
  * Replaced the previous “not implemented” response with working chat completion support.
  * Added structured error responses for missing agents, startup failures, unavailable runtimes, request failures, and timeouts.
* **Tests**
  * Expanded coverage for successful requests, configuration, missing agents, and runtime or adapter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->