### PR TITLE
CI: bump spa-build Node 20 -> 22 (Node 20 is EOL; unblocks jsdom 30 / Dependabot #2331)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: desktop/package-lock.json
 

--- a/changelog.d/2353-ci-node-22.md
+++ b/changelog.d/2353-ci-node-22.md
@@ -1,0 +1,4 @@
+### Changed
+
+- CI's `spa-build` job runs on Node 22 (was 20, now past end-of-life). Also
+  unblocks the jsdom 30 upgrade, which requires Node >= 22.13 (#2353).


### PR DESCRIPTION
CARD TITLE (intent, not commit subject): CI: bump spa-build Node 20 -> 22 (Node 20 is EOL; unblocks jsdom 30 / Dependabot #2331)

Autonomous build of board card tsk-6ijt67.

> **REVIEW WARNING (automated):** this card's text asks for tests, but the diff changes no test file. Either the acceptance criteria are unmet or the card needs correcting. Do not merge without resolving this.



Files:
 .github/workflows/ci.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SPA build environment to use Node.js 22.
  * Enabled compatibility with newer build tooling requiring Node.js 22.13 or later.

* **Documentation**
  * Added a changelog entry describing the CI environment update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->