### PR TITLE
chore(deps): bump dompurify 3.4.13 + nanoid 5.1.16 (desktop security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Versions follow semver beta: `1.0.0-beta.N`, bumped on each dev->master promotio
 
 ## [Unreleased]
 
+### Security
+
+- **Desktop deps**: bump `dompurify` 3.4.12 -> 3.4.13 (GHSA-55q2-fjhq-7xh7,
+  moderate) and `nanoid` 5.1.11 -> 5.1.16 (CVE-2026-67214, high) in
+  `desktop/package-lock.json`; lock-only, both already within the declared
+  ranges. Split out of Dependabot #2331, whose grouped jsdom 30 bump fails
+  spa-build (jsdom 30 requires Node >=22.13; CI pins Node 20).
+
 ### Added
 
 - **Docs**: mechanical-simple-auditable design law added to the agent manual

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tinyagentos-desktop",
-  "version": "1.0.0-beta.46",
+  "version": "1.0.0-beta.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tinyagentos-desktop",
-      "version": "1.0.0-beta.46",
+      "version": "1.0.0-beta.47",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language-data": "^6.5.2",
@@ -9707,9 +9707,9 @@
       "peer": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -12129,9 +12129,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "5.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
-      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Security lock-only refresh for `desktop/`, clearing both open Dependabot alerts:

- **dompurify 3.4.12 -> 3.4.13** (GHSA-55q2-fjhq-7xh7, moderate)
- **nanoid 5.1.11 -> 5.1.16** (CVE-2026-67214, high — had no Dependabot PR at all)

Both versions are inside the ranges `desktop/package.json` already declares (`^3.4.0`, `^5.0.9`), so this is `npm update dompurify nanoid` and nothing else; the only other lock delta is the lock's stale `1.0.0-beta.46` header catching up to the `beta.47` already in package.json on dev.

**Why not just merge Dependabot #2331:** its grouped update also bumps jsdom 29 -> 30, and jsdom 30 dropped Node 20 support (`engines: ^22.13.0 || >=24.0.0`) while CI's spa-build pins Node 20 — that is the actual cause of its `webidl.util.markAsUncloneable is not a function` vitest-worker crashes (389 unhandled errors). The jsdom major needs a CI Node decision first and is deliberately excluded here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated desktop dependencies to address security advisories.
  * Recorded the updates in the unreleased changelog.
  * No user-facing functionality or compatibility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->