### PR TITLE
fix(auth): apply session User-Agent binding uniformly across auth surfaces

### DIFF
--- a/changelog.d/fix-auth-status-ua-symmetry.md
+++ b/changelog.d/fix-auth-status-ua-symmetry.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **PWA refresh loop after a browser auto-update**: `/auth/status`, `/auth/me`
+  and the chat/canvas/terminal/web-chat WebSocket handlers now apply the same
+  session User-Agent binding check as the API middleware. Previously a session
+  created before a browser update kept reading as authenticated on
+  `/auth/status` while every `/api/*` call was rejected, so the desktop shell
+  remounted in a loop; the WebSocket endpoints conversely accepted a cookie
+  the APIs refused.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1211,3 +1211,53 @@ class TestSessionClientBinding:
         # No user_agent param => skip check
         user_id = mgr.validate_session(token)
         assert user_id == rec["id"]
+
+
+class TestAuthStatusUserAgentSymmetry:
+    """/auth/status and /auth/me must apply the SAME User-Agent binding check
+    as the API middleware. When they diverge, a session whose UA hash no
+    longer matches (browser auto-update rotates the UA string) reads
+    authenticated on /auth/status while every /api/* call 401s, and the SPA's
+    LoginGate remount-loops on the contradiction (beta.46 PWA refresh loop,
+    2026-08-10)."""
+
+    @pytest.mark.asyncio
+    async def test_status_rejects_session_with_rotated_user_agent(self, app, auth_client):
+        app.state.auth.set_password("passw0rd")
+        resp = await auth_client.post(
+            "/auth/login",
+            data={"password": "passw0rd"},
+            headers={"user-agent": "TaosPWA/1.0 (old browser)"},
+            follow_redirects=False,
+        )
+        assert "taos_session" in resp.headers.get("set-cookie", "")
+        # Same UA -> still authenticated.
+        ok = await auth_client.get(
+            "/auth/status", headers={"user-agent": "TaosPWA/1.0 (old browser)"}
+        )
+        assert ok.json()["authenticated"] is True
+        # Rotated UA (browser updated) -> the middleware would 401 every API
+        # call, so status must agree and report unauthenticated.
+        rotated = await auth_client.get(
+            "/auth/status", headers={"user-agent": "TaosPWA/2.0 (updated browser)"}
+        )
+        assert rotated.json()["authenticated"] is False
+
+    @pytest.mark.asyncio
+    async def test_me_rejects_session_with_rotated_user_agent(self, app, auth_client):
+        app.state.auth.set_password("passw0rd")
+        resp = await auth_client.post(
+            "/auth/login",
+            data={"password": "passw0rd"},
+            headers={"user-agent": "TaosPWA/1.0 (old browser)"},
+            follow_redirects=False,
+        )
+        assert "taos_session" in resp.headers.get("set-cookie", "")
+        ok = await auth_client.get(
+            "/auth/me", headers={"user-agent": "TaosPWA/1.0 (old browser)"}
+        )
+        assert ok.status_code != 401
+        rotated = await auth_client.get(
+            "/auth/me", headers={"user-agent": "TaosPWA/2.0 (updated browser)"}
+        )
+        assert rotated.status_code == 401

--- a/tinyagentos/routes/auth.py
+++ b/tinyagentos/routes/auth.py
@@ -654,7 +654,14 @@ async def auth_status(request: Request):
     auth_mgr = request.app.state.auth
     configured = auth_mgr.is_configured()
     token = request.cookies.get("taos_session", "")
-    user_id = auth_mgr.validate_session(token) if token else None
+    # Pass the request's User-Agent so the stolen-cookie binding check runs
+    # here exactly as it does in the API middleware. Without it a session
+    # whose UA hash no longer matches (browser auto-update rotated the UA)
+    # reads authenticated here while every /api/* call 401s, and the SPA's
+    # LoginGate remount-loops on that contradiction (the beta.46 PWA
+    # refresh-loop, 2026-08-10).
+    _ua = request.headers.get("user-agent", "")
+    user_id = auth_mgr.validate_session(token, user_agent=_ua) if token else None
     authenticated = user_id is not None
 
     user = None
@@ -681,7 +688,9 @@ async def auth_me(request: Request):
     """Return the current user's profile. 401 when not signed in."""
     auth_mgr = request.app.state.auth
     token = request.cookies.get("taos_session", "")
-    if not token or auth_mgr.validate_session(token) is None:
+    if not token or auth_mgr.validate_session(
+        token, user_agent=request.headers.get("user-agent", "")
+    ) is None:
         return JSONResponse({"error": "not authenticated"}, status_code=401)
     user = auth_mgr.get_user(token=token)
     if user is None:

--- a/tinyagentos/routes/canvas.py
+++ b/tinyagentos/routes/canvas.py
@@ -79,7 +79,13 @@ async def canvas_ws(websocket: WebSocket, canvas_id: str):
     """WebSocket for live canvas updates."""
     auth_mgr = websocket.app.state.auth
     token = websocket.cookies.get("taos_session", "")
-    user_id = auth_mgr.validate_session(token) if token else None
+    user_id = (
+        auth_mgr.validate_session(
+            token, user_agent=websocket.headers.get("user-agent", "")
+        )
+        if token
+        else None
+    )
     if user_id is None:
         await websocket.close(code=1008)
         return

--- a/tinyagentos/routes/channel_hub.py
+++ b/tinyagentos/routes/channel_hub.py
@@ -265,7 +265,13 @@ async def webchat_ws(websocket: WebSocket, agent_name: str):
     """WebSocket endpoint for web chat."""
     auth_mgr = websocket.app.state.auth
     token = websocket.cookies.get("taos_session", "")
-    user_id = auth_mgr.validate_session(token) if token else None
+    user_id = (
+        auth_mgr.validate_session(
+            token, user_agent=websocket.headers.get("user-agent", "")
+        )
+        if token
+        else None
+    )
     if user_id is None:
         await websocket.close(code=1008)
         return

--- a/tinyagentos/routes/chat.py
+++ b/tinyagentos/routes/chat.py
@@ -111,7 +111,13 @@ async def get_chat_guide():
 async def chat_ws(websocket: WebSocket):
     auth_mgr = websocket.app.state.auth
     token = websocket.cookies.get("taos_session", "")
-    user_id = auth_mgr.validate_session(token) if token else None
+    user_id = (
+        auth_mgr.validate_session(
+            token, user_agent=websocket.headers.get("user-agent", "")
+        )
+        if token
+        else None
+    )
     if user_id is None:
         await websocket.close(code=1008)
         return

--- a/tinyagentos/routes/terminal.py
+++ b/tinyagentos/routes/terminal.py
@@ -23,7 +23,11 @@ def _ws_session_user_id(websocket: WebSocket) -> str | None:
     token = websocket.cookies.get("taos_session", "")
     if not token:
         return None
-    return auth_mgr.validate_session(token)
+    # Same UA-binding check as the API middleware: the terminal is the most
+    # sensitive surface, it must not accept a cookie the APIs reject.
+    return auth_mgr.validate_session(
+        token, user_agent=websocket.headers.get("user-agent", "")
+    )
 
 
 def build_command(config: dict) -> list[str]:


### PR DESCRIPTION
Root cause of tonight's PWA refresh loop on the Pi (beta.46), fixed at the class level.

**Mechanism**: sessions store a SHA-256 hash of the login User-Agent as a stolen-cookie check. The API middleware verifies it on every request; `/auth/status` and `/auth/me` did not pass the UA, and the chat/canvas/terminal/web-chat WebSocket handlers did not either. When a browser auto-update rotated the UA string, the session became: authenticated per `/auth/status`, 401 per every `/api/*` call. LoginGate's session-expired handler re-checks status, sees authenticated, remounts the shell, the API barrage 401s again - a remount loop every few seconds. The WebSocket side is the same hole inverted: the most sensitive surfaces (terminal PTY) accepted a cookie the APIs reject.

**Fix**: all six call sites pass the request/websocket User-Agent, so the binding check gives one answer everywhere. UA-less (legacy/script) sessions still validate regardless - semantics unchanged.

**Proof**: two new route-level tests (login under UA A, query under UA B) FAIL on unfixed `routes/auth.py` (run demonstrated red before the fix was applied) and pass with it; `tests/test_auth.py` + both channel-hub suites: 180 passed.

**Ops note**: the live loop on the Pi was cleared by revoking the stale sessions (backup kept at `data/.auth_sessions.bak-ua-loop-*`); this PR prevents recurrence and lands with the next release train.