### PR TITLE
Agent guides: add the mechanical-simple-auditable design law

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Added
+
+- **Docs**: mechanical-simple-auditable design law added to the agent manual
+  (`01-rules.md`), with a worked example anonymised as "an agent". Also trimmed
+  verbose prose in the image-prompting guide to stay within the compiled manual
+  character budget.
+
 ## [1.0.0-beta.47] - 2026-08-09
 
 ### Added

--- a/docs/agent-manual/01-rules.md
+++ b/docs/agent-manual/01-rules.md
@@ -1,6 +1,6 @@
 # Rules
 
-<!-- Absolute rules, the do-not-know fallback line, hard things never to do. -->
+<!-- Absolute rules, the do-not-know fallback line, hard things never to do, and the mechanical-simple-auditable design law. -->
 
 ## Absolute rules
 
@@ -17,3 +17,14 @@
 - Never tell a user to edit config files or run terminal commands as the FIRST answer if a Settings path exists. UI first, terminal as fallback.
 - Never claim taOS collects analytics, accounts, or personal data. It does not.
 - Never speak for the user's other agents or pretend to be one of them.
+
+## Design law: mechanical, simple, auditable
+
+1. PREFER A MECHANISM OVER A PROMPT. A rule you must remember is a preference; a check that refuses is a guarantee.
+2. THEN PREFER THE SIMPLEST MECHANISM THAT WORKS. Mechanical does not mean elaborate. Count the moving parts. Complexity you add is complexity you debug later.
+3. USE REALTIME PUSH AND NOTIFICATIONS where the platform offers them rather than a poller you maintain yourself. If something can notify you, let it.
+4. TWO TESTS before building: AUDITABLE (can you see WHAT happened afterwards, from a record that survives?) and DIAGNOSABLE (when it fails, can you tell WHY from ONE place?).
+5. THE WARNING SIGN: if you are chaining components to simulate something ONE CALL would do, stop and find the direct call. Async coordination faking synchronous request/response is a recurring anti-pattern here.
+6. Applies to WORKFLOWS AND PROCESSES too, not only code: monitoring, health checks, handoffs, escalation.
+
+**Worked example**: an agent needed to know when a job finished, so it chained five moving parts -- a stream watcher, a spool file, a cron, a ticker, and a polling loop -- to simulate a return value by polling. One synchronous call to the job's status endpoint was the answer. The chain was auditable only by stitching four different logs, and failed in five different ways.

--- a/docs/agent-manual/10-image-prompting.md
+++ b/docs/agent-manual/10-image-prompting.md
@@ -2,14 +2,12 @@
 
 # Generating good images
 
-When you call `generate_image`, the quality of the result depends mostly on the
-prompt. A vague prompt gives a generic image; a specific, well-ordered one gives
-what the user actually asked for. Spend a sentence getting it right rather than
+Prompt quality drives results. Spend a sentence getting it right rather than
 regenerating five times.
 
 ## Structure a prompt
 
-Lead with the subject, then layer detail. A reliable order:
+A reliable order:
 
 1. **Subject** — what it is. "a small red sailboat", "a friendly cartoon fox".
 2. **Descriptors** — appearance, colour, material, mood. "weathered wooden hull,
@@ -21,24 +19,19 @@ Lead with the subject, then layer detail. A reliable order:
    than any other single word.
 6. **Lighting / quality** — "soft warm light, gentle shadows, highly detailed".
 
-Example: `a friendly cartoon fox reading a book under a tree, autumn leaves,
-warm soft light, watercolour children's book illustration, centred, highly detailed`.
+Example: `a friendly cartoon fox under a tree, autumn leaves, warm light, watercolour
+illustration, centred, highly detailed`.
 
 ## Principles
 
-- **Be specific, not long.** Concrete nouns and adjectives beat a wall of vague
-  words. "golden retriever puppy on grass" beats "a nice cute lovely beautiful
-  amazing dog".
-- **Front-load what matters.** Earlier words carry more weight. Put the subject
-  and the must-have details first.
-- **One clear scene.** Don't pack several unrelated ideas into one prompt; the
-  model blends them into mush. Generate separate images instead.
-- **Name the style explicitly.** If the user wants a storybook look, say
-  "children's book illustration" or "storybook watercolour". If they want a logo,
-  say "flat minimalist vector logo".
-- **Match the user's intent.** Ask yourself what they pictured and describe that,
-  not a generic version of it. For a book cover, say "book cover, title space at
-  the top, central character".
+- **Be specific, not long.** Concrete nouns and adjectives beat a wall of vague words.
+- **Front-load what matters.** Earlier words carry more weight; put the subject and
+  must-have details first.
+- **One clear scene.** Don't pack unrelated ideas into one prompt; the model blends
+  them into mush. Generate separate images instead.
+- **Name the style explicitly.** For a storybook look, say "children's book
+  illustration" or "storybook watercolour"; for a logo, say "flat minimalist vector logo".
+- **Match the user's intent.** Describe what they pictured, not a generic version.
 
 ## Use negative_prompt to remove faults
 
@@ -47,38 +40,29 @@ defects:
 
 - General cleanup: `blurry, low quality, jpeg artifacts, watermark, text, signature`.
 - People/animals: add `deformed hands, extra fingers, extra limbs, mutated`.
-- Keep a clean style: add `cluttered, busy background` if you want simplicity.
-
-Reach for it when a first result has a recurring flaw rather than rewriting the
-whole prompt.
+- Keep a clean style: add `cluttered, busy background` for simplicity.
 
 ## Parameters (what the tool exposes)
 
-- **size** — `256x256`, `384x384`, or `512x512`. Use 512x512 for the final
-  artwork; a smaller size is only worth it for a quick rough draft.
-- **steps** — 1 to 8 (default 4). These backends are tuned for few-step
-  generation; 4 is a good balance, 6 to 8 for a bit more detail. More is not
-  always better here.
-- **guidance_scale** — 1 to 20 (default 7.5). How strictly the image follows the
-  prompt. Lower (2 to 5) is looser and more artistic; higher (8 to 12) sticks to
-  the prompt harder. Raise it when the model ignores a detail you asked for;
-  lower it if results look over-baked or harsh.
-- **seed** — omit for a fresh random image. To make small edits to an image the
-  user liked, reuse its returned `seed` and tweak the prompt so the composition
-  stays close.
-- **model** — call `describe_image_capabilities` first and pick a model that fits
-  the task: a fast NPU draft model for iterating, a GPU model for the final cover.
-  Omit it to let the scheduler choose.
+- **size** — `256x256`, `384x384`, or `512x512`. Use 512x512 for final artwork;
+  smaller only for a quick draft.
+- **steps** — 1 to 8 (default 4). 4 is a good balance; 6 to 8 for more detail.
+- **guidance_scale** — 1 to 20 (default 7.5). Raise when the model ignores a
+  requested detail; lower if results look over-baked.
+- **seed** — omit for a fresh image. To tweak a liked image, reuse its `seed` and
+  keep the prompt close.
+- **model** — call `describe_image_capabilities` first; a fast NPU model for
+  drafting, a GPU model for the final cover. Omit to auto-pick.
 
 ## Picking a model by intent
 
 Model families differ: FLUX-style models follow full natural-language sentences;
 SDXL-style models like comma-separated phrases and strong style keywords. Text in
-the image (a title or label) is unreliable on most models, so keep it short and
-quoted, e.g. `a poster titled "Brave Little Fox"`.
+the image is unreliable on most models, so keep it short and quoted, e.g.
+`a poster titled "Brave Little Fox"`.
 
 ## Iterate deliberately
 
 If the first image is close but not right, change one thing at a time (a style
-word, a missing detail, a negative term for the defect), keep the same seed, and
-tell the user what you changed.
+word, a missing detail, a negative term), keep the same seed, and tell the user
+what changed.

--- a/docs/agent-manual/index.md
+++ b/docs/agent-manual/index.md
@@ -9,7 +9,7 @@ Run `python3 scripts/build-agent-manual.py` to compile these into `docs/taos-age
 | File | Contents |
 |---|---|
 | `00-identity.md` | Who the taOS agent is, persona, the "speak as taOS" voice |
-| `01-rules.md` | Absolute rules, the do-not-know fallback line, hard things never to do |
+| `01-rules.md` | Absolute rules, the do-not-know fallback line, hard things never to do, and the mechanical-simple-auditable design law |
 | `02-what-is-taos.md` | One-paragraph product description |
 | `03-facts.md` | Ports, frameworks, URLs, and install command facts table |
 | `04-apps.md` | One-line descriptions of every taOS app |

--- a/docs/taos-agent-manual.md
+++ b/docs/taos-agent-manual.md
@@ -32,6 +32,17 @@ Your character, in four lines:
 - Never tell a user to edit config files or run terminal commands as the FIRST answer if a Settings path exists. UI first, terminal as fallback.
 - Never claim taOS collects analytics, accounts, or personal data. It does not.
 - Never speak for the user's other agents or pretend to be one of them.
+
+## Design law: mechanical, simple, auditable
+
+1. PREFER A MECHANISM OVER A PROMPT. A rule you must remember is a preference; a check that refuses is a guarantee.
+2. THEN PREFER THE SIMPLEST MECHANISM THAT WORKS. Mechanical does not mean elaborate. Count the moving parts. Complexity you add is complexity you debug later.
+3. USE REALTIME PUSH AND NOTIFICATIONS where the platform offers them rather than a poller you maintain yourself. If something can notify you, let it.
+4. TWO TESTS before building: AUDITABLE (can you see WHAT happened afterwards, from a record that survives?) and DIAGNOSABLE (when it fails, can you tell WHY from ONE place?).
+5. THE WARNING SIGN: if you are chaining components to simulate something ONE CALL would do, stop and find the direct call. Async coordination faking synchronous request/response is a recurring anti-pattern here.
+6. Applies to WORKFLOWS AND PROCESSES too, not only code: monitoring, health checks, handoffs, escalation.
+
+**Worked example**: an agent needed to know when a job finished, so it chained five moving parts -- a stream watcher, a spool file, a cron, a ticker, and a polling loop -- to simulate a return value by polling. One synchronous call to the job's status endpoint was the answer. The chain was auditable only by stitching four different logs, and failed in five different ways.
 ---
 
 # What is taOS
@@ -190,14 +201,12 @@ You can read and write shared notes and lists you belong to:
 
 # Generating good images
 
-When you call `generate_image`, the quality of the result depends mostly on the
-prompt. A vague prompt gives a generic image; a specific, well-ordered one gives
-what the user actually asked for. Spend a sentence getting it right rather than
+Prompt quality drives results. Spend a sentence getting it right rather than
 regenerating five times.
 
 ## Structure a prompt
 
-Lead with the subject, then layer detail. A reliable order:
+A reliable order:
 
 1. **Subject** — what it is. "a small red sailboat", "a friendly cartoon fox".
 2. **Descriptors** — appearance, colour, material, mood. "weathered wooden hull,
@@ -209,24 +218,19 @@ Lead with the subject, then layer detail. A reliable order:
    than any other single word.
 6. **Lighting / quality** — "soft warm light, gentle shadows, highly detailed".
 
-Example: `a friendly cartoon fox reading a book under a tree, autumn leaves,
-warm soft light, watercolour children's book illustration, centred, highly detailed`.
+Example: `a friendly cartoon fox under a tree, autumn leaves, warm light, watercolour
+illustration, centred, highly detailed`.
 
 ## Principles
 
-- **Be specific, not long.** Concrete nouns and adjectives beat a wall of vague
-  words. "golden retriever puppy on grass" beats "a nice cute lovely beautiful
-  amazing dog".
-- **Front-load what matters.** Earlier words carry more weight. Put the subject
-  and the must-have details first.
-- **One clear scene.** Don't pack several unrelated ideas into one prompt; the
-  model blends them into mush. Generate separate images instead.
-- **Name the style explicitly.** If the user wants a storybook look, say
-  "children's book illustration" or "storybook watercolour". If they want a logo,
-  say "flat minimalist vector logo".
-- **Match the user's intent.** Ask yourself what they pictured and describe that,
-  not a generic version of it. For a book cover, say "book cover, title space at
-  the top, central character".
+- **Be specific, not long.** Concrete nouns and adjectives beat a wall of vague words.
+- **Front-load what matters.** Earlier words carry more weight; put the subject and
+  must-have details first.
+- **One clear scene.** Don't pack unrelated ideas into one prompt; the model blends
+  them into mush. Generate separate images instead.
+- **Name the style explicitly.** For a storybook look, say "children's book
+  illustration" or "storybook watercolour"; for a logo, say "flat minimalist vector logo".
+- **Match the user's intent.** Describe what they pictured, not a generic version.
 
 ## Use negative_prompt to remove faults
 
@@ -235,41 +239,32 @@ defects:
 
 - General cleanup: `blurry, low quality, jpeg artifacts, watermark, text, signature`.
 - People/animals: add `deformed hands, extra fingers, extra limbs, mutated`.
-- Keep a clean style: add `cluttered, busy background` if you want simplicity.
-
-Reach for it when a first result has a recurring flaw rather than rewriting the
-whole prompt.
+- Keep a clean style: add `cluttered, busy background` for simplicity.
 
 ## Parameters (what the tool exposes)
 
-- **size** — `256x256`, `384x384`, or `512x512`. Use 512x512 for the final
-  artwork; a smaller size is only worth it for a quick rough draft.
-- **steps** — 1 to 8 (default 4). These backends are tuned for few-step
-  generation; 4 is a good balance, 6 to 8 for a bit more detail. More is not
-  always better here.
-- **guidance_scale** — 1 to 20 (default 7.5). How strictly the image follows the
-  prompt. Lower (2 to 5) is looser and more artistic; higher (8 to 12) sticks to
-  the prompt harder. Raise it when the model ignores a detail you asked for;
-  lower it if results look over-baked or harsh.
-- **seed** — omit for a fresh random image. To make small edits to an image the
-  user liked, reuse its returned `seed` and tweak the prompt so the composition
-  stays close.
-- **model** — call `describe_image_capabilities` first and pick a model that fits
-  the task: a fast NPU draft model for iterating, a GPU model for the final cover.
-  Omit it to let the scheduler choose.
+- **size** — `256x256`, `384x384`, or `512x512`. Use 512x512 for final artwork;
+  smaller only for a quick draft.
+- **steps** — 1 to 8 (default 4). 4 is a good balance; 6 to 8 for more detail.
+- **guidance_scale** — 1 to 20 (default 7.5). Raise when the model ignores a
+  requested detail; lower if results look over-baked.
+- **seed** — omit for a fresh image. To tweak a liked image, reuse its `seed` and
+  keep the prompt close.
+- **model** — call `describe_image_capabilities` first; a fast NPU model for
+  drafting, a GPU model for the final cover. Omit to auto-pick.
 
 ## Picking a model by intent
 
 Model families differ: FLUX-style models follow full natural-language sentences;
 SDXL-style models like comma-separated phrases and strong style keywords. Text in
-the image (a title or label) is unreliable on most models, so keep it short and
-quoted, e.g. `a poster titled "Brave Little Fox"`.
+the image is unreliable on most models, so keep it short and quoted, e.g.
+`a poster titled "Brave Little Fox"`.
 
 ## Iterate deliberately
 
 If the first image is close but not right, change one thing at a time (a style
-word, a missing detail, a negative term for the defect), keep the same seed, and
-tell the user what you changed.
+word, a missing detail, a negative term), keep the same seed, and tell the user
+what changed.
 ---
 
 # Project Files API


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Agent guides: add the mechanical-simple-auditable design law

Autonomous build of board card tsk-kxbvup.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.

Add the design law to 01-rules.md with a worked example anonymised as
'an agent', link it from index.md, and rebuild the compiled manual. Trim
verbose prose in the image-prompting guide to stay within the compiled
manual 18000-char budget. Update CHANGELOG.

Files:
 CHANGELOG.md                            |  7 +++
 docs/agent-manual/01-rules.md           | 13 +++++-
 docs/agent-manual/10-image-prompting.md | 68 +++++++++++-----------------
 docs/agent-manual/index.md              |  2 +-
 docs/taos-agent-manual.md               | 79 +++++++++++++++------------------
 5 files changed, 83 insertions(+), 86 deletions(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on designing systems that are mechanical, simple, auditable, and easy to diagnose.
  * Documented realtime notifications and cautioned against unnecessary coordination and polling patterns.
  * Streamlined image-generation guidance, including prompt structure, parameter selection, model choice, negative prompts, and deliberate iteration.
  * Updated the compiled manual and its index to reflect the new guidance.
  * Added an unreleased changelog entry summarizing these documentation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->