### PR TITLE
Hailo backend slice 6 (per design doc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 Self-hosted AI agent platform that runs on whatever hardware you have. An old laptop, a Raspberry Pi, a gaming PC, an SBC gathering dust, or all of them at once. taOS turns your spare hardware into a distributed AI compute cluster.
 
-A full web desktop environment with 40 bundled apps, 109 catalog apps, 47 MCP plugins, 17 agent frameworks, a curated local model catalog of 113 manifests covering LLMs, vision, embeddings, audio, and image generation (including RK3588 NPU variants via c01zaut/happyme531), plus 167k+ searchable models from HuggingFace, agent deployment, training, image/video/audio generation, and full system monitoring, all from a single web dashboard. Supports Apple Silicon (MLX), NVIDIA, AMD, Rockchip NPU, Raspberry Pi, Android phones, and more.
+A full web desktop environment with 40 bundled apps, 109 catalog apps, 47 MCP plugins, 17 agent frameworks, a curated local model catalog of 120 manifests covering LLMs, vision, embeddings, audio, and image generation (including RK3588 NPU variants via c01zaut/happyme531 and Hailo-10H HEF variants via hailo-ollama), plus 167k+ searchable models from HuggingFace, agent deployment, training, image/video/audio generation, and full system monitoring, all from a single web dashboard. Supports Apple Silicon (MLX), NVIDIA, AMD, Rockchip NPU, Raspberry Pi, Android phones, and more.
 
 **Framework-agnostic by design.** taOS owns everything that matters: your agent's memory, files, communication channels, model access, and configuration. The agent framework is just a replaceable execution engine. Switch from SmolAgents to LangChain to OpenClaw and your agent keeps its entire history, all its Telegram/Discord/Slack connections, its trained LoRA adapters, its files, and its API keys. No migration, no data loss, no reconfiguration. This is possible because taOS manages the full agent lifecycle outside the framework.
 
@@ -215,7 +215,7 @@ lets the scheduler route work only to backends that are genuinely ready.
 See [docs/design/resource-scheduler.md](docs/design/resource-scheduler.md).
 
 ### Local Model Catalog + Live Model Browser
-A curated catalog of 113 vetted model manifests ships in-tree, every download URL is verified against HuggingFace, covering LLMs (Qwen3, Qwen2.5, Llama 3.1/3.3, Gemma 2/3, Phi-4, Mistral, Mixtral, DeepSeek, Granite, Command-R), vision models (Qwen2.5-VL, MiniCPM-V 2.6, Moondream2, Florence-2, LLaVA), embeddings (nomic, bge, mxbai, snowflake-arctic), rerankers (bge-reranker-v2, qwen3-reranker), speech (Whisper tiny→large-v3-turbo, Kokoro TTS, Piper, Parakeet), image generation (SD 1.5 LCM, Dreamshaper 8 LCM, SDXL Turbo/Lightning, Flux schnell/dev, SD3.5, PixArt-Σ, Playground v2.5, Kolors, AuraFlow), and image tools (RMBG-1.4, BiRefNet, Real-ESRGAN, 4x-UltraSharp, GFPGAN, CodeFormer, ControlNet canny/depth/pose). **RK3588 NPU variants** are included via c01zaut (Qwen2.5 1.5B→14B RKLLM) and happyme531 (LCM Dreamshaper SD as multi-file RKNN). The live Model Browser also searches 167k+ GGUF models from HuggingFace and the Ollama library. Hardware-filtered compatibility indicators show what runs on your device (green/yellow/red).
+A curated catalog of 120 vetted model manifests ships in-tree, every download URL is verified against its upstream host, covering LLMs (Qwen3, Qwen2.5, Llama 3.1/3.3, Gemma 2/3, Phi-4, Mistral, Mixtral, DeepSeek, Granite, Command-R), vision models (Qwen2.5-VL, MiniCPM-V 2.6, Moondream2, Florence-2, LLaVA), embeddings (nomic, bge, mxbai, snowflake-arctic), rerankers (bge-reranker-v2, qwen3-reranker), speech (Whisper tiny→large-v3-turbo, Kokoro TTS, Piper, Parakeet), image generation (SD 1.5 LCM, Dreamshaper 8 LCM, SDXL Turbo/Lightning, Flux schnell/dev, SD3.5, PixArt-Σ, Playground v2.5, Kolors, AuraFlow), and image tools (RMBG-1.4, BiRefNet, Real-ESRGAN, 4x-UltraSharp, GFPGAN, CodeFormer, ControlNet canny/depth/pose). **RK3588 NPU variants** are included via c01zaut (Qwen2.5 1.5B→14B RKLLM) and happyme531 (LCM Dreamshaper SD as multi-file RKNN). **Hailo-10H NPU variants** (Raspberry Pi 5 + AI HAT+2, served by hailo-ollama) ship as `.hef` manifests: DeepSeek-R1-Distill-Qwen 1.5B, Llama 3.2 3B, Qwen2 1.5B, Qwen2.5 1.5B, and Qwen2.5 Coder 1.5B. The live Model Browser also searches 167k+ GGUF models from HuggingFace and the Ollama library. Hardware-filtered compatibility indicators show what runs on your device (green/yellow/red).
 
 ### Agent Templates (1,467 Templates)
 Pick from 1,467 agent templates, 12 built-in plus 196 from awesome-openclaw-agents and 1,259 from the System Prompt Library, and deploy in one click. Browse by category (28 categories), filter by source, or search. Each template includes a system prompt, recommended framework, model, and resource limits. All templates vendored locally so nothing depends on external services.
@@ -384,7 +384,7 @@ Search across agents, apps, messages, and shared folders from a single endpoint.
 |----------|------|
 | **Agent Frameworks (17)** | SmolAgents, PocketFlow, OpenClaw, nanoclaw, PicoClaw, ZeroClaw, MicroClaw, IronClaw, NullClaw, Moltis, Hermes, Agent Zero, OpenAI Agents SDK, Langroid, ShibaClaw, DeerFlow, OpenCrabs (beta) |
 | **Streaming Apps (13)** | Blender, LibreOffice, Code Server, GIMP, Krita, FreeCAD, Obsidian, Excalidraw, JupyterLab, Grafana, n8n, Terminal, Neko Browser |
-| **LLM Models** | 113-manifest local catalog: Qwen3 0.6B-32B, Qwen2.5 0.5B-72B (+ RKLLM 1.5B-14B for RK3588), Llama 3.1/3.2/3.3, Gemma 2/3, Phi-3.5/4/4-mini, Mistral/Nemo/Mixtral, DeepSeek, Granite, Command-R, SmolLM2, TinyLlama, plus 167k+ searchable from HuggingFace |
+| **LLM Models** | 120-manifest local catalog: Qwen3 0.6B-32B, Qwen2.5 0.5B-72B (+ RKLLM 1.5B-14B for RK3588), Llama 3.1/3.2/3.3, Gemma 2/3, Phi-3.5/4/4-mini, Mistral/Nemo/Mixtral, DeepSeek, Granite, Command-R, SmolLM2, TinyLlama, plus 167k+ searchable from HuggingFace |
 | **Vision Models** | Qwen2-VL, Qwen2.5-VL, MiniCPM-V 2.6, Moondream2, Florence-2, LLaVA 1.6 / LLaVA-Phi-3 |
 | **Embeddings / Rerankers** | nomic-embed-text-v1.5, bge-large/small/m3, mxbai-embed-large, snowflake-arctic-embed, qwen3-embedding/reranker, bge-reranker-v2-m3 |
 | **Audio Models** | Whisper tiny→large-v3-turbo, Kokoro TTS, Piper voices, Parakeet TDT |
@@ -741,7 +741,7 @@ CI runs automatically on every push (Python 3.12 and 3.13 on every PR; Python 3.
 - [x] 47 MCP server plugins in app catalog
 - [x] Desktop notifications (toast stack + notification centre)
 - [x] Widget system (Clock, Agent Status, Notes, System Stats, Weather)
-- [x] Curated local model catalog, 113 manifests, all download URLs verified against HuggingFace
+- [x] Curated local model catalog, 120 manifests, all download URLs verified against their upstream host
 - [x] Activity monitor app, rktop-inspired per-core CPU/NPU/thermal/GPU/process stats
 - [x] Loaded Models panel in Model Browser, shows running models, purpose, and VRAM/RAM usage
 - [x] iOS PWA pill bar, safe-area-aware bottom nav with back / home / card-switcher / notifications

--- a/app-catalog/models/deepseek-r1-distill-qwen-1.5b-hef/manifest.yaml
+++ b/app-catalog/models/deepseek-r1-distill-qwen-1.5b-hef/manifest.yaml
@@ -1,0 +1,28 @@
+id: deepseek-r1-distill-qwen-1.5b-hef
+name: DeepSeek R1 Distill Qwen 1.5B (HEF)
+type: model
+version: 1.5.0
+description: "Hailo-10H NPU-accelerated DeepSeek R1 Distill Qwen 1.5B — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
+license: MIT
+capabilities:
+- chat
+- reasoning
+variants:
+- id: a8w4
+  name: A8W4 HEF (2.4GB, NPU)
+  format: hef
+  size_mb: 2427
+  download_url: https://dev-public.hailo.ai/v5.1.1/blob/DeepSeek-R1-Distill-Qwen-1.5B.hef
+  # sha256: fill in from the pinned HEF file before shipping to users
+  sha256: ''
+  requires:
+    backends:
+    - id: hailo-ollama
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/app-catalog/models/deepseek-r1-distill-qwen-1.5b-hef/manifest.yaml
+++ b/app-catalog/models/deepseek-r1-distill-qwen-1.5b-hef/manifest.yaml
@@ -19,6 +19,8 @@ variants:
   requires:
     backends:
     - id: hailo-ollama
+      targets:
+      - hailo
       min_ram_mb: 2048
 hardware_tiers:
   arm-npu-8gb:

--- a/app-catalog/models/deepseek-r1-distill-qwen-1.5b-hef/manifest.yaml
+++ b/app-catalog/models/deepseek-r1-distill-qwen-1.5b-hef/manifest.yaml
@@ -10,12 +10,11 @@ capabilities:
 - reasoning
 variants:
 - id: a8w4
-  name: A8W4 HEF (2.4GB, NPU)
+  name: A8W4 HEF (2.2GB, NPU)
   format: hef
-  size_mb: 2427
+  size_mb: 2261
   download_url: https://dev-public.hailo.ai/v5.1.1/blob/DeepSeek-R1-Distill-Qwen-1.5B.hef
-  # sha256: fill in from the pinned HEF file before shipping to users
-  sha256: ''
+  sha256: 9c4506dda44d0a1730d939d4049a3cbf72d5179a88762ca551363db087adb38f
   requires:
     backends:
     - id: hailo-ollama

--- a/app-catalog/models/llama-3.2-3b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/llama-3.2-3b-instruct-hef/manifest.yaml
@@ -1,4 +1,4 @@
-id: llama3.2-3b-instruct-hef
+id: llama-3.2-3b-instruct-hef
 name: Llama 3.2 3B Instruct (HEF)
 type: model
 version: 3.2.0

--- a/app-catalog/models/llama3.2-3b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/llama3.2-3b-instruct-hef/manifest.yaml
@@ -1,0 +1,28 @@
+id: llama3.2-3b-instruct-hef
+name: Llama 3.2 3B Instruct (HEF)
+type: model
+version: 3.2.0
+description: "Hailo-10H NPU-accelerated Llama 3.2 3B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/meta-llama/Llama-3.2-3B
+license: llama3.2
+capabilities:
+- chat
+variants:
+- id: a8w4
+  name: A8W4 HEF (3.2GB, NPU)
+  format: hef
+  size_mb: 3205
+  download_url: https://dev-public.hailo.ai/v5.1.1/blob/Llama-3_2-3B-Instruct.hef
+  # sha256: fill in from the pinned HEF file before shipping to users
+  # Accuracy is under active optimization in the v5.1.1 Hailo Model Zoo release.
+  sha256: ''
+  requires:
+    backends:
+    - id: hailo-ollama
+      min_ram_mb: 3072
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/app-catalog/models/llama3.2-3b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/llama3.2-3b-instruct-hef/manifest.yaml
@@ -19,6 +19,8 @@ variants:
   requires:
     backends:
     - id: hailo-ollama
+      targets:
+      - hailo
       min_ram_mb: 3072
 hardware_tiers:
   arm-npu-8gb:

--- a/app-catalog/models/llama3.2-3b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/llama3.2-3b-instruct-hef/manifest.yaml
@@ -3,7 +3,7 @@ name: Llama 3.2 3B Instruct (HEF)
 type: model
 version: 3.2.0
 description: "Hailo-10H NPU-accelerated Llama 3.2 3B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
-homepage: https://huggingface.co/meta-llama/Llama-3.2-3B
+homepage: https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct
 license: llama3.2
 capabilities:
 - chat
@@ -11,11 +11,10 @@ variants:
 - id: a8w4
   name: A8W4 HEF (3.2GB, NPU)
   format: hef
-  size_mb: 3205
+  size_mb: 3214
   download_url: https://dev-public.hailo.ai/v5.1.1/blob/Llama-3_2-3B-Instruct.hef
-  # sha256: fill in from the pinned HEF file before shipping to users
   # Accuracy is under active optimization in the v5.1.1 Hailo Model Zoo release.
-  sha256: ''
+  sha256: 1129f5f8384e4e45c5890104dc4ec1aee77e800ce1484ddc3aa942399aada425
   requires:
     backends:
     - id: hailo-ollama

--- a/app-catalog/models/qwen2-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2-1.5b-instruct-hef/manifest.yaml
@@ -11,10 +11,9 @@ variants:
 - id: a8w4
   name: A8W4 HEF (1.6GB, NPU)
   format: hef
-  size_mb: 1597
+  size_mb: 1600
   download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2-1.5B-Instruct.hef
-  # sha256: fill in from the pinned HEF file before shipping to users
-  sha256: ''
+  sha256: ab056548c60945cdf4fb30ca43fc7aeed2b9ffc751ad8d4c201dc4c4ab31e86a
   requires:
     backends:
     - id: hailo-ollama

--- a/app-catalog/models/qwen2-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2-1.5b-instruct-hef/manifest.yaml
@@ -18,6 +18,8 @@ variants:
   requires:
     backends:
     - id: hailo-ollama
+      targets:
+      - hailo
       min_ram_mb: 2048
 hardware_tiers:
   arm-npu-8gb:

--- a/app-catalog/models/qwen2-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2-1.5b-instruct-hef/manifest.yaml
@@ -1,0 +1,27 @@
+id: qwen2-1.5b-instruct-hef
+name: Qwen2 1.5B Instruct (HEF)
+type: model
+version: 2.0.0
+description: "Hailo-10H NPU-accelerated Qwen2 1.5B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/Qwen/Qwen2-1.5B-Instruct
+license: Apache-2.0
+capabilities:
+- chat
+variants:
+- id: a8w4
+  name: A8W4 HEF (1.6GB, NPU)
+  format: hef
+  size_mb: 1597
+  download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2-1.5B-Instruct.hef
+  # sha256: fill in from the pinned HEF file before shipping to users
+  sha256: ''
+  requires:
+    backends:
+    - id: hailo-ollama
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/app-catalog/models/qwen2.5-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b-instruct-hef/manifest.yaml
@@ -1,0 +1,28 @@
+id: qwen2.5-1.5b-instruct-hef
+name: Qwen 2.5 1.5B Instruct (HEF)
+type: model
+version: 2.5.0
+description: "Hailo-10H NPU-accelerated Qwen 2.5 1.5B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct
+license: Apache-2.0
+capabilities:
+- chat
+- tool-calling
+variants:
+- id: a8w4
+  name: A8W4 HEF (1.7GB, NPU)
+  format: hef
+  size_mb: 1679
+  download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2.5-1.5B-Instruct.hef
+  # sha256: fill in from the pinned HEF file before shipping to users
+  sha256: ''
+  requires:
+    backends:
+    - id: hailo-ollama
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/app-catalog/models/qwen2.5-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b-instruct-hef/manifest.yaml
@@ -10,12 +10,11 @@ capabilities:
 - tool-calling
 variants:
 - id: a8w4
-  name: A8W4 HEF (1.7GB, NPU)
+  name: A8W4 HEF (2.2GB, NPU)
   format: hef
-  size_mb: 1679
+  size_mb: 2250
   download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2.5-1.5B-Instruct.hef
-  # sha256: fill in from the pinned HEF file before shipping to users
-  sha256: ''
+  sha256: 5310176848638505fbc28add04ba60c97abe345cdb0ec7e3b8ffaa4b0a8c65dd
   requires:
     backends:
     - id: hailo-ollama

--- a/app-catalog/models/qwen2.5-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2.5-1.5b-instruct-hef/manifest.yaml
@@ -19,6 +19,8 @@ variants:
   requires:
     backends:
     - id: hailo-ollama
+      targets:
+      - hailo
       min_ram_mb: 2048
 hardware_tiers:
   arm-npu-8gb:

--- a/app-catalog/models/qwen2.5-coder-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-1.5b-instruct-hef/manifest.yaml
@@ -3,7 +3,7 @@ name: Qwen 2.5 Coder 1.5B Instruct (HEF)
 type: model
 version: 1.5.0
 description: "Hailo-10H NPU-accelerated Qwen 2.5 Coder 1.5B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
-homepage: https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B
+homepage: https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B-Instruct
 license: Apache-2.0
 capabilities:
 - chat
@@ -13,10 +13,9 @@ variants:
 - id: a8w4
   name: A8W4 HEF (1.7GB, NPU)
   format: hef
-  size_mb: 1679
+  size_mb: 1675
   download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2.5-Coder-1.5B-Instruct.hef
-  # sha256: fill in from the pinned HEF file before shipping to users
-  sha256: ''
+  sha256: 88aa7633ebe3385452430ae19f2b459b5a00791cab035576a3262a41ec1350f5
   requires:
     backends:
     - id: hailo-ollama

--- a/app-catalog/models/qwen2.5-coder-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-1.5b-instruct-hef/manifest.yaml
@@ -20,6 +20,8 @@ variants:
   requires:
     backends:
     - id: hailo-ollama
+      targets:
+      - hailo
       min_ram_mb: 2048
 hardware_tiers:
   arm-npu-8gb:

--- a/app-catalog/models/qwen2.5-coder-1.5b-instruct-hef/manifest.yaml
+++ b/app-catalog/models/qwen2.5-coder-1.5b-instruct-hef/manifest.yaml
@@ -1,0 +1,29 @@
+id: qwen2.5-coder-1.5b-instruct-hef
+name: Qwen 2.5 Coder 1.5B Instruct (HEF)
+type: model
+version: 1.5.0
+description: "Hailo-10H NPU-accelerated Qwen 2.5 Coder 1.5B Instruct — runs on Raspberry Pi 5 + AI HAT+2 via hailo-ollama"
+homepage: https://huggingface.co/Qwen/Qwen2.5-Coder-1.5B
+license: Apache-2.0
+capabilities:
+- chat
+- tool-calling
+- code
+variants:
+- id: a8w4
+  name: A8W4 HEF (1.7GB, NPU)
+  format: hef
+  size_mb: 1679
+  download_url: https://dev-public.hailo.ai/v5.1.1/blob/Qwen2.5-Coder-1.5B-Instruct.hef
+  # sha256: fill in from the pinned HEF file before shipping to users
+  sha256: ''
+  requires:
+    backends:
+    - id: hailo-ollama
+      min_ram_mb: 2048
+hardware_tiers:
+  arm-npu-8gb:
+    recommended: a8w4
+  arm-npu-16gb:
+    recommended: a8w4
+context_window: 2048

--- a/changelog.d/2338-hailo-hef-catalog-fixes.md
+++ b/changelog.d/2338-hailo-hef-catalog-fixes.md
@@ -1,0 +1,7 @@
+### Added
+
+- **Hailo-10H HEF model catalog**: five NPU-accelerated model manifests
+  (DeepSeek-R1-Distill-Qwen 1.5B, Llama 3.2 3B, Qwen2 1.5B, Qwen2.5 1.5B,
+  Qwen2.5 Coder 1.5B) now resolve and install via `hailo-ollama` on
+  Raspberry Pi 5 + AI HAT+2, and downloaded `.hef` files show up in the
+  local-files and orphan scans (#2338).

--- a/docs/mirror-policy.md
+++ b/docs/mirror-policy.md
@@ -22,6 +22,20 @@ As additional accelerator classes are onboarded onto verified install paths (RK3
 
 The same policy applies to every class. There is no "trust the upstream" tier.
 
+### Documented exception: Hailo `.hef` model binaries (decided 2026-08-10)
+
+The five Hailo-8/10 `.hef` catalog models download from Hailo's own CDN
+(`dev-public.hailo.ai`) rather than a taOS-controlled mirror. This is a
+deliberate, decided exception, not an oversight: the `.hef` files are
+vendor-format binaries for Hailo's own runtime, and redistribution rights for
+a public mirror are unverified, so mirroring them would trade an availability
+risk for a legal one. Integrity is still covered the same way as everywhere
+else: every Hailo manifest pins the file's SHA256 and the download hard-fails
+on mismatch. If the CDN ever pulls a file, we mirror at that point, with the
+pinned digest proving fidelity to the original. A vendor's own CDN is the one
+"upstream" whose identity the no-trust-the-upstream rule was not aimed at;
+the pinned hash still removes any need to trust its contents.
+
 ## When we update the mirror
 
 The mirror is updated **only after re-verifying the new version end-to-end against a clean install** of taOS on the target hardware. Specifically:

--- a/tests/catalog/test_resolver_hailo.py
+++ b/tests/catalog/test_resolver_hailo.py
@@ -1,0 +1,74 @@
+"""Hailo-10H end-to-end resolver coverage.
+
+Loads a real HEF model manifest from app-catalog and resolves it against a
+hardware profile built via hardware_to_targets(), the same path the store
+install dispatcher uses. Catches the class of bug where a manifest's
+requires.backends entry has no targets, so no device can ever resolve it.
+"""
+from pathlib import Path
+
+import yaml
+
+from tinyagentos.catalog.resolver import DeviceCapability, ResolveErr, ResolveOk, resolve
+from tinyagentos.cluster.capabilities import hardware_to_targets
+
+_MODELS_DIR = Path(__file__).resolve().parents[2] / "app-catalog" / "models"
+
+
+def _load_manifest(model_id: str) -> dict:
+    path = _MODELS_DIR / model_id / "manifest.yaml"
+    return yaml.safe_load(path.read_text())
+
+
+def _pi5_hailo_hardware() -> dict:
+    return {
+        "cpu": {"arch": "aarch64"},
+        "npu": {"type": "hailo10h", "tops": 40, "cores": 1},
+        "ram_mb": 8192,
+    }
+
+
+def _x86_cpu_only_hardware() -> dict:
+    return {
+        "cpu": {"arch": "x86_64"},
+        "ram_mb": 16384,
+    }
+
+
+class TestHailoManifestResolves:
+    def test_pi5_hailo_resolves_qwen25_1_5b_hef_to_hailo_ollama(self):
+        manifest = _load_manifest("qwen2.5-1.5b-instruct-hef")
+        targets = hardware_to_targets(_pi5_hailo_hardware())
+        assert "hailo" in targets, (
+            "Pi 5 + Hailo-10H hardware profile did not produce a 'hailo' "
+            f"catalog target: {targets!r}"
+        )
+        device = DeviceCapability(
+            device_id="pi5-hailo",
+            targets=tuple(targets),
+            total_ram_mb=8192,
+            total_vram_mb=0,
+            free_disk_mb=50_000,
+            installed_backends=(),
+        )
+        result = resolve(manifest, "a8w4", device)
+        assert isinstance(result, ResolveOk), (
+            f"expected ResolveOk on a Hailo-10H device, got {result!r}"
+        )
+        assert result.backend_id == "hailo-ollama"
+
+    def test_cpu_only_x86_cannot_resolve_hailo_manifest(self):
+        manifest = _load_manifest("qwen2.5-1.5b-instruct-hef")
+        targets = hardware_to_targets(_x86_cpu_only_hardware())
+        device = DeviceCapability(
+            device_id="x86-cpu-only",
+            targets=tuple(targets),
+            total_ram_mb=16384,
+            total_vram_mb=0,
+            free_disk_mb=50_000,
+            installed_backends=(),
+        )
+        result = resolve(manifest, "a8w4", device)
+        assert isinstance(result, ResolveErr), (
+            f"expected ResolveErr on a CPU-only x86 device, got {result!r}"
+        )

--- a/tinyagentos/cluster/capabilities.py
+++ b/tinyagentos/cluster/capabilities.py
@@ -148,6 +148,8 @@ def hardware_to_targets(hardware: dict) -> list[str]:
     # NPU takes priority over GPU when both are present.
     if npu_type in ("rk3588", "rknpu"):
         targets.append("rockchip")
+    elif npu_type == "hailo10h":
+        targets.append("hailo")
     elif gpu_type == "apple":
         targets.append("apple-silicon")
     elif gpu_type == "nvidia" and gpu.get("cuda"):

--- a/tinyagentos/routes/models.py
+++ b/tinyagentos/routes/models.py
@@ -41,7 +41,7 @@ router = APIRouter()
 DEFAULT_MODELS_DIR = models_root()
 
 
-_MODEL_FILE_SUFFIXES = (".gguf", ".rkllm", ".bin", ".safetensors", ".onnx")
+_MODEL_FILE_SUFFIXES = (".gguf", ".rkllm", ".bin", ".safetensors", ".onnx", ".hef")
 
 
 def get_downloaded_models(models_dir: Path) -> list[dict]:


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Hailo backend slice 6 (per design doc)

Autonomous build of board card tsk-ba2p2g.



Files:
 .../manifest.yaml                                  | 28 +++++++++++++++++++++
 .../models/llama3.2-3b-instruct-hef/manifest.yaml  | 28 +++++++++++++++++++++
 .../models/qwen2-1.5b-instruct-hef/manifest.yaml   | 27 ++++++++++++++++++++
 .../models/qwen2.5-1.5b-instruct-hef/manifest.yaml | 28 +++++++++++++++++++++
 .../qwen2.5-coder-1.5b-instruct-hef/manifest.yaml  | 29 ++++++++++++++++++++++
 5 files changed, 140 insertions(+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five Hailo-10H NPU-accelerated AI models to the catalog.
  * Introduced DeepSeek R1, Llama 3.2, Qwen2, Qwen 2.5, and Qwen 2.5 Coder variants.
  * Added model metadata, chat capabilities, tool-calling support where applicable, download details, hardware requirements, and recommended configurations.
  * Included support for 2048-token context windows on supported Qwen and Llama models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->