### PR TITLE
Quarantine audit trail records a false from_status; claimable route undocumented

### DIFF
--- a/docs/agent-coordination.md
+++ b/docs/agent-coordination.md
@@ -229,6 +229,11 @@ The surface, by scope:
   `POST .../tasks/{id}/(claim|release|close|reopen)`, and
   `GET /api/projects/tasks/{id}/context`. This is read + lifecycle + comments
   only. Granting project_tasks also makes the agent a project member.
+  `POST .../tasks/{id}/claimable` is also reachable, but LEAD-only: the
+  route (`_authorize_project_lead`) refuses a plain project_tasks worker.
+  It toggles only the `claimable` label (the fleet-pickup flag), preserving
+  every other label, so it does not widen the scope into free field edits
+  (cf. PATCH).
   `POST .../tasks/{id}/unquarantine` is also reachable, but LEAD-only: the
   route (`_authorize_project_lead`) refuses a plain project_tasks worker.
   It returns a quarantined card to the open pool and clears its strikes.

--- a/tests/test_task_store.py
+++ b/tests/test_task_store.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from tinyagentos.board_audit import BoardAuditLog
 from tinyagentos.projects import task_store as task_store_mod
 from tinyagentos.projects.task_store import ProjectTaskStore
 
@@ -599,3 +600,23 @@ async def test_no_broker_no_error(tmp_path):
     await s.claim_task(task["id"], "worker-1")
     await s.close_task(task["id"], "worker-1")
     await s.close()
+
+
+@pytest.mark.asyncio
+async def test_quarantine_claimed_task_records_actual_from_status(tmp_path):
+    audit = BoardAuditLog(tmp_path / "audit.db")
+    await audit.init()
+    s = ProjectTaskStore(tmp_path / "tasks.db", audit=audit)
+    await s.init()
+    try:
+        task = await s.create_task("prj-1", "Task", "alice")
+        await s.claim_task(task["id"], "worker-1")
+        ok = await s.quarantine_task(task["id"], "system")
+        assert ok is True
+        history = await audit.history(task["id"])
+        quarantined = [h for h in history if h["event"] == "task.quarantined"]
+        assert len(quarantined) == 1
+        assert quarantined[0]["from_status"] == "claimed"
+    finally:
+        await s.close()
+        await audit.close()

--- a/tinyagentos/projects/task_store.py
+++ b/tinyagentos/projects/task_store.py
@@ -446,8 +446,13 @@ class ProjectTaskStore(BaseStore):
                     "task.quarantined",
                     {"id": task_id, "actor": actor},
                 )
+            # Derive the pre-quarantine status race-free from the committed row
+            # rather than a separate pre-read (which would have a TOCTOU gap).
+            # quarantine does not clear claimed_by, so a set claimer means it was
+            # 'claimed' (cf. close_task's derivation).
+            from_status = "claimed" if existing and existing.get("claimed_by") else "open"
             await self._record_audit(
-                task_id, "task.quarantined", actor, "open", "quarantined",
+                task_id, "task.quarantined", actor, from_status, "quarantined",
                 project_id=existing["project_id"] if existing else "",
             )
         return changed


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Quarantine audit trail records a false from_status; claimable route undocumented

Autonomous build of board card tsk-dtanmd.

quarantine_task hardcoded from_status="open" in _record_audit, but its
WHERE clause permits quarantining a claimed card, so the audit trail logged
a false "open to quarantined" transition for claimed cards. Mirror
close_task's race-free derivation from the committed row's claimed_by so
the audit records the true pre-quarantine status. Add a test that
quarantines a claimed task and asserts from_status == "claimed".

Also document the LEAD-only mark-task-claimable route (POST
.../tasks/{id}/claimable) in the project_tasks scope bullet of
docs/agent-coordination.md -- it was allowlisted in auth_middleware.py
but never documented, unlike the unquarantine route added with the
strike-store wiring.

Files:
 docs/agent-coordination.md         |  5 +++++
 tests/test_task_store.py           | 21 +++++++++++++++++++++
 tinyagentos/projects/task_store.py |  7 ++++++-
 3 files changed, 32 insertions(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task quarantine audit records now accurately reflect whether the task was previously claimed or open.

* **Documentation**
  * Documented the lead-only endpoint for toggling a task’s claimable status.
  * Clarified access restrictions and label-change behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->