### PR TITLE
Chat migration S1: exporter + transformer for taOS chat -> bus (#2150)

### DIFF
--- a/tests/test_chat_exporter.py
+++ b/tests/test_chat_exporter.py
@@ -1,0 +1,440 @@
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from tinyagentos.chat.chat_exporter import ChatExportError, ChatExporter, flatten_body
+from tinyagentos.chat.message_store import ChatMessageStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def store(tmp_path):
+    s = ChatMessageStore(tmp_path / "chat.db")
+    await s.init()
+    yield s
+    await s.close()
+
+
+def _make_file_writer(root: Path):
+    async def writer(source_id: str, content: bytes) -> str:
+        dest = root / "chat-export" / f"{source_id}.txt"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(content)
+        return f"chat-export/{source_id}.txt"
+
+    return writer
+
+
+def _identity_map(user_ids: list[str], agent_ids: list[str] | None = None) -> dict[str, str]:
+    m: dict[str, str] = {}
+    for uid in user_ids:
+        m[uid] = f"@{uid}"
+    for aid in (agent_ids or []):
+        m[aid] = f"@{aid}"
+    return m
+
+
+# ---------------------------------------------------------------------------
+# flatten_body unit tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_flatten_empty_blocks():
+    assert flatten_body([]) == ""
+    assert flatten_body(None) == ""
+
+
+@pytest.mark.asyncio
+async def test_flatten_text_blocks():
+    blocks = [
+        {"type": "paragraph", "text": "Hello"},
+        {"type": "code", "lang": "py", "text": "print(1)"},
+    ]
+    assert flatten_body(blocks) == "Hello\nprint(1)"
+
+
+@pytest.mark.asyncio
+async def test_flatten_skips_empty_text():
+    blocks = [
+        {"type": "paragraph", "text": "Hello"},
+        {"type": "image", "url": "http://x/img.png"},
+        {"type": "paragraph", "text": ""},
+    ]
+    assert flatten_body(blocks) == "Hello"
+
+
+# ---------------------------------------------------------------------------
+# Exporter integration tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_export_channel_produces_valid_batch(store, tmp_path):
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="hello",
+        content_blocks=[{"type": "paragraph", "text": "hello"}],
+    )
+    await store.send_message(
+        channel_id="ch1",
+        author_id="agent-1",
+        author_type="agent",
+        content="hi",
+        content_blocks=[{"type": "paragraph", "text": "hi"}],
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"], ["agent-1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+
+    assert len(batch) == 2
+    for env in batch:
+        assert env["from"]
+        assert env["thread"] == "ch1"
+        assert env["ts"] > 0
+        assert env["source"] == "taos-chat"
+        assert env["source_id"]
+        assert isinstance(env["blocks"], list)
+
+
+@pytest.mark.asyncio
+async def test_every_message_has_non_empty_body(store):
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="",
+        content_blocks=[{"type": "paragraph", "text": "blocks present"}],
+    )
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="plain text",
+        content_blocks=[],
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    assert len(batch) == 2
+    for env in batch:
+        assert env["body"] != ""
+
+
+@pytest.mark.asyncio
+async def test_unmapped_author_fails_whole_batch(store):
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="first",
+    )
+    await store.send_message(
+        channel_id="ch1",
+        author_id="unknown-user",
+        author_type="user",
+        content="second",
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    with pytest.raises(ChatExportError, match="unmapped author_id 'unknown-user'"):
+        await exporter.export_channel("ch1")
+
+
+@pytest.mark.asyncio
+async def test_reexport_produces_byte_identical_output(store, tmp_path):
+    for i in range(3):
+        await store.send_message(
+            channel_id="ch1",
+            author_id="user1",
+            author_type="user",
+            content=f"msg{i}",
+            content_blocks=[{"type": "paragraph", "text": f"msg{i}"}],
+        )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch1 = await exporter.export_channel("ch1")
+    batch2 = await exporter.export_channel("ch1")
+
+    assert json.dumps(batch1, sort_keys=True, ensure_ascii=False) == json.dumps(
+        batch2, sort_keys=True, ensure_ascii=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_oversized_content_becomes_ref(store, tmp_path):
+    big_text = "x" * 100_000
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content=big_text,
+        content_blocks=[{"type": "paragraph", "text": big_text}],
+    )
+
+    writer = _make_file_writer(tmp_path)
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+        file_writer=writer,
+    )
+    batch = await exporter.export_channel("ch1")
+    assert len(batch) == 1
+    env = batch[0]
+    assert env["blocks"] == []
+    assert "chat-export/" in env["body"]
+    assert env["body"].endswith(".txt")
+    written = (tmp_path / env["body"]).read_bytes()
+    assert written.decode("utf-8") == big_text
+
+
+@pytest.mark.asyncio
+async def test_thread_ordering_preserved(store):
+    ts = time.time()
+    for i in range(3):
+        await store.send_message(
+            channel_id="ch1",
+            author_id="user1",
+            author_type="user",
+            content=f"msg{i}",
+            content_blocks=[{"type": "paragraph", "text": f"msg{i}"}],
+        )
+        await store._db.execute(
+            "UPDATE chat_messages SET created_at = ? WHERE id = (SELECT id FROM chat_messages ORDER BY created_at DESC LIMIT 1)",
+            (ts,),
+        )
+        await store._db.commit()
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch1 = await exporter.export_channel("ch1")
+    batch2 = await exporter.export_channel("ch1")
+    ids1 = [e["source_id"] for e in batch1]
+    ids2 = [e["source_id"] for e in batch2]
+    assert ids1 == ids2
+    assert len(ids1) == 3
+
+
+@pytest.mark.asyncio
+async def test_reply_to_relationships_preserved(store):
+    parent = await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="parent",
+        content_blocks=[{"type": "paragraph", "text": "parent"}],
+    )
+    reply = await store.send_message(
+        channel_id="ch1",
+        author_id="user2",
+        author_type="user",
+        content="reply",
+        content_blocks=[{"type": "paragraph", "text": "reply"}],
+        thread_id=parent["id"],
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1", "user2"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    reply_env = next(e for e in batch if e["source_id"] == reply["id"])
+    assert reply_env.get("reply_to") == parent["id"]
+    parent_env = next(e for e in batch if e["source_id"] == parent["id"])
+    assert "reply_to" not in parent_env
+
+
+@pytest.mark.asyncio
+async def test_deleted_parent_omits_reply_to(store):
+    parent = await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="parent",
+        content_blocks=[{"type": "paragraph", "text": "parent"}],
+    )
+    await store.soft_delete_message(parent["id"])
+    reply = await store.send_message(
+        channel_id="ch1",
+        author_id="user2",
+        author_type="user",
+        content="reply",
+        content_blocks=[{"type": "paragraph", "text": "reply"}],
+        thread_id=parent["id"],
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1", "user2"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    reply_env = next(e for e in batch if e["source_id"] == reply["id"])
+    assert "reply_to" not in reply_env
+
+
+@pytest.mark.asyncio
+async def test_export_all_channels(store):
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="ch1-msg",
+        content_blocks=[{"type": "paragraph", "text": "ch1-msg"}],
+    )
+    await store.send_message(
+        channel_id="ch2",
+        author_id="user1",
+        author_type="user",
+        content="ch2-msg",
+        content_blocks=[{"type": "paragraph", "text": "ch2-msg"}],
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_all_channels(["ch1", "ch2"])
+    assert len(batch) == 2
+    threads = {e["thread"] for e in batch}
+    assert threads == {"ch1", "ch2"}
+
+
+@pytest.mark.asyncio
+async def test_blocks_preserved_in_envelope(store):
+    blocks = [
+        {"type": "paragraph", "text": "line1"},
+        {"type": "code", "lang": "python", "text": "print(1)"},
+    ]
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="line1\nprint(1)",
+        content_blocks=blocks,
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    assert batch[0]["blocks"] == blocks
+
+
+@pytest.mark.asyncio
+async def test_ts_preserved(store):
+    msg = await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="hello",
+        content_blocks=[{"type": "paragraph", "text": "hello"}],
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    assert batch[0]["ts"] == msg["created_at"]
+
+
+@pytest.mark.asyncio
+async def test_source_id_is_original_message_id(store):
+    msg = await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="hello",
+        content_blocks=[{"type": "paragraph", "text": "hello"}],
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    assert batch[0]["source_id"] == msg["id"]
+
+
+@pytest.mark.asyncio
+async def test_custom_source_identifier(store):
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+        source="my-custom-source",
+    )
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="hello",
+        content_blocks=[{"type": "paragraph", "text": "hello"}],
+    )
+    batch = await exporter.export_channel("ch1")
+    assert batch[0]["source"] == "my-custom-source"
+
+
+@pytest.mark.asyncio
+async def test_empty_body_when_no_content(store):
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="",
+        content_blocks=[],
+    )
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    assert batch[0]["body"] == ""
+
+
+@pytest.mark.asyncio
+async def test_file_writer_receives_utf8_body(store, tmp_path):
+    text = "héllo wörld " * 10_000
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content=text,
+        content_blocks=[{"type": "paragraph", "text": text}],
+    )
+
+    writer = _make_file_writer(tmp_path)
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+        file_writer=writer,
+    )
+    batch = await exporter.export_channel("ch1")
+    ref = batch[0]["body"]
+    assert ref.startswith("chat-export/")
+    assert ref.endswith(".txt")
+    written = (tmp_path / ref).read_bytes()
+    assert written.decode("utf-8") == text

--- a/tests/test_chat_exporter.py
+++ b/tests/test_chat_exporter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import time
 from pathlib import Path
 
@@ -63,12 +64,15 @@ async def test_flatten_text_blocks():
 
 @pytest.mark.asyncio
 async def test_flatten_skips_empty_text():
+    # Updated for card rule 3: a non-text block (image) no longer vanishes
+    # silently — it flattens to a descriptive placeholder. An empty-text
+    # text-type block still contributes nothing.
     blocks = [
         {"type": "paragraph", "text": "Hello"},
         {"type": "image", "url": "http://x/img.png"},
         {"type": "paragraph", "text": ""},
     ]
-    assert flatten_body(blocks) == "Hello"
+    assert flatten_body(blocks) == "Hello\n[image: http://x/img.png]"
 
 
 # ---------------------------------------------------------------------------
@@ -183,13 +187,19 @@ async def test_reexport_produces_byte_identical_output(store, tmp_path):
 
 @pytest.mark.asyncio
 async def test_oversized_content_becomes_ref(store, tmp_path):
+    # Updated for card rule 5: the oversized envelope's blocks are no
+    # longer destroyed. The full original envelope (blocks intact) is
+    # written through file_writer, and the emitted body keeps the
+    # (possibly truncated) flattened text plus a note carrying the ref,
+    # rather than the body being replaced by the bare ref.
     big_text = "x" * 100_000
+    blocks = [{"type": "paragraph", "text": big_text}]
     await store.send_message(
         channel_id="ch1",
         author_id="user1",
         author_type="user",
         content=big_text,
-        content_blocks=[{"type": "paragraph", "text": big_text}],
+        content_blocks=blocks,
     )
 
     writer = _make_file_writer(tmp_path)
@@ -202,10 +212,13 @@ async def test_oversized_content_becomes_ref(store, tmp_path):
     assert len(batch) == 1
     env = batch[0]
     assert env["blocks"] == []
-    assert "chat-export/" in env["body"]
-    assert env["body"].endswith(".txt")
-    written = (tmp_path / env["body"]).read_bytes()
-    assert written.decode("utf-8") == big_text
+    ref_match = re.search(r"chat-export/[^\s\]]+\.txt", env["body"])
+    assert ref_match, f"no ref found in body: {env['body']!r}"
+    assert env["body"].endswith(f"[oversized content exported to: {ref_match.group(0)}]")
+    written = (tmp_path / ref_match.group(0)).read_bytes()
+    full_envelope = json.loads(written.decode("utf-8"))
+    assert full_envelope["blocks"] == blocks
+    assert full_envelope["body"] == big_text
 
 
 @pytest.mark.asyncio
@@ -398,6 +411,49 @@ async def test_custom_source_identifier(store):
 
 
 @pytest.mark.asyncio
+async def test_dropped_fields_are_not_exported(store):
+    """Card rule 5 (documented drops): a message carrying content_type,
+    embeds, components, attachments, reactions, metadata, edited_at,
+    pinned, ephemeral, expires_at, and a non-default author_type still
+    exports cleanly, with the envelope carrying only the agreed fields."""
+    msg = await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="agent",
+        content="hello",
+        content_type="markdown",
+        content_blocks=[{"type": "paragraph", "text": "hello"}],
+        embeds=[{"kind": "link"}],
+        components=[{"kind": "button"}],
+        attachments=[{"filename": "x.png"}],
+        metadata={"secret": "do-not-export"},
+        expires_at=time.time() + 1000,
+    )
+    await store.pin_message("ch1", msg["id"], pinned_by="user1")
+    await store.edit_message(msg["id"], "hello edited")
+    await store.add_reaction(msg["id"], "\U0001F44D", "user1")
+
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    assert len(batch) == 1
+    env = batch[0]
+    allowed_keys = {
+        "from", "thread", "body", "blocks", "ts", "source", "source_id",
+        "reply_to",
+    }
+    assert set(env.keys()) <= allowed_keys
+    for dropped in (
+        "content_type", "embeds", "components", "attachments", "reactions",
+        "metadata", "edited_at", "pinned", "ephemeral", "expires_at",
+        "author_type",
+    ):
+        assert dropped not in env
+
+
+@pytest.mark.asyncio
 async def test_empty_body_when_no_content(store):
     await store.send_message(
         channel_id="ch1",
@@ -433,8 +489,133 @@ async def test_file_writer_receives_utf8_body(store, tmp_path):
         file_writer=writer,
     )
     batch = await exporter.export_channel("ch1")
-    ref = batch[0]["body"]
-    assert ref.startswith("chat-export/")
-    assert ref.endswith(".txt")
-    written = (tmp_path / ref).read_bytes()
-    assert written.decode("utf-8") == text
+    body = batch[0]["body"]
+    ref_match = re.search(r"chat-export/[^\s\]]+\.txt", body)
+    assert ref_match, f"no ref found in body: {body!r}"
+    written = (tmp_path / ref_match.group(0)).read_bytes()
+    full_envelope = json.loads(written.decode("utf-8"))
+    assert full_envelope["body"] == text
+
+
+# ---------------------------------------------------------------------------
+# RED-FIRST proof tests for fix batch (card tsk-yfy5j5).
+# Each test below reproduces one of the 4 blockers found in review; they are
+# written and run against the UNFIXED source first (captured in
+# REDPROOF.txt), then the source is fixed until these go green.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_oversize_message_preserves_blocks_via_ref(store, tmp_path):
+    """Card rule 5: an oversized message must not silently drop its blocks.
+    The full original envelope (blocks intact) is written through
+    file_writer, and the emitted body carries a reference to it."""
+    big_text = "x" * 100_000
+    blocks = [
+        {"type": "paragraph", "text": big_text},
+        {"type": "image", "url": "http://x/big.png"},
+    ]
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content=big_text,
+        content_blocks=blocks,
+    )
+    writer = _make_file_writer(tmp_path)
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+        file_writer=writer,
+    )
+    batch = await exporter.export_channel("ch1")
+    env = batch[0]
+    assert env["blocks"] == []
+    ref_match = re.search(r"chat-export/[^\s\]]+\.txt", env["body"])
+    assert ref_match, f"no ref found in body: {env['body']!r}"
+    written = (tmp_path / ref_match.group(0)).read_text()
+    full_envelope = json.loads(written)
+    assert full_envelope["blocks"] == blocks
+    assert full_envelope["body"] == flatten_body(blocks)
+
+
+@pytest.mark.asyncio
+async def test_image_only_message_exports_with_placeholder_body(store):
+    """Card rule 3: a non-text (e.g. image) block must flatten to a
+    descriptive placeholder, never brick the whole channel export."""
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="",
+        content_blocks=[{"type": "image", "url": "http://x/img.png"}],
+    )
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    assert len(batch) == 1
+    assert batch[0]["body"] == "[image: http://x/img.png]"
+
+
+@pytest.mark.asyncio
+async def test_streaming_message_excluded_from_export(store):
+    """A message whose state is 'streaming' (or 'error') is not authentic
+    history and must be excluded, the same way deleted messages are."""
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="agent",
+        content="",
+        content_blocks=[{"type": "paragraph", "text": "partial"}],
+        state="streaming",
+    )
+    await store.send_message(
+        channel_id="ch1",
+        author_id="user1",
+        author_type="user",
+        content="done",
+        content_blocks=[{"type": "paragraph", "text": "done"}],
+        state="complete",
+    )
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    assert len(batch) == 1
+    assert batch[0]["body"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_same_timestamp_reply_sorts_after_parent(store):
+    """Card rule 7: sort key (created_at, id) with random ids can put a
+    reply before its parent on a timestamp tie. Ids are chosen so the
+    naive sort gets it wrong (\"a-reply\" < \"z-parent\" lexically)."""
+    ts = time.time()
+    await store.ensure_message({
+        "id": "z-parent",
+        "channel_id": "ch1",
+        "author_id": "user1",
+        "author_type": "user",
+        "content": "parent",
+        "content_blocks": [{"type": "paragraph", "text": "parent"}],
+        "created_at": ts,
+    })
+    await store.ensure_message({
+        "id": "a-reply",
+        "channel_id": "ch1",
+        "thread_id": "z-parent",
+        "author_id": "user1",
+        "author_type": "user",
+        "content": "reply",
+        "content_blocks": [{"type": "paragraph", "text": "reply"}],
+        "created_at": ts,
+    })
+    exporter = ChatExporter(
+        message_store=store,
+        identity_map=_identity_map(["user1"]),
+    )
+    batch = await exporter.export_channel("ch1")
+    ids = [e["source_id"] for e in batch]
+    assert ids.index("z-parent") < ids.index("a-reply")

--- a/tinyagentos/chat/chat_exporter.py
+++ b/tinyagentos/chat/chat_exporter.py
@@ -1,7 +1,18 @@
+"""Chat message exporter: transforms ChatMessageStore rows into A2A bus
+import-batch envelopes.
+
+DROPPED FIELDS: the following ``chat_messages`` columns (and the
+``chat_attachments`` table) are intentionally NOT carried into the export
+envelope — they live outside the agreed bus envelope by design:
+content_type, embeds, components, attachments (+ chat_attachments table),
+reactions, metadata, edited_at, pinned, ephemeral, expires_at, author_type.
+Only ``from``, ``thread``, ``body``, ``blocks``, ``ts``, ``source``,
+``source_id``, and (when applicable) ``reply_to`` are exported.
+"""
+
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any, Awaitable, Callable
 
 _MAX_MESSAGE_BYTES = 64 * 1024
@@ -13,22 +24,84 @@ class ChatExportError(Exception):
 
 
 def flatten_body(blocks: list[dict] | None) -> str:
-    """Flatten content blocks to plain text."""
+    """Flatten content blocks to plain text.
+
+    Blocks carrying a ``text`` key flatten as text (empty text contributes
+    nothing, same as before). Blocks without a ``text`` key (images, files,
+    and other non-text blocks) flatten to a descriptive placeholder built
+    from their type plus the most useful identifying field present, so a
+    non-text block never silently disappears or bricks the export.
+    """
     if not blocks:
         return ""
     parts = []
     for block in blocks:
         if isinstance(block, dict):
-            text = block.get("text") or block.get("content") or ""
-            if text:
-                parts.append(str(text))
+            if "text" in block:
+                text = block.get("text") or ""
+                if text:
+                    parts.append(str(text))
+                continue
+            block_type = block.get("type") or "block"
+            identifier = (
+                block.get("url") or block.get("name") or block.get("filename")
+            )
+            if identifier:
+                parts.append(f"[{block_type}: {identifier}]")
+            else:
+                parts.append(f"[{block_type} block]")
         elif isinstance(block, str):
-            parts.append(block)
+            if block:
+                parts.append(block)
     return "\n".join(parts)
 
 
 def _serialized_size(envelope: dict) -> int:
     return len(json.dumps(envelope, ensure_ascii=False).encode("utf-8"))
+
+
+def _causal_tiebreak(group: list[dict]) -> list[dict]:
+    """Stable topological sort of a same-timestamp group of messages: a
+    message replying (via ``thread_id``) to another message in the same
+    group is ordered after that parent. Messages with no such relationship
+    keep their original (already created_at/id sorted) relative order."""
+    ids = {m.get("id") for m in group}
+    indegree = {m.get("id"): 0 for m in group}
+    children: dict[Any, list[dict]] = {m.get("id"): [] for m in group}
+    for m in group:
+        parent_id = m.get("thread_id")
+        if parent_id in ids:
+            children[parent_id].append(m)
+            indegree[m.get("id")] += 1
+
+    ready = [m for m in group if indegree[m.get("id")] == 0]
+    ordered: list[dict] = []
+    while ready:
+        m = ready.pop(0)
+        ordered.append(m)
+        for child in children[m.get("id")]:
+            indegree[child.get("id")] -= 1
+            if indegree[child.get("id")] == 0:
+                ready.append(child)
+    return ordered
+
+
+def _sort_with_causality(messages: list[dict]) -> list[dict]:
+    """Sort by (created_at, id) then run a same-timestamp causality pass so
+    a reply never precedes its parent within an equal-timestamp group."""
+    messages = sorted(
+        messages, key=lambda m: (m.get("created_at") or 0.0, m.get("id") or "")
+    )
+    result: list[dict] = []
+    i, n = 0, len(messages)
+    while i < n:
+        j = i
+        ts = messages[i].get("created_at") or 0.0
+        while j < n and (messages[j].get("created_at") or 0.0) == ts:
+            j += 1
+        result.extend(_causal_tiebreak(messages[i:j]))
+        i = j
+    return result
 
 
 class ChatExporter:
@@ -56,17 +129,21 @@ class ChatExporter:
         self._file_writer = file_writer
 
     async def export_channel(self, channel_id: str) -> list[dict]:
-        """Export all non-deleted messages from a channel.
+        """Export all non-deleted, complete messages from a channel.
 
-        Returns envelopes ordered by (created_at ASC, id ASC) for
-        deterministic, reproducible output.  Raises ChatExportError if any
-        author_id is unmapped.
+        Returns envelopes ordered by (created_at ASC, id ASC), with a
+        same-timestamp causality pass so a reply never precedes its parent,
+        for deterministic, reproducible output.  Raises ChatExportError if
+        any author_id is unmapped.
         """
         messages = await self._msg_store.get_all_messages_for_channel(channel_id)
-        messages = [m for m in messages if m.get("deleted_at") is None]
-        messages.sort(
-            key=lambda m: (m.get("created_at") or 0.0, m.get("id") or "")
-        )
+        messages = [
+            m
+            for m in messages
+            if m.get("deleted_at") is None
+            and m.get("state") in (None, "complete")
+        ]
+        messages = _sort_with_causality(messages)
 
         batch: list[dict] = []
         exported_ids: set[str] = set()
@@ -128,8 +205,27 @@ class ChatExporter:
                     f"message {source_id!r} exceeds {self._max_message_bytes} bytes "
                     f"and no file_writer configured"
                 )
-            ref = await self._file_writer(source_id, body.encode("utf-8"))
-            envelope["body"] = ref
+            # Preserve the full original envelope (blocks intact) out-of-band
+            # rather than destroying it — oversize is usually caused by the
+            # blocks that would otherwise be dropped.
+            full_bytes = json.dumps(envelope, ensure_ascii=False).encode("utf-8")
+            ref = await self._file_writer(source_id, full_bytes)
+
+            emitted_body = body
+            body_bytes = emitted_body.encode("utf-8")
+            if len(body_bytes) > self._max_message_bytes:
+                truncate_note = "... [truncated]"
+                budget = max(
+                    self._max_message_bytes - len(truncate_note.encode("utf-8")), 0
+                )
+                emitted_body = (
+                    body_bytes[:budget].decode("utf-8", errors="ignore")
+                    + truncate_note
+                )
+
+            envelope["body"] = (
+                f"{emitted_body}\n[oversized content exported to: {ref}]"
+            )
             envelope["blocks"] = []
 
         return envelope

--- a/tinyagentos/chat/chat_exporter.py
+++ b/tinyagentos/chat/chat_exporter.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+_MAX_MESSAGE_BYTES = 64 * 1024
+_DEFAULT_SOURCE = "taos-chat"
+
+
+class ChatExportError(Exception):
+    """Raised when a batch cannot be exported."""
+
+
+def flatten_body(blocks: list[dict] | None) -> str:
+    """Flatten content blocks to plain text."""
+    if not blocks:
+        return ""
+    parts = []
+    for block in blocks:
+        if isinstance(block, dict):
+            text = block.get("text") or block.get("content") or ""
+            if text:
+                parts.append(str(text))
+        elif isinstance(block, str):
+            parts.append(block)
+    return "\n".join(parts)
+
+
+def _serialized_size(envelope: dict) -> int:
+    return len(json.dumps(envelope, ensure_ascii=False).encode("utf-8"))
+
+
+class ChatExporter:
+    """Export chat messages to A2A bus import batches.
+
+    Reads messages from a ChatMessageStore and transforms them into the
+    envelope format expected by the taOSmd bus import endpoint.
+
+    Identity mapping is explicit: every author_id in the batch must have a
+    corresponding handle in identity_map, or the whole batch fails.
+    """
+
+    def __init__(
+        self,
+        message_store: Any,
+        identity_map: dict[str, str],
+        source: str = _DEFAULT_SOURCE,
+        max_message_bytes: int = _MAX_MESSAGE_BYTES,
+        file_writer: Callable[[str, bytes], Awaitable[str]] | None = None,
+    ) -> None:
+        self._msg_store = message_store
+        self._identity_map = dict(identity_map)
+        self._source = source
+        self._max_message_bytes = max_message_bytes
+        self._file_writer = file_writer
+
+    async def export_channel(self, channel_id: str) -> list[dict]:
+        """Export all non-deleted messages from a channel.
+
+        Returns envelopes ordered by (created_at ASC, id ASC) for
+        deterministic, reproducible output.  Raises ChatExportError if any
+        author_id is unmapped.
+        """
+        messages = await self._msg_store.get_all_messages_for_channel(channel_id)
+        messages = [m for m in messages if m.get("deleted_at") is None]
+        messages.sort(
+            key=lambda m: (m.get("created_at") or 0.0, m.get("id") or "")
+        )
+
+        batch: list[dict] = []
+        exported_ids: set[str] = set()
+
+        for msg in messages:
+            envelope = await self._transform_message(msg)
+            batch.append(envelope)
+            exported_ids.add(envelope["source_id"])
+
+        for envelope in batch:
+            reply_to = envelope.get("reply_to")
+            if reply_to is not None and reply_to not in exported_ids:
+                del envelope["reply_to"]
+
+        return batch
+
+    async def _transform_message(self, msg: dict) -> dict:
+        """Transform a single chat message to a bus envelope.
+
+        Raises ChatExportError if author_id is not in identity_map.
+        """
+        author_id = msg.get("author_id", "")
+        handle = self._identity_map.get(author_id)
+        if handle is None:
+            raise ChatExportError(
+                f"unmapped author_id {author_id!r} for message {msg.get('id')!r}"
+            )
+
+        content_blocks = msg.get("content_blocks") or []
+        body = flatten_body(content_blocks)
+
+        if not body and msg.get("content"):
+            body = str(msg["content"])
+
+        if content_blocks and not body.strip():
+            raise ChatExportError(
+                f"message {msg.get('id')!r} has content_blocks but empty body"
+            )
+
+        source_id = msg.get("id", "")
+
+        envelope: dict[str, Any] = {
+            "from": handle,
+            "thread": msg.get("channel_id", ""),
+            "body": body,
+            "blocks": content_blocks,
+            "ts": msg.get("created_at", 0.0),
+            "source": self._source,
+            "source_id": source_id,
+        }
+
+        thread_id = msg.get("thread_id")
+        if thread_id:
+            envelope["reply_to"] = thread_id
+
+        if _serialized_size(envelope) > self._max_message_bytes:
+            if self._file_writer is None:
+                raise ChatExportError(
+                    f"message {source_id!r} exceeds {self._max_message_bytes} bytes "
+                    f"and no file_writer configured"
+                )
+            ref = await self._file_writer(source_id, body.encode("utf-8"))
+            envelope["body"] = ref
+            envelope["blocks"] = []
+
+        return envelope
+
+    async def export_all_channels(self, channel_ids: list[str]) -> list[dict]:
+        """Export multiple channels and concatenate the batches."""
+        batch: list[dict] = []
+        for ch_id in channel_ids:
+            batch.extend(await self.export_channel(ch_id))
+        return batch


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Chat migration S1: exporter + transformer for taOS chat -> bus (#2150)

Autonomous build of board card tsk-yfy5j5.

- ChatExporter reads ChatMessageStore and produces import-batch envelopes
- Explicit identity_map, whole-batch failure on unmapped author
- Flattened body from content_blocks, non-empty when blocks exist
- 64KB serialized limit, oversized content delegated to file_writer
- Deterministic ordering by (created_at ASC, id ASC)
- reply_to preserved for non-deleted parents, omitted for orphans
- Idempotent on (source, source_id), re-run produces byte-identical output
- 18 pytest tests covering all acceptance criteria

Files:
 tests/test_chat_exporter.py       | 440 ++++++++++++++++++++++++++++++++++++++
 tinyagentos/chat/chat_exporter.py | 142 ++++++++++++
 2 files changed, 582 insertions(+)