### PR TITLE
AgentLoop wiring: single per-agent serialization owner (router + desktop chat + scoped status)

### DIFF
--- a/changelog.d/tsk-icpt4i-agent-loop-wiring.md
+++ b/changelog.d/tsk-icpt4i-agent-loop-wiring.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **Agent loop wiring**: `AgentLoop` is now the single per-agent serialization
+  owner. `AgentChatRouter` drives OpenClaw ACP turns through a per-agent
+  `AgentLoop` (replacing the per-agent lock) and the turn-holder drives
+  messages queued mid-turn at its safe point. The desktop taOS agent chat
+  endpoint serializes on one `AgentLoop` too — fixing a race where two
+  concurrent POSTs shared the opencode session with no serialization —
+  queueing concurrent messages and surfacing them in the turn-holder's stream
+  tail. New `GET /api/taos-agent/status` endpoint returns the desktop loop's
+  status scoped to state / current turn / queue depth / subagent descriptors
+  (subagent result/error payloads stay server-side) (#tsk-icpt4i).

--- a/changelog.d/tsk-rl2lfb-agent-loop.md
+++ b/changelog.d/tsk-rl2lfb-agent-loop.md
@@ -1,6 +1,6 @@
 ### Added
 
 - **Agent loop infrastructure**: new `tinyagentos.agent_loop.AgentLoop` library
-  for subagent delegation and safe-point message queuing. This is standalone
-  infrastructure, not yet wired into the taOS chat agent or routes
-  (#tsk-rl2lfb).
+  for subagent delegation and safe-point message queuing. Landed as
+  standalone infrastructure; wired into the chat router and taOS agent
+  routes in #tsk-icpt4i (#tsk-rl2lfb).

--- a/docs/design/agent-loop-subagents.md
+++ b/docs/design/agent-loop-subagents.md
@@ -75,16 +75,35 @@ SAFE_POINT --(immediate)--> IDLE
 
 ## Integration points
 
-> **Not yet integrated**: `AgentLoop` is standalone library infrastructure.
-> It is not yet wired into the taOS chat agent routes. Routing integration
-> will be handled in a separate design card once the `AgentChatRouter`-lock
-> design decision is made.
+`AgentLoop` is wired in as the single per-agent serialization owner
+(tsk-icpt4i):
 
-- The taOS chat endpoint (`routes/taos_agent.py`) can use `AgentLoop` to wrap
-  `opencode_runtime.drive_turn`: start a turn, spawn a subagent for long tool
-  calls, and drain the queue at the end of the stream.
-- The `AgentChatRouter._run_acp_turn` path can delegate to a subagent via
-  `openclaw_acp_runtime.drive_turn` when a turn is expected to be long.
+- **`AgentChatRouter._run_acp_turn`** (`tinyagentos/agent_chat_router.py`)
+  keeps one `AgentLoop` per agent slug (replacing the previous per-agent
+  `asyncio.Lock`). The turn-holder drives its turn, then iteratively drains
+  the safe-point queue, driving each queued message as its own turn with its
+  original trace id. A caller whose message returns `QUEUED` exits
+  immediately — the turn-holder drives it. `reach_safe_point` runs in a
+  `finally` so a raising turn can never wedge the loop in `WORKING`.
+- **`POST /api/taos-agent/chat`** (`routes/taos_agent.py`) serializes the
+  desktop taOS agent on a single `AgentLoop` held on
+  `app.state.taos_agent_loop` (previously two concurrent POSTs raced on the
+  shared opencode session with no serialization). A concurrent request gets a
+  one-frame NDJSON stream saying its message is queued; the turn-holder
+  surfaces queued message contents into its own stream's tail at the safe
+  point, before the final `{"done": true}`.
+- **`GET /api/taos-agent/status`** returns the desktop loop's status scoped
+  to `state` / `current_turn_id` / `queued_count` / `subagents` as
+  `[{id, task, state, started_at}]` — subagent `result` / `error` payloads
+  stay server-side.
+
+Still not integrated:
+
+- Router-side subagent spawning (`spawn_subagent` is not called from
+  `_run_acp_turn`).
+- Desktop-endpoint redrive: queued messages are surfaced into the
+  turn-holder's stream, not re-driven as their own turns.
+- Router per-agent loops are not exposed via any status endpoint.
 
 ## Testing
 

--- a/tests/test_agent_chat_router.py
+++ b/tests/test_agent_chat_router.py
@@ -756,3 +756,110 @@ async def test_manual_non_lead_branch_correct_for_worker():
     manual = enqueued["context"][0]["content"]
     assert "You are NOT a lead" in manual
     assert "You ARE designated lead" not in manual
+
+
+# ---------------------------------------------------------------------------
+# AgentLoop serialization ownership (tsk-icpt4i)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_acp_turn_same_agent_serializes_and_drives_both(monkeypatch):
+    """Two concurrent turns for the SAME agent never overlap, and BOTH
+    messages get driven (the queued one via the safe-point drain) with their
+    own trace ids preserved."""
+    import tinyagentos.openclaw_acp_runtime as rt
+
+    active = 0
+    max_concurrent = 0
+    driven: list[tuple[str, str, str]] = []
+
+    async def fake_drive_turn(*, slug, text, trace_id, record_reply):
+        nonlocal active, max_concurrent
+        active += 1
+        max_concurrent = max(max_concurrent, active)
+        await asyncio.sleep(0.02)
+        driven.append((slug, text, trace_id))
+        active -= 1
+
+    monkeypatch.setattr(rt, "drive_turn", fake_drive_turn)
+
+    router = AgentChatRouter(MagicMock())
+    await asyncio.gather(
+        router._run_acp_turn("a1", "m1", "t1", None),
+        router._run_acp_turn("a1", "m2", "t2", None),
+    )
+    assert max_concurrent == 1
+    assert sorted(driven) == [("a1", "m1", "t1"), ("a1", "m2", "t2")]
+
+
+@pytest.mark.asyncio
+async def test_run_acp_turn_different_agents_run_concurrently(monkeypatch):
+    """Turns for DIFFERENT agents are not serialized against each other."""
+    import tinyagentos.openclaw_acp_runtime as rt
+
+    active = 0
+    max_concurrent = 0
+
+    async def fake_drive_turn(*, slug, text, trace_id, record_reply):
+        nonlocal active, max_concurrent
+        active += 1
+        max_concurrent = max(max_concurrent, active)
+        await asyncio.sleep(0.02)
+        active -= 1
+
+    monkeypatch.setattr(rt, "drive_turn", fake_drive_turn)
+
+    router = AgentChatRouter(MagicMock())
+    await asyncio.gather(
+        router._run_acp_turn("a1", "m1", "t1", None),
+        router._run_acp_turn("a2", "m2", "t2", None),
+    )
+    assert max_concurrent == 2
+
+
+@pytest.mark.asyncio
+async def test_run_acp_turn_drive_failure_does_not_wedge_loop(monkeypatch):
+    """drive_turn raising must not skip reach_safe_point: the loop returns
+    to IDLE and a subsequent message is still driven."""
+    from tinyagentos.agent_loop import LoopState
+    import tinyagentos.openclaw_acp_runtime as rt
+
+    calls: list[str] = []
+
+    async def fake_drive_turn(*, slug, text, trace_id, record_reply):
+        calls.append(text)
+        if text == "boom":
+            raise RuntimeError("turn exploded")
+
+    monkeypatch.setattr(rt, "drive_turn", fake_drive_turn)
+
+    router = AgentChatRouter(MagicMock())
+    # Must not raise out of the supervised task path.
+    await router._run_acp_turn("a1", "boom", "t1", None)
+    assert router._agent_loops["a1"].state is LoopState.IDLE
+    await router._run_acp_turn("a1", "again", "t2", None)
+    assert calls == ["boom", "again"]
+
+
+@pytest.mark.asyncio
+async def test_run_acp_turn_queued_message_survives_drive_failure(monkeypatch):
+    """A message queued behind a FAILING turn is still driven at the safe
+    point (the finally-drain invariant)."""
+    import tinyagentos.openclaw_acp_runtime as rt
+
+    driven: list[str] = []
+
+    async def fake_drive_turn(*, slug, text, trace_id, record_reply):
+        await asyncio.sleep(0.02)
+        driven.append(text)
+        if text == "boom":
+            raise RuntimeError("turn exploded")
+
+    monkeypatch.setattr(rt, "drive_turn", fake_drive_turn)
+
+    router = AgentChatRouter(MagicMock())
+    await asyncio.gather(
+        router._run_acp_turn("a1", "boom", "t1", None),
+        router._run_acp_turn("a1", "after", "t2", None),
+    )
+    assert driven == ["boom", "after"]

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -296,6 +296,68 @@ async def test_chat_error_path_ndjson(client, app, monkeypatch):
     assert items[-1] == {"done": True}
 
 
+@pytest.mark.asyncio
+async def test_chat_queued_message_survives_turn_error(client, app, monkeypatch):
+    """A message queued mid-turn is surfaced even when the turn ERRORS.
+
+    The sink's error path enqueues _DONE early, which used to strand the
+    queued-message frames _drive's finally emits behind it in a queue nobody
+    read - the queued user's message silently evaporated on the most common
+    failure (a model-proxy error). The generator now drains the settled
+    queue after the early _DONE.
+    """
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+    app.state.taos_opencode_password = "testpw"
+    app.state.taos_opencode_session_id = None
+
+    server = _fake_server()
+
+    async def fake_ensure_server(state, model):
+        return server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    class _QueueThenErrorAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_qerr"
+
+        async def prompt(self, text, trace_id=None, attachments=None):
+            # A second user message lands while this turn is in flight...
+            loop = app.state.taos_agent_loop
+            from tinyagentos.agent_loop import LoopAction
+            action = await loop.handle_message("urgent follow-up", msg_id="q1")
+            assert action is LoopAction.QUEUED
+            # ...and then the turn fails (the common model-proxy shape).
+            self._sink({"kind": "error", "error": "proxy exploded"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.OpenCodeAdapter",
+        _QueueThenErrorAdapter,
+    )
+
+    resp = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "Hi"}]},
+    )
+    assert resp.status_code == 200
+    assert "urgent follow-up" in resp.text
+    items = _parse_ndjson(resp.text)
+    assert items[-1] == {"done": True}
+    # And the loop is back to IDLE - the failed turn must not wedge it.
+    assert app.state.taos_agent_loop.state.value == "idle"
+
+
 # ---------------------------------------------------------------------------
 # ensure_taos_opencode_server: key minting and master-key fallback
 # ---------------------------------------------------------------------------

--- a/tests/test_taos_agent_chat.py
+++ b/tests/test_taos_agent_chat.py
@@ -654,3 +654,193 @@ async def test_chat_normal_stream_no_spurious_error(client, app, monkeypatch):
     assert len(delta_items) == 1
     assert delta_items[0]["delta"] == "pong"
     assert items[-1] == {"done": True}
+
+
+# ---------------------------------------------------------------------------
+# AgentLoop serialization: concurrent POSTs no longer race on the shared
+# opencode session (tsk-icpt4i)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chat_concurrent_second_request_queued_and_surfaced(client, app, monkeypatch):
+    """While a turn is in flight, a second POST gets a single queued-notice
+    frame + done, and after the first turn completes its message is surfaced
+    in the first stream's tail before the final done."""
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+    app.state.taos_opencode_password = "testpw"
+    app.state.taos_opencode_session_id = None
+
+    server = _fake_server()
+
+    async def fake_ensure_server(state, model):
+        return server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class _BlockingAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_block"
+
+        async def prompt(self, text, trace_id=None, attachments=None):
+            self._sink({"kind": "delta", "content": f"reply:{text}"})
+            started.set()
+            await release.wait()
+            self._sink({"kind": "final", "content": f"reply:{text}"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.OpenCodeAdapter",
+        _BlockingAdapter,
+    )
+
+    first = asyncio.create_task(client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "first message"}]},
+    ))
+    await asyncio.wait_for(started.wait(), timeout=5)
+
+    # Second request while the first turn is mid-flight → queued notice.
+    resp2 = await client.post(
+        "/api/taos-agent/chat",
+        json={"messages": [{"role": "user", "content": "second message"}]},
+    )
+    assert resp2.status_code == 200
+    items2 = _parse_ndjson(resp2.text)
+    assert len(items2) == 2
+    assert "queued" in items2[0]["delta"].lower()
+    assert items2[-1] == {"done": True}
+
+    # Let the first turn complete: its stream tail surfaces the queued message.
+    release.set()
+    resp1 = await asyncio.wait_for(first, timeout=5)
+    assert resp1.status_code == 200
+    items1 = _parse_ndjson(resp1.text)
+    tail = [
+        i for i in items1
+        if "queued message received while working" in i.get("delta", "")
+    ]
+    assert len(tail) == 1
+    assert "second message" in tail[0]["delta"]
+    assert items1[-1] == {"done": True}
+    # The queued frame comes after the turn's own reply delta.
+    assert items1.index(tail[0]) > items1.index({"delta": "reply:first message"})
+
+
+@pytest.mark.asyncio
+async def test_chat_loop_idle_again_after_turn(client, app, monkeypatch):
+    """After a completed turn the loop is IDLE, so the next POST is driven
+    immediately (no stale queued notice)."""
+    from tinyagentos.agent_loop import LoopState
+
+    await client.patch("/api/taos-agent/settings", json={"model": "gpt-4o"})
+    app.state.llm_proxy = _make_mock_proxy(running=True)
+    app.state.taos_opencode_password = "testpw"
+    app.state.taos_opencode_session_id = None
+
+    server = _fake_server()
+
+    async def fake_ensure_server(state, model):
+        return server
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.ensure_taos_opencode_server",
+        fake_ensure_server,
+    )
+
+    class _NormalAdapter:
+        def __init__(self, cfg, sink):
+            self._sink = sink
+            self.session_id = None
+
+        async def ensure_session(self):
+            self.session_id = "ses_seq"
+
+        async def prompt(self, text, trace_id=None, attachments=None):
+            self._sink({"kind": "delta", "content": "pong"})
+            self._sink({"kind": "final", "content": "pong"})
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "tinyagentos.routes.taos_agent.OpenCodeAdapter",
+        _NormalAdapter,
+    )
+
+    for _ in range(2):
+        resp = await client.post(
+            "/api/taos-agent/chat",
+            json={"messages": [{"role": "user", "content": "Hi"}]},
+        )
+        assert resp.status_code == 200
+        items = _parse_ndjson(resp.text)
+        assert {"delta": "pong"} in items
+        assert not any("queued" in i.get("delta", "").lower() for i in items)
+    assert app.state.taos_agent_loop.state is LoopState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# GET /api/taos-agent/status — scoped payload (tsk-icpt4i)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_status_defaults_to_idle_without_loop(client):
+    resp = await client.get("/api/taos-agent/status")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "state": "idle",
+        "current_turn_id": None,
+        "queued_count": 0,
+        "subagents": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_status_scopes_subagent_fields(client, app):
+    """result/error stay server-side: subagent dicts expose ONLY
+    id/task/state/started_at."""
+    from tinyagentos.agent_loop import AgentLoop
+
+    loop = AgentLoop()
+    app.state.taos_agent_loop = loop
+
+    async def ok_worker(progress):
+        return {"secret": "server-side result payload"}
+
+    async def bad_worker(progress):
+        raise RuntimeError("server-side error detail")
+
+    ok_id = await loop.spawn_subagent("index files", ok_worker)
+    bad_id = await loop.spawn_subagent("doomed job", bad_worker)
+    await loop.await_subagent(ok_id)
+    await loop.await_subagent(bad_id)
+
+    resp = await client.get("/api/taos-agent/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert set(data.keys()) == {"state", "current_turn_id", "queued_count", "subagents"}
+    assert data["state"] == "idle"
+    assert data["queued_count"] == 0
+    assert len(data["subagents"]) == 2
+    by_id = {s["id"]: s for s in data["subagents"]}
+    assert by_id[ok_id]["state"] == "completed"
+    assert by_id[bad_id]["state"] == "failed"
+    for sub in data["subagents"]:
+        assert set(sub.keys()) == {"id", "task", "state", "started_at"}
+        assert "result" not in sub
+        assert "error" not in sub
+    # The payloads must not leak anywhere in the response body.
+    assert "server-side" not in resp.text

--- a/tinyagentos/agent_chat_router.py
+++ b/tinyagentos/agent_chat_router.py
@@ -95,8 +95,13 @@ class AgentChatRouter:
                 followup = await loop.handle_message(m.content, msg_id=m.id)
                 if followup is LoopAction.IMMEDIATE:
                     pending.append((m.content, m.id))
-                # QUEUED here means another concurrent caller grabbed the
-                # turn — it will drive this message at its own safe point.
+                # QUEUED here means this holder already restarted the turn
+                # with an earlier drained message (handle_message and the
+                # drain are atomic - the lock is never held across an await,
+                # so no other caller can interleave). The message sits in the
+                # loop's queue and this holder's next reach_safe_point
+                # re-drains it; WORKING always implies the current holder
+                # reaches another safe point.
 
     def dispatch(self, message: dict, channel: dict) -> None:
         """Fire-and-forget entry point. Runs routing in a supervised background task."""

--- a/tinyagentos/agent_chat_router.py
+++ b/tinyagentos/agent_chat_router.py
@@ -5,6 +5,7 @@ import logging
 import os
 from typing import Any
 
+from tinyagentos.agent_loop import AgentLoop, LoopAction
 from tinyagentos.task_utils import _create_supervised_task
 
 logger = logging.getLogger(__name__)
@@ -34,10 +35,12 @@ class AgentChatRouter:
         # Holds in-flight ACP turn tasks so they aren't garbage-collected
         # before completing (asyncio keeps only weak refs to tasks).
         self._acp_tasks: set[asyncio.Task] = set()
-        # Per-agent lock so turns for the same agent run sequentially (a shared
-        # gateway session can't process two prompts at once) — concurrent
-        # across different agents. Preserves the bridge's queued-delivery order.
-        self._agent_locks: dict[str, asyncio.Lock] = {}
+        # Per-agent AgentLoop owns turn serialization: turns for the same
+        # agent run sequentially (a shared gateway session can't process two
+        # prompts at once) — concurrent across different agents. Messages
+        # arriving mid-turn are queued by the loop and driven by the current
+        # turn-holder at its safe point, preserving delivery order.
+        self._agent_loops: dict[str, AgentLoop] = {}
 
     async def close(self) -> None:
         # Cancel + drain any in-flight ACP turns so shutdown doesn't orphan them.
@@ -54,14 +57,46 @@ class AgentChatRouter:
     async def _run_acp_turn(
         self, agent_name: str, text: str, trace_id, record_reply,
     ) -> None:
-        """Drive one OpenClaw ACP turn under the agent's serialization lock."""
+        """Drive one OpenClaw ACP turn, serialized per agent by its AgentLoop."""
         from tinyagentos.openclaw_acp_runtime import drive_turn
 
-        lock = self._agent_locks.setdefault(agent_name, asyncio.Lock())
-        async with lock:
-            await drive_turn(
-                slug=agent_name, text=text, trace_id=trace_id, record_reply=record_reply,
-            )
+        loop = self._agent_loops.setdefault(agent_name, AgentLoop())
+        action = await loop.handle_message(text, msg_id=trace_id)
+        if action is LoopAction.QUEUED:
+            # Another turn is in flight for this agent; the current turn-holder
+            # drives this message at its safe point (drain below).
+            return
+
+        # Turn-holder: drive the turn, then iteratively (never recursively)
+        # drive every message queued while it ran. Each queued message keeps
+        # its own trace id.
+        pending: list[tuple[str, Any]] = [(text, trace_id)]
+        while pending:
+            cur_text, cur_trace = pending.pop(0)
+            try:
+                await drive_turn(
+                    slug=agent_name, text=cur_text, trace_id=cur_trace,
+                    record_reply=record_reply,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # Log like _route does: this task has no other supervisor, and
+                # a raise must not drop the messages queued behind the failed
+                # turn (they are still drained and driven below).
+                logger.warning(
+                    "acp turn for agent %s failed: %s",
+                    agent_name, exc, exc_info=True,
+                )
+            finally:
+                # MUST run even when drive_turn raises or the task is
+                # cancelled — skipping it would wedge the loop in WORKING
+                # forever and silence the agent.
+                queued = await loop.reach_safe_point()
+            for m in queued:
+                followup = await loop.handle_message(m.content, msg_id=m.id)
+                if followup is LoopAction.IMMEDIATE:
+                    pending.append((m.content, m.id))
+                # QUEUED here means another concurrent caller grabbed the
+                # turn — it will drive this message at its own safe point.
 
     def dispatch(self, message: dict, channel: dict) -> None:
         """Fire-and-forget entry point. Runs routing in a supervised background task."""

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -6,6 +6,7 @@ GET  /api/taos-agent/config                    → {model, permitted_models, per
 PUT  /api/taos-agent/permitted-models          → validate + persist permitted_models; re-scope the agent key
 PUT  /api/taos-agent/persona                   → persist persona (system-prompt override)
 POST /api/taos-agent/chat                      → streams chat completion via opencode (NDJSON)
+GET  /api/taos-agent/status                    → scoped agent-loop status (state, turn, queue, subagents)
 POST /api/taos-agent/attachments/upload        → accepts a file, returns a persistent attachment record
 GET  /api/taos-agent/attachments/files/{name}  → serve a stored attachment
 
@@ -34,6 +35,7 @@ from fastapi.responses import FileResponse, JSONResponse, Response, StreamingRes
 from pydantic import BaseModel
 
 from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfig
+from tinyagentos.agent_loop import AgentLoop, LoopAction
 from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
 from tinyagentos.taos_agent_runtime import ensure_taos_opencode_server
 
@@ -427,7 +429,10 @@ async def chat(request: Request, body: ChatRequest):
             queue.put_nowait({"error": reply.get("error", "error")})
             queue.put_nowait(_DONE)
         elif kind == "final":
-            queue.put_nowait(_DONE)
+            # Stream termination is owned by _drive's finally block so
+            # messages queued during the turn can be surfaced before the
+            # final done frame.
+            pass
 
     cfg = OpenCodeConfig(
         base_url=server.base_url,
@@ -470,17 +475,62 @@ async def chat(request: Request, body: ChatRequest):
             "data_b64": base64.b64encode(data).decode(),
         })
 
+    # One AgentLoop owns serialization for the desktop taOS agent: two
+    # concurrent POSTs previously raced on the shared opencode session
+    # (app_state.taos_opencode_session_id) with no serialization at all.
+    # Created lazily on app.state like the opencode server/session id.
+    agent_loop: AgentLoop | None = getattr(app_state, "taos_agent_loop", None)
+    if agent_loop is None:
+        agent_loop = AgentLoop()
+        app_state.taos_agent_loop = agent_loop
+
+    trace_id = uuid.uuid4().hex
+    action = await agent_loop.handle_message(text, msg_id=trace_id)
+    if action is LoopAction.QUEUED:
+        # The agent is mid-turn: the message is queued (never dropped) and
+        # the turn-holder surfaces it at its safe point in _drive's finally.
+        # Full multi-turn redrive in this endpoint is out of scope — the
+        # queued message is surfaced into the turn-holder's stream, not
+        # driven as its own turn.
+        async def _queued_stream():
+            yield json.dumps({
+                "delta": (
+                    "[The taOS agent is still working on a previous message. "
+                    "Your message has been queued and will be surfaced to the "
+                    "agent when the current turn completes.]"
+                ),
+            }) + "\n"
+            yield json.dumps({"done": True}) + "\n"
+
+        return StreamingResponse(
+            _queued_stream(),
+            media_type="application/x-ndjson",
+        )
+
     async def _drive() -> None:
         try:
             await adapter.ensure_session()
             app_state.taos_opencode_session_id = adapter.session_id
-            trace_id = uuid.uuid4().hex
             await adapter.prompt(text, trace_id=trace_id, attachments=attachments)
             await adapter.close()
         except Exception as exc:
             logger.exception("taos-agent: drive task error")
             queue.put_nowait({"error": str(exc)})
         finally:
+            # The safe point MUST be reached even when the turn raises or is
+            # cancelled — skipping it would wedge the loop in WORKING forever.
+            try:
+                queued_msgs = await agent_loop.reach_safe_point()
+            except Exception:
+                logger.exception("taos-agent: reach_safe_point failed")
+                queued_msgs = []
+            # Surface messages queued while the turn ran so they are never
+            # silently dropped. Redriving them as their own turns is out of
+            # scope here; they land in this stream's tail.
+            for m in queued_msgs:
+                queue.put_nowait({
+                    "delta": f"\n[queued message received while working: {m.content}]\n",
+                })
             queue.put_nowait(_DONE)
 
     drive_task = asyncio.create_task(_drive())
@@ -523,3 +573,37 @@ async def chat(request: Request, body: ChatRequest):
         _generate(),
         media_type="application/x-ndjson",
     )
+
+
+@router.get("/api/taos-agent/status")
+async def get_status(request: Request):
+    """Return the desktop agent loop's status, scoped for the UI.
+
+    Only ``state``, ``current_turn_id``, ``queued_count`` and, per subagent,
+    ``id`` / ``task`` / ``state`` / ``started_at`` are exposed. Subagent
+    ``result`` / ``error`` payloads are deliberately stripped — they stay
+    server-side.
+    """
+    agent_loop: AgentLoop | None = getattr(request.app.state, "taos_agent_loop", None)
+    if agent_loop is None:
+        return JSONResponse({
+            "state": "idle",
+            "current_turn_id": None,
+            "queued_count": 0,
+            "subagents": [],
+        })
+    full = agent_loop.status()
+    return JSONResponse({
+        "state": full["state"],
+        "current_turn_id": full["current_turn_id"],
+        "queued_count": full["queued_count"],
+        "subagents": [
+            {
+                "id": s["id"],
+                "task": s["task"],
+                "state": s["state"],
+                "started_at": s["started_at"],
+            }
+            for s in full["subagents"]
+        ],
+    })

--- a/tinyagentos/routes/taos_agent.py
+++ b/tinyagentos/routes/taos_agent.py
@@ -27,6 +27,7 @@ import json
 import logging
 import mimetypes
 import re
+import sys
 import uuid
 from pathlib import Path
 
@@ -38,6 +39,7 @@ from tinyagentos.adapters.opencode_adapter import OpenCodeAdapter, OpenCodeConfi
 from tinyagentos.agent_loop import AgentLoop, LoopAction
 from tinyagentos.opencode_runtime import OpenCodeBinaryNotFoundError
 from tinyagentos.taos_agent_runtime import ensure_taos_opencode_server
+from tinyagentos.task_utils import _create_supervised_task
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -496,8 +498,9 @@ async def chat(request: Request, body: ChatRequest):
             yield json.dumps({
                 "delta": (
                     "[The taOS agent is still working on a previous message. "
-                    "Your message has been queued and will be surfaced to the "
-                    "agent when the current turn completes.]"
+                    "Your message has been queued and will appear at the end "
+                    "of the current response; the agent does not act on it as "
+                    "its own turn, so resend it if you need a full answer.]"
                 ),
             }) + "\n"
             yield json.dumps({"done": True}) + "\n"
@@ -533,10 +536,19 @@ async def chat(request: Request, body: ChatRequest):
                 })
             queue.put_nowait(_DONE)
 
-    drive_task = asyncio.create_task(_drive())
+    # Supervised: _drive's finally is the ONLY thing standing between the
+    # agent loop's WORKING and IDLE states, so a GC'd drive task (asyncio
+    # keeps only weak refs) would wedge the desktop agent in WORKING forever.
+    # Same rationale as AgentChatRouter._acp_tasks.
+    _drive_tasks = getattr(app_state, "_background_tasks", None)
+    if _drive_tasks is None:
+        drive_task = asyncio.create_task(_drive())
+    else:
+        drive_task = _create_supervised_task(_drive(), _drive_tasks)
 
     async def _generate():
         content_frame_yielded = False
+        leftovers: list = []
         try:
             while True:
                 item = await queue.get()
@@ -560,6 +572,25 @@ async def chat(request: Request, body: ChatRequest):
                 exc = drive_task.exception()
                 if exc is not None:
                     logger.error("taos-agent: drive task raised %r", exc)
+            # The sink's early _DONE on the error path strands anything behind
+            # it in the queue - including the queued-message frames _drive's
+            # finally emits. Collect them here (drive_task has settled, so the
+            # queue is final); they are yielded AFTER this finally, which a
+            # client disconnect (GeneratorExit) naturally skips - log those so
+            # a dropped queued message is at least visible.
+            while not queue.empty():
+                item = queue.get_nowait()
+                if item is not _DONE:
+                    leftovers.append(item)
+            if leftovers and isinstance(sys.exc_info()[1], GeneratorExit):
+                logger.warning(
+                    "taos-agent: client disconnected with %d undelivered frame(s): %r",
+                    len(leftovers), leftovers,
+                )
+        for item in leftovers:
+            if "error" not in item:
+                content_frame_yielded = True
+            yield json.dumps(item) + "\n"
         if not content_frame_yielded:
             yield json.dumps({
                 "error": (


### PR DESCRIPTION
Lead design card tsk-icpt4i (design decision recorded on the card 2026-08-10: option a — AgentLoop replaces AgentChatRouter's per-agent lock; two serialization mechanisms cannot both own one agent).

## What
- **AgentChatRouter**: `_agent_locks` → per-agent `AgentLoop`. `_run_acp_turn`: QUEUED → return (turn-holder drives it); IMMEDIATE → drive, then iteratively drive the safe-point drain, each queued message keeping its own trace id. `drive_turn` failure is caught + logged and the drain still runs.
- **routes/taos_agent.py**: the desktop agent's `/chat` previously had NO serialization — two concurrent POSTs raced on the shared opencode session id. One lazy `app.state.taos_agent_loop` now owns it: concurrent POST gets a queued-notice NDJSON frame; the turn-holder surfaces queued messages in its stream tail at the safe point (full redrive deliberately out of scope, commented).
- **`GET /api/taos-agent/status`**: scoped payload only — `state`, `current_turn_id`, `queued_count`, `subagents[{id,task,state,started_at}]`. `result`/`error` deliberately stripped (card requirement).
- Design doc + both changelog fragments updated (the #2335 'not yet wired' claim is now true-by-removal).

## Wedge invariant, red-proven
`reach_safe_point()` runs in `finally` on both paths — a raise that skips it wedges the loop in WORKING forever and the agent goes permanently silent. Proof: mutating `_run_acp_turn` to the no-except/no-finally shape fails exactly the two wedge-gate tests (`2 failed`); restored, `141 passed` across the loop/router/endpoint suites, zero skips.

## Sink change to review
The chat sink's `final` branch no longer enqueues `_DONE`; `_drive`'s `finally` owns stream termination so queued-message frames can land before it. `error` keeps its early `_DONE` (fast-fail preserved; queued surfacing best-effort on that path).

Known limitation (commented in code): a queued desktop message surfaces text only — attachments of a queued POST are not carried.