### PR TITLE
context_window is inert repo-wide: AppManifest has no such field, every manifest value is silently dropped

### DIFF
--- a/changelog.d/tsk-ppgpln-context-window.md
+++ b/changelog.d/tsk-ppgpln-context-window.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Catalog manifests' `context_window` was silently dropped**: `AppManifest`
+  declared no `context_window` field and `from_dict` never read the YAML
+  value, so every manifest loaded as 0 and the chat context-window budget code
+  always fell back to the 4000-token "unknown window" default. The field now
+  loads onto `AppManifest` (0 reserved for unknown), so real windows — e.g.
+  rkllm 4096, qwen 32768 — drive the #1740 budget math. (#2338, #1740)

--- a/tests/test_chat_context_window.py
+++ b/tests/test_chat_context_window.py
@@ -30,6 +30,31 @@ def test_history_token_budget_floored_at_512():
     assert history_token_budget(1) == 512
 
 
+def test_history_token_budget_known_small_rkllm_window():
+    # rkllm manifests (e.g. qwen2.5-1.5b-rkllm) declare 4096. 4096 - 10000
+    # system reserve - 1024 response reserve underflows, so the 512 floor
+    # applies rather than the 4000 unknown-default (#1740).
+    assert history_token_budget(4096) == 512
+
+
+def test_build_context_window_budgets_for_known_small_window():
+    # With a 4096-token model the history budget is only 512 tokens, so a
+    # window of chatty messages must be trimmed hard and oldest-first, never
+    # exceeding that small budget (the #1740 budget math with a real value).
+    budget = history_token_budget(4096)
+    assert budget == 512
+
+    message = "x" * 400  # 100 tokens per message
+    msgs = [_msg("user", message) for _ in range(20)]  # 2000 tokens total
+    ctx = build_context_window(msgs, limit=20, max_tokens=budget)
+
+    total = sum(estimate_tokens(m["content"]) for m in ctx)
+    assert total <= budget
+    assert len(ctx) < 20
+    # Oldest dropped first -> the kept set is a contiguous suffix.
+    assert [m["content"] for m in ctx] == [message] * len(ctx)
+
+
 def test_history_token_budget_large_window_subtracts_reserves():
     # 32768 - 10000 - 1024 = 21744
     assert history_token_budget(32768) == 21744

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -106,6 +106,29 @@ class TestAppManifest:
         assert m.weights_license == "CC-BY-NC 4.0"
         assert m.license_class == "non-commercial"
 
+    def test_context_window_survives_when_present(self, tmp_path):
+        """A model manifest declaring ``context_window`` must surface it on the
+        loaded AppManifest object, not silently drop it to 0 (#1740 loader bug)."""
+        d = tmp_path / "models" / "rkllm-model"
+        d.mkdir(parents=True)
+        (d / "manifest.yaml").write_text(yaml.dump({
+            "id": "rkllm-model",
+            "name": "RKLLM Model",
+            "type": "model",
+            "version": "1.0.0",
+            "variants": [{"id": "w8a8", "format": "rkllm", "size_mb": 2040,
+                          "download_url": "https://example.com/x.rkllm"}],
+            "context_window": 4096,
+        }))
+        m = AppManifest.from_file(d / "manifest.yaml")
+        assert m.context_window == 4096
+
+    def test_context_window_defaults_to_zero_when_absent(self, catalog_dir):
+        """A manifest without ``context_window`` (e.g. a service) must report 0,
+        preserving the unknown-window semantics consumers rely on."""
+        m = AppManifest.from_file(catalog_dir / "services" / "gitea" / "manifest.yaml")
+        assert m.context_window == 0
+
 
 class TestAppRegistry:
     def test_load_catalog(self, registry):

--- a/tinyagentos/registry.py
+++ b/tinyagentos/registry.py
@@ -47,6 +47,7 @@ class AppManifest:
     hardware_tiers: dict = field(default_factory=dict)
     config_schema: list = field(default_factory=list)
     variants: list = field(default_factory=list)   # models only
+    context_window: int = 0                        # model token context window; 0 = unknown
     capabilities: list = field(default_factory=list)
     lifecycle: dict = field(default_factory=dict)
     manifest_dir: Path | None = None
@@ -75,6 +76,7 @@ class AppManifest:
             hardware_tiers=data.get("hardware_tiers", {}),
             config_schema=data.get("config_schema", []),
             variants=data.get("variants", []),
+            context_window=data.get("context_window", 0),
             capabilities=data.get("capabilities", []),
             lifecycle=data.get("lifecycle", {}),
             manifest_dir=manifest_dir,


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): context_window is inert repo-wide: AppManifest has no such field, every manifest value is silently dropped

Autonomous build of board card tsk-ppgpln.

AppManifest declared no context_window field and from_dict never read the
YAML value, so every catalog manifest loaded as 0. All consumers read it
via getattr(manifest, "context_window", 0), so the chat context-window
budget code (routes/store.py, routes/store_install.py, routes/taosmd.py,
agent_chat_router.py, routes/agents.py, chat/reactions.py) always hit the
4000-token "unknown window" fallback.

Add context_window: int = 0 to AppManifest (0 == unknown, preserving the
existing getattr fallback semantics) and wire it into from_dict. Real windows
now flow into history_token_budget, which floors tiny windows (e.g. rkllm
4096 -> 512) instead of defaulting to 4000.

Tests (red-first): a manifest declaring context_window=4096 loads onto
AppManifest; a manifest without it defaults to 0. Plus a build_context_window
budget test for a known small 4096-token window, asserting oldest-first
trimming under the resulting 512-token budget.

#2338, #1740

Files:
 changelog.d/tsk-ppgpln-context-window.md |  8 ++++++++
 tests/test_chat_context_window.py        | 25 +++++++++++++++++++++++++
 tests/test_registry.py                   | 23 +++++++++++++++++++++++
 tinyagentos/registry.py                  |  2 ++
 4 files changed, 58 insertions(+)