### PR TITLE
Fix-forward #2335: safe-point race + wait_for cancellation + task_utils reuse + wiring design note

### DIFF
--- a/changelog.d/tsk-rl2lfb-agent-loop.md
+++ b/changelog.d/tsk-rl2lfb-agent-loop.md
@@ -1,0 +1,6 @@
+### Added
+
+- **Agent loop infrastructure**: new `tinyagentos.agent_loop.AgentLoop` library
+  for subagent delegation and safe-point message queuing. This is standalone
+  infrastructure, not yet wired into the taOS chat agent or routes
+  (#tsk-rl2lfb).

--- a/docs/design/agent-loop-subagents.md
+++ b/docs/design/agent-loop-subagents.md
@@ -1,0 +1,101 @@
+# Agent loop: subagents for heavy work + safe-point message queue
+
+## Context
+
+The main taOS chat agent (driven over opencode or ACP) processes one user turn
+at a time. A turn is **atomic**: it spans prompt, tool calls, and the agent's
+full reply. Interrupting a turn mid-tool-call corrupts state (partial edits,
+half-written files, dangling subprocesses).
+
+Meanwhile, some user requests kick off heavy, long-running work (codebase
+refactors, large file operations, multi-step builds). Blocking the main loop on
+that work means the user cannot interrupt or redirect until it finishes, and
+the agent cannot surface intermediate results.
+
+## Design
+
+The `AgentLoop` class (in `tinyagentos/agent_loop.py`) wraps the main agent's
+turn loop with two mechanisms:
+
+### 1. Subagent delegation
+
+`spawn_subagent(task, worker)` runs an async `worker(progress_cb)` as a
+supervised background task. The main loop stays responsive -- it can accept
+messages, stream subagent progress via the `sink` callback, and surface
+results -- while the subagent works concurrently.
+
+Subagents are tracked in `self._subagents` keyed by id. Each handle records
+state (`running` / `completed` / `cancelled` / `failed`), result, and error.
+
+### 2. Safe-point message queue
+
+`handle_message(content, is_redirect=False)` is the single entry point for
+incoming user messages:
+
+- **IDLE** -> the message starts a new turn immediately; the loop transitions
+  to `WORKING`. Returns `LoopAction.IMMEDIATE`.
+- **WORKING** -> the message is appended to the queue; it is **never dropped**
+  and **never applied mid-step**. Returns `LoopAction.QUEUED`.
+
+`reach_safe_point()` is called at the end of a turn (the atomic boundary). It:
+
+1. Transitions `WORKING` -> `SAFE_POINT`.
+2. Drains the message queue and returns the messages for the caller to act on.
+3. If any queued message is a redirect, calls `cancel_subagents()` so in-flight
+   subagent work is aborted **at the safe boundary**, never mid-step.
+4. Transitions back to `IDLE`.
+
+### 3. Cancel / redirect propagation
+
+`cancel_subagents(reason=None)` cancels every running subagent task and awaits
+their unwind under a bounded timeout (mirrors `task_utils.cancel_and_wait`).
+A redirect message -- queued during `WORKING` -- triggers this automatically
+when `reach_safe_point` processes it.
+
+### 4. Visibility
+
+`status()` returns a snapshot dict with the current loop state, the current
+turn id, running subagents (id / task / state / result / error), and the
+queued message backlog (id / content / received_at / is_redirect). This lets
+the UI show "agent is working" plus "N messages queued".
+
+## State machine
+
+```
+text
+IDLE
+  |-- handle_message -> WORKING
+  |                     |-- spawn_subagent (concurrent)
+  |                     |-- handle_message -> QUEUED (buffered)
+  |                     |-- reach_safe_point -> SAFE_POINT
+  |                            |-- redirect? -> cancel_subagents
+  |                            |-- drain queue -> IDLE
+SAFE_POINT --(immediate)--> IDLE
+```
+
+## Integration points
+
+> **Not yet integrated**: `AgentLoop` is standalone library infrastructure.
+> It is not yet wired into the taOS chat agent routes. Routing integration
+> will be handled in a separate design card once the `AgentChatRouter`-lock
+> design decision is made.
+
+- The taOS chat endpoint (`routes/taos_agent.py`) can use `AgentLoop` to wrap
+  `opencode_runtime.drive_turn`: start a turn, spawn a subagent for long tool
+  calls, and drain the queue at the end of the stream.
+- The `AgentChatRouter._run_acp_turn` path can delegate to a subagent via
+  `openclaw_acp_runtime.drive_turn` when a turn is expected to be long.
+
+## Testing
+
+`tests/test_agent_loop.py` covers:
+
+- **queue-not-drop**: a mid-task message is queued and returned at the safe
+  point (never lost).
+- **safe-point-delivery**: a queued message is not acted on while the loop is
+  `WORKING`; it is surfaced only at `reach_safe_point`.
+- **cancel-propagation**: a redirect at the safe point cancels an in-flight
+  subagent; `cancel_subagents` directly cancels running tasks.
+- **visibility**: `status()` reports running subagents and the queue backlog.
+- **subagent lifecycle**: completion, progress streaming, failure, and
+  completion-with-running-subagent.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1,0 +1,555 @@
+"""Tests for the agent loop: subagent delegation + safe-point message queue.
+
+Covers the three acceptance-test categories from the task:
+  - queue-not-drop: a message sent mid-task is queued, never lost.
+  - safe-point-delivery: a queued message is delivered at the safe boundary,
+    never applied mid-step.
+  - cancel-propagation: a redirect cancels in-flight subagent work.
+
+Plus visibility (what-is-running / what-is-queued) and the subagent lifecycle.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tinyagentos.agent_loop import (
+    AgentLoop,
+    LoopAction,
+    LoopState,
+    QueuedMessage,
+    SubagentHandle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _RecordingSink:
+    """Collects progress dicts the subagent streams back via the sink."""
+
+    def __init__(self):
+        self.received: list[dict] = []
+
+    def __call__(self, msg: dict):
+        self.received.append(msg)
+
+
+async def _sleepy_worker(started: asyncio.Event, cancelled: asyncio.Event):
+    """A subagent worker that runs until cancelled, signalling both events."""
+
+    started.set()
+    try:
+        await asyncio.sleep(100)
+    except asyncio.CancelledError:
+        cancelled.set()
+        raise
+
+
+async def _slow_cancel_worker(started: asyncio.Event, cancelled: asyncio.Event):
+    """A subagent worker that delays after receiving cancellation."""
+
+    started.set()
+    try:
+        await asyncio.sleep(100)
+    except asyncio.CancelledError:
+        await asyncio.sleep(0.2)
+        cancelled.set()
+        raise
+
+
+async def _quick_worker(result="done"):
+    """A subagent worker that completes immediately with *result*."""
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# handle_message: IMMEDIATE vs QUEUED
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_handle_message_when_idle_returns_immediate_and_goes_working():
+    """A message arriving while IDLE starts a turn immediately."""
+    loop = AgentLoop()
+    assert loop.state == LoopState.IDLE
+
+    action = await loop.handle_message("hello")
+
+    assert action == LoopAction.IMMEDIATE
+    assert loop.state == LoopState.WORKING
+
+
+@pytest.mark.asyncio
+async def test_handle_message_when_working_is_queued_not_dropped():
+    """A message arriving while WORKING is queued, never dropped."""
+    loop = AgentLoop()
+
+    await loop.handle_message("first turn")          # IDLE -> WORKING
+    assert loop.state == LoopState.WORKING
+
+    action = await loop.handle_message("mid-task message")
+    assert action == LoopAction.QUEUED
+
+    # The message is buffered, visible via status and the message_queue property.
+    assert len(loop.message_queue) == 1
+    assert loop.message_queue[0].content == "mid-task message"
+    assert loop.state == LoopState.WORKING          # still working, not delivered
+
+
+@pytest.mark.asyncio
+async def test_multiple_messages_queued_in_arrival_order():
+    """Several messages arriving during one turn are queued in FIFO order."""
+    loop = AgentLoop()
+    await loop.handle_message("turn")
+
+    for i, text in enumerate(("m1", "m2", "m3")):
+        action = await loop.handle_message(text, msg_id=f"msg-{i}")
+        assert action == LoopAction.QUEUED
+
+    contents = [m.content for m in loop.message_queue]
+    assert contents == ["m1", "m2", "m3"]
+
+
+# ---------------------------------------------------------------------------
+# queue-not-drop: the queued message survives and is returned at the safe point
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_queued_message_survives_safe_point_and_is_returned():
+    """A queued message is not dropped when the turn ends.
+
+    After reaching the safe point the message is returned to the caller for
+    surfacing, and the delivered list is updated.
+    """
+    loop = AgentLoop()
+    await loop.handle_message("long task")
+
+    # Mid-task message is buffered.
+    await loop.handle_message("help", msg_id="mid-1")
+    assert len(loop.message_queue) == 1
+
+    delivered = await loop.reach_safe_point()
+
+    # The message was returned (not dropped).
+    assert len(delivered) == 1
+    assert delivered[0].content == "help"
+    assert delivered[0].id == "mid-1"
+
+    # Loop is idle again and the delivered log reflects the surface.
+    assert loop.state == LoopState.IDLE
+    assert loop.delivered[-1].content == "help"
+    assert len(loop.message_queue) == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_queue_at_safe_point_returns_empty_list():
+    """A safe point with no queued messages returns an empty list."""
+    loop = AgentLoop()
+    await loop.handle_message("work")
+
+    delivered = await loop.reach_safe_point()
+
+    assert delivered == []
+    assert loop.state == LoopState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# safe-point-delivery: the message is NOT applied mid-step
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_queued_message_is_not_applied_mid_step():
+    """A message queued during WORKING is not acted on until the safe point.
+
+    We model "applied" as: the message content would change the turn's
+    behaviour. By asserting the loop is still WORKING and the queue is
+    non-empty before reach_safe_point, and that reach_safe_point is the
+    only path that yields the message, we prove it is not applied mid-step.
+    """
+    loop = AgentLoop()
+    await loop.handle_message("original task")
+    assert loop.state == LoopState.WORKING
+
+    await loop.handle_message("redirect: do something else", is_redirect=True)
+
+    # While working, the redirect sits in the queue -- it has NOT been
+    # applied: the loop is still in the same turn.
+    assert loop.state == LoopState.WORKING
+    assert len(loop.message_queue) == 1
+    assert loop.current_turn_id != "redirect: do something else"
+
+    surfaced = await loop.reach_safe_point()
+
+    # The redirect is delivered AT the safe point, not mid-step.
+    assert len(surfaced) == 1
+    assert surfaced[0].content == "redirect: do something else"
+    assert surfaced[0].is_redirect is True
+    assert loop.state == LoopState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_safe_point_only_after_all_work_completes():
+    """reaching_safe_point while a subagent runs still delivers the queue.
+
+    The safe point is a turn boundary: messages are surfaced regardless of
+    whether a subagent has finished, so the caller can decide to cancel.
+    """
+    loop = AgentLoop()
+    await loop.handle_message("task")
+
+    started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+    sub_id = await loop.spawn_subagent("heavy work", lambda p: _sleepy_worker(started, cancelled_flag))
+    await started.wait()
+    assert loop.get_subagent(sub_id).state == "running"
+
+    await loop.handle_message("queued msg")
+    assert len(loop.message_queue) == 1
+
+    delivered = await loop.reach_safe_point()
+
+    # The message is surfaced at the safe boundary.
+    assert len(delivered) == 1
+    assert delivered[0].content == "queued msg"
+
+    # The subagent is still running (not cancelled -- no redirect this time).
+    assert loop.get_subagent(sub_id).state == "running"
+
+    # Clean up the lingering subagent.
+    await loop.cancel_subagents()
+    assert loop.get_subagent(sub_id).state == "cancelled"
+
+
+# ---------------------------------------------------------------------------
+# cancel-propagation: redirect cancels in-flight subagent work
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cancel_subagents_cancels_running_task():
+    """cancel_subagents cancels a running subagent and awaits its unwind."""
+    loop = AgentLoop()
+    started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+
+    sub_id = await loop.spawn_subagent(
+        "heavy work", lambda p: _sleepy_worker(started, cancelled_flag),
+    )
+    await started.wait()
+
+    assert loop.get_subagent(sub_id).state == "running"
+
+    count = await loop.cancel_subagents(reason="manual cancel")
+    assert count == 1
+
+    # The CancelledError propagated into the worker.
+    assert cancelled_flag.is_set()
+
+    # The handle reflects the cancellation.
+    handle = loop.get_subagent(sub_id)
+    assert handle is not None
+    assert handle.state == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_redirect_at_safe_point_cancels_inflight_subagent():
+    """A redirect queued during WORKING cancels subagents at the safe boundary.
+
+    This is the full cancel-propagation flow: spawn -> redirect queued ->
+    reach_safe_point -> subagent cancelled -> redirect returned for re-dispatch.
+    """
+    loop = AgentLoop()
+    await loop.handle_message("start a long build")
+
+    started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+
+    sub_id = await loop.spawn_subagent(
+        "building artifacts", lambda p: _sleepy_worker(started, cancelled_flag),
+    )
+    await started.wait()
+    assert loop.get_subagent(sub_id).state == "running"
+
+    # User sends a redirect while the subagent is busy.
+    action = await loop.handle_message("abort and restart", is_redirect=True)
+    assert action == LoopAction.QUEUED
+
+    # The redirect is NOT applied mid-step.
+    assert loop.state == LoopState.WORKING
+    assert loop.has_pending_redirect() is True
+
+    # Turn ends -> safe point. The redirect triggers subagent cancellation.
+    delivered = await loop.reach_safe_point()
+    await loop.await_subagent(sub_id)  # ensure task fully settled
+
+    # Subagent was cancelled by the redirect.
+    assert cancelled_flag.is_set()
+    assert loop.get_subagent(sub_id).state == "cancelled"
+
+    # The redirect is returned so the caller can start a new turn.
+    assert len(delivered) == 1
+    assert delivered[0].content == "abort and restart"
+    assert delivered[0].is_redirect is True
+    assert loop.state == LoopState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_cancel_subagents_when_none_running_is_noop():
+    """Cancelling with no in-flight subagents is a safe no-op."""
+    loop = AgentLoop()
+    count = await loop.cancel_subagents()
+    assert count == 0
+    assert loop.state == LoopState.IDLE
+
+
+@pytest.mark.asyncio
+async def test_cancel_subagents_only_cancels_running_not_completed():
+    """Only running subagents are cancelled; completed ones are left alone."""
+    loop = AgentLoop()
+
+    sub_id = await loop.spawn_subagent("quick", lambda p: _quick_worker("ok"))
+    await loop.await_subagent(sub_id)
+    assert loop.get_subagent(sub_id).state == "completed"
+
+    count = await loop.cancel_subagents()
+    assert count == 0  # nothing was running
+
+
+# ---------------------------------------------------------------------------
+# Subagent lifecycle & progress streaming
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_subagent_completes_and_result_is_accessible():
+    """A successful subagent populates its handle with the result."""
+    loop = AgentLoop()
+
+    sub_id = await loop.spawn_subagent("compute", lambda p: _quick_worker(42))
+    result = await loop.await_subagent(sub_id)
+
+    assert result == 42
+    handle = loop.get_subagent(sub_id)
+    assert handle.state == "completed"
+    assert handle.result == 42
+
+
+@pytest.mark.asyncio
+async def test_subagent_progress_streamed_to_sink():
+    """Progress dicts from the worker reach the loop's sink."""
+    sink = _RecordingSink()
+    loop = AgentLoop(sink=sink)
+
+    async def worker(progress):
+        progress({"kind": "reasoning", "content": "thinking..."})
+        await asyncio.sleep(0)
+        progress({"kind": "delta", "content": "partial"})
+        return "done"
+
+    sub_id = await loop.spawn_subagent("streamy task", worker)
+    result = await loop.await_subagent(sub_id)
+
+    assert result == "done"
+    assert len(sink.received) == 2
+    assert sink.received[0]["kind"] == "reasoning"
+    assert sink.received[1]["kind"] == "delta"
+
+
+@pytest.mark.asyncio
+async def test_subagent_failure_sets_state_to_failed():
+    """An exception in the worker sets state to 'failed' and records the error."""
+    loop = AgentLoop()
+
+    async def worker(progress):
+        raise RuntimeError("kaboom")
+
+    sub_id = await loop.spawn_subagent("doomed", worker)
+    await loop.await_subagent(sub_id)
+
+    handle = loop.get_subagent(sub_id)
+    assert handle.state == "failed"
+    assert "kaboom" in (handle.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Visibility: status() -- what is running / what is queued
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_status_reflects_state_subagents_and_queue():
+    """status() surfaces loop state, running subagents, and queued messages."""
+    loop = AgentLoop()
+    await loop.handle_message("turn")
+
+    started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+    sub_id = await loop.spawn_subagent(
+        "background scan", lambda p: _sleepy_worker(started, cancelled_flag),
+    )
+    await started.wait()
+
+    await loop.handle_message("queued user msg")
+
+    st = loop.status()
+    assert st["state"] == LoopState.WORKING.value
+    assert st["queued_count"] == 1
+    assert st["queued_messages"][0]["content"] == "queued user msg"
+    assert len(st["subagents"]) == 1
+    sa = st["subagents"][0]
+    assert sa["id"] == sub_id
+    assert sa["task"] == "background scan"
+    assert sa["state"] == "running"
+    assert st["current_turn_id"] is not None
+
+    await loop.cancel_subagents()
+
+
+@pytest.mark.asyncio
+async def test_status_empty_when_loop_idle():
+    """An idle loop reports no subagents and an empty queue."""
+    loop = AgentLoop()
+    st = loop.status()
+    assert st["state"] == LoopState.IDLE.value
+    assert st["queued_count"] == 0
+    assert st["subagents"] == []
+    assert st["queued_messages"] == []
+    assert st["current_turn_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Long task in subagent while main loop stays responsive
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_subagent_runs_while_main_loop_accepts_another_message():
+    """A long task runs in a subagent; the main loop still accepts messages.
+
+    The subagent works in the background (WORKING state) while a second
+    message arrives and is queued -- the main loop is responsive (it does
+    not block on the subagent). When the subagent finishes its result is
+    available; queued messages are surfaced at the safe point.
+    """
+    loop = AgentLoop()
+    await loop.handle_message("start")
+
+    # Spawn a subagent that takes a moment.
+    async def worker(progress):
+        await asyncio.sleep(0.05)
+        progress({"kind": "delta", "content": "subagent made progress"})
+        return "subagent result"
+
+    sub_id = await loop.spawn_subagent("long computation", worker)
+    assert loop.get_subagent(sub_id).state == "running"
+
+    # While the subagent runs, another message arrives -> queued (not blocked).
+    action = await loop.handle_message("are you still there?")
+    assert action == LoopAction.QUEUED
+    assert len(loop.message_queue) == 1
+
+    # Wait for the subagent to finish.
+    result = await loop.await_subagent(sub_id)
+    assert result == "subagent result"
+    assert loop.get_subagent(sub_id).state == "completed"
+
+    # Now reach the safe point; the queued message is delivered.
+    delivered = await loop.reach_safe_point()
+    assert len(delivered) == 1
+    assert delivered[0].content == "are you still there?"
+
+
+# ---------------------------------------------------------------------------
+# get_subagent returns None for unknown ids
+# ---------------------------------------------------------------------------
+
+def test_get_subagent_unknown_returns_none():
+    """Looking up an unknown subagent id returns None synchronously."""
+    loop = AgentLoop()
+    assert loop.get_subagent("nope") is None
+
+
+# ---------------------------------------------------------------------------
+# timeout-safe awaits: a timed-out poll must not cancel the subagent
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_await_subagent_timeout_does_not_cancel_subagent():
+    """A timeout on await_subagent does not cancel the underlying subagent task."""
+    loop = AgentLoop()
+    started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+
+    sub_id = await loop.spawn_subagent(
+        "long work", lambda p: _sleepy_worker(started, cancelled_flag),
+    )
+    await started.wait()
+    assert loop.get_subagent(sub_id).state == "running"
+
+    with pytest.raises(asyncio.TimeoutError):
+        await loop.await_subagent(sub_id, timeout=0.05)
+
+    assert loop.get_subagent(sub_id).state == "running"
+    assert not cancelled_flag.is_set()
+
+    await loop.cancel_subagents()
+
+
+@pytest.mark.asyncio
+async def test_await_all_subagents_timeout_does_not_cancel_subagents():
+    """await_all_subagents with a short timeout does not cancel running subagents."""
+    loop = AgentLoop()
+    started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+
+    sub_id = await loop.spawn_subagent(
+        "long work", lambda p: _sleepy_worker(started, cancelled_flag),
+    )
+    await started.wait()
+    assert loop.get_subagent(sub_id).state == "running"
+
+    with pytest.raises(asyncio.TimeoutError):
+        await loop.await_all_subagents(timeout=0.05)
+
+    assert loop.get_subagent(sub_id).state == "running"
+    assert not cancelled_flag.is_set()
+
+    await loop.cancel_subagents()
+
+
+# ---------------------------------------------------------------------------
+# safe-point race: message arriving during cancel window is not dropped
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_message_arriving_during_cancel_window_is_not_dropped_and_no_concurrent_turn():
+    """A message that arrives while reach_safe_point is awaiting cancel_subagents
+    is queued safely and delivered; no concurrent turn is started."""
+    loop = AgentLoop()
+    await loop.handle_message("start a long build")
+
+    started = asyncio.Event()
+    cancelled_flag = asyncio.Event()
+
+    sub_id = await loop.spawn_subagent(
+        "building artifacts", lambda p: _slow_cancel_worker(started, cancelled_flag),
+    )
+    await started.wait()
+    assert loop.get_subagent(sub_id).state == "running"
+
+    await loop.handle_message("abort and restart", is_redirect=True)
+    assert loop.has_pending_redirect() is True
+
+    async def _do_safe_point():
+        return await loop.reach_safe_point()
+
+    safe_point_task = asyncio.create_task(_do_safe_point())
+    await asyncio.sleep(0.05)
+
+    action = await loop.handle_message("message during cancel")
+    assert action == LoopAction.QUEUED
+
+    delivered = await safe_point_task
+
+    assert any(m.content == "message during cancel" for m in delivered)
+    assert loop.state == LoopState.IDLE
+    assert loop.current_turn_id is None

--- a/tinyagentos/agent_loop.py
+++ b/tinyagentos/agent_loop.py
@@ -1,0 +1,487 @@
+"""Agent loop: subagent delegation + safe-point message queue.
+
+The main chat agent delegates heavy/long work to subagents so its own loop
+stays free to present results and accept user interrupts/redirects. Messages
+that arrive while the agent is working are queued (never dropped, never
+applied mid-step) and surfaced at the next safe boundary -- a turn is atomic,
+so interrupting mid-tool-call corrupts state. A redirect cancels in-flight
+subagent work at that safe boundary.
+
+Public surface:
+    AgentLoop          -- the loop controller
+    LoopState          -- idle / working / safe_point
+    LoopAction         -- immediate / queued (return of ``handle_message``)
+    QueuedMessage      -- a buffered user message
+    SubagentHandle     -- status of a spawned subagent
+    ProgressCallback   -- callable for streaming subagent progress
+    SubagentWorker     -- async callable that performs a subagent's work
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+from tinyagentos.task_utils import _create_supervised_task, cancel_and_wait
+
+logger = logging.getLogger(__name__)
+
+# A sync callable that a subagent invokes to stream partial results (reply
+# dicts with ``kind``/``content``/etc.) back to the main loop's sink.
+ProgressCallback = Callable[[dict], None]
+
+# An async callable that does the subagent's heavy work. It receives a
+# progress callback so it can stream intermediate results without blocking the
+# main loop. Returning a value completes the subagent with that result.
+SubagentWorker = Callable[[ProgressCallback], Awaitable[Any]]
+
+
+# ---------------------------------------------------------------------------
+# Enums and dataclasses
+# ---------------------------------------------------------------------------
+
+class LoopState(enum.Enum):
+    """High-level loop state at any moment.
+
+    IDLE        -- no turn in progress; new messages start a turn immediately.
+    WORKING     -- a turn (or one or more subagents) is in flight; new
+                   messages are queued for the next safe point.
+    SAFE_POINT  -- transient; the turn just ended and queued messages are
+                   being surfaced. The loop returns to IDLE right after.
+    """
+
+    IDLE = "idle"
+    WORKING = "working"
+    SAFE_POINT = "safe_point"
+
+
+class LoopAction(enum.Enum):
+    """What :meth:`AgentLoop.handle_message` decided to do with a message."""
+
+    IMMEDIATE = "immediate"
+    QUEUED = "queued"
+
+
+@dataclass
+class QueuedMessage:
+    """A user message buffered while the loop was busy.
+
+    ``is_redirect`` marks a message that, when surfaced at a safe point,
+    cancels in-flight subagent work before the next turn starts.
+    """
+
+    id: str
+    content: str
+    received_at: float
+    is_redirect: bool = False
+
+
+@dataclass
+class SubagentHandle:
+    """Tracks a spawned subagent from creation through completion.
+
+    ``state`` is one of ``"running"``, ``"completed"``, ``"cancelled"`` or
+    ``"failed"``. ``result``/``error`` are populated on the latter three.
+    """
+
+    id: str
+    task: str
+    state: str = "running"
+    result: Any = None
+    error: str | None = None
+    started_at: float = field(default_factory=time.time)
+
+
+class _SubagentEntry:
+    """Internal pair of a handle and its backing asyncio task."""
+
+    __slots__ = ("handle", "task_obj")
+
+    def __init__(
+        self,
+        handle: SubagentHandle,
+        task_obj: asyncio.Task | None = None,
+    ) -> None:
+        self.handle = handle
+        self.task_obj = task_obj
+
+
+# ---------------------------------------------------------------------------
+# AgentLoop
+# ---------------------------------------------------------------------------
+
+class AgentLoop:
+    """Main agent loop with subagent delegation and safe-point message queue.
+
+    Responsibilities (matching the task spec):
+        (1) Agents can spawn subagents for long tasks so the main loop stays
+            responsive.
+        (2) Messages arriving while working are queued -- never dropped, never
+            applied mid-step.
+        (3) At the next safe boundary queued messages are surfaced. A redirect
+            among them cancels in-flight subagent work.
+        (4) ``status()`` lets the user see what is running and what is queued.
+
+    A *turn* is atomic: once ``handle_message`` returns ``IMMEDIATE`` the loop
+    is in ``WORKING`` state until :meth:`reach_safe_point` is called. Any
+    message that arrives in between is buffered. The caller drives the turn
+    (e.g. via :func:`tinyagentos.opencode_runtime.drive_turn` or an ACP turn)
+    and calls :meth:`reach_safe_point` at the end to drain the queue.
+    """
+
+    def __init__(self, sink: Callable[[dict], Any] | None = None) -> None:
+        """Create a new agent loop.
+
+        Args:
+            sink: Optional async-or-sync callable that receives subagent progress
+                  dicts (same reply-dict shape used elsewhere in taOS). May be
+                  None if no streaming is required.
+        """
+        self._state: LoopState = LoopState.IDLE
+        self._message_queue: list[QueuedMessage] = []
+        self._subagents: dict[str, _SubagentEntry] = {}
+        self._lock = asyncio.Lock()
+        self._sink = sink
+        # Messages surfaced at safe points, retained for inspection.
+        self._delivered: list[QueuedMessage] = []
+        self._current_turn_id: str | None = None
+        self._subagent_tasks: set[asyncio.Task] = set()
+        self._max_delivered = 1000
+        self._max_subagents = 100
+
+    # ----------------------------------------------------------------- state
+
+    @property
+    def state(self) -> LoopState:
+        """Current loop state."""
+        return self._state
+
+    @property
+    def current_turn_id(self) -> str | None:
+        """The message id at the head of the current turn, or None when idle."""
+        return self._current_turn_id
+
+    @property
+    def message_queue(self) -> list[QueuedMessage]:
+        """Snapshot of messages currently queued (not yet surfaced)."""
+        return list(self._message_queue)
+
+    @property
+    def delivered(self) -> list[QueuedMessage]:
+        """Messages surfaced at safe points, in delivery order."""
+        return list(self._delivered)
+
+    def has_pending_redirect(self) -> bool:
+        """True if a redirect is buffered and waiting at the next safe point."""
+        return any(m.is_redirect for m in self._message_queue)
+
+    def _prune_subagents(self) -> None:
+        if len(self._subagents) <= self._max_subagents:
+            return
+        to_remove = [
+            sid for sid, entry in self._subagents.items()
+            if entry.task_obj is not None and entry.task_obj.done()
+        ]
+        for sid in to_remove:
+            del self._subagents[sid]
+
+    def _prune_delivered(self) -> None:
+        if len(self._delivered) > self._max_delivered:
+            self._delivered = self._delivered[-self._max_delivered:]
+
+    # ------------------------------------------------------ message handling
+
+    async def handle_message(
+        self,
+        content: str,
+        msg_id: str | None = None,
+        is_redirect: bool = False,
+    ) -> LoopAction:
+        """Accept a user message for the main agent.
+
+        If the loop is IDLE, the message starts a new turn immediately and the
+        loop transitions to ``WORKING`` (returns ``IMMEDIATE``). The caller then
+        drives the turn and eventually calls :meth:`reach_safe_point`.
+
+        If the loop is already ``WORKING``, the message is appended to the
+        queue and delivered at the next safe point (returns ``QUEUED``).
+        It is never dropped and never applied mid-step.
+        """
+        msg_id = msg_id or uuid.uuid4().hex
+        msg = QueuedMessage(
+            id=msg_id,
+            content=content,
+            received_at=time.time(),
+            is_redirect=is_redirect,
+        )
+        async with self._lock:
+            if self._state in (LoopState.WORKING, LoopState.SAFE_POINT):
+                self._message_queue.append(msg)
+                return LoopAction.QUEUED
+            # IDLE -> start a new turn. The queue is already drained by
+            # reach_safe_point, so nothing is discarded here.
+            self._state = LoopState.WORKING
+            self._current_turn_id = msg_id
+        return LoopAction.IMMEDIATE
+
+    # ----------------------------------------------------- subagent lifecycle
+
+    async def spawn_subagent(
+        self,
+        task: str,
+        worker: SubagentWorker,
+    ) -> str:
+        """Spawn a subagent for heavy/long work.
+
+        The subagent runs concurrently as a supervised background task. The
+        main loop stays responsive -- it can accept messages, surface results
+        via ``sink``, and eventually reach a safe point -- while the subagent
+        works.
+
+        Args:
+            task:   Human-readable description of the delegated work.
+            worker: ``async def worker(progress: ProgressCallback) -> result``
+                    that performs the work. Call ``progress({...})`` to stream
+                    partial results to the main loop's sink.
+
+        Returns:
+            The subagent id (use with :meth:`await_subagent` or :meth:`status`).
+        """
+        sub_id = uuid.uuid4().hex[:12]
+        handle = SubagentHandle(id=sub_id, task=task, state="running")
+        entry = _SubagentEntry(handle)
+        async with self._lock:
+            self._subagents[sub_id] = entry
+
+        def _progress(msg: dict) -> None:
+            """Forward subagent progress to the main loop's sink."""
+            if self._sink is None:
+                return
+            try:
+                res = self._sink(msg)
+                if asyncio.iscoroutine(res):
+                    _create_supervised_task(res, self._subagent_tasks)
+            except Exception:
+                logger.exception("subagent %s: progress sink raised", sub_id)
+
+        async def _runner() -> None:
+            try:
+                result = await worker(_progress)
+                async with self._lock:
+                    handle.state = "completed"
+                    handle.result = result
+            except asyncio.CancelledError:
+                async with self._lock:
+                    handle.state = "cancelled"
+                raise
+            except Exception as exc:
+                async with self._lock:
+                    handle.state = "failed"
+                    handle.error = str(exc)
+                logger.exception("subagent %s (%s) failed", sub_id, task)
+
+        task_obj = _create_supervised_task(_runner(), self._subagent_tasks)
+        task_obj.set_name(f"subagent:{sub_id}")
+        entry.task_obj = task_obj
+        self._prune_subagents()
+        logger.debug("subagent %s spawned for task=%s", sub_id, task)
+        return sub_id
+
+    async def cancel_subagents(self, reason: str | None = None) -> int:
+        """Cancel all in-flight subagents.
+
+        Called when a redirect arrives at a safe boundary. Cancellation is
+        requested on every running subagent task and awaited with a bounded
+        timeout so a misbehaving worker cannot block the loop forever. The
+        worker itself decides how to unwind (cooperative cancellation via
+        ``CancelledError``).
+
+        Returns:
+            The number of subagents that were running and had cancellation
+            requested.
+        """
+        to_cancel: list[asyncio.Task] = []
+        async with self._lock:
+            for entry in self._subagents.values():
+                if entry.handle.state == "running" and entry.task_obj is not None:
+                    if not entry.task_obj.done():
+                        to_cancel.append(entry.task_obj)
+                        entry.task_obj.cancel()
+        # Wait outside the lock so the loop isn't held while workers unwind.
+        if to_cancel:
+            stragglers = await cancel_and_wait(to_cancel, timeout=10.0)
+            for t in stragglers:
+                logger.warning(
+                    "subagent %s did not exit within 10s after cancel",
+                    t.get_name(),
+                )
+        count = len(to_cancel)
+        if reason:
+            logger.info("subagent: cancelled %d task(s) -- %s", count, reason)
+        return count
+
+    # --------------------------------------------------------- safe boundary
+
+    async def reach_safe_point(self) -> list[QueuedMessage]:
+        """Transition to SAFE_POINT and surface queued messages.
+
+        Called at a turn boundary: the turn is atomic and complete. The loop
+        moves ``WORKING`` -> ``SAFE_POINT``, drains the message queue so the
+        caller can act on each buffered message, then returns to ``IDLE`` so
+        new messages are processed immediately on the next turn.
+
+        Messages that arrive while ``cancel_subagents`` is running are queued
+        safely (the loop stays in ``SAFE_POINT``) and included in the returned
+        list.
+
+        Returns:
+            The queued messages to surface, in arrival order. Callers iterate
+            these and start a fresh turn for each (or redirect as appropriate).
+        """
+        async with self._lock:
+            self._state = LoopState.SAFE_POINT
+            queued = list(self._message_queue)
+            self._message_queue.clear()
+
+        # If a redirect is among the queued messages, cancel subagents at this
+        # safe boundary (never mid-turn).
+        if any(m.is_redirect for m in queued):
+            await self.cancel_subagents(reason="redirect at safe point")
+
+        async with self._lock:
+            queued.extend(self._message_queue)
+            self._message_queue.clear()
+            if self._state == LoopState.SAFE_POINT:
+                self._state = LoopState.IDLE
+                self._current_turn_id = None
+            self._delivered.extend(queued)
+            self._prune_delivered()
+        return queued
+
+    # --------------------------------------------------- visibility / status
+
+    def status(self) -> dict[str, Any]:
+        """Return what is running and what is queued (for UI visibility).
+
+        Lets the user see:
+        - ``state``: current loop state (idle / working / safe_point)
+        - ``current_turn_id``: the message id driving the current turn
+        - ``subagents``: list of subagent descriptors (id, task, state, ...)
+        - ``queued_messages``: list of buffered message descriptors
+        - ``queued_count``: how many messages are buffered
+
+        Safe to call from any context (no I/O, no await).
+        """
+        subagents: list[dict[str, Any]] = []
+        for sid, entry in self._subagents.items():
+            h = entry.handle
+            subagents.append({
+                "id": sid,
+                "task": h.task,
+                "state": h.state,
+                "started_at": h.started_at,
+                "result": h.result,
+                "error": h.error,
+            })
+        queued: list[dict[str, Any]] = [
+            {
+                "id": m.id,
+                "content": m.content,
+                "received_at": m.received_at,
+                "is_redirect": m.is_redirect,
+            }
+            for m in self._message_queue
+        ]
+        return {
+            "state": self._state.value,
+            "current_turn_id": self._current_turn_id,
+            "subagents": subagents,
+            "queued_messages": queued,
+            "queued_count": len(self._message_queue),
+        }
+
+    # --------------------------------------------------- waiting for subagents
+
+    async def await_subagent(
+        self,
+        sub_id: str,
+        timeout: float | None = None,
+    ) -> Any:
+        """Wait for a subagent to finish and return its result.
+
+        If the subagent was cancelled (e.g. via ``cancel_subagents`` or a
+        redirect at a safe point), the handle state is ``"cancelled"`` and
+        the result (``None``) is returned without re-raising.
+
+        A *timeout* only limits how long this call waits. It does NOT cancel
+        the subagent task. The subagent keeps running and can be awaited again
+        later.
+
+        Raises:
+            KeyError: if *sub_id* is unknown.
+            asyncio.TimeoutError: if *timeout* is given and exceeded.
+        """
+        async with self._lock:
+            entry = self._subagents.get(sub_id)
+        if entry is None or entry.task_obj is None:
+            raise KeyError(sub_id)
+        if entry.task_obj.done():
+            if entry.handle.state == "cancelled":
+                return entry.handle.result
+            return entry.handle.result
+        done, pending = await asyncio.wait([entry.task_obj], timeout=timeout)
+        if entry.task_obj in pending:
+            raise asyncio.TimeoutError(
+                f"subagent {sub_id} did not finish within {timeout}s"
+            )
+        if entry.handle.state == "cancelled":
+            return entry.handle.result
+        return entry.handle.result
+
+    def get_subagent(self, sub_id: str) -> SubagentHandle | None:
+        """Return a snapshot of a subagent's handle, or None if unknown."""
+        entry = self._subagents.get(sub_id)
+        if entry is None:
+            return None
+        h = entry.handle
+        return SubagentHandle(
+            id=h.id,
+            task=h.task,
+            state=h.state,
+            result=h.result,
+            error=h.error,
+            started_at=h.started_at,
+        )
+
+    async def await_all_subagents(self, timeout: float | None = None) -> None:
+        """Wait for all running subagents to settle (success or cancel).
+
+        Does not cancel them -- just waits. A *timeout* only limits how long
+        this call waits. It does NOT cancel any subagent tasks. Tasks keep
+        running and can be awaited individually after the timeout.
+
+        Useful before the loop can safely reach a safe point and go idle.
+
+        Raises:
+            asyncio.TimeoutError: if *timeout* is given and any subagent did
+                not finish within it.
+        """
+        async with self._lock:
+            tasks = [
+                e.task_obj
+                for e in self._subagents.values()
+                if e.task_obj is not None and not e.task_obj.done()
+            ]
+        if not tasks:
+            return None
+        done, pending = await asyncio.wait(tasks, timeout=timeout)
+        if pending:
+            raise asyncio.TimeoutError(
+                f"{len(pending)} subagent(s) did not finish within {timeout}s"
+            )
+        self._prune_subagents()
+        return None


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Fix-forward #2335: safe-point race + wait_for cancellation + task_utils reuse + wiring design note

Autonomous build of board card tsk-32u2nj.

- hold SAFE_POINT state across cancel window, queue arriving messages,
  remove destructive _message_queue.clear() in handle_message
- use asyncio.wait instead of asyncio.wait_for in await_subagent and
  await_all_subagents so a timeout never cancels the subagent task
- reuse _create_supervised_task for progress and runner tasks,
  cancel_and_wait for bounded cancellation, prune settled subagents and
  delivered entries, switch UI timestamps to time.time()
- update changelog to describe library as not-yet-wired infrastructure,
  add not-yet-integrated banner to design doc

Files:
 changelog.d/tsk-rl2lfb-agent-loop.md |   6 +
 docs/design/agent-loop-subagents.md  | 101 +++++++
 tests/test_agent_loop.py             | 555 +++++++++++++++++++++++++++++++++++
 tinyagentos/agent_loop.py            | 487 ++++++++++++++++++++++++++++++
 4 files changed, 1149 insertions(+)