### PR TITLE
Make 3-strike QUARANTINE loud: store + lifespan wiring + surfacing + tests (FULL slice, replaces tsk-glxi4e)

### DIFF
--- a/changelog.d/2333-strike-quarantine-wiring.md
+++ b/changelog.d/2333-strike-quarantine-wiring.md
@@ -1,0 +1,5 @@
+### Added
+
+- Quarantined task cards surface their strike count and latest strike on the
+  task-detail response, and a lead can un-quarantine a card via
+  `POST /api/projects/{pid}/tasks/{tid}/unquarantine`, clearing its strikes (#2333).

--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -229,6 +229,9 @@ The surface, by scope:
   `POST .../tasks/{id}/(claim|release|close|reopen)`, and
   `GET /api/projects/tasks/{id}/context`. This is read + lifecycle + comments
   only. Granting project_tasks also makes the agent a project member.
+  `POST .../tasks/{id}/unquarantine` is also reachable, but LEAD-only: the
+  route (`_authorize_project_lead`) refuses a plain project_tasks worker.
+  It returns a quarantined card to the open pool and clears its strikes.
 - **project_tasks_create**: `POST /api/projects/{pid}/tasks` (author new cards).
   This is a SEPARATE scope from project_tasks and is off by default; grant it
   explicitly when an agent needs to create cards.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -356,6 +356,10 @@ async def client(app, tmp_data_dir):
     if receipt_store._db is not None:
         await receipt_store.close()
     await receipt_store.init()
+    task_strikes = app.state.task_strikes
+    if task_strikes._db is not None:
+        await task_strikes.close()
+    await task_strikes.init()
     project_task_store = app.state.project_task_store
     if project_task_store._db is not None:
         await project_task_store.close()

--- a/tests/projects/test_strike_wiring.py
+++ b/tests/projects/test_strike_wiring.py
@@ -1,0 +1,131 @@
+"""Wiring tests for the strike store (tsk-orqoif / #2333 follow-up).
+
+#2333 added StrikeStore and an optional ``strikes=`` param on ProjectTaskStore
+but never constructed the store, attached it to app.state, or passed it into
+ProjectTaskStore -- the param was inert. These tests exercise the REAL app
+lifespan (mirroring tests/projects/test_routes_beads.py) rather than the
+'client' fixture, because 'client' bypasses the lifespan entirely and would
+pass even with the store never wired up.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+def _auth_client(app):
+    """Return a session-cookie-authenticated AsyncClient for the given app."""
+    app.state.auth.setup_user("admin", "Test Admin", "", "testpass")
+    record = app.state.auth.find_user("admin")
+    uid = record["id"] if record else ""
+    token = app.state.auth.create_session(user_id=uid, long_lived=True)
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"taos_session": token},
+    )
+
+
+async def _make_project_and_task(c, slug: str) -> tuple[str, str]:
+    r = await c.post("/api/projects", json={"name": "Demo", "slug": slug})
+    assert r.status_code == 200, r.text
+    project_id = r.json()["id"]
+    r = await c.post(f"/api/projects/{project_id}/tasks", json={"title": "T1"})
+    assert r.status_code == 200, r.text
+    return project_id, r.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_app_state_has_task_strikes_store(app):
+    """StrikeStore must be attached to app.state and initialised by the lifespan."""
+    async with app.router.lifespan_context(app):
+        strikes = app.state.task_strikes
+        assert strikes is not None
+        # Prove it is actually usable (init() ran), not just non-None.
+        count = await strikes.record_strike("tsk-fake", "verify", log_tail="boom")
+        assert count == 1
+        assert await strikes.count_strikes("tsk-fake") == 1
+
+
+@pytest.mark.asyncio
+async def test_close_task_clears_strikes_via_taskstore_wiring(app):
+    """ProjectTaskStore must have actually received the strike store: closing
+    a task with recorded strikes should clear them (task_store.py's
+    close_task -> self._strikes.clear_strikes). This fails if the
+    strikes=strike_store constructor arg was never wired in app.py."""
+    async with app.router.lifespan_context(app):
+        async with _auth_client(app) as c:
+            _project_id, task_id = await _make_project_and_task(c, "strike-close")
+
+            strikes = app.state.task_strikes
+            await strikes.record_strike(task_id, "verify", log_tail="fail 1")
+            await strikes.record_strike(task_id, "verify", log_tail="fail 2")
+            assert await strikes.count_strikes(task_id) == 2
+
+            r = await c.post(
+                f"/api/projects/{_project_id}/tasks/{task_id}/close",
+                json={"closed_by": "tester"},
+            )
+            assert r.status_code == 200, r.text
+
+            assert await strikes.count_strikes(task_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_task_surfaces_strike_count_and_latest(app):
+    """Task-detail response must surface strike_count + latest_strike."""
+    async with app.router.lifespan_context(app):
+        async with _auth_client(app) as c:
+            project_id, task_id = await _make_project_and_task(c, "strike-surface")
+
+            strikes = app.state.task_strikes
+            await strikes.record_strike(task_id, "verify", log_tail="first")
+            await strikes.record_strike(task_id, "verify", log_tail="second")
+
+            r = await c.get(f"/api/projects/{project_id}/tasks/{task_id}")
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["strike_count"] == 2
+            assert body["latest_strike"] is not None
+            assert body["latest_strike"]["log_tail"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_unquarantine_route_lead_success_and_noauth_failure(app):
+    """The unquarantine route must work through the real HTTP layer with
+    proper (lead) auth, clear strikes, and be refused 401 without auth."""
+    async with app.router.lifespan_context(app):
+        async with _auth_client(app) as c:
+            project_id, task_id = await _make_project_and_task(c, "strike-unq")
+
+            task_store = app.state.project_task_store
+            strikes = app.state.task_strikes
+            await strikes.record_strike(task_id, "verify", log_tail="strike 3")
+            ok = await task_store.quarantine_task(task_id, "system")
+            assert ok is True
+
+            unauth = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+            try:
+                r = await unauth.post(
+                    f"/api/projects/{project_id}/tasks/{task_id}/unquarantine"
+                )
+            finally:
+                await unauth.aclose()
+            # No session cookie and no Authorization header at all: the global
+            # auth middleware gate refuses the request before it ever reaches
+            # the route (same as every other task route with zero credentials).
+            assert r.status_code == 401
+
+            # Task must still be quarantined -- the unauthenticated call above
+            # must not have mutated it.
+            still_quarantined = await task_store.get_task(task_id)
+            assert still_quarantined["status"] == "quarantined"
+
+            r = await c.post(
+                f"/api/projects/{project_id}/tasks/{task_id}/unquarantine"
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["status"] == "open"
+
+            assert await strikes.count_strikes(task_id) == 0

--- a/tinyagentos/app.py
+++ b/tinyagentos/app.py
@@ -412,11 +412,14 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     board_audit_store = BoardAuditLog(data_dir / "board_audit.db")
     from tinyagentos.receipt_store import ReceiptStore
     receipt_store = ReceiptStore(data_dir / "receipts.db")
+    from tinyagentos.projects.strike_store import StrikeStore
+    strike_store = StrikeStore(data_dir / "task_strikes.db")
     project_task_store = ProjectTaskStore(
         data_dir / "projects.db",
         broker=project_event_broker,
         audit=board_audit_store,
         project_store=project_store,
+        strikes=strike_store,
     )
     project_element_store = ProjectElementStore(data_dir / "projects.db")
     from tinyagentos.projects.routines_store import RoutineStore
@@ -586,6 +589,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await project_invite_store.init()
         await board_audit_store.init()
         await receipt_store.init()
+        await strike_store.init()
         await project_task_store.init()
         await project_element_store.init()
         await routine_store.init()
@@ -1458,6 +1462,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
         await doc_review_store.close()
         await project_notes_store.close()
         await project_invite_store.close()
+        await strike_store.close()
         await project_task_store.close()
         await project_element_store.close()
         await routine_store.close()
@@ -1614,6 +1619,7 @@ def create_app(data_dir: Path | None = None, catalog_dir: Path | None = None) ->
     app.state.project_invites = project_invite_store
     app.state.board_audit = board_audit_store
     app.state.receipt_store = receipt_store
+    app.state.task_strikes = strike_store
     app.state.project_task_store = project_task_store
     app.state.project_element_store = project_element_store
     app.state.routine_store = routine_store

--- a/tinyagentos/auth_middleware.py
+++ b/tinyagentos/auth_middleware.py
@@ -86,6 +86,10 @@ _AGENT_TASK_ROUTES = (
     # a plain project_tasks worker is refused. Toggles only the "claimable"
     # label, so it does not widen the scope into free field edits (cf. PATCH).
     ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/claimable$")),
+    # Un-quarantine curation: same LEAD-only gate as claimable above
+    # (_authorize_project_lead). Returns a quarantined card to the open pool
+    # and clears its strikes (see StrikeStore / unquarantine_task).
+    ("POST", re.compile(rf"^/api/projects/{_SEG}/tasks/{_SEG}/unquarantine$")),
 )
 
 # Project doc-review stamp store routes an agent may reach with its own registry

--- a/tinyagentos/projects/ids.py
+++ b/tinyagentos/projects/ids.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import secrets
 
-ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "lst", "rev", "cs", "rtn", "elm", "note")
+ID_PREFIXES = ("prj", "tsk", "cmt", "rel", "cve", "dec", "doc", "ent", "lst", "rev", "cs", "rtn", "elm", "note", "str")
 _ALPHABET = "abcdefghijklmnopqrstuvwxyz234567"
 
 

--- a/tinyagentos/projects/strike_store.py
+++ b/tinyagentos/projects/strike_store.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import time
+
+from tinyagentos.base_store import BaseStore
+from tinyagentos.projects.ids import new_id
+
+STRIKE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS task_strikes (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    step TEXT NOT NULL,
+    log_tail TEXT NOT NULL DEFAULT '',
+    actor TEXT NOT NULL DEFAULT '',
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_strikes_task ON task_strikes(task_id);
+"""
+
+
+def _row(r) -> dict:
+    keys = ("id", "task_id", "step", "log_tail", "actor", "created_at")
+    return dict(zip(keys, r))
+
+
+class StrikeStore(BaseStore):
+    """Append-only log of verification strikes per task.
+
+    The dispatch host (taOS-dev) records a strike each time a card fails
+    verification.  When the count reaches ``STRIKE_THRESHOLD`` the task is
+    quarantined (see ``ProjectTaskStore.quarantine_task``) and the lead is
+    notified.  Strikes are auto-cleared when the task closes or its PR
+    merges (see ``ProjectTaskStore.close_task`` and the unquarantine route).
+    """
+
+    SCHEMA = STRIKE_SCHEMA
+
+    # Number of failed verifications before a card is quarantined.
+    STRIKE_THRESHOLD = 3
+
+    async def record_strike(
+        self,
+        task_id: str,
+        step: str,
+        log_tail: str = "",
+        actor: str = "",
+    ) -> int:
+        """Record one verification strike for *task_id*.
+
+        Returns the total strike count for the task after this insert (so the
+        caller can decide whether the threshold was just crossed).
+        """
+        sid = new_id("str")
+        now = time.time()
+        await self._db.execute(
+            """INSERT INTO task_strikes
+               (id, task_id, step, log_tail, actor, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (sid, task_id, step, log_tail, actor, now),
+        )
+        await self._db.commit()
+        return await self.count_strikes(task_id)
+
+    async def count_strikes(self, task_id: str) -> int:
+        async with self._db.execute(
+            "SELECT COUNT(*) FROM task_strikes WHERE task_id = ?", (task_id,)
+        ) as cur:
+            row = await cur.fetchone()
+        return row[0] if row else 0
+
+    async def list_strikes(self, task_id: str) -> list[dict]:
+        """All strikes for *task_id*, oldest first."""
+        async with self._db.execute(
+            "SELECT * FROM task_strikes WHERE task_id = ? ORDER BY created_at ASC",
+            (task_id,),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [_row(r) for r in rows]
+
+    async def latest(self, task_id: str) -> dict | None:
+        """The most recent strike for *task_id*, or None."""
+        async with self._db.execute(
+            "SELECT * FROM task_strikes WHERE task_id = ? ORDER BY created_at DESC LIMIT 1",
+            (task_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        return _row(row) if row else None
+
+    async def clear_strikes(self, task_id: str) -> int:
+        """Delete every strike for *task_id*.
+
+        Returns the number of rows deleted (0 when there were none).
+        """
+        cursor = await self._db.execute(
+            "DELETE FROM task_strikes WHERE task_id = ?", (task_id,)
+        )
+        await self._db.commit()
+        return cursor.rowcount

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from tinyagentos.board_audit import BoardAuditLog
     from tinyagentos.projects.events import ProjectEventBroker
     from tinyagentos.projects.project_store import ProjectStore
+    from tinyagentos.projects.strike_store import StrikeStore
 
 logger = logging.getLogger(__name__)
 
@@ -110,11 +111,13 @@ class ProjectTaskStore(BaseStore):
         broker: "ProjectEventBroker | None" = None,
         audit: "BoardAuditLog | None" = None,
         project_store: "ProjectStore | None" = None,
+        strikes: "StrikeStore | None" = None,
     ) -> None:
         super().__init__(db_path)
         self._broker = broker
         self._audit = audit
         self._project_store = project_store
+        self._strikes = strikes
 
     async def _publish(self, project_id: str, kind: str, payload: dict) -> None:
         if self._broker is not None:
@@ -375,6 +378,15 @@ class ProjectTaskStore(BaseStore):
             existing = await self.get_task(task_id)
             if existing is not None:
                 await self._publish(existing["project_id"], "task.closed", {"id": task_id, "closed_by": closed_by})
+            # A closed card can never be re-landed, so any lingering strikes
+            # are stale garbage that would make the dispatch lanes redo landed
+            # work.  Clear them automatically (best-effort; the close itself
+            # has already committed).
+            if self._strikes is not None:
+                try:
+                    await self._strikes.clear_strikes(task_id)
+                except Exception:
+                    logger.warning("clear_strikes failed for task %s on close", task_id, exc_info=True)
             # Derive the pre-close status race-free from the committed row rather
             # than a separate pre-read (which would have a TOCTOU gap). close does
             # not clear claimed_by, so a set claimer means it was 'claimed'.
@@ -405,6 +417,73 @@ class ProjectTaskStore(BaseStore):
                 await self._publish(existing["project_id"], "task.reopened", {"id": task_id, "reopened_by": reopened_by})
             await self._record_audit(
                 task_id, "task.reopened", reopened_by, "closed", "open",
+                project_id=existing["project_id"] if existing else "",
+            )
+        return changed
+
+    async def quarantine_task(self, task_id: str, actor: str) -> bool:
+        """Move a task into the ``quarantined`` status.
+
+        A quarantined card is visible on the board (distinct column) but is
+        removed from the ready pool -- the fleet will not pick it up until a
+        lead explicitly un-quarantines it.  Only acts on a task that is not
+        already closed/cancelled; returns False otherwise.
+        """
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET status = 'quarantined', updated_at = ?
+               WHERE id = ? AND status NOT IN ('closed', 'cancelled', 'quarantined')""",
+            (now, task_id),
+        )
+        await self._db.commit()
+        changed = cursor.rowcount == 1
+        if changed:
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(
+                    existing["project_id"],
+                    "task.quarantined",
+                    {"id": task_id, "actor": actor},
+                )
+            await self._record_audit(
+                task_id, "task.quarantined", actor, "open", "quarantined",
+                project_id=existing["project_id"] if existing else "",
+            )
+        return changed
+
+    async def unquarantine_task(self, task_id: str, actor: str) -> bool:
+        """Return a quarantined task to the open pool and clear its strikes.
+
+        This is the explicit un-quarantine / retry action: the card re-enters
+        the ready pool so the fleet may pick it up again.  Strikes are cleared
+        so a fresh failure count starts from zero.  Only acts on a quarantined
+        task; returns False otherwise.
+        """
+        now = time.time()
+        cursor = await self._db.execute(
+            """UPDATE project_tasks
+               SET status = 'open', updated_at = ?
+               WHERE id = ? AND status = 'quarantined'""",
+            (now, task_id),
+        )
+        await self._db.commit()
+        changed = cursor.rowcount == 1
+        if changed:
+            if self._strikes is not None:
+                try:
+                    await self._strikes.clear_strikes(task_id)
+                except Exception:
+                    logger.warning("clear_strikes failed for task %s on unquarantine", task_id, exc_info=True)
+            existing = await self.get_task(task_id)
+            if existing is not None:
+                await self._publish(
+                    existing["project_id"],
+                    "task.unquarantined",
+                    {"id": task_id, "actor": actor},
+                )
+            await self._record_audit(
+                task_id, "task.unquarantined", actor, "quarantined", "open",
                 project_id=existing["project_id"] if existing else "",
             )
         return changed

--- a/tinyagentos/routes/projects.py
+++ b/tinyagentos/routes/projects.py
@@ -766,6 +766,10 @@ async def get_task(
     t = await store.get_task(task_id)
     if t is None or t["project_id"] != project_id:
         return JSONResponse({"error": "not found"}, status_code=404)
+    strikes = getattr(request.app.state, "task_strikes", None)
+    if strikes is not None:
+        t["strike_count"] = await strikes.count_strikes(task_id)
+        t["latest_strike"] = await strikes.latest(task_id)
     return t
 
 
@@ -1040,6 +1044,42 @@ async def reopen_task(
     notifs = getattr(request.app.state, "notifications", None)
     if notifs is not None:
         await notifs.emit_event("task.reopened", "Task reopened", f"{task_id} reopened by {actor}")
+    return await store.get_task(task_id)
+
+
+@router.post("/api/projects/{project_id}/tasks/{task_id}/unquarantine")
+async def unquarantine_task(
+    project_id: str,
+    task_id: str,
+    request: Request,
+):
+    """Return a quarantined card to the open pool and clear its strikes.
+
+    LEAD-only curation, mirroring mark_task_claimable: only a project LEAD
+    (session owner/admin, or the lead agent's ``project_tasks`` token) may
+    retry a quarantined card -- a plain project_tasks worker cannot self
+    un-quarantine. See ProjectTaskStore.unquarantine_task for the strike-clear
+    behaviour.
+    """
+    pstore = request.app.state.project_store
+    auth = await _authorize_project_lead(request, pstore, project_id)
+    if isinstance(auth, JSONResponse):
+        return auth
+    actor_id, _is_agent, _project = auth
+    store = request.app.state.project_task_store
+    existing = await store.get_task(task_id)
+    if existing is None or existing["project_id"] != project_id:
+        return JSONResponse({"error": "not found"}, status_code=404)
+    ok = await store.unquarantine_task(task_id, actor_id)
+    if not ok:
+        return JSONResponse({"error": "task is not quarantined"}, status_code=409)
+    _beads_mark_dirty(request, project_id)
+    await pstore.log_activity(project_id, actor_id, "task.unquarantined", {"task_id": task_id})
+    notifs = getattr(request.app.state, "notifications", None)
+    if notifs is not None:
+        await notifs.emit_event(
+            "task.unquarantined", "Task unquarantined", f"{task_id} unquarantined by {actor_id}"
+        )
     return await store.get_task(task_id)
 
 


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Make 3-strike QUARANTINE loud: store + lifespan wiring + surfacing + tests (FULL slice, replaces tsk-glxi4e)

Autonomous build of board card tsk-orqoif.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 tinyagentos/projects/strike_store.py | 98 ++++++++++++++++++++++++++++++++++++
 tinyagentos/projects/task_store.py   | 79 +++++++++++++++++++++++++++++
 2 files changed, 177 insertions(+)

----
## Summary by Gitar

- **Strike Store:**
    - Added `StrikeStore` for tracking verification strikes with `STRIKE_THRESHOLD` set to 3
- **Task Quarantine:**
    - Added `quarantine_task` and `unquarantine_task` methods to `ProjectTaskStore` with automatic strike clearing

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strike tracking for task verification, including recording, viewing, counting, and clearing strikes.
  * Quarantined task details now include strike counts and the latest strike information.
  * Added lead-only unquarantine actions to reopen tasks and clear associated strikes.
  * Added audit and event updates for quarantine changes.
  * Closing or unquarantining a task now clears its associated strikes.

* **Documentation**
  * Documented the unquarantine endpoint and its access requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->