### PR TITLE
Alias editing UI in Agents app

### DIFF
--- a/changelog.d/2349-alias-editing.md
+++ b/changelog.d/2349-alias-editing.md
@@ -1,0 +1,6 @@
+### Added
+
+- The Agents app registry panel shows each agent's handle (alias) and lets the
+  owner or an admin edit it inline, saved via
+  `PATCH /api/agents/registry/{canonical_id}`. A leading `@` is display syntax
+  and is stripped before save (#2349).

--- a/desktop/src/apps/agents/RegistryPanel.test.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.test.tsx
@@ -608,4 +608,90 @@ describe("RegistryPanel handle editing", () => {
       { timeout: 3000 },
     );
   });
+
+  it("displays a stored @-prefixed handle with a single @ (internal seeds)", async () => {
+    const entryWithHandle: RegistryEntry = {
+      ...fakeEntry,
+      handle: "@taOS-dev",
+    };
+    vi.stubGlobal("fetch", makeFetch([entryWithHandle]));
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("@taOS-dev")).toBeInTheDocument();
+        expect(screen.queryByText("@@taOS-dev")).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it("strips a typed leading @ before PATCH (@ is bus syntax, not part of the name)", async () => {
+    const entryWithHandle: RegistryEntry = {
+      ...fakeEntry,
+      handle: "old-alias",
+    };
+    const mockFetch = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (url === "/auth/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ user: { is_admin: true, id: "user-1" } }),
+        });
+      }
+      if (url === "/api/agents/registry") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([entryWithHandle]),
+        });
+      }
+      if (typeof url === "string" && url.includes("/api/agents/registry/") && opts?.method === "PATCH") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ...entryWithHandle, handle: "new-alias" }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("@old-alias")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    const editBtn = screen.getByTitle("Edit handle");
+    await act(async () => { editBtn.click(); });
+
+    const input = screen.getByRole("textbox");
+    await act(async () => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      nativeInputValueSetter.call(input, "@new-alias");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const saveBtn = screen.getByTitle("Save handle");
+    await act(async () => { saveBtn.click(); });
+    await act(async () => { await Promise.resolve(); });
+
+    const patchCalls = mockFetch.mock.calls.filter(
+      ([url, opts]) => typeof url === "string" && url.includes("/api/agents/registry/") && (opts as RequestInit)?.method === "PATCH",
+    );
+    expect(patchCalls.length).toBe(1);
+    const body = JSON.parse((patchCalls[0][1] as RequestInit).body as string);
+    expect(body.handle).toBe("new-alias");
+  });
 });

--- a/desktop/src/apps/agents/RegistryPanel.test.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.test.tsx
@@ -353,3 +353,259 @@ describe("RegistryPanel collapsed retired", () => {
     expect(retiredPanel!).not.toHaveClass("hidden");
   }, 10_000);
 });
+
+/* ------------------------------------------------------------------ */
+/*  Handle (alias) editing UI                                           */
+/* ------------------------------------------------------------------ */
+
+describe("RegistryPanel handle editing", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows the handle text and edit button for owner/admin", async () => {
+    const entryWithHandle: RegistryEntry = {
+      ...fakeEntry,
+      handle: "my-alias",
+    };
+    vi.stubGlobal("fetch", makeFetch([entryWithHandle]));
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("@my-alias")).toBeInTheDocument();
+        expect(screen.getByTitle("Edit handle")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it("hides edit button for non-owner non-admin", async () => {
+    const entryWithHandle: RegistryEntry = {
+      ...fakeEntry,
+      handle: "my-alias",
+      user_id: "other-user",
+    };
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url === "/auth/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ user: { is_admin: false, id: "viewer-user" } }),
+        });
+      }
+      if (url === "/api/agents/registry") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([entryWithHandle]),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("@my-alias")).toBeInTheDocument();
+        expect(screen.queryByTitle("Edit handle")).not.toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  });
+
+  it("enters edit mode and saves handle via PATCH", async () => {
+    const entryWithHandle: RegistryEntry = {
+      ...fakeEntry,
+      handle: "old-alias",
+    };
+    const mockFetch = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (url === "/auth/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ user: { is_admin: true, id: "user-1" } }),
+        });
+      }
+      if (url === "/api/agents/registry") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([entryWithHandle]),
+        });
+      }
+      if (typeof url === "string" && url.includes("/api/agents/registry/") && opts?.method === "PATCH") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ ...entryWithHandle, handle: "new-alias" }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("@old-alias")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    const editBtn = screen.getByTitle("Edit handle");
+    await act(async () => { editBtn.click(); });
+
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveValue("old-alias");
+
+    await act(async () => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      nativeInputValueSetter.call(input, "new-alias");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const saveBtn = screen.getByTitle("Save handle");
+    await act(async () => { saveBtn.click(); });
+    await act(async () => { await Promise.resolve(); });
+
+    const patchCalls = mockFetch.mock.calls.filter(
+      ([url, opts]) => typeof url === "string" && url.includes("/api/agents/registry/") && (opts as RequestInit)?.method === "PATCH",
+    );
+    expect(patchCalls.length).toBeGreaterThanOrEqual(1);
+    const body = JSON.parse((patchCalls[0][1] as RequestInit).body as string);
+    expect(body.handle).toBe("new-alias");
+  });
+
+  it("shows error message when PATCH fails", async () => {
+    const entryWithHandle: RegistryEntry = {
+      ...fakeEntry,
+      handle: "old-alias",
+    };
+    const mockFetch = vi.fn().mockImplementation((url: string, opts?: RequestInit) => {
+      if (url === "/auth/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ user: { is_admin: true, id: "user-1" } }),
+        });
+      }
+      if (url === "/api/agents/registry") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([entryWithHandle]),
+        });
+      }
+      if (typeof url === "string" && url.includes("/api/agents/registry/") && opts?.method === "PATCH") {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          json: () => Promise.resolve({ error: "handle is already owned by another active agent" }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("@old-alias")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    const editBtn = screen.getByTitle("Edit handle");
+    await act(async () => { editBtn.click(); });
+
+    const input = screen.getByRole("textbox");
+    await act(async () => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      nativeInputValueSetter.call(input, "taken-alias");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const saveBtn = screen.getByTitle("Save handle");
+    await act(async () => { saveBtn.click(); });
+    await act(async () => { await Promise.resolve(); });
+
+    expect(screen.getByText("handle is already owned by another active agent")).toBeInTheDocument();
+  });
+
+  it("cancel restores original handle and exits edit mode", async () => {
+    const entryWithHandle: RegistryEntry = {
+      ...fakeEntry,
+      handle: "original",
+    };
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url === "/auth/status") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ user: { is_admin: true, id: "user-1" } }),
+        });
+      }
+      if (url === "/api/agents/registry") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([entryWithHandle]),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    render(<RegistryPanel />);
+
+    const toggle = screen.getByRole("button", { name: /agent registry/i });
+    await act(async () => { toggle.click(); });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("@original")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    const editBtn = screen.getByTitle("Edit handle");
+    await act(async () => { editBtn.click(); });
+
+    const input = screen.getByRole("textbox");
+    await act(async () => {
+      const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      nativeInputValueSetter.call(input, "modified");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const cancelBtn = screen.getByTitle("Cancel");
+    await act(async () => { cancelBtn.click(); });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("@original")).toBeInTheDocument();
+        expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+        expect(screen.getByTitle("Edit handle")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  });
+});

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -147,7 +147,7 @@ function RegistryEntryRow({
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [editingHandle, setEditingHandle] = useState(false);
-  const [handleDraft, setHandleDraft] = useState(entry.handle);
+  const [handleDraft, setHandleDraft] = useState(stripAt(entry.handle));
   const [savingHandle, setSavingHandle] = useState(false);
   const [handleErr, setHandleErr] = useState<string | null>(null);
   const isOwner = entry.user_id === currentUserId;
@@ -156,12 +156,12 @@ function RegistryEntryRow({
   const canAssign = (isAdmin || isOwner) && entry.status === "active";
 
   useEffect(() => {
-    setHandleDraft(entry.handle);
+    setHandleDraft(stripAt(entry.handle));
   }, [entry.handle]);
 
   async function saveHandle() {
-    const trimmed = handleDraft.trim();
-    if (trimmed === entry.handle) {
+    const trimmed = stripAt(handleDraft.trim());
+    if (trimmed === stripAt(entry.handle)) {
       setEditingHandle(false);
       setHandleErr(null);
       return;
@@ -224,20 +224,21 @@ function RegistryEntryRow({
           </div>
           <div className="flex items-center gap-2 mt-1">
             <span className="text-[11px] text-shell-text-tertiary">
-              {entry.handle ? `@${entry.handle}` : "no handle"}
+              {entry.handle ? `@${stripAt(entry.handle)}` : "no handle"}
             </span>
             {canEditHandle && (
               editingHandle ? (
                 <>
                   <Input
                     value={handleDraft}
+                    aria-label="Agent handle"
                     onChange={(e) => setHandleDraft(e.target.value)}
                     className="h-7 text-xs w-40"
                     autoFocus
                     onKeyDown={(e) => {
                       if (e.key === "Enter") saveHandle();
                       if (e.key === "Escape") {
-                        setHandleDraft(entry.handle);
+                        setHandleDraft(stripAt(entry.handle));
                         setEditingHandle(false);
                         setHandleErr(null);
                       }
@@ -259,7 +260,7 @@ function RegistryEntryRow({
                     size="icon"
                     className="h-7 w-7 hover:bg-zinc-500/15 hover:text-zinc-400"
                     onClick={() => {
-                      setHandleDraft(entry.handle);
+                      setHandleDraft(stripAt(entry.handle));
                       setEditingHandle(false);
                       setHandleErr(null);
                     }}

--- a/desktop/src/apps/agents/RegistryPanel.tsx
+++ b/desktop/src/apps/agents/RegistryPanel.tsx
@@ -13,8 +13,9 @@ import {
   ArrowRight,
   UserPlus,
   Archive,
+  Pencil,
 } from "lucide-react";
-import { Button, Card } from "@/components/ui";
+import { Button, Card, Input } from "@/components/ui";
 import { projectsApi } from "@/lib/projects";
 import { AssignAgentToProjectDialog } from "./AssignAgentToProjectDialog";
 import { InviteAgentDialog } from "@/apps/ProjectsApp/InviteAgentDialog";
@@ -134,18 +135,48 @@ function RegistryEntryRow({
   currentUserId,
   onAction,
   onAssign,
+  onPatchHandle,
 }: {
   entry: RegistryEntry;
   isAdmin: boolean;
   currentUserId: string;
   onAction: (id: string, action: "approve" | "reject" | "suspend" | "reactivate" | "revoke") => Promise<void>;
   onAssign: (entry: RegistryEntry) => void;
+  onPatchHandle: (id: string, handle: string) => Promise<void>;
 }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [editingHandle, setEditingHandle] = useState(false);
+  const [handleDraft, setHandleDraft] = useState(entry.handle);
+  const [savingHandle, setSavingHandle] = useState(false);
+  const [handleErr, setHandleErr] = useState<string | null>(null);
   const isOwner = entry.user_id === currentUserId;
+  const canEditHandle = isAdmin || isOwner;
   const canRevoke = (isAdmin || isOwner) && (entry.status === "active" || entry.status === "suspended");
   const canAssign = (isAdmin || isOwner) && entry.status === "active";
+
+  useEffect(() => {
+    setHandleDraft(entry.handle);
+  }, [entry.handle]);
+
+  async function saveHandle() {
+    const trimmed = handleDraft.trim();
+    if (trimmed === entry.handle) {
+      setEditingHandle(false);
+      setHandleErr(null);
+      return;
+    }
+    setSavingHandle(true);
+    setHandleErr(null);
+    try {
+      await onPatchHandle(entry.canonical_id, trimmed);
+      setEditingHandle(false);
+    } catch (e: unknown) {
+      setHandleErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingHandle(false);
+    }
+  }
 
   async function act(action: "approve" | "reject" | "suspend" | "reactivate" | "revoke") {
     setBusy(true);
@@ -189,6 +220,69 @@ function RegistryEntryRow({
               <span className="text-[11px] text-shell-text-tertiary">
                 by {entry.user_id}
               </span>
+            )}
+          </div>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-[11px] text-shell-text-tertiary">
+              {entry.handle ? `@${entry.handle}` : "no handle"}
+            </span>
+            {canEditHandle && (
+              editingHandle ? (
+                <>
+                  <Input
+                    value={handleDraft}
+                    onChange={(e) => setHandleDraft(e.target.value)}
+                    className="h-7 text-xs w-40"
+                    autoFocus
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") saveHandle();
+                      if (e.key === "Escape") {
+                        setHandleDraft(entry.handle);
+                        setEditingHandle(false);
+                        setHandleErr(null);
+                      }
+                    }}
+                    disabled={savingHandle}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 hover:bg-emerald-500/15 hover:text-emerald-400"
+                    onClick={saveHandle}
+                    disabled={savingHandle}
+                    title="Save handle"
+                  >
+                    <CheckCircle size={14} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 hover:bg-zinc-500/15 hover:text-zinc-400"
+                    onClick={() => {
+                      setHandleDraft(entry.handle);
+                      setEditingHandle(false);
+                      setHandleErr(null);
+                    }}
+                    disabled={savingHandle}
+                    title="Cancel"
+                  >
+                    <XCircle size={14} />
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 hover:bg-white/[0.06] hover:text-shell-text"
+                  onClick={() => setEditingHandle(true)}
+                  title="Edit handle"
+                >
+                  <Pencil size={12} />
+                </Button>
+              )
+            )}
+            {handleErr && (
+              <span className="text-[11px] text-red-400" role="alert">{handleErr}</span>
             )}
           </div>
         </div>
@@ -745,6 +839,26 @@ export function RegistryPanel() {
     };
   }, [expanded, load]);
 
+  async function handlePatchHandle(
+    canonical_id: string,
+    handle: string,
+  ) {
+    const resp = await fetch(
+      `/api/agents/registry/${encodeURIComponent(canonical_id)}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ handle }),
+        credentials: "include",
+      },
+    );
+    if (!resp.ok) {
+      const err = await resp.json().catch(() => ({}));
+      throw new Error((err as { error?: string }).error ?? `HTTP ${resp.status}`);
+    }
+    await load({ quiet: true });
+  }
+
   async function handleAction(
     canonical_id: string,
     action: "approve" | "reject" | "suspend" | "reactivate" | "revoke",
@@ -822,6 +936,7 @@ export function RegistryPanel() {
                 currentUserId={currentUserId}
                 onAction={handleAction}
                 onAssign={setAssignEntry}
+                onPatchHandle={handlePatchHandle}
               />
             ))}
 
@@ -841,6 +956,7 @@ export function RegistryPanel() {
                       currentUserId={currentUserId}
                       onAction={handleAction}
                       onAssign={setAssignEntry}
+                      onPatchHandle={handlePatchHandle}
                     />
                   ))}
                 </div>
@@ -876,6 +992,7 @@ export function RegistryPanel() {
                       currentUserId={currentUserId}
                       onAction={handleAction}
                       onAssign={setAssignEntry}
+                      onPatchHandle={handlePatchHandle}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): Alias editing UI in Agents app

Autonomous build of board card tsk-kqffyv.



Files:
 desktop/src/apps/agents/RegistryPanel.test.tsx | 256 +++++++++++++++++++++++++
 desktop/src/apps/agents/RegistryPanel.tsx      | 119 +++++++++++-
 2 files changed, 374 insertions(+), 1 deletion(-)