### PR TITLE
CI check: a new BaseStore must be wired into the app lifespan (no orphan stores)

### DIFF
--- a/.claude/skills/taos-development-skill/SKILL.md
+++ b/.claude/skills/taos-development-skill/SKILL.md
@@ -148,7 +148,7 @@ uv run pytest tests/ --ignore=tests/e2e -n auto
 - Uses `uv sync --frozen` and `pytest -n auto`
 - Also required: `spa-build` (npm build + tsc + **vitest** - a desktop type error or failing
   component test fails CI), a "Verify app starts" `create_app` import smoke, `lint`
-  (`compileall`), and `cla`. The doc-gate is a separate workflow.
+  (`compileall`), and `cla`. The doc-gate and store-wiring gate are separate workflows.
 
 ## CLA - HUMAN signs
 
@@ -437,6 +437,20 @@ Docs-Reviewed: no user-facing change, internal refactor only
 
 Run `scripts/install-git-hooks.sh` to enable local hooks (`.githooks/pre-commit` and
 `.githooks/commit-msg`) so the gate runs before you push.
+
+## Store wiring gate
+
+A gate (`.github/workflows/store-wiring-gate.yml`, running `scripts/check_store_wiring.py`)
+blocks PRs that add a new `BaseStore` subclass without wiring it into `tinyagentos/app.py`.
+Routes reach stores ONLY via `request.app.state`, so an unwired store is unreachable dead
+code. The check is name-level (the class name must appear in `app.py`) and polices only
+classes added by the PR - pre-existing orphans are skipped.
+
+For a store genuinely constructed elsewhere (tests, CLI, workers), waive it with a PR-body
+trailer, which is logged by the gate:
+```
+Store-Unwired-Intentionally: <ClassName>, <why>
+```
 
 ## Upstream conventions (from CONTRIBUTING.md)
 

--- a/.github/workflows/store-wiring-gate.yml
+++ b/.github/workflows/store-wiring-gate.yml
@@ -16,6 +16,9 @@ name: Store wiring gate
 
 on:
   pull_request:
+    # "edited" so a waiver trailer added by editing the PR body retriggers the
+    # gate (a re-run replays the stale event payload with the old body).
+    types: [opened, synchronize, reopened, edited]
     branches: [master, dev]
 
 jobs:

--- a/.github/workflows/store-wiring-gate.yml
+++ b/.github/workflows/store-wiring-gate.yml
@@ -1,0 +1,43 @@
+name: Store wiring gate
+
+# Detects PRs that add a new BaseStore subclass without wiring it into
+# tinyagentos/app.py. Routes reach stores ONLY via request.app.state, so a
+# store that is never assigned to app.state is unreachable.
+#
+# Start with a NAME-LEVEL check (class name appears in the lifespan file).
+# Only newly added classes are policed; pre-existing orphans are skipped so
+# the check is mergeable on any branch.
+#
+# A "Store-Unwired-Intentionally: <ClassName>, <why>" trailer in the PR body
+# waives a named class and logs it, for stores genuinely constructed elsewhere
+# (tests, CLI, workers).
+#
+# See scripts/check_store_wiring.py for the implementation.
+
+on:
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  store-wiring-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BASE_REF: ${{ github.base_ref }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Fetch base branch
+        run: git fetch origin "$BASE_REF"
+
+      - name: Check for unwired BaseStore subclasses
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: python scripts/check_store_wiring.py --base "origin/$BASE_REF"

--- a/changelog.d/tsk-n3w5mh-store-wiring-gate.md
+++ b/changelog.d/tsk-n3w5mh-store-wiring-gate.md
@@ -1,0 +1,11 @@
+### Added
+
+- **CI**: store-wiring-gate workflow and `scripts/check_store_wiring.py` guard.
+  A PR that adds a new BaseStore subclass without wiring it into
+  `tinyagentos/app.py` now fails CI and names the unreachable class and file.
+  Routes reach stores ONLY via `request.app.state`, so an unwired store is
+  dead code. Start with a NAME-LEVEL check (class name appears in the lifespan
+  file). Only newly added classes are policed; pre-existing orphans are not
+  flagged. A `Store-Unwired-Intentionally: <ClassName>, <why>` trailer in the
+  PR body waives a named class and logs it, for stores genuinely constructed
+  elsewhere (tests, CLI, workers).

--- a/scripts/check_store_wiring.py
+++ b/scripts/check_store_wiring.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""BaseStore wiring guard.
+
+Detects PRs that add a new BaseStore subclass but never wire it into
+tinyagentos/app.py. Routes reach stores ONLY via request.app.state, so a
+store that is never assigned to app.state is unreachable.
+
+Algorithm:
+  1. Scan the PR diff for Python files under tinyagentos/.
+  2. For each newly added file, find classes that subclass BaseStore
+     (directly or transitively).
+  3. For each modified file, find classes whose ``class Foo(BaseStore)``
+     definition line appears in the added diff lines.
+  4. For each newly-added store class, check that its class name appears
+     somewhere in tinyagentos/app.py (name-level check).
+  5. A "Store-Unwired-Intentionally: <ClassName>, <why>" trailer in the PR
+     body waives a named class and logs it.
+
+Usage:
+    python scripts/check_store_wiring.py
+    python scripts/check_store_wiring.py --base origin/dev
+    python scripts/check_store_wiring.py --base origin/dev --pr-body "..."
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TRAILER = "Store-Unwired-Intentionally:"
+
+
+@dataclass
+class Violation:
+    class_name: str
+    file_path: str
+
+
+def _run_git(args: list[str], repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo_root, capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def _parse_name_status(output: str) -> list[tuple[str, str]]:
+    changed: list[tuple[str, str]] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        path = parts[-1]
+        changed.append((status[0], path))
+    return changed
+
+
+def _git_changed(base_ref: str, repo_root: Path) -> list[tuple[str, str]]:
+    out = _run_git(["diff", "--name-status", f"{base_ref}...HEAD"], repo_root)
+    return _parse_name_status(out)
+
+
+def _get_file_at_ref(file_path: str, ref: str, repo_root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{file_path}"],
+            cwd=repo_root, capture_output=True, text=True, check=True,
+        )
+        return result.stdout
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _class_def_in_added_lines(
+    file_path: str, class_name: str, base_ref: str, repo_root: Path,
+) -> bool:
+    """Return True if the class definition is newly added in the PR."""
+    base_content = _get_file_at_ref(file_path, base_ref, repo_root)
+    if base_content is not None:
+        try:
+            base_tree = ast.parse(base_content)
+            for node in ast.walk(base_tree):
+                if isinstance(node, ast.ClassDef) and node.name == class_name:
+                    return False
+        except SyntaxError:
+            pass
+
+    diff = _run_git(["diff", f"{base_ref}...HEAD", "--", file_path], repo_root)
+    pattern = re.compile(rf"^\+.*class\s+{re.escape(class_name)}\s*\(", re.MULTILINE)
+    return bool(pattern.search(diff))
+
+
+def build_class_hierarchy(repo_root: Path) -> dict[str, set[str]]:
+    """Build a map of class_name -> set of direct base class names."""
+    classes: dict[str, set[str]] = {}
+    tinyagentos_dir = repo_root / "tinyagentos"
+    if not tinyagentos_dir.is_dir():
+        return classes
+    for py_file in sorted(tinyagentos_dir.rglob("*.py")):
+        try:
+            source = py_file.read_text(encoding="utf-8", errors="ignore")
+            tree = ast.parse(source)
+        except (OSError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                bases = set()
+                for base in node.bases:
+                    if isinstance(base, ast.Name):
+                        bases.add(base.id)
+                classes[node.name] = bases
+    return classes
+
+
+def _inherits_base_store(
+    class_name: str,
+    classes: dict[str, set[str]],
+    visited: set[str] | None = None,
+) -> bool:
+    if visited is None:
+        visited = set()
+    if class_name == "BaseStore":
+        return True
+    if class_name in visited:
+        return False
+    visited.add(class_name)
+    for base in classes.get(class_name, set()):
+        if _inherits_base_store(base, classes, visited):
+            return True
+    return False
+
+
+def find_base_store_subclasses_in_file(
+    source: str, all_classes: dict[str, set[str]],
+) -> set[str]:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return set()
+
+    classes_in_file: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            classes_in_file.add(node.name)
+
+    return {
+        name for name in classes_in_file
+        if _inherits_base_store(name, all_classes)
+    }
+
+
+def parse_waived_classes(pr_body: str | None) -> set[str]:
+    """Parse Store-Unwired-Intentionally trailer from PR body text.
+
+    Expected format: ``Store-Unwired-Intentionally: <ClassName>, <why>``
+    Only the first comma-delimited token is treated as the class name; the
+    remainder is the human-readable reason.
+    """
+    waived: set[str] = set()
+    if not pr_body:
+        return waived
+    for line in pr_body.splitlines():
+        line = line.strip()
+        if line.startswith(TRAILER):
+            classes_str = line[len(TRAILER):].strip()
+            cls = classes_str.split(",", 1)[0].strip()
+            if cls:
+                waived.add(cls)
+    return waived
+
+
+def check_store_wiring(
+    base_ref: str,
+    repo_root: Path = REPO_ROOT,
+    pr_body: str | None = None,
+) -> tuple[list[Violation], set[str]]:
+    changed = _git_changed(base_ref, repo_root)
+
+    app_py_path = repo_root / "tinyagentos" / "app.py"
+    app_py_content = ""
+    if app_py_path.exists():
+        app_py_content = app_py_path.read_text(encoding="utf-8", errors="ignore")
+
+    all_classes = build_class_hierarchy(repo_root)
+
+    violations: list[Violation] = []
+    waived: set[str] = set()
+    waived.update(parse_waived_classes(pr_body))
+
+    for status, file_path in changed:
+        if not file_path.startswith("tinyagentos/") or not file_path.endswith(".py"):
+            continue
+        if status.startswith("D"):
+            continue
+        if not (status.startswith("A") or status.startswith("M")):
+            continue
+
+        abs_path = repo_root / file_path
+        if not abs_path.exists():
+            continue
+
+        source = abs_path.read_text(encoding="utf-8", errors="ignore")
+        store_classes = find_base_store_subclasses_in_file(source, all_classes)
+        if not store_classes:
+            continue
+
+        for class_name in sorted(store_classes):
+            is_new = False
+            if status.startswith("A"):
+                is_new = True
+            elif status.startswith("M"):
+                is_new = _class_def_in_added_lines(
+                    file_path, class_name, base_ref, repo_root,
+                )
+
+            if not is_new:
+                continue
+
+            if class_name in waived:
+                waived.add(class_name)
+                continue
+
+            if not re.search(rf"\b{re.escape(class_name)}\b", app_py_content):
+                violations.append(Violation(
+                    class_name=class_name,
+                    file_path=file_path,
+                ))
+
+    return violations, waived
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=None, help="Target branch ref (e.g. origin/dev)")
+    parser.add_argument("--pr-body", default=None, help="PR body text (for Store-Unwired-Intentionally trailer)")
+    args = parser.parse_args(argv)
+
+    base_ref = args.base
+    if base_ref is None:
+        base_ref = os.environ.get("BASE_REF", "origin/dev")
+
+    pr_body = args.pr_body
+    if pr_body is None:
+        pr_body = os.environ.get("PR_BODY")
+
+    violations, waived_classes = check_store_wiring(base_ref, REPO_ROOT, pr_body)
+
+    if waived_classes:
+        for cls in sorted(waived_classes):
+            print(f"store-wiring-guard: waived via Store-Unwired-Intentionally: {cls}")
+
+    if violations:
+        print(
+            f"STORE-WIRING FAIL: {len(violations)} new BaseStore subclass(es) are not wired "
+            f"into tinyagentos/app.py. Routes reach stores ONLY via request.app.state, "
+            f"so an unwired store is unreachable:"
+        )
+        for v in violations:
+            print(f"  - {v.class_name} in {v.file_path}")
+        return 1
+
+    print("store-wiring-guard: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_store_wiring.py
+++ b/tests/test_check_store_wiring.py
@@ -1,0 +1,415 @@
+"""Tests for the BaseStore wiring guard (scripts/check_store_wiring.py).
+
+Each integration test builds a synthetic git repo in a temp directory,
+merges a PR branch into base to produce the merge result, checks out the
+merge commit, and then calls check_store_wiring() directly against the
+pre-merge base tip. This proves the check goes RED (fails), GREEN (passes),
+and that the Store-Unwired-Intentionally trailer waives a named class.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import check_store_wiring as csw  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "user.email", "test@test.com")
+    _git(repo, "config", "commit.gpgsign", "false")
+    _git(repo, "branch", "-M", "main")
+
+
+def _write(repo: Path, rel_path: str, content: str) -> None:
+    full = repo / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content, encoding="utf-8")
+
+
+def _commit(repo: Path, rel_path: str, content: str, message: str) -> None:
+    _write(repo, rel_path, content)
+    _git(repo, "add", rel_path)
+    _git(repo, "commit", "-m", message)
+
+
+def _branch(repo: Path, name: str) -> None:
+    _git(repo, "branch", name)
+
+
+def _checkout(repo: Path, name: str) -> None:
+    _git(repo, "checkout", "-q", name)
+
+
+def _get_head(repo: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    )
+    return result.stdout.strip()
+
+
+def _setup_base_repo(repo: Path) -> str:
+    _init_repo(repo)
+    _commit(repo, "tinyagentos/__init__.py", "", "init: package root")
+    _commit(
+        repo, "tinyagentos/base_store.py",
+        "class BaseStore:\n    SCHEMA = ''\n    MIGRATIONS = []\n",
+        "feat: add BaseStore",
+    )
+    _commit(
+        repo, "tinyagentos/metrics_store.py",
+        "from tinyagentos.base_store import BaseStore\n\n"
+        "class MetricsStore(BaseStore):\n"
+        "    SCHEMA = 'CREATE TABLE IF NOT EXISTS metrics (id INTEGER PRIMARY KEY);'\n"
+        "    MIGRATIONS = []\n",
+        "feat: add MetricsStore",
+    )
+    _commit(
+        repo, "tinyagentos/app.py",
+        "from tinyagentos.base_store import BaseStore\n"
+        "from tinyagentos.metrics_store import MetricsStore\n\n"
+        "metrics_store = MetricsStore('/tmp/metrics.db')\n\n"
+        "async def lifespan(app):\n"
+        "    await metrics_store.init()\n"
+        "    app.state.metrics = metrics_store\n",
+        "feat: wire MetricsStore in app",
+    )
+    return _get_head(repo)
+
+
+# ---------------------------------------------------------------------------
+# Core logic unit tests (no git required)
+# ---------------------------------------------------------------------------
+
+
+class TestFindBaseStoreSubclasses:
+    def test_direct_subclass(self):
+        source = (
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class Foo(BaseStore):\n"
+            "    pass\n"
+        )
+        all_classes = {"BaseStore": set(), "Foo": {"BaseStore"}}
+        result = csw.find_base_store_subclasses_in_file(source, all_classes)
+        assert result == {"Foo"}
+
+    def test_transitive_subclass(self):
+        source = (
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class Parent(BaseStore):\n"
+            "    pass\n"
+            "\n"
+            "class Child(Parent):\n"
+            "    pass\n"
+        )
+        all_classes = {
+            "BaseStore": set(),
+            "Parent": {"BaseStore"},
+            "Child": {"Parent"},
+        }
+        result = csw.find_base_store_subclasses_in_file(source, all_classes)
+        assert result == {"Parent", "Child"}
+
+    def test_non_subclass_ignored(self):
+        source = "class NotAStore:\n    pass\n"
+        all_classes = {"BaseStore": set(), "NotAStore": set()}
+        result = csw.find_base_store_subclasses_in_file(source, all_classes)
+        assert result == set()
+
+    def test_syntax_error_returns_empty(self):
+        result = csw.find_base_store_subclasses_in_file("def (:\n", {"BaseStore": set()})
+        assert result == set()
+
+
+class TestParseWaivedClasses:
+    def test_parses_single_class(self):
+        body = "Store-Unwired-Intentionally: StrikeStore, test fixture"
+        assert csw.parse_waived_classes(body) == {"StrikeStore"}
+
+    def test_no_trailer_returns_empty(self):
+        assert csw.parse_waived_classes("just a description") == set()
+
+    def test_none_body_returns_empty(self):
+        assert csw.parse_waived_classes(None) == set()
+
+    def test_trailer_with_reason(self):
+        body = "Store-Unwired-Intentionally: Foo, test-only fixture"
+        assert csw.parse_waived_classes(body) == {"Foo"}
+
+    def test_multiple_trailer_lines(self):
+        body = "Store-Unwired-Intentionally: Foo\n\nStore-Unwired-Intentionally: Bar"
+        assert csw.parse_waived_classes(body) == {"Foo", "Bar"}
+
+
+class TestClassDefInAddedLines:
+    def test_new_class_in_new_file(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit(repo, "tinyagentos/app.py", "x = 1\n", "init")
+        base_tip = _get_head(repo)
+        _branch(repo, "pr")
+        _checkout(repo, "pr")
+        _commit(
+            repo, "tinyagentos/strike_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class StrikeStore(BaseStore):\n"
+            "    pass\n",
+            "feat: add StrikeStore",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr", "--no-edit")
+
+        assert csw._class_def_in_added_lines(
+            "tinyagentos/strike_store.py", "StrikeStore", base_tip, repo,
+        )
+
+    def test_existing_class_not_flagged_as_new(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit(
+            repo, "tinyagentos/orphan_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class OrphanStore(BaseStore):\n"
+            "    pass\n",
+            "feat: add OrphanStore",
+        )
+        base_tip = _get_head(repo)
+        _branch(repo, "pr")
+        _checkout(repo, "pr")
+        _commit(
+            repo, "tinyagentos/orphan_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class OrphanStore(BaseStore):\n"
+            "    pass\n"
+            "\n"
+            "    async def new_method(self):\n"
+            "        pass\n",
+            "refactor: add method to OrphanStore",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr", "--no-edit")
+
+        assert not csw._class_def_in_added_lines(
+            "tinyagentos/orphan_store.py", "OrphanStore", base_tip, repo,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests with synthetic git repos (merge-result model)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStoreWiring:
+    def test_new_unwired_store_fails(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        base_tip = _setup_base_repo(repo)
+
+        _branch(repo, "pr")
+        _checkout(repo, "pr")
+        _commit(
+            repo, "tinyagentos/strike_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class StrikeStore(BaseStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS strikes (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n",
+            "feat: add StrikeStore (#2172)",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr", "--no-edit")
+
+        violations, waived = csw.check_store_wiring(base_tip, repo)
+
+        assert len(violations) == 1
+        v = violations[0]
+        assert v.class_name == "StrikeStore"
+        assert v.file_path == "tinyagentos/strike_store.py"
+        assert waived == set()
+
+    def test_new_wired_store_passes(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        base_tip = _setup_base_repo(repo)
+
+        _branch(repo, "pr")
+        _checkout(repo, "pr")
+        _commit(
+            repo, "tinyagentos/wired_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class WiredStore(BaseStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS wired (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n",
+            "feat: add WiredStore",
+        )
+        _commit(
+            repo, "tinyagentos/app.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "from tinyagentos.metrics_store import MetricsStore\n"
+            "from tinyagentos.wired_store import WiredStore\n\n"
+            "metrics_store = MetricsStore('/tmp/metrics.db')\n"
+            "wired_store = WiredStore('/tmp/wired.db')\n\n"
+            "async def lifespan(app):\n"
+            "    await metrics_store.init()\n"
+            "    await wired_store.init()\n"
+            "    app.state.metrics = metrics_store\n"
+            "    app.state.wired_store = wired_store\n",
+            "feat: wire WiredStore in app",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr", "--no-edit")
+
+        violations, waived = csw.check_store_wiring(base_tip, repo)
+
+        assert violations == []
+        assert waived == set()
+
+    def test_existing_unwired_store_not_flagged(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        _commit(repo, "tinyagentos/__init__.py", "", "init: package root")
+        _commit(
+            repo, "tinyagentos/base_store.py",
+            "class BaseStore:\n    SCHEMA = ''\n    MIGRATIONS = []\n",
+            "feat: add BaseStore",
+        )
+        _commit(
+            repo, "tinyagentos/orphan_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class OrphanStore(BaseStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS orphans (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n",
+            "feat: add OrphanStore (unwired)",
+        )
+        _commit(
+            repo, "tinyagentos/app.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "async def lifespan(app):\n"
+            "    pass\n",
+            "feat: minimal app",
+        )
+        base_tip = _get_head(repo)
+
+        _branch(repo, "pr")
+        _checkout(repo, "pr")
+        _commit(
+            repo, "tinyagentos/orphan_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class OrphanStore(BaseStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS orphans (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n"
+            "\n"
+            "    async def new_method(self):\n"
+            "        pass\n",
+            "refactor: add method to existing OrphanStore",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr", "--no-edit")
+
+        violations, waived = csw.check_store_wiring(base_tip, repo)
+
+        assert violations == []
+        assert waived == set()
+
+    def test_unwired_intentionally_trailer_waives(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        base_tip = _setup_base_repo(repo)
+
+        _branch(repo, "pr")
+        _checkout(repo, "pr")
+        _commit(
+            repo, "tinyagentos/unwired_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class UnwiredStore(BaseStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS unwired (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n",
+            "feat: add UnwiredStore (test-only)",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr", "--no-edit")
+
+        pr_body = "Store-Unwired-Intentionally: UnwiredStore, used only in CLI tests"
+        violations, waived = csw.check_store_wiring(base_tip, repo, pr_body=pr_body)
+
+        assert violations == []
+        assert waived == {"UnwiredStore"}
+
+    def test_transitive_subclass_flagged(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        base_tip = _setup_base_repo(repo)
+
+        _branch(repo, "pr")
+        _checkout(repo, "pr")
+        _commit(
+            repo, "tinyagentos/child_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class ParentStore(BaseStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS parents (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n"
+            "\n"
+            "class ChildStore(ParentStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS children (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n",
+            "feat: add ParentStore and ChildStore",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr", "--no-edit")
+
+        violations, waived = csw.check_store_wiring(base_tip, repo)
+
+        assert len(violations) == 2
+        names = {v.class_name for v in violations}
+        assert names == {"ParentStore", "ChildStore"}
+        assert waived == set()
+
+    def test_new_class_added_to_existing_file_fails(self, tmp_path: Path):
+        repo = tmp_path / "repo"
+        base_tip = _setup_base_repo(repo)
+
+        _branch(repo, "pr")
+        _checkout(repo, "pr")
+        _commit(
+            repo, "tinyagentos/metrics_store.py",
+            "from tinyagentos.base_store import BaseStore\n"
+            "\n"
+            "class MetricsStore(BaseStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS metrics (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n"
+            "\n"
+            "\n"
+            "class NewStore(BaseStore):\n"
+            "    SCHEMA = 'CREATE TABLE IF NOT EXISTS new_store (id INTEGER PRIMARY KEY);'\n"
+            "    MIGRATIONS = []\n",
+            "feat: add NewStore alongside MetricsStore",
+        )
+        _checkout(repo, "main")
+        _git(repo, "merge", "pr", "--no-edit")
+
+        violations, waived = csw.check_store_wiring(base_tip, repo)
+
+        assert len(violations) == 1
+        assert violations[0].class_name == "NewStore"
+        assert violations[0].file_path == "tinyagentos/metrics_store.py"


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): CI check: a new BaseStore must be wired into the app lifespan (no orphan stores)

Autonomous build of board card tsk-n3w5mh.

- scripts/check_store_wiring.py detects PRs that add a new BaseStore
  subclass without wiring it into tinyagentos/app.py
- Uses name-level check (class name appears in app.py)
- Only flags newly added classes; pre-existing orphans are skipped
- Store-Unwired-Intentionally: <ClassName>, <why> trailer waives and logs
- .github/workflows/store-wiring-gate.yml runs the check on PRs
- tests/test_check_store_wiring.py proves FAIL, PASS, existing orphan
  not flagged, trailer waiver, and transitive subclass detection

Files:
 .github/workflows/store-wiring-gate.yml     |  43 +++
 changelog.d/tsk-n3w5mh-store-wiring-gate.md |  11 +
 scripts/check_store_wiring.py               | 273 ++++++++++++++++++
 tests/test_check_store_wiring.py            | 415 ++++++++++++++++++++++++++++
 4 files changed, 742 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated pull-request check to identify newly introduced stores that are not connected to the application.
  * Added support for documented waiver trailers for intentional exceptions.

* **Documentation**
  * Documented the store-wiring check and waiver process.

* **Tests**
  * Added coverage for store detection, wiring validation, inheritance, and intentional waivers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## RED-proof at the merge ref (gate-PRs-prove-red rule)

Lead-verified, two independent bad cases, both through the exact workflow entry point:

**Bad case 1 - the real defect this gate exists for.** Merge ref = dev + this PR, then merge #2333 (adds `StrikeStore` without wiring):
```
$ python3 scripts/check_store_wiring.py --base origin/dev
STORE-WIRING FAIL: 1 new BaseStore subclass(es) are not wired into tinyagentos/app.py. Routes reach stores ONLY via request.app.state, so an unwired store is unreachable:
  - StrikeStore in tinyagentos/projects/strike_store.py
exit 1
```

**Bad case 2 - synthetic unwired store** (`RedTestOrphanStore` under `tinyagentos/`):
```
STORE-WIRING FAIL: 1 new BaseStore subclass(es) are not wired into tinyagentos/app.py...
  - RedTestOrphanStore in tinyagentos/redtest_store.py
exit 1
```

**Green half**: the merge ref alone (no new stores) exits 0 `store-wiring-guard: clean`. Waiver via `PR_BODY` env verified working.
